### PR TITLE
SALTO-567: HubSpot permissions

### DIFF
--- a/packages/hubspot-adapter/package.json
+++ b/packages/hubspot-adapter/package.json
@@ -36,12 +36,13 @@
     "@salto-io/adapter-utils": "0.1.14",
     "@salto-io/logging": "0.1.14",
     "@salto-io/lowerdash": "0.1.14",
-    "@types/request-promise": "^4.1.45",
     "hubspot": "^2.3.8",
     "lodash": "^4.17.11",
+    "request-promise": "^4.2.5",
     "requestretry": "^4.0.2"
   },
   "devDependencies": {
+    "@types/request-promise": "^4.1.45",
     "@types/jest": "^24.0.0",
     "@types/lodash": "^4.14.133",
     "@types/node": "^12.7.1",

--- a/packages/hubspot-adapter/src/client/client.ts
+++ b/packages/hubspot-adapter/src/client/client.ts
@@ -208,12 +208,11 @@ export default class HubspotClient {
 
   async deleteInstance(typeName: string, hubspotMetadata: HubspotMetadata): Promise<void> {
     const objectAPI = await this.extractHubspotObjectAPI(typeName)
-
-    // The instance id have different names in each HubSpot object
-    const instanceId = extractInstanceId(hubspotMetadata, typeName)
-    const resp = await objectAPI.delete(instanceId)
-    if (resp) {
-      throw new Error(resp.message)
-    }
+    const resp = objectAPI.delete(extractInstanceId(hubspotMetadata, typeName))
+    await resp.catch((reason: StatusCodeError) => {
+      if (!_.isUndefined(reason)) {
+        throw new Error(reason.error.message)
+      }
+    })
   }
 }

--- a/packages/hubspot-adapter/test/client.test.ts
+++ b/packages/hubspot-adapter/test/client.test.ts
@@ -527,6 +527,26 @@ describe('Test HubSpot client', () => {
       })
     })
 
+    describe('no permissions', () => {
+      beforeEach(() => {
+        const noPermissionsResultMock = (): RequestPromise =>
+        Promise.reject(createTestStatusCodeError(403, {
+          status: 'error',
+          message: permissionsErrStr,
+          correlationId: 'db8f8a2f-d799-4353-8a67-b85df639b3df',
+          requestId: '493c8493-861b-4f56-be3b-3f6067238efd',
+        })) as unknown as RequestPromise
+
+        mockDeleteInstance = jest.fn().mockImplementation(noPermissionsResultMock)
+        connection.forms.delete = mockDeleteInstance
+      })
+
+      it('should return error', async () => {
+        await expect(client.deleteInstance(OBJECTS_NAMES.FORM, formToDelete as HubspotMetadata))
+          .rejects.toThrow(permissionsErrStr)
+      })
+    })
+
     describe('When delete instance success', () => {
       describe('Delete Form instance', () => {
         beforeEach(() => {


### PR DESCRIPTION
What's here?

Handle fetch (getAll) permissions case as expected (if there's no permissions - return empty)
I had to change our whole error handling in the client cause the best way to discover it's a permissions error was not available. That's why it might look much "bigger" than the product impact.