### PR TITLE
Add StaticFiles to SalesForce Apex files

### DIFF
--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -15,7 +15,9 @@
 */
 import {
   ElemID, ObjectType, BuiltinTypes, Field, CORE_ANNOTATIONS, ListType, createRestriction,
+  StaticFile,
 } from '@salto-io/adapter-api'
+import { MetadataInfo } from 'jsforce'
 import * as constants from './constants'
 
 export const METADATA_TYPES_SKIPPED_LIST = 'metadataTypesSkippedList'
@@ -95,3 +97,7 @@ export const configType = new ObjectType({
     ),
   },
 })
+
+export interface MetadataInfoWithStaticFile extends MetadataInfo {
+ content: StaticFile
+}

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -530,7 +530,7 @@ describe('SalesforceAdapter fetch', () => {
         .toEqual([constants.SALESFORCE, constants.RECORDS_PATH, 'EmailTemplate', 'MyFolder_MyEmailTemplate'])
       expect(testInst.value[constants.INSTANCE_FULL_NAME_FIELD]).toEqual('MyFolder/MyEmailTemplate')
       expect(testInst.value.name).toEqual('My Email Template')
-      expect(testInst.value.content).toEqual('Email Body')
+      expect(testInst.value.content.content.toString()).toEqual('Email Body')
     })
 
     it('should fetch metadata instances using retrieve in chunks', async () => {
@@ -591,8 +591,8 @@ describe('SalesforceAdapter fetch', () => {
       const [second] = findElements(result, 'ApexClass', 'MyApexClass2') as InstanceElement[]
       expect(first.value[constants.INSTANCE_FULL_NAME_FIELD]).toEqual('MyApexClass')
       expect(second.value[constants.INSTANCE_FULL_NAME_FIELD]).toEqual('MyApexClass2')
-      expect(first.value.content.includes('Instance1')).toBeTruthy()
-      expect(second.value.content.includes('Instance2')).toBeTruthy()
+      expect(first.value.content.content.toString().includes('Instance1')).toBeTruthy()
+      expect(second.value.content.content.toString().includes('Instance2')).toBeTruthy()
     })
 
     it('should fetch metadata instances folders using retrieve', async () => {


### PR DESCRIPTION
Basically changing all Apex* components to be StaticFiles

Instead of being saved as strings in the `content` parameter, the content will be saved in the `static-resources` dir, under the following convention `salesforce/{componentType}/filename.ext'.

E.g.

`static-resources/salesforce/classes/ApexClassForProfile.cls`

~Please note that the first commit (not SF related) might be dropped due to @ori-moisis 's fix at https://github.com/salto-io/salto/pull/986~