### PR TITLE
SALTO-732-Marketo email templates should be skipped by default

### DIFF
--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -70,7 +70,9 @@ export const configType = new ObjectType({
       INSTANCES_REGEX_SKIPPED_LIST,
       new ListType(BuiltinTypes.STRING),
       {
-        [CORE_ANNOTATIONS.DEFAULT]: [],
+        [CORE_ANNOTATIONS.DEFAULT]: [
+          '^EmailTemplate.MarketoEmailTemplates',
+        ],
       },
     ),
     [MAX_CONCURRENT_RETRIEVE_REQUESTS]: new Field(


### PR DESCRIPTION
MarketoEmailTemplates should be skipped by default.
[ticket](https://salto-io.atlassian.net/browse/SALTO-732)