### PR TITLE
replaced . usage in lexer ts regexes to [^\r\n] in order to catch u2028

### DIFF
--- a/packages/core/src/parser/internal/lexer.ts
+++ b/packages/core/src/parser/internal/lexer.ts
@@ -42,14 +42,14 @@ export const rules: Record<string, moo.Rules> = {
     wildcard: WILDCARD,
     reference: { match: /\$\{[ \t]*[\d\w.]+[ \t]*\}/, value: s => s.slice(2, -1).trim() },
     dq: { match: '"', pop: 1 },
-    content: { match: /[^\\](?=")|.+?[^\\](?=\$\{|"|\n)/, lineBreaks: false },
+    content: { match: /[^\\](?=")|[^\r\n]+?[^\\](?=\$\{|"|\n)/s, lineBreaks: false },
     invalidSyntax: { match: /[^ ]+/, error: true },
   },
   multilineString: {
     wildcard: WILDCARD,
     reference: { match: /\$\{[ \t]*[\d\w.]+[ \t]*\}/, value: s => s.slice(2, -1).trim() },
     mlEnd: { match: /^[ \t]*'''/, pop: 1 },
-    content: { match: /.*?(?=\$\{)|^.*[(\r\n)(\n)]|[(\r\n)(\n)]/, lineBreaks: true },
+    content: { match: /[^\r\n]*?(?=\$\{)|^[^\r\n]*[(\r\n)(\n)]|[(\r\n)(\n)]/, lineBreaks: true },
     invalidSyntax: { match: /[^ ]+/, error: true },
   },
 }

--- a/packages/core/test/parser/internal/hcl.test.ts
+++ b/packages/core/test/parser/internal/hcl.test.ts
@@ -257,6 +257,20 @@ describe('HCL parse', () => {
     expect(await evaluate(body.blocks[0].attrs.thing.expressions[0], functions)).toHaveLength(5)
   })
 
+  // If this  fails you probably used the . operator in a regex in the lexer. It does not
+  // catch the \u2028 and \u2029 operators so the regex breaks
+  it('Should not fail when parsing a string with \\u2028/9 in it.', async () => {
+    const strContent = 'Hello\u2028Do you want to\u2029know a secret?'
+    const blockDef = `type voodoo {
+      thing = "${strContent}"
+    }`
+    const { body } = parse(Buffer.from(blockDef), 'none')
+    expect(body.blocks.length).toEqual(1)
+    expect(body.blocks[0].attrs).toHaveProperty('thing')
+    expect(await evaluate(body.blocks[0].attrs.thing.expressions[0], functions))
+      .toEqual(strContent)
+  })
+
   describe('parse error', () => {
     const blockDef = 'type some:thing {}'
     let errors: HclParseError[]


### PR DESCRIPTION
The . operator in JS regexes catches everything expect line breaks. It turns out that JS consider the \u2028 and \u2029 chars to be line breaks as well for that purpose. This change remove the . operator from the lexer and replaces it with a group that catches anything but \r or \n to overcome this issue. 