### PR TITLE
SALTO-696: Variables fetch, preview and deploy

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -152,9 +152,34 @@ For example, if we want to define that the value of a certain field will referen
 valueSet = salesforce.StandardValueSet.instance.LeadSource.standardValue
 ```
 
->In the case you need to reference a specific element in a list, you should use the index as an additional key, e.g. `salesforce.Lead.field.MyField__c.valueSet.2.fullName` would access the fullName attribute of the 2nd element in the list valueSet under the custom field MyField__c which is part of salesforce.Lead
+>In the case you need to reference a specific element in a list, you should use the index as an additional key, e.g. `salesforce.Lead.field.MyField__c.valueSet.2.fullName` would access the fullName attribute of the 3rd element in the list valueSet under the custom field MyField__c which is part of salesforce.Lead
 
 >A reference implies a creation dependency between a source and a target element. Meaning that when element A references element B it also implies that Salto will make sure to create element B before element A is created.
+
+### Variables
+
+Variables let you define a primitive value, give it a name, and then use it multiple times. Variables are defined using a `vars` block:
+
+```hcl
+vars {
+    secondsPerDay = 86400
+    daysPerYear = 365
+    firstMonth = "January"
+}
+```
+
+Variables can be defined anywhere in the NaCl files, and there can be many `vars` blocks. The scope of a variable is always global, so any variable can be referenced from any NaCl file.
+
+A variable is referenced using the following schema: `var.<name>`. For example, we can set:
+
+```hcl
+salesforce.CompanySettings {
+    fiscalYear = {
+        fiscalYearNameBasedOn = "endingMonth"
+        startMonth = var.firstMonth
+    }
+}
+```
 
 ### Multiple Environments
 

--- a/packages/cli/e2e_test/NACL/add.nacl
+++ b/packages/cli/e2e_test/NACL/add.nacl
@@ -18,3 +18,15 @@ salesforce.Role NewInstanceName {
   description = "To Be Modified"
   name = "New Role Instance"
 }
+
+salesforce.Role NewInstance2Name {
+  description = var.desc
+  name = "Another new Role Instance"
+  mayForecastManagerShare = var.isStaging
+}
+
+vars {
+  desc = salesforce.Role.instance.NewInstanceName.description
+  isStaging = false
+  age = 60
+}

--- a/packages/cli/e2e_test/helpers/workspace.ts
+++ b/packages/cli/e2e_test/helpers/workspace.ts
@@ -218,6 +218,7 @@ export const verifyChanges = (plan: Plan,
   expectedChanges: { action: ActionName; element: string }[]): void => {
   expect(plan.size).toBe(expectedChanges.length)
   const changes = wu(plan.itemsByEvalOrder()).map(item => item.parent() as Change).toArray()
+
   expect(changes.every(change =>
     expectedChanges.some(expectedChange =>
       change.action === expectedChange.action

--- a/packages/core/src/core/expressions.ts
+++ b/packages/core/src/core/expressions.ts
@@ -134,7 +134,12 @@ export const resolveElement = (
   return element
 }
 
-export const resolve = (elements: readonly Element[]): Element[] => {
-  const contextElements = _.groupBy(elements, e => e.elemID.getFullName())
+export const resolve = (elements: readonly Element[],
+  additionalContext: ReadonlyArray<Element> = []): Element[] => {
+  const additionalContextElements = _.groupBy(additionalContext, e => e.elemID.getFullName())
+  const contextElements = {
+    ...additionalContextElements,
+    ..._.groupBy(elements, e => e.elemID.getFullName()),
+  }
   return elements.map(e => resolveElement(e, contextElements))
 }

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -71,8 +71,9 @@ export type MergeErrorWithElements = {
 export const getDetailedChanges = async (
   before: ReadonlyArray<Element>,
   after: ReadonlyArray<Element>,
+  additionalResolveContext?: ReadonlyArray<Element>,
 ): Promise<Iterable<DetailedChange>> =>
-  wu((await getPlan(before, after, {}, [])).itemsByEvalOrder())
+  wu((await getPlan(before, after, {}, [], additionalResolveContext)).itemsByEvalOrder())
     .map(item => item.detailedChanges())
     .flatten()
 

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -65,8 +65,8 @@ const addElements = (
   // Add top level elements to the graph
   elements.filter(isTopLevelElement).forEach(addElemToOutputGraph)
 
-  // We add fields to the graph seperately from their object types to allow for better granularity
-  // of cycle aviodance
+  // We add fields to the graph separately from their object types to allow for better granularity
+  // of cycle avoidance
   _(elements)
     .filter(isObjectType)
     .map(obj => Object.values(obj.fields))
@@ -166,10 +166,11 @@ export const getPlan = async (
   afterElements: readonly Element[],
   changeValidators: Record<string, ChangeValidator> = {},
   dependencyChangers: ReadonlyArray<DependencyChanger> = defaultDependencyChangers,
+  additionalResolveContext?: ReadonlyArray<Element>,
 ): Promise<Plan> => log.time(async () => {
   // Resolve elements before adding them to the graph
-  const resolvedBefore = resolve(beforeElements)
-  const resolvedAfter = resolve(afterElements)
+  const resolvedBefore = resolve(beforeElements, additionalResolveContext)
+  const resolvedAfter = resolve(afterElements, additionalResolveContext)
 
   const diffGraph = await buildDiffGraph(
     addElements(resolvedBefore, 'remove'),

--- a/packages/core/src/serializer/parse_result.ts
+++ b/packages/core/src/serializer/parse_result.ts
@@ -24,7 +24,7 @@ const serializeSourceMap = (sourceMap: SourceMap): string =>
   JSON.stringify(Array.from(sourceMap.entries()))
 
 export const serialize = (parseResult: ParseResult): string => [
-  elementSerializer.serialize(parseResult.elements),
+  elementSerializer.serialize(parseResult.elements, 'cache'),
   serializeErrors(parseResult.errors),
   serializeSourceMap(parseResult.sourceMap),
 ].join(EOL)

--- a/packages/core/src/serializer/parse_result.ts
+++ b/packages/core/src/serializer/parse_result.ts
@@ -24,7 +24,9 @@ const serializeSourceMap = (sourceMap: SourceMap): string =>
   JSON.stringify(Array.from(sourceMap.entries()))
 
 export const serialize = (parseResult: ParseResult): string => [
-  elementSerializer.serialize(parseResult.elements, 'cache'),
+  // When serializing for the cache, keep reference expressions
+  // since the idea is to reflect the nacl files, not the state file.
+  elementSerializer.serialize(parseResult.elements, 'keepRef'),
   serializeErrors(parseResult.errors),
   serializeSourceMap(parseResult.sourceMap),
 ].join(EOL)

--- a/packages/core/src/workspace/local/state.ts
+++ b/packages/core/src/workspace/local/state.ts
@@ -52,7 +52,7 @@ export const localState = (filePath: string): State => {
     const servicesUpdateDate = updateDateData
       ? _.mapValues(JSON.parse(updateDateData), dateStr => new Date(dateStr))
       : {}
-    log.debug(`loaded state [#elements=${elements.length}]`)
+    log.debug(`loaded state [#elements=${_.size(elements)}]`)
     return { elements, servicesUpdateDate }
   }
 

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -24,6 +24,7 @@ import {
   ObjectType,
   PrimitiveType,
   PrimitiveTypes,
+  Variable,
 } from '@salto-io/adapter-api'
 import wu from 'wu'
 import * as workspace from '../src/workspace/workspace'
@@ -173,13 +174,14 @@ describe('api.ts', () => {
         regField: 'regValue',
       }
     )
-    const stateElements = [stateInstance, typeWithHiddenField]
+    const variable = new Variable(new ElemID(ElemID.VARIABLES_NAMESPACE, 'name'), 8)
+    const stateElements = [stateInstance, typeWithHiddenField, variable]
 
     // workspace elements should not contains hidden values
     const workspaceInstance = stateInstance.clone()
     workspaceInstance.value = { regField: 'regValue' }
 
-    const workspaceElements = [workspaceInstance, typeWithHiddenField]
+    const workspaceElements = [workspaceInstance, typeWithHiddenField, variable]
     const ws = mockWorkspace(workspaceElements)
     const mockFlush = ws.flush as jest.Mock
     const mockedState = { ...mockState(), getAll: jest.fn().mockResolvedValue(stateElements) }
@@ -191,7 +193,7 @@ describe('api.ts', () => {
     it('should call getPlan with the correct elements', async () => {
       expect(mockedGetPlan).toHaveBeenCalledTimes(1)
 
-      // checking that we call get plan after adding hidden values to workspace elements
+      // check that we call get plan after adding hidden values and variables to workspace elements
       expect(mockedGetPlan).toHaveBeenCalledWith(
         stateElements,
         stateElements,
@@ -261,8 +263,9 @@ describe('api.ts', () => {
       it('should deploy changes', async () => {
         expect(mockedDeployActions).toHaveBeenCalledTimes(1)
       })
-      it('should get detailed changes', async () => {
+      it('should get detailed changes with resolve context', async () => {
         expect(mockedGetDetailedChanges).toHaveBeenCalledTimes(1)
+        expect(mockedGetDetailedChanges.mock.calls[0].length).toBe(3)
       })
 
       it('should return fetch changes', async () => {

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -624,7 +624,7 @@ describe('fetch', () => {
         changes.forEach(c => expect(c.pendingChange).toBeUndefined())
       })
 
-      it('shouldn remove hidden values from changes', () => {
+      it('shouldn\'t remove hidden values from changes', () => {
         const fetchedInst = getChangeElement(changes[1].change)
         expect(fetchedInst.value.hidden).toBeUndefined()
         expect(fetchedInst.value.notHidden).toEqual('notHidden')

--- a/packages/core/test/core/plan/plan.test.ts
+++ b/packages/core/test/core/plan/plan.test.ts
@@ -19,6 +19,7 @@ import {
   ElemID, ObjectType, Field, BuiltinTypes, InstanceElement, getChangeElement, PrimitiveType,
   PrimitiveTypes, Element, DependencyChanger, dependencyChange, ListType, isInstanceElement,
 } from '@salto-io/adapter-api'
+import * as expressions from '../../../src/core/expressions'
 import * as mock from '../../common/elements'
 import { getFirstPlanItem, getChange } from '../../common/plan'
 import { getPlan, Plan } from '../../../src/core/plan'
@@ -138,6 +139,16 @@ describe('getPlan', () => {
   it('should create empty plan', async () => {
     const plan = await getPlan(allElements, allElements)
     expect(plan.size).toBe(0)
+  })
+
+  it('should call resolve with additional context', async () => {
+    jest.spyOn(expressions, 'resolve')
+    const mockResolve = expressions.resolve as jest.Mock
+    const allElementsClone = _.cloneDeep(allElements)
+    await getPlan(allElements, allElements, {}, [], allElementsClone)
+    expect(mockResolve.mock.calls.length).toBe(2)
+    expect(mockResolve.mock.calls[0][1]).toBe(allElementsClone)
+    expect(mockResolve.mock.calls[1][1]).toBe(allElementsClone)
   })
 
   it('should create plan with add change', async () => {

--- a/packages/core/test/serializer/serializer.test.ts
+++ b/packages/core/test/serializer/serializer.test.ts
@@ -26,7 +26,7 @@ import {
 import { serialize, deserialize, SALTO_CLASS_FIELD } from '../../src/serializer/elements'
 import { resolve } from '../../src/core/expressions'
 
-describe('State serialization', () => {
+describe('State/cache serialization', () => {
   const strType = new PrimitiveType({
     elemID: new ElemID('salesforce', 'string'),
     primitive: PrimitiveTypes.STRING,
@@ -83,6 +83,22 @@ describe('State serialization', () => {
     }
   )
 
+  const refInstance2 = new InstanceElement(
+    'another',
+    model,
+    {
+      name: new ReferenceExpression(instance.elemID),
+    }
+  )
+
+  const refInstance3 = new InstanceElement(
+    'another3',
+    model,
+    {
+      name: new ReferenceExpression(refInstance2.elemID.createNestedID('name')),
+    }
+  )
+
   const templateRefInstance = new InstanceElement(
     'also_me_template',
     model,
@@ -118,8 +134,8 @@ describe('State serialization', () => {
     { name: 'other', num: 5 },
   )
 
-  const elements = [strType, numType, boolType, model, strListType, variable,
-    instance, refInstance, templateRefInstance, functionRefInstance, config]
+  const elements = [strType, numType, boolType, model, strListType, variable, instance,
+    refInstance, refInstance2, refInstance3, templateRefInstance, functionRefInstance, config]
 
   it('should serialize and deserialize all element types', async () => {
     const serialized = serialize(elements)
@@ -131,16 +147,41 @@ describe('State serialization', () => {
   it('should not serialize resolved values', async () => {
     // TemplateExpressions are discarded
     const elementsToSerialize = elements.filter(e => e.elemID.name !== 'also_me_template')
-    const serialized = serialize(resolve(elementsToSerialize))
+    const serialized = serialize(resolve(elementsToSerialize), 'cache')
     const deserialized = await deserialize(serialized)
     const sortedElements = _.sortBy(elementsToSerialize, e => e.elemID.getFullName())
+
     expect(deserialized).toEqual(sortedElements)
   })
+
+  // Serializing our nacls to the state file should be the same as serializing the result of fetch
+  it('should serialize resolved values to state', async () => {
+    const elementsToSerialize = elements.filter(e => e.elemID.name !== 'also_me_template')
+    const serialized = serialize(resolve(elementsToSerialize))
+    const deserialized = await deserialize(serialized)
+    const refInst = deserialized.find(
+      e => e.elemID.getFullName() === refInstance.elemID.getFullName()
+    ) as InstanceElement
+    const refInst2 = deserialized.find(
+      e => e.elemID.getFullName() === refInstance2.elemID.getFullName()
+    ) as InstanceElement
+    const refInst3 = deserialized.find(
+      e => e.elemID.getFullName() === refInstance3.elemID.getFullName()
+    ) as InstanceElement
+    expect(refInst.value.name).toEqual('I am a var')
+    expect(refInst.value.num).toEqual(7)
+    expect(refInst2.value.name).toBeInstanceOf(ReferenceExpression)
+    expect(refInst2.value.name.elemId.getFullName()).toEqual(instance.elemID.getFullName())
+    expect(refInst3.value.name).toBeInstanceOf(ReferenceExpression)
+    expect(refInst3.value.name.elemId.getFullName()).toEqual(instance.elemID.getFullName())
+  })
+
   it('should create the same result for the same input regardless of elements order', () => {
     const serialized = serialize(elements)
     const shuffledSer = serialize(_.shuffle(elements))
     expect(serialized).toEqual(shuffledSer)
   })
+
   it('should create the same result for the same input regardless of values order', () => {
     const serialized = serialize(elements)
     const shuffledConfig = _.last(elements) as InstanceElement
@@ -153,6 +194,7 @@ describe('State serialization', () => {
     ])
     expect(serialized).toEqual(shuffledSer)
   })
+
   describe('functions', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let funcElement: InstanceElement

--- a/packages/core/test/serializer/serializer.test.ts
+++ b/packages/core/test/serializer/serializer.test.ts
@@ -147,7 +147,7 @@ describe('State/cache serialization', () => {
   it('should not serialize resolved values', async () => {
     // TemplateExpressions are discarded
     const elementsToSerialize = elements.filter(e => e.elemID.name !== 'also_me_template')
-    const serialized = serialize(resolve(elementsToSerialize), 'cache')
+    const serialized = serialize(resolve(elementsToSerialize), 'keepRef')
     const deserialized = await deserialize(serialized)
     const sortedElements = _.sortBy(elementsToSerialize, e => e.elemID.getFullName())
 

--- a/packages/core/test/workspace/local/cache.test.ts
+++ b/packages/core/test/workspace/local/cache.test.ts
@@ -20,6 +20,7 @@ import { localDirectoryStore } from '../../../src/workspace/local/dir_store'
 import { parseResultCache } from '../../../src/workspace/cache'
 import { SourceMap } from '../../../src/parser/internal/types'
 import { mockStaticFilesSource } from '../static_files/common.test'
+import * as elementsModule from '../../../src/serializer/elements'
 
 
 jest.mock('@salto-io/file', () => ({
@@ -89,6 +90,17 @@ describe('localParseResultCache', () => {
       expect(replaceContents).toHaveBeenLastCalledWith(
         path.resolve(mockBaseDirPath, 'blabla/blurprint.jsonl'), mockSerializedCacheFile
       )
+    })
+
+    it('serializes with cache mode', async () => {
+      jest.spyOn(elementsModule, 'serialize')
+      await cache.put({
+        filename: 'blabla/blurprint.nacl',
+        lastModified: 0,
+      }, parseResult)
+      const mockSerialize = elementsModule.serialize as jest.Mock
+      expect(mockSerialize.mock.calls.length).toBe(1)
+      expect(mockSerialize.mock.calls[0][1]).toEqual('cache')
     })
   })
   describe('get', () => {

--- a/packages/core/test/workspace/local/cache.test.ts
+++ b/packages/core/test/workspace/local/cache.test.ts
@@ -100,7 +100,7 @@ describe('localParseResultCache', () => {
       }, parseResult)
       const mockSerialize = elementsModule.serialize as jest.Mock
       expect(mockSerialize.mock.calls.length).toBe(1)
-      expect(mockSerialize.mock.calls[0][1]).toEqual('cache')
+      expect(mockSerialize.mock.calls[0][1]).toEqual('keepRef')
     })
   })
   describe('get', () => {


### PR DESCRIPTION
* Added different serialization for state vs cache.
* Now fetch, deploy, etc. all work.
* Added tests.
* Added documentation.