### PR TITLE
fix instance annotation expected types to match the actual expected types

### DIFF
--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ElemID } from './element_id'
-import { Element, TypeMap, ObjectType, Field, PrimitiveType, PrimitiveTypes } from './elements'
+import { Element, TypeMap, ObjectType, Field, PrimitiveType, PrimitiveTypes, ListType } from './elements'
 
 export const GLOBAL_ADAPTER = ''
 
@@ -54,8 +54,8 @@ export const INSTANCE_ANNOTATIONS = {
 }
 
 export const InstanceAnnotationTypes: TypeMap = {
-  [INSTANCE_ANNOTATIONS.DEPENDS_ON]: BuiltinTypes.STRING,
-  [INSTANCE_ANNOTATIONS.PARENT]: BuiltinTypes.STRING,
+  [INSTANCE_ANNOTATIONS.DEPENDS_ON]: new ListType(BuiltinTypes.STRING),
+  [INSTANCE_ANNOTATIONS.PARENT]: new ListType(BuiltinTypes.STRING),
 }
 
 const RESTRICTION_ANNOTATIONS_FIELDS = {


### PR DESCRIPTION
before this, in every `deploy` / `preview` we would get a ton of warnings in the log like:
```
warn adapter-utils/utils Array value and isListType mis-match for field - _parent. Only ListTypes should have array values.
```

this fixes these warnings