### PR TITLE
fetch add changes go to env if there is no top level element in common

### DIFF
--- a/packages/cli/e2e_test/helpers/workspace.ts
+++ b/packages/cli/e2e_test/helpers/workspace.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Plan, Workspace, telemetrySender } from '@salto-io/core'
+import { Plan, Workspace, telemetrySender, parse } from '@salto-io/core'
 import { readTextFile, writeFile } from '@salto-io/file'
 import _ from 'lodash'
 import glob from 'glob'
@@ -95,6 +95,12 @@ export const editNaclFile = async (filename: string, replacements: ReplacementPa
     fileAsString = fileAsString.replace(pair[0], pair[1])
   })
   await writeFile(filename, fileAsString)
+}
+
+export const getNaclFileElements = async (filename: string):
+  Promise<Element[]> => {
+  const fileAsString = await readTextFile(filename)
+  return (await parse(Buffer.from(fileAsString), filename)).elements
 }
 
 export const runInit = async (

--- a/packages/cli/e2e_test/multi_env.test.ts
+++ b/packages/cli/e2e_test/multi_env.test.ts
@@ -419,9 +419,21 @@ describe('multi env tests', () => {
     const commonNaclFileInstName = `CommonInstNacl${tempID}`
     const env1NaclFileInstName = `Env1InstNacl${tempID}`
     const env2NaclFileInstName = `Env2InstNacl${tempID}`
-    const commonNaclFileName = path.join(baseDir, 'salesforce', 'common.nacl')
-    const env1NaclFileName = path.join(baseDir, 'envs', ENV1_NAME, 'salesforce', 'env1.nacl')
-    const env2NaclFileName = path.join(baseDir, 'envs', ENV2_NAME, 'salesforce', 'env2.nacl')
+    const commonNaclFileName = (): string => path.join(baseDir, 'salesforce', 'common.nacl')
+    const env1NaclFileName = (): string => path.join(
+      baseDir,
+      'envs',
+      ENV1_NAME,
+      'salesforce',
+      'env1.nacl'
+    )
+    const env2NaclFileName = (): string => path.join(
+      baseDir,
+      'envs',
+      ENV2_NAME,
+      'salesforce',
+      'env2.nacl'
+    )
 
     describe('handle nacl based add change', () => {
       beforeAll(async () => {
@@ -458,9 +470,9 @@ describe('multi env tests', () => {
             description: 'Env2 from Nacl',
           }),
         ])
-        await writeFile(commonNaclFileName, commonNaclFile)
-        await writeFile(env1NaclFileName, env1NaclFile)
-        await writeFile(env2NaclFileName, env2NaclFile)
+        await writeFile(commonNaclFileName(), commonNaclFile)
+        await writeFile(env1NaclFileName(), env1NaclFile)
+        await writeFile(env2NaclFileName(), env2NaclFile)
         await runSetEnv(baseDir, ENV1_NAME)
         await runPreviewGetPlan(baseDir)
         await runSetEnv(baseDir, ENV2_NAME)
@@ -507,9 +519,9 @@ describe('multi env tests', () => {
 
       it('should update the attributes added in the deploy in the proper file', async () => {
         await Promise.all([
-          env1NaclFileName,
-          env2NaclFileName,
-          commonNaclFileName,
+          env1NaclFileName(),
+          env2NaclFileName(),
+          commonNaclFileName(),
         ].map(async filename => {
           const element = (await getNaclFileElements(filename))[0]
           expect(isObjectType(element)).toBeTruthy()
@@ -523,9 +535,9 @@ describe('multi env tests', () => {
 
     describe('handle nacl file delete changes', () => {
       beforeAll(async () => {
-        await rm(commonNaclFileName)
-        await rm(env1NaclFileName)
-        await rm(env2NaclFileName)
+        await rm(commonNaclFileName())
+        await rm(env1NaclFileName())
+        await rm(env2NaclFileName())
         await rm(env2ObjFilePath())
         await rm(env2InstFilePath())
         await runSetEnv(baseDir, ENV1_NAME)

--- a/packages/cli/e2e_test/multi_env.test.ts
+++ b/packages/cli/e2e_test/multi_env.test.ts
@@ -419,7 +419,9 @@ describe('multi env tests', () => {
     const commonNaclFileInstName = `CommonInstNacl${tempID}`
     const env1NaclFileInstName = `Env1InstNacl${tempID}`
     const env2NaclFileInstName = `Env2InstNacl${tempID}`
-
+    const commonNaclFileName = path.join(baseDir, 'salesforce', 'common.nacl')
+    const env1NaclFileName = path.join(baseDir, 'envs', ENV1_NAME, 'salesforce', 'env1.nacl')
+    const env2NaclFileName = path.join(baseDir, 'envs', ENV2_NAME, 'salesforce', 'env2.nacl')
 
     describe('handle nacl based add change', () => {
       beforeAll(async () => {
@@ -456,9 +458,9 @@ describe('multi env tests', () => {
             description: 'Env2 from Nacl',
           }),
         ])
-        await writeFile(path.join(baseDir, 'salesforce', 'common.nacl'), commonNaclFile)
-        await writeFile(path.join(baseDir, 'envs', ENV1_NAME, 'salesforce', 'env1.nacl'), env1NaclFile)
-        await writeFile(path.join(baseDir, 'envs', ENV2_NAME, 'salesforce', 'env2.nacl'), env2NaclFile)
+        await writeFile(commonNaclFileName, commonNaclFile)
+        await writeFile(env1NaclFileName, env1NaclFile)
+        await writeFile(env2NaclFileName, env2NaclFile)
         await runSetEnv(baseDir, ENV1_NAME)
         await runPreviewGetPlan(baseDir)
         await runSetEnv(baseDir, ENV2_NAME)
@@ -505,9 +507,9 @@ describe('multi env tests', () => {
 
       it('should update the attributes added in the deploy in the proper file', async () => {
         await Promise.all([
-          env1NaclFileObjectName,
-          env2NaclFileObjectName,
-          commonNaclFileObjectName,
+          env1NaclFileName,
+          env2NaclFileName,
+          commonNaclFileName,
         ].map(async filename => {
           const element = (await getNaclFileElements(filename))[0]
           expect(isObjectType(element)).toBeTruthy()
@@ -521,9 +523,9 @@ describe('multi env tests', () => {
 
     describe('handle nacl file delete changes', () => {
       beforeAll(async () => {
-        await rm(path.join(baseDir, 'salesforce', 'common.nacl'))
-        await rm(path.join(baseDir, 'envs', ENV1_NAME, 'salesforce', 'env1.nacl'))
-        await rm(path.join(baseDir, 'envs', ENV2_NAME, 'salesforce', 'env2.nacl'))
+        await rm(commonNaclFileName)
+        await rm(env1NaclFileName)
+        await rm(env2NaclFileName)
         await rm(env2ObjFilePath())
         await rm(env2InstFilePath())
         await runSetEnv(baseDir, ENV1_NAME)

--- a/packages/cli/e2e_test/multi_env.test.ts
+++ b/packages/cli/e2e_test/multi_env.test.ts
@@ -19,10 +19,10 @@ import { Plan, dumpElements } from '@salto-io/core'
 import { strings } from '@salto-io/lowerdash'
 import tmp from 'tmp-promise'
 import { writeFile, rm } from '@salto-io/file'
-import { Element } from '@salto-io/adapter-api'
+import { Element, isObjectType, ObjectType } from '@salto-io/adapter-api'
 import { CredsLease } from '@salto-io/e2e-credentials-store/dist/src/jest-environment/creds'
 import { addElements, objectExists, naclNameToSFName, instanceExists, removeElements, getSalesforceCredsInstance } from './helpers/salesforce'
-import { ensureFilesExist, runInit, runSetEnv, runFetch, runPreviewGetPlan, runAddSalesforceService, runCreateEnv, runDeploy, ensureFilesDontExist } from './helpers/workspace'
+import { ensureFilesExist, runInit, runSetEnv, runFetch, runPreviewGetPlan, runAddSalesforceService, runCreateEnv, runDeploy, ensureFilesDontExist, getNaclFileElements } from './helpers/workspace'
 import * as templates from './helpers/templates'
 
 describe('multi env tests', () => {
@@ -500,6 +500,22 @@ describe('multi env tests', () => {
         expect(await objectExists(env2Client, naclNameToSFName(env1NaclFileObjectName))).toBeFalsy()
         expect(await instanceExists(env1Client, 'Role', env2NaclFileInstName)).toBeFalsy()
         expect(await instanceExists(env2Client, 'Role', env1NaclFileInstName)).toBeFalsy()
+      })
+
+
+      it('should update the attributes added in the deploy in the proper file', async () => {
+        await Promise.all([
+          env1NaclFileObjectName,
+          env2NaclFileObjectName,
+          commonNaclFileObjectName,
+        ].map(async filename => {
+          const element = (await getNaclFileElements(filename))[0]
+          expect(isObjectType(element)).toBeTruthy()
+          const obj = element as ObjectType
+          expect(obj.fields.alpha.annotations.apiName).toBeDefined()
+          expect(obj.fields.alpha.annotations.apiName).toBeDefined()
+          expect(obj.annotations.metadataType).toBeDefined()
+        }))
       })
     })
 


### PR DESCRIPTION
Changed normal fetch behaviour to route add changes to the env and not common if the top level element is env specific.