### PR TITLE
Make multienv work for static files

### DIFF
--- a/packages/core/src/parser/expressions.ts
+++ b/packages/core/src/parser/expressions.ts
@@ -74,11 +74,9 @@ const evaluate = async (
     },
     func: async exp => {
       const { value: { parameters } } = exp
-      const params: Value[] = (parameters.type && parameters.type === 'list')
-        ? await evaluators[parameters.type as ExpressionType](parameters)
-        : await Promise.all(
-          parameters.map((x: HclExpression) => evaluate(x, functions, baseId, sourceMap))
-        )
+      const params: Value[] = await Promise.all(
+        parameters.map((x: HclExpression) => evaluate(x, functions))
+      )
       return evaluateFunction(
         {
           ...exp,


### PR DESCRIPTION
~Delete static files upon delete changes~
~Use only first source map positions when deleting static files~
Calculate source map for functions expression without creating an extra id for the parameters.