### PR TITLE
Generate Netsuite Types Automatically

### DIFF
--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -28,7 +28,7 @@ import {
   transformValues, resolvePath, TransformFunc, restoreValues, resolveValues,
   naclCase, findElement, findElements, findObjectType,
   findInstances, flattenElementStr, valuesDeepSome, filterByID,
-  flatValues,
+  flatValues, mapKeysRecursive,
 } from '../src/utils'
 
 const mockFunction = <T extends (...args: never[]) => unknown>():
@@ -143,6 +143,12 @@ describe('Test utils.ts', () => {
           },
         },
       ],
+      objWithInnerObj: {
+        innerObj: {
+          listKey: [1, 2],
+          stringKey: 'val2',
+        },
+      },
     },
     ['yes', 'this', 'is', 'path'],
     {
@@ -1046,6 +1052,31 @@ describe('Test utils.ts', () => {
     it('should not transform static files', () => {
       const staticFile = valueFile
       expect(flatValues(staticFile)).toEqual(staticFile)
+    })
+  })
+
+  describe('mapKeysRecursive', () => {
+    it('should map all keys recursively', () => {
+      const result = mapKeysRecursive(mockInstance.value, ({ key }) => key.toUpperCase())
+      expect(Object.keys(result))
+        .toEqual(expect.arrayContaining(['BOOL', 'STR', 'OBJ', 'OBJWITHINNEROBJ']))
+      expect(Object.keys(result.OBJWITHINNEROBJ)).toContain('INNEROBJ')
+      expect(Object.keys(result.OBJWITHINNEROBJ.INNEROBJ))
+        .toEqual(expect.arrayContaining(['LISTKEY', 'STRINGKEY']))
+    })
+
+    it('should map keys recursively when passing the pathID', () => {
+      const result = mapKeysRecursive(mockInstance.value, ({ key, pathID }) => {
+        if (pathID?.getFullName().includes('Key')) {
+          return key.toUpperCase()
+        }
+        return key
+      }, mockInstance.elemID)
+      expect(Object.keys(result))
+        .toEqual(expect.arrayContaining(['bool', 'str', 'obj', 'objWithInnerObj']))
+      expect(Object.keys(result.objWithInnerObj)).toContain('innerObj')
+      expect(Object.keys(result.objWithInnerObj.innerObj))
+        .toEqual(expect.arrayContaining(['LISTKEY', 'STRINGKEY']))
     })
   })
 })

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -35,7 +35,7 @@
     "@salto-io/suitecloud-cli": "^1.0.2-salto-3",
     "lodash": "^4.17.11",
     "wu": "^2.1.0",
-    "xml-js": "^1.6.11"
+    "fast-xml-parser": "^3.15.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.0",

--- a/packages/netsuite-adapter/scripts/types_generator.py
+++ b/packages/netsuite-adapter/scripts/types_generator.py
@@ -1,0 +1,590 @@
+#!/usr/bin/python3
+
+from selenium import webdriver
+import os
+import pyotp
+import re
+import sys
+import time
+import logging
+import json
+
+logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=logging.INFO)
+
+SCRIPT_DIR = os.path.dirname(__file__)
+SRC_DIR = os.path.join(SCRIPT_DIR, '../src/')
+TYPES_DIR = os.path.join(SRC_DIR, 'types/')
+CUSTOM_TYPES_DIR = os.path.join(TYPES_DIR, 'custom_types/')
+
+enums_link_template = 'https://{account_id}.app.netsuite.com/app/help/helpcenter.nl?fid=SDFxml_2405618192.html'
+script_ids_prefix_link_template = 'https://{account_id}.app.netsuite.com/app/help/helpcenter.nl?fid=subsect_1537555588.html&whence='
+sdf_xml_definitions_link_template = 'https://{account_id}.app.netsuite.com/app/help/helpcenter.nl?fid=SDFxml.html'
+
+SCRIPT_ID_FIELD_NAME = 'scriptid'
+FIELDS = 'fields'
+ANNOTATIONS = 'annotations'
+NAME = 'name'
+IS_LIST = 'is_list'
+TYPE = 'type'
+DESCRIPTION = 'description'
+
+LICENSE_HEADER = '''/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+'''
+
+list_type_import = ' ListType,'
+enums_import = '''import { enums } from '../enums'
+'''
+
+import_statements_for_type_def_template = '''import {{
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType,{list_type_import}
+}} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+{enums_import}
+'''
+
+type_inner_types_array_template = '''export const {type_name}InnerTypes: ObjectType[] = []
+
+'''
+
+COMMON_IMPORT_STATEMENTS_FOR_ENUMS_DEF = '''import {{ CORE_ANNOTATIONS, createRestriction, ElemID, PrimitiveType, PrimitiveTypes }} from '@salto-io/adapter-api'
+import * as constants from '../constants'
+
+'''
+
+DISABLE_LINT_CAMEL_CASE = '''/* eslint-disable @typescript-eslint/camelcase */
+'''
+
+DISABLE_LINT_LINE_LENGTH = '''/* eslint-disable max-len */
+'''
+
+HEADER_FOR_DEFS = LICENSE_HEADER + DISABLE_LINT_LINE_LENGTH + DISABLE_LINT_CAMEL_CASE
+
+type_elem_id_template = '''const {type_name}ElemID = new ElemID(constants.NETSUITE, '{type_name}')
+'''
+
+SUBTYPES_FOLDER_PATH_DEF = '''const enumsFolderPath = [constants.NETSUITE, constants.TYPES_PATH, constants.SUBTYPES_PATH]
+
+'''
+
+primitive_string_type_entry_template = '''  {type_name}: new PrimitiveType({{
+    elemID: {type_name}ElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {{
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({{ values:
+        {values} }}),
+    }},
+    path: [...enumsFolderPath, {type_name}ElemID.name],
+  }}),
+'''
+
+enums_file_template = HEADER_FOR_DEFS + COMMON_IMPORT_STATEMENTS_FOR_ENUMS_DEF + SUBTYPES_FOLDER_PATH_DEF + '''{enums_elem_ids}
+export const enums: Record<string, PrimitiveType> = {{
+{enums_entries}}}
+'''
+
+inner_types_def_template = '''const {inner_type_name}ElemID = new ElemID(constants.NETSUITE, '{inner_type_name}')
+{type_def}
+{type_name}InnerTypes.push({inner_type_name})
+
+'''
+
+type_annotation_template = '''
+    {annotation_name}: '{annotation_value}','''
+
+type_annotations_template = '''
+  annotations: {{{annotations}
+  }},'''
+
+type_template = '''
+{export}const {type_name} = new ObjectType({{
+  elemID: {type_name}ElemID,{annotations}
+  fields: {{
+{field_definitions}
+  }},
+  path: {path},
+}})
+'''
+
+type_path_template = '[constants.NETSUITE, constants.TYPES_PATH, {type_name}ElemID.name]'
+
+field_template = '''    {field_name}: new Field(
+      {type_name}ElemID,
+      '{field_name}',
+      {field_type},
+      {{{annotations}
+      }},
+    ),'''
+
+field_annotation_template = '''
+        {annotation_name}: {annotation_value},'''
+
+import_type_statement_template = '''import {{ {type_name}, {type_name}InnerTypes }} from './types/custom_types/{type_name}'
+'''
+
+custom_types_map_entry_template = '''  {type_name},
+'''
+
+type_inner_types_vars_template = '''  ...{type_name}InnerTypes,
+'''
+
+types_file_template = LICENSE_HEADER + '''import {{ ObjectType, TypeElement }} from '@salto-io/adapter-api'
+import _ from 'lodash'
+{import_types_statements}
+
+/**
+* generated using types_generator.py as Netsuite don't expose a metadata API for them.
+*/
+export const customTypes: Readonly<Record<string, ObjectType>> = {{
+{custom_types_map_entries}}}
+
+const innerCustomTypes: ObjectType[] = [
+{all_inner_types_vars}]
+
+export const isCustomType = (type: ObjectType): boolean =>
+  !_.isUndefined(customTypes[type.elemID.name])
+
+export const getAllTypes = (): TypeElement[] => [
+  ...Object.values(customTypes),
+  ...innerCustomTypes,
+  ...Object.values(enums),
+]
+'''
+
+default_value_pattern = re.compile("[\s\S]*The default value is '?‘?([-|#\w]*)’?'?\.[\s\S]*") # e.g. ‘MIDDLE’, 'NORMAL', T, '|', '#000000', 'windows-1252'
+possible_values_pattern = re.compile("[\s\S]*For information about possible values, see ('*\w*'*)\.[\s\S]*")
+
+def extract_default_value_from_field_description(description):
+    regex_matches = default_value_pattern.match(description)
+    if regex_matches:
+        return regex_matches.groups()[0]
+    return None
+
+def parse_field_def(type_name, cells, is_attribute, is_inner_type):
+    def to_field_type(field_name, netsuite_field_type, description):
+        field_full_name = type_name + '_' + field_name
+        if field_full_name in field_name_to_type_name:
+            return field_name_to_type_name[field_full_name]
+        if field_name == SCRIPT_ID_FIELD_NAME:
+            return 'BuiltinTypes.SERVICE_ID'
+        if netsuite_field_type in ['string', 'date', 'time', 'rgb']:
+            return 'BuiltinTypes.STRING'
+        if netsuite_field_type == 'boolean':
+            return 'BuiltinTypes.BOOLEAN'
+        if netsuite_field_type == 'integer' or netsuite_field_type.startswith('float'): # in kpiscorecard.highlighting the field type (float) contains description
+            return 'BuiltinTypes.NUMBER'
+        if netsuite_field_type == 'single-select list':
+            references_to_single_enum = 'For information about possible values, see' in description
+            if references_to_single_enum:
+                regex_matches = possible_values_pattern.match(description)
+                if regex_matches:
+                    enum_name = regex_matches.groups()[0]
+                    return "enums.{0}".format(enum_name)
+        return 'BuiltinTypes.STRING /* Original type was {0} */'.format('   '.join(netsuite_field_type.splitlines()))
+
+    field_name = cells[0].text
+    description = cells[3].text
+    field_type = to_field_type(field_name, cells[1].text, description)
+    is_required = cells[2].text.lower() == 'required'
+    has_length_limitations = 'value can be up to' in description and 'BuiltinTypes.STRING' in field_type
+    is_name_field = type_name in top_level_type_name_to_name_field and top_level_type_name_to_name_field[type_name] == field_name
+    annotations = {}
+    if is_required and (field_name != SCRIPT_ID_FIELD_NAME or is_inner_type): # we don't set SCRIPT_ID_FIELD_NAME as required ONLY for top level types so the adapter will generate default in case it's missing to ease Salto user's add operation
+        annotations['[CORE_ANNOTATIONS.REQUIRED]'] = 'true'
+    if is_attribute:
+        annotations['[constants.IS_ATTRIBUTE]'] = 'true'
+    if is_name_field:
+        annotations['[constants.IS_NAME]'] = 'true'
+    if has_length_limitations:
+      regex_matches = re.match("[\s\S]*value can be up to (\d*) characters long\.[\s\S]*", description)
+      length_limit = regex_matches.groups()[0]
+      annotations['// [CORE_ANNOTATIONS.LENGTH_LIMIT]'] = length_limit
+
+    return { NAME: field_name, TYPE: field_type, ANNOTATIONS: annotations, DESCRIPTION: '   '.join(description.splitlines()) }
+
+
+def parse_enums(account_id):
+    webpage.get(enums_link_template.format(account_id = account_id))
+    enums_list_items = webpage.find_elements_by_xpath('//*[@id="nshelp"]/div[2]/div/ul/li/p/a')
+    enum_name_to_page_link = { enum_link.text : enum_link.get_attribute('href') for enum_link in enums_list_items }
+    enum_to_possible_values = {}
+    for enum_name, page_link in enum_name_to_page_link.items():
+        try:
+            webpage.get(page_link)
+            enum_to_possible_values[enum_name] = [possible_value.text.split()[0] for possible_value in webpage.find_elements_by_xpath('//*[@id="nshelp"]/div[2]/div/div/ul/li/p')]
+        except Exception as e:
+            logging.error('Failed to extract possible values for enum: ' + enum_name + '. Error: ', e)
+    return enum_to_possible_values
+
+
+def parse_type_for_inner_structured_field(type_name, inner_type_name_to_def, top_level_type_name):
+    type_def = parse_type(type_name, None, inner_type_name_to_def, top_level_type_name)
+    inner_type_name_to_def[type_name] = type_def
+    return type_name
+
+
+def parse_type(type_name, script_id_prefix, inner_type_name_to_def, top_level_type_name = None):
+    if top_level_type_name is None:
+        top_level_type_name = type_name
+
+    is_inner_type = type_name != top_level_type_name
+
+    def extract_script_id_prefix_from_description(field_cells):
+        script_id_prefix_from_description = extract_default_value_from_field_description(field_cells[3].text)
+        if script_id_prefix_from_description:
+            padded_script_id_prefix_from_description = pad_script_id_prefix_with_underscore(script_id_prefix_from_description)
+            if padded_script_id_prefix_from_description != script_id_prefix:
+                return padded_script_id_prefix_from_description
+        return None
+
+    def is_structured_list_field(fields_tables_len, structured_fields_len):
+        type_description_sections = webpage.find_elements_by_xpath('//*[@id="nshelp"]/div[2]/div/p')
+        is_explicitly_not_a_list = any([('field group is a DEFAULT' in type_description_section.text) for type_description_section in type_description_sections])
+        is_explicitly_a_list = any([('field group is a COLLECTION' in type_description_section.text) for type_description_section in type_description_sections])
+        return is_explicitly_a_list or (fields_tables_len == 1 and structured_fields_len == 1 and not is_explicitly_not_a_list)
+
+    fields_tables = webpage.find_elements_by_xpath('//*[@class="nshelp_section"]')
+    field_definitions = []
+    annotations = {}
+    for fields_table in fields_tables:
+        fields_section_headline = fields_table.find_element_by_xpath('.//h2').text
+        if fields_section_headline == 'Feature Dependencies':
+            # we don't have anything interesting to extract here
+            continue
+        if fields_section_headline == 'Additional Files':
+            annotations['[constants.ADDITIONAL_FILE_SUFFIX]'] = fields_table.find_element_by_xpath('.//ul/li/p/strong').text[len('Object-Script-ID'):]
+            continue
+        if fields_section_headline == 'Structured Fields':
+            inner_structured_field_name_to_link = { inner_structured_field.text : inner_structured_field.get_attribute('href')
+                for inner_structured_field in fields_table.find_elements_by_xpath('.//ul/li/p/a') }
+            is_list_from_doc = is_structured_list_field(len(fields_tables), len(inner_structured_field_name_to_link.items()))
+            for inner_structured_field_name, link in inner_structured_field_name_to_link.items():
+                webpage.get(link)
+                # we create inner types with their parent's type_name so there will be no Salto element naming collisions
+                created_inner_type_name = parse_type_for_inner_structured_field(type_name + '_' + inner_structured_field_name, inner_type_name_to_def, top_level_type_name)
+                is_list = False
+                if (is_list_from_doc and created_inner_type_name not in should_not_be_list) or created_inner_type_name in should_be_list:
+                    is_list = True
+                field_definitions.append({ NAME: inner_structured_field_name, TYPE: created_inner_type_name, ANNOTATIONS: {}, IS_LIST: is_list })
+            continue
+
+        if fields_section_headline == 'Attributes':
+            is_attribute = True
+        elif fields_section_headline == 'Fields':
+            is_attribute = False
+        else:
+            raise Exception('unknown fields section ', fields_section_headline)
+
+        for field_row in fields_table.find_elements_by_xpath('.//tbody/tr'):
+            cells = field_row.find_elements_by_xpath('.//td')
+            if is_attribute and cells[0].text == SCRIPT_ID_FIELD_NAME and not is_inner_type:
+                # extract script_id for top level types from the description since the script_ids prefixes aren't accurate in https://5635669.app.netsuite.com/app/help/helpcenter.nl?fid=subsect_1537555588.html
+                script_id_prefix_from_description = extract_script_id_prefix_from_description(cells)
+                annotations['[constants.SCRIPT_ID_PREFIX]'] = script_id_prefix_from_description if script_id_prefix_from_description is not None else script_id_prefix
+
+            field_def = parse_field_def(type_name, cells, is_attribute, is_inner_type)
+            field_def[IS_LIST] = False
+            field_definitions.append(field_def)
+
+    return { NAME: type_name, ANNOTATIONS: annotations, FIELDS: field_definitions }
+
+def pad_script_id_prefix_with_underscore(script_id_prefix):
+    return (script_id_prefix + '_') if not script_id_prefix.endswith('_') else script_id_prefix
+
+def parse_types_definitions(account_id, type_name_to_script_id_prefix):
+    def get_script_id_prefix(type_name):
+        if type_name.lower() in type_name_to_script_id_prefix:
+            return pad_script_id_prefix_with_underscore(type_name_to_script_id_prefix[type_name.lower()])
+        return "'FIX_ME!'"
+
+    webpage.get(sdf_xml_definitions_link_template.format(account_id = account_id))
+    types_list_items = webpage.find_elements_by_xpath('//*[@id="nshelp"]/div[2]/div/ul/li/p/a')
+    type_name_to_page_link = { type_link.text : type_link.get_attribute('href') for type_link in types_list_items }
+    type_name_to_types_defs = {}
+    for type_name, page_link in type_name_to_page_link.items():
+        try:
+            webpage.get(page_link)
+            script_id_prefix = get_script_id_prefix(type_name)
+            inner_type_name_to_def = {}
+            type_def = parse_type(type_name, script_id_prefix, inner_type_name_to_def)
+            type_name_to_types_defs[type_name] = { 'type_def': type_def, 'inner_type_name_to_def': inner_type_name_to_def }
+        except Exception as e:
+            logging.error('Failed to parse type: ' + type_name + '. Error: ', sys.exc_info())
+    return type_name_to_types_defs
+
+
+def generate_type_name_to_script_id_prefix():
+    type_name_to_script_id_prefix = {}
+    for row in webpage.find_elements_by_xpath('//*[@id="nshelp"]/div[2]/div/div[2]/table/tbody/tr'):
+        cells = row.find_elements_by_xpath('.//td/p')
+        type_name_to_script_id_prefix[cells[0].text] = cells[1].text
+    return type_name_to_script_id_prefix
+
+
+def login(username, password, secret_key_2fa):
+    # submit username & password
+    time.sleep(1)
+    webpage.find_element_by_xpath('/html/body/form/table/tbody/tr[2]/td/table/tbody/tr[1]/td[2]/input').send_keys(username)
+    webpage.find_element_by_xpath('/html/body/form/table/tbody/tr[2]/td/table/tbody/tr[2]/td[2]/input').send_keys(password)
+    webpage.find_element_by_xpath('//*[@id="rememberme"]').click()
+    webpage.find_element_by_xpath('//*[@id="Submit"]').click()
+    time.sleep(1)
+
+    # generate 2FA token and submit
+    token2fa = pyotp.TOTP(secret_key_2fa).now()
+    webpage.find_element_by_xpath('//*[@id="n-id-component-19"]').send_keys(token2fa)
+    webpage.find_element_by_xpath('//*[@id="n-id-component-44"]').click()
+    time.sleep(1)
+
+
+def create_types_file(type_names):
+    import_types_statements = ''.join([import_type_statement_template.format(type_name = type_name) for type_name in type_names])
+    import_types_statements += "import { enums } from './types/enums'\n"
+    custom_types_map_entries = ''.join([custom_types_map_entry_template.format(type_name = type_name) for type_name in type_names])
+    all_inner_types_vars = ''.join([type_inner_types_vars_template.format(type_name = type_name) for type_name in type_names])
+    file_content = types_file_template.format(import_types_statements = import_types_statements, custom_types_map_entries = custom_types_map_entries, all_inner_types_vars = all_inner_types_vars)
+    with open(SRC_DIR + 'types.ts', 'w') as file:
+        file.write(file_content)
+
+
+def parse_netsuite_types(account_id, username, password, secret_key_2fa):
+    try:
+        logging.info('Starting to parse Netsuite types')
+        webpage.get(script_ids_prefix_link_template.format(account_id = account_id))
+        login(username, password, secret_key_2fa)
+        logging.info('Logged in')
+
+        type_name_to_script_id_prefix = generate_type_name_to_script_id_prefix()
+        type_name_to_types_defs = parse_types_definitions(account_id, type_name_to_script_id_prefix)
+        if len(type_name_to_types_defs.keys()) != len(top_level_type_name_to_name_field):
+            logging.warning('Parsed {0} types while there are {1} top_level_type_name_to_name_field entries'.format(len(type_name_to_types_defs.keys()), len(top_level_type_name_to_name_field)))
+        logging.info('Parsed objects definitions')
+
+        enum_to_possible_values = parse_enums(account_id)
+        logging.info('Parsed enums definitions')
+        return type_name_to_types_defs, enum_to_possible_values
+    finally:
+        webpage.quit()
+
+
+def generate_enums_file(enum_to_possible_values):
+    enums_elem_ids_list = [type_elem_id_template.format(type_name = enum_name) for enum_name in enum_to_possible_values.keys()]
+    enums_entries_list = [primitive_string_type_entry_template.format(type_name = enum_name, values = values) for enum_name, values in enum_to_possible_values.items()]
+    file_content = enums_file_template.format(enums_elem_ids = ''.join(enums_elem_ids_list), enums_entries = ''.join(enums_entries_list))
+    with open(TYPES_DIR + 'enums.ts', 'w') as file:
+        file.write(file_content)
+
+
+def format_type_def(type_name, type_def, top_level_type_name = None):
+    def format_type_annotations():
+        formatted_type_annotations = ''
+        for key, val in type_def[ANNOTATIONS].items():
+            formatted_type_annotations += type_annotation_template.format(annotation_name = key, annotation_value = val)
+        return type_annotations_template.format(annotations = formatted_type_annotations)
+
+    def format_field_annotations(field_annotations):
+        formatted_field_annotations = ''
+        for key, val in field_annotations.items():
+            formatted_field_annotations += field_annotation_template.format(annotation_name = key, annotation_value = val)
+        return formatted_field_annotations
+
+    def format_field_def(field_def):
+        formatted_field_annotations = format_field_annotations(field_def[ANNOTATIONS])
+        field_type = 'new ListType({0})'.format(field_def[TYPE]) if field_def[IS_LIST] else field_def[TYPE]
+        formatted_field = field_template.format(field_name = field_def[NAME], type_name = type_name, field_type = field_type, annotations = formatted_field_annotations)
+        field_description_comment = ' /* Original description: {0} */'.format(field_def[DESCRIPTION]) if (DESCRIPTION in field_def and field_def[DESCRIPTION] != '') else ''
+        return formatted_field + field_description_comment
+
+    is_inner_type = top_level_type_name != None
+    annotations = format_type_annotations()
+    field_definitions = []
+    for field_def in type_def[FIELDS]:
+        field_definitions.append(format_field_def(field_def))
+    path = type_path_template.format(type_name = top_level_type_name if is_inner_type else type_name) # all inner_types will be located in the same file as their parent
+    export = 'export ' if not is_inner_type else ''
+    return type_template.format(type_name = type_name, export = export, annotations = annotations,
+      field_definitions = '\n'.join(field_definitions), path = path)
+
+
+def format_inner_types_defs(top_level_type_name, inner_type_name_to_def):
+    inner_types_defs = []
+    for inner_type_name, inner_type_def in inner_type_name_to_def.items():
+        formatted_inner_type_def = format_type_def(inner_type_name, inner_type_def, top_level_type_name)
+        inner_types_defs.append(inner_types_def_template.format(type_name = top_level_type_name, inner_type_name = inner_type_name, type_def = formatted_inner_type_def))
+    return ''.join(inner_types_defs)
+
+
+def generate_file_per_type(type_name_to_types_defs):
+    for type_name, type_defs in type_name_to_types_defs.items():
+        inner_type_name_to_def = type_defs['inner_type_name_to_def']
+        type_def = type_defs['type_def']
+        elem_id_def = type_elem_id_template.format(type_name = type_name)
+        formatted_type_def = format_type_def(type_name, type_def)
+        file_data = type_inner_types_array_template.format(type_name = type_name) + elem_id_def + format_inner_types_defs(type_name, inner_type_name_to_def) + formatted_type_def
+        import_statements = import_statements_for_type_def_template.format(
+            list_type_import = list_type_import if 'new ListType(' in file_data else '',
+            enums_import = enums_import if 'enums.' in file_data else '')
+        type_def_file_content = HEADER_FOR_DEFS + import_statements + file_data
+        with open(CUSTOM_TYPES_DIR + type_name + '.ts', 'w') as file:
+            file.write(type_def_file_content)
+
+
+should_not_be_list = {
+    'addressForm_mainFields_fieldGroup_fields',
+    'addressForm_mainFields_defaultFieldGroup_fields',
+    'entryForm_mainFields_fieldGroup_fields',
+    'entryForm_mainFields_defaultFieldGroup_fields',
+    'entryForm_tabs_tab_fieldGroups_fieldGroup_fields',
+    'entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields',
+    'entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields',
+    'entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields',
+    'transactionForm_mainFields_fieldGroup_fields',
+    'transactionForm_mainFields_defaultFieldGroup_fields',
+    'transactionForm_printingType_advanced',
+    'transactionForm_printingType_basic',
+    'transactionForm_tabs_tab_fieldGroups_fieldGroup_fields',
+    'transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields',
+    'transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields',
+    'transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields',
+}
+
+should_be_list = {
+    'addressForm_mainFields_fieldGroup',
+    'entryForm_mainFields_fieldGroup',
+    'entryForm_tabs_tab_fieldGroups_fieldGroup',
+    'entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup',
+    'transactionForm_mainFields_fieldGroup',
+    'transactionForm_tabs_tab_fieldGroups_fieldGroup',
+    'transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup',
+    'workflow_workflowstates_workflowstate_workflowactions',
+    'workflow_workflowstates_workflowstate_workflowactions_addbuttonaction',
+    'workflow_workflowstates_workflowstate_workflowactions_confirmaction',
+    'workflow_workflowstates_workflowstate_workflowactions_createlineaction',
+    'workflow_workflowstates_workflowstate_workflowactions_createrecordaction',
+    'workflow_workflowstates_workflowstate_workflowactions_customaction',
+    'workflow_workflowstates_workflowstate_workflowactions_gotopageaction',
+    'workflow_workflowstates_workflowstate_workflowactions_gotorecordaction',
+    'workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction',
+    'workflow_workflowstates_workflowstate_workflowactions_lockrecordaction',
+    'workflow_workflowstates_workflowstate_workflowactions_removebuttonaction',
+    'workflow_workflowstates_workflowstate_workflowactions_returnusererroraction',
+    'workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction',
+    'workflow_workflowstates_workflowstate_workflowactions_sendemailaction',
+    'workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction',
+    'workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction',
+    'workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction',
+    'workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction',
+    'workflow_workflowstates_workflowstate_workflowactions_showmessageaction',
+    'workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction',
+    'workflow_workflowstates_workflowstate_workflowactions_transformrecordaction',
+    'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup',
+    'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup',
+}
+
+top_level_type_name_to_name_field = {
+    'addressForm': 'name',
+    'advancedpdftemplate': 'title',
+    'bankstatementparserplugin': 'name',
+    'bundleinstallationscript': 'name',
+    'center': 'label',
+    'centercategory': 'label',
+    'centertab': 'label',
+    'clientscript': 'name',
+    'cmscontenttype': 'label',
+    'crmcustomfield': 'label',
+    'customglplugin': 'name',
+    'customlist': 'name',
+    'customrecordtype': 'recordname',
+    'customsegment': 'label',
+    'customtransactiontype': 'name',
+    'dataset': 'name',
+    'emailcaptureplugin': 'name',
+    'emailtemplate': 'name',
+    'entitycustomfield': 'label',
+    'entryForm': 'name',
+    'ficonnectivityplugin': 'name',
+    'itemcustomfield': 'label',
+    'itemnumbercustomfield': 'label',
+    'itemoptioncustomfield': 'label',
+    'kpiscorecard': 'name',
+    'mapreducescript': 'name',
+    'massupdatescript': 'name',
+    'othercustomfield': 'label',
+    'pluginimplementation': 'name',
+    'plugintype': 'name',
+    'portlet': 'name',
+    'promotionsplugin': 'name',
+    'publisheddashboard': 'name',
+    'restlet': 'name',
+    'role': 'name',
+    'savedcsvimport': 'importname',
+    'savedsearch': 'scriptid',
+    'scheduledscript': 'name',
+    'sdfinstallationscript': 'name',
+    'sspapplication': 'name',
+    'sublist': 'label',
+    'subtab': 'title',
+    'suitelet': 'name',
+    'transactionForm': 'name',
+    'transactionbodycustomfield': 'label',
+    'transactioncolumncustomfield': 'label',
+    'translationcollection': 'name',
+    'usereventscript': 'name',
+    'workbook': 'name',
+    'workflow': 'name',
+    'workflowactionscript': 'name',
+}
+
+field_name_to_type_name = {
+    'crmcustomfield_sourcefrom': 'BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */',
+    'customrecordtype_customrecordcustomfields_customrecordcustomfield_sourcefrom': 'BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */',
+    'entitycustomfield_sourcefrom': 'BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */',
+    'itemcustomfield_sourcefrom': 'BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */',
+    'itemnumbercustomfield_sourcefrom': 'BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */',
+    'itemoptioncustomfield_sourcefrom': 'BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */',
+    'othercustomfield_sourcefrom': 'BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */',
+    'transactionbodycustomfield_sourcefrom': 'BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */',
+    'transactioncolumncustomfield_sourcefrom': 'BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */',
+    'transactionForm_tabs_tab_subItems_subList_id': 'BuiltinTypes.STRING /* Original type was enums.transactionform_sublistid but it can also be CRMCONTACTS */',
+    'transactionForm_tabs_tab_subItems_subLists_subList_id': 'BuiltinTypes.STRING /* Original type was enums.transactionform_sublistid but it can also be CRMCONTACTS */',
+}
+
+
+webpage = webdriver.Chrome() # the web page is defined here to avoid passing it to all inner methods
+def main():
+    account_id, username, password, secret_key_2fa = (sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+    type_name_to_types_defs, enum_to_possible_values = parse_netsuite_types(account_id, username, password, secret_key_2fa)
+    generate_enums_file(enum_to_possible_values)
+    logging.info('Generated enums file')
+    generate_file_per_type(type_name_to_types_defs)
+    logging.info('Generated file per Netsuite type')
+    create_types_file(type_name_to_types_defs.keys())
+    logging.info('Generated Types file')
+    logging.info('Done!')
+
+
+main()
+
+
+
+# --- known issues that were handled in the script: ---
+# lists are not identified correctly -> should use also manual mappings (should_be_list, should_not_be_list)
+# script_ids table is not accurate and not complete -> we are calculating also from the scriptid field's description column
+# script_id is not always padded with '_'
+# we mark SCRIPT_ID_FIELD_NAME as not required so the adapter will add defaults in case it's missing
+# we set the type of SCRIPT_ID_FIELD_NAME as BuiltinTypes.SERVICE_ID
+# there are fields that suppose to have a certain type but in fact they have another type, handled using field_name_to_type_name
+# every top level type has its own IS_NAME field, we set it manually using top_level_type_name_to_name_field

--- a/packages/netsuite-adapter/src/change_validators/remove_custom_object.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_custom_object.ts
@@ -14,11 +14,11 @@
 * limitations under the License.
 */
 import { ChangeError, Element, isInstanceElement } from '@salto-io/adapter-api'
-import { Types } from '../types'
+import { isCustomType } from '../types'
 
 export const changeValidator = {
   onRemove: async (before: Element): Promise<ReadonlyArray<ChangeError>> => {
-    if (isInstanceElement(before) && Types.isCustomType(before.type)) {
+    if (isInstanceElement(before) && isCustomType(before.type)) {
       return [{
         elemID: before.elemID,
         severity: 'Error',

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -19,14 +19,15 @@ export const TYPES_PATH = 'Types'
 export const SUBTYPES_PATH = 'Subtypes'
 
 // Type names
-export const ENTITY_CUSTOM_FIELD = 'EntityCustomField'
+export const ENTITY_CUSTOM_FIELD = 'entitycustomfield'
 
 // Type Annotations
 export const SCRIPT_ID_PREFIX = 'scriptIdPrefix'
 
 // Fields
-export const SCRIPT_ID = 'scriptId'
+export const SCRIPT_ID = 'scriptid'
 
 // Field Annotations
 export const IS_ATTRIBUTE = 'isAttribute'
 export const IS_NAME = 'isName'
+export const ADDITIONAL_FILE_SUFFIX = 'additionalFileSuffix'

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -14,190 +14,123 @@
 * limitations under the License.
 */
 import {
-  ElemID, Field, InstanceElement, isListType, isObjectType, isPrimitiveType, ObjectType,
-  PrimitiveType, PrimitiveTypes, PrimitiveValue, TypeElement, Value, Values,
+  ElemID, Field, InstanceElement, isListType, isPrimitiveType, ObjectType, PrimitiveTypes, Value,
+  Values,
 } from '@salto-io/adapter-api'
-import { naclCase } from '@salto-io/adapter-utils'
-import { logger } from '@salto-io/logging'
-import { Attributes, Element as XmlElement } from 'xml-js'
+import {
+  applyRecursive, MapKeyFunc, mapKeysRecursive, naclCase, TransformFunc, transformValues,
+} from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { IS_ATTRIBUTE, IS_NAME, NETSUITE, RECORDS_PATH } from './constants'
+import { ATTRIBUTE_PREFIX, CustomizationInfo } from './client/client'
 
-const log = logger(module)
 const XML_TRUE_VALUE = 'T'
 const XML_FALSE_VALUE = 'F'
 
-const transformXmlElements = (elements: XmlElement[], type: ObjectType, attributes?: Attributes):
-  Values | undefined => {
-  const transformPrimitive = (val?: PrimitiveValue, primitiveType?: PrimitiveType): Value => {
-    if (_.isUndefined(primitiveType) || _.isUndefined(val)) {
-      return undefined
+const castToListRecursively = (
+  type: ObjectType,
+  values: Values,
+): void => {
+  // Cast all lists to list
+  const castLists = (field: Field, value: Value): Value => {
+    if (isListType(field.type) && !_.isArray(value)) {
+      return [value]
     }
-    switch (primitiveType.primitive) {
-      case PrimitiveTypes.NUMBER:
-        return Number(val)
-      case PrimitiveTypes.BOOLEAN:
-        return val === XML_TRUE_VALUE
-      default:
-        return val
-    }
+    return value
   }
-
-  const transformXmlElement = (element: XmlElement, field: Field): Values | undefined => {
-    if (field === undefined) {
-      log.warn('Unknown field with name=%. Skipping its transformation', element.name)
-      return undefined
-    }
-    const fieldType = field.type
-
-    if (isObjectType(fieldType)) {
-      if (!_.isArray(element.elements)) {
-        log.warn('Expected to have inner xml elements for object type %s. Skipping its transformation',
-          fieldType.elemID.name)
-        return undefined
-      }
-      const transformed = _.omitBy(
-        transformXmlElements(element.elements, fieldType, element.attributes),
-        _.isUndefined
-      )
-      return _.isEmpty(transformed) ? undefined : transformed
-    }
-
-    if (isListType(fieldType)) {
-      if (!_.isArray(element.elements)) {
-        log.warn('Expected to have inner xml elements for list type %s. Skipping its transformation',
-          fieldType.elemID.name)
-        return undefined
-      }
-      const transformed = element.elements
-        .map(e => transformXmlElement(e,
-          new Field(new ElemID(''), fieldType.innerType.elemID.name, fieldType.innerType)))
-        .filter((val: Value) => !_.isUndefined(val))
-      return transformed.length === 0 ? undefined : { [field.name]: transformed }
-    }
-
-    if (isPrimitiveType(fieldType)) {
-      return { [field.name]:
-          _.isArray(element.elements)
-            ? transformPrimitive(element.elements[0].text, fieldType)
-            : undefined }
-    }
-    return undefined
-  }
-
-  const loweredFieldMap = _.mapKeys(type.fields, (_field, name) => name.toLowerCase())
-
-  const transformAttributes = (): Values =>
-    _(attributes)
-      .entries()
-      .map(([lowerAttrName, val]) =>
-        [loweredFieldMap[lowerAttrName]?.name,
-          transformPrimitive(val, loweredFieldMap[lowerAttrName]?.type as PrimitiveType)])
-      .filter(([name, val]) => !_.isUndefined(name) && !_.isUndefined(val))
-      .fromPairs()
-      .value()
-
-  const result = _(Object.assign(
-    transformAttributes(),
-    ...elements.map(e => transformXmlElement(e, loweredFieldMap[e.name as string]))
-  )).omitBy(_.isUndefined).value()
-  return _.isEmpty(result) ? undefined : result
+  applyRecursive(type, values, castLists)
 }
 
-export const createInstanceElement = (rootXmlElement: XmlElement, type: ObjectType):
+export const createInstanceElement = (values: Values, type: ObjectType):
   InstanceElement => {
-  const findInnerElement = (name: string): XmlElement =>
-    rootXmlElement.elements?.find(e => e.name === name) as XmlElement
-
-  const getInstanceName = (): string => {
+  const getInstanceName = (transformedValues: Values): string => {
     const nameField = Object.values(type.fields)
       .find(f => f.annotations[IS_NAME]) as Field
-    return naclCase((findInnerElement(nameField.name.toLowerCase()).elements)?.[0].text as string)
+    return naclCase(transformedValues[nameField.name])
   }
 
-  const instanceName = getInstanceName()
-  return new InstanceElement(instanceName, type,
-    transformXmlElements(rootXmlElement.elements as XmlElement[], type, rootXmlElement.attributes),
+  const transformPrimitive: TransformFunc = ({ value, field }) => {
+    const fieldType = field?.type
+    if (!isPrimitiveType(fieldType)) {
+      return value
+    }
+
+    // We sometimes get empty strings that we want to filter out
+    if (value === '') {
+      return undefined
+    }
+
+    switch (fieldType.primitive) {
+      case PrimitiveTypes.NUMBER:
+        return Number(value)
+      case PrimitiveTypes.BOOLEAN:
+        return value === XML_TRUE_VALUE
+      default:
+        return String(value)
+    }
+  }
+
+  const transformAttributeKey: MapKeyFunc = ({ key }) =>
+    (key.startsWith(ATTRIBUTE_PREFIX) ? key.slice(ATTRIBUTE_PREFIX.length) : key)
+
+  const valuesWithTransformedAttrs = mapKeysRecursive(values, transformAttributeKey)
+  const transformedValues = transformValues({
+    values: valuesWithTransformedAttrs,
+    type,
+    transformFunc: transformPrimitive,
+  }) as Values
+  castToListRecursively(type, transformedValues)
+  const instanceName = getInstanceName(transformedValues)
+  return new InstanceElement(instanceName, type, transformedValues,
     [NETSUITE, RECORDS_PATH, type.elemID.name, instanceName])
 }
 
-const isXmlElement = (element: XmlElement | undefined): element is XmlElement =>
-  element !== undefined
-
-const isAttribute = (field: Field): boolean => field.annotations[IS_ATTRIBUTE]
-
-const transformValues = (values: Values, type: ObjectType): XmlElement[] =>
-  Object.entries(values)
-    .map(([key, val]) => {
-      const field = type.fields[key]
-      if (_.isUndefined(field) || isAttribute(field)) {
-        return undefined
-      }
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      return transformValue(val, field.type, field.name.toLowerCase())
-    })
-    .filter(isXmlElement)
-
-const transformValue = (value: Value, type: TypeElement, elementName: string):
-  XmlElement | undefined => {
-  const transformPrimitive = (primitiveValue: PrimitiveValue, primitiveType: PrimitiveType):
-    string => {
-    if (primitiveType.primitive === PrimitiveTypes.BOOLEAN) {
-      return primitiveValue ? XML_TRUE_VALUE : XML_FALSE_VALUE
+export const restoreAttributes = (values: Values, type: ObjectType, instancePath: ElemID):
+  Values => {
+  const allAttributesPaths = new Set<string>()
+  const createPathSetCallback: TransformFunc = ({ value, field, path }) => {
+    if (path && field && field.annotations[IS_ATTRIBUTE]) {
+      allAttributesPaths.add(path.getFullName())
     }
-    return String(primitiveValue)
+    return value
   }
 
-  const transformAttributes = (values: Values, objType: ObjectType): Attributes =>
-    _(Object.values(objType.fields)
-      .filter(isAttribute)
-      .map(f => f.name)
-      .map(name => [name.toLowerCase(), values[name]]))
-      .fromPairs()
-      .omitBy(_.isUndefined)
-      .value()
+  transformValues({
+    values,
+    type,
+    transformFunc: createPathSetCallback,
+    pathID: instancePath,
+    strict: false,
+  })
 
-  if (isObjectType(type)) {
-    if (!_.isPlainObject(value)) {
-      return undefined
+  const restoreAttributeFunc: MapKeyFunc = ({ key, pathID }) => {
+    if (pathID && allAttributesPaths.has(pathID.getFullName())) {
+      return ATTRIBUTE_PREFIX + key
     }
-    return {
-      type: 'element',
-      name: elementName,
-      elements: transformValues(value, type),
-      attributes: transformAttributes(value, type),
-    }
+    return key
   }
 
-  if (isListType(type)) {
-    if (!_.isArray(value)) {
-      return undefined
-    }
-    return {
-      type: 'element',
-      name: elementName,
-      elements: value.map(listValue =>
-        transformValue(listValue, type.innerType, type.innerType.elemID.name.toLowerCase()))
-        .filter(isXmlElement),
-    }
-  }
-
-  if (isPrimitiveType(type)) {
-    return {
-      type: 'element',
-      name: elementName,
-      elements: [{
-        type: 'text',
-        text: transformPrimitive(value, type),
-      }],
-    }
-  }
-  return undefined
+  return mapKeysRecursive(values, restoreAttributeFunc, instancePath)
 }
 
-export const createXmlElement = (instance: InstanceElement): XmlElement =>
-  ({
-    elements: [
-      transformValue(instance.value, instance.type, instance.type.elemID.name.toLowerCase()),
-    ] as XmlElement[],
-  })
+export const toCustomizationInfo = (instance: InstanceElement): CustomizationInfo => {
+  const transformPrimitive: TransformFunc = ({ value, field }) => {
+    const fieldType = field?.type
+    if (!isPrimitiveType(fieldType)) {
+      return value
+    }
+    if (fieldType.primitive === PrimitiveTypes.BOOLEAN) {
+      return value ? XML_TRUE_VALUE : XML_FALSE_VALUE
+    }
+    return String(value)
+  }
+
+  const transformedValues = transformValues({
+    values: instance.value,
+    type: instance.type,
+    transformFunc: transformPrimitive,
+  }) || {}
+
+  const values = restoreAttributes(transformedValues, instance.type, instance.elemID)
+  return { typeName: instance.type.elemID.name, values }
+}

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -13,287 +13,178 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import {
-  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, PrimitiveType, PrimitiveTypes,
-  ListType, TypeElement, createRestriction,
-} from '@salto-io/adapter-api'
+import { ObjectType, TypeElement } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import {
-  ENTITY_CUSTOM_FIELD, IS_ATTRIBUTE, IS_NAME, NETSUITE, SCRIPT_ID, SCRIPT_ID_PREFIX, SUBTYPES_PATH,
-  TYPES_PATH,
-} from './constants'
+import { addressForm, addressFormInnerTypes } from './types/custom_types/addressForm'
+import { advancedpdftemplate, advancedpdftemplateInnerTypes } from './types/custom_types/advancedpdftemplate'
+import { bankstatementparserplugin, bankstatementparserpluginInnerTypes } from './types/custom_types/bankstatementparserplugin'
+import { bundleinstallationscript, bundleinstallationscriptInnerTypes } from './types/custom_types/bundleinstallationscript'
+import { center, centerInnerTypes } from './types/custom_types/center'
+import { centercategory, centercategoryInnerTypes } from './types/custom_types/centercategory'
+import { centertab, centertabInnerTypes } from './types/custom_types/centertab'
+import { clientscript, clientscriptInnerTypes } from './types/custom_types/clientscript'
+import { cmscontenttype, cmscontenttypeInnerTypes } from './types/custom_types/cmscontenttype'
+import { crmcustomfield, crmcustomfieldInnerTypes } from './types/custom_types/crmcustomfield'
+import { customglplugin, customglpluginInnerTypes } from './types/custom_types/customglplugin'
+import { customlist, customlistInnerTypes } from './types/custom_types/customlist'
+import { customrecordtype, customrecordtypeInnerTypes } from './types/custom_types/customrecordtype'
+import { customsegment, customsegmentInnerTypes } from './types/custom_types/customsegment'
+import { customtransactiontype, customtransactiontypeInnerTypes } from './types/custom_types/customtransactiontype'
+import { dataset, datasetInnerTypes } from './types/custom_types/dataset'
+import { emailcaptureplugin, emailcapturepluginInnerTypes } from './types/custom_types/emailcaptureplugin'
+import { emailtemplate, emailtemplateInnerTypes } from './types/custom_types/emailtemplate'
+import { entitycustomfield, entitycustomfieldInnerTypes } from './types/custom_types/entitycustomfield'
+import { entryForm, entryFormInnerTypes } from './types/custom_types/entryForm'
+import { ficonnectivityplugin, ficonnectivitypluginInnerTypes } from './types/custom_types/ficonnectivityplugin'
+import { itemcustomfield, itemcustomfieldInnerTypes } from './types/custom_types/itemcustomfield'
+import { itemnumbercustomfield, itemnumbercustomfieldInnerTypes } from './types/custom_types/itemnumbercustomfield'
+import { itemoptioncustomfield, itemoptioncustomfieldInnerTypes } from './types/custom_types/itemoptioncustomfield'
+import { kpiscorecard, kpiscorecardInnerTypes } from './types/custom_types/kpiscorecard'
+import { mapreducescript, mapreducescriptInnerTypes } from './types/custom_types/mapreducescript'
+import { massupdatescript, massupdatescriptInnerTypes } from './types/custom_types/massupdatescript'
+import { othercustomfield, othercustomfieldInnerTypes } from './types/custom_types/othercustomfield'
+import { pluginimplementation, pluginimplementationInnerTypes } from './types/custom_types/pluginimplementation'
+import { plugintype, plugintypeInnerTypes } from './types/custom_types/plugintype'
+import { portlet, portletInnerTypes } from './types/custom_types/portlet'
+import { promotionsplugin, promotionspluginInnerTypes } from './types/custom_types/promotionsplugin'
+import { publisheddashboard, publisheddashboardInnerTypes } from './types/custom_types/publisheddashboard'
+import { restlet, restletInnerTypes } from './types/custom_types/restlet'
+import { role, roleInnerTypes } from './types/custom_types/role'
+import { savedcsvimport, savedcsvimportInnerTypes } from './types/custom_types/savedcsvimport'
+import { savedsearch, savedsearchInnerTypes } from './types/custom_types/savedsearch'
+import { scheduledscript, scheduledscriptInnerTypes } from './types/custom_types/scheduledscript'
+import { sdfinstallationscript, sdfinstallationscriptInnerTypes } from './types/custom_types/sdfinstallationscript'
+import { sspapplication, sspapplicationInnerTypes } from './types/custom_types/sspapplication'
+import { sublist, sublistInnerTypes } from './types/custom_types/sublist'
+import { subtab, subtabInnerTypes } from './types/custom_types/subtab'
+import { suitelet, suiteletInnerTypes } from './types/custom_types/suitelet'
+import { transactionForm, transactionFormInnerTypes } from './types/custom_types/transactionForm'
+import { transactionbodycustomfield, transactionbodycustomfieldInnerTypes } from './types/custom_types/transactionbodycustomfield'
+import { transactioncolumncustomfield, transactioncolumncustomfieldInnerTypes } from './types/custom_types/transactioncolumncustomfield'
+import { translationcollection, translationcollectionInnerTypes } from './types/custom_types/translationcollection'
+import { usereventscript, usereventscriptInnerTypes } from './types/custom_types/usereventscript'
+import { workbook, workbookInnerTypes } from './types/custom_types/workbook'
+import { workflow, workflowInnerTypes } from './types/custom_types/workflow'
+import { workflowactionscript, workflowactionscriptInnerTypes } from './types/custom_types/workflowactionscript'
+import { enums } from './types/enums'
 
-const entityCustomFieldElemID = new ElemID(NETSUITE, ENTITY_CUSTOM_FIELD)
-const roleAccessElemID = new ElemID(NETSUITE, 'RoleAccess')
-const accessLevelElemID = new ElemID(NETSUITE, 'AccessLevel')
-const searchLevelElemID = new ElemID(NETSUITE, 'SearchLevel')
-const onParentDeleteElemID = new ElemID(NETSUITE, 'OnParentDelete')
-const displayTypeElemID = new ElemID(NETSUITE, 'DisplayType')
-const dynamicDefaultElemID = new ElemID(NETSUITE, 'DynamicDefault')
-const customFieldFilterElemID = new ElemID(NETSUITE, 'CustomFieldFilter')
-const fieldFilterCompareTypeElemID = new ElemID(NETSUITE, 'FieldFilterCompareType')
-const fieldTypeElemID = new ElemID(NETSUITE, 'FieldType')
-
-const typesFolderPath = [NETSUITE, TYPES_PATH]
-const subtypesFolderPath = [NETSUITE, TYPES_PATH, SUBTYPES_PATH]
 
 /**
- * All supported Netsuite types.
- * This is a static creation because Netsuite API supports only instances.
- */
-export class Types {
-  private static accessLevelSubType = new PrimitiveType({
-    elemID: accessLevelElemID,
-    primitive: PrimitiveTypes.STRING,
-    annotations: {
-      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values: ['0', '1', '2'] }),
-    },
-    path: [...subtypesFolderPath, accessLevelElemID.name],
-  })
-
-  private static searchLevelSubType = new PrimitiveType({
-    elemID: searchLevelElemID,
-    primitive: PrimitiveTypes.STRING,
-    annotations: {
-      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values: ['0', '1', '2'] }),
-    },
-    path: [...subtypesFolderPath, searchLevelElemID.name],
-  })
-
-  private static onParentDeleteSubType = new PrimitiveType({
-    elemID: onParentDeleteElemID,
-    primitive: PrimitiveTypes.STRING,
-    annotations: {
-      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values: ['NO_ACTION', 'SET_NULL'] }),
-    },
-    path: [...subtypesFolderPath, onParentDeleteElemID.name],
-  })
-
-  private static displayTypeSubType = new PrimitiveType({
-    elemID: displayTypeElemID,
-    primitive: PrimitiveTypes.STRING,
-    annotations: {
-      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
-        values: ['HIDDEN', 'LOCKED', 'NORMAL', 'SHOWASLIST', 'STATICTEXT'],
-      }),
-    },
-    path: [...subtypesFolderPath, displayTypeElemID.name],
-  })
-
-  private static dynamicDefaultSubType = new PrimitiveType({
-    elemID: dynamicDefaultElemID,
-    primitive: PrimitiveTypes.STRING,
-    annotations: {
-      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
-        values: ['DEPARTMENT', 'LOCATION', 'ME', 'NOW', 'SUBSIDIARY', 'SUPERVISOR'],
-      }),
-    },
-    path: [...subtypesFolderPath, dynamicDefaultElemID.name],
-  })
-
-  private static fieldFilterCompareTypeSubType = new PrimitiveType({
-    elemID: fieldFilterCompareTypeElemID,
-    primitive: PrimitiveTypes.STRING,
-    annotations: {
-      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
-        values: ['EQ', 'GT', 'GTE', 'LIKE', 'LT', 'LTE', 'NE', 'NOTLIKE'],
-      }),
-    },
-    path: [...subtypesFolderPath, fieldFilterCompareTypeElemID.name],
-  })
-
-  private static customFieldFilterSubType = new ObjectType({
-    elemID: customFieldFilterElemID,
-    fields: {
-      // Todo fldFilter: should point to either standardFieldTypeSubType or reference
-      fldFilter: new Field(customFieldFilterElemID, 'fldFilter', BuiltinTypes.STRING),
-      fldFilterChecked: new Field(customFieldFilterElemID, 'fldFilterChecked',
-        BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-      fldFilterCompareType: new Field(customFieldFilterElemID, 'fldFilterCompareType',
-        Types.fieldFilterCompareTypeSubType, { [CORE_ANNOTATIONS.DEFAULT]: 'EQ' }),
-      // Todo fldFilterSel: list of references that is concated with '|' when transforming to xml
-      fldFilterSel: new Field(customFieldFilterElemID, 'fldFilterSel', BuiltinTypes.STRING),
-      fldFilterVal: new Field(customFieldFilterElemID, 'fldFilterVal', BuiltinTypes.STRING),
-      fldFilterNotNull: new Field(customFieldFilterElemID, 'fldFilterNotNull',
-        BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-      fldFilterNull: new Field(customFieldFilterElemID, 'fldFilterNull',
-        BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-      // Todo fldCompareField: should point to either standardFieldTypeSubType or reference
-      fldCompareField: new Field(customFieldFilterElemID, 'fldCompareField', BuiltinTypes.STRING),
-    },
-    path: [...subtypesFolderPath, customFieldFilterElemID.name],
-  })
-
-  private static roleAccessSubType = new ObjectType({
-    elemID: roleAccessElemID,
-    fields: {
-      // Todo role: should point to either customrecordtype_permittedrole or reference
-      role: new Field(roleAccessElemID, 'role', BuiltinTypes.STRING),
-      // Todo accessLevel: understand real values (not 0,1,2) and modify defaults
-      accessLevel: new Field(roleAccessElemID, 'accessLevel', Types.accessLevelSubType,
-        { [CORE_ANNOTATIONS.DEFAULT]: '0' }),
-      // Todo searchLevel: understand real values (not 0,1,2) and modify defaults
-      searchLevel: new Field(roleAccessElemID, 'searchLevel', Types.searchLevelSubType,
-        { [CORE_ANNOTATIONS.DEFAULT]: '0' }),
-    },
-    path: [...subtypesFolderPath, roleAccessElemID.name],
-  })
-
-  private static fieldTypeSubType = new PrimitiveType({
-    elemID: fieldTypeElemID,
-    primitive: PrimitiveTypes.STRING,
-    annotations: {
-      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
-        values: [
-          'CHECKBOX', 'CLOBTEXT', 'CURRENCY', 'DATE', 'DATETIMETZ', 'DOCUMENT', 'EMAIL', 'FLOAT',
-          'HELP', 'IMAGE', 'INLINEHTML', 'INTEGER', 'MULTISELECT', 'PASSWORD', 'PERCENT', 'PHONE',
-          'RICHTEXT', 'SELECT', 'TEXT', 'TEXTAREA', 'TIMEOFDAY', 'URL',
-        ],
-      }),
-    },
-    path: [...subtypesFolderPath, fieldTypeElemID.name],
-  })
-
-  // Todo generic_standard_field has ~4000 options. We should consider to write it to state only.
-  // Todo standardFieldTypeSubType: add to getAllTypes array once defined.
-  private static standardFieldTypeSubType = BuiltinTypes.STRING
-
-  public static customTypes: Record<string, ObjectType> = {
-    [ENTITY_CUSTOM_FIELD.toLowerCase()]: new ObjectType({
-      elemID: entityCustomFieldElemID,
-      annotations: {
-        [SCRIPT_ID_PREFIX]: 'custentity_',
-      },
-      fields: {
-        fieldType: new Field(entityCustomFieldElemID, 'fieldType',
-          Types.fieldTypeSubType, { [CORE_ANNOTATIONS.REQUIRED]: true }),
-        [SCRIPT_ID]: new Field(entityCustomFieldElemID, SCRIPT_ID, BuiltinTypes.SERVICE_ID,
-          { [IS_ATTRIBUTE]: true }),
-        label: new Field(entityCustomFieldElemID, 'label', BuiltinTypes.STRING,
-          { [IS_NAME]: true, [CORE_ANNOTATIONS.REQUIRED]: true }),
-        selectRecordType: new Field(entityCustomFieldElemID, 'selectRecordType',
-          BuiltinTypes.STRING), // Todo: this field is a reference
-        applyFormatting: new Field(entityCustomFieldElemID, 'applyFormatting', BuiltinTypes.BOOLEAN),
-        defaultChecked: new Field(entityCustomFieldElemID, 'defaultChecked', BuiltinTypes.BOOLEAN),
-        defaultSelection: new Field(entityCustomFieldElemID, 'defaultSelection',
-          BuiltinTypes.STRING), // Todo: this field is a reference
-        defaultValue: new Field(entityCustomFieldElemID, 'defaultValue', BuiltinTypes.STRING),
-        description: new Field(entityCustomFieldElemID, 'description', BuiltinTypes.STRING),
-        displayType: new Field(entityCustomFieldElemID, 'displayType',
-          Types.displayTypeSubType, { [CORE_ANNOTATIONS.DEFAULT]: 'NORMAL' }),
-        dynamicDefault: new Field(entityCustomFieldElemID, 'dynamicDefault',
-          Types.dynamicDefaultSubType),
-        help: new Field(entityCustomFieldElemID, 'help', BuiltinTypes.STRING),
-        linkText: new Field(entityCustomFieldElemID, 'linkText', BuiltinTypes.STRING),
-        minvalue: new Field(entityCustomFieldElemID, 'minValue', BuiltinTypes.STRING),
-        maxValue: new Field(entityCustomFieldElemID, 'maxValue', BuiltinTypes.STRING),
-        storeValue: new Field(entityCustomFieldElemID, 'storeValue', BuiltinTypes.BOOLEAN, {
-          [CORE_ANNOTATIONS.DEFAULT]: true,
-        }),
-        // Todo accessLevel: understand real values (not 0,1,2) and modify defaults
-        accessLevel: new Field(entityCustomFieldElemID, 'accessLevel',
-          Types.accessLevelSubType, { [CORE_ANNOTATIONS.DEFAULT]: '2' }),
-        checkSpelling: new Field(entityCustomFieldElemID, 'checkSpelling', BuiltinTypes.BOOLEAN, {
-          [CORE_ANNOTATIONS.DEFAULT]: false,
-        }),
-        encryptAtRest: new Field(entityCustomFieldElemID, 'encryptAtRest', BuiltinTypes.BOOLEAN, {
-          [CORE_ANNOTATIONS.DEFAULT]: false,
-        }),
-        displayHeight: new Field(entityCustomFieldElemID, 'displayHeight', BuiltinTypes.NUMBER),
-        displayWidth: new Field(entityCustomFieldElemID, 'displayWidth', BuiltinTypes.NUMBER),
-        globalSearch: new Field(entityCustomFieldElemID, 'globalSearch', BuiltinTypes.BOOLEAN, {
-          [CORE_ANNOTATIONS.DEFAULT]: false,
-        }),
-        isFormula: new Field(entityCustomFieldElemID, 'isFormula', BuiltinTypes.BOOLEAN, {
-          [CORE_ANNOTATIONS.DEFAULT]: false,
-        }),
-        isMandatory: new Field(entityCustomFieldElemID, 'isMandatory', BuiltinTypes.BOOLEAN, {
-          [CORE_ANNOTATIONS.DEFAULT]: false,
-        }),
-        maxLength: new Field(entityCustomFieldElemID, 'maxLength', BuiltinTypes.STRING),
-        onParentDelete: new Field(entityCustomFieldElemID, 'onParentDelete',
-          Types.onParentDeleteSubType),
-        searchCompareField: new Field(entityCustomFieldElemID, 'searchCompareField',
-          Types.standardFieldTypeSubType),
-        searchDefault: new Field(entityCustomFieldElemID, 'searchDefault',
-          BuiltinTypes.STRING), // Todo: this field is a reference
-        // Todo searchLevel: understand real values (not 0,1,2) and modify defaults
-        searchLevel: new Field(entityCustomFieldElemID, 'searchLevel',
-          Types.searchLevelSubType, { [CORE_ANNOTATIONS.DEFAULT]: '2' }),
-        showHierarchy: new Field(entityCustomFieldElemID, 'showHierarchy', BuiltinTypes.BOOLEAN, {
-          [CORE_ANNOTATIONS.DEFAULT]: false,
-        }),
-        showInList: new Field(entityCustomFieldElemID, 'showInList', BuiltinTypes.BOOLEAN, {
-          [CORE_ANNOTATIONS.DEFAULT]: false,
-        }),
-        sourceFilterBy: new Field(entityCustomFieldElemID, 'sourceFilterBy',
-          Types.standardFieldTypeSubType),
-        sourceFrom: new Field(entityCustomFieldElemID, 'sourceFrom',
-          Types.standardFieldTypeSubType),
-        // Todo sourceList: should point to either standardFieldTypeSubType or reference
-        sourceList: new Field(entityCustomFieldElemID, 'sourceList', BuiltinTypes.STRING),
-        isParent: new Field(entityCustomFieldElemID, 'isParent', BuiltinTypes.BOOLEAN, {
-          [CORE_ANNOTATIONS.DEFAULT]: false,
-        }),
-        // Todo parentSubtab: should point to either generic_tab_parent or reference
-        parentSubtab: new Field(entityCustomFieldElemID, 'parentSubtab', BuiltinTypes.STRING),
-        // Todo subtab: should point to either generic_entity_tab or reference
-        subtab: new Field(entityCustomFieldElemID, 'subtab', BuiltinTypes.STRING),
-        appliesToContact: new Field(entityCustomFieldElemID, 'appliesToContact',
-          BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-        appliesToCustomer: new Field(entityCustomFieldElemID, 'appliesToCustomer',
-          BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-        appliesToEmployee: new Field(entityCustomFieldElemID, 'appliesToEmployee',
-          BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-        appliesToGenericrSrc: new Field(entityCustomFieldElemID, 'appliesToGenericrSrc',
-          BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-        appliesToGroup: new Field(entityCustomFieldElemID, 'appliesToGroup',
-          BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-        appliesToOtherName: new Field(entityCustomFieldElemID, 'appliesToOtherName',
-          BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-        appliesToPartner: new Field(entityCustomFieldElemID, 'appliesToPartner',
-          BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-        appliesToPriceList: new Field(entityCustomFieldElemID, 'appliesToPriceList',
-          BuiltinTypes.BOOLEAN),
-        appliesToProject: new Field(entityCustomFieldElemID, 'appliesToProject',
-          BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-        appliesToProjectTemplate: new Field(entityCustomFieldElemID, 'appliesToProjectTemplate',
-          BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-        appliesToStatement: new Field(entityCustomFieldElemID, 'appliesToStatement',
-          BuiltinTypes.BOOLEAN),
-        appliesToVendor: new Field(entityCustomFieldElemID, 'appliesToVendor',
-          BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-        appliesToWebSite: new Field(entityCustomFieldElemID, 'appliesToWebSite',
-          BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-        availableExternally: new Field(entityCustomFieldElemID, 'availableExternally',
-          BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-        availableToSso: new Field(entityCustomFieldElemID, 'availableToSso',
-          BuiltinTypes.BOOLEAN, { [CORE_ANNOTATIONS.DEFAULT]: false }),
-        customFieldFilters: new Field(entityCustomFieldElemID, 'customFieldFilters',
-          new ListType(Types.customFieldFilterSubType)),
-        roleAccesses: new Field(entityCustomFieldElemID, 'roleAccesses',
-          new ListType(Types.roleAccessSubType)),
-      },
-      path: [...typesFolderPath, entityCustomFieldElemID.name],
-    }),
-  }
-
-  public static isCustomType(type: ObjectType): boolean {
-    return !_.isUndefined(Types.customTypes[type.elemID.name.toLowerCase()])
-  }
-
-  public static getAllTypes(): TypeElement[] {
-    return [
-      ...Object.values(Types.customTypes),
-      Types.accessLevelSubType,
-      Types.searchLevelSubType,
-      Types.onParentDeleteSubType,
-      Types.displayTypeSubType,
-      Types.dynamicDefaultSubType,
-      Types.fieldFilterCompareTypeSubType,
-      Types.customFieldFilterSubType,
-      Types.roleAccessSubType,
-      Types.fieldTypeSubType,
-    ]
-  }
+* generated using types_generator.py as Netsuite don't expose a metadata API for them.
+*/
+export const customTypes: Readonly<Record<string, ObjectType>> = {
+  addressForm,
+  advancedpdftemplate,
+  bankstatementparserplugin,
+  bundleinstallationscript,
+  center,
+  centercategory,
+  centertab,
+  clientscript,
+  cmscontenttype,
+  crmcustomfield,
+  customglplugin,
+  customlist,
+  customrecordtype,
+  customsegment,
+  customtransactiontype,
+  dataset,
+  emailcaptureplugin,
+  emailtemplate,
+  entitycustomfield,
+  entryForm,
+  ficonnectivityplugin,
+  itemcustomfield,
+  itemnumbercustomfield,
+  itemoptioncustomfield,
+  kpiscorecard,
+  mapreducescript,
+  massupdatescript,
+  othercustomfield,
+  pluginimplementation,
+  plugintype,
+  portlet,
+  promotionsplugin,
+  publisheddashboard,
+  restlet,
+  role,
+  savedcsvimport,
+  savedsearch,
+  scheduledscript,
+  sdfinstallationscript,
+  sspapplication,
+  sublist,
+  subtab,
+  suitelet,
+  transactionForm,
+  transactionbodycustomfield,
+  transactioncolumncustomfield,
+  translationcollection,
+  usereventscript,
+  workbook,
+  workflow,
+  workflowactionscript,
 }
+
+const innerCustomTypes: ObjectType[] = [
+  ...addressFormInnerTypes,
+  ...advancedpdftemplateInnerTypes,
+  ...bankstatementparserpluginInnerTypes,
+  ...bundleinstallationscriptInnerTypes,
+  ...centerInnerTypes,
+  ...centercategoryInnerTypes,
+  ...centertabInnerTypes,
+  ...clientscriptInnerTypes,
+  ...cmscontenttypeInnerTypes,
+  ...crmcustomfieldInnerTypes,
+  ...customglpluginInnerTypes,
+  ...customlistInnerTypes,
+  ...customrecordtypeInnerTypes,
+  ...customsegmentInnerTypes,
+  ...customtransactiontypeInnerTypes,
+  ...datasetInnerTypes,
+  ...emailcapturepluginInnerTypes,
+  ...emailtemplateInnerTypes,
+  ...entitycustomfieldInnerTypes,
+  ...entryFormInnerTypes,
+  ...ficonnectivitypluginInnerTypes,
+  ...itemcustomfieldInnerTypes,
+  ...itemnumbercustomfieldInnerTypes,
+  ...itemoptioncustomfieldInnerTypes,
+  ...kpiscorecardInnerTypes,
+  ...mapreducescriptInnerTypes,
+  ...massupdatescriptInnerTypes,
+  ...othercustomfieldInnerTypes,
+  ...pluginimplementationInnerTypes,
+  ...plugintypeInnerTypes,
+  ...portletInnerTypes,
+  ...promotionspluginInnerTypes,
+  ...publisheddashboardInnerTypes,
+  ...restletInnerTypes,
+  ...roleInnerTypes,
+  ...savedcsvimportInnerTypes,
+  ...savedsearchInnerTypes,
+  ...scheduledscriptInnerTypes,
+  ...sdfinstallationscriptInnerTypes,
+  ...sspapplicationInnerTypes,
+  ...sublistInnerTypes,
+  ...subtabInnerTypes,
+  ...suiteletInnerTypes,
+  ...transactionFormInnerTypes,
+  ...transactionbodycustomfieldInnerTypes,
+  ...transactioncolumncustomfieldInnerTypes,
+  ...translationcollectionInnerTypes,
+  ...usereventscriptInnerTypes,
+  ...workbookInnerTypes,
+  ...workflowInnerTypes,
+  ...workflowactionscriptInnerTypes,
+]
+
+export const isCustomType = (type: ObjectType): boolean =>
+  !_.isUndefined(customTypes[type.elemID.name])
+
+export const getAllTypes = (): TypeElement[] => [
+  ...Object.values(customTypes),
+  ...innerCustomTypes,
+  ...Object.values(enums),
+]

--- a/packages/netsuite-adapter/src/types/custom_types/addressForm.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/addressForm.ts
@@ -1,0 +1,388 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const addressFormInnerTypes: ObjectType[] = []
+
+const addressFormElemID = new ElemID(constants.NETSUITE, 'addressForm')
+const addressForm_mainFields_defaultFieldGroup_fields_fieldElemID = new ElemID(constants.NETSUITE, 'addressForm_mainFields_defaultFieldGroup_fields_field')
+
+const addressForm_mainFields_defaultFieldGroup_fields_field = new ObjectType({
+  elemID: addressForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      addressForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see addressform_fieldid. */
+    label: new Field(
+      addressForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      addressForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    mandatory: new Field(
+      addressForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'mandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayType: new Field(
+      addressForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'displayType',
+      enums.form_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_displaytype.   The default value is 'NORMAL'. */
+    columnBreak: new Field(
+      addressForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'columnBreak',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    spaceBefore: new Field(
+      addressForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'spaceBefore',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    sameRowAsPrevious: new Field(
+      addressForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'sameRowAsPrevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, addressFormElemID.name],
+})
+
+addressFormInnerTypes.push(addressForm_mainFields_defaultFieldGroup_fields_field)
+
+const addressForm_mainFields_defaultFieldGroup_fieldsElemID = new ElemID(constants.NETSUITE, 'addressForm_mainFields_defaultFieldGroup_fields')
+
+const addressForm_mainFields_defaultFieldGroup_fields = new ObjectType({
+  elemID: addressForm_mainFields_defaultFieldGroup_fieldsElemID,
+  annotations: {
+  },
+  fields: {
+    position: new Field(
+      addressForm_mainFields_defaultFieldGroup_fieldsElemID,
+      'position',
+      enums.form_fieldposition,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see form_fieldposition.   The default value is ‘MIDDLE’. */
+    field: new Field(
+      addressForm_mainFields_defaultFieldGroup_fieldsElemID,
+      'field',
+      new ListType(addressForm_mainFields_defaultFieldGroup_fields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, addressFormElemID.name],
+})
+
+addressFormInnerTypes.push(addressForm_mainFields_defaultFieldGroup_fields)
+
+const addressForm_mainFields_defaultFieldGroupElemID = new ElemID(constants.NETSUITE, 'addressForm_mainFields_defaultFieldGroup')
+
+const addressForm_mainFields_defaultFieldGroup = new ObjectType({
+  elemID: addressForm_mainFields_defaultFieldGroupElemID,
+  annotations: {
+  },
+  fields: {
+    fields: new Field(
+      addressForm_mainFields_defaultFieldGroupElemID,
+      'fields',
+      addressForm_mainFields_defaultFieldGroup_fields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, addressFormElemID.name],
+})
+
+addressFormInnerTypes.push(addressForm_mainFields_defaultFieldGroup)
+
+const addressForm_mainFields_fieldGroup_fields_fieldElemID = new ElemID(constants.NETSUITE, 'addressForm_mainFields_fieldGroup_fields_field')
+
+const addressForm_mainFields_fieldGroup_fields_field = new ObjectType({
+  elemID: addressForm_mainFields_fieldGroup_fields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      addressForm_mainFields_fieldGroup_fields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see addressform_fieldid. */
+    label: new Field(
+      addressForm_mainFields_fieldGroup_fields_fieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      addressForm_mainFields_fieldGroup_fields_fieldElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    mandatory: new Field(
+      addressForm_mainFields_fieldGroup_fields_fieldElemID,
+      'mandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayType: new Field(
+      addressForm_mainFields_fieldGroup_fields_fieldElemID,
+      'displayType',
+      enums.form_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_displaytype.   The default value is 'NORMAL'. */
+    columnBreak: new Field(
+      addressForm_mainFields_fieldGroup_fields_fieldElemID,
+      'columnBreak',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    spaceBefore: new Field(
+      addressForm_mainFields_fieldGroup_fields_fieldElemID,
+      'spaceBefore',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    sameRowAsPrevious: new Field(
+      addressForm_mainFields_fieldGroup_fields_fieldElemID,
+      'sameRowAsPrevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, addressFormElemID.name],
+})
+
+addressFormInnerTypes.push(addressForm_mainFields_fieldGroup_fields_field)
+
+const addressForm_mainFields_fieldGroup_fieldsElemID = new ElemID(constants.NETSUITE, 'addressForm_mainFields_fieldGroup_fields')
+
+const addressForm_mainFields_fieldGroup_fields = new ObjectType({
+  elemID: addressForm_mainFields_fieldGroup_fieldsElemID,
+  annotations: {
+  },
+  fields: {
+    position: new Field(
+      addressForm_mainFields_fieldGroup_fieldsElemID,
+      'position',
+      enums.form_fieldposition,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see form_fieldposition.   The default value is ‘MIDDLE’. */
+    field: new Field(
+      addressForm_mainFields_fieldGroup_fieldsElemID,
+      'field',
+      new ListType(addressForm_mainFields_fieldGroup_fields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, addressFormElemID.name],
+})
+
+addressFormInnerTypes.push(addressForm_mainFields_fieldGroup_fields)
+
+const addressForm_mainFields_fieldGroupElemID = new ElemID(constants.NETSUITE, 'addressForm_mainFields_fieldGroup')
+
+const addressForm_mainFields_fieldGroup = new ObjectType({
+  elemID: addressForm_mainFields_fieldGroupElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      addressForm_mainFields_fieldGroupElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long. */
+    label: new Field(
+      addressForm_mainFields_fieldGroupElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    visible: new Field(
+      addressForm_mainFields_fieldGroupElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    showTitle: new Field(
+      addressForm_mainFields_fieldGroupElemID,
+      'showTitle',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    singleColumn: new Field(
+      addressForm_mainFields_fieldGroupElemID,
+      'singleColumn',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fields: new Field(
+      addressForm_mainFields_fieldGroupElemID,
+      'fields',
+      addressForm_mainFields_fieldGroup_fields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, addressFormElemID.name],
+})
+
+addressFormInnerTypes.push(addressForm_mainFields_fieldGroup)
+
+const addressForm_mainFieldsElemID = new ElemID(constants.NETSUITE, 'addressForm_mainFields')
+
+const addressForm_mainFields = new ObjectType({
+  elemID: addressForm_mainFieldsElemID,
+  annotations: {
+  },
+  fields: {
+    defaultFieldGroup: new Field(
+      addressForm_mainFieldsElemID,
+      'defaultFieldGroup',
+      addressForm_mainFields_defaultFieldGroup,
+      {
+      },
+    ),
+    fieldGroup: new Field(
+      addressForm_mainFieldsElemID,
+      'fieldGroup',
+      new ListType(addressForm_mainFields_fieldGroup),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, addressFormElemID.name],
+})
+
+addressFormInnerTypes.push(addressForm_mainFields)
+
+
+export const addressForm = new ObjectType({
+  elemID: addressFormElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custform_',
+  },
+  fields: {
+    scriptid: new Field(
+      addressFormElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custform’. */
+    standard: new Field(
+      addressFormElemID,
+      'standard',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long. */
+    name: new Field(
+      addressFormElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+      },
+    ),
+    addressTemplate: new Field(
+      addressFormElemID,
+      'addressTemplate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 3990,
+      },
+    ), /* Original description: This field value can be up to 3990 characters long. */
+    countries: new Field(
+      addressFormElemID,
+      'countries',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see countries. */
+    mainFields: new Field(
+      addressFormElemID,
+      'mainFields',
+      addressForm_mainFields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, addressFormElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/advancedpdftemplate.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/advancedpdftemplate.ts
@@ -1,0 +1,106 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const advancedpdftemplateInnerTypes: ObjectType[] = []
+
+const advancedpdftemplateElemID = new ElemID(constants.NETSUITE, 'advancedpdftemplate')
+
+export const advancedpdftemplate = new ObjectType({
+  elemID: advancedpdftemplateElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custtmpl_',
+    [constants.ADDITIONAL_FILE_SUFFIX]: '.template.xml',
+  },
+  fields: {
+    scriptid: new Field(
+      advancedpdftemplateElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 98 characters long.   The default value is ‘custtmpl’. */
+    standard: new Field(
+      advancedpdftemplateElemID,
+      'standard',
+      enums.advancedpdftemplate_standard,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   For information about possible values, see advancedpdftemplate_standard. */
+    title: new Field(
+      advancedpdftemplateElemID,
+      'title',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 297,
+      },
+    ), /* Original description: This field value can be up to 297 characters long. */
+    description: new Field(
+      advancedpdftemplateElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 4000,
+      },
+    ), /* Original description: This field value can be up to 4000 characters long. */
+    displaysourcecode: new Field(
+      advancedpdftemplateElemID,
+      'displaysourcecode',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    preferred: new Field(
+      advancedpdftemplateElemID,
+      'preferred',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    isinactive: new Field(
+      advancedpdftemplateElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    savedsearch: new Field(
+      advancedpdftemplateElemID,
+      'savedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type.   If this field appears in the project, you must reference the SERVERSIDESCRIPTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. SERVERSIDESCRIPTING must be enabled for this field to appear in your account. */
+    recordtype: new Field(
+      advancedpdftemplateElemID,
+      'recordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customtransactiontype   customrecordtype */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, advancedpdftemplateElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/bankstatementparserplugin.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/bankstatementparserplugin.ts
@@ -1,0 +1,134 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const bankstatementparserpluginInnerTypes: ObjectType[] = []
+
+const bankstatementparserpluginElemID = new ElemID(constants.NETSUITE, 'bankstatementparserplugin')
+
+export const bankstatementparserplugin = new ObjectType({
+  elemID: bankstatementparserpluginElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      bankstatementparserpluginElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      bankstatementparserpluginElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      bankstatementparserpluginElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    description: new Field(
+      bankstatementparserpluginElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      bankstatementparserpluginElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      bankstatementparserpluginElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      bankstatementparserpluginElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      bankstatementparserpluginElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      bankstatementparserpluginElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      bankstatementparserpluginElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    loglevel: new Field(
+      bankstatementparserpluginElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+    runasrole: new Field(
+      bankstatementparserpluginElemID,
+      'runasrole',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    status: new Field(
+      bankstatementparserpluginElemID,
+      'status',
+      enums.script_status,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, bankstatementparserpluginElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/bundleinstallationscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/bundleinstallationscript.ts
@@ -1,0 +1,718 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const bundleinstallationscriptInnerTypes: ObjectType[] = []
+
+const bundleinstallationscriptElemID = new ElemID(constants.NETSUITE, 'bundleinstallationscript')
+const bundleinstallationscript_customplugintypes_plugintypeElemID = new ElemID(constants.NETSUITE, 'bundleinstallationscript_customplugintypes_plugintype')
+
+const bundleinstallationscript_customplugintypes_plugintype = new ObjectType({
+  elemID: bundleinstallationscript_customplugintypes_plugintypeElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      bundleinstallationscript_customplugintypes_plugintypeElemID,
+      'plugintype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the plugintype custom type. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, bundleinstallationscriptElemID.name],
+})
+
+bundleinstallationscriptInnerTypes.push(bundleinstallationscript_customplugintypes_plugintype)
+
+const bundleinstallationscript_customplugintypesElemID = new ElemID(constants.NETSUITE, 'bundleinstallationscript_customplugintypes')
+
+const bundleinstallationscript_customplugintypes = new ObjectType({
+  elemID: bundleinstallationscript_customplugintypesElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      bundleinstallationscript_customplugintypesElemID,
+      'plugintype',
+      new ListType(bundleinstallationscript_customplugintypes_plugintype),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, bundleinstallationscriptElemID.name],
+})
+
+bundleinstallationscriptInnerTypes.push(bundleinstallationscript_customplugintypes)
+
+const bundleinstallationscript_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'bundleinstallationscript_libraries_library')
+
+const bundleinstallationscript_libraries_library = new ObjectType({
+  elemID: bundleinstallationscript_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      bundleinstallationscript_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, bundleinstallationscriptElemID.name],
+})
+
+bundleinstallationscriptInnerTypes.push(bundleinstallationscript_libraries_library)
+
+const bundleinstallationscript_librariesElemID = new ElemID(constants.NETSUITE, 'bundleinstallationscript_libraries')
+
+const bundleinstallationscript_libraries = new ObjectType({
+  elemID: bundleinstallationscript_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      bundleinstallationscript_librariesElemID,
+      'library',
+      new ListType(bundleinstallationscript_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, bundleinstallationscriptElemID.name],
+})
+
+bundleinstallationscriptInnerTypes.push(bundleinstallationscript_libraries)
+
+const bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter')
+
+const bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, bundleinstallationscriptElemID.name],
+})
+
+bundleinstallationscriptInnerTypes.push(bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter)
+
+const bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters')
+
+const bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters = new ObjectType({
+  elemID: bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, bundleinstallationscriptElemID.name],
+})
+
+bundleinstallationscriptInnerTypes.push(bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters)
+
+const bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess')
+
+const bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, bundleinstallationscriptElemID.name],
+})
+
+bundleinstallationscriptInnerTypes.push(bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess)
+
+const bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses')
+
+const bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses = new ObjectType({
+  elemID: bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, bundleinstallationscriptElemID.name],
+})
+
+bundleinstallationscriptInnerTypes.push(bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses)
+
+const bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID = new ElemID(constants.NETSUITE, 'bundleinstallationscript_scriptcustomfields_scriptcustomfield')
+
+const bundleinstallationscript_scriptcustomfields_scriptcustomfield = new ObjectType({
+  elemID: bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custscript’. */
+    fieldtype: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    isformula: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    setting: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'setting',
+      enums.script_setting,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_setting. */
+    customfieldfilters: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'customfieldfilters',
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      bundleinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'roleaccesses',
+      bundleinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, bundleinstallationscriptElemID.name],
+})
+
+bundleinstallationscriptInnerTypes.push(bundleinstallationscript_scriptcustomfields_scriptcustomfield)
+
+const bundleinstallationscript_scriptcustomfieldsElemID = new ElemID(constants.NETSUITE, 'bundleinstallationscript_scriptcustomfields')
+
+const bundleinstallationscript_scriptcustomfields = new ObjectType({
+  elemID: bundleinstallationscript_scriptcustomfieldsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptcustomfield: new Field(
+      bundleinstallationscript_scriptcustomfieldsElemID,
+      'scriptcustomfield',
+      new ListType(bundleinstallationscript_scriptcustomfields_scriptcustomfield),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, bundleinstallationscriptElemID.name],
+})
+
+bundleinstallationscriptInnerTypes.push(bundleinstallationscript_scriptcustomfields)
+
+const bundleinstallationscript_scriptdeployments_scriptdeploymentElemID = new ElemID(constants.NETSUITE, 'bundleinstallationscript_scriptdeployments_scriptdeployment')
+
+const bundleinstallationscript_scriptdeployments_scriptdeployment = new ObjectType({
+  elemID: bundleinstallationscript_scriptdeployments_scriptdeploymentElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      bundleinstallationscript_scriptdeployments_scriptdeploymentElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customdeploy’. */
+    status: new Field(
+      bundleinstallationscript_scriptdeployments_scriptdeploymentElemID,
+      'status',
+      enums.script_status,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+    title: new Field(
+      bundleinstallationscript_scriptdeployments_scriptdeploymentElemID,
+      'title',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    isdeployed: new Field(
+      bundleinstallationscript_scriptdeployments_scriptdeploymentElemID,
+      'isdeployed',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    loglevel: new Field(
+      bundleinstallationscript_scriptdeployments_scriptdeploymentElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+    runasrole: new Field(
+      bundleinstallationscript_scriptdeployments_scriptdeploymentElemID,
+      'runasrole',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, bundleinstallationscriptElemID.name],
+})
+
+bundleinstallationscriptInnerTypes.push(bundleinstallationscript_scriptdeployments_scriptdeployment)
+
+const bundleinstallationscript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'bundleinstallationscript_scriptdeployments')
+
+const bundleinstallationscript_scriptdeployments = new ObjectType({
+  elemID: bundleinstallationscript_scriptdeploymentsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptdeployment: new Field(
+      bundleinstallationscript_scriptdeploymentsElemID,
+      'scriptdeployment',
+      new ListType(bundleinstallationscript_scriptdeployments_scriptdeployment),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, bundleinstallationscriptElemID.name],
+})
+
+bundleinstallationscriptInnerTypes.push(bundleinstallationscript_scriptdeployments)
+
+
+export const bundleinstallationscript = new ObjectType({
+  elemID: bundleinstallationscriptElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      bundleinstallationscriptElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      bundleinstallationscriptElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      bundleinstallationscriptElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    description: new Field(
+      bundleinstallationscriptElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      bundleinstallationscriptElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      bundleinstallationscriptElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      bundleinstallationscriptElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifyowner: new Field(
+      bundleinstallationscriptElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    afterinstallfunction: new Field(
+      bundleinstallationscriptElemID,
+      'afterinstallfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    afterupdatefunction: new Field(
+      bundleinstallationscriptElemID,
+      'afterupdatefunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    beforeinstallfunction: new Field(
+      bundleinstallationscriptElemID,
+      'beforeinstallfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    beforeuninstallfunction: new Field(
+      bundleinstallationscriptElemID,
+      'beforeuninstallfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    beforeupdatefunction: new Field(
+      bundleinstallationscriptElemID,
+      'beforeupdatefunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    customplugintypes: new Field(
+      bundleinstallationscriptElemID,
+      'customplugintypes',
+      bundleinstallationscript_customplugintypes,
+      {
+      },
+    ),
+    libraries: new Field(
+      bundleinstallationscriptElemID,
+      'libraries',
+      bundleinstallationscript_libraries,
+      {
+      },
+    ),
+    scriptcustomfields: new Field(
+      bundleinstallationscriptElemID,
+      'scriptcustomfields',
+      bundleinstallationscript_scriptcustomfields,
+      {
+      },
+    ),
+    scriptdeployments: new Field(
+      bundleinstallationscriptElemID,
+      'scriptdeployments',
+      bundleinstallationscript_scriptdeployments,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, bundleinstallationscriptElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/center.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/center.ts
@@ -1,0 +1,52 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+
+export const centerInnerTypes: ObjectType[] = []
+
+const centerElemID = new ElemID(constants.NETSUITE, 'center')
+
+export const center = new ObjectType({
+  elemID: centerElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custcenter_',
+  },
+  fields: {
+    scriptid: new Field(
+      centerElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custcenter’. */
+    label: new Field(
+      centerElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, centerElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/centercategory.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/centercategory.ts
@@ -1,0 +1,144 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const centercategoryInnerTypes: ObjectType[] = []
+
+const centercategoryElemID = new ElemID(constants.NETSUITE, 'centercategory')
+const centercategory_links_linkElemID = new ElemID(constants.NETSUITE, 'centercategory_links_link')
+
+const centercategory_links_link = new ObjectType({
+  elemID: centercategory_links_linkElemID,
+  annotations: {
+  },
+  fields: {
+    linkid: new Field(
+      centercategory_links_linkElemID,
+      'linkid',
+      enums.generic_task,
+      {
+      },
+    ), /* Original description: This field is mandatory when the linkobject value is not defined.   For information about possible values, see generic_task. */
+    linkobject: new Field(
+      centercategory_links_linkElemID,
+      'linkobject',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the linkid value is not defined.   This field accepts references to the following custom types:   workflowactionscript   usereventscript   scriptdeployment   suitelet   scheduledscript   savedsearch   restlet   portlet   massupdatescript   mapreducescript   customtransactiontype   customrecordtype   clientscript   centertab   bundleinstallationscript */
+    linktasktype: new Field(
+      centercategory_links_linkElemID,
+      'linktasktype',
+      enums.centercategory_tasktype,
+      {
+      },
+    ), /* Original description: This field is mandatory when the linkobject value is defined.   For information about possible values, see centercategory_tasktype. */
+    linklabel: new Field(
+      centercategory_links_linkElemID,
+      'linklabel',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    shortlist: new Field(
+      centercategory_links_linkElemID,
+      'shortlist',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, centercategoryElemID.name],
+})
+
+centercategoryInnerTypes.push(centercategory_links_link)
+
+const centercategory_linksElemID = new ElemID(constants.NETSUITE, 'centercategory_links')
+
+const centercategory_links = new ObjectType({
+  elemID: centercategory_linksElemID,
+  annotations: {
+  },
+  fields: {
+    link: new Field(
+      centercategory_linksElemID,
+      'link',
+      new ListType(centercategory_links_link),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, centercategoryElemID.name],
+})
+
+centercategoryInnerTypes.push(centercategory_links)
+
+
+export const centercategory = new ObjectType({
+  elemID: centercategoryElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custcentercategory_',
+  },
+  fields: {
+    scriptid: new Field(
+      centercategoryElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custcentercategory’. */
+    center: new Field(
+      centercategoryElemID,
+      'center',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the center custom type.   For information about other possible values, see generic_centertype. */
+    centertab: new Field(
+      centercategoryElemID,
+      'centertab',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the centertab custom type.   For information about other possible values, see generic_centertab. */
+    label: new Field(
+      centercategoryElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+      },
+    ),
+    links: new Field(
+      centercategoryElemID,
+      'links',
+      centercategory_links,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, centercategoryElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/centertab.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/centertab.ts
@@ -1,0 +1,173 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const centertabInnerTypes: ObjectType[] = []
+
+const centertabElemID = new ElemID(constants.NETSUITE, 'centertab')
+const centertab_portlets_portletElemID = new ElemID(constants.NETSUITE, 'centertab_portlets_portlet')
+
+const centertab_portlets_portlet = new ObjectType({
+  elemID: centertab_portlets_portletElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      centertab_portlets_portletElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long. */
+    portlet: new Field(
+      centertab_portlets_portletElemID,
+      'portlet',
+      enums.generic_portlet,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_portlet. */
+    portletcolumn: new Field(
+      centertab_portlets_portletElemID,
+      'portletcolumn',
+      enums.generic_portletcolumn,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_portletcolumn. */
+    isportletshown: new Field(
+      centertab_portlets_portletElemID,
+      'isportletshown',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, centertabElemID.name],
+})
+
+centertabInnerTypes.push(centertab_portlets_portlet)
+
+const centertab_portletsElemID = new ElemID(constants.NETSUITE, 'centertab_portlets')
+
+const centertab_portlets = new ObjectType({
+  elemID: centertab_portletsElemID,
+  annotations: {
+  },
+  fields: {
+    portlet: new Field(
+      centertab_portletsElemID,
+      'portlet',
+      new ListType(centertab_portlets_portlet),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, centertabElemID.name],
+})
+
+centertabInnerTypes.push(centertab_portlets)
+
+
+export const centertab = new ObjectType({
+  elemID: centertabElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custcentertab_',
+  },
+  fields: {
+    scriptid: new Field(
+      centertabElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custcentertab’. */
+    label: new Field(
+      centertabElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+      },
+    ),
+    center: new Field(
+      centertabElemID,
+      'center',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the center custom type.   For information about other possible values, see generic_centertype. */
+    allvendors: new Field(
+      centertabElemID,
+      'allvendors',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allroles: new Field(
+      centertabElemID,
+      'allroles',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allpartners: new Field(
+      centertabElemID,
+      'allpartners',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account. */
+    allcustomers: new Field(
+      centertabElemID,
+      'allcustomers',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allemployees: new Field(
+      centertabElemID,
+      'allemployees',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    audslctrole: new Field(
+      centertabElemID,
+      'audslctrole',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    portlets: new Field(
+      centertabElemID,
+      'portlets',
+      centertab_portlets,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, centertabElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/clientscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/clientscript.ts
@@ -1,0 +1,851 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const clientscriptInnerTypes: ObjectType[] = []
+
+const clientscriptElemID = new ElemID(constants.NETSUITE, 'clientscript')
+const clientscript_buttons_buttonElemID = new ElemID(constants.NETSUITE, 'clientscript_buttons_button')
+
+const clientscript_buttons_button = new ObjectType({
+  elemID: clientscript_buttons_buttonElemID,
+  annotations: {
+  },
+  fields: {
+    buttonlabel: new Field(
+      clientscript_buttons_buttonElemID,
+      'buttonlabel',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the string custom type. */
+    buttonfunction: new Field(
+      clientscript_buttons_buttonElemID,
+      'buttonfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, clientscriptElemID.name],
+})
+
+clientscriptInnerTypes.push(clientscript_buttons_button)
+
+const clientscript_buttonsElemID = new ElemID(constants.NETSUITE, 'clientscript_buttons')
+
+const clientscript_buttons = new ObjectType({
+  elemID: clientscript_buttonsElemID,
+  annotations: {
+  },
+  fields: {
+    button: new Field(
+      clientscript_buttonsElemID,
+      'button',
+      new ListType(clientscript_buttons_button),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, clientscriptElemID.name],
+})
+
+clientscriptInnerTypes.push(clientscript_buttons)
+
+const clientscript_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'clientscript_libraries_library')
+
+const clientscript_libraries_library = new ObjectType({
+  elemID: clientscript_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      clientscript_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, clientscriptElemID.name],
+})
+
+clientscriptInnerTypes.push(clientscript_libraries_library)
+
+const clientscript_librariesElemID = new ElemID(constants.NETSUITE, 'clientscript_libraries')
+
+const clientscript_libraries = new ObjectType({
+  elemID: clientscript_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      clientscript_librariesElemID,
+      'library',
+      new ListType(clientscript_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, clientscriptElemID.name],
+})
+
+clientscriptInnerTypes.push(clientscript_libraries)
+
+const clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter')
+
+const clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, clientscriptElemID.name],
+})
+
+clientscriptInnerTypes.push(clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter)
+
+const clientscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters')
+
+const clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters = new ObjectType({
+  elemID: clientscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      clientscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, clientscriptElemID.name],
+})
+
+clientscriptInnerTypes.push(clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters)
+
+const clientscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'clientscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess')
+
+const clientscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: clientscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      clientscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      clientscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      clientscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, clientscriptElemID.name],
+})
+
+clientscriptInnerTypes.push(clientscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess)
+
+const clientscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'clientscript_scriptcustomfields_scriptcustomfield_roleaccesses')
+
+const clientscript_scriptcustomfields_scriptcustomfield_roleaccesses = new ObjectType({
+  elemID: clientscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      clientscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(clientscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, clientscriptElemID.name],
+})
+
+clientscriptInnerTypes.push(clientscript_scriptcustomfields_scriptcustomfield_roleaccesses)
+
+const clientscript_scriptcustomfields_scriptcustomfieldElemID = new ElemID(constants.NETSUITE, 'clientscript_scriptcustomfields_scriptcustomfield')
+
+const clientscript_scriptcustomfields_scriptcustomfield = new ObjectType({
+  elemID: clientscript_scriptcustomfields_scriptcustomfieldElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custscript’. */
+    fieldtype: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    isformula: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    setting: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'setting',
+      enums.script_setting,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_setting. */
+    customfieldfilters: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'customfieldfilters',
+      clientscript_scriptcustomfields_scriptcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      clientscript_scriptcustomfields_scriptcustomfieldElemID,
+      'roleaccesses',
+      clientscript_scriptcustomfields_scriptcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, clientscriptElemID.name],
+})
+
+clientscriptInnerTypes.push(clientscript_scriptcustomfields_scriptcustomfield)
+
+const clientscript_scriptcustomfieldsElemID = new ElemID(constants.NETSUITE, 'clientscript_scriptcustomfields')
+
+const clientscript_scriptcustomfields = new ObjectType({
+  elemID: clientscript_scriptcustomfieldsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptcustomfield: new Field(
+      clientscript_scriptcustomfieldsElemID,
+      'scriptcustomfield',
+      new ListType(clientscript_scriptcustomfields_scriptcustomfield),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, clientscriptElemID.name],
+})
+
+clientscriptInnerTypes.push(clientscript_scriptcustomfields)
+
+const clientscript_scriptdeployments_scriptdeploymentElemID = new ElemID(constants.NETSUITE, 'clientscript_scriptdeployments_scriptdeployment')
+
+const clientscript_scriptdeployments_scriptdeployment = new ObjectType({
+  elemID: clientscript_scriptdeployments_scriptdeploymentElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customdeploy’. */
+    status: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'status',
+      enums.script_status,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+    recordtype: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'recordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customtransactiontype   customrecordtype   For information about other possible values, see the following lists:   scriptdeployment_recordtype   allrecord_script_deployment_recordtype */
+    allemployees: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'allemployees',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allpartners: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'allpartners',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account. */
+    allroles: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'allroles',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    auddepartment: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'auddepartment',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the DEPARTMENTS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. DEPARTMENTS must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    audemployee: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'audemployee',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   Note Account-specific values are not supported by SDF. */
+    audgroup: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'audgroup',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   Note Account-specific values are not supported by SDF. */
+    audpartner: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'audpartner',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    audslctrole: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'audslctrole',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    audsubsidiary: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'audsubsidiary',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the SUBSIDIARIES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. SUBSIDIARIES must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    eventtype: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'eventtype',
+      enums.script_eventtype,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_eventtype. */
+    isdeployed: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'isdeployed',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    loglevel: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+    executioncontext: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'executioncontext',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    localizationcontext: new Field(
+      clientscript_scriptdeployments_scriptdeploymentElemID,
+      'localizationcontext',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can filter your script to run based on the localization context of your users. For information about using localization context in NetSuite, see Record Localization Context.   This field is available when the alllocalizationcontexts value is equal to F.   You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see countries. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, clientscriptElemID.name],
+})
+
+clientscriptInnerTypes.push(clientscript_scriptdeployments_scriptdeployment)
+
+const clientscript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'clientscript_scriptdeployments')
+
+const clientscript_scriptdeployments = new ObjectType({
+  elemID: clientscript_scriptdeploymentsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptdeployment: new Field(
+      clientscript_scriptdeploymentsElemID,
+      'scriptdeployment',
+      new ListType(clientscript_scriptdeployments_scriptdeployment),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, clientscriptElemID.name],
+})
+
+clientscriptInnerTypes.push(clientscript_scriptdeployments)
+
+
+export const clientscript = new ObjectType({
+  elemID: clientscriptElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      clientscriptElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      clientscriptElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      clientscriptElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    description: new Field(
+      clientscriptElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      clientscriptElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      clientscriptElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      clientscriptElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      clientscriptElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      clientscriptElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      clientscriptElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fieldchangedfunction: new Field(
+      clientscriptElemID,
+      'fieldchangedfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    lineinitfunction: new Field(
+      clientscriptElemID,
+      'lineinitfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    pageinitfunction: new Field(
+      clientscriptElemID,
+      'pageinitfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    postsourcingfunction: new Field(
+      clientscriptElemID,
+      'postsourcingfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    recalcfunction: new Field(
+      clientscriptElemID,
+      'recalcfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    saverecordfunction: new Field(
+      clientscriptElemID,
+      'saverecordfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    validatedeletefunction: new Field(
+      clientscriptElemID,
+      'validatedeletefunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    validatefieldfunction: new Field(
+      clientscriptElemID,
+      'validatefieldfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    validateinsertfunction: new Field(
+      clientscriptElemID,
+      'validateinsertfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    validatelinefunction: new Field(
+      clientscriptElemID,
+      'validatelinefunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    buttons: new Field(
+      clientscriptElemID,
+      'buttons',
+      clientscript_buttons,
+      {
+      },
+    ),
+    libraries: new Field(
+      clientscriptElemID,
+      'libraries',
+      clientscript_libraries,
+      {
+      },
+    ),
+    scriptcustomfields: new Field(
+      clientscriptElemID,
+      'scriptcustomfields',
+      clientscript_scriptcustomfields,
+      {
+      },
+    ),
+    scriptdeployments: new Field(
+      clientscriptElemID,
+      'scriptdeployments',
+      clientscript_scriptdeployments,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, clientscriptElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/cmscontenttype.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/cmscontenttype.ts
@@ -1,0 +1,86 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+
+export const cmscontenttypeInnerTypes: ObjectType[] = []
+
+const cmscontenttypeElemID = new ElemID(constants.NETSUITE, 'cmscontenttype')
+
+export const cmscontenttype = new ObjectType({
+  elemID: cmscontenttypeElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custcontenttype_',
+  },
+  fields: {
+    scriptid: new Field(
+      cmscontenttypeElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custcontenttype’. */
+    name: new Field(
+      cmscontenttypeElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    label: new Field(
+      cmscontenttypeElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 18,
+      },
+    ), /* Original description: This field value can be up to 18 characters long. */
+    customrecordid: new Field(
+      cmscontenttypeElemID,
+      'customrecordid',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the customrecordtype custom type. */
+    description: new Field(
+      cmscontenttypeElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    iconimagepath: new Field(
+      cmscontenttypeElemID,
+      'iconimagepath',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, cmscontenttypeElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/crmcustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/crmcustomfield.ts
@@ -1,0 +1,552 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const crmcustomfieldInnerTypes: ObjectType[] = []
+
+const crmcustomfieldElemID = new ElemID(constants.NETSUITE, 'crmcustomfield')
+const crmcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'crmcustomfield_customfieldfilters_customfieldfilter')
+
+const crmcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: crmcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      crmcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      crmcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      crmcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      crmcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      crmcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      crmcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      crmcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      crmcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, crmcustomfieldElemID.name],
+})
+
+crmcustomfieldInnerTypes.push(crmcustomfield_customfieldfilters_customfieldfilter)
+
+const crmcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'crmcustomfield_customfieldfilters')
+
+const crmcustomfield_customfieldfilters = new ObjectType({
+  elemID: crmcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      crmcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(crmcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, crmcustomfieldElemID.name],
+})
+
+crmcustomfieldInnerTypes.push(crmcustomfield_customfieldfilters)
+
+const crmcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'crmcustomfield_roleaccesses_roleaccess')
+
+const crmcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: crmcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      crmcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      crmcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      crmcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, crmcustomfieldElemID.name],
+})
+
+crmcustomfieldInnerTypes.push(crmcustomfield_roleaccesses_roleaccess)
+
+const crmcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'crmcustomfield_roleaccesses')
+
+const crmcustomfield_roleaccesses = new ObjectType({
+  elemID: crmcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      crmcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(crmcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, crmcustomfieldElemID.name],
+})
+
+crmcustomfieldInnerTypes.push(crmcustomfield_roleaccesses)
+
+
+export const crmcustomfield = new ObjectType({
+  elemID: crmcustomfieldElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custevent_',
+  },
+  fields: {
+    scriptid: new Field(
+      crmcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 39 characters long.   The default value is ‘custevent’. */
+    fieldtype: new Field(
+      crmcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      crmcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      crmcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      crmcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      crmcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      crmcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      crmcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      crmcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      crmcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      crmcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      crmcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      crmcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      crmcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      crmcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      crmcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      crmcustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      crmcustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    encryptatrest: new Field(
+      crmcustomfieldElemID,
+      'encryptatrest',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      crmcustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      crmcustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    globalsearch: new Field(
+      crmcustomfieldElemID,
+      'globalsearch',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    isformula: new Field(
+      crmcustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      crmcustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      crmcustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      crmcustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      crmcustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      crmcustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      crmcustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    showhierarchy: new Field(
+      crmcustomfieldElemID,
+      'showhierarchy',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showinlist: new Field(
+      crmcustomfieldElemID,
+      'showinlist',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    sourcefilterby: new Field(
+      crmcustomfieldElemID,
+      'sourcefilterby',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcefrom: new Field(
+      crmcustomfieldElemID,
+      'sourcefrom',
+      BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcelist: new Field(
+      crmcustomfieldElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the crmcustomfield custom type.   For information about other possible values, see generic_standard_field. */
+    isparent: new Field(
+      crmcustomfieldElemID,
+      'isparent',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    parentsubtab: new Field(
+      crmcustomfieldElemID,
+      'parentsubtab',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   subtab   subtab   For information about other possible values, see generic_tab_parent. */
+    subtab: new Field(
+      crmcustomfieldElemID,
+      'subtab',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the subtab custom type.   For information about other possible values, see generic_crm_tab. */
+    appliestocampaign: new Field(
+      crmcustomfieldElemID,
+      'appliestocampaign',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the MARKETING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. MARKETING must be enabled for this field to appear in your account. */
+    appliestocase: new Field(
+      crmcustomfieldElemID,
+      'appliestocase',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the SUPPORT feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. SUPPORT must be enabled for this field to appear in your account. */
+    appliestoevent: new Field(
+      crmcustomfieldElemID,
+      'appliestoevent',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestoissue: new Field(
+      crmcustomfieldElemID,
+      'appliestoissue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ISSUEDB feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ISSUEDB must be enabled for this field to appear in your account. */
+    appliestomfgprojecttask: new Field(
+      crmcustomfieldElemID,
+      'appliestomfgprojecttask',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the MFGROUTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. MFGROUTING must be enabled for this field to appear in your account. */
+    appliesperkeyword: new Field(
+      crmcustomfieldElemID,
+      'appliesperkeyword',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the MARKETING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. MARKETING must be enabled for this field to appear in your account. */
+    appliestophonecall: new Field(
+      crmcustomfieldElemID,
+      'appliestophonecall',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestoprojecttask: new Field(
+      crmcustomfieldElemID,
+      'appliestoprojecttask',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ADVANCEDJOBS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ADVANCEDJOBS must be enabled for this field to appear in your account. */
+    appliestoresourceallocation: new Field(
+      crmcustomfieldElemID,
+      'appliestoresourceallocation',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the RESOURCEALLOCATIONS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. RESOURCEALLOCATIONS must be enabled for this field to appear in your account. */
+    appliestosolution: new Field(
+      crmcustomfieldElemID,
+      'appliestosolution',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the KNOWLEDGEBASE feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. KNOWLEDGEBASE must be enabled for this field to appear in your account. */
+    appliestotask: new Field(
+      crmcustomfieldElemID,
+      'appliestotask',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    availableexternally: new Field(
+      crmcustomfieldElemID,
+      'availableexternally',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showissuechanges: new Field(
+      crmcustomfieldElemID,
+      'showissuechanges',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ISSUEDB feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ISSUEDB must be enabled for this field to appear in your account. */
+    customfieldfilters: new Field(
+      crmcustomfieldElemID,
+      'customfieldfilters',
+      crmcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      crmcustomfieldElemID,
+      'roleaccesses',
+      crmcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, crmcustomfieldElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/customglplugin.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/customglplugin.ts
@@ -1,0 +1,182 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const customglpluginInnerTypes: ObjectType[] = []
+
+const customglpluginElemID = new ElemID(constants.NETSUITE, 'customglplugin')
+const customglplugin_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'customglplugin_libraries_library')
+
+const customglplugin_libraries_library = new ObjectType({
+  elemID: customglplugin_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      customglplugin_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customglpluginElemID.name],
+})
+
+customglpluginInnerTypes.push(customglplugin_libraries_library)
+
+const customglplugin_librariesElemID = new ElemID(constants.NETSUITE, 'customglplugin_libraries')
+
+const customglplugin_libraries = new ObjectType({
+  elemID: customglplugin_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      customglplugin_librariesElemID,
+      'library',
+      new ListType(customglplugin_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customglpluginElemID.name],
+})
+
+customglpluginInnerTypes.push(customglplugin_libraries)
+
+
+export const customglplugin = new ObjectType({
+  elemID: customglpluginElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      customglpluginElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      customglpluginElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      customglpluginElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    description: new Field(
+      customglpluginElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      customglpluginElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      customglpluginElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      customglpluginElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      customglpluginElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      customglpluginElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      customglpluginElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    loglevel: new Field(
+      customglpluginElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+    runasrole: new Field(
+      customglpluginElemID,
+      'runasrole',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    status: new Field(
+      customglpluginElemID,
+      'status',
+      enums.script_status,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+    libraries: new Field(
+      customglpluginElemID,
+      'libraries',
+      customglplugin_libraries,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customglpluginElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/customlist.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/customlist.ts
@@ -1,0 +1,152 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+
+export const customlistInnerTypes: ObjectType[] = []
+
+const customlistElemID = new ElemID(constants.NETSUITE, 'customlist')
+const customlist_customvalues_customvalueElemID = new ElemID(constants.NETSUITE, 'customlist_customvalues_customvalue')
+
+const customlist_customvalues_customvalue = new ObjectType({
+  elemID: customlist_customvalues_customvalueElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      customlist_customvalues_customvalueElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long. */
+    value: new Field(
+      customlist_customvalues_customvalueElemID,
+      'value',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    abbreviation: new Field(
+      customlist_customvalues_customvalueElemID,
+      'abbreviation',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is mandatory when the ismatrixoption value is equal to T.   If this field appears in the project, you must reference the MATRIXITEMS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. MATRIXITEMS must be enabled for this field to appear in your account. */
+    isinactive: new Field(
+      customlist_customvalues_customvalueElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customlistElemID.name],
+})
+
+customlistInnerTypes.push(customlist_customvalues_customvalue)
+
+const customlist_customvaluesElemID = new ElemID(constants.NETSUITE, 'customlist_customvalues')
+
+const customlist_customvalues = new ObjectType({
+  elemID: customlist_customvaluesElemID,
+  annotations: {
+  },
+  fields: {
+    customvalue: new Field(
+      customlist_customvaluesElemID,
+      'customvalue',
+      new ListType(customlist_customvalues_customvalue),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customlistElemID.name],
+})
+
+customlistInnerTypes.push(customlist_customvalues)
+
+
+export const customlist = new ObjectType({
+  elemID: customlistElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customlist_',
+  },
+  fields: {
+    scriptid: new Field(
+      customlistElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 38 characters long.   The default value is ‘customlist’. */
+    name: new Field(
+      customlistElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 30,
+      },
+    ), /* Original description: This field value can be up to 30 characters long. */
+    description: new Field(
+      customlistElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    isinactive: new Field(
+      customlistElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismatrixoption: new Field(
+      customlistElemID,
+      'ismatrixoption',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the MATRIXITEMS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. MATRIXITEMS must be enabled for this field to appear in your account. */
+    isordered: new Field(
+      customlistElemID,
+      'isordered',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    customvalues: new Field(
+      customlistElemID,
+      'customvalues',
+      customlist_customvalues,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customlistElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/customrecordtype.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/customrecordtype.ts
@@ -1,0 +1,1151 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const customrecordtypeInnerTypes: ObjectType[] = []
+
+const customrecordtypeElemID = new ElemID(constants.NETSUITE, 'customrecordtype')
+const customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilter')
+
+const customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilter)
+
+const customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters')
+
+const customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters = new ObjectType({
+  elemID: customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters)
+
+const customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses_roleaccess')
+
+const customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses_roleaccess)
+
+const customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses')
+
+const customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses = new ObjectType({
+  elemID: customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses)
+
+const customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID = new ElemID(constants.NETSUITE, 'customrecordtype_customrecordcustomfields_customrecordcustomfield')
+
+const customrecordtype_customrecordcustomfields_customrecordcustomfield = new ObjectType({
+  elemID: customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custrecord’. */
+    fieldtype: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    encryptatrest: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'encryptatrest',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    globalsearch: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'globalsearch',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    isformula: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    showinlist: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'showinlist',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    sourcefilterby: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'sourcefilterby',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcefrom: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'sourcefrom',
+      BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcelist: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the customrecordcustomfield custom type.   For information about other possible values, see generic_standard_field. */
+    isparent: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'isparent',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    parentsubtab: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'parentsubtab',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   subtab   subtab   For information about other possible values, see generic_tab_parent. */
+    subtab: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'subtab',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the subtab custom type. */
+    allowquickadd: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'allowquickadd',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    rolerestrict: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'rolerestrict',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    customfieldfilters: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'customfieldfilters',
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      customrecordtype_customrecordcustomfields_customrecordcustomfieldElemID,
+      'roleaccesses',
+      customrecordtype_customrecordcustomfields_customrecordcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_customrecordcustomfields_customrecordcustomfield)
+
+const customrecordtype_customrecordcustomfieldsElemID = new ElemID(constants.NETSUITE, 'customrecordtype_customrecordcustomfields')
+
+const customrecordtype_customrecordcustomfields = new ObjectType({
+  elemID: customrecordtype_customrecordcustomfieldsElemID,
+  annotations: {
+  },
+  fields: {
+    customrecordcustomfield: new Field(
+      customrecordtype_customrecordcustomfieldsElemID,
+      'customrecordcustomfield',
+      new ListType(customrecordtype_customrecordcustomfields_customrecordcustomfield),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_customrecordcustomfields)
+
+const customrecordtype_instances_instanceElemID = new ElemID(constants.NETSUITE, 'customrecordtype_instances_instance')
+
+const customrecordtype_instances_instance = new ObjectType({
+  elemID: customrecordtype_instances_instanceElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      customrecordtype_instances_instanceElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long. */
+    altname: new Field(
+      customrecordtype_instances_instanceElemID,
+      'altname',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is available when the includename value is equal to T.   This field is available when the enablenumbering value is equal to T.   This field is mandatory when the includename value is equal to T.   This field is mandatory when the enablenumbering value is equal to T. */
+    name: new Field(
+      customrecordtype_instances_instanceElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is available when the includename value is equal to T.   This field is available when the enablenumbering value is equal to F.   This field is mandatory when the includename value is equal to T.   This field is mandatory when the enablenumbering value is equal to F. */
+    isinactive: new Field(
+      customrecordtype_instances_instanceElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    parent: new Field(
+      customrecordtype_instances_instanceElemID,
+      'parent',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is available when the hierarchical value is equal to T.   This field accepts references to the instance custom type. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_instances_instance)
+
+const customrecordtype_instancesElemID = new ElemID(constants.NETSUITE, 'customrecordtype_instances')
+
+const customrecordtype_instances = new ObjectType({
+  elemID: customrecordtype_instancesElemID,
+  annotations: {
+  },
+  fields: {
+    instance: new Field(
+      customrecordtype_instancesElemID,
+      'instance',
+      new ListType(customrecordtype_instances_instance),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_instances)
+
+const customrecordtype_links_linkElemID = new ElemID(constants.NETSUITE, 'customrecordtype_links_link')
+
+const customrecordtype_links_link = new ObjectType({
+  elemID: customrecordtype_links_linkElemID,
+  annotations: {
+  },
+  fields: {
+    linkcategory: new Field(
+      customrecordtype_links_linkElemID,
+      'linkcategory',
+      enums.generic_centercategory,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_centercategory. */
+    linktasktype: new Field(
+      customrecordtype_links_linkElemID,
+      'linktasktype',
+      enums.customrecordtype_tasktype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see customrecordtype_tasktype. */
+    linklabel: new Field(
+      customrecordtype_links_linkElemID,
+      'linklabel',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_links_link)
+
+const customrecordtype_linksElemID = new ElemID(constants.NETSUITE, 'customrecordtype_links')
+
+const customrecordtype_links = new ObjectType({
+  elemID: customrecordtype_linksElemID,
+  annotations: {
+  },
+  fields: {
+    link: new Field(
+      customrecordtype_linksElemID,
+      'link',
+      new ListType(customrecordtype_links_link),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_links)
+
+const customrecordtype_permissions_permissionElemID = new ElemID(constants.NETSUITE, 'customrecordtype_permissions_permission')
+
+const customrecordtype_permissions_permission = new ObjectType({
+  elemID: customrecordtype_permissions_permissionElemID,
+  annotations: {
+  },
+  fields: {
+    permittedrole: new Field(
+      customrecordtype_permissions_permissionElemID,
+      'permittedrole',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    permittedlevel: new Field(
+      customrecordtype_permissions_permissionElemID,
+      'permittedlevel',
+      enums.generic_permission_level,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_permission_level.   The default value is 'NONE'. */
+    restriction: new Field(
+      customrecordtype_permissions_permissionElemID,
+      'restriction',
+      enums.role_restrict,
+      {
+      },
+    ), /* Original description: For information about possible values, see role_restrict. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_permissions_permission)
+
+const customrecordtype_permissionsElemID = new ElemID(constants.NETSUITE, 'customrecordtype_permissions')
+
+const customrecordtype_permissions = new ObjectType({
+  elemID: customrecordtype_permissionsElemID,
+  annotations: {
+  },
+  fields: {
+    permission: new Field(
+      customrecordtype_permissionsElemID,
+      'permission',
+      new ListType(customrecordtype_permissions_permission),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_permissions)
+
+const customrecordtype_recordsublists_recordsublistElemID = new ElemID(constants.NETSUITE, 'customrecordtype_recordsublists_recordsublist')
+
+const customrecordtype_recordsublists_recordsublist = new ObjectType({
+  elemID: customrecordtype_recordsublists_recordsublistElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      customrecordtype_recordsublists_recordsublistElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long. */
+    recordsearch: new Field(
+      customrecordtype_recordsublists_recordsublistElemID,
+      'recordsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    recorddescr: new Field(
+      customrecordtype_recordsublists_recordsublistElemID,
+      'recorddescr',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    recordtab: new Field(
+      customrecordtype_recordsublists_recordsublistElemID,
+      'recordtab',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the subtab custom type. */
+    recordfield: new Field(
+      customrecordtype_recordsublists_recordsublistElemID,
+      'recordfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the customrecordcustomfield custom type.   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_recordsublists_recordsublist)
+
+const customrecordtype_recordsublistsElemID = new ElemID(constants.NETSUITE, 'customrecordtype_recordsublists')
+
+const customrecordtype_recordsublists = new ObjectType({
+  elemID: customrecordtype_recordsublistsElemID,
+  annotations: {
+  },
+  fields: {
+    recordsublist: new Field(
+      customrecordtype_recordsublistsElemID,
+      'recordsublist',
+      new ListType(customrecordtype_recordsublists_recordsublist),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_recordsublists)
+
+const customrecordtype_subtabs_subtabElemID = new ElemID(constants.NETSUITE, 'customrecordtype_subtabs_subtab')
+
+const customrecordtype_subtabs_subtab = new ObjectType({
+  elemID: customrecordtype_subtabs_subtabElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      customrecordtype_subtabs_subtabElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long. */
+    tabtitle: new Field(
+      customrecordtype_subtabs_subtabElemID,
+      'tabtitle',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    tabparent: new Field(
+      customrecordtype_subtabs_subtabElemID,
+      'tabparent',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the subtab custom type. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_subtabs_subtab)
+
+const customrecordtype_subtabsElemID = new ElemID(constants.NETSUITE, 'customrecordtype_subtabs')
+
+const customrecordtype_subtabs = new ObjectType({
+  elemID: customrecordtype_subtabsElemID,
+  annotations: {
+  },
+  fields: {
+    subtab: new Field(
+      customrecordtype_subtabsElemID,
+      'subtab',
+      new ListType(customrecordtype_subtabs_subtab),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})
+
+customrecordtypeInnerTypes.push(customrecordtype_subtabs)
+
+
+export const customrecordtype = new ObjectType({
+  elemID: customrecordtypeElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customrecord_',
+  },
+  fields: {
+    scriptid: new Field(
+      customrecordtypeElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customrecord’. */
+    recordname: new Field(
+      customrecordtypeElemID,
+      'recordname',
+      BuiltinTypes.STRING,
+      {
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long.   This field is available when the customsegment value is equal to   This field is mandatory when the customsegment value is equal to */
+    customsegment: new Field(
+      customrecordtypeElemID,
+      'customsegment',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the customsegment custom type.   If this field appears in the project, you must reference the CUSTOMSEGMENTS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CUSTOMSEGMENTS must be enabled for this field to appear in your account. */
+    accesstype: new Field(
+      customrecordtypeElemID,
+      'accesstype',
+      enums.customrecordtype_accesstype,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to   For information about possible values, see customrecordtype_accesstype.   The default value is 'CUSTRECORDENTRYPERM'. */
+    allowattachments: new Field(
+      customrecordtypeElemID,
+      'allowattachments',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    allowinlineediting: new Field(
+      customrecordtypeElemID,
+      'allowinlineediting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allowinlinedeleting: new Field(
+      customrecordtypeElemID,
+      'allowinlinedeleting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allowinlinedetaching: new Field(
+      customrecordtypeElemID,
+      'allowinlinedetaching',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allowmobileaccess: new Field(
+      customrecordtypeElemID,
+      'allowmobileaccess',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to   The default value is F. */
+    allownumberingoverride: new Field(
+      customrecordtypeElemID,
+      'allownumberingoverride',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to   The default value is F. */
+    allowquickadd: new Field(
+      customrecordtypeElemID,
+      'allowquickadd',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    allowquicksearch: new Field(
+      customrecordtypeElemID,
+      'allowquicksearch',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allowuiaccess: new Field(
+      customrecordtypeElemID,
+      'allowuiaccess',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to   The default value is T. */
+    description: new Field(
+      customrecordtypeElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to */
+    enabledle: new Field(
+      customrecordtypeElemID,
+      'enabledle',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T.   If this field appears in the project, you must reference the EXTREMELIST feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. EXTREMELIST must be enabled for this field to appear in your account. */
+    enablekeywords: new Field(
+      customrecordtypeElemID,
+      'enablekeywords',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    enablemailmerge: new Field(
+      customrecordtypeElemID,
+      'enablemailmerge',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the MAILMERGE feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. MAILMERGE must be enabled for this field to appear in your account. */
+    enablenametranslation: new Field(
+      customrecordtypeElemID,
+      'enablenametranslation',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to   The default value is F.   If this field appears in the project, you must reference the MULTILANGUAGE feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. MULTILANGUAGE must be enabled for this field to appear in your account. */
+    enablenumbering: new Field(
+      customrecordtypeElemID,
+      'enablenumbering',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to   The default value is F. */
+    enableoptimisticlocking: new Field(
+      customrecordtypeElemID,
+      'enableoptimisticlocking',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    enablesystemnotes: new Field(
+      customrecordtypeElemID,
+      'enablesystemnotes',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    hierarchical: new Field(
+      customrecordtypeElemID,
+      'hierarchical',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to   The default value is F. */
+    numberingprefix: new Field(
+      customrecordtypeElemID,
+      'numberingprefix',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to */
+    numberingsuffix: new Field(
+      customrecordtypeElemID,
+      'numberingsuffix',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to */
+    numberingmindigits: new Field(
+      customrecordtypeElemID,
+      'numberingmindigits',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to */
+    numberinginit: new Field(
+      customrecordtypeElemID,
+      'numberinginit',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to */
+    icon: new Field(
+      customrecordtypeElemID,
+      'icon',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+      },
+    ),
+    iconbuiltin: new Field(
+      customrecordtypeElemID,
+      'iconbuiltin',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    iconindex: new Field(
+      customrecordtypeElemID,
+      'iconindex',
+      enums.generic_custom_record_icon,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_custom_record_icon. */
+    includeinsearchmenu: new Field(
+      customrecordtypeElemID,
+      'includeinsearchmenu',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    includename: new Field(
+      customrecordtypeElemID,
+      'includename',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to   The default value is T. */
+    isinactive: new Field(
+      customrecordtypeElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to   The default value is F. */
+    isordered: new Field(
+      customrecordtypeElemID,
+      'isordered',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to   The default value is F. */
+    showcreationdate: new Field(
+      customrecordtypeElemID,
+      'showcreationdate',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showcreationdateonlist: new Field(
+      customrecordtypeElemID,
+      'showcreationdateonlist',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showid: new Field(
+      customrecordtypeElemID,
+      'showid',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the customsegment value is equal to   The default value is F. */
+    showlastmodified: new Field(
+      customrecordtypeElemID,
+      'showlastmodified',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showlastmodifiedonlist: new Field(
+      customrecordtypeElemID,
+      'showlastmodifiedonlist',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    shownotes: new Field(
+      customrecordtypeElemID,
+      'shownotes',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    showowner: new Field(
+      customrecordtypeElemID,
+      'showowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showownerallowchange: new Field(
+      customrecordtypeElemID,
+      'showownerallowchange',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showowneronlist: new Field(
+      customrecordtypeElemID,
+      'showowneronlist',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    customrecordcustomfields: new Field(
+      customrecordtypeElemID,
+      'customrecordcustomfields',
+      customrecordtype_customrecordcustomfields,
+      {
+      },
+    ),
+    instances: new Field(
+      customrecordtypeElemID,
+      'instances',
+      customrecordtype_instances,
+      {
+      },
+    ),
+    links: new Field(
+      customrecordtypeElemID,
+      'links',
+      customrecordtype_links,
+      {
+      },
+    ),
+    permissions: new Field(
+      customrecordtypeElemID,
+      'permissions',
+      customrecordtype_permissions,
+      {
+      },
+    ),
+    recordsublists: new Field(
+      customrecordtypeElemID,
+      'recordsublists',
+      customrecordtype_recordsublists,
+      {
+      },
+    ),
+    subtabs: new Field(
+      customrecordtypeElemID,
+      'subtabs',
+      customrecordtype_subtabs,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customrecordtypeElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/customsegment.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/customsegment.ts
@@ -1,0 +1,729 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const customsegmentInnerTypes: ObjectType[] = []
+
+const customsegmentElemID = new ElemID(constants.NETSUITE, 'customsegment')
+const customsegment_permissions_permissionElemID = new ElemID(constants.NETSUITE, 'customsegment_permissions_permission')
+
+const customsegment_permissions_permission = new ObjectType({
+  elemID: customsegment_permissions_permissionElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      customsegment_permissions_permissionElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    valuemgmtaccesslevel: new Field(
+      customsegment_permissions_permissionElemID,
+      'valuemgmtaccesslevel',
+      enums.generic_permission_level,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_permission_level.   The default value is 'NONE'. */
+    recordaccesslevel: new Field(
+      customsegment_permissions_permissionElemID,
+      'recordaccesslevel',
+      enums.customsegment_access_search_level,
+      {
+      },
+    ), /* Original description: For information about possible values, see customsegment_access_search_level. */
+    searchaccesslevel: new Field(
+      customsegment_permissions_permissionElemID,
+      'searchaccesslevel',
+      enums.customsegment_access_search_level,
+      {
+      },
+    ), /* Original description: For information about possible values, see customsegment_access_search_level. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_permissions_permission)
+
+const customsegment_permissionsElemID = new ElemID(constants.NETSUITE, 'customsegment_permissions')
+
+const customsegment_permissions = new ObjectType({
+  elemID: customsegment_permissionsElemID,
+  annotations: {
+  },
+  fields: {
+    permission: new Field(
+      customsegment_permissionsElemID,
+      'permission',
+      new ListType(customsegment_permissions_permission),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_permissions)
+
+const customsegment_segmentapplication_crm_applications_applicationElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_crm_applications_application')
+
+const customsegment_segmentapplication_crm_applications_application = new ObjectType({
+  elemID: customsegment_segmentapplication_crm_applications_applicationElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      customsegment_segmentapplication_crm_applications_applicationElemID,
+      'id',
+      enums.customsegment_crm_application_id,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see customsegment_crm_application_id. */
+    isapplied: new Field(
+      customsegment_segmentapplication_crm_applications_applicationElemID,
+      'isapplied',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_crm_applications_application)
+
+const customsegment_segmentapplication_crm_applicationsElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_crm_applications')
+
+const customsegment_segmentapplication_crm_applications = new ObjectType({
+  elemID: customsegment_segmentapplication_crm_applicationsElemID,
+  annotations: {
+  },
+  fields: {
+    application: new Field(
+      customsegment_segmentapplication_crm_applicationsElemID,
+      'application',
+      new ListType(customsegment_segmentapplication_crm_applications_application),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_crm_applications)
+
+const customsegment_segmentapplication_crmElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_crm')
+
+const customsegment_segmentapplication_crm = new ObjectType({
+  elemID: customsegment_segmentapplication_crmElemID,
+  annotations: {
+  },
+  fields: {
+    sourcelist: new Field(
+      customsegment_segmentapplication_crmElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the crmcustomfield custom type.   For information about other possible values, see customsegment_crm_sourcelist. */
+    applications: new Field(
+      customsegment_segmentapplication_crmElemID,
+      'applications',
+      customsegment_segmentapplication_crm_applications,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_crm)
+
+const customsegment_segmentapplication_customrecords_applications_applicationElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_customrecords_applications_application')
+
+const customsegment_segmentapplication_customrecords_applications_application = new ObjectType({
+  elemID: customsegment_segmentapplication_customrecords_applications_applicationElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      customsegment_segmentapplication_customrecords_applications_applicationElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the customrecordtype custom type. */
+    isapplied: new Field(
+      customsegment_segmentapplication_customrecords_applications_applicationElemID,
+      'isapplied',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    sourcelist: new Field(
+      customsegment_segmentapplication_customrecords_applications_applicationElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is available when the isapplied value is equal to T.   This field accepts references to the customrecordcustomfield custom type. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_customrecords_applications_application)
+
+const customsegment_segmentapplication_customrecords_applicationsElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_customrecords_applications')
+
+const customsegment_segmentapplication_customrecords_applications = new ObjectType({
+  elemID: customsegment_segmentapplication_customrecords_applicationsElemID,
+  annotations: {
+  },
+  fields: {
+    application: new Field(
+      customsegment_segmentapplication_customrecords_applicationsElemID,
+      'application',
+      new ListType(customsegment_segmentapplication_customrecords_applications_application),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_customrecords_applications)
+
+const customsegment_segmentapplication_customrecordsElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_customrecords')
+
+const customsegment_segmentapplication_customrecords = new ObjectType({
+  elemID: customsegment_segmentapplication_customrecordsElemID,
+  annotations: {
+  },
+  fields: {
+    applications: new Field(
+      customsegment_segmentapplication_customrecordsElemID,
+      'applications',
+      customsegment_segmentapplication_customrecords_applications,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_customrecords)
+
+const customsegment_segmentapplication_entities_applications_applicationElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_entities_applications_application')
+
+const customsegment_segmentapplication_entities_applications_application = new ObjectType({
+  elemID: customsegment_segmentapplication_entities_applications_applicationElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      customsegment_segmentapplication_entities_applications_applicationElemID,
+      'id',
+      enums.customsegment_entities_application_id,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see customsegment_entities_application_id. */
+    isapplied: new Field(
+      customsegment_segmentapplication_entities_applications_applicationElemID,
+      'isapplied',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_entities_applications_application)
+
+const customsegment_segmentapplication_entities_applicationsElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_entities_applications')
+
+const customsegment_segmentapplication_entities_applications = new ObjectType({
+  elemID: customsegment_segmentapplication_entities_applicationsElemID,
+  annotations: {
+  },
+  fields: {
+    application: new Field(
+      customsegment_segmentapplication_entities_applicationsElemID,
+      'application',
+      new ListType(customsegment_segmentapplication_entities_applications_application),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_entities_applications)
+
+const customsegment_segmentapplication_entitiesElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_entities')
+
+const customsegment_segmentapplication_entities = new ObjectType({
+  elemID: customsegment_segmentapplication_entitiesElemID,
+  annotations: {
+  },
+  fields: {
+    sourcelist: new Field(
+      customsegment_segmentapplication_entitiesElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the entitycustomfield custom type.   For information about other possible values, see customsegment_entities_sourcelist. */
+    applications: new Field(
+      customsegment_segmentapplication_entitiesElemID,
+      'applications',
+      customsegment_segmentapplication_entities_applications,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_entities)
+
+const customsegment_segmentapplication_items_applications_applicationElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_items_applications_application')
+
+const customsegment_segmentapplication_items_applications_application = new ObjectType({
+  elemID: customsegment_segmentapplication_items_applications_applicationElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      customsegment_segmentapplication_items_applications_applicationElemID,
+      'id',
+      enums.customsegment_items_application_id,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see customsegment_items_application_id. */
+    isapplied: new Field(
+      customsegment_segmentapplication_items_applications_applicationElemID,
+      'isapplied',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_items_applications_application)
+
+const customsegment_segmentapplication_items_applicationsElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_items_applications')
+
+const customsegment_segmentapplication_items_applications = new ObjectType({
+  elemID: customsegment_segmentapplication_items_applicationsElemID,
+  annotations: {
+  },
+  fields: {
+    application: new Field(
+      customsegment_segmentapplication_items_applicationsElemID,
+      'application',
+      new ListType(customsegment_segmentapplication_items_applications_application),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_items_applications)
+
+const customsegment_segmentapplication_itemsElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_items')
+
+const customsegment_segmentapplication_items = new ObjectType({
+  elemID: customsegment_segmentapplication_itemsElemID,
+  annotations: {
+  },
+  fields: {
+    subtype: new Field(
+      customsegment_segmentapplication_itemsElemID,
+      'subtype',
+      enums.customsegment_items_subtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see customsegment_items_subtype.   The default value is 'BOTH'. */
+    sourcelist: new Field(
+      customsegment_segmentapplication_itemsElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the itemcustomfield custom type.   For information about other possible values, see customsegment_items_sourcelist. */
+    applications: new Field(
+      customsegment_segmentapplication_itemsElemID,
+      'applications',
+      customsegment_segmentapplication_items_applications,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_items)
+
+const customsegment_segmentapplication_transactionbody_applications_applicationElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_transactionbody_applications_application')
+
+const customsegment_segmentapplication_transactionbody_applications_application = new ObjectType({
+  elemID: customsegment_segmentapplication_transactionbody_applications_applicationElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      customsegment_segmentapplication_transactionbody_applications_applicationElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the customtransactiontype custom type.   For information about other possible values, see customsegment_transactionbody_application_id. */
+    isapplied: new Field(
+      customsegment_segmentapplication_transactionbody_applications_applicationElemID,
+      'isapplied',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_transactionbody_applications_application)
+
+const customsegment_segmentapplication_transactionbody_applicationsElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_transactionbody_applications')
+
+const customsegment_segmentapplication_transactionbody_applications = new ObjectType({
+  elemID: customsegment_segmentapplication_transactionbody_applicationsElemID,
+  annotations: {
+  },
+  fields: {
+    application: new Field(
+      customsegment_segmentapplication_transactionbody_applicationsElemID,
+      'application',
+      new ListType(customsegment_segmentapplication_transactionbody_applications_application),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_transactionbody_applications)
+
+const customsegment_segmentapplication_transactionbodyElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_transactionbody')
+
+const customsegment_segmentapplication_transactionbody = new ObjectType({
+  elemID: customsegment_segmentapplication_transactionbodyElemID,
+  annotations: {
+  },
+  fields: {
+    sourcelist: new Field(
+      customsegment_segmentapplication_transactionbodyElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the transactionbodycustomfield custom type.   For information about other possible values, see customsegment_transactionbody_sourcelist. */
+    applications: new Field(
+      customsegment_segmentapplication_transactionbodyElemID,
+      'applications',
+      customsegment_segmentapplication_transactionbody_applications,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_transactionbody)
+
+const customsegment_segmentapplication_transactionline_applications_applicationElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_transactionline_applications_application')
+
+const customsegment_segmentapplication_transactionline_applications_application = new ObjectType({
+  elemID: customsegment_segmentapplication_transactionline_applications_applicationElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      customsegment_segmentapplication_transactionline_applications_applicationElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the customtransactiontype custom type.   For information about other possible values, see customsegment_transactionline_application_id. */
+    isapplied: new Field(
+      customsegment_segmentapplication_transactionline_applications_applicationElemID,
+      'isapplied',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_transactionline_applications_application)
+
+const customsegment_segmentapplication_transactionline_applicationsElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_transactionline_applications')
+
+const customsegment_segmentapplication_transactionline_applications = new ObjectType({
+  elemID: customsegment_segmentapplication_transactionline_applicationsElemID,
+  annotations: {
+  },
+  fields: {
+    application: new Field(
+      customsegment_segmentapplication_transactionline_applicationsElemID,
+      'application',
+      new ListType(customsegment_segmentapplication_transactionline_applications_application),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_transactionline_applications)
+
+const customsegment_segmentapplication_transactionlineElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication_transactionline')
+
+const customsegment_segmentapplication_transactionline = new ObjectType({
+  elemID: customsegment_segmentapplication_transactionlineElemID,
+  annotations: {
+  },
+  fields: {
+    sourcelist: new Field(
+      customsegment_segmentapplication_transactionlineElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   For information about other possible values, see customsegment_transactionline_sourcelist. */
+    applications: new Field(
+      customsegment_segmentapplication_transactionlineElemID,
+      'applications',
+      customsegment_segmentapplication_transactionline_applications,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication_transactionline)
+
+const customsegment_segmentapplicationElemID = new ElemID(constants.NETSUITE, 'customsegment_segmentapplication')
+
+const customsegment_segmentapplication = new ObjectType({
+  elemID: customsegment_segmentapplicationElemID,
+  annotations: {
+  },
+  fields: {
+    crm: new Field(
+      customsegment_segmentapplicationElemID,
+      'crm',
+      customsegment_segmentapplication_crm,
+      {
+      },
+    ),
+    customrecords: new Field(
+      customsegment_segmentapplicationElemID,
+      'customrecords',
+      customsegment_segmentapplication_customrecords,
+      {
+      },
+    ),
+    entities: new Field(
+      customsegment_segmentapplicationElemID,
+      'entities',
+      customsegment_segmentapplication_entities,
+      {
+      },
+    ),
+    items: new Field(
+      customsegment_segmentapplicationElemID,
+      'items',
+      customsegment_segmentapplication_items,
+      {
+      },
+    ),
+    transactionbody: new Field(
+      customsegment_segmentapplicationElemID,
+      'transactionbody',
+      customsegment_segmentapplication_transactionbody,
+      {
+      },
+    ),
+    transactionline: new Field(
+      customsegment_segmentapplicationElemID,
+      'transactionline',
+      customsegment_segmentapplication_transactionline,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})
+
+customsegmentInnerTypes.push(customsegment_segmentapplication)
+
+
+export const customsegment = new ObjectType({
+  elemID: customsegmentElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'cseg_',
+  },
+  fields: {
+    scriptid: new Field(
+      customsegmentElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 19 characters long.   The default value is ‘cseg’. */
+    label: new Field(
+      customsegmentElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    recordtype: new Field(
+      customsegmentElemID,
+      'recordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the customrecordtype custom type. */
+    filteredby: new Field(
+      customsegmentElemID,
+      'filteredby',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the customsegment custom type.   For information about other possible values, see customsegment_parent. */
+    fieldtype: new Field(
+      customsegmentElemID,
+      'fieldtype',
+      enums.customsegment_fieldtype,
+      {
+      },
+    ), /* Original description: For information about possible values, see customsegment_fieldtype. */
+    description: new Field(
+      customsegmentElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    help: new Field(
+      customsegmentElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    hasglimpact: new Field(
+      customsegmentElemID,
+      'hasglimpact',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      customsegmentElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      customsegmentElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is available when the fieldtype value is not equal to MULTISELECT.   This field accepts references to the instance custom type. */
+    defaultrecordaccesslevel: new Field(
+      customsegmentElemID,
+      'defaultrecordaccesslevel',
+      enums.customsegment_access_search_level,
+      {
+      },
+    ), /* Original description: For information about possible values, see customsegment_access_search_level. */
+    defaultsearchaccesslevel: new Field(
+      customsegmentElemID,
+      'defaultsearchaccesslevel',
+      enums.customsegment_access_search_level,
+      {
+      },
+    ), /* Original description: For information about possible values, see customsegment_access_search_level. */
+    valuesdisplayorder: new Field(
+      customsegmentElemID,
+      'valuesdisplayorder',
+      enums.customsegment_valuesdisplayorder,
+      {
+      },
+    ), /* Original description: For information about possible values, see customsegment_valuesdisplayorder. */
+    permissions: new Field(
+      customsegmentElemID,
+      'permissions',
+      customsegment_permissions,
+      {
+      },
+    ),
+    segmentapplication: new Field(
+      customsegmentElemID,
+      'segmentapplication',
+      customsegment_segmentapplication,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customsegmentElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/customtransactiontype.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/customtransactiontype.ts
@@ -1,0 +1,328 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const customtransactiontypeInnerTypes: ObjectType[] = []
+
+const customtransactiontypeElemID = new ElemID(constants.NETSUITE, 'customtransactiontype')
+const customtransactiontype_accountingElemID = new ElemID(constants.NETSUITE, 'customtransactiontype_accounting')
+
+const customtransactiontype_accounting = new ObjectType({
+  elemID: customtransactiontype_accountingElemID,
+  annotations: {
+  },
+  fields: {
+    specifyaccountontransaction: new Field(
+      customtransactiontype_accountingElemID,
+      'specifyaccountontransaction',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the transactionstyle value is present in customtransactiontype_subliststyle_salesandpurchase.   The default value is F. */
+    filterbyaccounttypeall: new Field(
+      customtransactiontype_accountingElemID,
+      'filterbyaccounttypeall',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the specifyaccountontransaction value is equal to T.   The default value is F. */
+    filterbyaccounttype: new Field(
+      customtransactiontype_accountingElemID,
+      'filterbyaccounttype',
+      enums.customtransactiontype_filterbyaccounttype,
+      {
+      },
+    ), /* Original description: This field is available when the specifyaccountontransaction value is equal to T.   This field is available when the filterbyaccounttypeall value is equal to F.   For information about possible values, see customtransactiontype_filterbyaccounttype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customtransactiontypeElemID.name],
+})
+
+customtransactiontypeInnerTypes.push(customtransactiontype_accounting)
+
+const customtransactiontype_permissions_permissionElemID = new ElemID(constants.NETSUITE, 'customtransactiontype_permissions_permission')
+
+const customtransactiontype_permissions_permission = new ObjectType({
+  elemID: customtransactiontype_permissions_permissionElemID,
+  annotations: {
+  },
+  fields: {
+    permittedrole: new Field(
+      customtransactiontype_permissions_permissionElemID,
+      'permittedrole',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    permittedlevel: new Field(
+      customtransactiontype_permissions_permissionElemID,
+      'permittedlevel',
+      enums.generic_permission_level,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_permission_level.   The default value is 'NONE'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customtransactiontypeElemID.name],
+})
+
+customtransactiontypeInnerTypes.push(customtransactiontype_permissions_permission)
+
+const customtransactiontype_permissionsElemID = new ElemID(constants.NETSUITE, 'customtransactiontype_permissions')
+
+const customtransactiontype_permissions = new ObjectType({
+  elemID: customtransactiontype_permissionsElemID,
+  annotations: {
+  },
+  fields: {
+    permission: new Field(
+      customtransactiontype_permissionsElemID,
+      'permission',
+      new ListType(customtransactiontype_permissions_permission),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customtransactiontypeElemID.name],
+})
+
+customtransactiontypeInnerTypes.push(customtransactiontype_permissions)
+
+const customtransactiontype_segmentsElemID = new ElemID(constants.NETSUITE, 'customtransactiontype_segments')
+
+const customtransactiontype_segments = new ObjectType({
+  elemID: customtransactiontype_segmentsElemID,
+  annotations: {
+  },
+  fields: {
+    classposition: new Field(
+      customtransactiontype_segmentsElemID,
+      'classposition',
+      enums.customtransactiontype_classification_position,
+      {
+      },
+    ), /* Original description: This field is available when the transactionstyle value is not present in customtransactiontype_subliststyle_salesandpurchase.   For information about possible values, see customtransactiontype_classification_position.   The default value is 'NONE'.   If this field appears in the project, you must reference the CLASSES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CLASSES must be enabled for this field to appear in your account. */
+    isclassmandatory: new Field(
+      customtransactiontype_segmentsElemID,
+      'isclassmandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the classposition value is not equal to NONE.   This field is available when the transactionstyle value is not present in customtransactiontype_subliststyle_salesandpurchase.   The default value is F.   If this field appears in the project, you must reference the CLASSES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CLASSES must be enabled for this field to appear in your account. */
+    departmentposition: new Field(
+      customtransactiontype_segmentsElemID,
+      'departmentposition',
+      enums.customtransactiontype_classification_position,
+      {
+      },
+    ), /* Original description: This field is available when the transactionstyle value is not present in customtransactiontype_subliststyle_salesandpurchase.   For information about possible values, see customtransactiontype_classification_position.   The default value is 'NONE'.   If this field appears in the project, you must reference the DEPARTMENTS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. DEPARTMENTS must be enabled for this field to appear in your account. */
+    isdepartmentmandatory: new Field(
+      customtransactiontype_segmentsElemID,
+      'isdepartmentmandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the departmentposition value is not equal to NONE.   This field is available when the transactionstyle value is not present in customtransactiontype_subliststyle_salesandpurchase.   The default value is F.   If this field appears in the project, you must reference the DEPARTMENTS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. DEPARTMENTS must be enabled for this field to appear in your account. */
+    locationposition: new Field(
+      customtransactiontype_segmentsElemID,
+      'locationposition',
+      enums.customtransactiontype_classification_position,
+      {
+      },
+    ), /* Original description: This field is available when the transactionstyle value is not present in customtransactiontype_subliststyle_salesandpurchase.   For information about possible values, see customtransactiontype_classification_position.   The default value is 'NONE'.   If this field appears in the project, you must reference the LOCATIONS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. LOCATIONS must be enabled for this field to appear in your account. */
+    islocationmandatory: new Field(
+      customtransactiontype_segmentsElemID,
+      'islocationmandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the locationposition value is not equal to NONE.   This field is available when the transactionstyle value is not present in customtransactiontype_subliststyle_salesandpurchase.   The default value is F.   If this field appears in the project, you must reference the LOCATIONS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. LOCATIONS must be enabled for this field to appear in your account. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customtransactiontypeElemID.name],
+})
+
+customtransactiontypeInnerTypes.push(customtransactiontype_segments)
+
+const customtransactiontype_statuses_statusElemID = new ElemID(constants.NETSUITE, 'customtransactiontype_statuses_status')
+
+const customtransactiontype_statuses_status = new ObjectType({
+  elemID: customtransactiontype_statuses_statusElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      customtransactiontype_statuses_statusElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long. */
+    description: new Field(
+      customtransactiontype_statuses_statusElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 480,
+      },
+    ), /* Original description: This field value can be up to 480 characters long. */
+    id: new Field(
+      customtransactiontype_statuses_statusElemID,
+      'id',
+      enums.customtransactiontype_statuses_id,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see customtransactiontype_statuses_id. */
+    isposting: new Field(
+      customtransactiontype_statuses_statusElemID,
+      'isposting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customtransactiontypeElemID.name],
+})
+
+customtransactiontypeInnerTypes.push(customtransactiontype_statuses_status)
+
+const customtransactiontype_statusesElemID = new ElemID(constants.NETSUITE, 'customtransactiontype_statuses')
+
+const customtransactiontype_statuses = new ObjectType({
+  elemID: customtransactiontype_statusesElemID,
+  annotations: {
+  },
+  fields: {
+    status: new Field(
+      customtransactiontype_statusesElemID,
+      'status',
+      new ListType(customtransactiontype_statuses_status),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customtransactiontypeElemID.name],
+})
+
+customtransactiontypeInnerTypes.push(customtransactiontype_statuses)
+
+
+export const customtransactiontype = new ObjectType({
+  elemID: customtransactiontypeElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customtransaction_',
+  },
+  fields: {
+    scriptid: new Field(
+      customtransactiontypeElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long. */
+    name: new Field(
+      customtransactiontypeElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 96,
+      },
+    ), /* Original description: This field value can be up to 96 characters long. */
+    subliststyle: new Field(
+      customtransactiontypeElemID,
+      'subliststyle',
+      enums.customtransactiontype_subliststyle,
+      {
+      },
+    ), /* Original description: This field is mandatory when the transactionstyle value is not defined.   For information about possible values, see customtransactiontype_subliststyle.   The default value is 'BASIC'. */
+    transactionstyle: new Field(
+      customtransactiontypeElemID,
+      'transactionstyle',
+      enums.customtransactiontype_subliststyle,
+      {
+      },
+    ), /* Original description: For information about possible values, see customtransactiontype_subliststyle.   The default value is 'BASIC'. */
+    iscredit: new Field(
+      customtransactiontypeElemID,
+      'iscredit',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the transactionstyle value is present in customtransactiontype_creditsupportstyles.   The default value is F. */
+    isposting: new Field(
+      customtransactiontypeElemID,
+      'isposting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showstatus: new Field(
+      customtransactiontypeElemID,
+      'showstatus',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    isvoidable: new Field(
+      customtransactiontypeElemID,
+      'isvoidable',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    accounting: new Field(
+      customtransactiontypeElemID,
+      'accounting',
+      customtransactiontype_accounting,
+      {
+      },
+    ),
+    permissions: new Field(
+      customtransactiontypeElemID,
+      'permissions',
+      customtransactiontype_permissions,
+      {
+      },
+    ),
+    segments: new Field(
+      customtransactiontypeElemID,
+      'segments',
+      customtransactiontype_segments,
+      {
+      },
+    ),
+    statuses: new Field(
+      customtransactiontypeElemID,
+      'statuses',
+      customtransactiontype_statuses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, customtransactiontypeElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/dataset.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/dataset.ts
@@ -1,0 +1,89 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+
+export const datasetInnerTypes: ObjectType[] = []
+
+const datasetElemID = new ElemID(constants.NETSUITE, 'dataset')
+const dataset_dependenciesElemID = new ElemID(constants.NETSUITE, 'dataset_dependencies')
+
+const dataset_dependencies = new ObjectType({
+  elemID: dataset_dependenciesElemID,
+  annotations: {
+  },
+  fields: {
+    dependency: new Field(
+      dataset_dependenciesElemID,
+      'dependency',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customtransactiontype   customsegment   customrecordcustomfield   customrecordtype   crmcustomfield */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, datasetElemID.name],
+})
+
+datasetInnerTypes.push(dataset_dependencies)
+
+
+export const dataset = new ObjectType({
+  elemID: datasetElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custdataset_',
+  },
+  fields: {
+    scriptid: new Field(
+      datasetElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custdataset’. */
+    name: new Field(
+      datasetElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 50,
+      },
+    ), /* Original description: This field value can be up to 50 characters long. */
+    definition: new Field(
+      datasetElemID,
+      'definition',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    dependencies: new Field(
+      datasetElemID,
+      'dependencies',
+      dataset_dependencies,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, datasetElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/emailcaptureplugin.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/emailcaptureplugin.ts
@@ -1,0 +1,182 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const emailcapturepluginInnerTypes: ObjectType[] = []
+
+const emailcapturepluginElemID = new ElemID(constants.NETSUITE, 'emailcaptureplugin')
+const emailcaptureplugin_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'emailcaptureplugin_libraries_library')
+
+const emailcaptureplugin_libraries_library = new ObjectType({
+  elemID: emailcaptureplugin_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      emailcaptureplugin_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, emailcapturepluginElemID.name],
+})
+
+emailcapturepluginInnerTypes.push(emailcaptureplugin_libraries_library)
+
+const emailcaptureplugin_librariesElemID = new ElemID(constants.NETSUITE, 'emailcaptureplugin_libraries')
+
+const emailcaptureplugin_libraries = new ObjectType({
+  elemID: emailcaptureplugin_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      emailcaptureplugin_librariesElemID,
+      'library',
+      new ListType(emailcaptureplugin_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, emailcapturepluginElemID.name],
+})
+
+emailcapturepluginInnerTypes.push(emailcaptureplugin_libraries)
+
+
+export const emailcaptureplugin = new ObjectType({
+  elemID: emailcapturepluginElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      emailcapturepluginElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      emailcapturepluginElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      emailcapturepluginElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    description: new Field(
+      emailcapturepluginElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      emailcapturepluginElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      emailcapturepluginElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      emailcapturepluginElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      emailcapturepluginElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      emailcapturepluginElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      emailcapturepluginElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    loglevel: new Field(
+      emailcapturepluginElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+    runasrole: new Field(
+      emailcapturepluginElemID,
+      'runasrole',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    status: new Field(
+      emailcapturepluginElemID,
+      'status',
+      enums.script_status,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+    libraries: new Field(
+      emailcapturepluginElemID,
+      'libraries',
+      emailcaptureplugin_libraries,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, emailcapturepluginElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/emailtemplate.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/emailtemplate.ts
@@ -1,0 +1,120 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const emailtemplateInnerTypes: ObjectType[] = []
+
+const emailtemplateElemID = new ElemID(constants.NETSUITE, 'emailtemplate')
+
+export const emailtemplate = new ObjectType({
+  elemID: emailtemplateElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custemailtmpl_',
+    [constants.ADDITIONAL_FILE_SUFFIX]: '.template.html',
+  },
+  fields: {
+    scriptid: new Field(
+      emailtemplateElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custemailtmpl’. */
+    name: new Field(
+      emailtemplateElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 60,
+      },
+    ), /* Original description: This field value can be up to 60 characters long. */
+    mediaitem: new Field(
+      emailtemplateElemID,
+      'mediaitem',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the usesmedia value is equal to T.   This field must reference a file with any of the following extensions: .ftl, .html, .txt */
+    description: new Field(
+      emailtemplateElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 1000,
+      },
+    ), /* Original description: This field value can be up to 1000 characters long. */
+    recordtype: new Field(
+      emailtemplateElemID,
+      'recordtype',
+      enums.emailtemplate_recordtype,
+      {
+      },
+    ), /* Original description: For information about possible values, see emailtemplate_recordtype. */
+    isinactive: new Field(
+      emailtemplateElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    subject: new Field(
+      emailtemplateElemID,
+      'subject',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 199,
+      },
+    ), /* Original description: This field value can be up to 199 characters long. */
+    isprivate: new Field(
+      emailtemplateElemID,
+      'isprivate',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    addunsubscribelink: new Field(
+      emailtemplateElemID,
+      'addunsubscribelink',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    addcompanyaddress: new Field(
+      emailtemplateElemID,
+      'addcompanyaddress',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    usesmedia: new Field(
+      emailtemplateElemID,
+      'usesmedia',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, emailtemplateElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/entitycustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/entitycustomfield.ts
@@ -1,0 +1,566 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const entitycustomfieldInnerTypes: ObjectType[] = []
+
+const entitycustomfieldElemID = new ElemID(constants.NETSUITE, 'entitycustomfield')
+const entitycustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'entitycustomfield_customfieldfilters_customfieldfilter')
+
+const entitycustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: entitycustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      entitycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      entitycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      entitycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      entitycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      entitycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      entitycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      entitycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      entitycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entitycustomfieldElemID.name],
+})
+
+entitycustomfieldInnerTypes.push(entitycustomfield_customfieldfilters_customfieldfilter)
+
+const entitycustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'entitycustomfield_customfieldfilters')
+
+const entitycustomfield_customfieldfilters = new ObjectType({
+  elemID: entitycustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      entitycustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(entitycustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entitycustomfieldElemID.name],
+})
+
+entitycustomfieldInnerTypes.push(entitycustomfield_customfieldfilters)
+
+const entitycustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'entitycustomfield_roleaccesses_roleaccess')
+
+const entitycustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: entitycustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      entitycustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      entitycustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      entitycustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entitycustomfieldElemID.name],
+})
+
+entitycustomfieldInnerTypes.push(entitycustomfield_roleaccesses_roleaccess)
+
+const entitycustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'entitycustomfield_roleaccesses')
+
+const entitycustomfield_roleaccesses = new ObjectType({
+  elemID: entitycustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      entitycustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(entitycustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entitycustomfieldElemID.name],
+})
+
+entitycustomfieldInnerTypes.push(entitycustomfield_roleaccesses)
+
+
+export const entitycustomfield = new ObjectType({
+  elemID: entitycustomfieldElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custentity_',
+  },
+  fields: {
+    scriptid: new Field(
+      entitycustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custentity’. */
+    fieldtype: new Field(
+      entitycustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      entitycustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      entitycustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      entitycustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      entitycustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      entitycustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      entitycustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      entitycustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      entitycustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      entitycustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      entitycustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      entitycustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      entitycustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      entitycustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      entitycustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      entitycustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      entitycustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    encryptatrest: new Field(
+      entitycustomfieldElemID,
+      'encryptatrest',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      entitycustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      entitycustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    globalsearch: new Field(
+      entitycustomfieldElemID,
+      'globalsearch',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    isformula: new Field(
+      entitycustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      entitycustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      entitycustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      entitycustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      entitycustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      entitycustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      entitycustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    showhierarchy: new Field(
+      entitycustomfieldElemID,
+      'showhierarchy',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showinlist: new Field(
+      entitycustomfieldElemID,
+      'showinlist',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    sourcefilterby: new Field(
+      entitycustomfieldElemID,
+      'sourcefilterby',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcefrom: new Field(
+      entitycustomfieldElemID,
+      'sourcefrom',
+      BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcelist: new Field(
+      entitycustomfieldElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the entitycustomfield custom type.   For information about other possible values, see generic_standard_field. */
+    isparent: new Field(
+      entitycustomfieldElemID,
+      'isparent',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    parentsubtab: new Field(
+      entitycustomfieldElemID,
+      'parentsubtab',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   subtab   subtab   For information about other possible values, see generic_tab_parent. */
+    subtab: new Field(
+      entitycustomfieldElemID,
+      'subtab',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the subtab custom type.   For information about other possible values, see generic_entity_tab. */
+    appliestocontact: new Field(
+      entitycustomfieldElemID,
+      'appliestocontact',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestocustomer: new Field(
+      entitycustomfieldElemID,
+      'appliestocustomer',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestoemployee: new Field(
+      entitycustomfieldElemID,
+      'appliestoemployee',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestogenericrsrc: new Field(
+      entitycustomfieldElemID,
+      'appliestogenericrsrc',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ADVANCEDJOBS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ADVANCEDJOBS must be enabled for this field to appear in your account. */
+    appliestogroup: new Field(
+      entitycustomfieldElemID,
+      'appliestogroup',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestoothername: new Field(
+      entitycustomfieldElemID,
+      'appliestoothername',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestopartner: new Field(
+      entitycustomfieldElemID,
+      'appliestopartner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account. */
+    appliestopricelist: new Field(
+      entitycustomfieldElemID,
+      'appliestopricelist',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestoproject: new Field(
+      entitycustomfieldElemID,
+      'appliestoproject',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the JOBS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. JOBS must be enabled for this field to appear in your account. */
+    appliestoprojecttemplate: new Field(
+      entitycustomfieldElemID,
+      'appliestoprojecttemplate',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestostatement: new Field(
+      entitycustomfieldElemID,
+      'appliestostatement',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestovendor: new Field(
+      entitycustomfieldElemID,
+      'appliestovendor',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    appliestowebsite: new Field(
+      entitycustomfieldElemID,
+      'appliestowebsite',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the WEBSITE feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. WEBSITE must be enabled for this field to appear in your account. */
+    availableexternally: new Field(
+      entitycustomfieldElemID,
+      'availableexternally',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    availabletosso: new Field(
+      entitycustomfieldElemID,
+      'availabletosso',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the SUITESIGNON feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. SUITESIGNON must be enabled for this field to appear in your account. */
+    customfieldfilters: new Field(
+      entitycustomfieldElemID,
+      'customfieldfilters',
+      entitycustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      entitycustomfieldElemID,
+      'roleaccesses',
+      entitycustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entitycustomfieldElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/entryForm.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/entryForm.ts
@@ -1,0 +1,1731 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const entryFormInnerTypes: ObjectType[] = []
+
+const entryFormElemID = new ElemID(constants.NETSUITE, 'entryForm')
+const entryForm_actionbar_buttons_buttonElemID = new ElemID(constants.NETSUITE, 'entryForm_actionbar_buttons_button')
+
+const entryForm_actionbar_buttons_button = new ObjectType({
+  elemID: entryForm_actionbar_buttons_buttonElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      entryForm_actionbar_buttons_buttonElemID,
+      'id',
+      enums.entryform_buttonid,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see entryform_buttonid. */
+    label: new Field(
+      entryForm_actionbar_buttons_buttonElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    visible: new Field(
+      entryForm_actionbar_buttons_buttonElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_actionbar_buttons_button)
+
+const entryForm_actionbar_buttonsElemID = new ElemID(constants.NETSUITE, 'entryForm_actionbar_buttons')
+
+const entryForm_actionbar_buttons = new ObjectType({
+  elemID: entryForm_actionbar_buttonsElemID,
+  annotations: {
+  },
+  fields: {
+    button: new Field(
+      entryForm_actionbar_buttonsElemID,
+      'button',
+      new ListType(entryForm_actionbar_buttons_button),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_actionbar_buttons)
+
+const entryForm_actionbar_customButtons_customButtonElemID = new ElemID(constants.NETSUITE, 'entryForm_actionbar_customButtons_customButton')
+
+const entryForm_actionbar_customButtons_customButton = new ObjectType({
+  elemID: entryForm_actionbar_customButtons_customButtonElemID,
+  annotations: {
+  },
+  fields: {
+    label: new Field(
+      entryForm_actionbar_customButtons_customButtonElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+      },
+    ), /* Original description: This field value can be up to 99 characters long. */
+    function: new Field(
+      entryForm_actionbar_customButtons_customButtonElemID,
+      'function',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_actionbar_customButtons_customButton)
+
+const entryForm_actionbar_customButtonsElemID = new ElemID(constants.NETSUITE, 'entryForm_actionbar_customButtons')
+
+const entryForm_actionbar_customButtons = new ObjectType({
+  elemID: entryForm_actionbar_customButtonsElemID,
+  annotations: {
+  },
+  fields: {
+    customButton: new Field(
+      entryForm_actionbar_customButtonsElemID,
+      'customButton',
+      new ListType(entryForm_actionbar_customButtons_customButton),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_actionbar_customButtons)
+
+const entryForm_actionbar_customMenu_customMenuItemElemID = new ElemID(constants.NETSUITE, 'entryForm_actionbar_customMenu_customMenuItem')
+
+const entryForm_actionbar_customMenu_customMenuItem = new ObjectType({
+  elemID: entryForm_actionbar_customMenu_customMenuItemElemID,
+  annotations: {
+  },
+  fields: {
+    label: new Field(
+      entryForm_actionbar_customMenu_customMenuItemElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+      },
+    ), /* Original description: This field value can be up to 99 characters long. */
+    function: new Field(
+      entryForm_actionbar_customMenu_customMenuItemElemID,
+      'function',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_actionbar_customMenu_customMenuItem)
+
+const entryForm_actionbar_customMenuElemID = new ElemID(constants.NETSUITE, 'entryForm_actionbar_customMenu')
+
+const entryForm_actionbar_customMenu = new ObjectType({
+  elemID: entryForm_actionbar_customMenuElemID,
+  annotations: {
+  },
+  fields: {
+    customMenuItem: new Field(
+      entryForm_actionbar_customMenuElemID,
+      'customMenuItem',
+      new ListType(entryForm_actionbar_customMenu_customMenuItem),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_actionbar_customMenu)
+
+const entryForm_actionbar_menu_menuitemElemID = new ElemID(constants.NETSUITE, 'entryForm_actionbar_menu_menuitem')
+
+const entryForm_actionbar_menu_menuitem = new ObjectType({
+  elemID: entryForm_actionbar_menu_menuitemElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      entryForm_actionbar_menu_menuitemElemID,
+      'id',
+      enums.entryform_buttonid,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see entryform_buttonid. */
+    label: new Field(
+      entryForm_actionbar_menu_menuitemElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    visible: new Field(
+      entryForm_actionbar_menu_menuitemElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_actionbar_menu_menuitem)
+
+const entryForm_actionbar_menuElemID = new ElemID(constants.NETSUITE, 'entryForm_actionbar_menu')
+
+const entryForm_actionbar_menu = new ObjectType({
+  elemID: entryForm_actionbar_menuElemID,
+  annotations: {
+  },
+  fields: {
+    menuitem: new Field(
+      entryForm_actionbar_menuElemID,
+      'menuitem',
+      new ListType(entryForm_actionbar_menu_menuitem),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_actionbar_menu)
+
+const entryForm_actionbarElemID = new ElemID(constants.NETSUITE, 'entryForm_actionbar')
+
+const entryForm_actionbar = new ObjectType({
+  elemID: entryForm_actionbarElemID,
+  annotations: {
+  },
+  fields: {
+    buttons: new Field(
+      entryForm_actionbarElemID,
+      'buttons',
+      entryForm_actionbar_buttons,
+      {
+      },
+    ),
+    customButtons: new Field(
+      entryForm_actionbarElemID,
+      'customButtons',
+      entryForm_actionbar_customButtons,
+      {
+      },
+    ),
+    customMenu: new Field(
+      entryForm_actionbarElemID,
+      'customMenu',
+      entryForm_actionbar_customMenu,
+      {
+      },
+    ),
+    menu: new Field(
+      entryForm_actionbarElemID,
+      'menu',
+      entryForm_actionbar_menu,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_actionbar)
+
+const entryForm_buttons_standardButtons_buttonElemID = new ElemID(constants.NETSUITE, 'entryForm_buttons_standardButtons_button')
+
+const entryForm_buttons_standardButtons_button = new ObjectType({
+  elemID: entryForm_buttons_standardButtons_buttonElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      entryForm_buttons_standardButtons_buttonElemID,
+      'id',
+      enums.entryform_buttonid,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see entryform_buttonid. */
+    label: new Field(
+      entryForm_buttons_standardButtons_buttonElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      entryForm_buttons_standardButtons_buttonElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    style: new Field(
+      entryForm_buttons_standardButtons_buttonElemID,
+      'style',
+      enums.form_buttonstyle,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_buttonstyle.   The default value is 'BUTTON'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_buttons_standardButtons_button)
+
+const entryForm_buttons_standardButtonsElemID = new ElemID(constants.NETSUITE, 'entryForm_buttons_standardButtons')
+
+const entryForm_buttons_standardButtons = new ObjectType({
+  elemID: entryForm_buttons_standardButtonsElemID,
+  annotations: {
+  },
+  fields: {
+    button: new Field(
+      entryForm_buttons_standardButtonsElemID,
+      'button',
+      new ListType(entryForm_buttons_standardButtons_button),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_buttons_standardButtons)
+
+const entryForm_buttonsElemID = new ElemID(constants.NETSUITE, 'entryForm_buttons')
+
+const entryForm_buttons = new ObjectType({
+  elemID: entryForm_buttonsElemID,
+  annotations: {
+  },
+  fields: {
+    standardButtons: new Field(
+      entryForm_buttonsElemID,
+      'standardButtons',
+      entryForm_buttons_standardButtons,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_buttons)
+
+const entryForm_customCodeElemID = new ElemID(constants.NETSUITE, 'entryForm_customCode')
+
+const entryForm_customCode = new ObjectType({
+  elemID: entryForm_customCodeElemID,
+  annotations: {
+  },
+  fields: {
+    scriptFile: new Field(
+      entryForm_customCodeElemID,
+      'scriptFile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_customCode)
+
+const entryForm_mainFields_defaultFieldGroup_fields_fieldElemID = new ElemID(constants.NETSUITE, 'entryForm_mainFields_defaultFieldGroup_fields_field')
+
+const entryForm_mainFields_defaultFieldGroup_fields_field = new ObjectType({
+  elemID: entryForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      entryForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_fieldid. */
+    label: new Field(
+      entryForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      entryForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    mandatory: new Field(
+      entryForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'mandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayType: new Field(
+      entryForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'displayType',
+      enums.form_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_displaytype.   The default value is 'NORMAL'. */
+    columnBreak: new Field(
+      entryForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'columnBreak',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    spaceBefore: new Field(
+      entryForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'spaceBefore',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    sameRowAsPrevious: new Field(
+      entryForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'sameRowAsPrevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    quickAdd: new Field(
+      entryForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'quickAdd',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_mainFields_defaultFieldGroup_fields_field)
+
+const entryForm_mainFields_defaultFieldGroup_fieldsElemID = new ElemID(constants.NETSUITE, 'entryForm_mainFields_defaultFieldGroup_fields')
+
+const entryForm_mainFields_defaultFieldGroup_fields = new ObjectType({
+  elemID: entryForm_mainFields_defaultFieldGroup_fieldsElemID,
+  annotations: {
+  },
+  fields: {
+    position: new Field(
+      entryForm_mainFields_defaultFieldGroup_fieldsElemID,
+      'position',
+      enums.form_fieldposition,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see form_fieldposition.   The default value is ‘MIDDLE’. */
+    field: new Field(
+      entryForm_mainFields_defaultFieldGroup_fieldsElemID,
+      'field',
+      new ListType(entryForm_mainFields_defaultFieldGroup_fields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_mainFields_defaultFieldGroup_fields)
+
+const entryForm_mainFields_defaultFieldGroupElemID = new ElemID(constants.NETSUITE, 'entryForm_mainFields_defaultFieldGroup')
+
+const entryForm_mainFields_defaultFieldGroup = new ObjectType({
+  elemID: entryForm_mainFields_defaultFieldGroupElemID,
+  annotations: {
+  },
+  fields: {
+    fields: new Field(
+      entryForm_mainFields_defaultFieldGroupElemID,
+      'fields',
+      entryForm_mainFields_defaultFieldGroup_fields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_mainFields_defaultFieldGroup)
+
+const entryForm_mainFields_fieldGroup_fields_fieldElemID = new ElemID(constants.NETSUITE, 'entryForm_mainFields_fieldGroup_fields_field')
+
+const entryForm_mainFields_fieldGroup_fields_field = new ObjectType({
+  elemID: entryForm_mainFields_fieldGroup_fields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      entryForm_mainFields_fieldGroup_fields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_fieldid. */
+    label: new Field(
+      entryForm_mainFields_fieldGroup_fields_fieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      entryForm_mainFields_fieldGroup_fields_fieldElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    mandatory: new Field(
+      entryForm_mainFields_fieldGroup_fields_fieldElemID,
+      'mandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayType: new Field(
+      entryForm_mainFields_fieldGroup_fields_fieldElemID,
+      'displayType',
+      enums.form_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_displaytype.   The default value is 'NORMAL'. */
+    columnBreak: new Field(
+      entryForm_mainFields_fieldGroup_fields_fieldElemID,
+      'columnBreak',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    spaceBefore: new Field(
+      entryForm_mainFields_fieldGroup_fields_fieldElemID,
+      'spaceBefore',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    sameRowAsPrevious: new Field(
+      entryForm_mainFields_fieldGroup_fields_fieldElemID,
+      'sameRowAsPrevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    quickAdd: new Field(
+      entryForm_mainFields_fieldGroup_fields_fieldElemID,
+      'quickAdd',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_mainFields_fieldGroup_fields_field)
+
+const entryForm_mainFields_fieldGroup_fieldsElemID = new ElemID(constants.NETSUITE, 'entryForm_mainFields_fieldGroup_fields')
+
+const entryForm_mainFields_fieldGroup_fields = new ObjectType({
+  elemID: entryForm_mainFields_fieldGroup_fieldsElemID,
+  annotations: {
+  },
+  fields: {
+    position: new Field(
+      entryForm_mainFields_fieldGroup_fieldsElemID,
+      'position',
+      enums.form_fieldposition,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see form_fieldposition.   The default value is ‘MIDDLE’. */
+    field: new Field(
+      entryForm_mainFields_fieldGroup_fieldsElemID,
+      'field',
+      new ListType(entryForm_mainFields_fieldGroup_fields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_mainFields_fieldGroup_fields)
+
+const entryForm_mainFields_fieldGroupElemID = new ElemID(constants.NETSUITE, 'entryForm_mainFields_fieldGroup')
+
+const entryForm_mainFields_fieldGroup = new ObjectType({
+  elemID: entryForm_mainFields_fieldGroupElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      entryForm_mainFields_fieldGroupElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long. */
+    label: new Field(
+      entryForm_mainFields_fieldGroupElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    visible: new Field(
+      entryForm_mainFields_fieldGroupElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    showTitle: new Field(
+      entryForm_mainFields_fieldGroupElemID,
+      'showTitle',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    singleColumn: new Field(
+      entryForm_mainFields_fieldGroupElemID,
+      'singleColumn',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fields: new Field(
+      entryForm_mainFields_fieldGroupElemID,
+      'fields',
+      entryForm_mainFields_fieldGroup_fields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_mainFields_fieldGroup)
+
+const entryForm_mainFieldsElemID = new ElemID(constants.NETSUITE, 'entryForm_mainFields')
+
+const entryForm_mainFields = new ObjectType({
+  elemID: entryForm_mainFieldsElemID,
+  annotations: {
+  },
+  fields: {
+    defaultFieldGroup: new Field(
+      entryForm_mainFieldsElemID,
+      'defaultFieldGroup',
+      entryForm_mainFields_defaultFieldGroup,
+      {
+      },
+    ),
+    fieldGroup: new Field(
+      entryForm_mainFieldsElemID,
+      'fieldGroup',
+      new ListType(entryForm_mainFields_fieldGroup),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_mainFields)
+
+const entryForm_quickViewFields_fieldElemID = new ElemID(constants.NETSUITE, 'entryForm_quickViewFields_field')
+
+const entryForm_quickViewFields_field = new ObjectType({
+  elemID: entryForm_quickViewFields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      entryForm_quickViewFields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_fieldid. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_quickViewFields_field)
+
+const entryForm_quickViewFieldsElemID = new ElemID(constants.NETSUITE, 'entryForm_quickViewFields')
+
+const entryForm_quickViewFields = new ObjectType({
+  elemID: entryForm_quickViewFieldsElemID,
+  annotations: {
+  },
+  fields: {
+    field: new Field(
+      entryForm_quickViewFieldsElemID,
+      'field',
+      new ListType(entryForm_quickViewFields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_quickViewFields)
+
+const entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_field')
+
+const entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_field = new ObjectType({
+  elemID: entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_fieldid. */
+    label: new Field(
+      entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    mandatory: new Field(
+      entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'mandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayType: new Field(
+      entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'displayType',
+      enums.form_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_displaytype.   The default value is 'NORMAL'. */
+    columnBreak: new Field(
+      entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'columnBreak',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    spaceBefore: new Field(
+      entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'spaceBefore',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    sameRowAsPrevious: new Field(
+      entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'sameRowAsPrevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    quickAdd: new Field(
+      entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'quickAdd',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_field)
+
+const entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fieldsElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields')
+
+const entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields = new ObjectType({
+  elemID: entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fieldsElemID,
+  annotations: {
+  },
+  fields: {
+    position: new Field(
+      entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fieldsElemID,
+      'position',
+      enums.form_fieldposition,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see form_fieldposition.   The default value is ‘MIDDLE’. */
+    field: new Field(
+      entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fieldsElemID,
+      'field',
+      new ListType(entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields)
+
+const entryForm_tabs_tab_fieldGroups_defaultFieldGroupElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_fieldGroups_defaultFieldGroup')
+
+const entryForm_tabs_tab_fieldGroups_defaultFieldGroup = new ObjectType({
+  elemID: entryForm_tabs_tab_fieldGroups_defaultFieldGroupElemID,
+  annotations: {
+  },
+  fields: {
+    fields: new Field(
+      entryForm_tabs_tab_fieldGroups_defaultFieldGroupElemID,
+      'fields',
+      entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_fieldGroups_defaultFieldGroup)
+
+const entryForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_fieldGroups_fieldGroup_fields_field')
+
+const entryForm_tabs_tab_fieldGroups_fieldGroup_fields_field = new ObjectType({
+  elemID: entryForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_fieldid. */
+    label: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    mandatory: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'mandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayType: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'displayType',
+      enums.form_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_displaytype.   The default value is 'NORMAL'. */
+    columnBreak: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'columnBreak',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    spaceBefore: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'spaceBefore',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    sameRowAsPrevious: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'sameRowAsPrevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    quickAdd: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'quickAdd',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_fieldGroups_fieldGroup_fields_field)
+
+const entryForm_tabs_tab_fieldGroups_fieldGroup_fieldsElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_fieldGroups_fieldGroup_fields')
+
+const entryForm_tabs_tab_fieldGroups_fieldGroup_fields = new ObjectType({
+  elemID: entryForm_tabs_tab_fieldGroups_fieldGroup_fieldsElemID,
+  annotations: {
+  },
+  fields: {
+    position: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroup_fieldsElemID,
+      'position',
+      enums.form_fieldposition,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see form_fieldposition.   The default value is ‘MIDDLE’. */
+    field: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroup_fieldsElemID,
+      'field',
+      new ListType(entryForm_tabs_tab_fieldGroups_fieldGroup_fields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_fieldGroups_fieldGroup_fields)
+
+const entryForm_tabs_tab_fieldGroups_fieldGroupElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_fieldGroups_fieldGroup')
+
+const entryForm_tabs_tab_fieldGroups_fieldGroup = new ObjectType({
+  elemID: entryForm_tabs_tab_fieldGroups_fieldGroupElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroupElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long. */
+    label: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroupElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    visible: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroupElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    showTitle: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroupElemID,
+      'showTitle',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    singleColumn: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroupElemID,
+      'singleColumn',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fields: new Field(
+      entryForm_tabs_tab_fieldGroups_fieldGroupElemID,
+      'fields',
+      entryForm_tabs_tab_fieldGroups_fieldGroup_fields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_fieldGroups_fieldGroup)
+
+const entryForm_tabs_tab_fieldGroupsElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_fieldGroups')
+
+const entryForm_tabs_tab_fieldGroups = new ObjectType({
+  elemID: entryForm_tabs_tab_fieldGroupsElemID,
+  annotations: {
+  },
+  fields: {
+    defaultFieldGroup: new Field(
+      entryForm_tabs_tab_fieldGroupsElemID,
+      'defaultFieldGroup',
+      entryForm_tabs_tab_fieldGroups_defaultFieldGroup,
+      {
+      },
+    ),
+    fieldGroup: new Field(
+      entryForm_tabs_tab_fieldGroupsElemID,
+      'fieldGroup',
+      new ListType(entryForm_tabs_tab_fieldGroups_fieldGroup),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_fieldGroups)
+
+const entryForm_tabs_tab_subItems_subListElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_subItems_subList')
+
+const entryForm_tabs_tab_subItems_subList = new ObjectType({
+  elemID: entryForm_tabs_tab_subItems_subListElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      entryForm_tabs_tab_subItems_subListElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactionbodycustomfield   itemcustomfield   entitycustomfield   recordsublist   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_sublistid. */
+    label: new Field(
+      entryForm_tabs_tab_subItems_subListElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    visible: new Field(
+      entryForm_tabs_tab_subItems_subListElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_subItems_subList)
+
+const entryForm_tabs_tab_subItems_subLists_subListElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_subItems_subLists_subList')
+
+const entryForm_tabs_tab_subItems_subLists_subList = new ObjectType({
+  elemID: entryForm_tabs_tab_subItems_subLists_subListElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      entryForm_tabs_tab_subItems_subLists_subListElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactionbodycustomfield   itemcustomfield   entitycustomfield   recordsublist   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_sublistid. */
+    label: new Field(
+      entryForm_tabs_tab_subItems_subLists_subListElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    visible: new Field(
+      entryForm_tabs_tab_subItems_subLists_subListElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_subItems_subLists_subList)
+
+const entryForm_tabs_tab_subItems_subListsElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_subItems_subLists')
+
+const entryForm_tabs_tab_subItems_subLists = new ObjectType({
+  elemID: entryForm_tabs_tab_subItems_subListsElemID,
+  annotations: {
+  },
+  fields: {
+    subList: new Field(
+      entryForm_tabs_tab_subItems_subListsElemID,
+      'subList',
+      new ListType(entryForm_tabs_tab_subItems_subLists_subList),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_subItems_subLists)
+
+const entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_field')
+
+const entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_field = new ObjectType({
+  elemID: entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_fieldid. */
+    label: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    mandatory: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'mandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayType: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'displayType',
+      enums.form_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_displaytype.   The default value is 'NORMAL'. */
+    columnBreak: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'columnBreak',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    spaceBefore: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'spaceBefore',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    sameRowAsPrevious: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'sameRowAsPrevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    quickAdd: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'quickAdd',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_field)
+
+const entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fieldsElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields')
+
+const entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields = new ObjectType({
+  elemID: entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fieldsElemID,
+  annotations: {
+  },
+  fields: {
+    position: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fieldsElemID,
+      'position',
+      enums.form_fieldposition,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see form_fieldposition.   The default value is ‘MIDDLE’. */
+    field: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fieldsElemID,
+      'field',
+      new ListType(entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields)
+
+const entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroupElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup')
+
+const entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup = new ObjectType({
+  elemID: entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroupElemID,
+  annotations: {
+  },
+  fields: {
+    fields: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroupElemID,
+      'fields',
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup)
+
+const entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_field')
+
+const entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_field = new ObjectType({
+  elemID: entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_fieldid. */
+    label: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    mandatory: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'mandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayType: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'displayType',
+      enums.form_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_displaytype.   The default value is 'NORMAL'. */
+    columnBreak: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'columnBreak',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    spaceBefore: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'spaceBefore',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    sameRowAsPrevious: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'sameRowAsPrevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    quickAdd: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'quickAdd',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_field)
+
+const entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fieldsElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields')
+
+const entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields = new ObjectType({
+  elemID: entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fieldsElemID,
+  annotations: {
+  },
+  fields: {
+    position: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fieldsElemID,
+      'position',
+      enums.form_fieldposition,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see form_fieldposition.   The default value is ‘MIDDLE’. */
+    field: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fieldsElemID,
+      'field',
+      new ListType(entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields)
+
+const entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup')
+
+const entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup = new ObjectType({
+  elemID: entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long. */
+    label: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    visible: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    showTitle: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID,
+      'showTitle',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    singleColumn: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID,
+      'singleColumn',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fields: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID,
+      'fields',
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup)
+
+const entryForm_tabs_tab_subItems_subTab_fieldGroupsElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_subItems_subTab_fieldGroups')
+
+const entryForm_tabs_tab_subItems_subTab_fieldGroups = new ObjectType({
+  elemID: entryForm_tabs_tab_subItems_subTab_fieldGroupsElemID,
+  annotations: {
+  },
+  fields: {
+    defaultFieldGroup: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroupsElemID,
+      'defaultFieldGroup',
+      entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup,
+      {
+      },
+    ),
+    fieldGroup: new Field(
+      entryForm_tabs_tab_subItems_subTab_fieldGroupsElemID,
+      'fieldGroup',
+      new ListType(entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_subItems_subTab_fieldGroups)
+
+const entryForm_tabs_tab_subItems_subTabElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_subItems_subTab')
+
+const entryForm_tabs_tab_subItems_subTab = new ObjectType({
+  elemID: entryForm_tabs_tab_subItems_subTabElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      entryForm_tabs_tab_subItems_subTabElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   subtab   subtab   For information about other possible values, see entryform_subtabid. */
+    label: new Field(
+      entryForm_tabs_tab_subItems_subTabElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    visible: new Field(
+      entryForm_tabs_tab_subItems_subTabElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    fieldGroups: new Field(
+      entryForm_tabs_tab_subItems_subTabElemID,
+      'fieldGroups',
+      entryForm_tabs_tab_subItems_subTab_fieldGroups,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_subItems_subTab)
+
+const entryForm_tabs_tab_subItemsElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab_subItems')
+
+const entryForm_tabs_tab_subItems = new ObjectType({
+  elemID: entryForm_tabs_tab_subItemsElemID,
+  annotations: {
+  },
+  fields: {
+    subList: new Field(
+      entryForm_tabs_tab_subItemsElemID,
+      'subList',
+      new ListType(entryForm_tabs_tab_subItems_subList),
+      {
+      },
+    ),
+    subLists: new Field(
+      entryForm_tabs_tab_subItemsElemID,
+      'subLists',
+      new ListType(entryForm_tabs_tab_subItems_subLists),
+      {
+      },
+    ),
+    subTab: new Field(
+      entryForm_tabs_tab_subItemsElemID,
+      'subTab',
+      new ListType(entryForm_tabs_tab_subItems_subTab),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab_subItems)
+
+const entryForm_tabs_tabElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs_tab')
+
+const entryForm_tabs_tab = new ObjectType({
+  elemID: entryForm_tabs_tabElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      entryForm_tabs_tabElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   subtab   subtab   For information about other possible values, see entryform_tabid. */
+    label: new Field(
+      entryForm_tabs_tabElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    visible: new Field(
+      entryForm_tabs_tabElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    fieldGroups: new Field(
+      entryForm_tabs_tabElemID,
+      'fieldGroups',
+      entryForm_tabs_tab_fieldGroups,
+      {
+      },
+    ),
+    subItems: new Field(
+      entryForm_tabs_tabElemID,
+      'subItems',
+      entryForm_tabs_tab_subItems,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs_tab)
+
+const entryForm_tabsElemID = new ElemID(constants.NETSUITE, 'entryForm_tabs')
+
+const entryForm_tabs = new ObjectType({
+  elemID: entryForm_tabsElemID,
+  annotations: {
+  },
+  fields: {
+    tab: new Field(
+      entryForm_tabsElemID,
+      'tab',
+      new ListType(entryForm_tabs_tab),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})
+
+entryFormInnerTypes.push(entryForm_tabs)
+
+
+export const entryForm = new ObjectType({
+  elemID: entryFormElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custform_',
+  },
+  fields: {
+    scriptid: new Field(
+      entryFormElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custform’. */
+    standard: new Field(
+      entryFormElemID,
+      'standard',
+      enums.entryform_standard,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   For information about possible values, see entryform_standard. */
+    name: new Field(
+      entryFormElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+      },
+    ),
+    recordType: new Field(
+      entryFormElemID,
+      'recordType',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the customrecordtype custom type. */
+    inactive: new Field(
+      entryFormElemID,
+      'inactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    preferred: new Field(
+      entryFormElemID,
+      'preferred',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    storedWithRecord: new Field(
+      entryFormElemID,
+      'storedWithRecord',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    useForPopup: new Field(
+      entryFormElemID,
+      'useForPopup',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    editingInList: new Field(
+      entryFormElemID,
+      'editingInList',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    actionbar: new Field(
+      entryFormElemID,
+      'actionbar',
+      entryForm_actionbar,
+      {
+      },
+    ),
+    buttons: new Field(
+      entryFormElemID,
+      'buttons',
+      entryForm_buttons,
+      {
+      },
+    ),
+    customCode: new Field(
+      entryFormElemID,
+      'customCode',
+      entryForm_customCode,
+      {
+      },
+    ),
+    mainFields: new Field(
+      entryFormElemID,
+      'mainFields',
+      entryForm_mainFields,
+      {
+      },
+    ),
+    quickViewFields: new Field(
+      entryFormElemID,
+      'quickViewFields',
+      entryForm_quickViewFields,
+      {
+      },
+    ),
+    tabs: new Field(
+      entryFormElemID,
+      'tabs',
+      entryForm_tabs,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, entryFormElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/ficonnectivityplugin.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/ficonnectivityplugin.ts
@@ -1,0 +1,134 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const ficonnectivitypluginInnerTypes: ObjectType[] = []
+
+const ficonnectivitypluginElemID = new ElemID(constants.NETSUITE, 'ficonnectivityplugin')
+
+export const ficonnectivityplugin = new ObjectType({
+  elemID: ficonnectivitypluginElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      ficonnectivitypluginElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      ficonnectivitypluginElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      ficonnectivitypluginElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    description: new Field(
+      ficonnectivitypluginElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      ficonnectivitypluginElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      ficonnectivitypluginElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      ficonnectivitypluginElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      ficonnectivitypluginElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      ficonnectivitypluginElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      ficonnectivitypluginElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    loglevel: new Field(
+      ficonnectivitypluginElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+    runasrole: new Field(
+      ficonnectivitypluginElemID,
+      'runasrole',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    status: new Field(
+      ficonnectivitypluginElemID,
+      'status',
+      enums.script_status,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, ficonnectivitypluginElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/itemcustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/itemcustomfield.ts
@@ -1,0 +1,559 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const itemcustomfieldInnerTypes: ObjectType[] = []
+
+const itemcustomfieldElemID = new ElemID(constants.NETSUITE, 'itemcustomfield')
+const itemcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'itemcustomfield_customfieldfilters_customfieldfilter')
+
+const itemcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: itemcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      itemcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      itemcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      itemcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      itemcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      itemcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      itemcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      itemcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      itemcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemcustomfieldElemID.name],
+})
+
+itemcustomfieldInnerTypes.push(itemcustomfield_customfieldfilters_customfieldfilter)
+
+const itemcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'itemcustomfield_customfieldfilters')
+
+const itemcustomfield_customfieldfilters = new ObjectType({
+  elemID: itemcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      itemcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(itemcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemcustomfieldElemID.name],
+})
+
+itemcustomfieldInnerTypes.push(itemcustomfield_customfieldfilters)
+
+const itemcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'itemcustomfield_roleaccesses_roleaccess')
+
+const itemcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: itemcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      itemcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      itemcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      itemcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemcustomfieldElemID.name],
+})
+
+itemcustomfieldInnerTypes.push(itemcustomfield_roleaccesses_roleaccess)
+
+const itemcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'itemcustomfield_roleaccesses')
+
+const itemcustomfield_roleaccesses = new ObjectType({
+  elemID: itemcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      itemcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(itemcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemcustomfieldElemID.name],
+})
+
+itemcustomfieldInnerTypes.push(itemcustomfield_roleaccesses)
+
+
+export const itemcustomfield = new ObjectType({
+  elemID: itemcustomfieldElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custitem_',
+  },
+  fields: {
+    scriptid: new Field(
+      itemcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 38 characters long.   The default value is ‘custitem’. */
+    fieldtype: new Field(
+      itemcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      itemcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      itemcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      itemcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      itemcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      itemcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      itemcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      itemcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      itemcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      itemcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      itemcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      itemcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      itemcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      itemcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      itemcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      itemcustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      itemcustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    encryptatrest: new Field(
+      itemcustomfieldElemID,
+      'encryptatrest',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      itemcustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      itemcustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    globalsearch: new Field(
+      itemcustomfieldElemID,
+      'globalsearch',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    isformula: new Field(
+      itemcustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      itemcustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      itemcustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      itemcustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      itemcustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      itemcustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      itemcustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    showhierarchy: new Field(
+      itemcustomfieldElemID,
+      'showhierarchy',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showinlist: new Field(
+      itemcustomfieldElemID,
+      'showinlist',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    sourcefilterby: new Field(
+      itemcustomfieldElemID,
+      'sourcefilterby',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcefrom: new Field(
+      itemcustomfieldElemID,
+      'sourcefrom',
+      BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcelist: new Field(
+      itemcustomfieldElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the itemcustomfield custom type.   For information about other possible values, see generic_standard_field. */
+    isparent: new Field(
+      itemcustomfieldElemID,
+      'isparent',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    parentsubtab: new Field(
+      itemcustomfieldElemID,
+      'parentsubtab',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   subtab   subtab   For information about other possible values, see generic_tab_parent. */
+    subtab: new Field(
+      itemcustomfieldElemID,
+      'subtab',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the subtab custom type.   For information about other possible values, see generic_item_tab. */
+    appliestogroup: new Field(
+      itemcustomfieldElemID,
+      'appliestogroup',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestokit: new Field(
+      itemcustomfieldElemID,
+      'appliestokit',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestoinventory: new Field(
+      itemcustomfieldElemID,
+      'appliestoinventory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the INVENTORY feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. INVENTORY must be enabled for this field to appear in your account. */
+    appliestoitemassembly: new Field(
+      itemcustomfieldElemID,
+      'appliestoitemassembly',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ASSEMBLIES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ASSEMBLIES must be enabled for this field to appear in your account. */
+    appliestononinventory: new Field(
+      itemcustomfieldElemID,
+      'appliestononinventory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestoothercharge: new Field(
+      itemcustomfieldElemID,
+      'appliestoothercharge',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestopricelist: new Field(
+      itemcustomfieldElemID,
+      'appliestopricelist',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestoservice: new Field(
+      itemcustomfieldElemID,
+      'appliestoservice',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestospecificitems: new Field(
+      itemcustomfieldElemID,
+      'appliestospecificitems',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestosubplan: new Field(
+      itemcustomfieldElemID,
+      'appliestosubplan',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    includechilditems: new Field(
+      itemcustomfieldElemID,
+      'includechilditems',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    itemmatrix: new Field(
+      itemcustomfieldElemID,
+      'itemmatrix',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the MATRIXITEMS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. MATRIXITEMS must be enabled for this field to appear in your account. */
+    ismhitemattribute: new Field(
+      itemcustomfieldElemID,
+      'ismhitemattribute',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the MERCHANDISEHIERARCHY feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. MERCHANDISEHIERARCHY must be enabled for this field to appear in your account. */
+    itemsubtype: new Field(
+      itemcustomfieldElemID,
+      'itemsubtype',
+      enums.itemcustomfield_itemsubtype,
+      {
+      },
+    ), /* Original description: For information about possible values, see itemcustomfield_itemsubtype. */
+    customfieldfilters: new Field(
+      itemcustomfieldElemID,
+      'customfieldfilters',
+      itemcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      itemcustomfieldElemID,
+      'roleaccesses',
+      itemcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemcustomfieldElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/itemnumbercustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/itemnumbercustomfield.ts
@@ -1,0 +1,468 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const itemnumbercustomfieldInnerTypes: ObjectType[] = []
+
+const itemnumbercustomfieldElemID = new ElemID(constants.NETSUITE, 'itemnumbercustomfield')
+const itemnumbercustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'itemnumbercustomfield_customfieldfilters_customfieldfilter')
+
+const itemnumbercustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: itemnumbercustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      itemnumbercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      itemnumbercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      itemnumbercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      itemnumbercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      itemnumbercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      itemnumbercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      itemnumbercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      itemnumbercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemnumbercustomfieldElemID.name],
+})
+
+itemnumbercustomfieldInnerTypes.push(itemnumbercustomfield_customfieldfilters_customfieldfilter)
+
+const itemnumbercustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'itemnumbercustomfield_customfieldfilters')
+
+const itemnumbercustomfield_customfieldfilters = new ObjectType({
+  elemID: itemnumbercustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      itemnumbercustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(itemnumbercustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemnumbercustomfieldElemID.name],
+})
+
+itemnumbercustomfieldInnerTypes.push(itemnumbercustomfield_customfieldfilters)
+
+const itemnumbercustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'itemnumbercustomfield_roleaccesses_roleaccess')
+
+const itemnumbercustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: itemnumbercustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      itemnumbercustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      itemnumbercustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      itemnumbercustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemnumbercustomfieldElemID.name],
+})
+
+itemnumbercustomfieldInnerTypes.push(itemnumbercustomfield_roleaccesses_roleaccess)
+
+const itemnumbercustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'itemnumbercustomfield_roleaccesses')
+
+const itemnumbercustomfield_roleaccesses = new ObjectType({
+  elemID: itemnumbercustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      itemnumbercustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(itemnumbercustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemnumbercustomfieldElemID.name],
+})
+
+itemnumbercustomfieldInnerTypes.push(itemnumbercustomfield_roleaccesses)
+
+
+export const itemnumbercustomfield = new ObjectType({
+  elemID: itemnumbercustomfieldElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custitemnumber_',
+  },
+  fields: {
+    scriptid: new Field(
+      itemnumbercustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 44 characters long.   The default value is ‘custitemnumber’. */
+    fieldtype: new Field(
+      itemnumbercustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      itemnumbercustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      itemnumbercustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      itemnumbercustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      itemnumbercustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      itemnumbercustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      itemnumbercustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      itemnumbercustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      itemnumbercustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      itemnumbercustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      itemnumbercustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      itemnumbercustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      itemnumbercustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      itemnumbercustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      itemnumbercustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      itemnumbercustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      itemnumbercustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    encryptatrest: new Field(
+      itemnumbercustomfieldElemID,
+      'encryptatrest',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      itemnumbercustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      itemnumbercustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    globalsearch: new Field(
+      itemnumbercustomfieldElemID,
+      'globalsearch',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    isformula: new Field(
+      itemnumbercustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      itemnumbercustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      itemnumbercustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      itemnumbercustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      itemnumbercustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      itemnumbercustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      itemnumbercustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    showhierarchy: new Field(
+      itemnumbercustomfieldElemID,
+      'showhierarchy',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showinlist: new Field(
+      itemnumbercustomfieldElemID,
+      'showinlist',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    sourcefilterby: new Field(
+      itemnumbercustomfieldElemID,
+      'sourcefilterby',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcefrom: new Field(
+      itemnumbercustomfieldElemID,
+      'sourcefrom',
+      BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcelist: new Field(
+      itemnumbercustomfieldElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the itemnumbercustomfield custom type.   For information about other possible values, see generic_standard_field. */
+    appliestoallitems: new Field(
+      itemnumbercustomfieldElemID,
+      'appliestoallitems',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestogiftcerts: new Field(
+      itemnumbercustomfieldElemID,
+      'appliestogiftcerts',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestolots: new Field(
+      itemnumbercustomfieldElemID,
+      'appliestolots',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    appliestoserialized: new Field(
+      itemnumbercustomfieldElemID,
+      'appliestoserialized',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    customfieldfilters: new Field(
+      itemnumbercustomfieldElemID,
+      'customfieldfilters',
+      itemnumbercustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      itemnumbercustomfieldElemID,
+      'roleaccesses',
+      itemnumbercustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemnumbercustomfieldElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/itemoptioncustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/itemoptioncustomfield.ts
@@ -1,0 +1,482 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const itemoptioncustomfieldInnerTypes: ObjectType[] = []
+
+const itemoptioncustomfieldElemID = new ElemID(constants.NETSUITE, 'itemoptioncustomfield')
+const itemoptioncustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'itemoptioncustomfield_customfieldfilters_customfieldfilter')
+
+const itemoptioncustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: itemoptioncustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      itemoptioncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      itemoptioncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      itemoptioncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      itemoptioncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      itemoptioncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      itemoptioncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      itemoptioncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      itemoptioncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemoptioncustomfieldElemID.name],
+})
+
+itemoptioncustomfieldInnerTypes.push(itemoptioncustomfield_customfieldfilters_customfieldfilter)
+
+const itemoptioncustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'itemoptioncustomfield_customfieldfilters')
+
+const itemoptioncustomfield_customfieldfilters = new ObjectType({
+  elemID: itemoptioncustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      itemoptioncustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(itemoptioncustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemoptioncustomfieldElemID.name],
+})
+
+itemoptioncustomfieldInnerTypes.push(itemoptioncustomfield_customfieldfilters)
+
+const itemoptioncustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'itemoptioncustomfield_roleaccesses_roleaccess')
+
+const itemoptioncustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: itemoptioncustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      itemoptioncustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      itemoptioncustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      itemoptioncustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemoptioncustomfieldElemID.name],
+})
+
+itemoptioncustomfieldInnerTypes.push(itemoptioncustomfield_roleaccesses_roleaccess)
+
+const itemoptioncustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'itemoptioncustomfield_roleaccesses')
+
+const itemoptioncustomfield_roleaccesses = new ObjectType({
+  elemID: itemoptioncustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      itemoptioncustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(itemoptioncustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemoptioncustomfieldElemID.name],
+})
+
+itemoptioncustomfieldInnerTypes.push(itemoptioncustomfield_roleaccesses)
+
+
+export const itemoptioncustomfield = new ObjectType({
+  elemID: itemoptioncustomfieldElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custcol_',
+  },
+  fields: {
+    scriptid: new Field(
+      itemoptioncustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 37 characters long.   The default value is ‘custcol’. */
+    fieldtype: new Field(
+      itemoptioncustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      itemoptioncustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      itemoptioncustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      itemoptioncustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      itemoptioncustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      itemoptioncustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      itemoptioncustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      itemoptioncustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      itemoptioncustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      itemoptioncustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      itemoptioncustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      itemoptioncustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      itemoptioncustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      itemoptioncustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      itemoptioncustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      itemoptioncustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    displayheight: new Field(
+      itemoptioncustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      itemoptioncustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    isformula: new Field(
+      itemoptioncustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      itemoptioncustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      itemoptioncustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      itemoptioncustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      itemoptioncustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      itemoptioncustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      itemoptioncustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    showhierarchy: new Field(
+      itemoptioncustomfieldElemID,
+      'showhierarchy',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    sourcefilterby: new Field(
+      itemoptioncustomfieldElemID,
+      'sourcefilterby',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcefrom: new Field(
+      itemoptioncustomfieldElemID,
+      'sourcefrom',
+      BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcelist: new Field(
+      itemoptioncustomfieldElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the itemoptioncustomfield custom type.   For information about other possible values, see generic_standard_field. */
+    colallitems: new Field(
+      itemoptioncustomfieldElemID,
+      'colallitems',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    colkititem: new Field(
+      itemoptioncustomfieldElemID,
+      'colkititem',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    colopportunity: new Field(
+      itemoptioncustomfieldElemID,
+      'colopportunity',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the OPPORTUNITIES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. OPPORTUNITIES must be enabled for this field to appear in your account. */
+    coloptionlabel: new Field(
+      itemoptioncustomfieldElemID,
+      'coloptionlabel',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    colpurchase: new Field(
+      itemoptioncustomfieldElemID,
+      'colpurchase',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    colsale: new Field(
+      itemoptioncustomfieldElemID,
+      'colsale',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    colstore: new Field(
+      itemoptioncustomfieldElemID,
+      'colstore',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the WEBSITE feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. WEBSITE must be enabled for this field to appear in your account. */
+    colstorehidden: new Field(
+      itemoptioncustomfieldElemID,
+      'colstorehidden',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the WEBSITE feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. WEBSITE must be enabled for this field to appear in your account. */
+    coltransferorder: new Field(
+      itemoptioncustomfieldElemID,
+      'coltransferorder',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the MULTILOCINVT feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. MULTILOCINVT must be enabled for this field to appear in your account. */
+    includechilditems: new Field(
+      itemoptioncustomfieldElemID,
+      'includechilditems',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    customfieldfilters: new Field(
+      itemoptioncustomfieldElemID,
+      'customfieldfilters',
+      itemoptioncustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      itemoptioncustomfieldElemID,
+      'roleaccesses',
+      itemoptioncustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, itemoptioncustomfieldElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/kpiscorecard.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/kpiscorecard.ts
@@ -1,0 +1,501 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const kpiscorecardInnerTypes: ObjectType[] = []
+
+const kpiscorecardElemID = new ElemID(constants.NETSUITE, 'kpiscorecard')
+const kpiscorecard_audienceElemID = new ElemID(constants.NETSUITE, 'kpiscorecard_audience')
+
+const kpiscorecard_audience = new ObjectType({
+  elemID: kpiscorecard_audienceElemID,
+  annotations: {
+  },
+  fields: {
+    allroles: new Field(
+      kpiscorecard_audienceElemID,
+      'allroles',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allpartners: new Field(
+      kpiscorecard_audienceElemID,
+      'allpartners',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account. */
+    allemployees: new Field(
+      kpiscorecard_audienceElemID,
+      'allemployees',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    audslctrole: new Field(
+      kpiscorecard_audienceElemID,
+      'audslctrole',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: This field is available when the allroles value is not equal to T.   You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, kpiscorecardElemID.name],
+})
+
+kpiscorecardInnerTypes.push(kpiscorecard_audience)
+
+const kpiscorecard_customElemID = new ElemID(constants.NETSUITE, 'kpiscorecard_custom')
+
+const kpiscorecard_custom = new ObjectType({
+  elemID: kpiscorecard_customElemID,
+  annotations: {
+  },
+  fields: {
+    kpi1: new Field(
+      kpiscorecard_customElemID,
+      'kpi1',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type.   For information about other possible values, see the following lists:   generic_savedsearches_period   generic_savedsearches_daterange */
+    kpi2: new Field(
+      kpiscorecard_customElemID,
+      'kpi2',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type.   For information about other possible values, see the following lists:   generic_savedsearches_period   generic_savedsearches_daterange */
+    kpi3: new Field(
+      kpiscorecard_customElemID,
+      'kpi3',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type.   For information about other possible values, see the following lists:   generic_savedsearches_period   generic_savedsearches_daterange */
+    kpi4: new Field(
+      kpiscorecard_customElemID,
+      'kpi4',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type.   For information about other possible values, see the following lists:   generic_savedsearches_period   generic_savedsearches_daterange */
+    kpi5: new Field(
+      kpiscorecard_customElemID,
+      'kpi5',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type.   For information about other possible values, see the following lists:   generic_savedsearches_period   generic_savedsearches_daterange */
+    kpi6: new Field(
+      kpiscorecard_customElemID,
+      'kpi6',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type.   For information about other possible values, see the following lists:   generic_savedsearches_period   generic_savedsearches_daterange */
+    kpi7: new Field(
+      kpiscorecard_customElemID,
+      'kpi7',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type.   For information about other possible values, see the following lists:   generic_savedsearches_period   generic_savedsearches_daterange */
+    kpi8: new Field(
+      kpiscorecard_customElemID,
+      'kpi8',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type.   For information about other possible values, see the following lists:   generic_savedsearches_period   generic_savedsearches_daterange */
+    kpi9: new Field(
+      kpiscorecard_customElemID,
+      'kpi9',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type.   For information about other possible values, see the following lists:   generic_savedsearches_period   generic_savedsearches_daterange */
+    kpi10: new Field(
+      kpiscorecard_customElemID,
+      'kpi10',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type.   For information about other possible values, see the following lists:   generic_savedsearches_period   generic_savedsearches_daterange */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, kpiscorecardElemID.name],
+})
+
+kpiscorecardInnerTypes.push(kpiscorecard_custom)
+
+const kpiscorecard_highlightings_highlightingElemID = new ElemID(constants.NETSUITE, 'kpiscorecard_highlightings_highlighting')
+
+const kpiscorecard_highlightings_highlighting = new ObjectType({
+  elemID: kpiscorecard_highlightings_highlightingElemID,
+  annotations: {
+  },
+  fields: {
+    kpiindex: new Field(
+      kpiscorecard_highlightings_highlightingElemID,
+      'kpiindex',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: The default value is 'ALL'. */
+    condition: new Field(
+      kpiscorecard_highlightings_highlightingElemID,
+      'condition',
+      enums.kpiscorecards_highlight_conditions,
+      {
+      },
+    ), /* Original description: For information about possible values, see kpiscorecards_highlight_conditions. */
+    threshold: new Field(
+      kpiscorecard_highlightings_highlightingElemID,
+      'threshold',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    rangeindex: new Field(
+      kpiscorecard_highlightings_highlightingElemID,
+      'rangeindex',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: The default value is 'ALL'. */
+    icon: new Field(
+      kpiscorecard_highlightings_highlightingElemID,
+      'icon',
+      enums.kpiscorecards_highlight_icons,
+      {
+      },
+    ), /* Original description: For information about possible values, see kpiscorecards_highlight_icons. */
+    foregroundcolor: new Field(
+      kpiscorecard_highlightings_highlightingElemID,
+      'foregroundcolor',
+      BuiltinTypes.STRING /* Original type was rgb   RGB field types must be set to a valid 6–digit hexadecimal value between #000000 and #FFFFFF. The # prefix is optional. */,
+      {
+      },
+    ), /* Original description: The default value is '#000000'. */
+    backgroundcolor: new Field(
+      kpiscorecard_highlightings_highlightingElemID,
+      'backgroundcolor',
+      BuiltinTypes.STRING /* Original type was rgb   RGB field types must be set to a valid 6–digit hexadecimal value between #000000 and #FFFFFF. The # prefix is optional. */,
+      {
+      },
+    ), /* Original description: The default value is '#FFFFFF'. */
+    bold: new Field(
+      kpiscorecard_highlightings_highlightingElemID,
+      'bold',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    headline: new Field(
+      kpiscorecard_highlightings_highlightingElemID,
+      'headline',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, kpiscorecardElemID.name],
+})
+
+kpiscorecardInnerTypes.push(kpiscorecard_highlightings_highlighting)
+
+const kpiscorecard_highlightingsElemID = new ElemID(constants.NETSUITE, 'kpiscorecard_highlightings')
+
+const kpiscorecard_highlightings = new ObjectType({
+  elemID: kpiscorecard_highlightingsElemID,
+  annotations: {
+  },
+  fields: {
+    highlighting: new Field(
+      kpiscorecard_highlightingsElemID,
+      'highlighting',
+      new ListType(kpiscorecard_highlightings_highlighting),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, kpiscorecardElemID.name],
+})
+
+kpiscorecardInnerTypes.push(kpiscorecard_highlightings)
+
+const kpiscorecard_kpis_kpiElemID = new ElemID(constants.NETSUITE, 'kpiscorecard_kpis_kpi')
+
+const kpiscorecard_kpis_kpi = new ObjectType({
+  elemID: kpiscorecard_kpis_kpiElemID,
+  annotations: {
+  },
+  fields: {
+    kpi: new Field(
+      kpiscorecard_kpis_kpiElemID,
+      'kpi',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see the following lists:   kpi_snapshots_formula   kpi_snapshots_daterange_or_period   kpi_snapshots_daterange   kpi_snapshots_custom */
+    comparevalueto: new Field(
+      kpiscorecard_kpis_kpiElemID,
+      'comparevalueto',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is available when the kpi value is not present in kpi_snapshots_formula.   For information about possible values, see the following lists:   kpi_snapshots_formula   kpi_snapshots_daterange_or_period   kpi_snapshots_daterange   kpi_snapshots_custom */
+    comparewithprevious: new Field(
+      kpiscorecard_kpis_kpiElemID,
+      'comparewithprevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the kpi value is not present in kpi_snapshots_formula.   The default value is F. */
+    comparisontype: new Field(
+      kpiscorecard_kpis_kpiElemID,
+      'comparisontype',
+      enums.kpiscorecards_comparisons,
+      {
+      },
+    ), /* Original description: This field is available when the kpi value is not present in kpi_snapshots_formula.   For information about possible values, see kpiscorecards_comparisons. */
+    invertcomparison: new Field(
+      kpiscorecard_kpis_kpiElemID,
+      'invertcomparison',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the kpi value is not present in kpi_snapshots_formula.   The default value is F. */
+    formula: new Field(
+      kpiscorecard_kpis_kpiElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long.   This field is available when the kpi value is present in kpi_snapshots_formula. */
+    lessismore: new Field(
+      kpiscorecard_kpis_kpiElemID,
+      'lessismore',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the kpi value is present in kpi_snapshots_formula.   The default value is F. */
+    hidden: new Field(
+      kpiscorecard_kpis_kpiElemID,
+      'hidden',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    label: new Field(
+      kpiscorecard_kpis_kpiElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+      },
+    ), /* Original description: This field value can be up to 99 characters long. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, kpiscorecardElemID.name],
+})
+
+kpiscorecardInnerTypes.push(kpiscorecard_kpis_kpi)
+
+const kpiscorecard_kpisElemID = new ElemID(constants.NETSUITE, 'kpiscorecard_kpis')
+
+const kpiscorecard_kpis = new ObjectType({
+  elemID: kpiscorecard_kpisElemID,
+  annotations: {
+  },
+  fields: {
+    kpi: new Field(
+      kpiscorecard_kpisElemID,
+      'kpi',
+      new ListType(kpiscorecard_kpis_kpi),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, kpiscorecardElemID.name],
+})
+
+kpiscorecardInnerTypes.push(kpiscorecard_kpis)
+
+const kpiscorecard_ranges_rangeElemID = new ElemID(constants.NETSUITE, 'kpiscorecard_ranges_range')
+
+const kpiscorecard_ranges_range = new ObjectType({
+  elemID: kpiscorecard_ranges_rangeElemID,
+  annotations: {
+  },
+  fields: {
+    range: new Field(
+      kpiscorecard_ranges_rangeElemID,
+      'range',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see the following lists:   kpi_ranges_period   kpi_ranges_daterange_report   kpi_ranges_daterange_or_period   kpi_ranges_daterange */
+    comparevalueto: new Field(
+      kpiscorecard_ranges_rangeElemID,
+      'comparevalueto',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: For information about possible values, see the following lists:   kpi_ranges_period   kpi_ranges_daterange_report   kpi_ranges_daterange_or_period   kpi_ranges_daterange */
+    comparewithprevious: new Field(
+      kpiscorecard_ranges_rangeElemID,
+      'comparewithprevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    comparisontype: new Field(
+      kpiscorecard_ranges_rangeElemID,
+      'comparisontype',
+      enums.kpiscorecards_comparisons,
+      {
+      },
+    ), /* Original description: For information about possible values, see kpiscorecards_comparisons. */
+    invertcomparison: new Field(
+      kpiscorecard_ranges_rangeElemID,
+      'invertcomparison',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    label: new Field(
+      kpiscorecard_ranges_rangeElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+      },
+    ), /* Original description: This field value can be up to 99 characters long. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, kpiscorecardElemID.name],
+})
+
+kpiscorecardInnerTypes.push(kpiscorecard_ranges_range)
+
+const kpiscorecard_rangesElemID = new ElemID(constants.NETSUITE, 'kpiscorecard_ranges')
+
+const kpiscorecard_ranges = new ObjectType({
+  elemID: kpiscorecard_rangesElemID,
+  annotations: {
+  },
+  fields: {
+    range: new Field(
+      kpiscorecard_rangesElemID,
+      'range',
+      new ListType(kpiscorecard_ranges_range),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, kpiscorecardElemID.name],
+})
+
+kpiscorecardInnerTypes.push(kpiscorecard_ranges)
+
+
+export const kpiscorecard = new ObjectType({
+  elemID: kpiscorecardElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custkpiscorecard_',
+  },
+  fields: {
+    scriptid: new Field(
+      kpiscorecardElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custkpiscorecard’. */
+    name: new Field(
+      kpiscorecardElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 25,
+      },
+    ), /* Original description: This field value can be up to 25 characters long. */
+    useperiods: new Field(
+      kpiscorecardElemID,
+      'useperiods',
+      enums.kpiscorecards_useperiods,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see kpiscorecards_useperiods. */
+    description: new Field(
+      kpiscorecardElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    audience: new Field(
+      kpiscorecardElemID,
+      'audience',
+      kpiscorecard_audience,
+      {
+      },
+    ),
+    custom: new Field(
+      kpiscorecardElemID,
+      'custom',
+      kpiscorecard_custom,
+      {
+      },
+    ),
+    highlightings: new Field(
+      kpiscorecardElemID,
+      'highlightings',
+      kpiscorecard_highlightings,
+      {
+      },
+    ),
+    kpis: new Field(
+      kpiscorecardElemID,
+      'kpis',
+      kpiscorecard_kpis,
+      {
+      },
+    ),
+    ranges: new Field(
+      kpiscorecardElemID,
+      'ranges',
+      kpiscorecard_ranges,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, kpiscorecardElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/mapreducescript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/mapreducescript.ts
@@ -1,0 +1,1203 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const mapreducescriptInnerTypes: ObjectType[] = []
+
+const mapreducescriptElemID = new ElemID(constants.NETSUITE, 'mapreducescript')
+const mapreducescript_customplugintypes_plugintypeElemID = new ElemID(constants.NETSUITE, 'mapreducescript_customplugintypes_plugintype')
+
+const mapreducescript_customplugintypes_plugintype = new ObjectType({
+  elemID: mapreducescript_customplugintypes_plugintypeElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      mapreducescript_customplugintypes_plugintypeElemID,
+      'plugintype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the plugintype custom type. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_customplugintypes_plugintype)
+
+const mapreducescript_customplugintypesElemID = new ElemID(constants.NETSUITE, 'mapreducescript_customplugintypes')
+
+const mapreducescript_customplugintypes = new ObjectType({
+  elemID: mapreducescript_customplugintypesElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      mapreducescript_customplugintypesElemID,
+      'plugintype',
+      new ListType(mapreducescript_customplugintypes_plugintype),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_customplugintypes)
+
+const mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter')
+
+const mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter)
+
+const mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters')
+
+const mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters = new ObjectType({
+  elemID: mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters)
+
+const mapreducescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess')
+
+const mapreducescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: mapreducescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess)
+
+const mapreducescript_scriptcustomfields_scriptcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptcustomfields_scriptcustomfield_roleaccesses')
+
+const mapreducescript_scriptcustomfields_scriptcustomfield_roleaccesses = new ObjectType({
+  elemID: mapreducescript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(mapreducescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptcustomfields_scriptcustomfield_roleaccesses)
+
+const mapreducescript_scriptcustomfields_scriptcustomfieldElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptcustomfields_scriptcustomfield')
+
+const mapreducescript_scriptcustomfields_scriptcustomfield = new ObjectType({
+  elemID: mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custscript’. */
+    fieldtype: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    isformula: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    setting: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'setting',
+      enums.script_setting,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_setting. */
+    customfieldfilters: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'customfieldfilters',
+      mapreducescript_scriptcustomfields_scriptcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      mapreducescript_scriptcustomfields_scriptcustomfieldElemID,
+      'roleaccesses',
+      mapreducescript_scriptcustomfields_scriptcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptcustomfields_scriptcustomfield)
+
+const mapreducescript_scriptcustomfieldsElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptcustomfields')
+
+const mapreducescript_scriptcustomfields = new ObjectType({
+  elemID: mapreducescript_scriptcustomfieldsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptcustomfield: new Field(
+      mapreducescript_scriptcustomfieldsElemID,
+      'scriptcustomfield',
+      new ListType(mapreducescript_scriptcustomfields_scriptcustomfield),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptcustomfields)
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_dailyElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptdeployments_scriptdeployment_recurrence_daily')
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_daily = new ObjectType({
+  elemID: mapreducescript_scriptdeployments_scriptdeployment_recurrence_dailyElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_dailyElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_dailyElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    everyxdays: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_dailyElemID,
+      'everyxdays',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_dailyElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    repeat: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_dailyElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptdeployments_scriptdeployment_recurrence_daily)
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_everyweekdayElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptdeployments_scriptdeployment_recurrence_everyweekday')
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_everyweekday = new ObjectType({
+  elemID: mapreducescript_scriptdeployments_scriptdeployment_recurrence_everyweekdayElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_everyweekdayElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_everyweekdayElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_everyweekdayElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    repeat: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_everyweekdayElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptdeployments_scriptdeployment_recurrence_everyweekday)
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlyElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthly')
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthly = new ObjectType({
+  elemID: mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlyElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlyElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlyElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    everyxmonths: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlyElemID,
+      'everyxmonths',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlyElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    repeat: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlyElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthly)
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweek')
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweek = new ObjectType({
+  elemID: mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    orderofweek: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+      'orderofweek',
+      enums.generic_order_of_week,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_order_of_week. */
+    dayofweek: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+      'dayofweek',
+      enums.generic_day_of_week,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_day_of_week. */
+    everyxmonths: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+      'everyxmonths',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    repeat: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweek)
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_singleElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptdeployments_scriptdeployment_recurrence_single')
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_single = new ObjectType({
+  elemID: mapreducescript_scriptdeployments_scriptdeployment_recurrence_singleElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_singleElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_singleElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    repeat: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_singleElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptdeployments_scriptdeployment_recurrence_single)
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptdeployments_scriptdeployment_recurrence_weekly')
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_weekly = new ObjectType({
+  elemID: mapreducescript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    everyxweeks: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'everyxweeks',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    sunday: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'sunday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    monday: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'monday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    tuesday: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'tuesday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    wednesday: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'wednesday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    thursday: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'thursday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    friday: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'friday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    saturday: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'saturday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    enddate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    repeat: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptdeployments_scriptdeployment_recurrence_weekly)
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlyElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearly')
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearly = new ObjectType({
+  elemID: mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlyElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlyElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlyElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlyElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    repeat: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlyElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearly)
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweek')
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweek = new ObjectType({
+  elemID: mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    orderofweek: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID,
+      'orderofweek',
+      enums.generic_order_of_week,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_order_of_week. */
+    dayofweek: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID,
+      'dayofweek',
+      enums.generic_day_of_week,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_day_of_week. */
+    enddate: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    repeat: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweek)
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrenceElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptdeployments_scriptdeployment_recurrence')
+
+const mapreducescript_scriptdeployments_scriptdeployment_recurrence = new ObjectType({
+  elemID: mapreducescript_scriptdeployments_scriptdeployment_recurrenceElemID,
+  annotations: {
+  },
+  fields: {
+    daily: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'daily',
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_daily,
+      {
+      },
+    ),
+    everyweekday: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'everyweekday',
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_everyweekday,
+      {
+      },
+    ),
+    monthly: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'monthly',
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthly,
+      {
+      },
+    ),
+    monthlydayofweek: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'monthlydayofweek',
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweek,
+      {
+      },
+    ),
+    single: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'single',
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_single,
+      {
+      },
+    ),
+    weekly: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'weekly',
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_weekly,
+      {
+      },
+    ),
+    yearly: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'yearly',
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearly,
+      {
+      },
+    ),
+    yearlydayofweek: new Field(
+      mapreducescript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'yearlydayofweek',
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweek,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptdeployments_scriptdeployment_recurrence)
+
+const mapreducescript_scriptdeployments_scriptdeploymentElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptdeployments_scriptdeployment')
+
+const mapreducescript_scriptdeployments_scriptdeployment = new ObjectType({
+  elemID: mapreducescript_scriptdeployments_scriptdeploymentElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      mapreducescript_scriptdeployments_scriptdeploymentElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customdeploy’. */
+    status: new Field(
+      mapreducescript_scriptdeployments_scriptdeploymentElemID,
+      'status',
+      enums.script_status,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+    title: new Field(
+      mapreducescript_scriptdeployments_scriptdeploymentElemID,
+      'title',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    isdeployed: new Field(
+      mapreducescript_scriptdeployments_scriptdeploymentElemID,
+      'isdeployed',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    loglevel: new Field(
+      mapreducescript_scriptdeployments_scriptdeploymentElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+    runasrole: new Field(
+      mapreducescript_scriptdeployments_scriptdeploymentElemID,
+      'runasrole',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    buffersize: new Field(
+      mapreducescript_scriptdeployments_scriptdeploymentElemID,
+      'buffersize',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: The default value is '1'. */
+    concurrencylimit: new Field(
+      mapreducescript_scriptdeployments_scriptdeploymentElemID,
+      'concurrencylimit',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: The default value is '1'. */
+    queueallstagesatonce: new Field(
+      mapreducescript_scriptdeployments_scriptdeploymentElemID,
+      'queueallstagesatonce',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    yieldaftermins: new Field(
+      mapreducescript_scriptdeployments_scriptdeploymentElemID,
+      'yieldaftermins',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: The default value is '60'. */
+    recurrence: new Field(
+      mapreducescript_scriptdeployments_scriptdeploymentElemID,
+      'recurrence',
+      mapreducescript_scriptdeployments_scriptdeployment_recurrence,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptdeployments_scriptdeployment)
+
+const mapreducescript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptdeployments')
+
+const mapreducescript_scriptdeployments = new ObjectType({
+  elemID: mapreducescript_scriptdeploymentsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptdeployment: new Field(
+      mapreducescript_scriptdeploymentsElemID,
+      'scriptdeployment',
+      new ListType(mapreducescript_scriptdeployments_scriptdeployment),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})
+
+mapreducescriptInnerTypes.push(mapreducescript_scriptdeployments)
+
+
+export const mapreducescript = new ObjectType({
+  elemID: mapreducescriptElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      mapreducescriptElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      mapreducescriptElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      mapreducescriptElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    description: new Field(
+      mapreducescriptElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      mapreducescriptElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      mapreducescriptElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      mapreducescriptElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      mapreducescriptElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      mapreducescriptElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    customplugintypes: new Field(
+      mapreducescriptElemID,
+      'customplugintypes',
+      mapreducescript_customplugintypes,
+      {
+      },
+    ),
+    scriptcustomfields: new Field(
+      mapreducescriptElemID,
+      'scriptcustomfields',
+      mapreducescript_scriptcustomfields,
+      {
+      },
+    ),
+    scriptdeployments: new Field(
+      mapreducescriptElemID,
+      'scriptdeployments',
+      mapreducescript_scriptdeployments,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, mapreducescriptElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/massupdatescript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/massupdatescript.ts
@@ -1,0 +1,719 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const massupdatescriptInnerTypes: ObjectType[] = []
+
+const massupdatescriptElemID = new ElemID(constants.NETSUITE, 'massupdatescript')
+const massupdatescript_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'massupdatescript_libraries_library')
+
+const massupdatescript_libraries_library = new ObjectType({
+  elemID: massupdatescript_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      massupdatescript_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, massupdatescriptElemID.name],
+})
+
+massupdatescriptInnerTypes.push(massupdatescript_libraries_library)
+
+const massupdatescript_librariesElemID = new ElemID(constants.NETSUITE, 'massupdatescript_libraries')
+
+const massupdatescript_libraries = new ObjectType({
+  elemID: massupdatescript_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      massupdatescript_librariesElemID,
+      'library',
+      new ListType(massupdatescript_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, massupdatescriptElemID.name],
+})
+
+massupdatescriptInnerTypes.push(massupdatescript_libraries)
+
+const massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter')
+
+const massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, massupdatescriptElemID.name],
+})
+
+massupdatescriptInnerTypes.push(massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter)
+
+const massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters')
+
+const massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters = new ObjectType({
+  elemID: massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, massupdatescriptElemID.name],
+})
+
+massupdatescriptInnerTypes.push(massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters)
+
+const massupdatescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'massupdatescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess')
+
+const massupdatescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: massupdatescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, massupdatescriptElemID.name],
+})
+
+massupdatescriptInnerTypes.push(massupdatescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess)
+
+const massupdatescript_scriptcustomfields_scriptcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'massupdatescript_scriptcustomfields_scriptcustomfield_roleaccesses')
+
+const massupdatescript_scriptcustomfields_scriptcustomfield_roleaccesses = new ObjectType({
+  elemID: massupdatescript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(massupdatescript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, massupdatescriptElemID.name],
+})
+
+massupdatescriptInnerTypes.push(massupdatescript_scriptcustomfields_scriptcustomfield_roleaccesses)
+
+const massupdatescript_scriptcustomfields_scriptcustomfieldElemID = new ElemID(constants.NETSUITE, 'massupdatescript_scriptcustomfields_scriptcustomfield')
+
+const massupdatescript_scriptcustomfields_scriptcustomfield = new ObjectType({
+  elemID: massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custscript’. */
+    fieldtype: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    isformula: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    setting: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'setting',
+      enums.script_setting,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_setting. */
+    customfieldfilters: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'customfieldfilters',
+      massupdatescript_scriptcustomfields_scriptcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      massupdatescript_scriptcustomfields_scriptcustomfieldElemID,
+      'roleaccesses',
+      massupdatescript_scriptcustomfields_scriptcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, massupdatescriptElemID.name],
+})
+
+massupdatescriptInnerTypes.push(massupdatescript_scriptcustomfields_scriptcustomfield)
+
+const massupdatescript_scriptcustomfieldsElemID = new ElemID(constants.NETSUITE, 'massupdatescript_scriptcustomfields')
+
+const massupdatescript_scriptcustomfields = new ObjectType({
+  elemID: massupdatescript_scriptcustomfieldsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptcustomfield: new Field(
+      massupdatescript_scriptcustomfieldsElemID,
+      'scriptcustomfield',
+      new ListType(massupdatescript_scriptcustomfields_scriptcustomfield),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, massupdatescriptElemID.name],
+})
+
+massupdatescriptInnerTypes.push(massupdatescript_scriptcustomfields)
+
+const massupdatescript_scriptdeployments_scriptdeploymentElemID = new ElemID(constants.NETSUITE, 'massupdatescript_scriptdeployments_scriptdeployment')
+
+const massupdatescript_scriptdeployments_scriptdeployment = new ObjectType({
+  elemID: massupdatescript_scriptdeployments_scriptdeploymentElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customdeploy’. */
+    status: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'status',
+      enums.script_status,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+    recordtype: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'recordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customtransactiontype   customrecordtype   For information about other possible values, see scriptdeployment_recordtype. */
+    allemployees: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'allemployees',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allpartners: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'allpartners',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account. */
+    allroles: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'allroles',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    auddepartment: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'auddepartment',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the DEPARTMENTS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. DEPARTMENTS must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    audemployee: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'audemployee',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   Note Account-specific values are not supported by SDF. */
+    audgroup: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'audgroup',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   Note Account-specific values are not supported by SDF. */
+    audpartner: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'audpartner',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    audslctrole: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'audslctrole',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    audsubsidiary: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'audsubsidiary',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the SUBSIDIARIES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. SUBSIDIARIES must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    isdeployed: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'isdeployed',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    loglevel: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+    runasrole: new Field(
+      massupdatescript_scriptdeployments_scriptdeploymentElemID,
+      'runasrole',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, massupdatescriptElemID.name],
+})
+
+massupdatescriptInnerTypes.push(massupdatescript_scriptdeployments_scriptdeployment)
+
+const massupdatescript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'massupdatescript_scriptdeployments')
+
+const massupdatescript_scriptdeployments = new ObjectType({
+  elemID: massupdatescript_scriptdeploymentsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptdeployment: new Field(
+      massupdatescript_scriptdeploymentsElemID,
+      'scriptdeployment',
+      new ListType(massupdatescript_scriptdeployments_scriptdeployment),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, massupdatescriptElemID.name],
+})
+
+massupdatescriptInnerTypes.push(massupdatescript_scriptdeployments)
+
+
+export const massupdatescript = new ObjectType({
+  elemID: massupdatescriptElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      massupdatescriptElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      massupdatescriptElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      massupdatescriptElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    defaultfunction: new Field(
+      massupdatescriptElemID,
+      'defaultfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      massupdatescriptElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      massupdatescriptElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      massupdatescriptElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      massupdatescriptElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      massupdatescriptElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      massupdatescriptElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      massupdatescriptElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    libraries: new Field(
+      massupdatescriptElemID,
+      'libraries',
+      massupdatescript_libraries,
+      {
+      },
+    ),
+    scriptcustomfields: new Field(
+      massupdatescriptElemID,
+      'scriptcustomfields',
+      massupdatescript_scriptcustomfields,
+      {
+      },
+    ),
+    scriptdeployments: new Field(
+      massupdatescriptElemID,
+      'scriptdeployments',
+      massupdatescript_scriptdeployments,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, massupdatescriptElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/othercustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/othercustomfield.ts
@@ -1,0 +1,462 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const othercustomfieldInnerTypes: ObjectType[] = []
+
+const othercustomfieldElemID = new ElemID(constants.NETSUITE, 'othercustomfield')
+const othercustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'othercustomfield_customfieldfilters_customfieldfilter')
+
+const othercustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: othercustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      othercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      othercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      othercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      othercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      othercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      othercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      othercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      othercustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, othercustomfieldElemID.name],
+})
+
+othercustomfieldInnerTypes.push(othercustomfield_customfieldfilters_customfieldfilter)
+
+const othercustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'othercustomfield_customfieldfilters')
+
+const othercustomfield_customfieldfilters = new ObjectType({
+  elemID: othercustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      othercustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(othercustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, othercustomfieldElemID.name],
+})
+
+othercustomfieldInnerTypes.push(othercustomfield_customfieldfilters)
+
+const othercustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'othercustomfield_roleaccesses_roleaccess')
+
+const othercustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: othercustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      othercustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      othercustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      othercustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, othercustomfieldElemID.name],
+})
+
+othercustomfieldInnerTypes.push(othercustomfield_roleaccesses_roleaccess)
+
+const othercustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'othercustomfield_roleaccesses')
+
+const othercustomfield_roleaccesses = new ObjectType({
+  elemID: othercustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      othercustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(othercustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, othercustomfieldElemID.name],
+})
+
+othercustomfieldInnerTypes.push(othercustomfield_roleaccesses)
+
+
+export const othercustomfield = new ObjectType({
+  elemID: othercustomfieldElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custrecord_',
+  },
+  fields: {
+    scriptid: new Field(
+      othercustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custrecord’. */
+    fieldtype: new Field(
+      othercustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      othercustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    rectype: new Field(
+      othercustomfieldElemID,
+      'rectype',
+      enums.generic_customrecordothercustomfield_rectype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customrecordothercustomfield_rectype. */
+    selectrecordtype: new Field(
+      othercustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      othercustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      othercustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      othercustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      othercustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      othercustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      othercustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      othercustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      othercustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      othercustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      othercustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      othercustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      othercustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      othercustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      othercustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    encryptatrest: new Field(
+      othercustomfieldElemID,
+      'encryptatrest',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      othercustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      othercustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    globalsearch: new Field(
+      othercustomfieldElemID,
+      'globalsearch',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    isformula: new Field(
+      othercustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      othercustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      othercustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      othercustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      othercustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      othercustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      othercustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    showhierarchy: new Field(
+      othercustomfieldElemID,
+      'showhierarchy',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showinlist: new Field(
+      othercustomfieldElemID,
+      'showinlist',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    sourcefilterby: new Field(
+      othercustomfieldElemID,
+      'sourcefilterby',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcefrom: new Field(
+      othercustomfieldElemID,
+      'sourcefrom',
+      BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcelist: new Field(
+      othercustomfieldElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the othercustomfield custom type.   For information about other possible values, see generic_standard_field. */
+    applytoallforms: new Field(
+      othercustomfieldElemID,
+      'applytoallforms',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    applytoselectedforms: new Field(
+      othercustomfieldElemID,
+      'applytoselectedforms',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    customfieldfilters: new Field(
+      othercustomfieldElemID,
+      'customfieldfilters',
+      othercustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      othercustomfieldElemID,
+      'roleaccesses',
+      othercustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, othercustomfieldElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/pluginimplementation.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/pluginimplementation.ts
@@ -1,0 +1,184 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const pluginimplementationInnerTypes: ObjectType[] = []
+
+const pluginimplementationElemID = new ElemID(constants.NETSUITE, 'pluginimplementation')
+const pluginimplementation_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'pluginimplementation_libraries_library')
+
+const pluginimplementation_libraries_library = new ObjectType({
+  elemID: pluginimplementation_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      pluginimplementation_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, pluginimplementationElemID.name],
+})
+
+pluginimplementationInnerTypes.push(pluginimplementation_libraries_library)
+
+const pluginimplementation_librariesElemID = new ElemID(constants.NETSUITE, 'pluginimplementation_libraries')
+
+const pluginimplementation_libraries = new ObjectType({
+  elemID: pluginimplementation_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      pluginimplementation_librariesElemID,
+      'library',
+      new ListType(pluginimplementation_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, pluginimplementationElemID.name],
+})
+
+pluginimplementationInnerTypes.push(pluginimplementation_libraries)
+
+
+export const pluginimplementation = new ObjectType({
+  elemID: pluginimplementationElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      pluginimplementationElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      pluginimplementationElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      pluginimplementationElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    customplugintype: new Field(
+      pluginimplementationElemID,
+      'customplugintype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the plugintype custom type. */
+    status: new Field(
+      pluginimplementationElemID,
+      'status',
+      enums.plugintype_status,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see plugintype_status.   The default value is 'TESTING'. */
+    description: new Field(
+      pluginimplementationElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      pluginimplementationElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      pluginimplementationElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      pluginimplementationElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      pluginimplementationElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      pluginimplementationElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      pluginimplementationElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    loglevel: new Field(
+      pluginimplementationElemID,
+      'loglevel',
+      enums.plugintype_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see plugintype_loglevel.   The default value is 'DEBUG'. */
+    libraries: new Field(
+      pluginimplementationElemID,
+      'libraries',
+      pluginimplementation_libraries,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, pluginimplementationElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/plugintype.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/plugintype.ts
@@ -1,0 +1,256 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const plugintypeInnerTypes: ObjectType[] = []
+
+const plugintypeElemID = new ElemID(constants.NETSUITE, 'plugintype')
+const plugintype_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'plugintype_libraries_library')
+
+const plugintype_libraries_library = new ObjectType({
+  elemID: plugintype_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      plugintype_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, plugintypeElemID.name],
+})
+
+plugintypeInnerTypes.push(plugintype_libraries_library)
+
+const plugintype_librariesElemID = new ElemID(constants.NETSUITE, 'plugintype_libraries')
+
+const plugintype_libraries = new ObjectType({
+  elemID: plugintype_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      plugintype_librariesElemID,
+      'library',
+      new ListType(plugintype_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, plugintypeElemID.name],
+})
+
+plugintypeInnerTypes.push(plugintype_libraries)
+
+const plugintype_methods_methodElemID = new ElemID(constants.NETSUITE, 'plugintype_methods_method')
+
+const plugintype_methods_method = new ObjectType({
+  elemID: plugintype_methods_methodElemID,
+  annotations: {
+  },
+  fields: {
+    method: new Field(
+      plugintype_methods_methodElemID,
+      'method',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 30,
+      },
+    ), /* Original description: This field value can be up to 30 characters long. */
+    description: new Field(
+      plugintype_methods_methodElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 30,
+      },
+    ), /* Original description: This field value can be up to 30 characters long. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, plugintypeElemID.name],
+})
+
+plugintypeInnerTypes.push(plugintype_methods_method)
+
+const plugintype_methodsElemID = new ElemID(constants.NETSUITE, 'plugintype_methods')
+
+const plugintype_methods = new ObjectType({
+  elemID: plugintype_methodsElemID,
+  annotations: {
+  },
+  fields: {
+    method: new Field(
+      plugintype_methodsElemID,
+      'method',
+      new ListType(plugintype_methods_method),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, plugintypeElemID.name],
+})
+
+plugintypeInnerTypes.push(plugintype_methods)
+
+
+export const plugintype = new ObjectType({
+  elemID: plugintypeElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      plugintypeElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      plugintypeElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      plugintypeElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    deploymentmodel: new Field(
+      plugintypeElemID,
+      'deploymentmodel',
+      enums.plugintype_deployment_model,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see plugintype_deployment_model. */
+    status: new Field(
+      plugintypeElemID,
+      'status',
+      enums.plugintype_status,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see plugintype_status.   The default value is 'TESTING'. */
+    description: new Field(
+      plugintypeElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      plugintypeElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      plugintypeElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      plugintypeElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      plugintypeElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      plugintypeElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      plugintypeElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    class: new Field(
+      plugintypeElemID,
+      'class',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    documentationfile: new Field(
+      plugintypeElemID,
+      'documentationfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+      },
+    ), /* Original description: This field must reference a .pdf file. */
+    loglevel: new Field(
+      plugintypeElemID,
+      'loglevel',
+      enums.plugintype_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see plugintype_loglevel.   The default value is 'DEBUG'. */
+    libraries: new Field(
+      plugintypeElemID,
+      'libraries',
+      plugintype_libraries,
+      {
+      },
+    ),
+    methods: new Field(
+      plugintypeElemID,
+      'methods',
+      plugintype_methods,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, plugintypeElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/portlet.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/portlet.ts
@@ -1,0 +1,781 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const portletInnerTypes: ObjectType[] = []
+
+const portletElemID = new ElemID(constants.NETSUITE, 'portlet')
+const portlet_customplugintypes_plugintypeElemID = new ElemID(constants.NETSUITE, 'portlet_customplugintypes_plugintype')
+
+const portlet_customplugintypes_plugintype = new ObjectType({
+  elemID: portlet_customplugintypes_plugintypeElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      portlet_customplugintypes_plugintypeElemID,
+      'plugintype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the plugintype custom type. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, portletElemID.name],
+})
+
+portletInnerTypes.push(portlet_customplugintypes_plugintype)
+
+const portlet_customplugintypesElemID = new ElemID(constants.NETSUITE, 'portlet_customplugintypes')
+
+const portlet_customplugintypes = new ObjectType({
+  elemID: portlet_customplugintypesElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      portlet_customplugintypesElemID,
+      'plugintype',
+      new ListType(portlet_customplugintypes_plugintype),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, portletElemID.name],
+})
+
+portletInnerTypes.push(portlet_customplugintypes)
+
+const portlet_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'portlet_libraries_library')
+
+const portlet_libraries_library = new ObjectType({
+  elemID: portlet_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      portlet_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, portletElemID.name],
+})
+
+portletInnerTypes.push(portlet_libraries_library)
+
+const portlet_librariesElemID = new ElemID(constants.NETSUITE, 'portlet_libraries')
+
+const portlet_libraries = new ObjectType({
+  elemID: portlet_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      portlet_librariesElemID,
+      'library',
+      new ListType(portlet_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, portletElemID.name],
+})
+
+portletInnerTypes.push(portlet_libraries)
+
+const portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter')
+
+const portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, portletElemID.name],
+})
+
+portletInnerTypes.push(portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter)
+
+const portlet_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'portlet_scriptcustomfields_scriptcustomfield_customfieldfilters')
+
+const portlet_scriptcustomfields_scriptcustomfield_customfieldfilters = new ObjectType({
+  elemID: portlet_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      portlet_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(portlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, portletElemID.name],
+})
+
+portletInnerTypes.push(portlet_scriptcustomfields_scriptcustomfield_customfieldfilters)
+
+const portlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'portlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess')
+
+const portlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: portlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      portlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      portlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      portlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, portletElemID.name],
+})
+
+portletInnerTypes.push(portlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess)
+
+const portlet_scriptcustomfields_scriptcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'portlet_scriptcustomfields_scriptcustomfield_roleaccesses')
+
+const portlet_scriptcustomfields_scriptcustomfield_roleaccesses = new ObjectType({
+  elemID: portlet_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      portlet_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(portlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, portletElemID.name],
+})
+
+portletInnerTypes.push(portlet_scriptcustomfields_scriptcustomfield_roleaccesses)
+
+const portlet_scriptcustomfields_scriptcustomfieldElemID = new ElemID(constants.NETSUITE, 'portlet_scriptcustomfields_scriptcustomfield')
+
+const portlet_scriptcustomfields_scriptcustomfield = new ObjectType({
+  elemID: portlet_scriptcustomfields_scriptcustomfieldElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custscript’. */
+    fieldtype: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    isformula: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    setting: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'setting',
+      enums.script_setting,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_setting. */
+    customfieldfilters: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'customfieldfilters',
+      portlet_scriptcustomfields_scriptcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      portlet_scriptcustomfields_scriptcustomfieldElemID,
+      'roleaccesses',
+      portlet_scriptcustomfields_scriptcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, portletElemID.name],
+})
+
+portletInnerTypes.push(portlet_scriptcustomfields_scriptcustomfield)
+
+const portlet_scriptcustomfieldsElemID = new ElemID(constants.NETSUITE, 'portlet_scriptcustomfields')
+
+const portlet_scriptcustomfields = new ObjectType({
+  elemID: portlet_scriptcustomfieldsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptcustomfield: new Field(
+      portlet_scriptcustomfieldsElemID,
+      'scriptcustomfield',
+      new ListType(portlet_scriptcustomfields_scriptcustomfield),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, portletElemID.name],
+})
+
+portletInnerTypes.push(portlet_scriptcustomfields)
+
+const portlet_scriptdeployments_scriptdeploymentElemID = new ElemID(constants.NETSUITE, 'portlet_scriptdeployments_scriptdeployment')
+
+const portlet_scriptdeployments_scriptdeployment = new ObjectType({
+  elemID: portlet_scriptdeployments_scriptdeploymentElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customdeploy’. */
+    status: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'status',
+      enums.script_status,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+    title: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'title',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    allemployees: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'allemployees',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allpartners: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'allpartners',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account. */
+    allroles: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'allroles',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    auddepartment: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'auddepartment',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the DEPARTMENTS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. DEPARTMENTS must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    audemployee: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'audemployee',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   Note Account-specific values are not supported by SDF. */
+    audgroup: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'audgroup',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   Note Account-specific values are not supported by SDF. */
+    audpartner: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'audpartner',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    audslctrole: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'audslctrole',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    audsubsidiary: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'audsubsidiary',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the SUBSIDIARIES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. SUBSIDIARIES must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    isdeployed: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'isdeployed',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    loglevel: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+    runasrole: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'runasrole',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    dashboardapp: new Field(
+      portlet_scriptdeployments_scriptdeploymentElemID,
+      'dashboardapp',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, portletElemID.name],
+})
+
+portletInnerTypes.push(portlet_scriptdeployments_scriptdeployment)
+
+const portlet_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'portlet_scriptdeployments')
+
+const portlet_scriptdeployments = new ObjectType({
+  elemID: portlet_scriptdeploymentsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptdeployment: new Field(
+      portlet_scriptdeploymentsElemID,
+      'scriptdeployment',
+      new ListType(portlet_scriptdeployments_scriptdeployment),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, portletElemID.name],
+})
+
+portletInnerTypes.push(portlet_scriptdeployments)
+
+
+export const portlet = new ObjectType({
+  elemID: portletElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      portletElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      portletElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      portletElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    defaultfunction: new Field(
+      portletElemID,
+      'defaultfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      portletElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      portletElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      portletElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      portletElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      portletElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      portletElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      portletElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    portlettype: new Field(
+      portletElemID,
+      'portlettype',
+      enums.script_portlettype,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_portlettype. */
+    customplugintypes: new Field(
+      portletElemID,
+      'customplugintypes',
+      portlet_customplugintypes,
+      {
+      },
+    ),
+    libraries: new Field(
+      portletElemID,
+      'libraries',
+      portlet_libraries,
+      {
+      },
+    ),
+    scriptcustomfields: new Field(
+      portletElemID,
+      'scriptcustomfields',
+      portlet_scriptcustomfields,
+      {
+      },
+    ),
+    scriptdeployments: new Field(
+      portletElemID,
+      'scriptdeployments',
+      portlet_scriptdeployments,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, portletElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/promotionsplugin.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/promotionsplugin.ts
@@ -1,0 +1,182 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const promotionspluginInnerTypes: ObjectType[] = []
+
+const promotionspluginElemID = new ElemID(constants.NETSUITE, 'promotionsplugin')
+const promotionsplugin_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'promotionsplugin_libraries_library')
+
+const promotionsplugin_libraries_library = new ObjectType({
+  elemID: promotionsplugin_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      promotionsplugin_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, promotionspluginElemID.name],
+})
+
+promotionspluginInnerTypes.push(promotionsplugin_libraries_library)
+
+const promotionsplugin_librariesElemID = new ElemID(constants.NETSUITE, 'promotionsplugin_libraries')
+
+const promotionsplugin_libraries = new ObjectType({
+  elemID: promotionsplugin_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      promotionsplugin_librariesElemID,
+      'library',
+      new ListType(promotionsplugin_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, promotionspluginElemID.name],
+})
+
+promotionspluginInnerTypes.push(promotionsplugin_libraries)
+
+
+export const promotionsplugin = new ObjectType({
+  elemID: promotionspluginElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      promotionspluginElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      promotionspluginElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      promotionspluginElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    description: new Field(
+      promotionspluginElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      promotionspluginElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      promotionspluginElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      promotionspluginElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      promotionspluginElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      promotionspluginElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      promotionspluginElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    loglevel: new Field(
+      promotionspluginElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+    runasrole: new Field(
+      promotionspluginElemID,
+      'runasrole',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    status: new Field(
+      promotionspluginElemID,
+      'status',
+      enums.script_status,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+    libraries: new Field(
+      promotionspluginElemID,
+      'libraries',
+      promotionsplugin_libraries,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, promotionspluginElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/publisheddashboard.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/publisheddashboard.ts
@@ -1,0 +1,1160 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const publisheddashboardInnerTypes: ObjectType[] = []
+
+const publisheddashboardElemID = new ElemID(constants.NETSUITE, 'publisheddashboard')
+const publisheddashboard_dashboards_dashboard_centercolumn_calendarElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_calendar')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_calendar = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_calendarElemID,
+  annotations: {
+  },
+  fields: {
+    numberofrecordsinagenda: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_calendarElemID,
+      'numberofrecordsinagenda',
+      BuiltinTypes.NUMBER,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field value must be greater than or equal to 0.   The default value is '7'. */
+    isminimized: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_calendarElemID,
+      'isminimized',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showevents: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_calendarElemID,
+      'showevents',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    showblockingtasks: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_calendarElemID,
+      'showblockingtasks',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    shownonblockingtasks: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_calendarElemID,
+      'shownonblockingtasks',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    showblockingcalls: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_calendarElemID,
+      'showblockingcalls',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    shownonblockingcalls: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_calendarElemID,
+      'shownonblockingcalls',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    showcanceledevents: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_calendarElemID,
+      'showcanceledevents',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showweekendsinmonthlyview: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_calendarElemID,
+      'showweekendsinmonthlyview',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    recordstodisplayinagenda: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_calendarElemID,
+      'recordstodisplayinagenda',
+      enums.portlet_calendar_agenda,
+      {
+      },
+    ), /* Original description: For information about possible values, see portlet_calendar_agenda.   The default value is 'TODAY_ONLY'. */
+    showcampaignevents: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_calendarElemID,
+      'showcampaignevents',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showresourceallocations: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_calendarElemID,
+      'showresourceallocations',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the RESOURCEALLOCATIONS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. RESOURCEALLOCATIONS must be enabled for this field to appear in your account. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_calendar)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_customportletElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_customportlet')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_customportlet = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_customportletElemID,
+  annotations: {
+  },
+  fields: {
+    source: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_customportletElemID,
+      'source',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the scriptdeployment custom type. */
+    isminimized: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_customportletElemID,
+      'isminimized',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_customportlet)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_customsearchElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_customsearch')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_customsearch = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_customsearchElemID,
+  annotations: {
+  },
+  fields: {
+    savedsearch: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_customsearchElemID,
+      'savedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type.   For information about other possible values, see portlet_customsearch_savedsearch. */
+    resultssize: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_customsearchElemID,
+      'resultssize',
+      BuiltinTypes.NUMBER,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is '10'. */
+    isminimized: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_customsearchElemID,
+      'isminimized',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    drilldown: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_customsearchElemID,
+      'drilldown',
+      enums.portlet_customsearch_drilldown,
+      {
+      },
+    ), /* Original description: For information about possible values, see portlet_customsearch_drilldown.   The default value is 'NEW_PAGE'. */
+    charttheme: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_customsearchElemID,
+      'charttheme',
+      enums.portlet_customsearch_charttheme,
+      {
+      },
+    ), /* Original description: For information about possible values, see portlet_customsearch_charttheme.   The default value is 'GLOBAL_THEME'. */
+    backgroundtype: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_customsearchElemID,
+      'backgroundtype',
+      enums.portlet_customsearch_backgroundtype,
+      {
+      },
+    ), /* Original description: For information about possible values, see portlet_customsearch_backgroundtype.   The default value is 'GLOBAL_BACKGROUND'. */
+    allowinlineediting: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_customsearchElemID,
+      'allowinlineediting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T.   If this field appears in the project, you must reference the EXTREMELIST feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. EXTREMELIST must be enabled for this field to appear in your account. */
+    title: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_customsearchElemID,
+      'title',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_customsearch)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpiElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpi')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpi = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpiElemID,
+  annotations: {
+  },
+  fields: {
+    kpi: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpiElemID,
+      'kpi',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see the following lists:   snapshot_type_period_range_not_comparable   snapshot_type_period_range_comparable   snapshot_type_date_range_not_comparable   snapshot_type_date_range_comparable   snapshot_type_custom */
+    daterange: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpiElemID,
+      'daterange',
+      enums.report_date_range,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see report_date_range. */
+    comparedaterange: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpiElemID,
+      'comparedaterange',
+      enums.report_date_range,
+      {
+      },
+    ), /* Original description: This field is available when the kpi value is present in any of the following lists or values: snapshot_type_date_range_comparable, snapshot_type_period_range_comparable, snapshot_type_custom.   This field is mandatory when the kpi value is present in any of the following lists or values: snapshot_type_date_range_comparable, snapshot_type_period_range_comparable, snapshot_type_custom.   This field is mandatory when the compare value is equal to T.   For information about possible values, see report_date_range. */
+    compareperiodrange: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpiElemID,
+      'compareperiodrange',
+      enums.report_period_range,
+      {
+      },
+    ), /* Original description: This field is available when the kpi value is present in any of the following lists or values: snapshot_type_period_range_comparable, snapshot_type_custom.   This field is mandatory when the kpi value is present in any of the following lists or values: snapshot_type_period_range_comparable, snapshot_type_custom.   This field is mandatory when the compare value is equal to T.   For information about possible values, see report_period_range. */
+    savedsearch: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpiElemID,
+      'savedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is available when the kpi value is present in snapshot_type_custom.   This field is mandatory when the kpi value is present in snapshot_type_custom.   This field accepts references to the savedsearch custom type. */
+    periodrange: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpiElemID,
+      'periodrange',
+      enums.report_period_range,
+      {
+      },
+    ), /* Original description: This field is available when the kpi value is present in any of the following lists or values: snapshot_type_period_range_comparable, snapshot_type_period_range_not_comparable, snapshot_type_custom.   This field is mandatory when the kpi value is present in any of the following lists or values: snapshot_type_period_range_comparable, snapshot_type_period_range_not_comparable, snapshot_type_custom.   For information about possible values, see report_period_range. */
+    compare: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpiElemID,
+      'compare',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the kpi value is present in any of the following lists or values: snapshot_type_date_range_comparable, snapshot_type_period_range_comparable, snapshot_type_custom.   This field is mandatory when the kpi value is present in any of the following lists or values: snapshot_type_date_range_comparable, snapshot_type_period_range_comparable, snapshot_type_custom.   The default value is T. */
+    employees: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpiElemID,
+      'employees',
+      enums.portlet_kpi_employees,
+      {
+      },
+    ), /* Original description: This field is available when the center value is equal to any of the following lists or values: SALESCENTER, SUPPORTCENTER.   For information about possible values, see portlet_kpi_employees.   The default value is 'ME_ONLY'. */
+    headline: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpiElemID,
+      'headline',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    highlightif: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpiElemID,
+      'highlightif',
+      enums.portlet_kpi_highlightif,
+      {
+      },
+    ), /* Original description: For information about possible values, see portlet_kpi_highlightif. */
+    threshold: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpiElemID,
+      'threshold',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpi)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpisElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpisElemID,
+  annotations: {
+  },
+  fields: {
+    kpi: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpisElemID,
+      'kpi',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis_kpi),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicatorsElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicatorsElemID,
+  annotations: {
+  },
+  fields: {
+    isminimized: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicatorsElemID,
+      'isminimized',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    cacheddata: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicatorsElemID,
+      'cacheddata',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    kpis: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicatorsElemID,
+      'kpis',
+      publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators_kpis,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_kpimeterElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_kpimeter')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_kpimeter = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_kpimeterElemID,
+  annotations: {
+  },
+  fields: {
+    kpi: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_kpimeterElemID,
+      'kpi',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see the following lists:   snapshot_type_period_range_not_comparable   snapshot_type_period_range_comparable   snapshot_type_date_range_not_comparable   snapshot_type_date_range_comparable   snapshot_type_custom   portlet_kpimeter_combined_snapshots */
+    isminimized: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_kpimeterElemID,
+      'isminimized',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_kpimeter)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_listElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_list')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_list = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_listElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_listElemID,
+      'type',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the customrecordtype custom type.   For information about other possible values, see portlet_list_type. */
+    size: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_listElemID,
+      'size',
+      BuiltinTypes.NUMBER,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field value must range from 1 through 50. (inclusive)   The default value is '10'. */
+    isminimized: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_listElemID,
+      'isminimized',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allowinlineediting: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_listElemID,
+      'allowinlineediting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_list)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_quicksearchElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_quicksearch')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_quicksearch = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_quicksearchElemID,
+  annotations: {
+  },
+  fields: {
+    searchtype: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_quicksearchElemID,
+      'searchtype',
+      enums.portlet_quicksearch_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see portlet_quicksearch_type.   The default value is 'GENERIC'. */
+    isminimized: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_quicksearchElemID,
+      'isminimized',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultgeneraltype: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_quicksearchElemID,
+      'defaultgeneraltype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the customrecordtype custom type.   For information about other possible values, see portlet_quicksearch_generic. */
+    defaulttransactiontype: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_quicksearchElemID,
+      'defaulttransactiontype',
+      enums.portlet_quicksearch_transaction,
+      {
+      },
+    ), /* Original description: For information about possible values, see portlet_quicksearch_transaction. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_quicksearch)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrules_ruleElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrules_rule')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrules_rule = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrules_ruleElemID,
+  annotations: {
+  },
+  fields: {
+    greaterthanorequalto: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrules_ruleElemID,
+      'greaterthanorequalto',
+      BuiltinTypes.NUMBER,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field value must range from -9999999 through 99999999. (inclusive) */
+    color: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrules_ruleElemID,
+      'color',
+      enums.reminders_highlighting_rules_colors,
+      {
+      },
+    ), /* Original description: For information about possible values, see reminders_highlighting_rules_colors.   The default value is 'YELLOW'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrules_rule)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrulesElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrules')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrules = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrulesElemID,
+  annotations: {
+  },
+  fields: {
+    rule: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrulesElemID,
+      'rule',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrules_rule),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrules)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminderElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminderElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminderElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type.   For information about other possible values, see the following lists:   reminders_standard_reminders_without_days   reminders_standard_reminders_with_days */
+    days: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminderElemID,
+      'days',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must range from -9999999 through 99999999. (inclusive)   This field is available when the id value is present in reminders_standard_reminders_with_days.   The default value is '5'. */
+    highlightingrules: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminderElemID,
+      'highlightingrules',
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder_highlightingrules,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_headlineElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_reminders_headlineElemID,
+  annotations: {
+  },
+  fields: {
+    reminder: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_headlineElemID,
+      'reminder',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline_reminder),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrules_ruleElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrules_rule')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrules_rule = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrules_ruleElemID,
+  annotations: {
+  },
+  fields: {
+    greaterthanorequalto: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrules_ruleElemID,
+      'greaterthanorequalto',
+      BuiltinTypes.NUMBER,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field value must range from -9999999 through 99999999. (inclusive) */
+    color: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrules_ruleElemID,
+      'color',
+      enums.reminders_highlighting_rules_colors,
+      {
+      },
+    ), /* Original description: For information about possible values, see reminders_highlighting_rules_colors.   The default value is 'YELLOW'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrules_rule)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrulesElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrules')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrules = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrulesElemID,
+  annotations: {
+  },
+  fields: {
+    rule: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrulesElemID,
+      'rule',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrules_rule),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrules)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminderElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminderElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminderElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type.   For information about other possible values, see the following lists:   reminders_standard_reminders_without_days   reminders_standard_reminders_with_days */
+    days: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminderElemID,
+      'days',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must range from -9999999 through 99999999. (inclusive)   This field is available when the id value is present in reminders_standard_reminders_with_days.   The default value is '5'. */
+    highlightingrules: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminderElemID,
+      'highlightingrules',
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder_highlightingrules,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_otherElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_reminders_other')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders_other = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_reminders_otherElemID,
+  annotations: {
+  },
+  fields: {
+    reminder: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_otherElemID,
+      'reminder',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_reminders_other_reminder),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_reminders_other)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_remindersElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_reminders')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_reminders = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_remindersElemID,
+  annotations: {
+  },
+  fields: {
+    isminimized: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_remindersElemID,
+      'isminimized',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showzeroresults: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_remindersElemID,
+      'showzeroresults',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    headline: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_remindersElemID,
+      'headline',
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_headline,
+      {
+      },
+    ),
+    other: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_remindersElemID,
+      'other',
+      publisheddashboard_dashboards_dashboard_centercolumn_reminders_other,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_reminders)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_searchformElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_searchform')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_searchform = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_searchformElemID,
+  annotations: {
+  },
+  fields: {
+    savedsearch: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_searchformElemID,
+      'savedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    isminimized: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_searchformElemID,
+      'isminimized',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_searchform)
+
+const publisheddashboard_dashboards_dashboard_centercolumn_trendgraphElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn_trendgraph')
+
+const publisheddashboard_dashboards_dashboard_centercolumn_trendgraph = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumn_trendgraphElemID,
+  annotations: {
+  },
+  fields: {
+    kpi: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_trendgraphElemID,
+      'kpi',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see the following lists:   snapshot_type_trendgraph   snapshot_type_custom */
+    trendtype: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_trendgraphElemID,
+      'trendtype',
+      enums.portlet_trendgraph_trendtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see portlet_trendgraph_trendtype. */
+    movingaverageperiod: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_trendgraphElemID,
+      'movingaverageperiod',
+      BuiltinTypes.NUMBER,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field value must range from 1 through 10. (inclusive)   The default value is '2'. */
+    savedsearch: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_trendgraphElemID,
+      'savedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is available when the kpi value is present in snapshot_type_custom.   This field is mandatory when the kpi value is present in snapshot_type_custom.   This field accepts references to the savedsearch custom type. */
+    isminimized: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_trendgraphElemID,
+      'isminimized',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    backgroundtype: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_trendgraphElemID,
+      'backgroundtype',
+      enums.portlet_trendgraph_backgroundtype,
+      {
+      },
+    ), /* Original description: For information about possible values, see portlet_trendgraph_backgroundtype.   The default value is 'GLOBAL_BACKGROUND'. */
+    charttheme: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_trendgraphElemID,
+      'charttheme',
+      enums.portlet_trendgraph_charttheme,
+      {
+      },
+    ), /* Original description: For information about possible values, see portlet_trendgraph_charttheme.   The default value is 'GLOBAL_THEME'. */
+    customseriescolor: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_trendgraphElemID,
+      'customseriescolor',
+      BuiltinTypes.STRING /* Original type was rgb   RGB field types must be set to a valid 6–digit hexadecimal value between #000000 and #FFFFFF. The # prefix is optional. */,
+      {
+      },
+    ),
+    defaultcharttype: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_trendgraphElemID,
+      'defaultcharttype',
+      enums.portlet_trendgraph_charttype,
+      {
+      },
+    ), /* Original description: For information about possible values, see portlet_trendgraph_charttype.   The default value is 'AREA'. */
+    includezeroonyaxis: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_trendgraphElemID,
+      'includezeroonyaxis',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showmovingaverage: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_trendgraphElemID,
+      'showmovingaverage',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    showlastdatapoint: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumn_trendgraphElemID,
+      'showlastdatapoint',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn_trendgraph)
+
+const publisheddashboard_dashboards_dashboard_centercolumnElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_centercolumn')
+
+const publisheddashboard_dashboards_dashboard_centercolumn = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_centercolumnElemID,
+  annotations: {
+  },
+  fields: {
+    calendar: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumnElemID,
+      'calendar',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_calendar),
+      {
+      },
+    ),
+    customportlet: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumnElemID,
+      'customportlet',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_customportlet),
+      {
+      },
+    ),
+    customsearch: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumnElemID,
+      'customsearch',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_customsearch),
+      {
+      },
+    ),
+    keyperformanceindicators: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumnElemID,
+      'keyperformanceindicators',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_keyperformanceindicators),
+      {
+      },
+    ),
+    kpimeter: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumnElemID,
+      'kpimeter',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_kpimeter),
+      {
+      },
+    ),
+    list: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumnElemID,
+      'list',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_list),
+      {
+      },
+    ),
+    quicksearch: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumnElemID,
+      'quicksearch',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_quicksearch),
+      {
+      },
+    ),
+    reminders: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumnElemID,
+      'reminders',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_reminders),
+      {
+      },
+    ),
+    searchform: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumnElemID,
+      'searchform',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_searchform),
+      {
+      },
+    ),
+    trendgraph: new Field(
+      publisheddashboard_dashboards_dashboard_centercolumnElemID,
+      'trendgraph',
+      new ListType(publisheddashboard_dashboards_dashboard_centercolumn_trendgraph),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_centercolumn)
+
+const publisheddashboard_dashboards_dashboard_leftcolumnElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_leftcolumn')
+
+const publisheddashboard_dashboards_dashboard_leftcolumn = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_leftcolumnElemID,
+  annotations: {
+  },
+  fields: {
+
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_leftcolumn)
+
+const publisheddashboard_dashboards_dashboard_rightcolumnElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard_rightcolumn')
+
+const publisheddashboard_dashboards_dashboard_rightcolumn = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboard_rightcolumnElemID,
+  annotations: {
+  },
+  fields: {
+
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard_rightcolumn)
+
+const publisheddashboard_dashboards_dashboardElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards_dashboard')
+
+const publisheddashboard_dashboards_dashboard = new ObjectType({
+  elemID: publisheddashboard_dashboards_dashboardElemID,
+  annotations: {
+  },
+  fields: {
+    centertab: new Field(
+      publisheddashboard_dashboards_dashboardElemID,
+      'centertab',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the centertab custom type.   For information about other possible values, see generic_centertab. */
+    mode: new Field(
+      publisheddashboard_dashboards_dashboardElemID,
+      'mode',
+      enums.dashboard_mode,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see dashboard_mode.   The default value is 'UNLOCKED'. */
+    layout: new Field(
+      publisheddashboard_dashboards_dashboardElemID,
+      'layout',
+      enums.dashboard_layout,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see dashboard_layout.   The default value is 'TWO_COLUMN'. */
+    centercolumn: new Field(
+      publisheddashboard_dashboards_dashboardElemID,
+      'centercolumn',
+      publisheddashboard_dashboards_dashboard_centercolumn,
+      {
+      },
+    ),
+    leftcolumn: new Field(
+      publisheddashboard_dashboards_dashboardElemID,
+      'leftcolumn',
+      publisheddashboard_dashboards_dashboard_leftcolumn,
+      {
+      },
+    ),
+    rightcolumn: new Field(
+      publisheddashboard_dashboards_dashboardElemID,
+      'rightcolumn',
+      publisheddashboard_dashboards_dashboard_rightcolumn,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards_dashboard)
+
+const publisheddashboard_dashboardsElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_dashboards')
+
+const publisheddashboard_dashboards = new ObjectType({
+  elemID: publisheddashboard_dashboardsElemID,
+  annotations: {
+  },
+  fields: {
+    dashboard: new Field(
+      publisheddashboard_dashboardsElemID,
+      'dashboard',
+      new ListType(publisheddashboard_dashboards_dashboard),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_dashboards)
+
+const publisheddashboard_roles_roleElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_roles_role')
+
+const publisheddashboard_roles_role = new ObjectType({
+  elemID: publisheddashboard_roles_roleElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      publisheddashboard_roles_roleElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_roles_role)
+
+const publisheddashboard_rolesElemID = new ElemID(constants.NETSUITE, 'publisheddashboard_roles')
+
+const publisheddashboard_roles = new ObjectType({
+  elemID: publisheddashboard_rolesElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      publisheddashboard_rolesElemID,
+      'role',
+      new ListType(publisheddashboard_roles_role),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})
+
+publisheddashboardInnerTypes.push(publisheddashboard_roles)
+
+
+export const publisheddashboard = new ObjectType({
+  elemID: publisheddashboardElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custpubdashboard_',
+  },
+  fields: {
+    scriptid: new Field(
+      publisheddashboardElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custpubdashboard’. */
+    name: new Field(
+      publisheddashboardElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 30,
+      },
+    ), /* Original description: This field value can be up to 30 characters long. */
+    center: new Field(
+      publisheddashboardElemID,
+      'center',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the center custom type.   For information about other possible values, see role_centertype. */
+    lockshortcuts: new Field(
+      publisheddashboardElemID,
+      'lockshortcuts',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    locknewbar: new Field(
+      publisheddashboardElemID,
+      'locknewbar',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notes: new Field(
+      publisheddashboardElemID,
+      'notes',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 4000,
+      },
+    ), /* Original description: This field value can be up to 4000 characters long. */
+    dashboards: new Field(
+      publisheddashboardElemID,
+      'dashboards',
+      publisheddashboard_dashboards,
+      {
+      },
+    ),
+    roles: new Field(
+      publisheddashboardElemID,
+      'roles',
+      publisheddashboard_roles,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, publisheddashboardElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/restlet.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/restlet.ts
@@ -1,0 +1,781 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const restletInnerTypes: ObjectType[] = []
+
+const restletElemID = new ElemID(constants.NETSUITE, 'restlet')
+const restlet_customplugintypes_plugintypeElemID = new ElemID(constants.NETSUITE, 'restlet_customplugintypes_plugintype')
+
+const restlet_customplugintypes_plugintype = new ObjectType({
+  elemID: restlet_customplugintypes_plugintypeElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      restlet_customplugintypes_plugintypeElemID,
+      'plugintype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the plugintype custom type. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, restletElemID.name],
+})
+
+restletInnerTypes.push(restlet_customplugintypes_plugintype)
+
+const restlet_customplugintypesElemID = new ElemID(constants.NETSUITE, 'restlet_customplugintypes')
+
+const restlet_customplugintypes = new ObjectType({
+  elemID: restlet_customplugintypesElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      restlet_customplugintypesElemID,
+      'plugintype',
+      new ListType(restlet_customplugintypes_plugintype),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, restletElemID.name],
+})
+
+restletInnerTypes.push(restlet_customplugintypes)
+
+const restlet_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'restlet_libraries_library')
+
+const restlet_libraries_library = new ObjectType({
+  elemID: restlet_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      restlet_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, restletElemID.name],
+})
+
+restletInnerTypes.push(restlet_libraries_library)
+
+const restlet_librariesElemID = new ElemID(constants.NETSUITE, 'restlet_libraries')
+
+const restlet_libraries = new ObjectType({
+  elemID: restlet_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      restlet_librariesElemID,
+      'library',
+      new ListType(restlet_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, restletElemID.name],
+})
+
+restletInnerTypes.push(restlet_libraries)
+
+const restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter')
+
+const restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, restletElemID.name],
+})
+
+restletInnerTypes.push(restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter)
+
+const restlet_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'restlet_scriptcustomfields_scriptcustomfield_customfieldfilters')
+
+const restlet_scriptcustomfields_scriptcustomfield_customfieldfilters = new ObjectType({
+  elemID: restlet_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      restlet_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(restlet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, restletElemID.name],
+})
+
+restletInnerTypes.push(restlet_scriptcustomfields_scriptcustomfield_customfieldfilters)
+
+const restlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'restlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess')
+
+const restlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: restlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      restlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      restlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      restlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, restletElemID.name],
+})
+
+restletInnerTypes.push(restlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess)
+
+const restlet_scriptcustomfields_scriptcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'restlet_scriptcustomfields_scriptcustomfield_roleaccesses')
+
+const restlet_scriptcustomfields_scriptcustomfield_roleaccesses = new ObjectType({
+  elemID: restlet_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      restlet_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(restlet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, restletElemID.name],
+})
+
+restletInnerTypes.push(restlet_scriptcustomfields_scriptcustomfield_roleaccesses)
+
+const restlet_scriptcustomfields_scriptcustomfieldElemID = new ElemID(constants.NETSUITE, 'restlet_scriptcustomfields_scriptcustomfield')
+
+const restlet_scriptcustomfields_scriptcustomfield = new ObjectType({
+  elemID: restlet_scriptcustomfields_scriptcustomfieldElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custscript’. */
+    fieldtype: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    isformula: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    setting: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'setting',
+      enums.script_setting,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_setting. */
+    customfieldfilters: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'customfieldfilters',
+      restlet_scriptcustomfields_scriptcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      restlet_scriptcustomfields_scriptcustomfieldElemID,
+      'roleaccesses',
+      restlet_scriptcustomfields_scriptcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, restletElemID.name],
+})
+
+restletInnerTypes.push(restlet_scriptcustomfields_scriptcustomfield)
+
+const restlet_scriptcustomfieldsElemID = new ElemID(constants.NETSUITE, 'restlet_scriptcustomfields')
+
+const restlet_scriptcustomfields = new ObjectType({
+  elemID: restlet_scriptcustomfieldsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptcustomfield: new Field(
+      restlet_scriptcustomfieldsElemID,
+      'scriptcustomfield',
+      new ListType(restlet_scriptcustomfields_scriptcustomfield),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, restletElemID.name],
+})
+
+restletInnerTypes.push(restlet_scriptcustomfields)
+
+const restlet_scriptdeployments_scriptdeploymentElemID = new ElemID(constants.NETSUITE, 'restlet_scriptdeployments_scriptdeployment')
+
+const restlet_scriptdeployments_scriptdeployment = new ObjectType({
+  elemID: restlet_scriptdeployments_scriptdeploymentElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      restlet_scriptdeployments_scriptdeploymentElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customdeploy’. */
+    status: new Field(
+      restlet_scriptdeployments_scriptdeploymentElemID,
+      'status',
+      enums.script_status,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+    title: new Field(
+      restlet_scriptdeployments_scriptdeploymentElemID,
+      'title',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    allemployees: new Field(
+      restlet_scriptdeployments_scriptdeploymentElemID,
+      'allemployees',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allpartners: new Field(
+      restlet_scriptdeployments_scriptdeploymentElemID,
+      'allpartners',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account. */
+    allroles: new Field(
+      restlet_scriptdeployments_scriptdeploymentElemID,
+      'allroles',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    auddepartment: new Field(
+      restlet_scriptdeployments_scriptdeploymentElemID,
+      'auddepartment',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the DEPARTMENTS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. DEPARTMENTS must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    audemployee: new Field(
+      restlet_scriptdeployments_scriptdeploymentElemID,
+      'audemployee',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   Note Account-specific values are not supported by SDF. */
+    audgroup: new Field(
+      restlet_scriptdeployments_scriptdeploymentElemID,
+      'audgroup',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   Note Account-specific values are not supported by SDF. */
+    audpartner: new Field(
+      restlet_scriptdeployments_scriptdeploymentElemID,
+      'audpartner',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    audslctrole: new Field(
+      restlet_scriptdeployments_scriptdeploymentElemID,
+      'audslctrole',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    audsubsidiary: new Field(
+      restlet_scriptdeployments_scriptdeploymentElemID,
+      'audsubsidiary',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the SUBSIDIARIES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. SUBSIDIARIES must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    isdeployed: new Field(
+      restlet_scriptdeployments_scriptdeploymentElemID,
+      'isdeployed',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    loglevel: new Field(
+      restlet_scriptdeployments_scriptdeploymentElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, restletElemID.name],
+})
+
+restletInnerTypes.push(restlet_scriptdeployments_scriptdeployment)
+
+const restlet_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'restlet_scriptdeployments')
+
+const restlet_scriptdeployments = new ObjectType({
+  elemID: restlet_scriptdeploymentsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptdeployment: new Field(
+      restlet_scriptdeploymentsElemID,
+      'scriptdeployment',
+      new ListType(restlet_scriptdeployments_scriptdeployment),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, restletElemID.name],
+})
+
+restletInnerTypes.push(restlet_scriptdeployments)
+
+
+export const restlet = new ObjectType({
+  elemID: restletElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      restletElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      restletElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      restletElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    description: new Field(
+      restletElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      restletElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      restletElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      restletElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      restletElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      restletElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      restletElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    deletefunction: new Field(
+      restletElemID,
+      'deletefunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    getfunction: new Field(
+      restletElemID,
+      'getfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    postfunction: new Field(
+      restletElemID,
+      'postfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    putfunction: new Field(
+      restletElemID,
+      'putfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    customplugintypes: new Field(
+      restletElemID,
+      'customplugintypes',
+      restlet_customplugintypes,
+      {
+      },
+    ),
+    libraries: new Field(
+      restletElemID,
+      'libraries',
+      restlet_libraries,
+      {
+      },
+    ),
+    scriptcustomfields: new Field(
+      restletElemID,
+      'scriptcustomfields',
+      restlet_scriptcustomfields,
+      {
+      },
+    ),
+    scriptdeployments: new Field(
+      restletElemID,
+      'scriptdeployments',
+      restlet_scriptdeployments,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, restletElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/role.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/role.ts
@@ -1,0 +1,250 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const roleInnerTypes: ObjectType[] = []
+
+const roleElemID = new ElemID(constants.NETSUITE, 'role')
+const role_permissions_permissionElemID = new ElemID(constants.NETSUITE, 'role_permissions_permission')
+
+const role_permissions_permission = new ObjectType({
+  elemID: role_permissions_permissionElemID,
+  annotations: {
+  },
+  fields: {
+    permkey: new Field(
+      role_permissions_permissionElemID,
+      'permkey',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customtransactiontype   customsegment   customrecordtype   For information about other possible values, see generic_permission. */
+    permlevel: new Field(
+      role_permissions_permissionElemID,
+      'permlevel',
+      enums.generic_permission_level,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_permission_level. */
+    restriction: new Field(
+      role_permissions_permissionElemID,
+      'restriction',
+      enums.role_restrict,
+      {
+      },
+    ), /* Original description: For information about possible values, see role_restrict. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, roleElemID.name],
+})
+
+roleInnerTypes.push(role_permissions_permission)
+
+const role_permissionsElemID = new ElemID(constants.NETSUITE, 'role_permissions')
+
+const role_permissions = new ObjectType({
+  elemID: role_permissionsElemID,
+  annotations: {
+  },
+  fields: {
+    permission: new Field(
+      role_permissionsElemID,
+      'permission',
+      new ListType(role_permissions_permission),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, roleElemID.name],
+})
+
+roleInnerTypes.push(role_permissions)
+
+const role_recordrestrictions_recordrestrictionElemID = new ElemID(constants.NETSUITE, 'role_recordrestrictions_recordrestriction')
+
+const role_recordrestrictions_recordrestriction = new ObjectType({
+  elemID: role_recordrestrictions_recordrestrictionElemID,
+  annotations: {
+  },
+  fields: {
+    segment: new Field(
+      role_recordrestrictions_recordrestrictionElemID,
+      'segment',
+      enums.role_restrictionsegment,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see role_restrictionsegment. */
+    restriction: new Field(
+      role_recordrestrictions_recordrestrictionElemID,
+      'restriction',
+      enums.role_restrictions,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see role_restrictions. */
+    viewingallowed: new Field(
+      role_recordrestrictions_recordrestrictionElemID,
+      'viewingallowed',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the restriction value is not equal to DEFAULTTOOWN.   The default value is F. */
+    itemsrestricted: new Field(
+      role_recordrestrictions_recordrestrictionElemID,
+      'itemsrestricted',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the restriction value is not equal to DEFAULTTOOWN.   The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, roleElemID.name],
+})
+
+roleInnerTypes.push(role_recordrestrictions_recordrestriction)
+
+const role_recordrestrictionsElemID = new ElemID(constants.NETSUITE, 'role_recordrestrictions')
+
+const role_recordrestrictions = new ObjectType({
+  elemID: role_recordrestrictionsElemID,
+  annotations: {
+  },
+  fields: {
+    recordrestriction: new Field(
+      role_recordrestrictionsElemID,
+      'recordrestriction',
+      new ListType(role_recordrestrictions_recordrestriction),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, roleElemID.name],
+})
+
+roleInnerTypes.push(role_recordrestrictions)
+
+
+export const role = new ObjectType({
+  elemID: roleElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customrole_',
+  },
+  fields: {
+    scriptid: new Field(
+      roleElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customrole’. */
+    name: new Field(
+      roleElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+      },
+    ),
+    centertype: new Field(
+      roleElemID,
+      'centertype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the center custom type.   For information about other possible values, see role_centertype. */
+    issalesrole: new Field(
+      roleElemID,
+      'issalesrole',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    issupportrole: new Field(
+      roleElemID,
+      'issupportrole',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    iswebserviceonlyrole: new Field(
+      roleElemID,
+      'iswebserviceonlyrole',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the WEBSERVICES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. WEBSERVICES must be enabled for this field to appear in your account. */
+    restrictip: new Field(
+      roleElemID,
+      'restrictip',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the IPADDRESSRULES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. IPADDRESSRULES must be enabled for this field to appear in your account. */
+    employeerestriction: new Field(
+      roleElemID,
+      'employeerestriction',
+      enums.role_fullrestrictions,
+      {
+      },
+    ), /* Original description: For information about possible values, see role_fullrestrictions. */
+    employeeviewingallowed: new Field(
+      roleElemID,
+      'employeeviewingallowed',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the employeerestriction value is not equal to any of the following lists or values: DEFAULTTOOWN, NONE.   The default value is F. */
+    restricttimeandexpenses: new Field(
+      roleElemID,
+      'restricttimeandexpenses',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    restrictbydevice: new Field(
+      roleElemID,
+      'restrictbydevice',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    permissions: new Field(
+      roleElemID,
+      'permissions',
+      role_permissions,
+      {
+      },
+    ),
+    recordrestrictions: new Field(
+      roleElemID,
+      'recordrestrictions',
+      role_recordrestrictions,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, roleElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/savedcsvimport.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/savedcsvimport.ts
@@ -1,0 +1,470 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const savedcsvimportInnerTypes: ObjectType[] = []
+
+const savedcsvimportElemID = new ElemID(constants.NETSUITE, 'savedcsvimport')
+const savedcsvimport_audienceElemID = new ElemID(constants.NETSUITE, 'savedcsvimport_audience')
+
+const savedcsvimport_audience = new ObjectType({
+  elemID: savedcsvimport_audienceElemID,
+  annotations: {
+  },
+  fields: {
+    ispublic: new Field(
+      savedcsvimport_audienceElemID,
+      'ispublic',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    globaledit: new Field(
+      savedcsvimport_audienceElemID,
+      'globaledit',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allemployees: new Field(
+      savedcsvimport_audienceElemID,
+      'allemployees',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allpartners: new Field(
+      savedcsvimport_audienceElemID,
+      'allpartners',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allroles: new Field(
+      savedcsvimport_audienceElemID,
+      'allroles',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    roles: new Field(
+      savedcsvimport_audienceElemID,
+      'roles',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, savedcsvimportElemID.name],
+})
+
+savedcsvimportInnerTypes.push(savedcsvimport_audience)
+
+const savedcsvimport_filemappings_filemappingElemID = new ElemID(constants.NETSUITE, 'savedcsvimport_filemappings_filemapping')
+
+const savedcsvimport_filemappings_filemapping = new ObjectType({
+  elemID: savedcsvimport_filemappings_filemappingElemID,
+  annotations: {
+  },
+  fields: {
+    file: new Field(
+      savedcsvimport_filemappings_filemappingElemID,
+      'file',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol. */
+    primarykey: new Field(
+      savedcsvimport_filemappings_filemappingElemID,
+      'primarykey',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    foreignkey: new Field(
+      savedcsvimport_filemappings_filemappingElemID,
+      'foreignkey',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, savedcsvimportElemID.name],
+})
+
+savedcsvimportInnerTypes.push(savedcsvimport_filemappings_filemapping)
+
+const savedcsvimport_filemappingsElemID = new ElemID(constants.NETSUITE, 'savedcsvimport_filemappings')
+
+const savedcsvimport_filemappings = new ObjectType({
+  elemID: savedcsvimport_filemappingsElemID,
+  annotations: {
+  },
+  fields: {
+    filemapping: new Field(
+      savedcsvimport_filemappingsElemID,
+      'filemapping',
+      new ListType(savedcsvimport_filemappings_filemapping),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, savedcsvimportElemID.name],
+})
+
+savedcsvimportInnerTypes.push(savedcsvimport_filemappings)
+
+const savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping_columnreferenceElemID = new ElemID(constants.NETSUITE, 'savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping_columnreference')
+
+const savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping_columnreference = new ObjectType({
+  elemID: savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping_columnreferenceElemID,
+  annotations: {
+  },
+  fields: {
+    file: new Field(
+      savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping_columnreferenceElemID,
+      'file',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol. */
+    column: new Field(
+      savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping_columnreferenceElemID,
+      'column',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    type: new Field(
+      savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping_columnreferenceElemID,
+      'type',
+      enums.csvimport_referencetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see csvimport_referencetype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, savedcsvimportElemID.name],
+})
+
+savedcsvimportInnerTypes.push(savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping_columnreference)
+
+const savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmappingElemID = new ElemID(constants.NETSUITE, 'savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping')
+
+const savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping = new ObjectType({
+  elemID: savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmappingElemID,
+  annotations: {
+  },
+  fields: {
+    field: new Field(
+      savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmappingElemID,
+      'field',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customsegment   customrecordcustomfield   crmcustomfield */
+    value: new Field(
+      savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmappingElemID,
+      'value',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    columnreference: new Field(
+      savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmappingElemID,
+      'columnreference',
+      savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping_columnreference,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, savedcsvimportElemID.name],
+})
+
+savedcsvimportInnerTypes.push(savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping)
+
+const savedcsvimport_recordmappings_recordmapping_fieldmappingsElemID = new ElemID(constants.NETSUITE, 'savedcsvimport_recordmappings_recordmapping_fieldmappings')
+
+const savedcsvimport_recordmappings_recordmapping_fieldmappings = new ObjectType({
+  elemID: savedcsvimport_recordmappings_recordmapping_fieldmappingsElemID,
+  annotations: {
+  },
+  fields: {
+    fieldmapping: new Field(
+      savedcsvimport_recordmappings_recordmapping_fieldmappingsElemID,
+      'fieldmapping',
+      new ListType(savedcsvimport_recordmappings_recordmapping_fieldmappings_fieldmapping),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, savedcsvimportElemID.name],
+})
+
+savedcsvimportInnerTypes.push(savedcsvimport_recordmappings_recordmapping_fieldmappings)
+
+const savedcsvimport_recordmappings_recordmappingElemID = new ElemID(constants.NETSUITE, 'savedcsvimport_recordmappings_recordmapping')
+
+const savedcsvimport_recordmappings_recordmapping = new ObjectType({
+  elemID: savedcsvimport_recordmappings_recordmappingElemID,
+  annotations: {
+  },
+  fields: {
+    record: new Field(
+      savedcsvimport_recordmappings_recordmappingElemID,
+      'record',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol. */
+    line: new Field(
+      savedcsvimport_recordmappings_recordmappingElemID,
+      'line',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    fieldmappings: new Field(
+      savedcsvimport_recordmappings_recordmappingElemID,
+      'fieldmappings',
+      savedcsvimport_recordmappings_recordmapping_fieldmappings,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, savedcsvimportElemID.name],
+})
+
+savedcsvimportInnerTypes.push(savedcsvimport_recordmappings_recordmapping)
+
+const savedcsvimport_recordmappingsElemID = new ElemID(constants.NETSUITE, 'savedcsvimport_recordmappings')
+
+const savedcsvimport_recordmappings = new ObjectType({
+  elemID: savedcsvimport_recordmappingsElemID,
+  annotations: {
+  },
+  fields: {
+    recordmapping: new Field(
+      savedcsvimport_recordmappingsElemID,
+      'recordmapping',
+      new ListType(savedcsvimport_recordmappings_recordmapping),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, savedcsvimportElemID.name],
+})
+
+savedcsvimportInnerTypes.push(savedcsvimport_recordmappings)
+
+
+export const savedcsvimport = new ObjectType({
+  elemID: savedcsvimportElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custimport_',
+  },
+  fields: {
+    scriptid: new Field(
+      savedcsvimportElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custimport’. */
+    recordtype: new Field(
+      savedcsvimportElemID,
+      'recordtype',
+      enums.csvimport_recordtypes,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see csvimport_recordtypes. */
+    importname: new Field(
+      savedcsvimportElemID,
+      'importname',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 50,
+      },
+    ), /* Original description: This field value can be up to 50 characters long. */
+    datahandling: new Field(
+      savedcsvimportElemID,
+      'datahandling',
+      enums.csvimport_datahandling,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see csvimport_datahandling.   The default value is 'ADD'. */
+    decimaldelimiter: new Field(
+      savedcsvimportElemID,
+      'decimaldelimiter',
+      enums.csvimport_decimaldelimiter,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see csvimport_decimaldelimiter. */
+    columndelimiter: new Field(
+      savedcsvimportElemID,
+      'columndelimiter',
+      enums.csvimport_columndelimiter,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see csvimport_columndelimiter. */
+    entryform: new Field(
+      savedcsvimportElemID,
+      'entryform',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is available when the recordtype value is present in any of the following lists or values: csvimports_entryformrecordtypes, csvimport_customrecordtype.   This field is mandatory when the recordtype value is present in csvimports_entryformrecordtypes.   This field accepts references to the entryForm custom type.   For information about other possible values, see csvimport_entryform_standard. */
+    transactionform: new Field(
+      savedcsvimportElemID,
+      'transactionform',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is available when the recordtype value is present in any of the following lists or values: csvimports_transactionformrecordtypes, csvimport_customtransactiontype.   This field is mandatory when the recordtype value is present in csvimports_transactionformrecordtypes.   This field accepts references to the transactionForm custom type.   For information about other possible values, see csvimport_transactionform_standard. */
+    customrecord: new Field(
+      savedcsvimportElemID,
+      'customrecord',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is available when the recordtype value is equal to CUSTOMRECORD.   This field is mandatory when the recordtype value is equal to CUSTOMRECORD.   This field accepts references to the customrecordtype custom type.   For information about other possible values, see generic_standard_recordtype. */
+    customtransaction: new Field(
+      savedcsvimportElemID,
+      'customtransaction',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is available when the recordtype value is equal to CUSTOMTRANSACTION.   This field is mandatory when the recordtype value is equal to CUSTOMTRANSACTION.   This field accepts references to the customtransactiontype custom type. */
+    charencoding: new Field(
+      savedcsvimportElemID,
+      'charencoding',
+      enums.csvimport_encoding,
+      {
+      },
+    ), /* Original description: For information about possible values, see csvimport_encoding.   The default value is 'windows-1252'. */
+    logsystemnotescustfields: new Field(
+      savedcsvimportElemID,
+      'logsystemnotescustfields',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    overwritemissingfields: new Field(
+      savedcsvimportElemID,
+      'overwritemissingfields',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the recordtype value is not equal to CURRENCYRATE.   The default value is F. */
+    validatemandatorycustfields: new Field(
+      savedcsvimportElemID,
+      'validatemandatorycustfields',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    overwritesublists: new Field(
+      savedcsvimportElemID,
+      'overwritesublists',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ignorereadonly: new Field(
+      savedcsvimportElemID,
+      'ignorereadonly',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the recordtype value is not equal to any of the following lists or values: CUSTOMERANDCONTACT, LEADANDCONTACT, PROSPECTANDCONTACT.   The default value is T. */
+    preventduplicates: new Field(
+      savedcsvimportElemID,
+      'preventduplicates',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the recordtype value is equal to any of the following lists or values: CUSTOMERANDCONTACT, LEADANDCONTACT, PROSPECTANDCONTACT, CONTACT, LEAD, PARTNER, VENDOR, CUSTOMER, PROSPECT.   The default value is F. */
+    usemultithread: new Field(
+      savedcsvimportElemID,
+      'usemultithread',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    runserversuitescript: new Field(
+      savedcsvimportElemID,
+      'runserversuitescript',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    multiselectdelimiter: new Field(
+      savedcsvimportElemID,
+      'multiselectdelimiter',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 1,
+      },
+    ), /* Original description: This field value can be up to 1 characters long.   The default value is '|'. */
+    description: new Field(
+      savedcsvimportElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 499,
+      },
+    ), /* Original description: This field value can be up to 499 characters long. */
+    audience: new Field(
+      savedcsvimportElemID,
+      'audience',
+      savedcsvimport_audience,
+      {
+      },
+    ),
+    filemappings: new Field(
+      savedcsvimportElemID,
+      'filemappings',
+      savedcsvimport_filemappings,
+      {
+      },
+    ),
+    recordmappings: new Field(
+      savedcsvimportElemID,
+      'recordmappings',
+      savedcsvimport_recordmappings,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, savedcsvimportElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/savedsearch.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/savedsearch.ts
@@ -1,0 +1,80 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+
+export const savedsearchInnerTypes: ObjectType[] = []
+
+const savedsearchElemID = new ElemID(constants.NETSUITE, 'savedsearch')
+const savedsearch_dependenciesElemID = new ElemID(constants.NETSUITE, 'savedsearch_dependencies')
+
+const savedsearch_dependencies = new ObjectType({
+  elemID: savedsearch_dependenciesElemID,
+  annotations: {
+  },
+  fields: {
+    dependency: new Field(
+      savedsearch_dependenciesElemID,
+      'dependency',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field only accepts references to any custom type. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, savedsearchElemID.name],
+})
+
+savedsearchInnerTypes.push(savedsearch_dependencies)
+
+
+export const savedsearch = new ObjectType({
+  elemID: savedsearchElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customsearch_',
+  },
+  fields: {
+    scriptid: new Field(
+      savedsearchElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+        [constants.IS_NAME]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customsearch’. */
+    definition: new Field(
+      savedsearchElemID,
+      'definition',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    dependencies: new Field(
+      savedsearchElemID,
+      'dependencies',
+      savedsearch_dependencies,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, savedsearchElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/scheduledscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/scheduledscript.ts
@@ -1,0 +1,1223 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const scheduledscriptInnerTypes: ObjectType[] = []
+
+const scheduledscriptElemID = new ElemID(constants.NETSUITE, 'scheduledscript')
+const scheduledscript_customplugintypes_plugintypeElemID = new ElemID(constants.NETSUITE, 'scheduledscript_customplugintypes_plugintype')
+
+const scheduledscript_customplugintypes_plugintype = new ObjectType({
+  elemID: scheduledscript_customplugintypes_plugintypeElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      scheduledscript_customplugintypes_plugintypeElemID,
+      'plugintype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the plugintype custom type. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_customplugintypes_plugintype)
+
+const scheduledscript_customplugintypesElemID = new ElemID(constants.NETSUITE, 'scheduledscript_customplugintypes')
+
+const scheduledscript_customplugintypes = new ObjectType({
+  elemID: scheduledscript_customplugintypesElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      scheduledscript_customplugintypesElemID,
+      'plugintype',
+      new ListType(scheduledscript_customplugintypes_plugintype),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_customplugintypes)
+
+const scheduledscript_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'scheduledscript_libraries_library')
+
+const scheduledscript_libraries_library = new ObjectType({
+  elemID: scheduledscript_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      scheduledscript_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_libraries_library)
+
+const scheduledscript_librariesElemID = new ElemID(constants.NETSUITE, 'scheduledscript_libraries')
+
+const scheduledscript_libraries = new ObjectType({
+  elemID: scheduledscript_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      scheduledscript_librariesElemID,
+      'library',
+      new ListType(scheduledscript_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_libraries)
+
+const scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter')
+
+const scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter)
+
+const scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters')
+
+const scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters = new ObjectType({
+  elemID: scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters)
+
+const scheduledscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess')
+
+const scheduledscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: scheduledscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess)
+
+const scheduledscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptcustomfields_scriptcustomfield_roleaccesses')
+
+const scheduledscript_scriptcustomfields_scriptcustomfield_roleaccesses = new ObjectType({
+  elemID: scheduledscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(scheduledscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptcustomfields_scriptcustomfield_roleaccesses)
+
+const scheduledscript_scriptcustomfields_scriptcustomfieldElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptcustomfields_scriptcustomfield')
+
+const scheduledscript_scriptcustomfields_scriptcustomfield = new ObjectType({
+  elemID: scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custscript’. */
+    fieldtype: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    isformula: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    setting: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'setting',
+      enums.script_setting,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_setting. */
+    customfieldfilters: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'customfieldfilters',
+      scheduledscript_scriptcustomfields_scriptcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      scheduledscript_scriptcustomfields_scriptcustomfieldElemID,
+      'roleaccesses',
+      scheduledscript_scriptcustomfields_scriptcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptcustomfields_scriptcustomfield)
+
+const scheduledscript_scriptcustomfieldsElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptcustomfields')
+
+const scheduledscript_scriptcustomfields = new ObjectType({
+  elemID: scheduledscript_scriptcustomfieldsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptcustomfield: new Field(
+      scheduledscript_scriptcustomfieldsElemID,
+      'scriptcustomfield',
+      new ListType(scheduledscript_scriptcustomfields_scriptcustomfield),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptcustomfields)
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_dailyElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptdeployments_scriptdeployment_recurrence_daily')
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_daily = new ObjectType({
+  elemID: scheduledscript_scriptdeployments_scriptdeployment_recurrence_dailyElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_dailyElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_dailyElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    everyxdays: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_dailyElemID,
+      'everyxdays',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_dailyElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    repeat: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_dailyElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptdeployments_scriptdeployment_recurrence_daily)
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_everyweekdayElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptdeployments_scriptdeployment_recurrence_everyweekday')
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_everyweekday = new ObjectType({
+  elemID: scheduledscript_scriptdeployments_scriptdeployment_recurrence_everyweekdayElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_everyweekdayElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_everyweekdayElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_everyweekdayElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    repeat: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_everyweekdayElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptdeployments_scriptdeployment_recurrence_everyweekday)
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlyElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthly')
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthly = new ObjectType({
+  elemID: scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlyElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlyElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlyElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    everyxmonths: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlyElemID,
+      'everyxmonths',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlyElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    repeat: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlyElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthly)
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweek')
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweek = new ObjectType({
+  elemID: scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    orderofweek: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+      'orderofweek',
+      enums.generic_order_of_week,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_order_of_week. */
+    dayofweek: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+      'dayofweek',
+      enums.generic_day_of_week,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_day_of_week. */
+    everyxmonths: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+      'everyxmonths',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    repeat: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweekElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweek)
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_singleElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptdeployments_scriptdeployment_recurrence_single')
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_single = new ObjectType({
+  elemID: scheduledscript_scriptdeployments_scriptdeployment_recurrence_singleElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_singleElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_singleElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    repeat: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_singleElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptdeployments_scriptdeployment_recurrence_single)
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptdeployments_scriptdeployment_recurrence_weekly')
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_weekly = new ObjectType({
+  elemID: scheduledscript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    everyxweeks: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'everyxweeks',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    sunday: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'sunday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    monday: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'monday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    tuesday: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'tuesday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    wednesday: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'wednesday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    thursday: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'thursday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    friday: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'friday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    saturday: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'saturday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    enddate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    repeat: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_weeklyElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptdeployments_scriptdeployment_recurrence_weekly)
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlyElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearly')
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearly = new ObjectType({
+  elemID: scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlyElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlyElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlyElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlyElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    repeat: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlyElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearly)
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweek')
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweek = new ObjectType({
+  elemID: scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    orderofweek: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID,
+      'orderofweek',
+      enums.generic_order_of_week,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_order_of_week. */
+    dayofweek: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID,
+      'dayofweek',
+      enums.generic_day_of_week,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_day_of_week. */
+    enddate: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    repeat: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweekElemID,
+      'repeat',
+      enums.generic_repeat_time,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_repeat_time. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweek)
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrenceElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptdeployments_scriptdeployment_recurrence')
+
+const scheduledscript_scriptdeployments_scriptdeployment_recurrence = new ObjectType({
+  elemID: scheduledscript_scriptdeployments_scriptdeployment_recurrenceElemID,
+  annotations: {
+  },
+  fields: {
+    daily: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'daily',
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_daily,
+      {
+      },
+    ),
+    everyweekday: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'everyweekday',
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_everyweekday,
+      {
+      },
+    ),
+    monthly: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'monthly',
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthly,
+      {
+      },
+    ),
+    monthlydayofweek: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'monthlydayofweek',
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_monthlydayofweek,
+      {
+      },
+    ),
+    single: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'single',
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_single,
+      {
+      },
+    ),
+    weekly: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'weekly',
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_weekly,
+      {
+      },
+    ),
+    yearly: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'yearly',
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearly,
+      {
+      },
+    ),
+    yearlydayofweek: new Field(
+      scheduledscript_scriptdeployments_scriptdeployment_recurrenceElemID,
+      'yearlydayofweek',
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence_yearlydayofweek,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptdeployments_scriptdeployment_recurrence)
+
+const scheduledscript_scriptdeployments_scriptdeploymentElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptdeployments_scriptdeployment')
+
+const scheduledscript_scriptdeployments_scriptdeployment = new ObjectType({
+  elemID: scheduledscript_scriptdeployments_scriptdeploymentElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      scheduledscript_scriptdeployments_scriptdeploymentElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customdeploy’. */
+    status: new Field(
+      scheduledscript_scriptdeployments_scriptdeploymentElemID,
+      'status',
+      enums.script_status,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+    title: new Field(
+      scheduledscript_scriptdeployments_scriptdeploymentElemID,
+      'title',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    isdeployed: new Field(
+      scheduledscript_scriptdeployments_scriptdeploymentElemID,
+      'isdeployed',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    loglevel: new Field(
+      scheduledscript_scriptdeployments_scriptdeploymentElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+    recurrence: new Field(
+      scheduledscript_scriptdeployments_scriptdeploymentElemID,
+      'recurrence',
+      scheduledscript_scriptdeployments_scriptdeployment_recurrence,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptdeployments_scriptdeployment)
+
+const scheduledscript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptdeployments')
+
+const scheduledscript_scriptdeployments = new ObjectType({
+  elemID: scheduledscript_scriptdeploymentsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptdeployment: new Field(
+      scheduledscript_scriptdeploymentsElemID,
+      'scriptdeployment',
+      new ListType(scheduledscript_scriptdeployments_scriptdeployment),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})
+
+scheduledscriptInnerTypes.push(scheduledscript_scriptdeployments)
+
+
+export const scheduledscript = new ObjectType({
+  elemID: scheduledscriptElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      scheduledscriptElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      scheduledscriptElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      scheduledscriptElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    defaultfunction: new Field(
+      scheduledscriptElemID,
+      'defaultfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      scheduledscriptElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      scheduledscriptElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      scheduledscriptElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      scheduledscriptElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      scheduledscriptElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      scheduledscriptElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    customplugintypes: new Field(
+      scheduledscriptElemID,
+      'customplugintypes',
+      scheduledscript_customplugintypes,
+      {
+      },
+    ),
+    libraries: new Field(
+      scheduledscriptElemID,
+      'libraries',
+      scheduledscript_libraries,
+      {
+      },
+    ),
+    scriptcustomfields: new Field(
+      scheduledscriptElemID,
+      'scriptcustomfields',
+      scheduledscript_scriptcustomfields,
+      {
+      },
+    ),
+    scriptdeployments: new Field(
+      scheduledscriptElemID,
+      'scriptdeployments',
+      scheduledscript_scriptdeployments,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, scheduledscriptElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/sdfinstallationscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/sdfinstallationscript.ts
@@ -1,0 +1,642 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const sdfinstallationscriptInnerTypes: ObjectType[] = []
+
+const sdfinstallationscriptElemID = new ElemID(constants.NETSUITE, 'sdfinstallationscript')
+const sdfinstallationscript_customplugintypes_plugintypeElemID = new ElemID(constants.NETSUITE, 'sdfinstallationscript_customplugintypes_plugintype')
+
+const sdfinstallationscript_customplugintypes_plugintype = new ObjectType({
+  elemID: sdfinstallationscript_customplugintypes_plugintypeElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      sdfinstallationscript_customplugintypes_plugintypeElemID,
+      'plugintype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the plugintype custom type. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sdfinstallationscriptElemID.name],
+})
+
+sdfinstallationscriptInnerTypes.push(sdfinstallationscript_customplugintypes_plugintype)
+
+const sdfinstallationscript_customplugintypesElemID = new ElemID(constants.NETSUITE, 'sdfinstallationscript_customplugintypes')
+
+const sdfinstallationscript_customplugintypes = new ObjectType({
+  elemID: sdfinstallationscript_customplugintypesElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      sdfinstallationscript_customplugintypesElemID,
+      'plugintype',
+      new ListType(sdfinstallationscript_customplugintypes_plugintype),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sdfinstallationscriptElemID.name],
+})
+
+sdfinstallationscriptInnerTypes.push(sdfinstallationscript_customplugintypes)
+
+const sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter')
+
+const sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sdfinstallationscriptElemID.name],
+})
+
+sdfinstallationscriptInnerTypes.push(sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter)
+
+const sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters')
+
+const sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters = new ObjectType({
+  elemID: sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sdfinstallationscriptElemID.name],
+})
+
+sdfinstallationscriptInnerTypes.push(sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters)
+
+const sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess')
+
+const sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sdfinstallationscriptElemID.name],
+})
+
+sdfinstallationscriptInnerTypes.push(sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess)
+
+const sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses')
+
+const sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses = new ObjectType({
+  elemID: sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sdfinstallationscriptElemID.name],
+})
+
+sdfinstallationscriptInnerTypes.push(sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses)
+
+const sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID = new ElemID(constants.NETSUITE, 'sdfinstallationscript_scriptcustomfields_scriptcustomfield')
+
+const sdfinstallationscript_scriptcustomfields_scriptcustomfield = new ObjectType({
+  elemID: sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custscript’. */
+    fieldtype: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    isformula: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    setting: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'setting',
+      enums.script_setting,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_setting. */
+    customfieldfilters: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'customfieldfilters',
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      sdfinstallationscript_scriptcustomfields_scriptcustomfieldElemID,
+      'roleaccesses',
+      sdfinstallationscript_scriptcustomfields_scriptcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sdfinstallationscriptElemID.name],
+})
+
+sdfinstallationscriptInnerTypes.push(sdfinstallationscript_scriptcustomfields_scriptcustomfield)
+
+const sdfinstallationscript_scriptcustomfieldsElemID = new ElemID(constants.NETSUITE, 'sdfinstallationscript_scriptcustomfields')
+
+const sdfinstallationscript_scriptcustomfields = new ObjectType({
+  elemID: sdfinstallationscript_scriptcustomfieldsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptcustomfield: new Field(
+      sdfinstallationscript_scriptcustomfieldsElemID,
+      'scriptcustomfield',
+      new ListType(sdfinstallationscript_scriptcustomfields_scriptcustomfield),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sdfinstallationscriptElemID.name],
+})
+
+sdfinstallationscriptInnerTypes.push(sdfinstallationscript_scriptcustomfields)
+
+const sdfinstallationscript_scriptdeployments_scriptdeploymentElemID = new ElemID(constants.NETSUITE, 'sdfinstallationscript_scriptdeployments_scriptdeployment')
+
+const sdfinstallationscript_scriptdeployments_scriptdeployment = new ObjectType({
+  elemID: sdfinstallationscript_scriptdeployments_scriptdeploymentElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      sdfinstallationscript_scriptdeployments_scriptdeploymentElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customdeploy’. */
+    status: new Field(
+      sdfinstallationscript_scriptdeployments_scriptdeploymentElemID,
+      'status',
+      enums.script_status,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+    title: new Field(
+      sdfinstallationscript_scriptdeployments_scriptdeploymentElemID,
+      'title',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    isdeployed: new Field(
+      sdfinstallationscript_scriptdeployments_scriptdeploymentElemID,
+      'isdeployed',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    loglevel: new Field(
+      sdfinstallationscript_scriptdeployments_scriptdeploymentElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sdfinstallationscriptElemID.name],
+})
+
+sdfinstallationscriptInnerTypes.push(sdfinstallationscript_scriptdeployments_scriptdeployment)
+
+const sdfinstallationscript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'sdfinstallationscript_scriptdeployments')
+
+const sdfinstallationscript_scriptdeployments = new ObjectType({
+  elemID: sdfinstallationscript_scriptdeploymentsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptdeployment: new Field(
+      sdfinstallationscript_scriptdeploymentsElemID,
+      'scriptdeployment',
+      new ListType(sdfinstallationscript_scriptdeployments_scriptdeployment),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sdfinstallationscriptElemID.name],
+})
+
+sdfinstallationscriptInnerTypes.push(sdfinstallationscript_scriptdeployments)
+
+
+export const sdfinstallationscript = new ObjectType({
+  elemID: sdfinstallationscriptElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      sdfinstallationscriptElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      sdfinstallationscriptElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      sdfinstallationscriptElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    description: new Field(
+      sdfinstallationscriptElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      sdfinstallationscriptElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      sdfinstallationscriptElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      sdfinstallationscriptElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      sdfinstallationscriptElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      sdfinstallationscriptElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      sdfinstallationscriptElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    customplugintypes: new Field(
+      sdfinstallationscriptElemID,
+      'customplugintypes',
+      sdfinstallationscript_customplugintypes,
+      {
+      },
+    ),
+    scriptcustomfields: new Field(
+      sdfinstallationscriptElemID,
+      'scriptcustomfields',
+      sdfinstallationscript_scriptcustomfields,
+      {
+      },
+    ),
+    scriptdeployments: new Field(
+      sdfinstallationscriptElemID,
+      'scriptdeployments',
+      sdfinstallationscript_scriptdeployments,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sdfinstallationscriptElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/sspapplication.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/sspapplication.ts
@@ -1,0 +1,213 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const sspapplicationInnerTypes: ObjectType[] = []
+
+const sspapplicationElemID = new ElemID(constants.NETSUITE, 'sspapplication')
+const sspapplication_entrypoints_entrypointElemID = new ElemID(constants.NETSUITE, 'sspapplication_entrypoints_entrypoint')
+
+const sspapplication_entrypoints_entrypoint = new ObjectType({
+  elemID: sspapplication_entrypoints_entrypointElemID,
+  annotations: {
+  },
+  fields: {
+    entrytype: new Field(
+      sspapplication_entrypoints_entrypointElemID,
+      'entrytype',
+      enums.webapp_entrytype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see webapp_entrytype. */
+    entryitem: new Field(
+      sspapplication_entrypoints_entrypointElemID,
+      'entryitem',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a file with any of the following extensions: .html, .ss, .ssp */
+    entryparameter: new Field(
+      sspapplication_entrypoints_entrypointElemID,
+      'entryparameter',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 60,
+      },
+    ), /* Original description: This field value can be up to 60 characters long. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sspapplicationElemID.name],
+})
+
+sspapplicationInnerTypes.push(sspapplication_entrypoints_entrypoint)
+
+const sspapplication_entrypointsElemID = new ElemID(constants.NETSUITE, 'sspapplication_entrypoints')
+
+const sspapplication_entrypoints = new ObjectType({
+  elemID: sspapplication_entrypointsElemID,
+  annotations: {
+  },
+  fields: {
+    entrypoint: new Field(
+      sspapplication_entrypointsElemID,
+      'entrypoint',
+      new ListType(sspapplication_entrypoints_entrypoint),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sspapplicationElemID.name],
+})
+
+sspapplicationInnerTypes.push(sspapplication_entrypoints)
+
+const sspapplication_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'sspapplication_libraries_library')
+
+const sspapplication_libraries_library = new ObjectType({
+  elemID: sspapplication_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      sspapplication_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sspapplicationElemID.name],
+})
+
+sspapplicationInnerTypes.push(sspapplication_libraries_library)
+
+const sspapplication_librariesElemID = new ElemID(constants.NETSUITE, 'sspapplication_libraries')
+
+const sspapplication_libraries = new ObjectType({
+  elemID: sspapplication_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      sspapplication_librariesElemID,
+      'library',
+      new ListType(sspapplication_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sspapplicationElemID.name],
+})
+
+sspapplicationInnerTypes.push(sspapplication_libraries)
+
+
+export const sspapplication = new ObjectType({
+  elemID: sspapplicationElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'webapp_',
+  },
+  fields: {
+    scriptid: new Field(
+      sspapplicationElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 34 characters long.   The default value is ‘webapp’. */
+    name: new Field(
+      sspapplicationElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    status: new Field(
+      sspapplicationElemID,
+      'status',
+      enums.plugintype_status,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see plugintype_status.   The default value is 'TESTING'. */
+    rootpath: new Field(
+      sspapplicationElemID,
+      'rootpath',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    appfolder: new Field(
+      sspapplicationElemID,
+      'appfolder',
+      BuiltinTypes.STRING /* Original type was folderreference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    description: new Field(
+      sspapplicationElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 3999,
+      },
+    ), /* Original description: This field value can be up to 3999 characters long. */
+    isinactive: new Field(
+      sspapplicationElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    loglevel: new Field(
+      sspapplicationElemID,
+      'loglevel',
+      enums.plugintype_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see plugintype_loglevel.   The default value is 'DEBUG'. */
+    entrypoints: new Field(
+      sspapplicationElemID,
+      'entrypoints',
+      sspapplication_entrypoints,
+      {
+      },
+    ),
+    libraries: new Field(
+      sspapplicationElemID,
+      'libraries',
+      sspapplication_libraries,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sspapplicationElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/sublist.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/sublist.ts
@@ -1,0 +1,335 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const sublistInnerTypes: ObjectType[] = []
+
+const sublistElemID = new ElemID(constants.NETSUITE, 'sublist')
+
+export const sublist = new ObjectType({
+  elemID: sublistElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custsublist_',
+  },
+  fields: {
+    scriptid: new Field(
+      sublistElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custsublist’. */
+    label: new Field(
+      sublistElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+      },
+    ),
+    savedsearch: new Field(
+      sublistElemID,
+      'savedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    sublisttype: new Field(
+      sublistElemID,
+      'sublisttype',
+      enums.generic_tab_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_tab_type. */
+    tab: new Field(
+      sublistElemID,
+      'tab',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the subtab custom type.   For information about other possible values, see generic_tab_parent. */
+    field: new Field(
+      sublistElemID,
+      'field',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactionbodycustomfield   itemcustomfield   entitycustomfield   crmcustomfield   For information about other possible values, see sublist_standard_fields. */
+    purchase: new Field(
+      sublistElemID,
+      'purchase',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    sale: new Field(
+      sublistElemID,
+      'sale',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    opportunity: new Field(
+      sublistElemID,
+      'opportunity',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    journal: new Field(
+      sublistElemID,
+      'journal',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    expensereport: new Field(
+      sublistElemID,
+      'expensereport',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    inventoryadjustment: new Field(
+      sublistElemID,
+      'inventoryadjustment',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    assemblybuild: new Field(
+      sublistElemID,
+      'assemblybuild',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fulfillmentrequest: new Field(
+      sublistElemID,
+      'fulfillmentrequest',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    storepickup: new Field(
+      sublistElemID,
+      'storepickup',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    itemreceipt: new Field(
+      sublistElemID,
+      'itemreceipt',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    itemfulfillment: new Field(
+      sublistElemID,
+      'itemfulfillment',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    payment: new Field(
+      sublistElemID,
+      'payment',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    vendorpayment: new Field(
+      sublistElemID,
+      'vendorpayment',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    deposit: new Field(
+      sublistElemID,
+      'deposit',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    depositapplication: new Field(
+      sublistElemID,
+      'depositapplication',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    customtransactions: new Field(
+      sublistElemID,
+      'customtransactions',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: This field is available when the sublisttype value is equal to TRANSACTION.   You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the customtransactiontype custom type.   If this field appears in the project, you must reference the CUSTOMTRANSACTIONS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CUSTOMTRANSACTIONS must be enabled for this field to appear in your account. */
+    customer: new Field(
+      sublistElemID,
+      'customer',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    job: new Field(
+      sublistElemID,
+      'job',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    vendor: new Field(
+      sublistElemID,
+      'vendor',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    employee: new Field(
+      sublistElemID,
+      'employee',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    partner: new Field(
+      sublistElemID,
+      'partner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    contact: new Field(
+      sublistElemID,
+      'contact',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    inventoryitem: new Field(
+      sublistElemID,
+      'inventoryitem',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    noninventoryitem: new Field(
+      sublistElemID,
+      'noninventoryitem',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    service: new Field(
+      sublistElemID,
+      'service',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    othercharge: new Field(
+      sublistElemID,
+      'othercharge',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    itemgroup: new Field(
+      sublistElemID,
+      'itemgroup',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    kit: new Field(
+      sublistElemID,
+      'kit',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    billofmaterials: new Field(
+      sublistElemID,
+      'billofmaterials',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    case: new Field(
+      sublistElemID,
+      'case',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    task: new Field(
+      sublistElemID,
+      'task',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    call: new Field(
+      sublistElemID,
+      'call',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    event: new Field(
+      sublistElemID,
+      'event',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    solution: new Field(
+      sublistElemID,
+      'solution',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    campaign: new Field(
+      sublistElemID,
+      'campaign',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    issue: new Field(
+      sublistElemID,
+      'issue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, sublistElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/subtab.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/subtab.ts
@@ -1,0 +1,68 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const subtabInnerTypes: ObjectType[] = []
+
+const subtabElemID = new ElemID(constants.NETSUITE, 'subtab')
+
+export const subtab = new ObjectType({
+  elemID: subtabElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custtab_',
+  },
+  fields: {
+    scriptid: new Field(
+      subtabElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custtab’. */
+    title: new Field(
+      subtabElemID,
+      'title',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+      },
+    ),
+    tabtype: new Field(
+      subtabElemID,
+      'tabtype',
+      enums.generic_tab_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_tab_type. */
+    parent: new Field(
+      subtabElemID,
+      'parent',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the subtab custom type.   For information about other possible values, see generic_tab_parent. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, subtabElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/suitelet.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/suitelet.ts
@@ -1,0 +1,843 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const suiteletInnerTypes: ObjectType[] = []
+
+const suiteletElemID = new ElemID(constants.NETSUITE, 'suitelet')
+const suitelet_customplugintypes_plugintypeElemID = new ElemID(constants.NETSUITE, 'suitelet_customplugintypes_plugintype')
+
+const suitelet_customplugintypes_plugintype = new ObjectType({
+  elemID: suitelet_customplugintypes_plugintypeElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      suitelet_customplugintypes_plugintypeElemID,
+      'plugintype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the plugintype custom type. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})
+
+suiteletInnerTypes.push(suitelet_customplugintypes_plugintype)
+
+const suitelet_customplugintypesElemID = new ElemID(constants.NETSUITE, 'suitelet_customplugintypes')
+
+const suitelet_customplugintypes = new ObjectType({
+  elemID: suitelet_customplugintypesElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      suitelet_customplugintypesElemID,
+      'plugintype',
+      new ListType(suitelet_customplugintypes_plugintype),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})
+
+suiteletInnerTypes.push(suitelet_customplugintypes)
+
+const suitelet_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'suitelet_libraries_library')
+
+const suitelet_libraries_library = new ObjectType({
+  elemID: suitelet_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      suitelet_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})
+
+suiteletInnerTypes.push(suitelet_libraries_library)
+
+const suitelet_librariesElemID = new ElemID(constants.NETSUITE, 'suitelet_libraries')
+
+const suitelet_libraries = new ObjectType({
+  elemID: suitelet_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      suitelet_librariesElemID,
+      'library',
+      new ListType(suitelet_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})
+
+suiteletInnerTypes.push(suitelet_libraries)
+
+const suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter')
+
+const suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})
+
+suiteletInnerTypes.push(suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter)
+
+const suitelet_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters')
+
+const suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters = new ObjectType({
+  elemID: suitelet_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      suitelet_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})
+
+suiteletInnerTypes.push(suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters)
+
+const suitelet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'suitelet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess')
+
+const suitelet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: suitelet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      suitelet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      suitelet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      suitelet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})
+
+suiteletInnerTypes.push(suitelet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess)
+
+const suitelet_scriptcustomfields_scriptcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'suitelet_scriptcustomfields_scriptcustomfield_roleaccesses')
+
+const suitelet_scriptcustomfields_scriptcustomfield_roleaccesses = new ObjectType({
+  elemID: suitelet_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      suitelet_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(suitelet_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})
+
+suiteletInnerTypes.push(suitelet_scriptcustomfields_scriptcustomfield_roleaccesses)
+
+const suitelet_scriptcustomfields_scriptcustomfieldElemID = new ElemID(constants.NETSUITE, 'suitelet_scriptcustomfields_scriptcustomfield')
+
+const suitelet_scriptcustomfields_scriptcustomfield = new ObjectType({
+  elemID: suitelet_scriptcustomfields_scriptcustomfieldElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custscript’. */
+    fieldtype: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    isformula: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    setting: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'setting',
+      enums.script_setting,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_setting. */
+    customfieldfilters: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'customfieldfilters',
+      suitelet_scriptcustomfields_scriptcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      suitelet_scriptcustomfields_scriptcustomfieldElemID,
+      'roleaccesses',
+      suitelet_scriptcustomfields_scriptcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})
+
+suiteletInnerTypes.push(suitelet_scriptcustomfields_scriptcustomfield)
+
+const suitelet_scriptcustomfieldsElemID = new ElemID(constants.NETSUITE, 'suitelet_scriptcustomfields')
+
+const suitelet_scriptcustomfields = new ObjectType({
+  elemID: suitelet_scriptcustomfieldsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptcustomfield: new Field(
+      suitelet_scriptcustomfieldsElemID,
+      'scriptcustomfield',
+      new ListType(suitelet_scriptcustomfields_scriptcustomfield),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})
+
+suiteletInnerTypes.push(suitelet_scriptcustomfields)
+
+const suitelet_scriptdeployments_scriptdeployment_links_linkElemID = new ElemID(constants.NETSUITE, 'suitelet_scriptdeployments_scriptdeployment_links_link')
+
+const suitelet_scriptdeployments_scriptdeployment_links_link = new ObjectType({
+  elemID: suitelet_scriptdeployments_scriptdeployment_links_linkElemID,
+  annotations: {
+  },
+  fields: {
+    linkcategory: new Field(
+      suitelet_scriptdeployments_scriptdeployment_links_linkElemID,
+      'linkcategory',
+      enums.generic_centercategory,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_centercategory. */
+    linktasktype: new Field(
+      suitelet_scriptdeployments_scriptdeployment_links_linkElemID,
+      'linktasktype',
+      enums.suiteletdeployment_tasktype,
+      {
+      },
+    ), /* Original description: For information about possible values, see suiteletdeployment_tasktype. */
+    linklabel: new Field(
+      suitelet_scriptdeployments_scriptdeployment_links_linkElemID,
+      'linklabel',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})
+
+suiteletInnerTypes.push(suitelet_scriptdeployments_scriptdeployment_links_link)
+
+const suitelet_scriptdeployments_scriptdeployment_linksElemID = new ElemID(constants.NETSUITE, 'suitelet_scriptdeployments_scriptdeployment_links')
+
+const suitelet_scriptdeployments_scriptdeployment_links = new ObjectType({
+  elemID: suitelet_scriptdeployments_scriptdeployment_linksElemID,
+  annotations: {
+  },
+  fields: {
+    link: new Field(
+      suitelet_scriptdeployments_scriptdeployment_linksElemID,
+      'link',
+      new ListType(suitelet_scriptdeployments_scriptdeployment_links_link),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})
+
+suiteletInnerTypes.push(suitelet_scriptdeployments_scriptdeployment_links)
+
+const suitelet_scriptdeployments_scriptdeploymentElemID = new ElemID(constants.NETSUITE, 'suitelet_scriptdeployments_scriptdeployment')
+
+const suitelet_scriptdeployments_scriptdeployment = new ObjectType({
+  elemID: suitelet_scriptdeployments_scriptdeploymentElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customdeploy’. */
+    status: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'status',
+      enums.script_status,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+    title: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'title',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    allemployees: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'allemployees',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allpartners: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'allpartners',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account. */
+    allroles: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'allroles',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    auddepartment: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'auddepartment',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the DEPARTMENTS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. DEPARTMENTS must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    audemployee: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'audemployee',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   Note Account-specific values are not supported by SDF. */
+    audgroup: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'audgroup',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   Note Account-specific values are not supported by SDF. */
+    audpartner: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'audpartner',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    audslctrole: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'audslctrole',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    audsubsidiary: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'audsubsidiary',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the SUBSIDIARIES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. SUBSIDIARIES must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    eventtype: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'eventtype',
+      enums.script_eventtype,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_eventtype. */
+    isdeployed: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'isdeployed',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    isonline: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'isonline',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    loglevel: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+    runasrole: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'runasrole',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    links: new Field(
+      suitelet_scriptdeployments_scriptdeploymentElemID,
+      'links',
+      suitelet_scriptdeployments_scriptdeployment_links,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})
+
+suiteletInnerTypes.push(suitelet_scriptdeployments_scriptdeployment)
+
+const suitelet_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'suitelet_scriptdeployments')
+
+const suitelet_scriptdeployments = new ObjectType({
+  elemID: suitelet_scriptdeploymentsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptdeployment: new Field(
+      suitelet_scriptdeploymentsElemID,
+      'scriptdeployment',
+      new ListType(suitelet_scriptdeployments_scriptdeployment),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})
+
+suiteletInnerTypes.push(suitelet_scriptdeployments)
+
+
+export const suitelet = new ObjectType({
+  elemID: suiteletElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      suiteletElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      suiteletElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      suiteletElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    defaultfunction: new Field(
+      suiteletElemID,
+      'defaultfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      suiteletElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      suiteletElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      suiteletElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      suiteletElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      suiteletElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      suiteletElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      suiteletElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    customplugintypes: new Field(
+      suiteletElemID,
+      'customplugintypes',
+      suitelet_customplugintypes,
+      {
+      },
+    ),
+    libraries: new Field(
+      suiteletElemID,
+      'libraries',
+      suitelet_libraries,
+      {
+      },
+    ),
+    scriptcustomfields: new Field(
+      suiteletElemID,
+      'scriptcustomfields',
+      suitelet_scriptcustomfields,
+      {
+      },
+    ),
+    scriptdeployments: new Field(
+      suiteletElemID,
+      'scriptdeployments',
+      suitelet_scriptdeployments,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, suiteletElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/transactionForm.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/transactionForm.ts
@@ -1,0 +1,1929 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const transactionFormInnerTypes: ObjectType[] = []
+
+const transactionFormElemID = new ElemID(constants.NETSUITE, 'transactionForm')
+const transactionForm_actionbar_buttons_buttonElemID = new ElemID(constants.NETSUITE, 'transactionForm_actionbar_buttons_button')
+
+const transactionForm_actionbar_buttons_button = new ObjectType({
+  elemID: transactionForm_actionbar_buttons_buttonElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_actionbar_buttons_buttonElemID,
+      'id',
+      enums.transactionform_buttonid,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see transactionform_buttonid. */
+    label: new Field(
+      transactionForm_actionbar_buttons_buttonElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    visible: new Field(
+      transactionForm_actionbar_buttons_buttonElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_actionbar_buttons_button)
+
+const transactionForm_actionbar_buttonsElemID = new ElemID(constants.NETSUITE, 'transactionForm_actionbar_buttons')
+
+const transactionForm_actionbar_buttons = new ObjectType({
+  elemID: transactionForm_actionbar_buttonsElemID,
+  annotations: {
+  },
+  fields: {
+    button: new Field(
+      transactionForm_actionbar_buttonsElemID,
+      'button',
+      new ListType(transactionForm_actionbar_buttons_button),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_actionbar_buttons)
+
+const transactionForm_actionbar_customButtons_customButtonElemID = new ElemID(constants.NETSUITE, 'transactionForm_actionbar_customButtons_customButton')
+
+const transactionForm_actionbar_customButtons_customButton = new ObjectType({
+  elemID: transactionForm_actionbar_customButtons_customButtonElemID,
+  annotations: {
+  },
+  fields: {
+    label: new Field(
+      transactionForm_actionbar_customButtons_customButtonElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+      },
+    ), /* Original description: This field value can be up to 99 characters long. */
+    function: new Field(
+      transactionForm_actionbar_customButtons_customButtonElemID,
+      'function',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_actionbar_customButtons_customButton)
+
+const transactionForm_actionbar_customButtonsElemID = new ElemID(constants.NETSUITE, 'transactionForm_actionbar_customButtons')
+
+const transactionForm_actionbar_customButtons = new ObjectType({
+  elemID: transactionForm_actionbar_customButtonsElemID,
+  annotations: {
+  },
+  fields: {
+    customButton: new Field(
+      transactionForm_actionbar_customButtonsElemID,
+      'customButton',
+      new ListType(transactionForm_actionbar_customButtons_customButton),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_actionbar_customButtons)
+
+const transactionForm_actionbar_customMenu_customMenuItemElemID = new ElemID(constants.NETSUITE, 'transactionForm_actionbar_customMenu_customMenuItem')
+
+const transactionForm_actionbar_customMenu_customMenuItem = new ObjectType({
+  elemID: transactionForm_actionbar_customMenu_customMenuItemElemID,
+  annotations: {
+  },
+  fields: {
+    label: new Field(
+      transactionForm_actionbar_customMenu_customMenuItemElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+      },
+    ), /* Original description: This field value can be up to 99 characters long. */
+    function: new Field(
+      transactionForm_actionbar_customMenu_customMenuItemElemID,
+      'function',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_actionbar_customMenu_customMenuItem)
+
+const transactionForm_actionbar_customMenuElemID = new ElemID(constants.NETSUITE, 'transactionForm_actionbar_customMenu')
+
+const transactionForm_actionbar_customMenu = new ObjectType({
+  elemID: transactionForm_actionbar_customMenuElemID,
+  annotations: {
+  },
+  fields: {
+    customMenuItem: new Field(
+      transactionForm_actionbar_customMenuElemID,
+      'customMenuItem',
+      new ListType(transactionForm_actionbar_customMenu_customMenuItem),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_actionbar_customMenu)
+
+const transactionForm_actionbar_menu_menuitemElemID = new ElemID(constants.NETSUITE, 'transactionForm_actionbar_menu_menuitem')
+
+const transactionForm_actionbar_menu_menuitem = new ObjectType({
+  elemID: transactionForm_actionbar_menu_menuitemElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_actionbar_menu_menuitemElemID,
+      'id',
+      enums.transactionform_buttonid,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see transactionform_buttonid. */
+    label: new Field(
+      transactionForm_actionbar_menu_menuitemElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    visible: new Field(
+      transactionForm_actionbar_menu_menuitemElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_actionbar_menu_menuitem)
+
+const transactionForm_actionbar_menuElemID = new ElemID(constants.NETSUITE, 'transactionForm_actionbar_menu')
+
+const transactionForm_actionbar_menu = new ObjectType({
+  elemID: transactionForm_actionbar_menuElemID,
+  annotations: {
+  },
+  fields: {
+    menuitem: new Field(
+      transactionForm_actionbar_menuElemID,
+      'menuitem',
+      new ListType(transactionForm_actionbar_menu_menuitem),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_actionbar_menu)
+
+const transactionForm_actionbarElemID = new ElemID(constants.NETSUITE, 'transactionForm_actionbar')
+
+const transactionForm_actionbar = new ObjectType({
+  elemID: transactionForm_actionbarElemID,
+  annotations: {
+  },
+  fields: {
+    buttons: new Field(
+      transactionForm_actionbarElemID,
+      'buttons',
+      transactionForm_actionbar_buttons,
+      {
+      },
+    ),
+    customButtons: new Field(
+      transactionForm_actionbarElemID,
+      'customButtons',
+      transactionForm_actionbar_customButtons,
+      {
+      },
+    ),
+    customMenu: new Field(
+      transactionForm_actionbarElemID,
+      'customMenu',
+      transactionForm_actionbar_customMenu,
+      {
+      },
+    ),
+    menu: new Field(
+      transactionForm_actionbarElemID,
+      'menu',
+      transactionForm_actionbar_menu,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_actionbar)
+
+const transactionForm_buttons_standardButtons_buttonElemID = new ElemID(constants.NETSUITE, 'transactionForm_buttons_standardButtons_button')
+
+const transactionForm_buttons_standardButtons_button = new ObjectType({
+  elemID: transactionForm_buttons_standardButtons_buttonElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_buttons_standardButtons_buttonElemID,
+      'id',
+      enums.transactionform_buttonid,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see transactionform_buttonid. */
+    label: new Field(
+      transactionForm_buttons_standardButtons_buttonElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      transactionForm_buttons_standardButtons_buttonElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    style: new Field(
+      transactionForm_buttons_standardButtons_buttonElemID,
+      'style',
+      enums.form_buttonstyle,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_buttonstyle.   The default value is 'BUTTON'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_buttons_standardButtons_button)
+
+const transactionForm_buttons_standardButtonsElemID = new ElemID(constants.NETSUITE, 'transactionForm_buttons_standardButtons')
+
+const transactionForm_buttons_standardButtons = new ObjectType({
+  elemID: transactionForm_buttons_standardButtonsElemID,
+  annotations: {
+  },
+  fields: {
+    button: new Field(
+      transactionForm_buttons_standardButtonsElemID,
+      'button',
+      new ListType(transactionForm_buttons_standardButtons_button),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_buttons_standardButtons)
+
+const transactionForm_buttonsElemID = new ElemID(constants.NETSUITE, 'transactionForm_buttons')
+
+const transactionForm_buttons = new ObjectType({
+  elemID: transactionForm_buttonsElemID,
+  annotations: {
+  },
+  fields: {
+    standardButtons: new Field(
+      transactionForm_buttonsElemID,
+      'standardButtons',
+      transactionForm_buttons_standardButtons,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_buttons)
+
+const transactionForm_customCodeElemID = new ElemID(constants.NETSUITE, 'transactionForm_customCode')
+
+const transactionForm_customCode = new ObjectType({
+  elemID: transactionForm_customCodeElemID,
+  annotations: {
+  },
+  fields: {
+    scriptFile: new Field(
+      transactionForm_customCodeElemID,
+      'scriptFile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_customCode)
+
+const transactionForm_mainFields_defaultFieldGroup_fields_fieldElemID = new ElemID(constants.NETSUITE, 'transactionForm_mainFields_defaultFieldGroup_fields_field')
+
+const transactionForm_mainFields_defaultFieldGroup_fields_field = new ObjectType({
+  elemID: transactionForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see transactionform_fieldid. */
+    label: new Field(
+      transactionForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      transactionForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    mandatory: new Field(
+      transactionForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'mandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayType: new Field(
+      transactionForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'displayType',
+      enums.form_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_displaytype.   The default value is 'NORMAL'. */
+    columnBreak: new Field(
+      transactionForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'columnBreak',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    spaceBefore: new Field(
+      transactionForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'spaceBefore',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    sameRowAsPrevious: new Field(
+      transactionForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'sameRowAsPrevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    quickAdd: new Field(
+      transactionForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'quickAdd',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    checkBoxDefault: new Field(
+      transactionForm_mainFields_defaultFieldGroup_fields_fieldElemID,
+      'checkBoxDefault',
+      enums.transactionform_checkboxdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see transactionform_checkboxdefault.   The default value is 'UNCHECKED'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_mainFields_defaultFieldGroup_fields_field)
+
+const transactionForm_mainFields_defaultFieldGroup_fieldsElemID = new ElemID(constants.NETSUITE, 'transactionForm_mainFields_defaultFieldGroup_fields')
+
+const transactionForm_mainFields_defaultFieldGroup_fields = new ObjectType({
+  elemID: transactionForm_mainFields_defaultFieldGroup_fieldsElemID,
+  annotations: {
+  },
+  fields: {
+    position: new Field(
+      transactionForm_mainFields_defaultFieldGroup_fieldsElemID,
+      'position',
+      enums.form_fieldposition,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see form_fieldposition.   The default value is ‘MIDDLE’. */
+    field: new Field(
+      transactionForm_mainFields_defaultFieldGroup_fieldsElemID,
+      'field',
+      new ListType(transactionForm_mainFields_defaultFieldGroup_fields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_mainFields_defaultFieldGroup_fields)
+
+const transactionForm_mainFields_defaultFieldGroupElemID = new ElemID(constants.NETSUITE, 'transactionForm_mainFields_defaultFieldGroup')
+
+const transactionForm_mainFields_defaultFieldGroup = new ObjectType({
+  elemID: transactionForm_mainFields_defaultFieldGroupElemID,
+  annotations: {
+  },
+  fields: {
+    fields: new Field(
+      transactionForm_mainFields_defaultFieldGroupElemID,
+      'fields',
+      transactionForm_mainFields_defaultFieldGroup_fields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_mainFields_defaultFieldGroup)
+
+const transactionForm_mainFields_fieldGroup_fields_fieldElemID = new ElemID(constants.NETSUITE, 'transactionForm_mainFields_fieldGroup_fields_field')
+
+const transactionForm_mainFields_fieldGroup_fields_field = new ObjectType({
+  elemID: transactionForm_mainFields_fieldGroup_fields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_mainFields_fieldGroup_fields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see transactionform_fieldid. */
+    label: new Field(
+      transactionForm_mainFields_fieldGroup_fields_fieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      transactionForm_mainFields_fieldGroup_fields_fieldElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    mandatory: new Field(
+      transactionForm_mainFields_fieldGroup_fields_fieldElemID,
+      'mandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayType: new Field(
+      transactionForm_mainFields_fieldGroup_fields_fieldElemID,
+      'displayType',
+      enums.form_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_displaytype.   The default value is 'NORMAL'. */
+    columnBreak: new Field(
+      transactionForm_mainFields_fieldGroup_fields_fieldElemID,
+      'columnBreak',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    spaceBefore: new Field(
+      transactionForm_mainFields_fieldGroup_fields_fieldElemID,
+      'spaceBefore',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    sameRowAsPrevious: new Field(
+      transactionForm_mainFields_fieldGroup_fields_fieldElemID,
+      'sameRowAsPrevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    quickAdd: new Field(
+      transactionForm_mainFields_fieldGroup_fields_fieldElemID,
+      'quickAdd',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    checkBoxDefault: new Field(
+      transactionForm_mainFields_fieldGroup_fields_fieldElemID,
+      'checkBoxDefault',
+      enums.transactionform_checkboxdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see transactionform_checkboxdefault.   The default value is 'UNCHECKED'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_mainFields_fieldGroup_fields_field)
+
+const transactionForm_mainFields_fieldGroup_fieldsElemID = new ElemID(constants.NETSUITE, 'transactionForm_mainFields_fieldGroup_fields')
+
+const transactionForm_mainFields_fieldGroup_fields = new ObjectType({
+  elemID: transactionForm_mainFields_fieldGroup_fieldsElemID,
+  annotations: {
+  },
+  fields: {
+    position: new Field(
+      transactionForm_mainFields_fieldGroup_fieldsElemID,
+      'position',
+      enums.form_fieldposition,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see form_fieldposition.   The default value is ‘MIDDLE’. */
+    field: new Field(
+      transactionForm_mainFields_fieldGroup_fieldsElemID,
+      'field',
+      new ListType(transactionForm_mainFields_fieldGroup_fields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_mainFields_fieldGroup_fields)
+
+const transactionForm_mainFields_fieldGroupElemID = new ElemID(constants.NETSUITE, 'transactionForm_mainFields_fieldGroup')
+
+const transactionForm_mainFields_fieldGroup = new ObjectType({
+  elemID: transactionForm_mainFields_fieldGroupElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      transactionForm_mainFields_fieldGroupElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long. */
+    label: new Field(
+      transactionForm_mainFields_fieldGroupElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    visible: new Field(
+      transactionForm_mainFields_fieldGroupElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    showTitle: new Field(
+      transactionForm_mainFields_fieldGroupElemID,
+      'showTitle',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    singleColumn: new Field(
+      transactionForm_mainFields_fieldGroupElemID,
+      'singleColumn',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fields: new Field(
+      transactionForm_mainFields_fieldGroupElemID,
+      'fields',
+      transactionForm_mainFields_fieldGroup_fields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_mainFields_fieldGroup)
+
+const transactionForm_mainFieldsElemID = new ElemID(constants.NETSUITE, 'transactionForm_mainFields')
+
+const transactionForm_mainFields = new ObjectType({
+  elemID: transactionForm_mainFieldsElemID,
+  annotations: {
+  },
+  fields: {
+    defaultFieldGroup: new Field(
+      transactionForm_mainFieldsElemID,
+      'defaultFieldGroup',
+      transactionForm_mainFields_defaultFieldGroup,
+      {
+      },
+    ),
+    fieldGroup: new Field(
+      transactionForm_mainFieldsElemID,
+      'fieldGroup',
+      new ListType(transactionForm_mainFields_fieldGroup),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_mainFields)
+
+const transactionForm_printingType_advancedElemID = new ElemID(constants.NETSUITE, 'transactionForm_printingType_advanced')
+
+const transactionForm_printingType_advanced = new ObjectType({
+  elemID: transactionForm_printingType_advancedElemID,
+  annotations: {
+  },
+  fields: {
+    printTemplate: new Field(
+      transactionForm_printingType_advancedElemID,
+      'printTemplate',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the advancedpdftemplate custom type.   For information about other possible values, see transactionform_advancedtemplate.   If this field appears in the project, you must reference the ADVANCEDPRINTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ADVANCEDPRINTING must be enabled for this field to appear in your account. */
+    emailTemplate: new Field(
+      transactionForm_printingType_advancedElemID,
+      'emailTemplate',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the advancedpdftemplate custom type.   For information about other possible values, see transactionform_advancedtemplate.   If this field appears in the project, you must reference the ADVANCEDPRINTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ADVANCEDPRINTING must be enabled for this field to appear in your account. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_printingType_advanced)
+
+const transactionForm_printingType_basicElemID = new ElemID(constants.NETSUITE, 'transactionForm_printingType_basic')
+
+const transactionForm_printingType_basic = new ObjectType({
+  elemID: transactionForm_printingType_basicElemID,
+  annotations: {
+  },
+  fields: {
+    pdfLayout: new Field(
+      transactionForm_printingType_basicElemID,
+      'pdfLayout',
+      enums.transactionform_pdflayout,
+      {
+      },
+    ), /* Original description: For information about possible values, see transactionform_pdflayout. */
+    htmlLayout: new Field(
+      transactionForm_printingType_basicElemID,
+      'htmlLayout',
+      enums.transactionform_htmllayout,
+      {
+      },
+    ), /* Original description: For information about possible values, see transactionform_htmllayout. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_printingType_basic)
+
+const transactionForm_printingTypeElemID = new ElemID(constants.NETSUITE, 'transactionForm_printingType')
+
+const transactionForm_printingType = new ObjectType({
+  elemID: transactionForm_printingTypeElemID,
+  annotations: {
+  },
+  fields: {
+    advanced: new Field(
+      transactionForm_printingTypeElemID,
+      'advanced',
+      transactionForm_printingType_advanced,
+      {
+      },
+    ),
+    basic: new Field(
+      transactionForm_printingTypeElemID,
+      'basic',
+      transactionForm_printingType_basic,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_printingType)
+
+const transactionForm_quickViewFields_fieldElemID = new ElemID(constants.NETSUITE, 'transactionForm_quickViewFields_field')
+
+const transactionForm_quickViewFields_field = new ObjectType({
+  elemID: transactionForm_quickViewFields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_quickViewFields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see transactionform_fieldid. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_quickViewFields_field)
+
+const transactionForm_quickViewFieldsElemID = new ElemID(constants.NETSUITE, 'transactionForm_quickViewFields')
+
+const transactionForm_quickViewFields = new ObjectType({
+  elemID: transactionForm_quickViewFieldsElemID,
+  annotations: {
+  },
+  fields: {
+    field: new Field(
+      transactionForm_quickViewFieldsElemID,
+      'field',
+      new ListType(transactionForm_quickViewFields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_quickViewFields)
+
+const transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_field')
+
+const transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_field = new ObjectType({
+  elemID: transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see transactionform_fieldid. */
+    label: new Field(
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    mandatory: new Field(
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'mandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayType: new Field(
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'displayType',
+      enums.form_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_displaytype.   The default value is 'NORMAL'. */
+    columnBreak: new Field(
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'columnBreak',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    spaceBefore: new Field(
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'spaceBefore',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    sameRowAsPrevious: new Field(
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'sameRowAsPrevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    quickAdd: new Field(
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'quickAdd',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    checkBoxDefault: new Field(
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'checkBoxDefault',
+      enums.transactionform_checkboxdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see transactionform_checkboxdefault.   The default value is 'USE_FIELD_DEFAULT'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_field)
+
+const transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fieldsElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields')
+
+const transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields = new ObjectType({
+  elemID: transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fieldsElemID,
+  annotations: {
+  },
+  fields: {
+    position: new Field(
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fieldsElemID,
+      'position',
+      enums.form_fieldposition,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see form_fieldposition.   The default value is ‘MIDDLE’. */
+    field: new Field(
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fieldsElemID,
+      'field',
+      new ListType(transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields)
+
+const transactionForm_tabs_tab_fieldGroups_defaultFieldGroupElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_fieldGroups_defaultFieldGroup')
+
+const transactionForm_tabs_tab_fieldGroups_defaultFieldGroup = new ObjectType({
+  elemID: transactionForm_tabs_tab_fieldGroups_defaultFieldGroupElemID,
+  annotations: {
+  },
+  fields: {
+    fields: new Field(
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroupElemID,
+      'fields',
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_fieldGroups_defaultFieldGroup)
+
+const transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_field')
+
+const transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_field = new ObjectType({
+  elemID: transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see transactionform_fieldid. */
+    label: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    mandatory: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'mandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayType: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'displayType',
+      enums.form_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_displaytype.   The default value is 'NORMAL'. */
+    columnBreak: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'columnBreak',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    spaceBefore: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'spaceBefore',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    sameRowAsPrevious: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'sameRowAsPrevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    quickAdd: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'quickAdd',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    checkBoxDefault: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'checkBoxDefault',
+      enums.transactionform_checkboxdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see transactionform_checkboxdefault.   The default value is 'USE_FIELD_DEFAULT'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_field)
+
+const transactionForm_tabs_tab_fieldGroups_fieldGroup_fieldsElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_fieldGroups_fieldGroup_fields')
+
+const transactionForm_tabs_tab_fieldGroups_fieldGroup_fields = new ObjectType({
+  elemID: transactionForm_tabs_tab_fieldGroups_fieldGroup_fieldsElemID,
+  annotations: {
+  },
+  fields: {
+    position: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroup_fieldsElemID,
+      'position',
+      enums.form_fieldposition,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see form_fieldposition.   The default value is ‘MIDDLE’. */
+    field: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroup_fieldsElemID,
+      'field',
+      new ListType(transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_fieldGroups_fieldGroup_fields)
+
+const transactionForm_tabs_tab_fieldGroups_fieldGroupElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_fieldGroups_fieldGroup')
+
+const transactionForm_tabs_tab_fieldGroups_fieldGroup = new ObjectType({
+  elemID: transactionForm_tabs_tab_fieldGroups_fieldGroupElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroupElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long. */
+    label: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroupElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    visible: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroupElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    showTitle: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroupElemID,
+      'showTitle',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    singleColumn: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroupElemID,
+      'singleColumn',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fields: new Field(
+      transactionForm_tabs_tab_fieldGroups_fieldGroupElemID,
+      'fields',
+      transactionForm_tabs_tab_fieldGroups_fieldGroup_fields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_fieldGroups_fieldGroup)
+
+const transactionForm_tabs_tab_fieldGroupsElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_fieldGroups')
+
+const transactionForm_tabs_tab_fieldGroups = new ObjectType({
+  elemID: transactionForm_tabs_tab_fieldGroupsElemID,
+  annotations: {
+  },
+  fields: {
+    defaultFieldGroup: new Field(
+      transactionForm_tabs_tab_fieldGroupsElemID,
+      'defaultFieldGroup',
+      transactionForm_tabs_tab_fieldGroups_defaultFieldGroup,
+      {
+      },
+    ),
+    fieldGroup: new Field(
+      transactionForm_tabs_tab_fieldGroupsElemID,
+      'fieldGroup',
+      new ListType(transactionForm_tabs_tab_fieldGroups_fieldGroup),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_fieldGroups)
+
+const transactionForm_tabs_tab_subItems_subList_columns_columnElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_subItems_subList_columns_column')
+
+const transactionForm_tabs_tab_subItems_subList_columns_column = new ObjectType({
+  elemID: transactionForm_tabs_tab_subItems_subList_columns_columnElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_tabs_tab_subItems_subList_columns_columnElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the transactioncolumncustomfield custom type.   For information about other possible values, see transactionform_columnid. */
+    label: new Field(
+      transactionForm_tabs_tab_subItems_subList_columns_columnElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      transactionForm_tabs_tab_subItems_subList_columns_columnElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_subItems_subList_columns_column)
+
+const transactionForm_tabs_tab_subItems_subList_columnsElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_subItems_subList_columns')
+
+const transactionForm_tabs_tab_subItems_subList_columns = new ObjectType({
+  elemID: transactionForm_tabs_tab_subItems_subList_columnsElemID,
+  annotations: {
+  },
+  fields: {
+    column: new Field(
+      transactionForm_tabs_tab_subItems_subList_columnsElemID,
+      'column',
+      new ListType(transactionForm_tabs_tab_subItems_subList_columns_column),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_subItems_subList_columns)
+
+const transactionForm_tabs_tab_subItems_subListElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_subItems_subList')
+
+const transactionForm_tabs_tab_subItems_subList = new ObjectType({
+  elemID: transactionForm_tabs_tab_subItems_subListElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_tabs_tab_subItems_subListElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was enums.transactionform_sublistid but it can also be CRMCONTACTS */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see transactionform_sublistid. */
+    label: new Field(
+      transactionForm_tabs_tab_subItems_subListElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      transactionForm_tabs_tab_subItems_subListElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    columns: new Field(
+      transactionForm_tabs_tab_subItems_subListElemID,
+      'columns',
+      transactionForm_tabs_tab_subItems_subList_columns,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_subItems_subList)
+
+const transactionForm_tabs_tab_subItems_subLists_subListElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_subItems_subLists_subList')
+
+const transactionForm_tabs_tab_subItems_subLists_subList = new ObjectType({
+  elemID: transactionForm_tabs_tab_subItems_subLists_subListElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_tabs_tab_subItems_subLists_subListElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was enums.transactionform_sublistid but it can also be CRMCONTACTS */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see transactionform_sublistid. */
+    label: new Field(
+      transactionForm_tabs_tab_subItems_subLists_subListElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    visible: new Field(
+      transactionForm_tabs_tab_subItems_subLists_subListElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_subItems_subLists_subList)
+
+const transactionForm_tabs_tab_subItems_subListsElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_subItems_subLists')
+
+const transactionForm_tabs_tab_subItems_subLists = new ObjectType({
+  elemID: transactionForm_tabs_tab_subItems_subListsElemID,
+  annotations: {
+  },
+  fields: {
+    subList: new Field(
+      transactionForm_tabs_tab_subItems_subListsElemID,
+      'subList',
+      new ListType(transactionForm_tabs_tab_subItems_subLists_subList),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_subItems_subLists)
+
+const transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_field')
+
+const transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_field = new ObjectType({
+  elemID: transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see transactionform_fieldid. */
+    label: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    mandatory: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'mandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayType: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'displayType',
+      enums.form_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_displaytype.   The default value is 'NORMAL'. */
+    columnBreak: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'columnBreak',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    spaceBefore: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'spaceBefore',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    sameRowAsPrevious: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'sameRowAsPrevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    quickAdd: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'quickAdd',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    checkBoxDefault: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fieldElemID,
+      'checkBoxDefault',
+      enums.transactionform_checkboxdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see transactionform_checkboxdefault.   The default value is 'USE_FIELD_DEFAULT'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_field)
+
+const transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fieldsElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields')
+
+const transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields = new ObjectType({
+  elemID: transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fieldsElemID,
+  annotations: {
+  },
+  fields: {
+    position: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fieldsElemID,
+      'position',
+      enums.form_fieldposition,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see form_fieldposition.   The default value is ‘MIDDLE’. */
+    field: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fieldsElemID,
+      'field',
+      new ListType(transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields)
+
+const transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroupElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup')
+
+const transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup = new ObjectType({
+  elemID: transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroupElemID,
+  annotations: {
+  },
+  fields: {
+    fields: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroupElemID,
+      'fields',
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup)
+
+const transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_field')
+
+const transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_field = new ObjectType({
+  elemID: transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see transactionform_fieldid. */
+    label: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    visible: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    mandatory: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'mandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayType: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'displayType',
+      enums.form_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see form_displaytype.   The default value is 'NORMAL'. */
+    columnBreak: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'columnBreak',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    spaceBefore: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'spaceBefore',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    sameRowAsPrevious: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'sameRowAsPrevious',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    quickAdd: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'quickAdd',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    checkBoxDefault: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fieldElemID,
+      'checkBoxDefault',
+      enums.transactionform_checkboxdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see transactionform_checkboxdefault.   The default value is 'USE_FIELD_DEFAULT'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_field)
+
+const transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fieldsElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields')
+
+const transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields = new ObjectType({
+  elemID: transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fieldsElemID,
+  annotations: {
+  },
+  fields: {
+    position: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fieldsElemID,
+      'position',
+      enums.form_fieldposition,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see form_fieldposition.   The default value is ‘MIDDLE’. */
+    field: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fieldsElemID,
+      'field',
+      new ListType(transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_field),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields)
+
+const transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup')
+
+const transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup = new ObjectType({
+  elemID: transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long. */
+    label: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    visible: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    showTitle: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID,
+      'showTitle',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    singleColumn: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID,
+      'singleColumn',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fields: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroupElemID,
+      'fields',
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup)
+
+const transactionForm_tabs_tab_subItems_subTab_fieldGroupsElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_subItems_subTab_fieldGroups')
+
+const transactionForm_tabs_tab_subItems_subTab_fieldGroups = new ObjectType({
+  elemID: transactionForm_tabs_tab_subItems_subTab_fieldGroupsElemID,
+  annotations: {
+  },
+  fields: {
+    defaultFieldGroup: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroupsElemID,
+      'defaultFieldGroup',
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup,
+      {
+      },
+    ),
+    fieldGroup: new Field(
+      transactionForm_tabs_tab_subItems_subTab_fieldGroupsElemID,
+      'fieldGroup',
+      new ListType(transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_subItems_subTab_fieldGroups)
+
+const transactionForm_tabs_tab_subItems_subTabElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_subItems_subTab')
+
+const transactionForm_tabs_tab_subItems_subTab = new ObjectType({
+  elemID: transactionForm_tabs_tab_subItems_subTabElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_tabs_tab_subItems_subTabElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   subtab   subtab   For information about other possible values, see transactionform_subtabid. */
+    label: new Field(
+      transactionForm_tabs_tab_subItems_subTabElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    visible: new Field(
+      transactionForm_tabs_tab_subItems_subTabElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    fieldGroups: new Field(
+      transactionForm_tabs_tab_subItems_subTabElemID,
+      'fieldGroups',
+      transactionForm_tabs_tab_subItems_subTab_fieldGroups,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_subItems_subTab)
+
+const transactionForm_tabs_tab_subItemsElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab_subItems')
+
+const transactionForm_tabs_tab_subItems = new ObjectType({
+  elemID: transactionForm_tabs_tab_subItemsElemID,
+  annotations: {
+  },
+  fields: {
+    subList: new Field(
+      transactionForm_tabs_tab_subItemsElemID,
+      'subList',
+      new ListType(transactionForm_tabs_tab_subItems_subList),
+      {
+      },
+    ),
+    subLists: new Field(
+      transactionForm_tabs_tab_subItemsElemID,
+      'subLists',
+      new ListType(transactionForm_tabs_tab_subItems_subLists),
+      {
+      },
+    ),
+    subTab: new Field(
+      transactionForm_tabs_tab_subItemsElemID,
+      'subTab',
+      new ListType(transactionForm_tabs_tab_subItems_subTab),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab_subItems)
+
+const transactionForm_tabs_tabElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs_tab')
+
+const transactionForm_tabs_tab = new ObjectType({
+  elemID: transactionForm_tabs_tabElemID,
+  annotations: {
+  },
+  fields: {
+    id: new Field(
+      transactionForm_tabs_tabElemID,
+      'id',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   subtab   subtab   For information about other possible values, see transactionform_tabid. */
+    label: new Field(
+      transactionForm_tabs_tabElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    visible: new Field(
+      transactionForm_tabs_tabElemID,
+      'visible',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    fieldGroups: new Field(
+      transactionForm_tabs_tabElemID,
+      'fieldGroups',
+      transactionForm_tabs_tab_fieldGroups,
+      {
+      },
+    ),
+    subItems: new Field(
+      transactionForm_tabs_tabElemID,
+      'subItems',
+      transactionForm_tabs_tab_subItems,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs_tab)
+
+const transactionForm_tabsElemID = new ElemID(constants.NETSUITE, 'transactionForm_tabs')
+
+const transactionForm_tabs = new ObjectType({
+  elemID: transactionForm_tabsElemID,
+  annotations: {
+  },
+  fields: {
+    tab: new Field(
+      transactionForm_tabsElemID,
+      'tab',
+      new ListType(transactionForm_tabs_tab),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})
+
+transactionFormInnerTypes.push(transactionForm_tabs)
+
+
+export const transactionForm = new ObjectType({
+  elemID: transactionFormElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custform_',
+  },
+  fields: {
+    scriptid: new Field(
+      transactionFormElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custform’. */
+    standard: new Field(
+      transactionFormElemID,
+      'standard',
+      enums.transactionform_standard,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   For information about possible values, see transactionform_standard. */
+    name: new Field(
+      transactionFormElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+      },
+    ),
+    recordType: new Field(
+      transactionFormElemID,
+      'recordType',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ),
+    inactive: new Field(
+      transactionFormElemID,
+      'inactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    preferred: new Field(
+      transactionFormElemID,
+      'preferred',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    storedWithRecord: new Field(
+      transactionFormElemID,
+      'storedWithRecord',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    disclaimer: new Field(
+      transactionFormElemID,
+      'disclaimer',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    address: new Field(
+      transactionFormElemID,
+      'address',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    allowAddMultiple: new Field(
+      transactionFormElemID,
+      'allowAddMultiple',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    actionbar: new Field(
+      transactionFormElemID,
+      'actionbar',
+      transactionForm_actionbar,
+      {
+      },
+    ),
+    buttons: new Field(
+      transactionFormElemID,
+      'buttons',
+      transactionForm_buttons,
+      {
+      },
+    ),
+    customCode: new Field(
+      transactionFormElemID,
+      'customCode',
+      transactionForm_customCode,
+      {
+      },
+    ),
+    mainFields: new Field(
+      transactionFormElemID,
+      'mainFields',
+      transactionForm_mainFields,
+      {
+      },
+    ),
+    printingType: new Field(
+      transactionFormElemID,
+      'printingType',
+      transactionForm_printingType,
+      {
+      },
+    ),
+    quickViewFields: new Field(
+      transactionFormElemID,
+      'quickViewFields',
+      transactionForm_quickViewFields,
+      {
+      },
+    ),
+    tabs: new Field(
+      transactionFormElemID,
+      'tabs',
+      transactionForm_tabs,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionFormElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/transactionbodycustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/transactionbodycustomfield.ts
@@ -1,0 +1,671 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const transactionbodycustomfieldInnerTypes: ObjectType[] = []
+
+const transactionbodycustomfieldElemID = new ElemID(constants.NETSUITE, 'transactionbodycustomfield')
+const transactionbodycustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'transactionbodycustomfield_customfieldfilters_customfieldfilter')
+
+const transactionbodycustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: transactionbodycustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      transactionbodycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      transactionbodycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      transactionbodycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      transactionbodycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      transactionbodycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      transactionbodycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      transactionbodycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      transactionbodycustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionbodycustomfieldElemID.name],
+})
+
+transactionbodycustomfieldInnerTypes.push(transactionbodycustomfield_customfieldfilters_customfieldfilter)
+
+const transactionbodycustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'transactionbodycustomfield_customfieldfilters')
+
+const transactionbodycustomfield_customfieldfilters = new ObjectType({
+  elemID: transactionbodycustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      transactionbodycustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(transactionbodycustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionbodycustomfieldElemID.name],
+})
+
+transactionbodycustomfieldInnerTypes.push(transactionbodycustomfield_customfieldfilters)
+
+const transactionbodycustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'transactionbodycustomfield_roleaccesses_roleaccess')
+
+const transactionbodycustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: transactionbodycustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      transactionbodycustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      transactionbodycustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      transactionbodycustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionbodycustomfieldElemID.name],
+})
+
+transactionbodycustomfieldInnerTypes.push(transactionbodycustomfield_roleaccesses_roleaccess)
+
+const transactionbodycustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'transactionbodycustomfield_roleaccesses')
+
+const transactionbodycustomfield_roleaccesses = new ObjectType({
+  elemID: transactionbodycustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      transactionbodycustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(transactionbodycustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionbodycustomfieldElemID.name],
+})
+
+transactionbodycustomfieldInnerTypes.push(transactionbodycustomfield_roleaccesses)
+
+
+export const transactionbodycustomfield = new ObjectType({
+  elemID: transactionbodycustomfieldElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custbody_',
+  },
+  fields: {
+    scriptid: new Field(
+      transactionbodycustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 38 characters long.   The default value is ‘custbody’. */
+    fieldtype: new Field(
+      transactionbodycustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      transactionbodycustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      transactionbodycustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      transactionbodycustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      transactionbodycustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      transactionbodycustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      transactionbodycustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      transactionbodycustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      transactionbodycustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      transactionbodycustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      transactionbodycustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      transactionbodycustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      transactionbodycustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      transactionbodycustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      transactionbodycustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      transactionbodycustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      transactionbodycustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    encryptatrest: new Field(
+      transactionbodycustomfieldElemID,
+      'encryptatrest',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      transactionbodycustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      transactionbodycustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    globalsearch: new Field(
+      transactionbodycustomfieldElemID,
+      'globalsearch',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    isformula: new Field(
+      transactionbodycustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      transactionbodycustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      transactionbodycustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      transactionbodycustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      transactionbodycustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      transactionbodycustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      transactionbodycustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    showhierarchy: new Field(
+      transactionbodycustomfieldElemID,
+      'showhierarchy',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    showinlist: new Field(
+      transactionbodycustomfieldElemID,
+      'showinlist',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    sourcefilterby: new Field(
+      transactionbodycustomfieldElemID,
+      'sourcefilterby',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcefrom: new Field(
+      transactionbodycustomfieldElemID,
+      'sourcefrom',
+      BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcelist: new Field(
+      transactionbodycustomfieldElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the transactionbodycustomfield custom type.   For information about other possible values, see generic_standard_field. */
+    isparent: new Field(
+      transactionbodycustomfieldElemID,
+      'isparent',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    parentsubtab: new Field(
+      transactionbodycustomfieldElemID,
+      'parentsubtab',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   subtab   subtab   For information about other possible values, see generic_tab_parent. */
+    subtab: new Field(
+      transactionbodycustomfieldElemID,
+      'subtab',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the subtab custom type.   For information about other possible values, see generic_body_tab. */
+    bodyassemblybuild: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyassemblybuild',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ASSEMBLIES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ASSEMBLIES must be enabled for this field to appear in your account. */
+    bodybom: new Field(
+      transactionbodycustomfieldElemID,
+      'bodybom',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the WORKORDERS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. WORKORDERS must be enabled for this field to appear in your account. */
+    bodycustomerpayment: new Field(
+      transactionbodycustomfieldElemID,
+      'bodycustomerpayment',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the RECEIVABLES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. RECEIVABLES must be enabled for this field to appear in your account. */
+    bodydeposit: new Field(
+      transactionbodycustomfieldElemID,
+      'bodydeposit',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    bodydepositapplication: new Field(
+      transactionbodycustomfieldElemID,
+      'bodydepositapplication',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    bodyexpensereport: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyexpensereport',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the EXPREPORTS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. EXPREPORTS must be enabled for this field to appear in your account. */
+    bodyinventoryadjustment: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyinventoryadjustment',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the INVENTORY feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. INVENTORY must be enabled for this field to appear in your account. */
+    bodyfulfillmentrequest: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyfulfillmentrequest',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the FULFILLMENTREQUEST feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. FULFILLMENTREQUEST must be enabled for this field to appear in your account. */
+    bodystorepickup: new Field(
+      transactionbodycustomfieldElemID,
+      'bodystorepickup',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the STOREPICKUP feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. STOREPICKUP must be enabled for this field to appear in your account. */
+    bodyitemfulfillment: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyitemfulfillment',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    bodyitemfulfillmentorder: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyitemfulfillmentorder',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    bodyitemreceipt: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyitemreceipt',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ADVRECEIVING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ADVRECEIVING must be enabled for this field to appear in your account. */
+    bodyitemreceiptorder: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyitemreceiptorder',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ADVRECEIVING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ADVRECEIVING must be enabled for this field to appear in your account. */
+    bodyjournal: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyjournal',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    bodyperiodendjournal: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyperiodendjournal',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the PERIODENDJOURNALENTRIES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. PERIODENDJOURNALENTRIES must be enabled for this field to appear in your account. */
+    bodyopportunity: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyopportunity',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the OPPORTUNITIES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. OPPORTUNITIES must be enabled for this field to appear in your account. */
+    bodyothertransaction: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyothertransaction',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    bodypaycheck: new Field(
+      transactionbodycustomfieldElemID,
+      'bodypaycheck',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the PAYCHECKJOURNAL feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. PAYCHECKJOURNAL must be enabled for this field to appear in your account. */
+    bodypickingticket: new Field(
+      transactionbodycustomfieldElemID,
+      'bodypickingticket',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    bodyprintflag: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyprintflag',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    bodyprintpackingslip: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyprintpackingslip',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    bodyprintstatement: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyprintstatement',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    bodypurchase: new Field(
+      transactionbodycustomfieldElemID,
+      'bodypurchase',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    bodysale: new Field(
+      transactionbodycustomfieldElemID,
+      'bodysale',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    bodystore: new Field(
+      transactionbodycustomfieldElemID,
+      'bodystore',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the WEBSTORE feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. WEBSTORE must be enabled for this field to appear in your account. */
+    bodytransferorder: new Field(
+      transactionbodycustomfieldElemID,
+      'bodytransferorder',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the MULTILOCINVT feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. MULTILOCINVT must be enabled for this field to appear in your account. */
+    bodyvendorpayment: new Field(
+      transactionbodycustomfieldElemID,
+      'bodyvendorpayment',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the PAYABLES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. PAYABLES must be enabled for this field to appear in your account. */
+    bodybtegata: new Field(
+      transactionbodycustomfieldElemID,
+      'bodybtegata',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    fldsizelabel: new Field(
+      transactionbodycustomfieldElemID,
+      'fldsizelabel',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    bodycustomtransactions: new Field(
+      transactionbodycustomfieldElemID,
+      'bodycustomtransactions',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the customtransactiontype custom type.   If this field appears in the project, you must reference the CUSTOMTRANSACTIONS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CUSTOMTRANSACTIONS must be enabled for this field to appear in your account. */
+    customfieldfilters: new Field(
+      transactionbodycustomfieldElemID,
+      'customfieldfilters',
+      transactionbodycustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      transactionbodycustomfieldElemID,
+      'roleaccesses',
+      transactionbodycustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactionbodycustomfieldElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/transactioncolumncustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/transactioncolumncustomfield.ts
@@ -1,0 +1,643 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const transactioncolumncustomfieldInnerTypes: ObjectType[] = []
+
+const transactioncolumncustomfieldElemID = new ElemID(constants.NETSUITE, 'transactioncolumncustomfield')
+const transactioncolumncustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'transactioncolumncustomfield_customfieldfilters_customfieldfilter')
+
+const transactioncolumncustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: transactioncolumncustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      transactioncolumncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      transactioncolumncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      transactioncolumncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      transactioncolumncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      transactioncolumncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      transactioncolumncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      transactioncolumncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      transactioncolumncustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactioncolumncustomfieldElemID.name],
+})
+
+transactioncolumncustomfieldInnerTypes.push(transactioncolumncustomfield_customfieldfilters_customfieldfilter)
+
+const transactioncolumncustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'transactioncolumncustomfield_customfieldfilters')
+
+const transactioncolumncustomfield_customfieldfilters = new ObjectType({
+  elemID: transactioncolumncustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      transactioncolumncustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(transactioncolumncustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactioncolumncustomfieldElemID.name],
+})
+
+transactioncolumncustomfieldInnerTypes.push(transactioncolumncustomfield_customfieldfilters)
+
+const transactioncolumncustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'transactioncolumncustomfield_roleaccesses_roleaccess')
+
+const transactioncolumncustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: transactioncolumncustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      transactioncolumncustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      transactioncolumncustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      transactioncolumncustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactioncolumncustomfieldElemID.name],
+})
+
+transactioncolumncustomfieldInnerTypes.push(transactioncolumncustomfield_roleaccesses_roleaccess)
+
+const transactioncolumncustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'transactioncolumncustomfield_roleaccesses')
+
+const transactioncolumncustomfield_roleaccesses = new ObjectType({
+  elemID: transactioncolumncustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      transactioncolumncustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(transactioncolumncustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactioncolumncustomfieldElemID.name],
+})
+
+transactioncolumncustomfieldInnerTypes.push(transactioncolumncustomfield_roleaccesses)
+
+
+export const transactioncolumncustomfield = new ObjectType({
+  elemID: transactioncolumncustomfieldElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custcol_',
+  },
+  fields: {
+    scriptid: new Field(
+      transactioncolumncustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 37 characters long.   The default value is ‘custcol’. */
+    fieldtype: new Field(
+      transactioncolumncustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      transactioncolumncustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      transactioncolumncustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      transactioncolumncustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      transactioncolumncustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      transactioncolumncustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      transactioncolumncustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      transactioncolumncustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      transactioncolumncustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      transactioncolumncustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      transactioncolumncustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      transactioncolumncustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      transactioncolumncustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      transactioncolumncustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      transactioncolumncustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      transactioncolumncustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    encryptatrest: new Field(
+      transactioncolumncustomfieldElemID,
+      'encryptatrest',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      transactioncolumncustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      transactioncolumncustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    isformula: new Field(
+      transactioncolumncustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      transactioncolumncustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      transactioncolumncustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      transactioncolumncustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      transactioncolumncustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      transactioncolumncustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      transactioncolumncustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    showhierarchy: new Field(
+      transactioncolumncustomfieldElemID,
+      'showhierarchy',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    sourcefilterby: new Field(
+      transactioncolumncustomfieldElemID,
+      'sourcefilterby',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcefrom: new Field(
+      transactioncolumncustomfieldElemID,
+      'sourcefrom',
+      BuiltinTypes.STRING /* Original type was enums.generic_standard_field but it can also be reference */,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    sourcelist: new Field(
+      transactioncolumncustomfieldElemID,
+      'sourcelist',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the transactioncolumncustomfield custom type.   For information about other possible values, see generic_standard_field. */
+    colbuild: new Field(
+      transactioncolumncustomfieldElemID,
+      'colbuild',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the WORKORDERS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. WORKORDERS must be enabled for this field to appear in your account. */
+    colexpense: new Field(
+      transactioncolumncustomfieldElemID,
+      'colexpense',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    colexpensereport: new Field(
+      transactioncolumncustomfieldElemID,
+      'colexpensereport',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the EXPREPORTS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. EXPREPORTS must be enabled for this field to appear in your account. */
+    colgrouponinvoices: new Field(
+      transactioncolumncustomfieldElemID,
+      'colgrouponinvoices',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    colinventoryadjustment: new Field(
+      transactioncolumncustomfieldElemID,
+      'colinventoryadjustment',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    colfulfillmentrequest: new Field(
+      transactioncolumncustomfieldElemID,
+      'colfulfillmentrequest',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the FULFILLMENTREQUEST feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. FULFILLMENTREQUEST must be enabled for this field to appear in your account. */
+    colstorepickup: new Field(
+      transactioncolumncustomfieldElemID,
+      'colstorepickup',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the STOREPICKUP feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. STOREPICKUP must be enabled for this field to appear in your account. */
+    colitemfulfillment: new Field(
+      transactioncolumncustomfieldElemID,
+      'colitemfulfillment',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    colitemfulfillmentorder: new Field(
+      transactioncolumncustomfieldElemID,
+      'colitemfulfillmentorder',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    colitemreceipt: new Field(
+      transactioncolumncustomfieldElemID,
+      'colitemreceipt',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ADVRECEIVING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ADVRECEIVING must be enabled for this field to appear in your account. */
+    colitemreceiptorder: new Field(
+      transactioncolumncustomfieldElemID,
+      'colitemreceiptorder',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: If this field appears in the project, you must reference the ADVRECEIVING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ADVRECEIVING must be enabled for this field to appear in your account. */
+    coljournal: new Field(
+      transactioncolumncustomfieldElemID,
+      'coljournal',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    colperiodendjournal: new Field(
+      transactioncolumncustomfieldElemID,
+      'colperiodendjournal',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the PERIODENDJOURNALENTRIES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. PERIODENDJOURNALENTRIES must be enabled for this field to appear in your account. */
+    colkititem: new Field(
+      transactioncolumncustomfieldElemID,
+      'colkititem',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    colopportunity: new Field(
+      transactioncolumncustomfieldElemID,
+      'colopportunity',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the OPPORTUNITIES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. OPPORTUNITIES must be enabled for this field to appear in your account. */
+    colpackingslip: new Field(
+      transactioncolumncustomfieldElemID,
+      'colpackingslip',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    colpaycheckcompanycontribution: new Field(
+      transactioncolumncustomfieldElemID,
+      'colpaycheckcompanycontribution',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the PAYCHECKJOURNAL feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. PAYCHECKJOURNAL must be enabled for this field to appear in your account. */
+    colpaycheckcompanytax: new Field(
+      transactioncolumncustomfieldElemID,
+      'colpaycheckcompanytax',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the PAYCHECKJOURNAL feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. PAYCHECKJOURNAL must be enabled for this field to appear in your account. */
+    colpaycheckdeduction: new Field(
+      transactioncolumncustomfieldElemID,
+      'colpaycheckdeduction',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the PAYCHECKJOURNAL feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. PAYCHECKJOURNAL must be enabled for this field to appear in your account. */
+    colpaycheckearning: new Field(
+      transactioncolumncustomfieldElemID,
+      'colpaycheckearning',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the PAYCHECKJOURNAL feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. PAYCHECKJOURNAL must be enabled for this field to appear in your account. */
+    colpaycheckemployeetax: new Field(
+      transactioncolumncustomfieldElemID,
+      'colpaycheckemployeetax',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the PAYCHECKJOURNAL feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. PAYCHECKJOURNAL must be enabled for this field to appear in your account. */
+    colpickingticket: new Field(
+      transactioncolumncustomfieldElemID,
+      'colpickingticket',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    colprintflag: new Field(
+      transactioncolumncustomfieldElemID,
+      'colprintflag',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    colpurchase: new Field(
+      transactioncolumncustomfieldElemID,
+      'colpurchase',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    colreturnform: new Field(
+      transactioncolumncustomfieldElemID,
+      'colreturnform',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the ACCOUNTING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. ACCOUNTING must be enabled for this field to appear in your account. */
+    colsale: new Field(
+      transactioncolumncustomfieldElemID,
+      'colsale',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    colstore: new Field(
+      transactioncolumncustomfieldElemID,
+      'colstore',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the WEBSITE feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. WEBSITE must be enabled for this field to appear in your account. */
+    colstorehidden: new Field(
+      transactioncolumncustomfieldElemID,
+      'colstorehidden',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the WEBSITE feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. WEBSITE must be enabled for this field to appear in your account. */
+    colstorewithgroups: new Field(
+      transactioncolumncustomfieldElemID,
+      'colstorewithgroups',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    coltime: new Field(
+      transactioncolumncustomfieldElemID,
+      'coltime',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the TIMETRACKING feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. TIMETRACKING must be enabled for this field to appear in your account. */
+    coltransferorder: new Field(
+      transactioncolumncustomfieldElemID,
+      'coltransferorder',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the MULTILOCINVT feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. MULTILOCINVT must be enabled for this field to appear in your account. */
+    columncustomtransactions: new Field(
+      transactioncolumncustomfieldElemID,
+      'columncustomtransactions',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the customtransactiontype custom type.   If this field appears in the project, you must reference the CUSTOMTRANSACTIONS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CUSTOMTRANSACTIONS must be enabled for this field to appear in your account. */
+    customfieldfilters: new Field(
+      transactioncolumncustomfieldElemID,
+      'customfieldfilters',
+      transactioncolumncustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      transactioncolumncustomfieldElemID,
+      'roleaccesses',
+      transactioncolumncustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, transactioncolumncustomfieldElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/translationcollection.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/translationcollection.ts
@@ -1,0 +1,136 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const translationcollectionInnerTypes: ObjectType[] = []
+
+const translationcollectionElemID = new ElemID(constants.NETSUITE, 'translationcollection')
+const translationcollection_strings_stringElemID = new ElemID(constants.NETSUITE, 'translationcollection_strings_string')
+
+const translationcollection_strings_string = new ObjectType({
+  elemID: translationcollection_strings_stringElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      translationcollection_strings_stringElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 60 characters long. */
+    defaulttranslation: new Field(
+      translationcollection_strings_stringElemID,
+      'defaulttranslation',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 1000,
+      },
+    ), /* Original description: This field value can be up to 1000 characters long. */
+    description: new Field(
+      translationcollection_strings_stringElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 1000,
+      },
+    ), /* Original description: This field value can be up to 1000 characters long. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, translationcollectionElemID.name],
+})
+
+translationcollectionInnerTypes.push(translationcollection_strings_string)
+
+const translationcollection_stringsElemID = new ElemID(constants.NETSUITE, 'translationcollection_strings')
+
+const translationcollection_strings = new ObjectType({
+  elemID: translationcollection_stringsElemID,
+  annotations: {
+  },
+  fields: {
+    string: new Field(
+      translationcollection_stringsElemID,
+      'string',
+      new ListType(translationcollection_strings_string),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, translationcollectionElemID.name],
+})
+
+translationcollectionInnerTypes.push(translationcollection_strings)
+
+
+export const translationcollection = new ObjectType({
+  elemID: translationcollectionElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custcollection_',
+  },
+  fields: {
+    scriptid: new Field(
+      translationcollectionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 60 characters long.   The default value is ‘custcollection’. */
+    name: new Field(
+      translationcollectionElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 100,
+      },
+    ), /* Original description: This field value can be up to 100 characters long. */
+    defaultlanguage: new Field(
+      translationcollectionElemID,
+      'defaultlanguage',
+      enums.translationcollection_defaultlanguage,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see translationcollection_defaultlanguage. */
+    description: new Field(
+      translationcollectionElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 1000,
+      },
+    ), /* Original description: This field value can be up to 1000 characters long. */
+    strings: new Field(
+      translationcollectionElemID,
+      'strings',
+      translationcollection_strings,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, translationcollectionElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/usereventscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/usereventscript.ts
@@ -1,0 +1,809 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const usereventscriptInnerTypes: ObjectType[] = []
+
+const usereventscriptElemID = new ElemID(constants.NETSUITE, 'usereventscript')
+const usereventscript_customplugintypes_plugintypeElemID = new ElemID(constants.NETSUITE, 'usereventscript_customplugintypes_plugintype')
+
+const usereventscript_customplugintypes_plugintype = new ObjectType({
+  elemID: usereventscript_customplugintypes_plugintypeElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      usereventscript_customplugintypes_plugintypeElemID,
+      'plugintype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the plugintype custom type. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, usereventscriptElemID.name],
+})
+
+usereventscriptInnerTypes.push(usereventscript_customplugintypes_plugintype)
+
+const usereventscript_customplugintypesElemID = new ElemID(constants.NETSUITE, 'usereventscript_customplugintypes')
+
+const usereventscript_customplugintypes = new ObjectType({
+  elemID: usereventscript_customplugintypesElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      usereventscript_customplugintypesElemID,
+      'plugintype',
+      new ListType(usereventscript_customplugintypes_plugintype),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, usereventscriptElemID.name],
+})
+
+usereventscriptInnerTypes.push(usereventscript_customplugintypes)
+
+const usereventscript_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'usereventscript_libraries_library')
+
+const usereventscript_libraries_library = new ObjectType({
+  elemID: usereventscript_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      usereventscript_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, usereventscriptElemID.name],
+})
+
+usereventscriptInnerTypes.push(usereventscript_libraries_library)
+
+const usereventscript_librariesElemID = new ElemID(constants.NETSUITE, 'usereventscript_libraries')
+
+const usereventscript_libraries = new ObjectType({
+  elemID: usereventscript_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      usereventscript_librariesElemID,
+      'library',
+      new ListType(usereventscript_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, usereventscriptElemID.name],
+})
+
+usereventscriptInnerTypes.push(usereventscript_libraries)
+
+const usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter')
+
+const usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, usereventscriptElemID.name],
+})
+
+usereventscriptInnerTypes.push(usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter)
+
+const usereventscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters')
+
+const usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters = new ObjectType({
+  elemID: usereventscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, usereventscriptElemID.name],
+})
+
+usereventscriptInnerTypes.push(usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters)
+
+const usereventscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'usereventscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess')
+
+const usereventscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: usereventscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, usereventscriptElemID.name],
+})
+
+usereventscriptInnerTypes.push(usereventscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess)
+
+const usereventscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'usereventscript_scriptcustomfields_scriptcustomfield_roleaccesses')
+
+const usereventscript_scriptcustomfields_scriptcustomfield_roleaccesses = new ObjectType({
+  elemID: usereventscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(usereventscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, usereventscriptElemID.name],
+})
+
+usereventscriptInnerTypes.push(usereventscript_scriptcustomfields_scriptcustomfield_roleaccesses)
+
+const usereventscript_scriptcustomfields_scriptcustomfieldElemID = new ElemID(constants.NETSUITE, 'usereventscript_scriptcustomfields_scriptcustomfield')
+
+const usereventscript_scriptcustomfields_scriptcustomfield = new ObjectType({
+  elemID: usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custscript’. */
+    fieldtype: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    isformula: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    setting: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'setting',
+      enums.script_setting,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_setting. */
+    customfieldfilters: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'customfieldfilters',
+      usereventscript_scriptcustomfields_scriptcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      usereventscript_scriptcustomfields_scriptcustomfieldElemID,
+      'roleaccesses',
+      usereventscript_scriptcustomfields_scriptcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, usereventscriptElemID.name],
+})
+
+usereventscriptInnerTypes.push(usereventscript_scriptcustomfields_scriptcustomfield)
+
+const usereventscript_scriptcustomfieldsElemID = new ElemID(constants.NETSUITE, 'usereventscript_scriptcustomfields')
+
+const usereventscript_scriptcustomfields = new ObjectType({
+  elemID: usereventscript_scriptcustomfieldsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptcustomfield: new Field(
+      usereventscript_scriptcustomfieldsElemID,
+      'scriptcustomfield',
+      new ListType(usereventscript_scriptcustomfields_scriptcustomfield),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, usereventscriptElemID.name],
+})
+
+usereventscriptInnerTypes.push(usereventscript_scriptcustomfields)
+
+const usereventscript_scriptdeployments_scriptdeploymentElemID = new ElemID(constants.NETSUITE, 'usereventscript_scriptdeployments_scriptdeployment')
+
+const usereventscript_scriptdeployments_scriptdeployment = new ObjectType({
+  elemID: usereventscript_scriptdeployments_scriptdeploymentElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customdeploy’. */
+    status: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'status',
+      enums.script_status,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+    recordtype: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'recordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customtransactiontype   customrecordtype   For information about other possible values, see the following lists:   generic_standard_recordtype   allrecord_script_deployment_recordtype */
+    allemployees: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'allemployees',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allpartners: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'allpartners',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account. */
+    allroles: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'allroles',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    auddepartment: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'auddepartment',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the DEPARTMENTS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. DEPARTMENTS must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    audemployee: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'audemployee',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   Note Account-specific values are not supported by SDF. */
+    audgroup: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'audgroup',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   Note Account-specific values are not supported by SDF. */
+    audpartner: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'audpartner',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    audslctrole: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'audslctrole',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    audsubsidiary: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'audsubsidiary',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the SUBSIDIARIES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. SUBSIDIARIES must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    eventtype: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'eventtype',
+      enums.script_eventtype,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_eventtype. */
+    isdeployed: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'isdeployed',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    loglevel: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+    runasrole: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'runasrole',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    alllocalizationcontexts: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'alllocalizationcontexts',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    executioncontext: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'executioncontext',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    localizationcontext: new Field(
+      usereventscript_scriptdeployments_scriptdeploymentElemID,
+      'localizationcontext',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can filter your script to run based on the localization context of your users. For information about using localization context in NetSuite, see Record Localization Context.   This field is available when the alllocalizationcontexts value is equal to F.   You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see countries. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, usereventscriptElemID.name],
+})
+
+usereventscriptInnerTypes.push(usereventscript_scriptdeployments_scriptdeployment)
+
+const usereventscript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'usereventscript_scriptdeployments')
+
+const usereventscript_scriptdeployments = new ObjectType({
+  elemID: usereventscript_scriptdeploymentsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptdeployment: new Field(
+      usereventscript_scriptdeploymentsElemID,
+      'scriptdeployment',
+      new ListType(usereventscript_scriptdeployments_scriptdeployment),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, usereventscriptElemID.name],
+})
+
+usereventscriptInnerTypes.push(usereventscript_scriptdeployments)
+
+
+export const usereventscript = new ObjectType({
+  elemID: usereventscriptElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      usereventscriptElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      usereventscriptElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      usereventscriptElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    description: new Field(
+      usereventscriptElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      usereventscriptElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      usereventscriptElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      usereventscriptElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      usereventscriptElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      usereventscriptElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      usereventscriptElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    aftersubmitfunction: new Field(
+      usereventscriptElemID,
+      'aftersubmitfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    beforeloadfunction: new Field(
+      usereventscriptElemID,
+      'beforeloadfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    beforesubmitfunction: new Field(
+      usereventscriptElemID,
+      'beforesubmitfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    customplugintypes: new Field(
+      usereventscriptElemID,
+      'customplugintypes',
+      usereventscript_customplugintypes,
+      {
+      },
+    ),
+    libraries: new Field(
+      usereventscriptElemID,
+      'libraries',
+      usereventscript_libraries,
+      {
+      },
+    ),
+    scriptcustomfields: new Field(
+      usereventscriptElemID,
+      'scriptcustomfields',
+      usereventscript_scriptcustomfields,
+      {
+      },
+    ),
+    scriptdeployments: new Field(
+      usereventscriptElemID,
+      'scriptdeployments',
+      usereventscript_scriptdeployments,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, usereventscriptElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/workbook.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/workbook.ts
@@ -1,0 +1,89 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+
+export const workbookInnerTypes: ObjectType[] = []
+
+const workbookElemID = new ElemID(constants.NETSUITE, 'workbook')
+const workbook_dependenciesElemID = new ElemID(constants.NETSUITE, 'workbook_dependencies')
+
+const workbook_dependencies = new ObjectType({
+  elemID: workbook_dependenciesElemID,
+  annotations: {
+  },
+  fields: {
+    dependency: new Field(
+      workbook_dependenciesElemID,
+      'dependency',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the dataset custom type. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workbookElemID.name],
+})
+
+workbookInnerTypes.push(workbook_dependencies)
+
+
+export const workbook = new ObjectType({
+  elemID: workbookElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'custworkbook_',
+  },
+  fields: {
+    scriptid: new Field(
+      workbookElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custworkbook’. */
+    name: new Field(
+      workbookElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 50,
+      },
+    ), /* Original description: This field value can be up to 50 characters long. */
+    definition: new Field(
+      workbookElemID,
+      'definition',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    dependencies: new Field(
+      workbookElemID,
+      'dependencies',
+      workbook_dependencies,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workbookElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/workflow.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/workflow.ts
@@ -1,0 +1,9424 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const workflowInnerTypes: ObjectType[] = []
+
+const workflowElemID = new ElemID(constants.NETSUITE, 'workflow')
+const workflow_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_initcondition_parameters_parameter')
+
+const workflow_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_initcondition_parameters_parameter)
+
+const workflow_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_initcondition_parameters')
+
+const workflow_initcondition_parameters = new ObjectType({
+  elemID: workflow_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_initcondition_parameters)
+
+const workflow_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_initcondition')
+
+const workflow_initcondition = new ObjectType({
+  elemID: workflow_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_initconditionElemID,
+      'parameters',
+      workflow_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_initcondition)
+
+const workflow_recurrence_dailyElemID = new ElemID(constants.NETSUITE, 'workflow_recurrence_daily')
+
+const workflow_recurrence_daily = new ObjectType({
+  elemID: workflow_recurrence_dailyElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      workflow_recurrence_dailyElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      workflow_recurrence_dailyElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    everyxdays: new Field(
+      workflow_recurrence_dailyElemID,
+      'everyxdays',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      workflow_recurrence_dailyElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_recurrence_daily)
+
+const workflow_recurrence_every30minutesElemID = new ElemID(constants.NETSUITE, 'workflow_recurrence_every30minutes')
+
+const workflow_recurrence_every30minutes = new ObjectType({
+  elemID: workflow_recurrence_every30minutesElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      workflow_recurrence_every30minutesElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      workflow_recurrence_every30minutesElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_recurrence_every30minutes)
+
+const workflow_recurrence_everyweekdayElemID = new ElemID(constants.NETSUITE, 'workflow_recurrence_everyweekday')
+
+const workflow_recurrence_everyweekday = new ObjectType({
+  elemID: workflow_recurrence_everyweekdayElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      workflow_recurrence_everyweekdayElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      workflow_recurrence_everyweekdayElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      workflow_recurrence_everyweekdayElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_recurrence_everyweekday)
+
+const workflow_recurrence_monthlyElemID = new ElemID(constants.NETSUITE, 'workflow_recurrence_monthly')
+
+const workflow_recurrence_monthly = new ObjectType({
+  elemID: workflow_recurrence_monthlyElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      workflow_recurrence_monthlyElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      workflow_recurrence_monthlyElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    dayofmonth: new Field(
+      workflow_recurrence_monthlyElemID,
+      'dayofmonth',
+      enums.generic_day_of_month,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_day_of_month. */
+    everyxmonths: new Field(
+      workflow_recurrence_monthlyElemID,
+      'everyxmonths',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      workflow_recurrence_monthlyElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_recurrence_monthly)
+
+const workflow_recurrence_monthlydayofweekElemID = new ElemID(constants.NETSUITE, 'workflow_recurrence_monthlydayofweek')
+
+const workflow_recurrence_monthlydayofweek = new ObjectType({
+  elemID: workflow_recurrence_monthlydayofweekElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      workflow_recurrence_monthlydayofweekElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      workflow_recurrence_monthlydayofweekElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    orderofweek: new Field(
+      workflow_recurrence_monthlydayofweekElemID,
+      'orderofweek',
+      enums.workflow_order_of_week,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_order_of_week. */
+    dayofweek: new Field(
+      workflow_recurrence_monthlydayofweekElemID,
+      'dayofweek',
+      enums.generic_day_of_week,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_day_of_week. */
+    everyxmonths: new Field(
+      workflow_recurrence_monthlydayofweekElemID,
+      'everyxmonths',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    enddate: new Field(
+      workflow_recurrence_monthlydayofweekElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_recurrence_monthlydayofweek)
+
+const workflow_recurrence_singleElemID = new ElemID(constants.NETSUITE, 'workflow_recurrence_single')
+
+const workflow_recurrence_single = new ObjectType({
+  elemID: workflow_recurrence_singleElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      workflow_recurrence_singleElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      workflow_recurrence_singleElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_recurrence_single)
+
+const workflow_recurrence_weeklyElemID = new ElemID(constants.NETSUITE, 'workflow_recurrence_weekly')
+
+const workflow_recurrence_weekly = new ObjectType({
+  elemID: workflow_recurrence_weeklyElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      workflow_recurrence_weeklyElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      workflow_recurrence_weeklyElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    everyxweeks: new Field(
+      workflow_recurrence_weeklyElemID,
+      'everyxweeks',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    sunday: new Field(
+      workflow_recurrence_weeklyElemID,
+      'sunday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    monday: new Field(
+      workflow_recurrence_weeklyElemID,
+      'monday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    tuesday: new Field(
+      workflow_recurrence_weeklyElemID,
+      'tuesday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    wednesday: new Field(
+      workflow_recurrence_weeklyElemID,
+      'wednesday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    thursday: new Field(
+      workflow_recurrence_weeklyElemID,
+      'thursday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    friday: new Field(
+      workflow_recurrence_weeklyElemID,
+      'friday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    saturday: new Field(
+      workflow_recurrence_weeklyElemID,
+      'saturday',
+      BuiltinTypes.BOOLEAN,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: The default value is F. */
+    enddate: new Field(
+      workflow_recurrence_weeklyElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_recurrence_weekly)
+
+const workflow_recurrence_yearlyElemID = new ElemID(constants.NETSUITE, 'workflow_recurrence_yearly')
+
+const workflow_recurrence_yearly = new ObjectType({
+  elemID: workflow_recurrence_yearlyElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      workflow_recurrence_yearlyElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      workflow_recurrence_yearlyElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    month: new Field(
+      workflow_recurrence_yearlyElemID,
+      'month',
+      enums.generic_month,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_month. */
+    dayofmonth: new Field(
+      workflow_recurrence_yearlyElemID,
+      'dayofmonth',
+      enums.generic_day_of_month,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_day_of_month. */
+    enddate: new Field(
+      workflow_recurrence_yearlyElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_recurrence_yearly)
+
+const workflow_recurrence_yearlydayofweekElemID = new ElemID(constants.NETSUITE, 'workflow_recurrence_yearlydayofweek')
+
+const workflow_recurrence_yearlydayofweek = new ObjectType({
+  elemID: workflow_recurrence_yearlydayofweekElemID,
+  annotations: {
+  },
+  fields: {
+    startdate: new Field(
+      workflow_recurrence_yearlydayofweekElemID,
+      'startdate',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    starttime: new Field(
+      workflow_recurrence_yearlydayofweekElemID,
+      'starttime',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    orderofweek: new Field(
+      workflow_recurrence_yearlydayofweekElemID,
+      'orderofweek',
+      enums.generic_order_of_week,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_order_of_week. */
+    dayofweek: new Field(
+      workflow_recurrence_yearlydayofweekElemID,
+      'dayofweek',
+      enums.generic_day_of_week,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_day_of_week. */
+    month: new Field(
+      workflow_recurrence_yearlydayofweekElemID,
+      'month',
+      enums.generic_month,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_month. */
+    enddate: new Field(
+      workflow_recurrence_yearlydayofweekElemID,
+      'enddate',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_recurrence_yearlydayofweek)
+
+const workflow_recurrenceElemID = new ElemID(constants.NETSUITE, 'workflow_recurrence')
+
+const workflow_recurrence = new ObjectType({
+  elemID: workflow_recurrenceElemID,
+  annotations: {
+  },
+  fields: {
+    daily: new Field(
+      workflow_recurrenceElemID,
+      'daily',
+      workflow_recurrence_daily,
+      {
+      },
+    ),
+    every30minutes: new Field(
+      workflow_recurrenceElemID,
+      'every30minutes',
+      workflow_recurrence_every30minutes,
+      {
+      },
+    ),
+    everyweekday: new Field(
+      workflow_recurrenceElemID,
+      'everyweekday',
+      workflow_recurrence_everyweekday,
+      {
+      },
+    ),
+    monthly: new Field(
+      workflow_recurrenceElemID,
+      'monthly',
+      workflow_recurrence_monthly,
+      {
+      },
+    ),
+    monthlydayofweek: new Field(
+      workflow_recurrenceElemID,
+      'monthlydayofweek',
+      workflow_recurrence_monthlydayofweek,
+      {
+      },
+    ),
+    single: new Field(
+      workflow_recurrenceElemID,
+      'single',
+      workflow_recurrence_single,
+      {
+      },
+    ),
+    weekly: new Field(
+      workflow_recurrenceElemID,
+      'weekly',
+      workflow_recurrence_weekly,
+      {
+      },
+    ),
+    yearly: new Field(
+      workflow_recurrenceElemID,
+      'yearly',
+      workflow_recurrence_yearly,
+      {
+      },
+    ),
+    yearlydayofweek: new Field(
+      workflow_recurrenceElemID,
+      'yearlydayofweek',
+      workflow_recurrence_yearlydayofweek,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_recurrence)
+
+const workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilter')
+
+const workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilter)
+
+const workflow_workflowcustomfields_workflowcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowcustomfields_workflowcustomfield_customfieldfilters')
+
+const workflow_workflowcustomfields_workflowcustomfield_customfieldfilters = new ObjectType({
+  elemID: workflow_workflowcustomfields_workflowcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      workflow_workflowcustomfields_workflowcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(workflow_workflowcustomfields_workflowcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowcustomfields_workflowcustomfield_customfieldfilters)
+
+const workflow_workflowcustomfields_workflowcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'workflow_workflowcustomfields_workflowcustomfield_roleaccesses_roleaccess')
+
+const workflow_workflowcustomfields_workflowcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: workflow_workflowcustomfields_workflowcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      workflow_workflowcustomfields_workflowcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      workflow_workflowcustomfields_workflowcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      workflow_workflowcustomfields_workflowcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowcustomfields_workflowcustomfield_roleaccesses_roleaccess)
+
+const workflow_workflowcustomfields_workflowcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'workflow_workflowcustomfields_workflowcustomfield_roleaccesses')
+
+const workflow_workflowcustomfields_workflowcustomfield_roleaccesses = new ObjectType({
+  elemID: workflow_workflowcustomfields_workflowcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      workflow_workflowcustomfields_workflowcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(workflow_workflowcustomfields_workflowcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowcustomfields_workflowcustomfield_roleaccesses)
+
+const workflow_workflowcustomfields_workflowcustomfieldElemID = new ElemID(constants.NETSUITE, 'workflow_workflowcustomfields_workflowcustomfield')
+
+const workflow_workflowcustomfields_workflowcustomfield = new ObjectType({
+  elemID: workflow_workflowcustomfields_workflowcustomfieldElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 42 characters long.   The default value is ‘custworkflow’. */
+    fieldtype: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    customfieldfilters: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'customfieldfilters',
+      workflow_workflowcustomfields_workflowcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      workflow_workflowcustomfields_workflowcustomfieldElemID,
+      'roleaccesses',
+      workflow_workflowcustomfields_workflowcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowcustomfields_workflowcustomfield)
+
+const workflow_workflowcustomfieldsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowcustomfields')
+
+const workflow_workflowcustomfields = new ObjectType({
+  elemID: workflow_workflowcustomfieldsElemID,
+  annotations: {
+  },
+  fields: {
+    workflowcustomfield: new Field(
+      workflow_workflowcustomfieldsElemID,
+      'workflowcustomfield',
+      new ListType(workflow_workflowcustomfields_workflowcustomfield),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowcustomfields)
+
+const workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_addbuttonactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_addbuttonaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_addbuttonaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_addbuttonactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    label: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonactionElemID,
+      'label',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the string custom type. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    saverecordfirst: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonactionElemID,
+      'saverecordfirst',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    checkconditionbeforeexecution: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonactionElemID,
+      'checkconditionbeforeexecution',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_addbuttonaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_addbuttonaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_confirmaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_confirmaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_confirmactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_confirmaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_confirmaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_confirmactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    messagetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmactionElemID,
+      'messagetext',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the string custom type. */
+    clienttriggerfieldssublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmactionElemID,
+      'clienttriggerfieldssublist',
+      enums.workflow_sublists,
+      {
+      },
+    ), /* Original description: This field is available when the clienttriggerfieldsissublistfield value is equal to T.   This field is mandatory when the clienttriggerfieldsissublistfield value is equal to T.   For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    clienttriggerfieldsissublistfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmactionElemID,
+      'clienttriggerfieldsissublistfield',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the triggertype value is present in workflowaction_triggertype_client.   The default value is F. */
+    clienttriggerfields: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmactionElemID,
+      'clienttriggerfields',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_confirmactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_confirmaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_confirmaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings_fieldsettingElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings_fieldsetting')
+
+const workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings_fieldsetting = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings_fieldsettingElemID,
+  annotations: {
+  },
+  fields: {
+    targetfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings_fieldsettingElemID,
+      'targetfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings_fieldsettingElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings_fieldsettingElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ),
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings_fieldsettingElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings_fieldsettingElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings_fieldsettingElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings_fieldsettingElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings_fieldsettingElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings_fieldsetting)
+
+const workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettingsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings')
+
+const workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettingsElemID,
+  annotations: {
+  },
+  fields: {
+    fieldsetting: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettingsElemID,
+      'fieldsetting',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings_fieldsetting),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings)
+
+const workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_createlineaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_createlineaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_createlineactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_createlineaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_createlineaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_createlineactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    sublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineactionElemID,
+      'sublist',
+      enums.workflow_sublists,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    position: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineactionElemID,
+      'position',
+      enums.workflowaction_createline_position,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_createline_position.   The default value is 'AFTERLASTLINE'. */
+    fieldsettings: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineactionElemID,
+      'fieldsettings',
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_fieldsettings,
+      {
+      },
+    ),
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createlineactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_createlineaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_createlineaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings_fieldsettingElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings_fieldsetting')
+
+const workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings_fieldsetting = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings_fieldsettingElemID,
+  annotations: {
+  },
+  fields: {
+    targetfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings_fieldsettingElemID,
+      'targetfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ),
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings_fieldsetting)
+
+const workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettingsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings')
+
+const workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettingsElemID,
+  annotations: {
+  },
+  fields: {
+    fieldsetting: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettingsElemID,
+      'fieldsetting',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings_fieldsetting),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings)
+
+const workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_createrecordaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_createrecordaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    recordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+      'recordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customtransactiontype   customrecordtype   For information about other possible values, see generic_standard_recordtype. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    scheduledelay: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+      'scheduledelay',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeofday: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+      'scheduletimeofday',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    schedulerecurrence: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+      'schedulerecurrence',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeunit: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+      'scheduletimeunit',
+      enums.workflow_timeunit,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflow_timeunit. */
+    schedulemode: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+      'schedulemode',
+      enums.workflowaction_radioschedulemode,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_radioschedulemode. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    resultfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+      'resultfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fieldsettings: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+      'fieldsettings',
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_fieldsettings,
+      {
+      },
+    ),
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_createrecordactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_createrecordaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_createrecordaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_customaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_customaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersettingElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersetting')
+
+const workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersetting = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersettingElemID,
+  annotations: {
+  },
+  fields: {
+    targetparameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersettingElemID,
+      'targetparameter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersettingElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersettingElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ),
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersettingElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersettingElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersettingElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersettingElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersettingElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersetting)
+
+const workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettingsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings')
+
+const workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettingsElemID,
+  annotations: {
+  },
+  fields: {
+    parametersetting: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettingsElemID,
+      'parametersetting',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings_parametersetting),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings)
+
+const workflow_workflowstates_workflowstate_workflowactions_customactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_customaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_customaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    scripttype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+      'scripttype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the workflowactionscript custom type. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    scheduledelay: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+      'scheduledelay',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeofday: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+      'scheduletimeofday',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    schedulerecurrence: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+      'schedulerecurrence',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeunit: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+      'scheduletimeunit',
+      enums.workflow_timeunit,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflow_timeunit. */
+    schedulemode: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+      'schedulemode',
+      enums.workflowaction_radioschedulemode,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_radioschedulemode. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    resultfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+      'resultfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_customaction_initcondition,
+      {
+      },
+    ),
+    parametersettings: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_customactionElemID,
+      'parametersettings',
+      workflow_workflowstates_workflowstate_workflowactions_customaction_parametersettings,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_customaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_gotopageactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_gotopageaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_gotopageaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_gotopageactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    targetpage: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageactionElemID,
+      'targetpage',
+      enums.generic_standard_task,
+      {
+      },
+    ), /* Original description: This field is mandatory when the targetpageobject value is not defined.   For information about possible values, see generic_standard_task. */
+    targetpageobject: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageactionElemID,
+      'targetpageobject',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the targetpage value is not defined.   This field accepts references to the following custom types:   workflowactionscript   usereventscript   scriptdeployment   suitelet   scheduledscript   savedsearch   restlet   portlet   massupdatescript   mapreducescript   customrecordtype   clientscript   centertab   bundleinstallationscript */
+    targetpagetasktype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageactionElemID,
+      'targetpagetasktype',
+      enums.centercategory_tasktype,
+      {
+      },
+    ), /* Original description: This field is mandatory when the targetpageobject value is defined.   For information about possible values, see centercategory_tasktype. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotopageactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_gotopageaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_gotopageaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings_fieldsettingElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings_fieldsetting')
+
+const workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings_fieldsetting = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings_fieldsettingElemID,
+  annotations: {
+  },
+  fields: {
+    targetfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'targetfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ),
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings_fieldsetting)
+
+const workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettingsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings')
+
+const workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettingsElemID,
+  annotations: {
+  },
+  fields: {
+    fieldsetting: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettingsElemID,
+      'fieldsetting',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings_fieldsetting),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings)
+
+const workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_gotorecordactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_gotorecordaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_gotorecordaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_gotorecordactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    recordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordactionElemID,
+      'recordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customtransactiontype   customrecordtype   For information about other possible values, see generic_standard_recordtype. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    recordidfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordactionElemID,
+      'recordidfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    recordidjoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordactionElemID,
+      'recordidjoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    ineditmode: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordactionElemID,
+      'ineditmode',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fieldsettings: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordactionElemID,
+      'fieldsettings',
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_fieldsettings,
+      {
+      },
+    ),
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_gotorecordaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_gotorecordaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings_workflowfieldsetting')
+
+const workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings_workflowfieldsetting = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+  annotations: {
+  },
+  fields: {
+    targetworkflowfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'targetworkflowfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ),
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings_workflowfieldsetting)
+
+const workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettingsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings')
+
+const workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettingsElemID,
+  annotations: {
+  },
+  fields: {
+    workflowfieldsetting: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettingsElemID,
+      'workflowfieldsetting',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings_workflowfieldsetting),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings)
+
+const workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    initiatedworkflow: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID,
+      'initiatedworkflow',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the workflow custom type. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    scheduledelay: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID,
+      'scheduledelay',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeofday: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID,
+      'scheduletimeofday',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    schedulerecurrence: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID,
+      'schedulerecurrence',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeunit: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID,
+      'scheduletimeunit',
+      enums.workflow_timeunit,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflow_timeunit. */
+    schedulemode: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID,
+      'schedulemode',
+      enums.workflowaction_radioschedulemode,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_radioschedulemode. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_initcondition,
+      {
+      },
+    ),
+    workflowfieldsettings: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowactionElemID,
+      'workflowfieldsettings',
+      workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction_workflowfieldsettings,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_lockrecordactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_lockrecordaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_lockrecordaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_lockrecordactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_lockrecordaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_lockrecordaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_removebuttonactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_removebuttonaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_removebuttonaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_removebuttonactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    buttonid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonactionElemID,
+      'buttonid',
+      enums.workflowaction_buttonid,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflowaction_buttonid. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_removebuttonaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_removebuttonaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_returnusererroractionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_returnusererroraction')
+
+const workflow_workflowstates_workflowstate_workflowactions_returnusererroraction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_returnusererroractionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroractionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    errortext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroractionElemID,
+      'errortext',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the string custom type. */
+    clienttriggerfieldssublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroractionElemID,
+      'clienttriggerfieldssublist',
+      enums.workflow_sublists,
+      {
+      },
+    ), /* Original description: This field is available when the clienttriggerfieldsissublistfield value is equal to T.   This field is mandatory when the clienttriggerfieldsissublistfield value is equal to T.   For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    clienttriggerfieldsissublistfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroractionElemID,
+      'clienttriggerfieldsissublistfield',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the triggertype value is present in workflowaction_triggertype_client.   The default value is F. */
+    clienttriggerfields: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroractionElemID,
+      'clienttriggerfields',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroractionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroractionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroractionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroractionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroractionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_returnusererroraction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_returnusererroraction)
+
+const workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    recipientfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'recipientfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    scheduledelay: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'scheduledelay',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeofday: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'scheduletimeofday',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    schedulerecurrence: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'schedulerecurrence',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeunit: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'scheduletimeunit',
+      enums.workflow_timeunit,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflow_timeunit. */
+    schedulemode: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'schedulemode',
+      enums.workflowaction_radioschedulemode,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_radioschedulemode. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    resultfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'resultfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    recipientiscurrentrecord: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'recipientiscurrentrecord',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    recipientjoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'recipientjoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    campaignevent: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'campaignevent',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_sendemailaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_sendemailaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    sendertype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'sendertype',
+      enums.workflowaction_sendertype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflowaction_sendertype. */
+    recipienttype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'recipienttype',
+      enums.workflowaction_recipienttype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflowaction_recipienttype. */
+    sender: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'sender',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is mandatory when the sendertype value is equal to SPECIFIC.   Note Account-specific values are not supported by SDF. */
+    senderfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'senderfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the sendertype value is equal to FIELD.   This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    recipient: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'recipient',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is mandatory when the recipienttype value is equal to SPECIFIC.   Note Account-specific values are not supported by SDF. */
+    recipientemail: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'recipientemail',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is mandatory when the recipienttype value is equal to ADDRESS. */
+    recipientfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'recipientfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the recipienttype value is equal to FIELD.   This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    template: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'template',
+      enums.generic_standard_template,
+      {
+      },
+    ), /* Original description: This field is mandatory when the usetemplate value is equal to T.   For information about possible values, see generic_standard_template. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    scheduledelay: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'scheduledelay',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeofday: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'scheduletimeofday',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    schedulerecurrence: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'schedulerecurrence',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeunit: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'scheduletimeunit',
+      enums.workflow_timeunit,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflow_timeunit. */
+    schedulemode: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'schedulemode',
+      enums.workflowaction_radioschedulemode,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_radioschedulemode. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    senderjoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'senderjoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    recipientjoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'recipientjoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    recipientccemail: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'recipientccemail',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    recipientbccemail: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'recipientbccemail',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    usetemplate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'usetemplate',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    subject: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'subject',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    body: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'body',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    includerecordlink: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'includerecordlink',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    attachmenttype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'attachmenttype',
+      enums.workflowaction_attachmenttype,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_attachmenttype. */
+    attachmentfile: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'attachmentfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+      },
+    ),
+    attachmentjoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'attachmentjoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    attachmentfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'attachmentfield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    includetransaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'includetransaction',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    includeformat: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'includeformat',
+      enums.workflowaction_transtatementtype,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_transtatementtype. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_sendemailactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_sendemailaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_sendemailaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    clienttriggerfieldssublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID,
+      'clienttriggerfieldssublist',
+      enums.workflow_sublists,
+      {
+      },
+    ), /* Original description: This field is available when the clienttriggerfieldsissublistfield value is equal to T.   This field is mandatory when the clienttriggerfieldsissublistfield value is equal to T.   For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    sublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID,
+      'sublist',
+      enums.workflow_sublists,
+      {
+      },
+    ), /* Original description: This field is available when the issublistfield value is equal to T.   This field is mandatory when the issublistfield value is equal to T.   For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    clienttriggerfieldsissublistfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID,
+      'clienttriggerfieldsissublistfield',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the triggertype value is present in workflowaction_triggertype_client.   The default value is F. */
+    clienttriggerfields: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID,
+      'clienttriggerfields',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    field: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID,
+      'field',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    issublistfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID,
+      'issublistfield',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displaylabel: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID,
+      'displaylabel',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    displaytype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID,
+      'displaytype',
+      enums.workflowaction_displaytype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflowaction_displaytype. */
+    clienttriggerfieldssublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID,
+      'clienttriggerfieldssublist',
+      enums.workflow_sublists,
+      {
+      },
+    ), /* Original description: This field is available when the clienttriggerfieldsissublistfield value is equal to T.   This field is mandatory when the clienttriggerfieldsissublistfield value is equal to T.   For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    sublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID,
+      'sublist',
+      enums.workflow_sublists,
+      {
+      },
+    ), /* Original description: This field is available when the issublistfield value is equal to T.   This field is mandatory when the issublistfield value is equal to T.   For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    clienttriggerfieldsissublistfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID,
+      'clienttriggerfieldsissublistfield',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the triggertype value is present in workflowaction_triggertype_client.   The default value is F. */
+    clienttriggerfields: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID,
+      'clienttriggerfields',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    field: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID,
+      'field',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    issublistfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID,
+      'issublistfield',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    clienttriggerfieldssublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID,
+      'clienttriggerfieldssublist',
+      enums.workflow_sublists,
+      {
+      },
+    ), /* Original description: This field is available when the clienttriggerfieldsissublistfield value is equal to T.   This field is mandatory when the clienttriggerfieldsissublistfield value is equal to T.   For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    sublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID,
+      'sublist',
+      enums.workflow_sublists,
+      {
+      },
+    ), /* Original description: This field is available when the issublistfield value is equal to T.   This field is mandatory when the issublistfield value is equal to T.   For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    clienttriggerfieldsissublistfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID,
+      'clienttriggerfieldsissublistfield',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the triggertype value is present in workflowaction_triggertype_client.   The default value is F. */
+    clienttriggerfields: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID,
+      'clienttriggerfields',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    field: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID,
+      'field',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    issublistfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID,
+      'issublistfield',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    field: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'field',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    clienttriggerfieldssublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'clienttriggerfieldssublist',
+      enums.workflow_sublists,
+      {
+      },
+    ), /* Original description: This field is available when the clienttriggerfieldsissublistfield value is equal to T.   This field is mandatory when the clienttriggerfieldsissublistfield value is equal to T.   For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    clienttriggerfieldsissublistfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'clienttriggerfieldsissublistfield',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the triggertype value is present in workflowaction_triggertype_client.   The default value is F. */
+    clienttriggerfields: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'clienttriggerfields',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    scheduledelay: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'scheduledelay',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeofday: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'scheduletimeofday',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    schedulerecurrence: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'schedulerecurrence',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeunit: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'scheduletimeunit',
+      enums.workflow_timeunit,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflow_timeunit. */
+    schedulemode: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'schedulemode',
+      enums.workflowaction_radioschedulemode,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_radioschedulemode. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    valuetype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'valuetype',
+      enums.workflowaction_valuetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuetype. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuemultiselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'valuemultiselect',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_showmessageactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_showmessageaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_showmessageaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_showmessageactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    messagetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageactionElemID,
+      'messagetext',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the string custom type. */
+    clienttriggerfieldssublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageactionElemID,
+      'clienttriggerfieldssublist',
+      enums.workflow_sublists,
+      {
+      },
+    ), /* Original description: This field is available when the clienttriggerfieldsissublistfield value is equal to T.   This field is mandatory when the clienttriggerfieldsissublistfield value is equal to T.   For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    clienttriggerfieldsissublistfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageactionElemID,
+      'clienttriggerfieldsissublistfield',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: This field is available when the triggertype value is present in workflowaction_triggertype_client.   The default value is F. */
+    clienttriggerfields: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageactionElemID,
+      'clienttriggerfields',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_showmessageactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_showmessageaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_showmessageaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_subscribetorecordactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_subscribetorecordactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    scheduledelay: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordactionElemID,
+      'scheduledelay',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeofday: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordactionElemID,
+      'scheduletimeofday',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    schedulerecurrence: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordactionElemID,
+      'schedulerecurrence',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeunit: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordactionElemID,
+      'scheduletimeunit',
+      enums.workflow_timeunit,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflow_timeunit. */
+    schedulemode: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordactionElemID,
+      'schedulemode',
+      enums.workflowaction_radioschedulemode,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_radioschedulemode. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    recordfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordactionElemID,
+      'recordfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings_fieldsettingElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings_fieldsetting')
+
+const workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings_fieldsetting = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings_fieldsettingElemID,
+  annotations: {
+  },
+  fields: {
+    targetfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'targetfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ),
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings_fieldsetting)
+
+const workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettingsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings')
+
+const workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettingsElemID,
+  annotations: {
+  },
+  fields: {
+    fieldsetting: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettingsElemID,
+      'fieldsetting',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings_fieldsetting),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings)
+
+const workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_transformrecordaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_transformrecordaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    recordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+      'recordtype',
+      enums.generic_standard_recordtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_standard_recordtype. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    scheduledelay: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+      'scheduledelay',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeofday: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+      'scheduletimeofday',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    schedulerecurrence: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+      'schedulerecurrence',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeunit: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+      'scheduletimeunit',
+      enums.workflow_timeunit,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflow_timeunit. */
+    schedulemode: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+      'schedulemode',
+      enums.workflowaction_radioschedulemode,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_radioschedulemode. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    resultfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+      'resultfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fieldsettings: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+      'fieldsettings',
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_fieldsettings,
+      {
+      },
+    ),
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_transformrecordaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_transformrecordaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_addbuttonactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_addbuttonaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_addbuttonaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_addbuttonactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_addbuttonactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    label: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_addbuttonactionElemID,
+      'label',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the string custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_addbuttonactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    saverecordfirst: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_addbuttonactionElemID,
+      'saverecordfirst',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    checkconditionbeforeexecution: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_addbuttonactionElemID,
+      'checkconditionbeforeexecution',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_addbuttonaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings_fieldsettingElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings_fieldsetting')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings_fieldsetting = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings_fieldsettingElemID,
+  annotations: {
+  },
+  fields: {
+    targetfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings_fieldsettingElemID,
+      'targetfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings_fieldsettingElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings_fieldsettingElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ),
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings_fieldsettingElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings_fieldsettingElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings_fieldsettingElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings_fieldsettingElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings_fieldsettingElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings_fieldsetting)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettingsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettingsElemID,
+  annotations: {
+  },
+  fields: {
+    fieldsetting: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettingsElemID,
+      'fieldsetting',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings_fieldsetting),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    sublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineactionElemID,
+      'sublist',
+      enums.workflow_sublists,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    position: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineactionElemID,
+      'position',
+      enums.workflowaction_createline_position,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_createline_position.   The default value is 'AFTERLASTLINE'. */
+    fieldsettings: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineactionElemID,
+      'fieldsettings',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction_fieldsettings,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings_fieldsettingElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings_fieldsetting')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings_fieldsetting = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+  annotations: {
+  },
+  fields: {
+    targetfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'targetfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ),
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings_fieldsetting)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettingsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettingsElemID,
+  annotations: {
+  },
+  fields: {
+    fieldsetting: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettingsElemID,
+      'fieldsetting',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings_fieldsetting),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    recordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordactionElemID,
+      'recordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customtransactiontype   customrecordtype   For information about other possible values, see generic_standard_recordtype. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    resultfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordactionElemID,
+      'resultfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fieldsettings: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordactionElemID,
+      'fieldsettings',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction_fieldsettings,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersettingElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersetting')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersetting = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersettingElemID,
+  annotations: {
+  },
+  fields: {
+    targetparameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersettingElemID,
+      'targetparameter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersettingElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersettingElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ),
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersettingElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersettingElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersettingElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersettingElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersettingElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersetting)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettingsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettingsElemID,
+  annotations: {
+  },
+  fields: {
+    parametersetting: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettingsElemID,
+      'parametersetting',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings_parametersetting),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    scripttype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customactionElemID,
+      'scripttype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the workflowactionscript custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    resultfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customactionElemID,
+      'resultfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    parametersettings: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customactionElemID,
+      'parametersettings',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction_parametersettings,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotopageactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotopageaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotopageaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotopageactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotopageactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    targetpage: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotopageactionElemID,
+      'targetpage',
+      enums.generic_standard_task,
+      {
+      },
+    ), /* Original description: This field is mandatory when the targetpageobject value is not defined.   For information about possible values, see generic_standard_task. */
+    targetpageobject: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotopageactionElemID,
+      'targetpageobject',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the targetpage value is not defined.   This field accepts references to the following custom types:   workflowactionscript   usereventscript   scriptdeployment   suitelet   scheduledscript   savedsearch   restlet   portlet   massupdatescript   mapreducescript   customrecordtype   clientscript   centertab   bundleinstallationscript */
+    targetpagetasktype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotopageactionElemID,
+      'targetpagetasktype',
+      enums.centercategory_tasktype,
+      {
+      },
+    ), /* Original description: This field is mandatory when the targetpageobject value is defined.   For information about possible values, see centercategory_tasktype. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotopageactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotopageaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings_fieldsettingElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings_fieldsetting')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings_fieldsetting = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings_fieldsettingElemID,
+  annotations: {
+  },
+  fields: {
+    targetfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'targetfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ),
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings_fieldsettingElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings_fieldsetting)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettingsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettingsElemID,
+  annotations: {
+  },
+  fields: {
+    fieldsetting: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettingsElemID,
+      'fieldsetting',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings_fieldsetting),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    recordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordactionElemID,
+      'recordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customtransactiontype   customrecordtype   For information about other possible values, see generic_standard_recordtype. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    recordidfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordactionElemID,
+      'recordidfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    recordidjoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordactionElemID,
+      'recordidjoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    ineditmode: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordactionElemID,
+      'ineditmode',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fieldsettings: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordactionElemID,
+      'fieldsettings',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction_fieldsettings,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings_workflowfieldsetting')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings_workflowfieldsetting = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+  annotations: {
+  },
+  fields: {
+    targetworkflowfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'targetworkflowfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ),
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings_workflowfieldsettingElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings_workflowfieldsetting)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettingsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettingsElemID,
+  annotations: {
+  },
+  fields: {
+    workflowfieldsetting: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettingsElemID,
+      'workflowfieldsetting',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings_workflowfieldsetting),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    initiatedworkflow: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowactionElemID,
+      'initiatedworkflow',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the workflow custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    workflowfieldsettings: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowactionElemID,
+      'workflowfieldsettings',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction_workflowfieldsettings,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_lockrecordactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_lockrecordaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_lockrecordaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_lockrecordactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_lockrecordactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_lockrecordactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_lockrecordaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_removebuttonactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_removebuttonaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_removebuttonaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_removebuttonactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_removebuttonactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    buttonid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_removebuttonactionElemID,
+      'buttonid',
+      enums.workflowaction_buttonid,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflowaction_buttonid. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_removebuttonactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_removebuttonaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_returnusererroractionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_returnusererroraction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_returnusererroraction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_returnusererroractionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_returnusererroractionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    errortext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_returnusererroractionElemID,
+      'errortext',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the string custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_returnusererroractionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_returnusererroraction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendcampaignemailactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendcampaignemailaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendcampaignemailaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendcampaignemailactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendcampaignemailactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    recipientfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendcampaignemailactionElemID,
+      'recipientfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendcampaignemailactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    resultfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendcampaignemailactionElemID,
+      'resultfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    recipientiscurrentrecord: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendcampaignemailactionElemID,
+      'recipientiscurrentrecord',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    recipientjoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendcampaignemailactionElemID,
+      'recipientjoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    campaignevent: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendcampaignemailactionElemID,
+      'campaignevent',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendcampaignemailaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    sendertype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'sendertype',
+      enums.workflowaction_sendertype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflowaction_sendertype. */
+    recipienttype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'recipienttype',
+      enums.workflowaction_recipienttype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflowaction_recipienttype. */
+    sender: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'sender',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is mandatory when the sendertype value is equal to SPECIFIC.   Note Account-specific values are not supported by SDF. */
+    senderfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'senderfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the sendertype value is equal to FIELD.   This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    recipient: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'recipient',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is mandatory when the recipienttype value is equal to SPECIFIC.   Note Account-specific values are not supported by SDF. */
+    recipientemail: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'recipientemail',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is mandatory when the recipienttype value is equal to ADDRESS. */
+    recipientfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'recipientfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the recipienttype value is equal to FIELD.   This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    template: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'template',
+      enums.generic_standard_template,
+      {
+      },
+    ), /* Original description: This field is mandatory when the usetemplate value is equal to T.   For information about possible values, see generic_standard_template. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    senderjoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'senderjoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    recipientjoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'recipientjoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    recipientccemail: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'recipientccemail',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    recipientbccemail: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'recipientbccemail',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    usetemplate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'usetemplate',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    subject: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'subject',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    body: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'body',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    includerecordlink: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'includerecordlink',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    attachmenttype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'attachmenttype',
+      enums.workflowaction_attachmenttype,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_attachmenttype. */
+    attachmentfile: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'attachmentfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+      },
+    ),
+    attachmentjoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'attachmentjoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    attachmentfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'attachmentfield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    includetransaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'includetransaction',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    includeformat: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailactionElemID,
+      'includeformat',
+      enums.workflowaction_transtatementtype,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_transtatementtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaylabelactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaylabelaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaylabelaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaylabelactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaylabelactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    sublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaylabelactionElemID,
+      'sublist',
+      enums.workflow_sublists,
+      {
+      },
+    ), /* Original description: This field is available when the issublistfield value is equal to T.   This field is mandatory when the issublistfield value is equal to T.   For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    field: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaylabelactionElemID,
+      'field',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaylabelactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    issublistfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaylabelactionElemID,
+      'issublistfield',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displaylabel: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaylabelactionElemID,
+      'displaylabel',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaylabelaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaytypeactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaytypeaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaytypeaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaytypeactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaytypeactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    displaytype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaytypeactionElemID,
+      'displaytype',
+      enums.workflowaction_displaytype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflowaction_displaytype. */
+    sublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaytypeactionElemID,
+      'sublist',
+      enums.workflow_sublists,
+      {
+      },
+    ), /* Original description: This field is available when the issublistfield value is equal to T.   This field is mandatory when the issublistfield value is equal to T.   For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    field: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaytypeactionElemID,
+      'field',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaytypeactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    issublistfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaytypeactionElemID,
+      'issublistfield',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaytypeaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldmandatoryactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldmandatoryaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldmandatoryaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldmandatoryactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldmandatoryactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    sublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldmandatoryactionElemID,
+      'sublist',
+      enums.workflow_sublists,
+      {
+      },
+    ), /* Original description: This field is available when the issublistfield value is equal to T.   This field is mandatory when the issublistfield value is equal to T.   For information about possible values, see workflow_sublists.   The default value is 'item'. */
+    field: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldmandatoryactionElemID,
+      'field',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldmandatoryactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    issublistfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldmandatoryactionElemID,
+      'issublistfield',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldmandatoryactionElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldmandatoryaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    field: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueactionElemID,
+      'field',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    valuetype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueactionElemID,
+      'valuetype',
+      enums.workflowaction_valuetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuetype. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueactionElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueactionElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueactionElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuemultiselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueactionElemID,
+      'valuemultiselect',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueactionElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueactionElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueactionElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueactionElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_subscribetorecordactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_subscribetorecordaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_subscribetorecordaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_subscribetorecordactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_subscribetorecordactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_subscribetorecordactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    recordfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_subscribetorecordactionElemID,
+      'recordfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_subscribetorecordaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings_fieldsettingElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings_fieldsetting')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings_fieldsetting = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings_fieldsettingElemID,
+  annotations: {
+  },
+  fields: {
+    targetfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'targetfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ),
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings_fieldsettingElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings_fieldsetting)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettingsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettingsElemID,
+  annotations: {
+  },
+  fields: {
+    fieldsetting: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettingsElemID,
+      'fieldsetting',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings_fieldsetting),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    recordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordactionElemID,
+      'recordtype',
+      enums.generic_standard_recordtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_standard_recordtype. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    resultfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordactionElemID,
+      'resultfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fieldsettings: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordactionElemID,
+      'fieldsettings',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction_fieldsettings,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    scheduletimeofday: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'scheduletimeofday',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is mandatory when the schedulemode value is equal to TIMEOFDAY. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    scheduledelay: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'scheduledelay',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    schedulerecurrence: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'schedulerecurrence',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeunit: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'scheduletimeunit',
+      enums.workflow_timeunit,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflow_timeunit. */
+    schedulemode: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'schedulemode',
+      enums.workflowaction_radioschedulemode,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_radioschedulemode. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    addbuttonaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'addbuttonaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_addbuttonaction,
+      {
+      },
+    ),
+    createlineaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'createlineaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createlineaction,
+      {
+      },
+    ),
+    createrecordaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'createrecordaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_createrecordaction,
+      {
+      },
+    ),
+    customaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'customaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_customaction,
+      {
+      },
+    ),
+    gotopageaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'gotopageaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotopageaction,
+      {
+      },
+    ),
+    gotorecordaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'gotorecordaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_gotorecordaction,
+      {
+      },
+    ),
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initcondition,
+      {
+      },
+    ),
+    initiateworkflowaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'initiateworkflowaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_initiateworkflowaction,
+      {
+      },
+    ),
+    lockrecordaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'lockrecordaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_lockrecordaction,
+      {
+      },
+    ),
+    removebuttonaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'removebuttonaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_removebuttonaction,
+      {
+      },
+    ),
+    returnusererroraction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'returnusererroraction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_returnusererroraction,
+      {
+      },
+    ),
+    sendcampaignemailaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'sendcampaignemailaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendcampaignemailaction,
+      {
+      },
+    ),
+    sendemailaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'sendemailaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_sendemailaction,
+      {
+      },
+    ),
+    setdisplaylabelaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'setdisplaylabelaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaylabelaction,
+      {
+      },
+    ),
+    setdisplaytypeaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'setdisplaytypeaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setdisplaytypeaction,
+      {
+      },
+    ),
+    setfieldmandatoryaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'setfieldmandatoryaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldmandatoryaction,
+      {
+      },
+    ),
+    setfieldvalueaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'setfieldvalueaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_setfieldvalueaction,
+      {
+      },
+    ),
+    subscribetorecordaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'subscribetorecordaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_subscribetorecordaction,
+      {
+      },
+    ),
+    transformrecordaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroupElemID,
+      'transformrecordaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup_transformrecordaction,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsettingElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsetting')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsetting = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+  annotations: {
+  },
+  fields: {
+    targetfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'targetfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ),
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsettingElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsetting)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettingsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettingsElemID,
+  annotations: {
+  },
+  fields: {
+    fieldsetting: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettingsElemID,
+      'fieldsetting',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings_fieldsetting),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    recordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordactionElemID,
+      'recordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customtransactiontype   customrecordtype   For information about other possible values, see generic_standard_recordtype. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    resultfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordactionElemID,
+      'resultfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fieldsettings: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordactionElemID,
+      'fieldsettings',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_fieldsettings,
+      {
+      },
+    ),
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroractionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroractionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroractionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    errortext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroractionElemID,
+      'errortext',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the string custom type. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroractionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroractionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroractionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    sendertype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'sendertype',
+      enums.workflowaction_sendertype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflowaction_sendertype. */
+    recipienttype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'recipienttype',
+      enums.workflowaction_recipienttype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflowaction_recipienttype. */
+    sender: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'sender',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is mandatory when the sendertype value is equal to SPECIFIC.   Note Account-specific values are not supported by SDF. */
+    senderfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'senderfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the sendertype value is equal to FIELD.   This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    recipient: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'recipient',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is mandatory when the recipienttype value is equal to SPECIFIC.   Note Account-specific values are not supported by SDF. */
+    recipientemail: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'recipientemail',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is mandatory when the recipienttype value is equal to ADDRESS. */
+    recipientfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'recipientfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the recipienttype value is equal to FIELD.   This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    template: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'template',
+      enums.generic_standard_template,
+      {
+      },
+    ), /* Original description: This field is mandatory when the usetemplate value is equal to T.   For information about possible values, see generic_standard_template. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    senderjoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'senderjoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    recipientjoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'recipientjoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    recipientccemail: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'recipientccemail',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    recipientbccemail: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'recipientbccemail',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    usetemplate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'usetemplate',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    subject: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'subject',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    body: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'body',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    includerecordlink: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'includerecordlink',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    attachmenttype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'attachmenttype',
+      enums.workflowaction_attachmenttype,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_attachmenttype. */
+    attachmentfile: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'attachmentfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+      },
+    ),
+    attachmentjoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'attachmentjoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    attachmentfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'attachmentfield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    includetransaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'includetransaction',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    includeformat: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'includeformat',
+      enums.workflowaction_transtatementtype,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_transtatementtype. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    field: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+      'field',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    valuetype: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+      'valuetype',
+      enums.workflowaction_valuetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuetype. */
+    valuetext: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+      'valuetext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    valuechecked: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+      'valuechecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    valueselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+      'valueselect',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuemultiselect: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+      'valuemultiselect',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    valuedate: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+      'valuedate',
+      enums.workflowaction_valuedate,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_valuedate. */
+    valuejoinfield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+      'valuejoinfield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valuefield: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+      'valuefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    valueformula: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+      'valueformula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueactionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction)
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup')
+
+const workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowaction’. */
+    sublist: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'sublist',
+      enums.workflow_sublists,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_sublists. */
+    scheduletimeofday: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'scheduletimeofday',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: This field is mandatory when the schedulemode value is equal to TIMEOFDAY. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    scheduledelay: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'scheduledelay',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    schedulerecurrence: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'schedulerecurrence',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    scheduletimeunit: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'scheduletimeunit',
+      enums.workflow_timeunit,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflow_timeunit. */
+    schedulemode: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'schedulemode',
+      enums.workflowaction_radioschedulemode,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowaction_radioschedulemode. */
+    isinactive: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    createrecordaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'createrecordaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_createrecordaction,
+      {
+      },
+    ),
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_initcondition,
+      {
+      },
+    ),
+    returnusererroraction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'returnusererroraction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_returnusererroraction,
+      {
+      },
+    ),
+    sendemailaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'sendemailaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_sendemailaction,
+      {
+      },
+    ),
+    setfieldvalueaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroupElemID,
+      'setfieldvalueaction',
+      workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup_setfieldvalueaction,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup)
+
+const workflow_workflowstates_workflowstate_workflowactionsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowactions')
+
+const workflow_workflowstates_workflowstate_workflowactions = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowactionsElemID,
+  annotations: {
+  },
+  fields: {
+    triggertype: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'triggertype',
+      enums.workflowaction_triggertype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: For information about possible values, see workflowaction_triggertype. */
+    addbuttonaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'addbuttonaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_addbuttonaction),
+      {
+      },
+    ),
+    confirmaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'confirmaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_confirmaction),
+      {
+      },
+    ),
+    createlineaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'createlineaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_createlineaction),
+      {
+      },
+    ),
+    createrecordaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'createrecordaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_createrecordaction),
+      {
+      },
+    ),
+    customaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'customaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_customaction),
+      {
+      },
+    ),
+    gotopageaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'gotopageaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_gotopageaction),
+      {
+      },
+    ),
+    gotorecordaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'gotorecordaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_gotorecordaction),
+      {
+      },
+    ),
+    initiateworkflowaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'initiateworkflowaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_initiateworkflowaction),
+      {
+      },
+    ),
+    lockrecordaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'lockrecordaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_lockrecordaction),
+      {
+      },
+    ),
+    removebuttonaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'removebuttonaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_removebuttonaction),
+      {
+      },
+    ),
+    returnusererroraction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'returnusererroraction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_returnusererroraction),
+      {
+      },
+    ),
+    sendcampaignemailaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'sendcampaignemailaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_sendcampaignemailaction),
+      {
+      },
+    ),
+    sendemailaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'sendemailaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_sendemailaction),
+      {
+      },
+    ),
+    setdisplaylabelaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'setdisplaylabelaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_setdisplaylabelaction),
+      {
+      },
+    ),
+    setdisplaytypeaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'setdisplaytypeaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_setdisplaytypeaction),
+      {
+      },
+    ),
+    setfieldmandatoryaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'setfieldmandatoryaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_setfieldmandatoryaction),
+      {
+      },
+    ),
+    setfieldvalueaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'setfieldvalueaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction),
+      {
+      },
+    ),
+    showmessageaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'showmessageaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_showmessageaction),
+      {
+      },
+    ),
+    subscribetorecordaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'subscribetorecordaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_subscribetorecordaction),
+      {
+      },
+    ),
+    transformrecordaction: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'transformrecordaction',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_transformrecordaction),
+      {
+      },
+    ),
+    workflowactiongroup: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'workflowactiongroup',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowactiongroup),
+      {
+      },
+    ),
+    workflowsublistactiongroup: new Field(
+      workflow_workflowstates_workflowstate_workflowactionsElemID,
+      'workflowsublistactiongroup',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions_workflowsublistactiongroup),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowactions)
+
+const workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilter')
+
+const workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   workflowstatecustomfield   workflowcustomfield   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilter)
+
+const workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters')
+
+const workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters)
+
+const workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses_roleaccess')
+
+const workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses_roleaccess)
+
+const workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses')
+
+const workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses)
+
+const workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield')
+
+const workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 41 characters long.   The default value is ‘custwfstate’. */
+    fieldtype: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    customfieldfilters: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'customfieldfilters',
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfieldElemID,
+      'roleaccesses',
+      workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield)
+
+const workflow_workflowstates_workflowstate_workflowstatecustomfieldsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowstatecustomfields')
+
+const workflow_workflowstates_workflowstate_workflowstatecustomfields = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowstatecustomfieldsElemID,
+  annotations: {
+  },
+  fields: {
+    workflowstatecustomfield: new Field(
+      workflow_workflowstates_workflowstate_workflowstatecustomfieldsElemID,
+      'workflowstatecustomfield',
+      new ListType(workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowstatecustomfield),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowstatecustomfields)
+
+const workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters_parameterElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters_parameter')
+
+const workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters_parameter = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters_parameterElemID,
+  annotations: {
+  },
+  fields: {
+    name: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters_parameterElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ),
+    value: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters_parameterElemID,
+      'value',
+      BuiltinTypes.STRING /* Original type was join   Join field types must be set to a colon-delimited list of values. */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   customsegment   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    selectrecordtype: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters_parameterElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters_parameter)
+
+const workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parametersElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters')
+
+const workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parametersElemID,
+  annotations: {
+  },
+  fields: {
+    parameter: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parametersElemID,
+      'parameter',
+      new ListType(workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters_parameter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters)
+
+const workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initconditionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition')
+
+const workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initconditionElemID,
+  annotations: {
+  },
+  fields: {
+    type: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initconditionElemID,
+      'type',
+      enums.workflow_condition_type,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see workflow_condition_type. */
+    formula: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initconditionElemID,
+      'formula',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    parameters: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initconditionElemID,
+      'parameters',
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition_parameters,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition)
+
+const workflow_workflowstates_workflowstate_workflowtransitions_workflowtransitionElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition')
+
+const workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowtransitions_workflowtransitionElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransitionElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowtransition’. */
+    tostate: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransitionElemID,
+      'tostate',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the workflowstate custom type. */
+    eventtypes: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransitionElemID,
+      'eventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflowaction_eventtype. */
+    contexttypes: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransitionElemID,
+      'contexttypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    conditionsavedsearch: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransitionElemID,
+      'conditionsavedsearch',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    triggertype: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransitionElemID,
+      'triggertype',
+      enums.workflowtransition_triggertype,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflowtransition_triggertype. */
+    waitforworkflow: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransitionElemID,
+      'waitforworkflow',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the workflow custom type. */
+    waitforworkflowstate: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransitionElemID,
+      'waitforworkflowstate',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the workflowstate custom type. */
+    buttonaction: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransitionElemID,
+      'buttonaction',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   addbuttonaction   addbuttonaction */
+    scheduledelay: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransitionElemID,
+      'scheduledelay',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    scheduletimeunit: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransitionElemID,
+      'scheduletimeunit',
+      enums.workflow_timeunit,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflow_timeunit. */
+    initcondition: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransitionElemID,
+      'initcondition',
+      workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition_initcondition,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition)
+
+const workflow_workflowstates_workflowstate_workflowtransitionsElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate_workflowtransitions')
+
+const workflow_workflowstates_workflowstate_workflowtransitions = new ObjectType({
+  elemID: workflow_workflowstates_workflowstate_workflowtransitionsElemID,
+  annotations: {
+  },
+  fields: {
+    workflowtransition: new Field(
+      workflow_workflowstates_workflowstate_workflowtransitionsElemID,
+      'workflowtransition',
+      new ListType(workflow_workflowstates_workflowstate_workflowtransitions_workflowtransition),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate_workflowtransitions)
+
+const workflow_workflowstates_workflowstateElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates_workflowstate')
+
+const workflow_workflowstates_workflowstate = new ObjectType({
+  elemID: workflow_workflowstates_workflowstateElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflow_workflowstates_workflowstateElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘workflowstate’. */
+    name: new Field(
+      workflow_workflowstates_workflowstateElemID,
+      'name',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the string custom type. */
+    description: new Field(
+      workflow_workflowstates_workflowstateElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    donotexitworkflow: new Field(
+      workflow_workflowstates_workflowstateElemID,
+      'donotexitworkflow',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    positionx: new Field(
+      workflow_workflowstates_workflowstateElemID,
+      'positionx',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    positiony: new Field(
+      workflow_workflowstates_workflowstateElemID,
+      'positiony',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ),
+    workflowactions: new Field(
+      workflow_workflowstates_workflowstateElemID,
+      'workflowactions',
+      new ListType(workflow_workflowstates_workflowstate_workflowactions),
+      {
+      },
+    ),
+    workflowstatecustomfields: new Field(
+      workflow_workflowstates_workflowstateElemID,
+      'workflowstatecustomfields',
+      workflow_workflowstates_workflowstate_workflowstatecustomfields,
+      {
+      },
+    ),
+    workflowtransitions: new Field(
+      workflow_workflowstates_workflowstateElemID,
+      'workflowtransitions',
+      workflow_workflowstates_workflowstate_workflowtransitions,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates_workflowstate)
+
+const workflow_workflowstatesElemID = new ElemID(constants.NETSUITE, 'workflow_workflowstates')
+
+const workflow_workflowstates = new ObjectType({
+  elemID: workflow_workflowstatesElemID,
+  annotations: {
+  },
+  fields: {
+    workflowstate: new Field(
+      workflow_workflowstatesElemID,
+      'workflowstate',
+      new ListType(workflow_workflowstates_workflowstate),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})
+
+workflowInnerTypes.push(workflow_workflowstates)
+
+
+export const workflow = new ObjectType({
+  elemID: workflowElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customworkflow_',
+  },
+  fields: {
+    scriptid: new Field(
+      workflowElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customworkflow’. */
+    name: new Field(
+      workflowElemID,
+      'name',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+      },
+    ), /* Original description: This field accepts references to the string custom type. */
+    recordtypes: new Field(
+      workflowElemID,
+      'recordtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   customtransactiontype   customrecordtype   For information about other possible values, see generic_standard_recordtype. */
+    description: new Field(
+      workflowElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    initcontexts: new Field(
+      workflowElemID,
+      'initcontexts',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see execution_context. */
+    initeventtypes: new Field(
+      workflowElemID,
+      'initeventtypes',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   For information about possible values, see workflow_eventtype. */
+    initsavedsearchcondition: new Field(
+      workflowElemID,
+      'initsavedsearchcondition',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    initsavedsearchfilter: new Field(
+      workflowElemID,
+      'initsavedsearchfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    inittriggertype: new Field(
+      workflowElemID,
+      'inittriggertype',
+      enums.workflow_triggertype,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflow_triggertype. */
+    initoncreate: new Field(
+      workflowElemID,
+      'initoncreate',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    initonvieworupdate: new Field(
+      workflowElemID,
+      'initonvieworupdate',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    isinactive: new Field(
+      workflowElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    islogenabled: new Field(
+      workflowElemID,
+      'islogenabled',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    releasestatus: new Field(
+      workflowElemID,
+      'releasestatus',
+      enums.workflow_releasestatus,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflow_releasestatus.   The default value is 'NOTINITIATING'. */
+    runasadmin: new Field(
+      workflowElemID,
+      'runasadmin',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    keephistory: new Field(
+      workflowElemID,
+      'keephistory',
+      enums.workflow_keephistory,
+      {
+      },
+    ), /* Original description: For information about possible values, see workflow_keephistory.   The default value is 'ONLYWHENTESTING'. */
+    initcondition: new Field(
+      workflowElemID,
+      'initcondition',
+      workflow_initcondition,
+      {
+      },
+    ),
+    recurrence: new Field(
+      workflowElemID,
+      'recurrence',
+      workflow_recurrence,
+      {
+      },
+    ),
+    workflowcustomfields: new Field(
+      workflowElemID,
+      'workflowcustomfields',
+      workflow_workflowcustomfields,
+      {
+      },
+    ),
+    workflowstates: new Field(
+      workflowElemID,
+      'workflowstates',
+      workflow_workflowstates,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/custom_types/workflowactionscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/workflowactionscript.ts
@@ -1,0 +1,781 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import {
+  BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ListType,
+} from '@salto-io/adapter-api'
+import * as constants from '../../constants'
+import { enums } from '../enums'
+
+export const workflowactionscriptInnerTypes: ObjectType[] = []
+
+const workflowactionscriptElemID = new ElemID(constants.NETSUITE, 'workflowactionscript')
+const workflowactionscript_customplugintypes_plugintypeElemID = new ElemID(constants.NETSUITE, 'workflowactionscript_customplugintypes_plugintype')
+
+const workflowactionscript_customplugintypes_plugintype = new ObjectType({
+  elemID: workflowactionscript_customplugintypes_plugintypeElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      workflowactionscript_customplugintypes_plugintypeElemID,
+      'plugintype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the plugintype custom type. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowactionscriptElemID.name],
+})
+
+workflowactionscriptInnerTypes.push(workflowactionscript_customplugintypes_plugintype)
+
+const workflowactionscript_customplugintypesElemID = new ElemID(constants.NETSUITE, 'workflowactionscript_customplugintypes')
+
+const workflowactionscript_customplugintypes = new ObjectType({
+  elemID: workflowactionscript_customplugintypesElemID,
+  annotations: {
+  },
+  fields: {
+    plugintype: new Field(
+      workflowactionscript_customplugintypesElemID,
+      'plugintype',
+      new ListType(workflowactionscript_customplugintypes_plugintype),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowactionscriptElemID.name],
+})
+
+workflowactionscriptInnerTypes.push(workflowactionscript_customplugintypes)
+
+const workflowactionscript_libraries_libraryElemID = new ElemID(constants.NETSUITE, 'workflowactionscript_libraries_library')
+
+const workflowactionscript_libraries_library = new ObjectType({
+  elemID: workflowactionscript_libraries_libraryElemID,
+  annotations: {
+  },
+  fields: {
+    scriptfile: new Field(
+      workflowactionscript_libraries_libraryElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowactionscriptElemID.name],
+})
+
+workflowactionscriptInnerTypes.push(workflowactionscript_libraries_library)
+
+const workflowactionscript_librariesElemID = new ElemID(constants.NETSUITE, 'workflowactionscript_libraries')
+
+const workflowactionscript_libraries = new ObjectType({
+  elemID: workflowactionscript_librariesElemID,
+  annotations: {
+  },
+  fields: {
+    library: new Field(
+      workflowactionscript_librariesElemID,
+      'library',
+      new ListType(workflowactionscript_libraries_library),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowactionscriptElemID.name],
+})
+
+workflowactionscriptInnerTypes.push(workflowactionscript_libraries)
+
+const workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID = new ElemID(constants.NETSUITE, 'workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter')
+
+const workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter = new ObjectType({
+  elemID: workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+  annotations: {
+  },
+  fields: {
+    fldfilter: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilter',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+    fldfilterchecked: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfiltercomparetype: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltercomparetype',
+      enums.generic_customfield_fldfiltercomparetype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fldfiltercomparetype.   The default value is 'EQ'. */
+    fldfiltersel: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfiltersel',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    fldfilterval: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilterval',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    fldfilternotnull: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternotnull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldfilternull: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldfilternull',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    fldcomparefield: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilterElemID,
+      'fldcomparefield',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see generic_standard_field. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowactionscriptElemID.name],
+})
+
+workflowactionscriptInnerTypes.push(workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter)
+
+const workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID = new ElemID(constants.NETSUITE, 'workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters')
+
+const workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters = new ObjectType({
+  elemID: workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+  annotations: {
+  },
+  fields: {
+    customfieldfilter: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfiltersElemID,
+      'customfieldfilter',
+      new ListType(workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters_customfieldfilter),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowactionscriptElemID.name],
+})
+
+workflowactionscriptInnerTypes.push(workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters)
+
+const workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID = new ElemID(constants.NETSUITE, 'workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess')
+
+const workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess = new ObjectType({
+  elemID: workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+  annotations: {
+  },
+  fields: {
+    role: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'role',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see customrecordtype_permittedrole. */
+    accesslevel: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+    searchlevel: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccessElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '0'. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowactionscriptElemID.name],
+})
+
+workflowactionscriptInnerTypes.push(workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess)
+
+const workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID = new ElemID(constants.NETSUITE, 'workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccesses')
+
+const workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccesses = new ObjectType({
+  elemID: workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+  annotations: {
+  },
+  fields: {
+    roleaccess: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccessesElemID,
+      'roleaccess',
+      new ListType(workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccesses_roleaccess),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowactionscriptElemID.name],
+})
+
+workflowactionscriptInnerTypes.push(workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccesses)
+
+const workflowactionscript_scriptcustomfields_scriptcustomfieldElemID = new ElemID(constants.NETSUITE, 'workflowactionscript_scriptcustomfields_scriptcustomfield')
+
+const workflowactionscript_scriptcustomfields_scriptcustomfield = new ObjectType({
+  elemID: workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘custscript’. */
+    fieldtype: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'fieldtype',
+      enums.generic_customfield_fieldtype,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype.   The default value is 'TEXT'. */
+    label: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'label',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+      },
+    ), /* Original description: This field value can be up to 200 characters long. */
+    selectrecordtype: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'selectrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the fieldtype value is equal to any of the following lists or values: SELECT, MULTISELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see generic_customfield_selectrecordtype. */
+    applyformatting: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'applyformatting',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    defaultchecked: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultchecked',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    defaultselection: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultselection',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the following custom types:   scriptdeployment   workflowactionscript   workflowstatecustomfield   workflowcustomfield   workflow   scriptdeployment   usereventscript   transactioncolumncustomfield   transactionbodycustomfield   transactionForm   scriptdeployment   suitelet   scriptdeployment   scheduledscript   savedsearch   role   scriptdeployment   restlet   scriptdeployment   portlet   othercustomfield   scriptdeployment   massupdatescript   scriptdeployment   mapreducescript   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entryForm   entitycustomfield   statuses   customtransactiontype   instance   customrecordcustomfield   customrecordtype   customvalue   crmcustomfield   scriptdeployment   clientscript   scriptdeployment   bundleinstallationscript   advancedpdftemplate   addressForm */
+    defaultvalue: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'defaultvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    displaytype: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaytype',
+      enums.generic_customfield_displaytype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_displaytype.   The default value is 'NORMAL'. */
+    dynamicdefault: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'dynamicdefault',
+      enums.generic_customfield_dynamicdefault,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_dynamicdefault. */
+    help: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'help',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    linktext: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'linktext',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    minvalue: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'minvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    maxvalue: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxvalue',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    storevalue: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'storevalue',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    accesslevel: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'accesslevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    checkspelling: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'checkspelling',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    displayheight: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displayheight',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    displaywidth: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'displaywidth',
+      BuiltinTypes.NUMBER,
+      {
+      },
+    ), /* Original description: This field value must be greater than or equal to 0. */
+    isformula: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'isformula',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    ismandatory: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'ismandatory',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    maxlength: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'maxlength',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    onparentdelete: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'onparentdelete',
+      enums.generic_customfield_onparentdelete,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_onparentdelete. */
+    searchcomparefield: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchcomparefield',
+      enums.generic_standard_field,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_standard_field. */
+    searchdefault: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchdefault',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the savedsearch custom type. */
+    searchlevel: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'searchlevel',
+      enums.generic_accesslevel_searchlevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_accesslevel_searchlevel.   The default value is '2'. */
+    setting: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'setting',
+      enums.script_setting,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_setting. */
+    customfieldfilters: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'customfieldfilters',
+      workflowactionscript_scriptcustomfields_scriptcustomfield_customfieldfilters,
+      {
+      },
+    ),
+    roleaccesses: new Field(
+      workflowactionscript_scriptcustomfields_scriptcustomfieldElemID,
+      'roleaccesses',
+      workflowactionscript_scriptcustomfields_scriptcustomfield_roleaccesses,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowactionscriptElemID.name],
+})
+
+workflowactionscriptInnerTypes.push(workflowactionscript_scriptcustomfields_scriptcustomfield)
+
+const workflowactionscript_scriptcustomfieldsElemID = new ElemID(constants.NETSUITE, 'workflowactionscript_scriptcustomfields')
+
+const workflowactionscript_scriptcustomfields = new ObjectType({
+  elemID: workflowactionscript_scriptcustomfieldsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptcustomfield: new Field(
+      workflowactionscript_scriptcustomfieldsElemID,
+      'scriptcustomfield',
+      new ListType(workflowactionscript_scriptcustomfields_scriptcustomfield),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowactionscriptElemID.name],
+})
+
+workflowactionscriptInnerTypes.push(workflowactionscript_scriptcustomfields)
+
+const workflowactionscript_scriptdeployments_scriptdeploymentElemID = new ElemID(constants.NETSUITE, 'workflowactionscript_scriptdeployments_scriptdeployment')
+
+const workflowactionscript_scriptdeployments_scriptdeployment = new ObjectType({
+  elemID: workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+  annotations: {
+  },
+  fields: {
+    scriptid: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customdeploy’. */
+    status: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'status',
+      enums.script_status,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: For information about possible values, see script_status.   The default value is 'TESTING'. */
+    recordtype: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'recordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field accepts references to the following custom types:   customtransactiontype   customrecordtype   For information about other possible values, see the following lists:   scriptdeployment_recordtype   allrecord_script_deployment_recordtype */
+    allemployees: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'allemployees',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    allpartners: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'allpartners',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account. */
+    allroles: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'allroles',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    auddepartment: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'auddepartment',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the DEPARTMENTS feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. DEPARTMENTS must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    audemployee: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'audemployee',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   Note Account-specific values are not supported by SDF. */
+    audgroup: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'audgroup',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   Note Account-specific values are not supported by SDF. */
+    audpartner: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'audpartner',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the CRM feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. CRM must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    audslctrole: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'audslctrole',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+    audsubsidiary: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'audsubsidiary',
+      BuiltinTypes.STRING /* Original type was multi-select list */,
+      {
+      },
+    ), /* Original description: You can specify multiple values by separating each value with a pipe (|) symbol.   If this field appears in the project, you must reference the SUBSIDIARIES feature in the manifest file to avoid project warnings. In the manifest file, you can specify whether this feature is required in your account. SUBSIDIARIES must be enabled for this field to appear in your account.   Note Account-specific values are not supported by SDF. */
+    isdeployed: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'isdeployed',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    loglevel: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'loglevel',
+      enums.script_loglevel,
+      {
+      },
+    ), /* Original description: For information about possible values, see script_loglevel.   The default value is 'DEBUG'. */
+    runasrole: new Field(
+      workflowactionscript_scriptdeployments_scriptdeploymentElemID,
+      'runasrole',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field accepts references to the role custom type.   For information about other possible values, see generic_role. */
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowactionscriptElemID.name],
+})
+
+workflowactionscriptInnerTypes.push(workflowactionscript_scriptdeployments_scriptdeployment)
+
+const workflowactionscript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'workflowactionscript_scriptdeployments')
+
+const workflowactionscript_scriptdeployments = new ObjectType({
+  elemID: workflowactionscript_scriptdeploymentsElemID,
+  annotations: {
+  },
+  fields: {
+    scriptdeployment: new Field(
+      workflowactionscript_scriptdeploymentsElemID,
+      'scriptdeployment',
+      new ListType(workflowactionscript_scriptdeployments_scriptdeployment),
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowactionscriptElemID.name],
+})
+
+workflowactionscriptInnerTypes.push(workflowactionscript_scriptdeployments)
+
+
+export const workflowactionscript = new ObjectType({
+  elemID: workflowactionscriptElemID,
+  annotations: {
+    [constants.SCRIPT_ID_PREFIX]: 'customscript_',
+  },
+  fields: {
+    scriptid: new Field(
+      workflowactionscriptElemID,
+      'scriptid',
+      BuiltinTypes.SERVICE_ID,
+      {
+        [constants.IS_ATTRIBUTE]: true,
+      },
+    ), /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
+    name: new Field(
+      workflowactionscriptElemID,
+      'name',
+      BuiltinTypes.STRING,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+        [constants.IS_NAME]: true,
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+      },
+    ), /* Original description: This field value can be up to 40 characters long. */
+    scriptfile: new Field(
+      workflowactionscriptElemID,
+      'scriptfile',
+      BuiltinTypes.STRING /* Original type was filereference */,
+      {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    ), /* Original description: This field must reference a .js file. */
+    returnrecordtype: new Field(
+      workflowactionscriptElemID,
+      'returnrecordtype',
+      BuiltinTypes.STRING /* Original type was single-select list */,
+      {
+      },
+    ), /* Original description: This field is mandatory when the returntype value is equal to SELECT.   This field accepts references to the following custom types:   customrecordtype   customlist   For information about other possible values, see script_returnrecordtype. */
+    defaultfunction: new Field(
+      workflowactionscriptElemID,
+      'defaultfunction',
+      BuiltinTypes.STRING,
+      {
+      },
+    ),
+    description: new Field(
+      workflowactionscriptElemID,
+      'description',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    isinactive: new Field(
+      workflowactionscriptElemID,
+      'isinactive',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyadmins: new Field(
+      workflowactionscriptElemID,
+      'notifyadmins',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    notifyemails: new Field(
+      workflowactionscriptElemID,
+      'notifyemails',
+      BuiltinTypes.STRING,
+      {
+        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+      },
+    ), /* Original description: This field value can be up to 999 characters long. */
+    notifygroup: new Field(
+      workflowactionscriptElemID,
+      'notifygroup',
+      BuiltinTypes.STRING,
+      {
+      },
+    ), /* Original description: Note Account-specific values are not supported by SDF. */
+    notifyowner: new Field(
+      workflowactionscriptElemID,
+      'notifyowner',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is T. */
+    notifyuser: new Field(
+      workflowactionscriptElemID,
+      'notifyuser',
+      BuiltinTypes.BOOLEAN,
+      {
+      },
+    ), /* Original description: The default value is F. */
+    returntype: new Field(
+      workflowactionscriptElemID,
+      'returntype',
+      enums.generic_customfield_fieldtype,
+      {
+      },
+    ), /* Original description: For information about possible values, see generic_customfield_fieldtype. */
+    customplugintypes: new Field(
+      workflowactionscriptElemID,
+      'customplugintypes',
+      workflowactionscript_customplugintypes,
+      {
+      },
+    ),
+    libraries: new Field(
+      workflowactionscriptElemID,
+      'libraries',
+      workflowactionscript_libraries,
+      {
+      },
+    ),
+    scriptcustomfields: new Field(
+      workflowactionscriptElemID,
+      'scriptcustomfields',
+      workflowactionscript_scriptcustomfields,
+      {
+      },
+    ),
+    scriptdeployments: new Field(
+      workflowactionscriptElemID,
+      'scriptdeployments',
+      workflowactionscript_scriptdeployments,
+      {
+      },
+    ),
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, workflowactionscriptElemID.name],
+})

--- a/packages/netsuite-adapter/src/types/enums.ts
+++ b/packages/netsuite-adapter/src/types/enums.ts
@@ -1,0 +1,2095 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/camelcase */
+import { CORE_ANNOTATIONS, createRestriction, ElemID, PrimitiveType, PrimitiveTypes } from '@salto-io/adapter-api'
+import * as constants from '../constants'
+
+const enumsFolderPath = [constants.NETSUITE, constants.TYPES_PATH, constants.SUBTYPES_PATH]
+
+const addressform_fieldidElemID = new ElemID(constants.NETSUITE, 'addressform_fieldid')
+const advancedpdftemplate_standardElemID = new ElemID(constants.NETSUITE, 'advancedpdftemplate_standard')
+const allrecord_script_deployment_recordtypeElemID = new ElemID(constants.NETSUITE, 'allrecord_script_deployment_recordtype')
+const centercategory_tasktypeElemID = new ElemID(constants.NETSUITE, 'centercategory_tasktype')
+const configurable_featuresElemID = new ElemID(constants.NETSUITE, 'configurable_features')
+const countriesElemID = new ElemID(constants.NETSUITE, 'countries')
+const crmcustomfield_searchcomparefieldElemID = new ElemID(constants.NETSUITE, 'crmcustomfield_searchcomparefield')
+const csvimport_columndelimiterElemID = new ElemID(constants.NETSUITE, 'csvimport_columndelimiter')
+const csvimport_customrecordtypeElemID = new ElemID(constants.NETSUITE, 'csvimport_customrecordtype')
+const csvimport_customtransactiontypeElemID = new ElemID(constants.NETSUITE, 'csvimport_customtransactiontype')
+const csvimport_datahandlingElemID = new ElemID(constants.NETSUITE, 'csvimport_datahandling')
+const csvimport_decimaldelimiterElemID = new ElemID(constants.NETSUITE, 'csvimport_decimaldelimiter')
+const csvimport_encodingElemID = new ElemID(constants.NETSUITE, 'csvimport_encoding')
+const csvimport_entryform_standardElemID = new ElemID(constants.NETSUITE, 'csvimport_entryform_standard')
+const csvimport_recordtypesElemID = new ElemID(constants.NETSUITE, 'csvimport_recordtypes')
+const csvimport_referencetypeElemID = new ElemID(constants.NETSUITE, 'csvimport_referencetype')
+const csvimport_transactionform_standardElemID = new ElemID(constants.NETSUITE, 'csvimport_transactionform_standard')
+const csvimports_entryformrecordtypesElemID = new ElemID(constants.NETSUITE, 'csvimports_entryformrecordtypes')
+const csvimports_transactionformrecordtypesElemID = new ElemID(constants.NETSUITE, 'csvimports_transactionformrecordtypes')
+const customrecordtype_accesstypeElemID = new ElemID(constants.NETSUITE, 'customrecordtype_accesstype')
+const customrecordtype_permission_restrictionElemID = new ElemID(constants.NETSUITE, 'customrecordtype_permission_restriction')
+const customrecordtype_permittedlevelElemID = new ElemID(constants.NETSUITE, 'customrecordtype_permittedlevel')
+const customrecordtype_permittedroleElemID = new ElemID(constants.NETSUITE, 'customrecordtype_permittedrole')
+const customrecordtype_tasktypeElemID = new ElemID(constants.NETSUITE, 'customrecordtype_tasktype')
+const customsegment_access_search_levelElemID = new ElemID(constants.NETSUITE, 'customsegment_access_search_level')
+const customsegment_crm_application_idElemID = new ElemID(constants.NETSUITE, 'customsegment_crm_application_id')
+const customsegment_crm_sourcelistElemID = new ElemID(constants.NETSUITE, 'customsegment_crm_sourcelist')
+const customsegment_entities_application_idElemID = new ElemID(constants.NETSUITE, 'customsegment_entities_application_id')
+const customsegment_entities_sourcelistElemID = new ElemID(constants.NETSUITE, 'customsegment_entities_sourcelist')
+const customsegment_fieldtypeElemID = new ElemID(constants.NETSUITE, 'customsegment_fieldtype')
+const customsegment_items_application_idElemID = new ElemID(constants.NETSUITE, 'customsegment_items_application_id')
+const customsegment_items_sourcelistElemID = new ElemID(constants.NETSUITE, 'customsegment_items_sourcelist')
+const customsegment_items_subtypeElemID = new ElemID(constants.NETSUITE, 'customsegment_items_subtype')
+const customsegment_otherrecords_application_idElemID = new ElemID(constants.NETSUITE, 'customsegment_otherrecords_application_id')
+const customsegment_parentElemID = new ElemID(constants.NETSUITE, 'customsegment_parent')
+const customsegment_transactionbody_application_idElemID = new ElemID(constants.NETSUITE, 'customsegment_transactionbody_application_id')
+const customsegment_transactionbody_sourcelistElemID = new ElemID(constants.NETSUITE, 'customsegment_transactionbody_sourcelist')
+const customsegment_transactionline_application_idElemID = new ElemID(constants.NETSUITE, 'customsegment_transactionline_application_id')
+const customsegment_transactionline_sourcelistElemID = new ElemID(constants.NETSUITE, 'customsegment_transactionline_sourcelist')
+const customsegment_valuesdisplayorderElemID = new ElemID(constants.NETSUITE, 'customsegment_valuesdisplayorder')
+const customtransactiontype_classification_positionElemID = new ElemID(constants.NETSUITE, 'customtransactiontype_classification_position')
+const customtransactiontype_creditsupportstylesElemID = new ElemID(constants.NETSUITE, 'customtransactiontype_creditsupportstyles')
+const customtransactiontype_filterbyaccounttypeElemID = new ElemID(constants.NETSUITE, 'customtransactiontype_filterbyaccounttype')
+const customtransactiontype_statuses_idElemID = new ElemID(constants.NETSUITE, 'customtransactiontype_statuses_id')
+const customtransactiontype_subliststyleElemID = new ElemID(constants.NETSUITE, 'customtransactiontype_subliststyle')
+const customtransactiontype_subliststyle_salesandpurchaseElemID = new ElemID(constants.NETSUITE, 'customtransactiontype_subliststyle_salesandpurchase')
+const dashboard_layoutElemID = new ElemID(constants.NETSUITE, 'dashboard_layout')
+const dashboard_modeElemID = new ElemID(constants.NETSUITE, 'dashboard_mode')
+const emailtemplate_recordtypeElemID = new ElemID(constants.NETSUITE, 'emailtemplate_recordtype')
+const engine_versionsElemID = new ElemID(constants.NETSUITE, 'engine_versions')
+const entryform_buttonidElemID = new ElemID(constants.NETSUITE, 'entryform_buttonid')
+const entryform_fieldidElemID = new ElemID(constants.NETSUITE, 'entryform_fieldid')
+const entryform_standardElemID = new ElemID(constants.NETSUITE, 'entryform_standard')
+const entryform_sublistidElemID = new ElemID(constants.NETSUITE, 'entryform_sublistid')
+const entryform_subtabidElemID = new ElemID(constants.NETSUITE, 'entryform_subtabid')
+const entryform_tabidElemID = new ElemID(constants.NETSUITE, 'entryform_tabid')
+const execution_contextElemID = new ElemID(constants.NETSUITE, 'execution_context')
+const feature_statusElemID = new ElemID(constants.NETSUITE, 'feature_status')
+const featuresElemID = new ElemID(constants.NETSUITE, 'features')
+const forbidden_featuresElemID = new ElemID(constants.NETSUITE, 'forbidden_features')
+const form_buttonstyleElemID = new ElemID(constants.NETSUITE, 'form_buttonstyle')
+const form_displaytypeElemID = new ElemID(constants.NETSUITE, 'form_displaytype')
+const form_fieldpositionElemID = new ElemID(constants.NETSUITE, 'form_fieldposition')
+const generic_accesslevel_searchlevelElemID = new ElemID(constants.NETSUITE, 'generic_accesslevel_searchlevel')
+const generic_body_tabElemID = new ElemID(constants.NETSUITE, 'generic_body_tab')
+const generic_centercategoryElemID = new ElemID(constants.NETSUITE, 'generic_centercategory')
+const generic_centertabElemID = new ElemID(constants.NETSUITE, 'generic_centertab')
+const generic_centertypeElemID = new ElemID(constants.NETSUITE, 'generic_centertype')
+const generic_crm_tabElemID = new ElemID(constants.NETSUITE, 'generic_crm_tab')
+const generic_custom_record_iconElemID = new ElemID(constants.NETSUITE, 'generic_custom_record_icon')
+const generic_customfield_displaytypeElemID = new ElemID(constants.NETSUITE, 'generic_customfield_displaytype')
+const generic_customfield_dynamicdefaultElemID = new ElemID(constants.NETSUITE, 'generic_customfield_dynamicdefault')
+const generic_customfield_fieldtypeElemID = new ElemID(constants.NETSUITE, 'generic_customfield_fieldtype')
+const generic_customfield_fldfiltercomparetypeElemID = new ElemID(constants.NETSUITE, 'generic_customfield_fldfiltercomparetype')
+const generic_customfield_onparentdeleteElemID = new ElemID(constants.NETSUITE, 'generic_customfield_onparentdelete')
+const generic_customfield_parentsubtabElemID = new ElemID(constants.NETSUITE, 'generic_customfield_parentsubtab')
+const generic_customfield_selectrecordtypeElemID = new ElemID(constants.NETSUITE, 'generic_customfield_selectrecordtype')
+const generic_customrecordothercustomfield_fieldElemID = new ElemID(constants.NETSUITE, 'generic_customrecordothercustomfield_field')
+const generic_customrecordothercustomfield_rectypeElemID = new ElemID(constants.NETSUITE, 'generic_customrecordothercustomfield_rectype')
+const generic_day_of_monthElemID = new ElemID(constants.NETSUITE, 'generic_day_of_month')
+const generic_day_of_weekElemID = new ElemID(constants.NETSUITE, 'generic_day_of_week')
+const generic_entity_tabElemID = new ElemID(constants.NETSUITE, 'generic_entity_tab')
+const generic_item_tabElemID = new ElemID(constants.NETSUITE, 'generic_item_tab')
+const generic_itemoptionitemcol_fieldElemID = new ElemID(constants.NETSUITE, 'generic_itemoptionitemcol_field')
+const generic_itemoptionitemcol_fieldtypeElemID = new ElemID(constants.NETSUITE, 'generic_itemoptionitemcol_fieldtype')
+const generic_itemoptionitemcol_searchcomparefieldElemID = new ElemID(constants.NETSUITE, 'generic_itemoptionitemcol_searchcomparefield')
+const generic_monthElemID = new ElemID(constants.NETSUITE, 'generic_month')
+const generic_order_of_weekElemID = new ElemID(constants.NETSUITE, 'generic_order_of_week')
+const generic_permissionElemID = new ElemID(constants.NETSUITE, 'generic_permission')
+const generic_permission_levelElemID = new ElemID(constants.NETSUITE, 'generic_permission_level')
+const generic_portletElemID = new ElemID(constants.NETSUITE, 'generic_portlet')
+const generic_portletcolumnElemID = new ElemID(constants.NETSUITE, 'generic_portletcolumn')
+const generic_repeat_timeElemID = new ElemID(constants.NETSUITE, 'generic_repeat_time')
+const generic_repeat_time_in_minutesElemID = new ElemID(constants.NETSUITE, 'generic_repeat_time_in_minutes')
+const generic_roleElemID = new ElemID(constants.NETSUITE, 'generic_role')
+const generic_savedsearches_daterangeElemID = new ElemID(constants.NETSUITE, 'generic_savedsearches_daterange')
+const generic_savedsearches_periodElemID = new ElemID(constants.NETSUITE, 'generic_savedsearches_period')
+const generic_standard_fieldElemID = new ElemID(constants.NETSUITE, 'generic_standard_field')
+const generic_standard_recordtypeElemID = new ElemID(constants.NETSUITE, 'generic_standard_recordtype')
+const generic_standard_taskElemID = new ElemID(constants.NETSUITE, 'generic_standard_task')
+const generic_standard_templateElemID = new ElemID(constants.NETSUITE, 'generic_standard_template')
+const generic_standard_transactionsElemID = new ElemID(constants.NETSUITE, 'generic_standard_transactions')
+const generic_tab_parentElemID = new ElemID(constants.NETSUITE, 'generic_tab_parent')
+const generic_tab_typeElemID = new ElemID(constants.NETSUITE, 'generic_tab_type')
+const generic_taskElemID = new ElemID(constants.NETSUITE, 'generic_task')
+const generic_year_monthElemID = new ElemID(constants.NETSUITE, 'generic_year_month')
+const hiding_actionsElemID = new ElemID(constants.NETSUITE, 'hiding_actions')
+const itemcustomfield_itemsubtypeElemID = new ElemID(constants.NETSUITE, 'itemcustomfield_itemsubtype')
+const itemnumbercustomfield_fieldElemID = new ElemID(constants.NETSUITE, 'itemnumbercustomfield_field')
+const kpi_ranges_daterangeElemID = new ElemID(constants.NETSUITE, 'kpi_ranges_daterange')
+const kpi_ranges_daterange_or_periodElemID = new ElemID(constants.NETSUITE, 'kpi_ranges_daterange_or_period')
+const kpi_ranges_daterange_reportElemID = new ElemID(constants.NETSUITE, 'kpi_ranges_daterange_report')
+const kpi_ranges_periodElemID = new ElemID(constants.NETSUITE, 'kpi_ranges_period')
+const kpi_snapshots_customElemID = new ElemID(constants.NETSUITE, 'kpi_snapshots_custom')
+const kpi_snapshots_daterangeElemID = new ElemID(constants.NETSUITE, 'kpi_snapshots_daterange')
+const kpi_snapshots_daterange_or_periodElemID = new ElemID(constants.NETSUITE, 'kpi_snapshots_daterange_or_period')
+const kpi_snapshots_formulaElemID = new ElemID(constants.NETSUITE, 'kpi_snapshots_formula')
+const kpi_snapshots_internalElemID = new ElemID(constants.NETSUITE, 'kpi_snapshots_internal')
+const kpiscorecards_comparisonsElemID = new ElemID(constants.NETSUITE, 'kpiscorecards_comparisons')
+const kpiscorecards_highlight_conditionsElemID = new ElemID(constants.NETSUITE, 'kpiscorecards_highlight_conditions')
+const kpiscorecards_highlight_iconsElemID = new ElemID(constants.NETSUITE, 'kpiscorecards_highlight_icons')
+const kpiscorecards_useperiodsElemID = new ElemID(constants.NETSUITE, 'kpiscorecards_useperiods')
+const locking_actionsElemID = new ElemID(constants.NETSUITE, 'locking_actions')
+const plugintype_deployment_modelElemID = new ElemID(constants.NETSUITE, 'plugintype_deployment_model')
+const plugintype_loglevelElemID = new ElemID(constants.NETSUITE, 'plugintype_loglevel')
+const plugintype_statusElemID = new ElemID(constants.NETSUITE, 'plugintype_status')
+const portlet_calendar_agendaElemID = new ElemID(constants.NETSUITE, 'portlet_calendar_agenda')
+const portlet_customsearch_backgroundtypeElemID = new ElemID(constants.NETSUITE, 'portlet_customsearch_backgroundtype')
+const portlet_customsearch_chartthemeElemID = new ElemID(constants.NETSUITE, 'portlet_customsearch_charttheme')
+const portlet_customsearch_drilldownElemID = new ElemID(constants.NETSUITE, 'portlet_customsearch_drilldown')
+const portlet_customsearch_savedsearchElemID = new ElemID(constants.NETSUITE, 'portlet_customsearch_savedsearch')
+const portlet_kpi_employeesElemID = new ElemID(constants.NETSUITE, 'portlet_kpi_employees')
+const portlet_kpi_highlightifElemID = new ElemID(constants.NETSUITE, 'portlet_kpi_highlightif')
+const portlet_kpimeter_combined_snapshotsElemID = new ElemID(constants.NETSUITE, 'portlet_kpimeter_combined_snapshots')
+const portlet_list_typeElemID = new ElemID(constants.NETSUITE, 'portlet_list_type')
+const portlet_quicksearch_genericElemID = new ElemID(constants.NETSUITE, 'portlet_quicksearch_generic')
+const portlet_quicksearch_transactionElemID = new ElemID(constants.NETSUITE, 'portlet_quicksearch_transaction')
+const portlet_quicksearch_typeElemID = new ElemID(constants.NETSUITE, 'portlet_quicksearch_type')
+const portlet_trendgraph_backgroundtypeElemID = new ElemID(constants.NETSUITE, 'portlet_trendgraph_backgroundtype')
+const portlet_trendgraph_chartthemeElemID = new ElemID(constants.NETSUITE, 'portlet_trendgraph_charttheme')
+const portlet_trendgraph_charttypeElemID = new ElemID(constants.NETSUITE, 'portlet_trendgraph_charttype')
+const portlet_trendgraph_trendtypeElemID = new ElemID(constants.NETSUITE, 'portlet_trendgraph_trendtype')
+const reminders_highlighting_rules_colorsElemID = new ElemID(constants.NETSUITE, 'reminders_highlighting_rules_colors')
+const reminders_standard_reminders_with_daysElemID = new ElemID(constants.NETSUITE, 'reminders_standard_reminders_with_days')
+const reminders_standard_reminders_without_daysElemID = new ElemID(constants.NETSUITE, 'reminders_standard_reminders_without_days')
+const report_date_rangeElemID = new ElemID(constants.NETSUITE, 'report_date_range')
+const report_period_rangeElemID = new ElemID(constants.NETSUITE, 'report_period_range')
+const role_centertypeElemID = new ElemID(constants.NETSUITE, 'role_centertype')
+const role_fullrestrictionsElemID = new ElemID(constants.NETSUITE, 'role_fullrestrictions')
+const role_restrictElemID = new ElemID(constants.NETSUITE, 'role_restrict')
+const role_restrictionsElemID = new ElemID(constants.NETSUITE, 'role_restrictions')
+const role_restrictionsegmentElemID = new ElemID(constants.NETSUITE, 'role_restrictionsegment')
+const script_deploymentmodelElemID = new ElemID(constants.NETSUITE, 'script_deploymentmodel')
+const script_eventtypeElemID = new ElemID(constants.NETSUITE, 'script_eventtype')
+const script_frequencyElemID = new ElemID(constants.NETSUITE, 'script_frequency')
+const script_loglevelElemID = new ElemID(constants.NETSUITE, 'script_loglevel')
+const script_portlettypeElemID = new ElemID(constants.NETSUITE, 'script_portlettype')
+const script_recurrenceminutesElemID = new ElemID(constants.NETSUITE, 'script_recurrenceminutes')
+const script_returnrecordtypeElemID = new ElemID(constants.NETSUITE, 'script_returnrecordtype')
+const script_scripttypeElemID = new ElemID(constants.NETSUITE, 'script_scripttype')
+const script_settingElemID = new ElemID(constants.NETSUITE, 'script_setting')
+const script_starttimeElemID = new ElemID(constants.NETSUITE, 'script_starttime')
+const script_statusElemID = new ElemID(constants.NETSUITE, 'script_status')
+const scriptdeployment_recordtypeElemID = new ElemID(constants.NETSUITE, 'scriptdeployment_recordtype')
+const snapshot_type_customElemID = new ElemID(constants.NETSUITE, 'snapshot_type_custom')
+const snapshot_type_date_range_comparableElemID = new ElemID(constants.NETSUITE, 'snapshot_type_date_range_comparable')
+const snapshot_type_date_range_not_comparableElemID = new ElemID(constants.NETSUITE, 'snapshot_type_date_range_not_comparable')
+const snapshot_type_period_range_comparableElemID = new ElemID(constants.NETSUITE, 'snapshot_type_period_range_comparable')
+const snapshot_type_period_range_not_comparableElemID = new ElemID(constants.NETSUITE, 'snapshot_type_period_range_not_comparable')
+const snapshot_type_trendgraphElemID = new ElemID(constants.NETSUITE, 'snapshot_type_trendgraph')
+const sublist_standard_fieldsElemID = new ElemID(constants.NETSUITE, 'sublist_standard_fields')
+const suiteletdeployment_tasktypeElemID = new ElemID(constants.NETSUITE, 'suiteletdeployment_tasktype')
+const transactionform_advancedtemplateElemID = new ElemID(constants.NETSUITE, 'transactionform_advancedtemplate')
+const transactionform_buttonidElemID = new ElemID(constants.NETSUITE, 'transactionform_buttonid')
+const transactionform_checkboxdefaultElemID = new ElemID(constants.NETSUITE, 'transactionform_checkboxdefault')
+const transactionform_columnidElemID = new ElemID(constants.NETSUITE, 'transactionform_columnid')
+const transactionform_fieldidElemID = new ElemID(constants.NETSUITE, 'transactionform_fieldid')
+const transactionform_htmllayoutElemID = new ElemID(constants.NETSUITE, 'transactionform_htmllayout')
+const transactionform_pdflayoutElemID = new ElemID(constants.NETSUITE, 'transactionform_pdflayout')
+const transactionform_standardElemID = new ElemID(constants.NETSUITE, 'transactionform_standard')
+const transactionform_sublistidElemID = new ElemID(constants.NETSUITE, 'transactionform_sublistid')
+const transactionform_subtabidElemID = new ElemID(constants.NETSUITE, 'transactionform_subtabid')
+const transactionform_tabidElemID = new ElemID(constants.NETSUITE, 'transactionform_tabid')
+const translationcollection_defaultlanguageElemID = new ElemID(constants.NETSUITE, 'translationcollection_defaultlanguage')
+const webapp_entrytypeElemID = new ElemID(constants.NETSUITE, 'webapp_entrytype')
+const workflow_condition_typeElemID = new ElemID(constants.NETSUITE, 'workflow_condition_type')
+const workflow_eventtypeElemID = new ElemID(constants.NETSUITE, 'workflow_eventtype')
+const workflow_keephistoryElemID = new ElemID(constants.NETSUITE, 'workflow_keephistory')
+const workflow_order_of_weekElemID = new ElemID(constants.NETSUITE, 'workflow_order_of_week')
+const workflow_releasestatusElemID = new ElemID(constants.NETSUITE, 'workflow_releasestatus')
+const workflow_sublistsElemID = new ElemID(constants.NETSUITE, 'workflow_sublists')
+const workflow_timeunitElemID = new ElemID(constants.NETSUITE, 'workflow_timeunit')
+const workflow_triggertypeElemID = new ElemID(constants.NETSUITE, 'workflow_triggertype')
+const workflowaction_attachmenttypeElemID = new ElemID(constants.NETSUITE, 'workflowaction_attachmenttype')
+const workflowaction_buttonidElemID = new ElemID(constants.NETSUITE, 'workflowaction_buttonid')
+const workflowaction_createline_positionElemID = new ElemID(constants.NETSUITE, 'workflowaction_createline_position')
+const workflowaction_displaytypeElemID = new ElemID(constants.NETSUITE, 'workflowaction_displaytype')
+const workflowaction_eventtypeElemID = new ElemID(constants.NETSUITE, 'workflowaction_eventtype')
+const workflowaction_radioschedulemodeElemID = new ElemID(constants.NETSUITE, 'workflowaction_radioschedulemode')
+const workflowaction_recipienttypeElemID = new ElemID(constants.NETSUITE, 'workflowaction_recipienttype')
+const workflowaction_sendertypeElemID = new ElemID(constants.NETSUITE, 'workflowaction_sendertype')
+const workflowaction_transtatementtypeElemID = new ElemID(constants.NETSUITE, 'workflowaction_transtatementtype')
+const workflowaction_triggertypeElemID = new ElemID(constants.NETSUITE, 'workflowaction_triggertype')
+const workflowaction_triggertype_clientElemID = new ElemID(constants.NETSUITE, 'workflowaction_triggertype_client')
+const workflowaction_valuedateElemID = new ElemID(constants.NETSUITE, 'workflowaction_valuedate')
+const workflowaction_valuetypeElemID = new ElemID(constants.NETSUITE, 'workflowaction_valuetype')
+const workflowtransition_triggertypeElemID = new ElemID(constants.NETSUITE, 'workflowtransition_triggertype')
+
+export const enums: Record<string, PrimitiveType> = {
+  addressform_fieldid: new PrimitiveType({
+    elemID: addressform_fieldidElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ADDR1', 'ADDR2', 'ADDR3', 'ADDRESSEE', 'ADDRPHONE', 'ATTENTION', 'CITY', 'COUNTRY', 'STATE', 'ZIP'] }),
+    },
+    path: [...enumsFolderPath, addressform_fieldidElemID.name],
+  }),
+  advancedpdftemplate_standard: new PrimitiveType({
+    elemID: advancedpdftemplate_standardElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['OLDSTDTMPLPACKINGSLIP', 'STDTMPLAUVENDPYMT', 'STDTMPLAUVOUCHERCHECK', 'STDTMPLBCUSTTRAN', 'STDTMPLBOM', 'STDTMPLCASHRFND', 'STDTMPLCASHRFNDST', 'STDTMPLCASHSALE', 'STDTMPLCASHSALEST', 'STDTMPLCHECK', 'STDTMPLCUSTCRED', 'STDTMPLCUSTCREDST', 'STDTMPLCUSTDEP', 'STDTMPLCUSTINVC', 'STDTMPLCUSTINVCST', 'STDTMPLCUSTPYMT', 'STDTMPLEMPTY', 'STDTMPLEXPREPT', 'STDTMPLFRPICKINGTICKET', 'STDTMPLGLIMPACT', 'STDTMPLHCUSTTRAN', 'STDTMPLINVCGROUP2ST', 'STDTMPLINVCGROUPST', 'STDTMPLITEMLABEL', 'STDTMPLJCUSTTRAN', 'STDTMPLJOURNAL', 'STDTMPLMAILINGLABEL', 'STDTMPLMULTICURRSTMT', 'STDTMPLPACKINGSLIP', 'STDTMPLPAYCHECK', 'STDTMPLPAYMENTVOUCHER', 'STDTMPLPCUSTTRAN', 'STDTMPLPERIODENDJOURNAL', 'STDTMPLPICKINGTICKET', 'STDTMPLPRICELIST', 'STDTMPLPURCHORD', 'STDTMPLPURCHORDST', 'STDTMPLQUOTE', 'STDTMPLQUOTEST', 'STDTMPLRTNAUTH', 'STDTMPLRTNAUTHST', 'STDTMPLSALESORD', 'STDTMPLSALESORDST', 'STDTMPLSCUSTTRAN', 'STDTMPLSHIPPINGLABEL', 'STDTMPLSTATEMENT', 'STDTMPLSVPREP', 'STDTMPLUKCHECK', 'STDTMPLUKVENDPYMT', 'STDTMPLUKVOUCHERCHECK', 'STDTMPLUSVENDPYMT', 'STDTMPLUSVOUCHERCHECK', 'STDTMPLWAVE'] }),
+    },
+    path: [...enumsFolderPath, advancedpdftemplate_standardElemID.name],
+  }),
+  allrecord_script_deployment_recordtype: new PrimitiveType({
+    elemID: allrecord_script_deployment_recordtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['RECORD'] }),
+    },
+    path: [...enumsFolderPath, allrecord_script_deployment_recordtypeElemID.name],
+  }),
+  centercategory_tasktype: new PrimitiveType({
+    elemID: centercategory_tasktypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CARD', 'EDIT', 'LIST', 'SCRIPT', 'SRCH', 'SRCH_FORM', 'SRCH_RSLT'] }),
+    },
+    path: [...enumsFolderPath, centercategory_tasktypeElemID.name],
+  }),
+  configurable_features: new PrimitiveType({
+    elemID: configurable_featuresElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNTING', 'ACCOUNTINGPERIODS', 'ACHVEND', 'ACTIVITYCODES', 'ADDONS', 'ADMINKERNELPERM', 'ADVANCEDBILLOFMATERIALS', 'ADVANCEDEMPLOYEEPERMISSIONS', 'ADVANCEDGVMNTISSUEDIDTRACKING', 'ADVANCEDJOBS', 'ADVANCEDPRINTING', 'ADVANCEDPROJECTACCOUNTING', 'ADVANCEDREVENUERECOGNITION', 'ADVANCEDSITECUST', 'ADVANCEDSITEMANAGEMENT', 'ADVBILLING', 'ADVBINSERIALLOTMGMT', 'ADVFORECASTING', 'ADVINVENTORYMGMT', 'ADVPARTNERACCESS', 'ADVRECEIVING', 'ADVSHIPPING', 'ADVSUBSCRIPTIONBILLING', 'ADVTAXENGINE', 'ADVWEBREPORTS', 'ADVWEBSEARCH', 'ALTSALESAMOUNT', 'AMORTIZATION', 'APPROVALROUTING', 'ASSEMBLIES', 'ASYNCCUSTOMER', 'ASYNCSALESORDER', 'AUTOAPPLYPROMOTIONS', 'AUTOLOCATIONASSIGNMENT', 'AVAILABLETOPROMISE', 'BALANCING_SEGMENTS', 'BARCODES', 'BASICGVMNTISSUEDIDTRACKING', 'BILLINGACCOUNTS', 'BILLINGCLASSES', 'BILLINGRATECARDS', 'BILLINGWORKCENTER', 'BILLSCOSTS', 'BINMANAGEMENT', 'BLANKETPURCHASEORDERS', 'CAMPAIGNSUBSCRIPTIONS', 'CCTRACKING', 'CHARGEBASEDBILLING', 'CHECKOUTSUBDOMAIN', 'CLASSES', 'COMMERCECATEGORIES', 'COMMERCESEARCHANALYTICS', 'COMMISSIONONCUSTOMFIELDS', 'COMMISSIONS', 'COMPENSATIONTRACKING', 'CONSOLPAYMENTS', 'CREATESUITEBUNDLES', 'CRM', 'CRMTIME', 'CRM_TEMPLATE_CATEGORIES', 'CROSSSUBSIDIARYFULFILLMENT', 'CUSTOMCODE', 'CUSTOMERACCESS', 'CUSTOMGLLINES', 'CUSTOMRECORDS', 'CUSTOMSEGMENTS', 'CUSTOMTRANSACTIONS', 'DEPARTMENTS', 'DISTRIBUTIONRESOURCEPLANNING', 'DOCUMENTPUBLISHING', 'DOWNLOADITEMS', 'DROPSHIPMENTS', 'DUPLICATES', 'DYNALLOCATION', 'EFFECTIVEDATING', 'EFT', 'EMAILINTEGRATION', 'EMPLOYEECENTERPUBLISHING', 'EMPLOYEECHANGEREQUESTS', 'EMPPERMS', 'ENHANCEDINVENTORYLOCATION', 'ENHANCEDPREMIERPAYROLL', 'ESCALATIONRULES', 'ESTIMATES', 'EXPENSEALLOCATION', 'EXPREPORTS', 'EXTCRM', 'EXTREMELIST', 'EXTSTORE', 'FCADVANCEDSECURITY', 'FCEXPENSE', 'FULFILLMENTREQUEST', 'FXRATEUPDATES', 'GAINLOSSACCTMAPPING', 'GIFTCERTIFICATES', 'GLAUDITNUMBERING', 'GROSSPROFIT', 'GROUPAVERAGECOSTING', 'HELPDESK', 'HISTORICALMETRICS', 'HRANALYSIS', 'INBOUNDCASEEMAIL', 'INBOUNDSHIPMENT', 'INSTALLMENTS', 'INTERCOMPANYAUTODROPSHIP', 'INTERCOMPANYAUTOELIMINATION', 'INTERCOMPANYTIMEEXPENSE', 'INTRANET', 'INTRANSITPAYMENTS', 'INVENTORY', 'INVENTORYCOUNT', 'INVENTORYSTATUS', 'IPADDRESSRULES', 'ISSUEDB', 'ITEMDEMANDPLANNING', 'ITEMOPTIONS', 'JOBCOSTING', 'JOBMANAGEMENT', 'JOBREQUISITION', 'JOBS', 'KNOWLEDGEBASE', 'KPIREPORTS', 'KUDOS', 'LANDEDCOST', 'LEADMANAGEMENT', 'LOCATIONS', 'LOTNUMBEREDINVENTORY', 'MAILMERGE', 'MARKETING', 'MATRIXITEMS', 'MERCHANDISEHIERARCHY', 'MFGROUTING', 'MFGWORKINPROCESS', 'MOBILEPUSHNTF', 'MOSS', 'MULTICURRENCY', 'MULTICURRENCYCUSTOMER', 'MULTICURRENCYVENDOR', 'MULTILANGUAGE', 'MULTILOCINVT', 'MULTIPARTNER', 'MULTIPLEBUDGETS', 'MULTIPLECALENDARS', 'MULTISHIPTO', 'MULTISITE', 'MULTISUBSIDIARYCUSTOMER', 'MULTIVENDOR', 'MULTPRICE', 'OAUTH2', 'OIDC', 'ONLINEORDERING', 'OPENIDSSO', 'OPPORTUNITIES', 'OUTSOURCEDMFG', 'PARTNERACCESS', 'PARTNERCOMMISSIONS', 'PAYABLES', 'PAYCHECKJOURNAL', 'PAYMENTINSTRUMENTS', 'PAYPALINTEGRATION', 'PAYROLL', 'PAYROLLSERVICE', 'PERIODENDJOURNALENTRIES', 'PERSONALIZED_CATALOG_VIEWS', 'PICKPACKSHIP', 'PI_REMOVAL', 'PLANNEDWORK', 'PRM', 'PROMOCODES', 'PURCHASECARDDATA', 'PURCHASECONTRACTS', 'PURCHASEORDERS', 'PURCHASEREQS', 'QUANTITYPRICING', 'RECEIVABLES', 'REQUISITIONS', 'RESOURCEALLOCATIONS', 'RESTWEBSERVICES', 'RETURNAUTHS', 'REVENUECOMMITMENTS', 'REVENUERECOGNITION', 'REVRECSALESORDERFORECASTING', 'REVRECVSOE', 'RFQ', 'RULEBASEDRECOGNITIONTREATMENT', 'RUM', 'SALESCAMPAIGNS', 'SALESORDERS', 'SAMLSSO', 'SERIALIZEDINVENTORY', 'SERVERSIDESCRIPTING', 'SERVICEPRINTEDCHECKS', 'SERVICEPRINTEDW2S', 'SFA', 'SHIPPINGLABELS', 'SITELOCATIONALIASES', 'SOFTDESCRIPTORS', 'STACKABLEPROMOTIONS', 'STANDARDCOSTING', 'STATACCOUNTING', 'STOREPICKUP', 'SUBSCRIPTIONBILLING', 'SUITEANALYTICSCONNECT', 'SUITEAPPCONTROLCENTER', 'SUITECOMMERCE', 'SUITECOMMERCE_ADVANCED', 'SUITECOMMERCE_IN_STORE', 'SUITECOMMERCE_MY_ACCOUNT', 'SUITESIGNON', 'SUPPLYALLOCATION', 'SUPPLYCHAINCONTROLTOWER', 'SUPPLYCHAINPREDICTEDRISKS', 'SUPPORT', 'TABLEAU', 'TALENTMANAGEMENT', 'TBA', 'TEAMSELLING', 'TELEPHONY', 'TERMINATIONREASONTRACKING', 'TIMEBASEDPRICING', 'TIMEOFFMANAGEMENT', 'TIMETRACKING', 'TRANDELETIONREASONCODE', 'UNITSOFMEASURE', 'UPSELL', 'URLCOMPONENTALIASES', 'USR', 'VENDORACCESS', 'VENDORPREPAYMENTS', 'VENDORRETURNAUTHS', 'WBS', 'WEBAPPLICATIONS', 'WEBAPPLICATIONVERSIONING', 'WEBDUPLICATEEMAILMANAGEMENT', 'WEBHOSTING', 'WEBSERVICESEXTERNAL', 'WEBSITE', 'WEBSTORE', 'WEEKLYTIMESHEETS', 'WEEKLYTIMESHEETSNEWUI', 'WORKFLOW', 'WORKORDERS'] }),
+    },
+    path: [...enumsFolderPath, configurable_featuresElemID.name],
+  }),
+  countries: new PrimitiveType({
+    elemID: countriesElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['AD', 'AE', 'AF', 'AG', 'AI', 'AL', 'AM', 'AN', 'AO', 'AQ', 'AR', 'AS', 'AT', 'AU', 'AW', 'AX', 'AZ', 'BA', 'BB', 'BD', 'BE', 'BF', 'BG', 'BH', 'BI', 'BJ', 'BL', 'BM', 'BN', 'BO', 'BQ', 'BR', 'BS', 'BT', 'BV', 'BW', 'BY', 'BZ', 'CA', 'CC', 'CD', 'CF', 'CG', 'CH', 'CI', 'CK', 'CL', 'CM', 'CN', 'CO', 'CR', 'CS', 'CU', 'CV', 'CW', 'CX', 'CY', 'CZ', 'DE', 'DJ', 'DK', 'DM', 'DO', 'DZ', 'EA', 'EC', 'EE', 'EG', 'EH', 'ER', 'ES', 'ET', 'FI', 'FJ', 'FK', 'FM', 'FO', 'FR', 'GA', 'GB', 'GD', 'GE', 'GF', 'GG', 'GH', 'GI', 'GL', 'GM', 'GN', 'GP', 'GQ', 'GR', 'GS', 'GT', 'GU', 'GW', 'GY', 'HK', 'HM', 'HN', 'HR', 'HT', 'HU', 'IC', 'ID', 'IE', 'IL', 'IM', 'IN', 'IO', 'IQ', 'IR', 'IS', 'IT', 'JE', 'JM', 'JO', 'JP', 'KE', 'KG', 'KH', 'KI', 'KM', 'KN', 'KP', 'KR', 'KW', 'KY', 'KZ', 'LA', 'LB', 'LC', 'LI', 'LK', 'LR', 'LS', 'LT', 'LU', 'LV', 'LY', 'MA', 'MC', 'MD', 'ME', 'MF', 'MG', 'MH', 'MK', 'ML', 'MM', 'MN', 'MO', 'MP', 'MQ', 'MR', 'MS', 'MT', 'MU', 'MV', 'MW', 'MX', 'MY', 'MZ', 'NA', 'NC', 'NE', 'NF', 'NG', 'NI', 'NL', 'NO', 'NP', 'NR', 'NU', 'NZ', 'OM', 'PA', 'PE', 'PF', 'PG', 'PH', 'PK', 'PL', 'PM', 'PN', 'PR', 'PS', 'PT', 'PW', 'PY', 'QA', 'RE', 'RO', 'RS', 'RU', 'RW', 'SA', 'SB', 'SC', 'SD', 'SE', 'SG', 'SH', 'SI', 'SJ', 'SK', 'SL', 'SM', 'SN', 'SO', 'SR', 'SS', 'ST', 'SV', 'SX', 'SY', 'SZ', 'TC', 'TD', 'TF', 'TG', 'TH', 'TJ', 'TK', 'TL', 'TM', 'TN', 'TO', 'TR', 'TT', 'TV', 'TW', 'TZ', 'UA', 'UG', 'UM', 'US', 'UY', 'UZ', 'VA', 'VC', 'VE', 'VG', 'VI', 'VN', 'VU', 'WF', 'WS', 'XK', 'YE', 'YT', 'ZA', 'ZM', 'ZW'] }),
+    },
+    path: [...enumsFolderPath, countriesElemID.name],
+  }),
+  crmcustomfield_searchcomparefield: new PrimitiveType({
+    elemID: crmcustomfield_searchcomparefieldElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['STDEVENTALLOCATIONPROJECT', 'STDEVENTALLOCATIONPROJECTTASK', 'STDEVENTALLOCATIONTYPE', 'STDEVENTAPPROVALSTATUS', 'STDEVENTASSIGNED', 'STDEVENTAUDIENCE', 'STDEVENTCALLSTATUS', 'STDEVENTCAMPAIGNCATEGORY', 'STDEVENTCASECATEGORY', 'STDEVENTCASEPRIORITY', 'STDEVENTCASEPROFILE', 'STDEVENTCASESTATUS', 'STDEVENTCOMPANY', 'STDEVENTCONSTRAINTTYPE', 'STDEVENTCONTACT', 'STDEVENTCUSTOMER', 'STDEVENTCUSTOMFORM', 'STDEVENTDUPLICATEOF', 'STDEVENTFAMILY', 'STDEVENTHELPDESKEMPLOYEE', 'STDEVENTISSUE', 'STDEVENTISSUESTATUS', 'STDEVENTISSUETYPE', 'STDEVENTITEM', 'STDEVENTJOB', 'STDEVENTMILESTONE', 'STDEVENTMODULE', 'STDEVENTNEXTAPPROVER', 'STDEVENTOFFER', 'STDEVENTOPPORTUNITY', 'STDEVENTORDER', 'STDEVENTORGANIZER', 'STDEVENTORIGIN', 'STDEVENTOWNER', 'STDEVENTPARENT', 'STDEVENTPRIORITY', 'STDEVENTPRODUCT', 'STDEVENTPRODUCTTEAM', 'STDEVENTPROMOTIONCODE', 'STDEVENTREMINDERMINUTES', 'STDEVENTREMINDERTYPE', 'STDEVENTREPORTEDBY', 'STDEVENTREPRODUCE', 'STDEVENTREQUESTEDBY', 'STDEVENTRESOURCE', 'STDEVENTREVIEWER', 'STDEVENTSEARCHENGINE', 'STDEVENTSEVERITY', 'STDEVENTSOURCE', 'STDEVENTSTATUS', 'STDEVENTSUBSIDIARY', 'STDEVENTSUPPORTCASE', 'STDEVENTTASKSTATUS', 'STDEVENTTRANSACTION', 'STDEVENTVERTICAL'] }),
+    },
+    path: [...enumsFolderPath, crmcustomfield_searchcomparefieldElemID.name],
+  }),
+  csvimport_columndelimiter: new PrimitiveType({
+    elemID: csvimport_columndelimiterElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['COMMA', 'PIPE', 'SEMICOLON', 'SPACE', 'TAB'] }),
+    },
+    path: [...enumsFolderPath, csvimport_columndelimiterElemID.name],
+  }),
+  csvimport_customrecordtype: new PrimitiveType({
+    elemID: csvimport_customrecordtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CUSTOMRECORD'] }),
+    },
+    path: [...enumsFolderPath, csvimport_customrecordtypeElemID.name],
+  }),
+  csvimport_customtransactiontype: new PrimitiveType({
+    elemID: csvimport_customtransactiontypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CUSTOMTRANSACTION'] }),
+    },
+    path: [...enumsFolderPath, csvimport_customtransactiontypeElemID.name],
+  }),
+  csvimport_datahandling: new PrimitiveType({
+    elemID: csvimport_datahandlingElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ADD', 'ADDUPDATE', 'UPDATE'] }),
+    },
+    path: [...enumsFolderPath, csvimport_datahandlingElemID.name],
+  }),
+  csvimport_decimaldelimiter: new PrimitiveType({
+    elemID: csvimport_decimaldelimiterElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['COMMA', 'PERIOD'] }),
+    },
+    path: [...enumsFolderPath, csvimport_decimaldelimiterElemID.name],
+  }),
+  csvimport_encoding: new PrimitiveType({
+    elemID: csvimport_encodingElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['Big5', 'EUC_KR', 'GB18030', 'GBK', 'ISO_2022_KR', 'ISO_8859_1', 'MacRoman', 'SHIFT_JIS', 'UTF_8', 'windows-1252'] }),
+    },
+    path: [...enumsFolderPath, csvimport_encodingElemID.name],
+  }),
+  csvimport_entryform_standard: new PrimitiveType({
+    elemID: csvimport_entryform_standardElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BILLOFDISTRIBUTIONFORM', 'CLASSSEGMENTMAPPINGFORM', 'DEPARTMENTSEGMENTMAPPINGFORM', 'DISTRIBUTIONNETWORKFORM', 'INVENTORYCOSTTEMPLATEFORM', 'LOCATIONCOSTINGGROUPFORM', 'LOCATIONSEGMENTMAPPINGFORM', 'MANUFACTURINGCOSTTEMPLATEFORM', 'MANUFACTURINGROUTINGFORM', 'MANUFACTURINGTASK', 'SHIPPINGPARTNERPACKAGEFORM', 'SHIPPINGPARTNERREGISTRATIONFORM', 'SHIPPINGPARTNERSHIPMENTFORM', 'STANDARDACCOUNTINGBOOKFORM', 'STANDARDADDRESSFORM', 'STANDARDASCHARGEDPROJECTREVENUERULE', 'STANDARDAUTOMATICLOCATIONASSIGNMENTCONFIGURATIONFORM', 'STANDARDAUTOMATICLOCATIONASSIGNMENTRULEFORM', 'STANDARDBILLINGACCOUNT', 'STANDARDBILLINGRATECARDFORM', 'STANDARDBILLOFMATERIALS', 'STANDARDBILLOFMATERIALSREVISION', 'STANDARDCAMPAIGNFORM', 'STANDARDCASEFORM', 'STANDARDCHARGEFORM', 'STANDARDCOMPETITORFORM', 'STANDARDCONTACTFORM', 'STANDARDCUSTOMERFORM', 'STANDARDDESCRIPTIONFORM', 'STANDARDDISCOUNTFORM', 'STANDARDEMPLOYEEFORM', 'STANDARDENTITYACCOUNTMAPPINGFORM', 'STANDARDEVENTFORM', 'STANDARDEXPENSEAMORTIZATIONEVENTFORM', 'STANDARDEXPENSEAMORTIZATIONRULEFORM', 'STANDARDEXPENSEBASEDCHARGERULEFORM', 'STANDARDEXPENSEFORM', 'STANDARDEXPENSEPLANFORM', 'STANDARDFAIRVALUEFORMULAFORM', 'STANDARDFAIRVALUEPRICEFORM', 'STANDARDFIXEDAMOUNTPROJECTREVENUERULE', 'STANDARDFIXEDDATECHARGERULEFORM', 'STANDARDGAINLOSSACCOUNTMAPPINGFORM', 'STANDARDGENERICRESOURCEFORM', 'STANDARDGLOBALACCOUNTMAPPINGFORM', 'STANDARDGLOBALINVENTORYRELATIONSHIPFORM', 'STANDARDGROUPITEMFORM', 'STANDARDHELPDESKFORM', 'STANDARDINBOUNDSHIPMENT', 'STANDARDINVENTORYDETAILFORM', 'STANDARDINVENTORYPARTFORM', 'STANDARDINVENTORYSTATUS', 'STANDARDISSUEFORM', 'STANDARDITEMACCOUNTMAPPINGFORM', 'STANDARDITEMDEMANDPLANFORM', 'STANDARDITEMLOCATIONCONFIGURATIONFORM', 'STANDARDITEMPROCESSFAMILYFORM', 'STANDARDITEMPROCESSGROUPFORM', 'STANDARDITEMREVENUECATEGORYFORM', 'STANDARDITEMSUPPLYPLANFORM', 'STANDARDJOBFORM', 'STANDARDLABORBASEDPROJECTREVENUERULE', 'STANDARDLEADFORM', 'STANDARDMILESTONECHARGERULEFORM', 'STANDARDNEXUS', 'STANDARDNONINVENTORYPARTFORM', 'STANDARDNOTEFORM', 'STANDARDPARTNERFORM', 'STANDARDPAYMENTFORM', 'STANDARDPERCENTCOMPLETEPROJECTREVENUERULE', 'STANDARDPHONECALLFORM', 'STANDARDPLANNEDREVENUEFORM', 'STANDARDPLANNEDSTANDARDCOSTFORM', 'STANDARDPRICEBOOKFORM', 'STANDARDPRICEPLANFORM', 'STANDARDPROJECTBUDGETFORM', 'STANDARDPROJECTICCHARGEREQFORM', 'STANDARDPROJECTPROGRESSCHARGERULEFORM', 'STANDARDPROJECTTASKFORM', 'STANDARDPROJECTTEMPLATEFORM', 'STANDARDPROMOTIONCODEFIXEDPRICE', 'STANDARDPROMOTIONCODEFORM', 'STANDARDPROMOTIONCODEFREEGIFT', 'STANDARDPROMOTIONCODEITEM', 'STANDARDPROMOTIONCODEORDER', 'STANDARDPROMOTIONCODESHIPPING', 'STANDARDPURCHASERULEFORM', 'STANDARDREGIONFORM', 'STANDARDRESOURCEALLOCATIONFORM', 'STANDARDRESOURCEGROUPFORM', 'STANDARDREVENUEELEMENTFORM', 'STANDARDREVENUERECOGNITIONEVENTFORM', 'STANDARDREVENUERECOGNITIONRULEFORM', 'STANDARDSOLUTIONFORM', 'STANDARDSTANDARDCOSTVERSIONFORM', 'STANDARDSUBSCRIPTIONCHANGEORDER', 'STANDARDSUBSCRIPTIONFORM', 'STANDARDSUBSCRIPTIONLINEFORM', 'STANDARDSUBSCRIPTIONPLANFORM', 'STANDARDSUPPLYCHAINSNAPSHOT', 'STANDARDTASKFORM', 'STANDARDTIMEBASEDCHARGERULEFORM', 'STANDARDTIMEENTRYFORM', 'STANDARDTIMESHEETFORM', 'STANDARDTIMETRACKINGFORM', 'STANDARDUSAGEFORM', 'STANDARDVENDORFORM', 'STANDARDWBSFORM', 'STDBONUSFORM', 'STDFORMATPROFILEFORM', 'STDSTUDENTRECORDFORM', 'STDSUPPLYCHAINSNAPSHOTSIMULATIONFORM'] }),
+    },
+    path: [...enumsFolderPath, csvimport_entryform_standardElemID.name],
+  }),
+  csvimport_recordtypes: new PrimitiveType({
+    elemID: csvimport_recordtypesElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNT', 'ADVINTERCOMPANYJOURNALENTRY', 'ASSEMBLYITEM', 'BILLINGACCOUNT', 'BIN', 'BOM', 'BOMREVISION', 'BUDGETEXCHANGERATE', 'CALENDAREVENT', 'CASHSALE', 'CHECK', 'CLASSIFICATION', 'CMSPAGE', 'COMMERCECATEGORY', 'CONSOLIDATEDEXCHANGERATE', 'CONTACT', 'CREDITCARDCHARGE', 'CREDITCARDREFUND', 'CREDITMEMO', 'CURRENCYRATE', 'CUSTOMER', 'CUSTOMERANDCONTACT', 'CUSTOMERPAYMENT', 'CUSTOMERSUBSIDIARYRELATIONSHIP', 'CUSTOMLIST', 'CUSTOMPURCHASE', 'CUSTOMRECORD', 'CUSTOMSALE', 'CUSTOMTRANSACTION', 'DEPARTMENT', 'DESCRIPTIONITEM', 'DISCOUNTITEM', 'EMPLOYEE', 'ESTIMATE', 'EXPENSECATEGORY', 'EXPENSEREPORT', 'FAIRVALUEPRICE', 'GAINLOSSACCTMAPPING', 'GENERALTOKEN', 'GLOBALACCOUNTMAPPING', 'HCMJOB', 'INBOUNDSHIPMENT', 'INTERCOMPANYJOURNALENTRY', 'INVENTORYADJUSTMENT', 'INVENTORYCOSTREVALUATION', 'INVENTORYITEM', 'INVENTORYTRANSFER', 'INVOICE', 'ISSUE', 'ITEMACCOUNTMAPPING', 'ITEMCOLLECTION', 'ITEMCOLLECTIONITEMMAP', 'ITEMDEMANDPLAN', 'ITEMGROUP', 'ITEMLOCATIONCONFIGURATION', 'ITEMREVISION', 'ITEMSUPPLYPLAN', 'JOB', 'JOURNALENTRY', 'KITITEM', 'LEAD', 'LEADANDCONTACT', 'LOCATION', 'LOTNUMBEREDASSEMBLYITEM', 'LOTNUMBEREDINVENTORYITEM', 'MANUFACTURINGCOSTTEMPLATE', 'MANUFACTURINGROUTING', 'MARKUPITEM', 'MERCHANDISEHIERARCHYNODE', 'MESSAGE', 'NONINVENTORYPURCHASEITEM', 'NONINVENTORYRESALEITEM', 'NONINVENTORYSALEITEM', 'NOTE', 'OPPORTUNITY', 'OTHERCHARGEPURCHASEITEM', 'OTHERCHARGERESALEITEM', 'OTHERCHARGESALEITEM', 'PARTNER', 'PAYCHECK', 'PAYMENTCARD', 'PAYMENTCARDTOKEN', 'PAYMENTITEM', 'PERIODENDJOURNAL', 'PHONECALL', 'PRICEBOOK', 'PRICEPLAN', 'PROSPECT', 'PROSPECTANDCONTACT', 'PURCHASEORDER', 'RESOURCEALLOCATION', 'RETURNAUTHORIZATION', 'SALESORDER', 'SERIALIZEDASSEMBLYITEM', 'SERIALIZEDINVENTORYITEM', 'SERVICEPURCHASEITEM', 'SERVICERESALEITEM', 'SERVICESALEITEM', 'SITECATEGORY', 'SOLUTION', 'STATISTICALJOURNALENTRY', 'SUBSCRIPTION', 'SUBSCRIPTIONCHANGEORDER', 'SUBSCRIPTIONLINE', 'SUBSCRIPTIONPLAN', 'SUBTOTALITEM', 'SUPPORTCASE', 'TASK', 'TIMEBILL', 'TIMEOFFCHANGE', 'TIMESHEET', 'TOPIC', 'TRANSFERORDER', 'USAGE', 'VENDOR', 'VENDORBILL', 'VENDORCREDIT', 'VENDORPAYMENT', 'VENDORRETURNAUTHORIZATION', 'VENDORSUBSIDIARYRELATIONSHIP'] }),
+    },
+    path: [...enumsFolderPath, csvimport_recordtypesElemID.name],
+  }),
+  csvimport_referencetype: new PrimitiveType({
+    elemID: csvimport_referencetypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['EXTERNAL_ID', 'INTERNAL_ID', 'NAME'] }),
+    },
+    path: [...enumsFolderPath, csvimport_referencetypeElemID.name],
+  }),
+  csvimport_transactionform_standard: new PrimitiveType({
+    elemID: csvimport_transactionform_standardElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['STANDARDASSEMBLYBUILD', 'STANDARDASSEMBLYUNBUILD', 'STANDARDBILLPAYMENT', 'STANDARDBILLPAYMENTSFORM', 'STANDARDBINPUTAWAYWORKSHEETFORM', 'STANDARDBINTRANSFERFORM', 'STANDARDBLANKETPURCHASEORDER', 'STANDARDBOM', 'STANDARDCANADAFINANCECHARGE', 'STANDARDCASHREFUND', 'STANDARDCASHSALE', 'STANDARDCHECK', 'STANDARDCOMMISSIONFORM', 'STANDARDCREDITCARDCHARGE', 'STANDARDCREDITMEMO', 'STANDARDCURRENCYREVALUATIONFORM', 'STANDARDCUSTOMERDEPOSIT', 'STANDARDCUSTOMERPAYMENT', 'STANDARDCUSTOMERPAYMENTAUTHORIZATION', 'STANDARDCUSTOMERREFUND', 'STANDARDDEPOSIT', 'STANDARDDEPOSITAPPLICATIONFORM', 'STANDARDDROPSHIPPURCHASEORDER', 'STANDARDESTIMATE', 'STANDARDEXPENSEREPORT', 'STANDARDFINANCECHARGE', 'STANDARDFULFILLMENTREQUEST', 'STANDARDFULFILLMENTREQUESTPICKINGTICKET', 'STANDARDINVENTORYADJUSTMENT', 'STANDARDINVENTORYCOSTREVALUATION', 'STANDARDINVENTORYCOUNT', 'STANDARDINVENTORYDISTRIBUTIONFORM', 'STANDARDINVENTORYTRANSFER', 'STANDARDINVENTORYWORKSHEET', 'STANDARDITEMFULFILLMENT', 'STANDARDITEMRECEIPT', 'STANDARDJOURNALENTRY', 'STANDARDOPPORTUNITY', 'STANDARDOUTSOURCEDPURCHASEORDER', 'STANDARDPACKINGSLIP', 'STANDARDPAYCHECK2FORM', 'STANDARDPAYCHECKFORM', 'STANDARDPAYCHECKJOURNAL', 'STANDARDPAYROLLADJUSTMENTFORM', 'STANDARDPAYROLLLIABILITYCHECKFORM', 'STANDARDPERIODENDJOURNAL', 'STANDARDPICKINGTICKET', 'STANDARDPRICELIST', 'STANDARDPRODUCTINVOICE', 'STANDARDPROFESSIONALINVOICE', 'STANDARDPROGRESSINVOICE', 'STANDARDPURCHASECONTRACT', 'STANDARDPURCHASEORDER', 'STANDARDPURCHTYPECUSTOMTRANSACTION', 'STANDARDREMITTANCESLIP', 'STANDARDREQUESTFORQUOTE', 'STANDARDREQUISITION', 'STANDARDRETURNAUTHORIZATIONCASH', 'STANDARDRETURNAUTHORIZATIONCREDIT', 'STANDARDRETURNFORM', 'STANDARDREVENUEARRANGEMENT', 'STANDARDREVENUECOMMITMENT', 'STANDARDREVENUECOMMITMENTREVERSAL', 'STANDARDREVENUECONTRACT', 'STANDARDSALESORDER', 'STANDARDSALESORDERCASHSALE', 'STANDARDSALESORDERINVOICE', 'STANDARDSALESORDERPROGRESSBILLING', 'STANDARDSALESTAXPAYMENTFORM', 'STANDARDSALESTYPECUSTOMTRANSACTION', 'STANDARDSERVICEINVOICE', 'STANDARDSHIPPINGLABEL', 'STANDARDSTATEMENT', 'STANDARDSTATEMENTCHARGEFORM', 'STANDARDSTOREPICKUPFULFILLMENT', 'STANDARDTAXLIABILITYCHEQUEFORM', 'STANDARDTEGATAPAYABLE', 'STANDARDTEGATARECEIVABLE', 'STANDARDTRANSFERFORM', 'STANDARDTRANSFERORDER', 'STANDARDVENDORBILL', 'STANDARDVENDORCREDIT', 'STANDARDVENDORREQUESTFORQUOTE', 'STANDARDVENDORRETURNAUTHORIZATION', 'STANDARDWAVEFORM', 'STANDARDWORKORDER', 'STANDARDWORKORDERCLOSE', 'STANDARDWORKORDERCOMPLETION', 'STANDARDWORKORDERISSUE', 'STDVENDORPREPAYMENTAPPLICATIONFORM', 'STDVENDORPREPAYMENTFORM'] }),
+    },
+    path: [...enumsFolderPath, csvimport_transactionform_standardElemID.name],
+  }),
+  csvimports_entryformrecordtypes: new PrimitiveType({
+    elemID: csvimports_entryformrecordtypesElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ASSEMBLYITEM', 'BILLINGACCOUNT', 'CALENDAREVENT', 'CONTACT', 'CUSTOMER', 'CUSTOMERANDCONTACT', 'DESCRIPTIONITEM', 'DISCOUNTITEM', 'EMPLOYEE', 'INBOUNDSHIPMENT', 'INVENTORYITEM', 'ISSUE', 'ITEMGROUP', 'ITEMPROCESSFAMILY', 'ITEMPROCESSGROUP', 'JOB', 'KITITEM', 'LEAD', 'LEADANDCONTACT', 'LOTNUMBEREDASSEMBLYITEM', 'LOTNUMBEREDINVENTORYITEM', 'MARKUPITEM', 'PARTNER', 'PAYMENTITEM', 'PHONECALL', 'PRICEBOOK', 'PRICEPLAN', 'PROSPECT', 'PROSPECTANDCONTACT', 'RESOURCEALLOCATION', 'SERIALIZEDASSEMBLYITEM', 'SERIALIZEDINVENTORYITEM', 'SOLUTION', 'SUBSCRIPTION', 'SUBSCRIPTIONCHANGEORDER', 'SUBSCRIPTIONLINE', 'SUBSCRIPTIONPLAN', 'SUBTOTALITEM', 'SUPPORTCASE', 'TASK', 'TIMEBILL', 'TIMESHEET', 'VENDOR'] }),
+    },
+    path: [...enumsFolderPath, csvimports_entryformrecordtypesElemID.name],
+  }),
+  csvimports_transactionformrecordtypes: new PrimitiveType({
+    elemID: csvimports_transactionformrecordtypesElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ADVINTERCOMPANYJOURNALENTRY', 'CASHSALE', 'CHECK', 'CREDITCARDCHARGE', 'CREDITMEMO', 'CUSTOMERPAYMENT', 'ESTIMATE', 'EXPENSEREPORT', 'INTERCOMPANYJOURNALENTRY', 'INVENTORYADJUSTMENT', 'INVENTORYCOSTREVALUATION', 'INVENTORYTRANSFER', 'INVOICE', 'JOURNALENTRY', 'OPPORTUNITY', 'PERIODENDJOURNAL', 'PURCHASEORDER', 'RETURNAUTHORIZATION', 'SALESORDER', 'STATISTICALJOURNALENTRY', 'TRANSFERORDER', 'VENDORBILL', 'VENDORCREDIT', 'VENDORPAYMENT', 'VENDORRETURNAUTHORIZATION'] }),
+    },
+    path: [...enumsFolderPath, csvimports_transactionformrecordtypesElemID.name],
+  }),
+  customrecordtype_accesstype: new PrimitiveType({
+    elemID: customrecordtype_accesstypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CUSTRECORDENTRYPERM', 'NONENEEDED', 'USEPERMISSIONLIST'] }),
+    },
+    path: [...enumsFolderPath, customrecordtype_accesstypeElemID.name],
+  }),
+  customrecordtype_permission_restriction: new PrimitiveType({
+    elemID: customrecordtype_permission_restrictionElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['1', '3'] }),
+    },
+    path: [...enumsFolderPath, customrecordtype_permission_restrictionElemID.name],
+  }),
+  customrecordtype_permittedlevel: new PrimitiveType({
+    elemID: customrecordtype_permittedlevelElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['0', '1', '2', '3', '4'] }),
+    },
+    path: [...enumsFolderPath, customrecordtype_permittedlevelElemID.name],
+  }),
+  customrecordtype_permittedrole: new PrimitiveType({
+    elemID: customrecordtype_permittedroleElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNTANT', 'ACCOUNTANT__REVIEWER', 'ADMINISTRATOR', 'ADVANCED_PARTNER_CENTER', 'AP_CLERK', 'AR_CLERK', 'BOOKKEEPER', 'BUYER', 'CEO', 'CEO_HANDS_OFF', 'CHIEF_PEOPLE_OFFICER_CPO', 'CONSULTANT', 'CUSTOMER_CENTER', 'CUSTOMROLE41', 'CUSTOMROLE42', 'CUSTOMROLE43', 'CUSTOMROLE56', 'DEVELOPER', 'EMPLOYEE_CENTER', 'ENGINEER', 'ENGINEERING_MANAGER', 'FULL_ACCESS', 'HUMAN_RESOURCES_ADMINISTRATOR', 'HUMAN_RESOURCES_GENERALIST', 'INTRANET_MANAGER', 'ISSUE_ADMINISTRATOR', 'MARKETING_ADMINISTRATOR', 'MARKETING_ASSISTANT', 'MARKETING_MANAGER', 'NETSUITE_SUPPORT_CENTER__BASIC', 'ONLINE_FORM_USER', 'PARTNER_CENTER', 'PAYROLL_MANAGER', 'PAYROLL_SETUP', 'PM_MANAGER', 'PRODUCT_MANAGER', 'QA_ENGINEER', 'QA_MANAGER', 'RESOURCE_MANAGER', 'REVENUE_ACCOUNTANT', 'REVENUE_MANAGER', 'SALES_ADMINISTRATOR', 'SALES_MANAGER', 'SALES_PERSON', 'SALES_VICE_PRESIDENT', 'SHOPPER', 'STORE_MANAGER', 'SUITEAPPRELEASEMANAGER', 'SUPPORT_ADMINISTRATOR', 'SUPPORT_MANAGER', 'SUPPORT_PERSON', 'SYSTEM_ADMINISTRATOR', 'TAX_ENGINE', 'VENDOR_CENTER', 'WAREHOUSE_MANAGER', '_ALL_ROLES'] }),
+    },
+    path: [...enumsFolderPath, customrecordtype_permittedroleElemID.name],
+  }),
+  customrecordtype_tasktype: new PrimitiveType({
+    elemID: customrecordtype_tasktypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['EDIT', 'LIST', 'SRCH'] }),
+    },
+    path: [...enumsFolderPath, customrecordtype_tasktypeElemID.name],
+  }),
+  customsegment_access_search_level: new PrimitiveType({
+    elemID: customsegment_access_search_levelElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['EDIT', 'NONE', 'VIEW'] }),
+    },
+    path: [...enumsFolderPath, customsegment_access_search_levelElemID.name],
+  }),
+  customsegment_crm_application_id: new PrimitiveType({
+    elemID: customsegment_crm_application_idElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CALENDAREVENT', 'CAMPAIGN', 'ISSUE', 'PHONECALL', 'PROJECTTASK', 'SOLUTION', 'SUPPORTCASE', 'TASK'] }),
+    },
+    path: [...enumsFolderPath, customsegment_crm_application_idElemID.name],
+  }),
+  customsegment_crm_sourcelist: new PrimitiveType({
+    elemID: customsegment_crm_sourcelistElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['STDEVENTALLOCATIONPROJECT', 'STDEVENTALLOCATIONPROJECTTASK', 'STDEVENTASSIGNED', 'STDEVENTCOMPANY', 'STDEVENTCONTACT', 'STDEVENTCUSTOMER', 'STDEVENTDUPLICATEOF', 'STDEVENTHELPDESKEMPLOYEE', 'STDEVENTITEM', 'STDEVENTJOB', 'STDEVENTNEXTAPPROVER', 'STDEVENTOPPORTUNITY', 'STDEVENTORDER', 'STDEVENTORGANIZER', 'STDEVENTOWNER', 'STDEVENTPARENT', 'STDEVENTPRODUCT', 'STDEVENTPROMOTIONCODE', 'STDEVENTREPORTEDBY', 'STDEVENTREQUESTEDBY', 'STDEVENTRESOURCE', 'STDEVENTREVIEWER', 'STDEVENTSUBSIDIARY', 'STDEVENTSUPPORTCASE', 'STDEVENTTRANSACTION'] }),
+    },
+    path: [...enumsFolderPath, customsegment_crm_sourcelistElemID.name],
+  }),
+  customsegment_entities_application_id: new PrimitiveType({
+    elemID: customsegment_entities_application_idElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CONTACT', 'CUSTOMER', 'EMPLOYEE', 'ENTITYGROUP', 'GENERICRESOURCE', 'JOB', 'OTHERNAME', 'PARTNER', 'PROJECTTEMPLATE', 'VENDOR', 'WEBSITE'] }),
+    },
+    path: [...enumsFolderPath, customsegment_entities_application_idElemID.name],
+  }),
+  customsegment_entities_sourcelist: new PrimitiveType({
+    elemID: customsegment_entities_sourcelistElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['STDENTITYAPPROVER', 'STDENTITYASSISTANT', 'STDENTITYCAMPAIGNEVENT', 'STDENTITYCLASS', 'STDENTITYCOMPANY', 'STDENTITYCONTACTCAMPAIGNEVENT', 'STDENTITYCONTACTSOURCE', 'STDENTITYDEFAULTACCTCORPCARDEXP', 'STDENTITYDEPARTMENT', 'STDENTITYDRACCOUNT', 'STDENTITYEXPENSEACCOUNT', 'STDENTITYFXACCOUNT', 'STDENTITYJOBITEM', 'STDENTITYLEADSOURCE', 'STDENTITYLOCATION', 'STDENTITYPARENT', 'STDENTITYPARENTPARTNER', 'STDENTITYPARTNER', 'STDENTITYPAYABLESACCOUNT', 'STDENTITYPROJECTMANAGER', 'STDENTITYPURCHASEORDERAPPROVER', 'STDENTITYRECEIVABLESACCOUNT', 'STDENTITYSALESREP', 'STDENTITYSUBSIDIARY', 'STDENTITYSUPERVISOR', 'STDENTITYTAXITEM', 'STDENTITYTIMEAPPROVER', 'STDENTITYVENDORTIMEAPPROVER', 'STDENTITYWORKPLACE'] }),
+    },
+    path: [...enumsFolderPath, customsegment_entities_sourcelistElemID.name],
+  }),
+  customsegment_fieldtype: new PrimitiveType({
+    elemID: customsegment_fieldtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['MULTISELECT', 'SELECT'] }),
+    },
+    path: [...enumsFolderPath, customsegment_fieldtypeElemID.name],
+  }),
+  customsegment_items_application_id: new PrimitiveType({
+    elemID: customsegment_items_application_idElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ASSEMBLYITEM', 'INVENTORYITEM', 'ITEMGROUP', 'KITITEM', 'NONINVENTORYITEM', 'OTHERCHARGEITEM', 'SERVICEITEM'] }),
+    },
+    path: [...enumsFolderPath, customsegment_items_application_idElemID.name],
+  }),
+  customsegment_items_sourcelist: new PrimitiveType({
+    elemID: customsegment_items_sourcelistElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['STDITEMACCOUNT', 'STDITEMASSETACCOUNT', 'STDITEMBILLEXCHRATEVARIANCEACCT', 'STDITEMBILLPRICEVARIANCEACCT', 'STDITEMBILLQTYVARIANCEACCT', 'STDITEMCLASS', 'STDITEMCOGSACCOUNT', 'STDITEMCUSTRETURNVARIANCEACCOUNT', 'STDITEMDEFAULTRENEWALPLAN', 'STDITEMDEFERRALACCOUNT', 'STDITEMDEFERREDREVENUEACCOUNT', 'STDITEMDEPARTMENT', 'STDITEMDROPSHIPEXPENSEACCOUNT', 'STDITEMEXPENSEACCOUNT', 'STDITEMGAINLOSSACCOUNT', 'STDITEMINCOMEACCOUNT', 'STDITEMISSUEPRODUCT', 'STDITEMITEMREVENUECATEGORY', 'STDITEMLIABILITYACCOUNT', 'STDITEMLOCATION', 'STDITEMPARENT', 'STDITEMPREFERREDLOCATION', 'STDITEMPROJECTTEMPLATE', 'STDITEMREVENUERECOGNITIONRULE', 'STDITEMTAXACCOUNT', 'STDITEMTAXAGENCY', 'STDITEMUNBUILDVARIANCEACCOUNT', 'STDITEMVENDOR', 'STDITEMVENDRETURNVARIANCEACCOUNT'] }),
+    },
+    path: [...enumsFolderPath, customsegment_items_sourcelistElemID.name],
+  }),
+  customsegment_items_subtype: new PrimitiveType({
+    elemID: customsegment_items_subtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BOTH', 'PURCHASE', 'SALE'] }),
+    },
+    path: [...enumsFolderPath, customsegment_items_subtypeElemID.name],
+  }),
+  customsegment_otherrecords_application_id: new PrimitiveType({
+    elemID: customsegment_otherrecords_application_idElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNT', 'ACCOUNTINGBOOK', 'ADDRESS', 'ALLOCATIONSCHEDULEDESTINATION', 'ALLOCATIONSCHEDULESOURCE', 'BIN', 'BUDGETIMPORT', 'CHARGERULE', 'CLASSIFICATION', 'CLASSSEGMENTMAPPING', 'COMPETITOR', 'CURRENCYRATETYPE', 'DEPARTMENT', 'DEPTSEGMENTMAPPING', 'ENTITYACCOUNTMAPPING', 'EXPENSEAMORTIZATIONRULE', 'EXPENSECATEGORY', 'EXPENSEPLAN', 'FAIRVALUEFORMULA', 'FAIRVALUEPRICE', 'GLOBALACCOUNTMAPPING', 'GLOBALINVENTORYRELATIONSHIP', 'ISSUEPRODUCT', 'ISSUEPRODUCTVERSION', 'ITEMACCOUNTMAPPING', 'ITEMDEMANDPLAN', 'ITEMREVENUECATEGORY', 'ITEMSUPPLYPLAN', 'LOCASSIGNCONF', 'LOCATION', 'LOCATIONCOSTINGGROUP', 'LOCSEGMENTMAPPING', 'MANUFACTURINGCOSTTEMPLATE', 'MANUFACTURINGROUTING', 'NOTE', 'PAYROLLBATCH', 'PAYROLLITEM', 'PLANNEDSTANDARDCOST', 'PRICEPLAN', 'PROJECTBUDGET', 'PROJECTBUDGETLINE', 'PROJECTICCHARGEREQUEST', 'PROMOTIONCODE', 'RECOGNITIONTREATMENTRULE', 'REGION', 'REVENUEELEMENT', 'REVENUEPLAN', 'REVENUERECOGNITIONRULE', 'REVENUERECOGNITIONTREATMENT', 'SALESTAXITEM', 'SHIPPINGPARTNERPACKAGE', 'SHIPPINGPARTNERREGISTRATION', 'SHIPPINGPARTNERSHIPMENT', 'STANDARDCOSTVERSION', 'SUBSIDIARY', 'TIMEENTRY', 'TIMESHEET', 'WBS', 'WBSLINE', 'WORKFLOW', 'WORKPLACE'] }),
+    },
+    path: [...enumsFolderPath, customsegment_otherrecords_application_idElemID.name],
+  }),
+  customsegment_parent: new PrimitiveType({
+    elemID: customsegment_parentElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CLASS', 'DEPARTMENT', 'LOCATION', 'SUBSIDIARY'] }),
+    },
+    path: [...enumsFolderPath, customsegment_parentElemID.name],
+  }),
+  customsegment_transactionbody_application_id: new PrimitiveType({
+    elemID: customsegment_transactionbody_application_idElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ASSEMBLYBUILD', 'CUSTOMERPAYMENT', 'DEPOSIT', 'EXPENSEREPORT', 'INVENTORYADJUSTMENT', 'ITEMFULFILLMENT', 'ITEMRECEIPT', 'JOURNALENTRY', 'OPPORTUNITY', 'OTHERTRANSACTION', 'PAYCHECKJOURNAL', 'PERIODENDJOURNAL', 'PURCHASE', 'REVENUEARRANGEMENT', 'SALE', 'STORE', 'TEGATA', 'TRANSFERORDER', 'VENDORPAYMENT'] }),
+    },
+    path: [...enumsFolderPath, customsegment_transactionbody_application_idElemID.name],
+  }),
+  customsegment_transactionbody_sourcelist: new PrimitiveType({
+    elemID: customsegment_transactionbody_sourcelistElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['STDBODYACCOUNT', 'STDBODYACCOUNTINGBOOK', 'STDBODYACCTCORPCARDEXP', 'STDBODYADJLOCATION', 'STDBODYADVANCEACCOUNT', 'STDBODYALACONFIGURATION', 'STDBODYAPACCT', 'STDBODYARACCT', 'STDBODYASSEMBLYITEM', 'STDBODYCLASS', 'STDBODYCREATEDFROM', 'STDBODYCUSTOMER', 'STDBODYDECISIONMAKER', 'STDBODYDEPARTMENT', 'STDBODYDEPOSIT', 'STDBODYDISCOUNTITEM', 'STDBODYDRACCOUNT', 'STDBODYEMPLOYEE', 'STDBODYENTITY', 'STDBODYENTITYEMPLOYEE', 'STDBODYEXPENSEACCOUNT', 'STDBODYFXACCOUNT', 'STDBODYITEM', 'STDBODYITEMFULFILLMENT', 'STDBODYJOB', 'STDBODYLEADSOURCE', 'STDBODYLOCATION', 'STDBODYNEXTAPPROVER', 'STDBODYOPPORTUNITY', 'STDBODYPARTNER', 'STDBODYPAYMENTCUSTOMER', 'STDBODYPROMOCODE', 'STDBODYPURCHASECONTRACT', 'STDBODYREVERSALENTRY', 'STDBODYSALESORDER', 'STDBODYSALESREP', 'STDBODYSHIPPINGTAXCODE', 'STDBODYSHIPTO', 'STDBODYSUBSIDIARY', 'STDBODYTAXITEM', 'STDBODYTOLOCATION', 'STDBODYTOSUBSIDIARY', 'STDBODYTRANSFERLOCATION', 'STDBODYVENDOR'] }),
+    },
+    path: [...enumsFolderPath, customsegment_transactionbody_sourcelistElemID.name],
+  }),
+  customsegment_transactionline_application_id: new PrimitiveType({
+    elemID: customsegment_transactionline_application_idElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['EXPENSE', 'EXPENSEREPORT', 'INVENTORYADJUSTMENT', 'ITEMFULFILLMENT', 'ITEMRECEIPT', 'JOURNALENTRY', 'KITITEM', 'OPPORTUNITY', 'OWNERSHIPTRANSFER', 'PAYCHECKCOMPANYCONTRIBUTION', 'PAYCHECKCOMPANYTAX', 'PAYCHECKDEDUCTION', 'PAYCHECKEARNING', 'PAYCHECKEMPLOYEETAX', 'PERIODENDJOURNAL', 'PURCHASE', 'REVENUEARRANGEMENT', 'SALE', 'STORE', 'STOREWITHGROUPS', 'TIME', 'TRANSFERORDER', 'WORKORDER'] }),
+    },
+    path: [...enumsFolderPath, customsegment_transactionline_application_idElemID.name],
+  }),
+  customsegment_transactionline_sourcelist: new PrimitiveType({
+    elemID: customsegment_transactionline_sourcelistElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['STDBODYACCOUNT', 'STDBODYACCOUNTINGBOOK', 'STDBODYACCTCORPCARDEXP', 'STDBODYADJLOCATION', 'STDBODYADVANCEACCOUNT', 'STDBODYALACONFIGURATION', 'STDBODYAPACCT', 'STDBODYARACCT', 'STDBODYASSEMBLYITEM', 'STDBODYCLASS', 'STDBODYCREATEDFROM', 'STDBODYCUSTOMER', 'STDBODYDECISIONMAKER', 'STDBODYDEPARTMENT', 'STDBODYDEPOSIT', 'STDBODYDISCOUNTITEM', 'STDBODYDRACCOUNT', 'STDBODYEMPLOYEE', 'STDBODYENTITY', 'STDBODYENTITYEMPLOYEE', 'STDBODYEXPENSEACCOUNT', 'STDBODYFXACCOUNT', 'STDBODYITEM', 'STDBODYITEMFULFILLMENT', 'STDBODYJOB', 'STDBODYLEADSOURCE', 'STDBODYLOCATION', 'STDBODYNEXTAPPROVER', 'STDBODYOPPORTUNITY', 'STDBODYPARTNER', 'STDBODYPAYMENTCUSTOMER', 'STDBODYPROMOCODE', 'STDBODYPURCHASECONTRACT', 'STDBODYREVERSALENTRY', 'STDBODYSALESORDER', 'STDBODYSALESREP', 'STDBODYSHIPPINGTAXCODE', 'STDBODYSHIPTO', 'STDBODYSUBSIDIARY', 'STDBODYTAXITEM', 'STDBODYTOLOCATION', 'STDBODYTOSUBSIDIARY', 'STDBODYTRANSFERLOCATION', 'STDBODYVENDOR', 'STDCOLACCOUNT', 'STDCOLCALL', 'STDCOLCASE', 'STDCOLCASETASKEVENT', 'STDCOLCLASS', 'STDCOLCREATEDFROM', 'STDCOLCUSTOMER', 'STDCOLDEPARTMENT', 'STDCOLEMPLOYEE', 'STDCOLEVENT', 'STDCOLITEM', 'STDCOLJOB', 'STDCOLLOCATION', 'STDCOLPROJECTTASK', 'STDCOLSUBSIDIARY', 'STDCOLTASK'] }),
+    },
+    path: [...enumsFolderPath, customsegment_transactionline_sourcelistElemID.name],
+  }),
+  customsegment_valuesdisplayorder: new PrimitiveType({
+    elemID: customsegment_valuesdisplayorderElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ALPHABETICAL', 'SUBLIST'] }),
+    },
+    path: [...enumsFolderPath, customsegment_valuesdisplayorderElemID.name],
+  }),
+  customtransactiontype_classification_position: new PrimitiveType({
+    elemID: customtransactiontype_classification_positionElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['HEADER', 'LINES', 'NONE'] }),
+    },
+    path: [...enumsFolderPath, customtransactiontype_classification_positionElemID.name],
+  }),
+  customtransactiontype_creditsupportstyles: new PrimitiveType({
+    elemID: customtransactiontype_creditsupportstylesElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BASIC', 'PURCHASE', 'SALES'] }),
+    },
+    path: [...enumsFolderPath, customtransactiontype_creditsupportstylesElemID.name],
+  }),
+  customtransactiontype_filterbyaccounttype: new PrimitiveType({
+    elemID: customtransactiontype_filterbyaccounttypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCTPAY', 'ACCTREC', 'BANK', 'COGS', 'CREDCARD', 'DEFEREXPENSE', 'DEFERREVENUE', 'EQUITY', 'EXPENSE', 'FIXEDASSET', 'INCOME', 'LONGTERMLIAB', 'OTHASSET', 'OTHCURRASSET', 'OTHCURRLIAB', 'OTHEXPENSE', 'OTHINCOME', 'UNBILLEDREC'] }),
+    },
+    path: [...enumsFolderPath, customtransactiontype_filterbyaccounttypeElemID.name],
+  }),
+  customtransactiontype_statuses_id: new PrimitiveType({
+    elemID: customtransactiontype_statuses_idElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'W', 'X', 'Z'] }),
+    },
+    path: [...enumsFolderPath, customtransactiontype_statuses_idElemID.name],
+  }),
+  customtransactiontype_subliststyle: new PrimitiveType({
+    elemID: customtransactiontype_subliststyleElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BASIC', 'HEADER_ONLY', 'JOURNAL', 'PURCHASE', 'SALES'] }),
+    },
+    path: [...enumsFolderPath, customtransactiontype_subliststyleElemID.name],
+  }),
+  customtransactiontype_subliststyle_salesandpurchase: new PrimitiveType({
+    elemID: customtransactiontype_subliststyle_salesandpurchaseElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['PURCHASE', 'SALES'] }),
+    },
+    path: [...enumsFolderPath, customtransactiontype_subliststyle_salesandpurchaseElemID.name],
+  }),
+  dashboard_layout: new PrimitiveType({
+    elemID: dashboard_layoutElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['SINGLE_COLUMN', 'THREE_COLUMN', 'TWO_COLUMN', 'TWO_COLUMN_RIGHT'] }),
+    },
+    path: [...enumsFolderPath, dashboard_layoutElemID.name],
+  }),
+  dashboard_mode: new PrimitiveType({
+    elemID: dashboard_modeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ADD_MOVE', 'LOCKED', 'UNLOCKED'] }),
+    },
+    path: [...enumsFolderPath, dashboard_modeElemID.name],
+  }),
+  emailtemplate_recordtype: new PrimitiveType({
+    elemID: emailtemplate_recordtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CUSTOM', 'ENTITY', 'EVENT', 'PROJECT', 'TRANSACTION'] }),
+    },
+    path: [...enumsFolderPath, emailtemplate_recordtypeElemID.name],
+  }),
+  engine_versions: new PrimitiveType({
+    elemID: engine_versionsElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['0.1', '1.0'] }),
+    },
+    path: [...enumsFolderPath, engine_versionsElemID.name],
+  }),
+  entryform_buttonid: new PrimitiveType({
+    elemID: entryform_buttonidElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCEPT', 'ACCEPTPAYMENT', 'ACTIVATE', 'ACTIVITYHISTORY', 'APPROVE', 'APPROVEALLPENDING', 'CANCEL', 'CHANGECUSTOMER', 'CLEARREVISIONS', 'COPY', 'COPYTIMESHEET', 'CREATENEWVERSION', 'CREATEPROJECT', 'CREATE_EMPLOYEE_CHANGE_REQUEST', 'DECLINE', 'DELETE', 'DELETELASTVERSION', 'EDIT_CHANGE_REASON', 'GENERATEPRICELIST', 'GENERATESTATEMENT', 'IMPORTPLANNEDTIME', 'MAKECOPY', 'MERGE', 'MODIFY_PRICING', 'NEW', 'NEXTBILL', 'NEXTVERSION', 'PREVIOUSVERSION', 'PRINT', 'QUICKACCEPT', 'REACTIVATE', 'RECALCULATEACCOUNTINGDATA', 'RECALCULATEPROJECTPLAN', 'REJECT', 'REJECTALLPENDINGWITHNOTE', 'REJECTWITHNOTE', 'RENEW', 'RESETTER', 'SAVE', 'SEARCH', 'SELECT_EFFECTIVE_DATE', 'SUBMITAS', 'SUBMITCOPY', 'SUBMITEDIT', 'SUBMITNEW', 'SUBMITNEXT', 'SUSPEND', 'TENTATIVE', 'TERMINATE', 'TERMINATE_EMPLOYEE', 'UNLOCKTIMEPERIOD', 'VIEWALLTRANSACTIONS', 'VIEW_EMPLOYEE_TIMELINE', 'W4DATA'] }),
+    },
+    path: [...enumsFolderPath, entryform_buttonidElemID.name],
+  }),
+  entryform_fieldid: new PrimitiveType({
+    elemID: entryform_fieldidElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACADEMICYEAR', 'ACCESSLEVEL', 'ACCESSROLE', 'ACCOUNT', 'ACCOUNTINGBOOK', 'ACCOUNTINGBOOK', 'ACCOUNTINGBOOK', 'ACCOUNTMAPPINGDESCRIPTION', 'ACCOUNTMAPPINGID', 'ACCOUNTMAPPINGKEY', 'ACCOUNTNUMBER', 'ACTION', 'ACTUALDELIVERYDATE', 'ACTUALRUNTIME', 'ACTUALSETUPTIME', 'ACTUALSHIPPINGDATE', 'ACTUALTIME', 'ACTUALWORK', 'ADATE', 'ADDR1', 'ADDR2', 'ADDR3', 'ADDRESS', 'ADDRESSEE', 'ADDRPHONE', 'ADVANCERENEWALPERIODNUMBER', 'ADVANCERENEWALPERIODUNIT', 'AEIC', 'AGING', 'ALCOHOLRECIPIENTTYPE', 'ALIENNUMBER', 'ALLDAYEVENT', 'ALLLOCATIONSCUSTOMERRETURN', 'ALLLOCATIONSFULFILLMENT', 'ALLOCATEDCONTRACTCOSTAMOUNT', 'ALLOCATEDHOURS', 'ALLOCATEDTIME', 'ALLOCATEDWORK', 'ALLOCATEPAYROLLEXPENSES', 'ALLOCATIONAMOUNT', 'ALLOCATIONRESOURCE', 'ALLOCATIONTYPE', 'ALLOWALLRESOURCESFORTASKS', 'ALLOWANCE', 'ALLOWCROSSSUBCUSTOMERRETURN', 'ALLOWCROSSSUBFULFILLMENT', 'ALLOWEDSUBSIDIARIES', 'ALLOWEXPENSES', 'ALLOWTASKTIMEFORRSRCALLOC', 'ALLOWTIME', 'ALTEMAIL', 'ALTERNATEDEMANDSOURCEITEM', 'ALTERNATEQUANTITY', 'ALTERNATESOURCEITEM', 'ALTERNATEUNITS', 'ALTERNATEUNITSTYPE', 'ALTNAME', 'ALTPHONE', 'ALTPHONE', 'AMORTIZATIONENDDATE', 'AMORTIZATIONPERIOD', 'AMORTIZATIONSCHEDULE', 'AMORTIZATIONSTARTDATE', 'AMORTIZATIONTEMPLATE', 'AMOUNT', 'AMOUNT', 'AMOUNTSOURCE', 'AMOUNTSOURCE', 'ANALYSISDURATION', 'APPLYDISCOUNTTO', 'APPLYPROJECTEXPENSETYPETOALL', 'APPROVALDATE', 'APPROVALLIMIT', 'APPROVALSTATUS', 'APPROVALSTATUS', 'APPROVER', 'ARRANGEMENTLEVELRECLASS', 'ASSETACCOUNT', 'ASSIGNED', 'ASSIGNEDWEBSITE', 'ASSIGNTASKS', 'ASSISTANT', 'ASSISTANTPHONE', 'ATPLEADTIME', 'ATPLEADTIME', 'ATPMETHOD', 'ATRIGGER', 'ATTENTION', 'AUDIENCE', 'AUTHWORKDATE', 'AUTOCALCULATELAG', 'AUTOEXPANDKITFORREVENUEMGMT', 'AUTOLEADTIME', 'AUTONAME', 'AUTONAME', 'AUTONAME', 'AUTOPARTNERCODE', 'AUTOPREFERREDSTOCKLEVEL', 'AUTORENEWAL', 'AUTOREORDERPOINT', 'AVAILABLEFORALLASSEMBLIES', 'AVAILABLEFORALLLOCATIONS', 'AVAILABLENOW', 'AVAILABLEOFFLINE', 'AVAILABLETOPARTNERS', 'AVERAGECOST', 'BACKWARDCONSUMPTIONDAYS', 'BACKWARDCONSUMPTIONDAYS', 'BALANCE', 'BALANCE', 'BALANCEPRIMARY', 'BANKTRANSACTIONCODE', 'BASEBOOK', 'BASECOST', 'BASELINE', 'BASEUNIT', 'BASEWAGE', 'BASEWAGETYPE', 'BBUDGETSHOWCALCULATEDLINES', 'BBUDGETUSECALCULATEDVALUES', 'BCN', 'BEFORESUBSCRIPTIONENDDATE', 'BILLADDRESS', 'BILLADDRESSLIST', 'BILLDATE', 'BILLEXCHRATEVARIANCEACCT', 'BILLINGACCOUNT', 'BILLINGACCOUNT', 'BILLINGACCOUNT', 'BILLINGACCOUNT', 'BILLINGACCOUNTSTARTDATE', 'BILLINGCLASS', 'BILLINGCLASS', 'BILLINGITEM', 'BILLINGMODE', 'BILLINGRATECARD', 'BILLINGRATECARD', 'BILLINGSCHEDULE', 'BILLINGSCHEDULE', 'BILLINGSCHEDULE', 'BILLINGSUBSCRIPTIONSTATUS', 'BILLINGSUBSIDIARY', 'BILLINGTRANSACTIONFORM', 'BILLINGTRANSACTIONTYPE', 'BILLOFLADING', 'BILLOFMATERIALS', 'BILLOFMATERIALS', 'BILLPAY', 'BILLPRICEVARIANCEACCT', 'BILLQTYVARIANCEACCT', 'BILLTO', 'BIRTHDATE', 'BOMQUANTITY', 'BONUSAMOUNTABSOLUTE', 'BONUSAMOUNTPERCENTAGE', 'BONUSAWARDDATE', 'BONUSCOMMENT', 'BONUSCURRENCY', 'BONUSEMPLOYEE', 'BONUSEMPLOYEEBASEWAGE', 'BONUSEMPLOYEEBASEWAGETYPE', 'BONUSEMPLOYEECURRENCY', 'BONUSSTATUS', 'BONUSTARGET', 'BONUSTARGETCOMMENT', 'BONUSTARGETPAYFREQUENCY', 'BONUSTARGETTYPE', 'BONUSTYPE', 'BUILDBROKEN', 'BUILDENTIREASSEMBLY', 'BUILDFIXED', 'BUILDTARGET', 'BUILDTIME', 'BUILDTIME', 'BUYINGREASON', 'BUYINGTIMEFRAME', 'CALCULATEDAMOUNT', 'CALCULATEDENDDATE', 'CALCULATEDENDDATEBASELINE', 'CALCULATEDSTARTDATE', 'CALCULATEDSTARTDATEBASELINE', 'CALCULATEDWORK', 'CALCULATEDWORKBASELINE', 'CAMPAIGNCATEGORY', 'CAMPAIGNEVENT', 'CAMPAIGNID', 'CANBEAUTOAPPLIED', 'CANNOTBECOMBINED', 'CAP', 'CAPHOURS', 'CAPMONEY', 'CAPTYPE', 'CASENUMBER', 'CASETASKEVENT', 'CASHSALEFORM', 'CATALOGTYPE', 'CATCHUPPERIOD', 'CATCHUPPERIOD', 'CATEGORY', 'CBUDGETLABORBUDGETFROMALLOC', 'CBUDGETSHOWCALCULATEDLINES', 'CBUDGETUSECALCULATEDVALUES', 'CHARGEAMOUNTBILLED', 'CHARGEAMOUNTHOLDFORBILLING', 'CHARGEAMOUNTPENDING', 'CHARGEAMOUNTREADYFORBILLING', 'CHARGEAMOUNTREMAINING', 'CHARGEDATE', 'CHARGEEMPLOYEE', 'CHARGEEXPENSEAMOUNT', 'CHARGELABORAMOUNT', 'CHARGERULETYPE', 'CHARGETYPE', 'CITY', 'CITYZIP', 'CLASS', 'CLASS', 'CLASS', 'CLEVEL', 'CLICKSTREAM', 'CODE', 'CODEPATTERN', 'COGSACCOUNT', 'COMBINATIONTYPE', 'COMMENTS', 'COMMENTS', 'COMMISSIONPAYMENTPREFERENCE', 'COMPANY', 'COMPANYNAME', 'COMPENSATIONCURRENCY', 'COMPLETEDDATE', 'COMPLETEDQUANTITY', 'COMPONENTYIELD', 'CONCURRENTWEBSERVICESUSER', 'CONFIGID', 'CONNECTIVITYMETHOD', 'CONSOLAGING', 'CONSOLBALANCE', 'CONSOLDAYSOVERDUE', 'CONSOLDEPOSITBALANCE', 'CONSOLOVERDUEBALANCE', 'CONSOLUNBILLEDORDERS', 'CONSTRAINTTYPE', 'CONSUMPTIONUNIT', 'CONTACT', 'CONTACTCAMPAIGNEVENT', 'CONTACTSOURCE', 'CONTACTSOURCECAMPAIGNCATEGORY', 'CONTINGENTREVENUEHANDLING', 'CONTINGENTREVENUEHANDLING', 'CONTRAACCOUNT', 'CONTRACTCOSTALLOCATIONPCT', 'CONTRACTEXPENSEACCT', 'CONTRACTEXPENSEOFFSETACCT', 'CONVCOSTPERCUSTOMER', 'CONVERSIONS', 'COPYDESCRIPTION', 'COST', 'COST', 'COSTACCOUNTINGSTATUS', 'COSTAMORTIZATIONAMOUNT', 'COSTCATEGORY', 'COSTCHART', 'COSTESTIMATE', 'COSTESTIMATETYPE', 'COSTINGGROUPCURRENCY', 'COSTINGLOTSIZE', 'COSTINGMETHOD', 'COSTPERCUSTOMER', 'COUNTRY', 'COUNTRYOFMANUFACTURE', 'COUPONCODEFILE', 'COURSEID', 'CREATECHARGERULE', 'CREATEDBY', 'CREATEDBY', 'CREATEDBY', 'CREATEDDATE', 'CREATEDDATE', 'CREATEDFROM', 'CREATEDFROM', 'CREATEEXPENSEPLANSON', 'CREATEREVENUEPLANSON', 'CREATEREVENUEPLANSON', 'CREATIONTRIGGEREDBY', 'CREATIONTRIGGEREDBY', 'CREDITDEBIT', 'CREDITHOLDOVERRIDE', 'CREDITLIMIT', 'CREDITMEMO', 'CREDITMEMOLINE', 'CSCHOOL', 'CUMULATIVEPERCENTCOMPLETE', 'CURRENCY', 'CURRENCY', 'CURRENCY', 'CURRENCYFORMATSAMPLE', 'CUSTOMDIMENSION', 'CUSTOMER', 'CUSTOMER', 'CUSTOMER', 'CUSTOMER', 'CUSTOMER', 'CUSTOMERCATEGORY', 'CUSTOMERDEFAULT', 'CUSTOMERGROUP', 'CUSTOMERS', 'CUSTOMFORM', 'CUSTOMFORM', 'CUSTOMFORM', 'CUSTOMFORM', 'CUSTOMFORM', 'CUSTOMFORM', 'CUSTRETURNVARIANCEACCOUNT', 'DATECONVERTEDTOINV', 'DATECREATED', 'DATECREATED', 'DATEENROLLED', 'DATERUN', 'DAYSBEFOREEXPIRATION', 'DAYSOVERDUE', 'DECLAREDVALUE', 'DEFAULTACCTCORPCARDEXP', 'DEFAULTADDRESS', 'DEFAULTALLOCATIONSTRATEGY', 'DEFAULTBANKACCOUNT', 'DEFAULTEXPENSEREPORTCURRENCY', 'DEFAULTITEMSHIPMETHOD', 'DEFAULTJOBRESOURCEROLE', 'DEFAULTORDERPRIORITY', 'DEFAULTRENEWALMETHOD', 'DEFAULTRENEWALPLAN', 'DEFAULTRENEWALPRICEBOOK', 'DEFAULTRENEWALTERM', 'DEFAULTRENEWALTRANTYPE', 'DEFAULTRETURNCOST', 'DEFAULTREVISION', 'DEFAULTTAXREG', 'DEFERCONTRACTEXPENSEACCT', 'DEFERRALACCOUNT', 'DEFERREDREVENUEACCOUNT', 'DEFERREVREC', 'DELIVERED', 'DEMANDLOCATION', 'DEMANDLOCATIONDATE', 'DEMANDLOCATIONSUBSIDIARY', 'DEMANDMODIFIER', 'DEMANDSOURCE', 'DEMANDTIMEFENCE', 'DEMANDTIMEFENCE', 'DEPARTMENT', 'DEPARTMENT', 'DEPARTMENT', 'DEPOSITBALANCE', 'DESCRIPTION', 'DESCRIPTION', 'DESCRIPTION', 'DESCRIPTION', 'DESCRIPTION', 'DESTINATIONACCOUNT', 'DESTINATIONCLASS', 'DESTINATIONDEPARTMENT', 'DESTINATIONLOCATION', 'DIMENSION1', 'DIMENSION10', 'DIMENSION2', 'DIMENSION3', 'DIMENSION4', 'DIMENSION5', 'DIMENSION6', 'DIMENSION7', 'DIMENSION8', 'DIMENSION9', 'DIRECTDEPOSIT', 'DIRECTION', 'DIRECTREVENUEPOSTING', 'DISCOUNT', 'DISCOUNTEDSALESAMOUNT', 'DISPLAYLINEDISCOUNTS', 'DISPLAYNAME', 'DISPLAYNAME', 'DISPLAYONLINE', 'DISPLAYSYMBOL', 'DISTANCEUNIT', 'DISTRIBUTIONCATEGORY', 'DISTRIBUTIONCATEGORY', 'DISTRIBUTIONNETWORK', 'DISTRIBUTIONNETWORK', 'DOB', 'DOCNUMCREATEDFROM', 'DONTSHOWPRICE', 'DRACCOUNT', 'DRIVERSLICENSENUMBER', 'DROPSHIPEXPENSEACCOUNT', 'DUEDATE', 'DUPLICATEOF', 'EFFECTIVEBOMCONTROL', 'EFFECTIVEDATE', 'EFFECTIVEDATE', 'EFFECTIVEENDDATE', 'EFFECTIVEENDDATE', 'EFFECTIVEPERIOD', 'EFFECTIVESTARTDATE', 'EFFECTIVESTARTDATE', 'ELEMENTDATE', 'ELIGIBLEFORCOMMISSION', 'ELIGIBLEFORCOMMISSION', 'EMAIL', 'EMAIL', 'EMAILASSIGNEE', 'EMAILCELLS', 'EMAILEMPLOYEES', 'EMAILFORM', 'EMAILPREFERENCE', 'EMPLOYEE', 'EMPLOYEEFTESTATUS', 'EMPLOYEESTATUS', 'EMPLOYEETYPE', 'ENABLELIMITLOCATIONS', 'ENABLEPERIODENDJOURNALS', 'ENABLERADIUS', 'ENDDATE', 'ENDDATEBASELINE', 'ENDDATECHANGEIMPACT', 'ENDDATECHANGEIMPACT', 'ENDTIME', 'ENFORCEMINQTYINTERNALLY', 'ENTITY', 'ENTITYACCOUNT', 'ENTITYID', 'ENTITYSTATUS', 'ESCALATIONMESSAGE', 'ESTIMATEDBUDGET', 'ESTIMATEDCOST', 'ESTIMATEDCOST', 'ESTIMATEDCOSTJC', 'ESTIMATEDGROSSPROFIT', 'ESTIMATEDGROSSPROFITPERCENT', 'ESTIMATEDLABORCOST', 'ESTIMATEDLABORCOST', 'ESTIMATEDLABORCOSTBASELINE', 'ESTIMATEDLABORCOSTBASELINE', 'ESTIMATEDLABORREVENUE', 'ESTIMATEDLABORREVENUE', 'ESTIMATEDMARGIN', 'ESTIMATEDREVENUE', 'ESTIMATEDREVENUE', 'ESTIMATEDREVENUEJC', 'ESTIMATEDREVRECENDDATE', 'ESTIMATEDTIME', 'ESTIMATEDTIMEOVERRIDE', 'ESTIMATEDTIMEOVERRIDE', 'ESTIMATEDTIMEOVERRIDEBASELINE', 'ESTIMATEDTIMEOVERRIDEBASELINE', 'ESTIMATEDWORK', 'ESTIMATEDWORK', 'ESTIMATEDWORKBASELINE', 'ESTIMATEREVRECTEMPLATE', 'ETHNICITY', 'EVENTDATE', 'EVENTID', 'EVENTPURPOSE', 'EVENTTYPE', 'EXCHANGERATE', 'EXCHANGERATE', 'EXCLUDEFROMSITEMAP', 'EXCLUDEITEMS', 'EXPAMTMULTIPLIER', 'EXPECTEDDELIVERYDATE', 'EXPECTEDRATE', 'EXPECTEDREVENUE', 'EXPECTEDSHIPPINGDATE', 'EXPENSEACCOUNT', 'EXPENSEAMORTIZATIONRULE', 'EXPENSELIMIT', 'EXPENSEMIGRATEADJACCOUNT', 'EXPRBUILDER', 'EXTERNALABSTRACT', 'EXTERNALDETAILS', 'EXTERNALDOCUMENTNUMBER', 'EXTERNALID', 'EXTERNALID', 'EXTERNALID', 'EXTRA', 'FAIRVALUE', 'FAIRVALUEFORMULA', 'FAIRVALUEOVERRIDE', 'FAIRVALUERANGEPOLICY', 'FAMILY', 'FANAME', 'FAX', 'FAX', 'FEATUREDDESCRIPTION', 'FEDSTATUS', 'FEDUNEMP', 'FEDWITH', 'FEE', 'FEMAIL', 'FILLPASSWORD', 'FINANCIALINSTITUTION', 'FINISHBYDATE', 'FIRSTISSUEATTACHED', 'FIRSTISSUEREMOVED', 'FIRSTNAME', 'FIRSTUPDATED', 'FIRSTVISIT', 'FIXEDLOTSIZE', 'FNAME', 'FORECASTCHARGERUNONDEMAND', 'FORECASTENDDATE', 'FORECASTSTARTDATE', 'FORMATPROFILE', 'FORWARDCONSUMPTIONDAYS', 'FORWARDCONSUMPTIONDAYS', 'FRAUDRISK', 'FREESHIPMETHOD', 'FREQUENCY', 'FREQUENCY', 'FROMSUBSIDIARY', 'FULFILLMENTPRIORITYLEVEL', 'FUTUREHORIZON', 'FUTUREHORIZON', 'FUTUREHORIZONDATE', 'FXACCOUNT', 'FXRATE', 'GAINLOSSACCOUNT', 'GAINLOSSOFFSETTINGACCTTYPE', 'GDATE', 'GENDER', 'GENERATEACCRUALS', 'GENERATEMODIFICATIONELEMENTS', 'GIVEACCESS', 'GLOBALSUBSCRIPTIONSTATUS', 'GPATOTAL', 'GRADE', 'GROUPINGSTRATEGY', 'GROUPINVOICES', 'GROUPORDER', 'HANDLINGCOST', 'HASOFFLINEACCESS', 'HEIGHT', 'HELPDESK', 'HIGHVALUE', 'HIGHVALUEPERCENT', 'HIREDATE', 'HOLDREVENUERECOGNITION', 'HOLDREVENUERECOGNITION', 'HOMEPHONE', 'HOURS', 'I9VERIFIED', 'ID', 'IDNUMBER', 'IDNUMBER', 'IDNUMBER', 'IMAGE', 'IMMEDIATEDOWNLOAD', 'INACTIVE', 'INACTIVE', 'INACTIVE', 'INACTIVE', 'INBOUNDEMAIL', 'INCLUDECHILDREN', 'INCLUDECRMTASKSINTOTALS', 'INCLUDEDQUANTITY', 'INCLUDEDUSAGE', 'INCLUDEINRENEWAL', 'INCLUDESTARTENDLINES', 'INCOMEACCOUNT', 'INCOMEACCOUNT', 'INCOMINGMESSAGE', 'INCOTERM', 'INCOTERM', 'INHERITIPRULES', 'INITIALAMOUNT', 'INITIALAMOUNT', 'INITIALRESPONSETIME', 'INITIALS', 'INITIALTERM', 'INITIALTERM', 'INPUTQUANTITY', 'INTERCOCOGSACCOUNT', 'INTERCODEFREVACCOUNT', 'INTERCOEXPENSEACCOUNT', 'INTERCOINCOMEACCOUNT', 'INTERNALID', 'INTERNALID', 'INTERNALID', 'INTERNALONLY', 'INTRANSITBALANCE', 'INVENTORYAVAILABLE', 'INVENTORYAVAILFORALLOC', 'INVENTORYCOSTTEMPLATE', 'INVENTORYSTANDARDCOST', 'INVENTORYSUBSIDIARY', 'INVOICE', 'INVOICEFORM', 'INVOICELINE', 'INVTCLASSIFICATION', 'INVTCOUNTINTERVAL', 'IPADDRESSRULE', 'IS1099ELIGIBLE', 'ISACCOUNTMAPPINGINACTIVE', 'ISADJUSTMENTONLY', 'ISAUTOLOCASSIGNMENTALLOWED', 'ISAUTOLOCASSIGNMENTSUSPENDED', 'ISBILLABLE', 'ISBOMITEMTYPE', 'ISBUDGETAPPROVED', 'ISCONSOLIDATED', 'ISDEFAULT', 'ISDONATIONITEM', 'ISDROPSHIPITEM', 'ISELIMINATE', 'ISELIMINATE', 'ISEXEMPT', 'ISEXEMPTTIME', 'ISFORRESCHEDULE', 'ISFULFILLABLE', 'ISGCOCOMPLIANT', 'ISINACTIVE', 'ISINACTIVE', 'ISINACTIVE', 'ISINDIVIDUAL', 'ISINTERCOMPANY', 'ISJOBMANAGER', 'ISJOBRESOURCE', 'ISJOBRESOURCEVEND', 'ISONLINE', 'ISOWNER', 'ISPHANTOM', 'ISPRETAX', 'ISPRIMARY', 'ISPRIVATE', 'ISPRODUCTIVE', 'ISPRODUCTIVETIME', 'ISPUBLIC', 'ISREVIEWED', 'ISSALESREP', 'ISSHOWSTOPPER', 'ISSPECIALORDERITEM', 'ISSPECIALWORKORDERITEM', 'ISSTOREPICKUPALLOWED', 'ISSUE', 'ISSUEABSTRACT', 'ISSUENUMBER', 'ISSUEPRODUCT', 'ISSUEPRODUCT', 'ISSUEROLE', 'ISSUESTATUS', 'ISSUETAGS', 'ISSUETYPE', 'ISSUPPORTREP', 'ISTAXABLE', 'ISTRANCODEMAPPINGEXCLUDE', 'ISTRANCODEMAPPINGINACTIVE', 'ISUTILIZED', 'ISUTILIZEDTIME', 'ISVSOEBUNDLE', 'ISVSOEPRICE', 'ISWIP', 'ITEM', 'ITEM', 'ITEMACCOUNT', 'ITEMCARRIER', 'ITEMDESCRIPTION', 'ITEMID', 'ITEMID', 'ITEMLABORCOSTAMOUNT', 'ITEMNAMENUMBER', 'ITEMPROCESSFAMILY', 'ITEMPROCESSGROUP', 'ITEMRESALECOSTAMOUNT', 'ITEMREVENUECATEGORY', 'ITEMREVENUECATEGORY', 'ITEMSHIPMETHOD', 'ITEMSOURCE', 'ITEMTYPE', 'JOB', 'JOBBILLINGTYPE', 'JOBDESCRIPTION', 'JOBITEM', 'JOBPRICE', 'JOBTYPE', 'JOURNALENTRY', 'KEYWORD', 'KEYWORDS', 'LABORCOST', 'LABORDEFERREDEXPENSEACCT', 'LABOREXPENSEACCT', 'LABORPRICE', 'LABORRESOURCES', 'LANDEDCOSTALLOCATIONMETHOD', 'LANDEDCOSTAMOUNT', 'LANDEDCOSTCOSTCATEGORY', 'LANDEDCOSTCURRENCY', 'LANDEDCOSTEFFECTIVEDATE', 'LANDEDCOSTEXCHANGERATE', 'LANDEDCOSTSHIPMENTITEMS', 'LANGUAGE', 'LASTBASELINEDATE', 'LASTBILLCYCLEDATE', 'LASTBILLCYCLEDATE', 'LASTBILLDATE', 'LASTBILLDATE', 'LASTCUSTOMERMESSAGERECEIVED', 'LASTISSUEATTACHED', 'LASTISSUEREMOVED', 'LASTMERGEDFROMARRANGEMENT', 'LASTMESSAGEDATE', 'LASTMODIFIEDBY', 'LASTMODIFIEDDATE', 'LASTNAME', 'LASTPAGEVISITED', 'LASTPAIDDATE', 'LASTPURCHASEPRICE', 'LASTREOPENEDDATE', 'LASTREVIEWDATE', 'LASTVISIT', 'LEADSGENERATED', 'LEADSOURCE', 'LEADTIME', 'LEADTIME', 'LEGACYBOMFORASSEMBLY', 'LEGALNAME', 'LENGTH', 'LIABILITYACCOUNT', 'LIMITEDLOCATIONS', 'LIMITTIMETOASSIGNEES', 'LINECREATEDFROM', 'LINENUMBER', 'LNAME', 'LOCATION', 'LOCATION', 'LOCATION', 'LOCATIONALLOWSTOREPICKUP', 'LOCATIONRADIUS', 'LOCATIONSTOREPICKUPBUFFERSTOCK', 'LOCATIONTYPE', 'LOCATIONURLALIAS', 'LOCKSTATUS', 'LONGDESCRIPTION', 'LOWVALUE', 'LOWVALUEPERCENT', 'MACHINERESOURCES', 'MANUFACTURER', 'MANUFACTURERADDR1', 'MANUFACTURERCITY', 'MANUFACTURERSTATE', 'MANUFACTURERTARIFF', 'MANUFACTURERTAXID', 'MANUFACTURERZIP', 'MANUFACTURINGCHARGEITEM', 'MANUFACTURINGCOSTTEMPLATE', 'MANUFACTURINGLOCATIONS', 'MANUFACTURINGWORKCENTER', 'MAPPEDNETSUITEACCOUNT', 'MARGINTARGET', 'MARITALSTATUS', 'MATCHBILLTORECEIPT', 'MATERIALIZETIME', 'MATRIXITEMNAMETEMPLATE', 'MAXDONATIONAMOUNT', 'MAXIMUMQUANTITY', 'MAXLOCATIONS', 'MEDICARE', 'MEMO', 'MEMO', 'MEMO', 'MESSAGE', 'METATAGHTML', 'MILESTONE', 'MINIMUMORDERAMOUNT', 'MINIMUMQUANTITY', 'MNAME', 'MOBILEPHONE', 'MODIFIEDBY', 'MODULE', 'MONTHLYCLOSING', 'MOSSAPPLIES', 'MPN', 'MSPROJOUTLINENUM', 'MSPROJPREDS', 'MSPROJRESOURCES', 'MSPROJSCHEDWORK', 'MSPROJSERVICEITEM', 'MSPROJUID', 'MULTMANUFACTUREADDR', 'NAME', 'NAME', 'NAME', 'NAME', 'NAME', 'NAME', 'NEGATIVENUMBERFORMAT', 'NETSUITETRANSACTIONTYPE', 'NEWDETAILS', 'NEWSTANDARDMIGRATEDATE', 'NEXTAGCATEGORY', 'NEXTAPPROVER', 'NEXTAPPROVER', 'NEXTBILLCYCLEDATE', 'NEXTBILLCYCLEDATE', 'NEXTINVTCOUNTDATE', 'NEXTRENEWALSTARTDATE', 'NEXTREVIEWDATE', 'NONBILLABLETASK', 'NOPRICEMESSAGE', 'NOTE', 'NOTEDATE', 'NOTES', 'NOTETYPE', 'NUMBERFORMAT', 'NUMBERTOGENERATE', 'NUMOFALLOWEDDOWNLOADS', 'OFFER', 'OFFERSUPPORT', 'OFFICEPHONE', 'ONSPECIAL', 'OPENINGBALANCE', 'OPENINGBALANCEACCOUNT', 'OPENINGBALANCEDATE', 'OPERATIONSEQUENCE', 'OPTFULFILLMENT', 'ORDER', 'ORGANIZER', 'ORIGIN', 'ORIGINALCHANGEORDERDISCAMOUNT', 'ORIGINALCHANGEORDERQUANTITY', 'ORIGINALITEMSUBTYPE', 'ORIGINALITEMTYPE', 'ORIGINATINGSUBSIDIARY', 'OTHERRELATIONSHIPS', 'OUTGOINGMESSAGE', 'OUTOFSTOCKBEHAVIOR', 'OUTOFSTOCKMESSAGE', 'OUTSIDEPROJECTPLAN', 'OVERALLQUANTITYPRICINGTYPE', 'OVERDUEBALANCE', 'OVERHEADTYPE', 'OVERRIDECURRENCYFORMAT', 'OVERRIDERATE', 'OWNER', 'OWNERROLE', 'PAGETITLE', 'PAIDEXTERNALLY', 'PARENT', 'PARENTBOMELEMENT', 'PARENTLINECURRENCY', 'PARENTLINECURRENCY', 'PARTNER', 'PARTNERCODE', 'PASSPORTNUMBER', 'PASSWORD', 'PASSWORD2', 'PASTHORIZON', 'PASTHORIZONDATE', 'PAYABLESACCOUNT', 'PAYFREQUENCY', 'PAYMENTMETHOD', 'PAYROLLITEM', 'PAYROLLWORKPLACE', 'PERCENTCOMPLETE', 'PERCENTCOMPLETEBYRSRCALLOC', 'PERCENTTIMECOMPLETE', 'PERCENTWORKCOMPLETE', 'PERIODICLOTSIZEDAYS', 'PERIODICLOTSIZETYPE', 'PERIODOFFSET', 'PERIODOFFSET', 'PERMITDISCOUNT', 'PHONE', 'PHONE', 'PHONETICNAME', 'PLANNEDHOURS', 'PLANNEDPERIOD', 'PLANNEDWORK', 'PLANNEDWORKBASELINE', 'POCURRENCY', 'PONUMBER', 'PORATE', 'PORECEIPTCOST', 'POSTED', 'POSTINGDISCOUNTAPPLIED', 'POVENDOR', 'PREDCONFIDENCE', 'PREDICTEDDAYS', 'PREFCCPROCESSOR', 'PREFERENCECRITERION', 'PREFERREDLOCATION', 'PREFERREDSTOCKLEVEL', 'PREFERREDSTOCKLEVELDAYS', 'PRICE', 'PRICE', 'PRICEBOOK', 'PRICEINTERVALFREQUENCY', 'PRICELEVEL', 'PRICEMODELTYPE', 'PRICINGGROUP', 'PRINTITEMS', 'PRINTONCHECKAS', 'PRIORITY', 'PROBABILITY', 'PRODPRICEVARIANCEACCT', 'PRODQTYVARIANCEACCT', 'PRODUCER', 'PRODUCT', 'PRODUCTFEED', 'PRODUCTSERVICE', 'PRODUCTTEAM', 'PROFILE', 'PROFIT', 'PROJECT', 'PROJECTCOMPLETELYBILLED', 'PROJECTEDENDDATE', 'PROJECTEDENDDATEBASELINE', 'PROJECTEXPENSETYPE', 'PROJECTFORMTEMPLATE', 'PROJECTIONDURATION', 'PROJECTIONINTERVAL', 'PROJECTIONMETHOD', 'PROJECTIONSTARTDATE', 'PROJECTMANAGER', 'PROJECTREVENUERULE', 'PROJECTTASK', 'PROJECTTEMPLATE', 'PROMOTIONCODE', 'PRORATEENDDATE', 'PRORATESTARTDATE', 'PURCHASEDESCRIPTION', 'PURCHASEORDER', 'PURCHASEORDERAMOUNT', 'PURCHASEORDERAPPROVALLIMIT', 'PURCHASEORDERAPPROVER', 'PURCHASEORDERLIMIT', 'PURCHASEORDERQUANTITY', 'PURCHASEORDERQUANTITYDIFF', 'PURCHASEPRICEVARIANCEACCT', 'PURCHASETAXCODE', 'PURCHASEUNIT', 'QUANTITY', 'QUANTITYAVAILABLE', 'QUANTITYAVAILABLEBASE', 'QUANTITYBACKORDERED', 'QUANTITYBILLED', 'QUANTITYCOMMITTED', 'QUANTITYEXPECTED', 'QUANTITYONHAND', 'QUANTITYONHANDBASE', 'QUANTITYONORDER', 'QUANTITYPRICINGSCHEDULE', 'QUANTITYRECEIVED', 'QUANTITYREMAINING', 'QUICKNOTE', 'RATE', 'RATE', 'RATEINCLUDINGTAX', 'RATEMULTIPLIER', 'RATEROUNDINGTYPE', 'RATESOURCETYPE', 'REACTIVATIONOPTION', 'RECALCADJUSTPERIODOFFSET', 'RECALCADJUSTPERIODOFFSET', 'RECEIPTAMOUNT', 'RECEIPTQUANTITY', 'RECEIPTQUANTITYDIFF', 'RECEIVABLESACCOUNT', 'RECEIVINGLOCATION', 'RECOGNITIONACCOUNT', 'RECOGNITIONMETHOD', 'RECOGNITIONMETHOD', 'RECOGNITIONPERIOD', 'RECOGNITIONPERIOD', 'RECOGNITIONTREATMENT', 'RECOGNITIONTREATMENTRULE', 'RECORD', 'RECORDNUMBER', 'RECORDNUMBER', 'RECORDTYPE', 'RECURRENCESTARTDATE', 'REFERENCEID', 'REFERRER', 'REFERRINGURL', 'REFORECASTMETHOD', 'REFORECASTMETHOD', 'REJECTEDHOURS', 'REJECTIONNOTE', 'RELATEDITEMSDESCRIPTION', 'RELATEDREVENUEARRANGEMENT', 'RELATEDREVENUEELEMENT', 'RELATEDTRANSACTIONS', 'RELEASEDATE', 'REMAININGDEFERREDBALANCE', 'REMAININGDEFERREDBALANCE', 'REMAININGDEFERREDCOSTBALANCE', 'REMAININGTIMETOCHARGE', 'REMAININGWORK', 'REMINDERDAYS', 'REMINDERMINUTES', 'REMINDERTYPE', 'RENEWALENDDATE', 'RENEWALMETHOD', 'RENEWALPLAN', 'RENEWALPRICEBOOK', 'RENEWALSTARTDATE', 'RENEWALTERM', 'RENEWALTRANTYPE', 'REORDERMULTIPLE', 'REORDERPOINT', 'REPLENISHMENTMETHOD', 'REPORTEDBY', 'REPRESENTINGSUBSIDIARY', 'REPRODUCE', 'REQUESTEDBY', 'REQUESTOFFCYCLEINVOICE', 'REQUESTOFFCYCLEINVOICE', 'REQUESTOR', 'REQUIREPWDCHANGE', 'RESALENUMBER', 'RESCHEDULEINDAYS', 'RESCHEDULEINDAYS', 'RESCHEDULEOUTDAYS', 'RESCHEDULEOUTDAYS', 'RESIDENTSTATUS', 'RESIDUAL', 'RESIDUAL', 'RESIDUALDISCSALESAMOUNT', 'RESTRICTTOASSEMBLIES', 'RESTRICTTOLOCATIONS', 'RETURNOFELEMENT', 'REVENUEALLOCATIONGROUP', 'REVENUEALLOCATIONGROUP', 'REVENUEALLOCATIONRATIO', 'REVENUEARRANGEMENT', 'REVENUEMIGRATEADJACCOUNT', 'REVENUEPLAN', 'REVENUEPLANCURRENCY', 'REVENUEPLANCURRENCY', 'REVENUEPLANSTATUS', 'REVENUEPLANTYPE', 'REVENUEPLANTYPE', 'REVENUERECOGNITIONRULE', 'REVENUERECOGNITIONRULE', 'REVENUERECOGNITIONRULE', 'REVENUERECONCILED', 'REVIEWER', 'REVRECENDDATE', 'REVRECENDDATE', 'REVRECENDDATESOURCE', 'REVRECENDDATESOURCE', 'REVRECFORECASTRULE', 'REVRECFORECASTRULE', 'REVRECLASSFXACCOUNT', 'REVRECOPTION', 'REVRECSCHEDULE', 'REVRECSTARTDATE', 'REVRECSTARTDATE', 'REVRECSTARTDATESOURCE', 'REVRECSTARTDATESOURCE', 'ROI', 'ROTATIONTYPE', 'ROUNDUPASCOMPONENT', 'RULE', 'RULEID', 'RULEORDER', 'RUNID', 'RUNRATE', 'SAFETYSTOCKLEVEL', 'SAFETYSTOCKLEVELDAYS', 'SALESAMOUNT', 'SALESDESCRIPTION', 'SALESORDER', 'SALESORDERLINE', 'SALESORDERLINENUMBER', 'SALESREADINESS', 'SALESREP', 'SALESROLE', 'SALESTAXCODE', 'SALEUNIT', 'SALEUNIT', 'SALUTATION', 'SCHEDULEBCODE', 'SCHEDULEBNUMBER', 'SCHEDULEBQUANTITY', 'SCHEDULEDENDDATE', 'SCHEDULEDENDDATEBASELINE', 'SCHEDULINGMETHOD', 'SCRAPACCT', 'SEARCHENGINE', 'SEARCHKEYWORDS', 'SEASONALDEMAND', 'SEMESTER', 'SENDEMAIL', 'SENDTRANSACTIONSVIA', 'SERIALNUMBER', 'SERIALNUMBERS', 'SERVICEENDDATE', 'SERVICEGROUP', 'SERVICEITEM', 'SERVICESTARTDATE', 'SETUPTIME', 'SEVERITY', 'SHIPADDRESS', 'SHIPADDRESSLIST', 'SHIPCOMPLETE', 'SHIPINDIVIDUALLY', 'SHIPMENTBASECURRENCY', 'SHIPMENTCREATEDDATE', 'SHIPMENTITEM', 'SHIPMENTITEMAMOUNT', 'SHIPMENTITEMDESCRIPTION', 'SHIPMENTITEMEFFECTIVEDATE', 'SHIPMENTITEMEXCHANGERATE', 'SHIPMENTMEMO', 'SHIPMENTNUMBER', 'SHIPMENTSTATUS', 'SHIPPACKAGE', 'SHIPPINGCARRIER', 'SHIPPINGCOST', 'SHIPPINGITEM', 'SHIPPINGPARTNER', 'SHOPPINGDOTCOMCATEGORY', 'SHOPZILLACATEGORYID', 'SHOWDEFAULTDONATIONAMOUNT', 'SIMULATIONNUMBER', 'SITEMAPPRIORITY', 'SOCIALSECURITY', 'SOCIALSECURITYNUMBER', 'SOFTDESCRIPTOR', 'SOLUTIONCODE', 'SOURCE', 'SOURCEACCOUNT', 'SOURCECLASS', 'SOURCEDEPARTMENT', 'SOURCELOCATION', 'SOURCESERVICEITEMFROMRATECARD', 'SOURCETYPE', 'SOURCEWEBSITE', 'SPAMLOCK', 'SPECIALSDESCRIPTION', 'SSCORE', 'STAGE', 'STANDARDCOSTVERSION', 'STARTDATE', 'STARTDATE', 'STARTDATEBASELINE', 'STARTDATEBASELINE', 'STARTDATETIMEOFFCALC', 'STARTOFFSET', 'STARTOFFSET', 'STARTTIME', 'STATE', 'STATUS', 'STATUS', 'STATUS', 'STOCKDESCRIPTION', 'STOCKUNIT', 'STOPIFCAPPED', 'STOREDESCRIPTION', 'STOREDETAILEDDESCRIPTION', 'STOREDISPLAYIMAGE', 'STOREDISPLAYNAME', 'STOREDISPLAYTHUMBNAIL', 'STOREITEMTEMPLATE', 'STRATEGY', 'STRENGTHS', 'STUDENTID', 'STUDEPARTMENT', 'STUEMAIL', 'STUNATIONALITY', 'SUBMITTEDHOURS', 'SUBPARTNERLOGIN', 'SUBSCRIPTION', 'SUBSCRIPTION', 'SUBSCRIPTIONCHANGEORDERSTATUS', 'SUBSCRIPTIONLINE', 'SUBSCRIPTIONLINE', 'SUBSCRIPTIONLINEDISCOUNT', 'SUBSCRIPTIONLINEQUANTITY', 'SUBSCRIPTIONLINESTATUS', 'SUBSCRIPTIONLINETYPE', 'SUBSCRIPTIONPLAN', 'SUBSCRIPTIONPLAN', 'SUBSCRIPTIONPLANLINE', 'SUBSCRIPTIONREVISION', 'SUBSIDIARY', 'SUBSIDIARY', 'SUBSIDIARY', 'SUPERVISOR', 'SUPERVISORAPPROVAL', 'SUPERVISORPHONE', 'SUPPLYLOCATION', 'SUPPLYLOCATIONDATE', 'SUPPLYLOCATIONSUBSIDIARY', 'SUPPLYLOTSIZINGMETHOD', 'SUPPLYREPLENISHMENTMETHOD', 'SUPPLYTIMEFENCE', 'SUPPLYTIMEFENCE', 'SUPPLYTYPE', 'SUPPLYTYPE', 'SUPPORTCASE', 'SUPPORTFIRSTREPLY', 'SYMBOLPLACEMENT', 'TARGETUTILIZATION', 'TAXABLE', 'TAXEXEMPT', 'TAXFRACTIONUNIT', 'TAXIDNUM', 'TAXITEM', 'TAXROUNDING', 'TAXSCHEDULE', 'TEGATAMATURITY', 'TEMPLATE', 'TEMPLATESTORED', 'TERMINATIONBYDEATH', 'TERMINATIONCATEGORY', 'TERMINATIONDATE', 'TERMINATIONDETAILS', 'TERMINATIONREASON', 'TERMINATIONREGRETTED', 'TERMINDAYS', 'TERMINDAYS', 'TERMINMONTHS', 'TERMINMONTHS', 'TERMINMONTHS', 'TERMS', 'TERMS', 'TERRITORY', 'TIME', 'TIMEAPPROVAL', 'TIMEAPPROVER', 'TIMEAPPROVER', 'TIMEDEVENT', 'TIMEELAPSED', 'TIMELINETYPE', 'TIMEMODIFIED', 'TIMEOFFBALANCES', 'TIMEOFFPLAN', 'TIMEOFFTYPE', 'TIMEONHOLD', 'TIMEOPEN', 'TIMERECORD', 'TIMEREMAINING', 'TIMETOASSIGN', 'TIMETOCLOSE', 'TITLE', 'TOSUBSIDIARY', 'TOTAL', 'TOTALAMORTIZED', 'TOTALHOURS', 'TOTALQUANTITYONHAND', 'TOTALRECOGNIZED', 'TOTALRECOGNIZED', 'TOTALREVENUE', 'TOTALUNITCOST', 'TOTALVALUE', 'TRACKCODE', 'TRACKLANDEDCOST', 'TRANCODEMAPPINGDESCRIPTION', 'TRANCODEMAPPINGID', 'TRANDATE', 'TRANSACTION', 'TRANSACTIONLINE', 'TRANSACTIONPARSER', 'TRANSACTIONPOLARITY', 'TRANSACTIONTYPE', 'TRANSFERPRICE', 'TREATMENTOVERRIDE', 'TSCORE', 'TWOSTEPREVENUEALLOCATION', 'TYPE', 'UNBILLEDORDERS', 'UNBILLEDORDERS', 'UNBILLEDORDERSPRIMARY', 'UNBILLEDRECEIVABLEGROUP', 'UNBILLEDRECEIVABLEGROUPING', 'UNBUILDVARIANCEACCOUNT', 'UNIQUEVISITORS', 'UNIT', 'UNIT', 'UNITLANDEDCOST', 'UNITS', 'UNITS', 'UNITSTYPE', 'UNITSTYPE', 'UPCCODE', 'URL', 'URLCOMPONENT', 'USAGEDATE', 'USAGEMULTIPLIERLINE', 'USAGEQUANTITY', 'USAGESUBSCRIPTION', 'USAGESUBSCRIPTIONLINE', 'USE', 'USEALLOCATEDTIMEFORFORECAST', 'USEBINS', 'USECACHEDCRMGROUP', 'USECOMPONENTYIELD', 'USECOMPONENTYIELD', 'USEEMPLOYEETEMPLATE', 'USEMARGINALRATES', 'USEMATERIALIZEDSAVEDSEARCH', 'USEPERCENTCOMPLETEOVERRIDE', 'USEPERQUEST', 'USESUBSTARTDATEASRSD', 'USETIMEDATA', 'USETYPE', 'VARIANCETYPE', 'VATREGNUMBER', 'VENDOR', 'VENDORNAME', 'VENDRETURNVARIANCEACCOUNT', 'VERSION', 'VERSIONBROKEN', 'VERSIONFIXED', 'VERSIONTARGET', 'VERTICAL', 'VESSELNUMBER', 'VISAEXPDATE', 'VISATYPE', 'VISITS', 'VSOEDEFERRAL', 'VSOEDELIVERED', 'VSOEPERMITDISCOUNT', 'VSOEPRICE', 'VSOESOPGROUP', 'W4COMPLETED', 'WEAKNESSES', 'WEBLEAD', 'WEBSITE', 'WEIGHT', 'WIDTH', 'WIPACCT', 'WIPVARIANCEACCT', 'WORKCALENDAR', 'WORKCALENDAR', 'WORKCALENDARHOURS', 'WORKORDER', 'WORKPLACE', 'ZIP', 'ZIPCODE'] }),
+    },
+    path: [...enumsFolderPath, entryform_fieldidElemID.name],
+  }),
+  entryform_standard: new PrimitiveType({
+    elemID: entryform_standardElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BILLOFDISTRIBUTIONFORM', 'CLASSSEGMENTMAPPINGFORM', 'DASHBOARDCUSTOMERFORM', 'DASHBOARDVENDORFORM', 'DEPARTMENTSEGMENTMAPPINGFORM', 'DISTRIBUTIONNETWORKFORM', 'INVENTORYCOSTTEMPLATEFORM', 'LOCATIONCOSTINGGROUPFORM', 'LOCATIONSEGMENTMAPPINGFORM', 'MANUFACTURINGCOSTTEMPLATEFORM', 'MANUFACTURINGROUTINGFORM', 'MANUFACTURINGTASK', 'SHIPPINGPARTNERPACKAGEFORM', 'SHIPPINGPARTNERREGISTRATIONFORM', 'SHIPPINGPARTNERSHIPMENTFORM', 'STANDARDACCOUNTINGBOOKFORM', 'STANDARDADDRESSFORM', 'STANDARDASCHARGEDPROJECTREVENUERULE', 'STANDARDAUTOMATICLOCATIONASSIGNMENTCONFIGURATIONFORM', 'STANDARDAUTOMATICLOCATIONASSIGNMENTRULEFORM', 'STANDARDBILLINGACCOUNT', 'STANDARDBILLINGRATECARDFORM', 'STANDARDBILLOFMATERIALS', 'STANDARDBILLOFMATERIALSREVISION', 'STANDARDCAMPAIGNFORM', 'STANDARDCASEFORM', 'STANDARDCHARGEFORM', 'STANDARDCOMPETITORFORM', 'STANDARDCONTACTFORM', 'STANDARDCUSTOMERFORM', 'STANDARDDESCRIPTIONFORM', 'STANDARDDISCOUNTFORM', 'STANDARDEMPLOYEEFORM', 'STANDARDENTITYACCOUNTMAPPINGFORM', 'STANDARDEVENTFORM', 'STANDARDEXPENSEAMORTIZATIONEVENTFORM', 'STANDARDEXPENSEAMORTIZATIONRULEFORM', 'STANDARDEXPENSEBASEDCHARGERULEFORM', 'STANDARDEXPENSEFORM', 'STANDARDEXPENSEPLANFORM', 'STANDARDEXTERNALCASEFORM', 'STANDARDEXTERNALCUSTOMERFORM', 'STANDARDEXTERNALISSUEFORM', 'STANDARDEXTERNALPARTNERFORM', 'STANDARDFAIRVALUEFORMULAFORM', 'STANDARDFAIRVALUEPRICEFORM', 'STANDARDFIXEDAMOUNTPROJECTREVENUERULE', 'STANDARDFIXEDDATECHARGERULEFORM', 'STANDARDGAINLOSSACCOUNTMAPPINGFORM', 'STANDARDGENERICRESOURCEFORM', 'STANDARDGLOBALACCOUNTMAPPINGFORM', 'STANDARDGLOBALINVENTORYRELATIONSHIPFORM', 'STANDARDGROUPITEMFORM', 'STANDARDHELPDESKFORM', 'STANDARDINBOUNDSHIPMENT', 'STANDARDINVENTORYDETAILFORM', 'STANDARDINVENTORYPARTFORM', 'STANDARDINVENTORYSTATUS', 'STANDARDISSUEFORM', 'STANDARDITEMACCOUNTMAPPINGFORM', 'STANDARDITEMDEMANDPLANFORM', 'STANDARDITEMLOCATIONCONFIGURATIONFORM', 'STANDARDITEMPROCESSFAMILYFORM', 'STANDARDITEMPROCESSGROUPFORM', 'STANDARDITEMREVENUECATEGORYFORM', 'STANDARDITEMSUPPLYPLANFORM', 'STANDARDJOBFORM', 'STANDARDLABORBASEDPROJECTREVENUERULE', 'STANDARDLEADFORM', 'STANDARDMANAGERGROUPITEMFORM', 'STANDARDMANAGERINVENTORYPARTFORM', 'STANDARDMANAGERNONINVENTORYPARTFORM', 'STANDARDMILESTONECHARGERULEFORM', 'STANDARDNEXUS', 'STANDARDNONINVENTORYPARTFORM', 'STANDARDNOTEFORM', 'STANDARDONLINEINVENTORYDETAILFORM', 'STANDARDONLINEJOBFORM', 'STANDARDPARTNERFORM', 'STANDARDPAYMENTFORM', 'STANDARDPERCENTCOMPLETEPROJECTREVENUERULE', 'STANDARDPHONECALLFORM', 'STANDARDPLANNEDREVENUEFORM', 'STANDARDPLANNEDSTANDARDCOSTFORM', 'STANDARDPOPUPCONTACTFORM', 'STANDARDPOPUPCUSTOMERFORM', 'STANDARDPOPUPEMPLOYEEFORM', 'STANDARDPOPUPPARTNERFORM', 'STANDARDPOPUPVENDORFORM', 'STANDARDPRICEBOOKFORM', 'STANDARDPRICEPLANFORM', 'STANDARDPROJECTBUDGETFORM', 'STANDARDPROJECTICCHARGEREQFORM', 'STANDARDPROJECTPROGRESSCHARGERULEFORM', 'STANDARDPROJECTTASKFORM', 'STANDARDPROJECTTEMPLATEFORM', 'STANDARDPROMOTIONCODEFIXEDPRICE', 'STANDARDPROMOTIONCODEFORM', 'STANDARDPROMOTIONCODEFREEGIFT', 'STANDARDPROMOTIONCODEITEM', 'STANDARDPROMOTIONCODEORDER', 'STANDARDPROMOTIONCODESHIPPING', 'STANDARDPURCHASERULEFORM', 'STANDARDREGIONFORM', 'STANDARDRESOURCEALLOCATIONFORM', 'STANDARDRESOURCEGROUPFORM', 'STANDARDREVENUEELEMENTFORM', 'STANDARDREVENUERECOGNITIONEVENTFORM', 'STANDARDREVENUERECOGNITIONPLANFORM', 'STANDARDREVENUERECOGNITIONRULEFORM', 'STANDARDSOLUTIONFORM', 'STANDARDSTANDARDCOSTVERSIONFORM', 'STANDARDSUBSCRIPTIONCHANGEORDER', 'STANDARDSUBSCRIPTIONFORM', 'STANDARDSUBSCRIPTIONLINEFORM', 'STANDARDSUBSCRIPTIONPLANFORM', 'STANDARDSUPPLYCHAINSNAPSHOT', 'STANDARDTASKFORM', 'STANDARDTIMEBASEDCHARGERULEFORM', 'STANDARDTIMEENTRYFORM', 'STANDARDTIMESHEETFORM', 'STANDARDTIMETRACKINGFORM', 'STANDARDUSAGEFORM', 'STANDARDVENDORFORM', 'STANDARDWBSFORM', 'STDBONUSFORM', 'STDFORMATPROFILEFORM', 'STDSTUDENTRECORDFORM', 'STDSUPPLYCHAINSNAPSHOTSIMULATIONFORM'] }),
+    },
+    path: [...enumsFolderPath, entryform_standardElemID.name],
+  }),
+  entryform_sublistid: new PrimitiveType({
+    elemID: entryform_sublistidElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BOMCALLS', 'BOMCOMPONENT', 'BOMEVENTS', 'BOMMEDIAITEM', 'BOMSYSTEMNOTES', 'BOMTASKS', 'ENTITYACCESS', 'ENTITYACCESSHISTORY', 'ENTITYACHACCT', 'ENTITYACTIVEWORKFLOWS', 'ENTITYACTIVITIES', 'ENTITYADDRESSBOOK', 'ENTITYADDRESSBOOK', 'ENTITYBILLINGACCOUNTS', 'ENTITYBILLINGSUBSCRIPTIONS', 'ENTITYBONUSES', 'ENTITYBULKMERGE', 'ENTITYCALLS', 'ENTITYCAMPAIGNS', 'ENTITYCARTCONTENTS', 'ENTITYCASES', 'ENTITYCLICKSTREAMS', 'ENTITYCOMMISSION', 'ENTITYCOMPANY', 'ENTITYCONTACT', 'ENTITYCREDITCARDS', 'ENTITYCURJURISDICTIONS', 'ENTITYCURRENCY', 'ENTITYCURRENCY', 'ENTITYCUSTOMERS', 'ENTITYDD', 'ENTITYDEALITEM', 'ENTITYDOWNLOAD', 'ENTITYEDUCATION', 'ENTITYEFTACCT', 'ENTITYEMERGENCYCONTACT', 'ENTITYEMPPERMS', 'ENTITYEVENTS', 'ENTITYFINHIST', 'ENTITYGROUPPRICING', 'ENTITYHOSTEDHITS', 'ENTITYHREDUCATION', 'ENTITYHRSUPERVISORHIST', 'ENTITYISSUES', 'ENTITYITEMORDERS', 'ENTITYITEMPRICING', 'ENTITYITEMS', 'ENTITYJOBRESOURCES', 'ENTITYJOBS', 'ENTITYJOBTASKS', 'ENTITYJURISDICTIONHIST', 'ENTITYKEYWORDS', 'ENTITYMEDIAITEM', 'ENTITYMESSAGES', 'ENTITYMILESTONES', 'ENTITYONLINEFORMEVENTS', 'ENTITYONLINEFORMS', 'ENTITYOPPORTUNITIES', 'ENTITYPAGEHITS', 'ENTITYPARTNERS', 'ENTITYPAYACCRUED', 'ENTITYPAYCONTRIB', 'ENTITYPAYDEDUCT', 'ENTITYPAYEARN', 'ENTITYPAYMENTINSTRUMENTS', 'ENTITYPAYWITH', 'ENTITYPAYWITHOTHER', 'ENTITYPAYWITHSTATE', 'ENTITYPCTCOMPLETEOVERRIDE', 'ENTITYPLSTATEMENT', 'ENTITYPRICINGSCHEDULE', 'ENTITYPROMOCODE', 'ENTITYRATES', 'ENTITYREFERRER', 'ENTITYRESOURCEALLOCATION', 'ENTITYROLES', 'ENTITYSALESTEAM', 'ENTITYSUBMACHINE', 'ENTITYSUBMACHINE', 'ENTITYSUBORDINATES', 'ENTITYSUBS', 'ENTITYSUBSCRIPTIONMSGMACH', 'ENTITYSUBSCRIPTIONS', 'ENTITYSYSTEMNOTES', 'ENTITYTASKS', 'ENTITYTAXREGISTRATION', 'ENTITYTIME', 'ENTITYTIME', 'ENTITYTIMEITEM', 'ENTITYTIMEOFFCONFLICTS', 'ENTITYUPSELL', 'ENTITYUSERNOTES', 'ENTITYWBS', 'ENTITYWORKFLOWHISTORY', 'EVENTACTIVEWORKFLOWS', 'EVENTACTIVITIES', 'EVENTASSIGNEE', 'EVENTATTENDEE', 'EVENTBROKENINVERSION', 'EVENTCALLS', 'EVENTCAMPAIGNDIRECTMAIL', 'EVENTCAMPAIGNDRIP', 'EVENTCAMPAIGNEMAIL', 'EVENTCAMPAIGNEVENT', 'EVENTCASE', 'EVENTCASES', 'EVENTCONTACT', 'EVENTCOSTDETAIL', 'EVENTDEFAULTEVENT', 'EVENTDETAILS', 'EVENTESCALATEHIST', 'EVENTESCALATETO', 'EVENTEVENTRESPONSE', 'EVENTEVENTS', 'EVENTFIXEDINVERSION', 'EVENTINVITECALENDAR', 'EVENTISSUES', 'EVENTMEDIAITEM', 'EVENTMESSAGES', 'EVENTPREDECESSOR', 'EVENTRELATEDISSUES', 'EVENTRESOURCE', 'EVENTSOLUTIONS', 'EVENTSYSTEMNOTES', 'EVENTTARGETVERSION', 'EVENTTASKS', 'EVENTTIMEITEM', 'EVENTTIMEOFFCONFLICTS', 'EVENTTIMEOFFDETAILS', 'EVENTTOPICS', 'EVENTTRANSACTIONS', 'EVENTUSERNOTES', 'EVENTWORKFLOWHISTORY', 'ITEMACTIVEWORKFLOWS', 'ITEMACTIVEWORKFLOWS', 'ITEMBILLINGRATE', 'ITEMBINNUMBER', 'ITEMBINNUMBERSEARCH', 'ITEMCALLS', 'ITEMCORRELATEDITEMS', 'ITEMEVENTS', 'ITEMHIERARCHYVERSIONS', 'ITEMINVENTORYDETAILSRCH', 'ITEMINVENTORYNUMBERSRCH', 'ITEMINVENTORYSTATUSSRCH', 'ITEMITEMVENDOR', 'ITEMLOCATIONS', 'ITEMMEDIAITEM', 'ITEMMEMBER', 'ITEMMFGROUTING', 'ITEMNUMBERS', 'ITEMPRESITEMS', 'ITEMPRICE', 'ITEMSITECATEGORY', 'ITEMSYSTEMNOTES', 'ITEMSYSTEMNOTES', 'ITEMTASKS', 'ITEMTRANSACTIONS', 'ITEMTRANSACTIONS', 'ITEMTRANSLATIONS', 'ITEMUSERNOTES', 'ITEMUSERNOTES', 'ITEMWORKFLOWHISTORY', 'ITEMWORKFLOWHISTORY', 'OTHERACCOUNTMAPPING', 'OTHERACTIVEWORKFLOWS', 'OTHERACTIVEWORKFLOWS', 'OTHERBILLINGSCHEDULE', 'OTHERBILLREQUEST', 'OTHERCALLS', 'OTHERCAMPAIGNS', 'OTHERCHANGEORDER', 'OTHERCHARGERULE', 'OTHERCHARGES', 'OTHERCHARGES', 'OTHERCOSTDETAIL', 'OTHERCUSTOMERRETURN', 'OTHERDATESFIXEDAMOUNT', 'OTHERDATESPCTFROMTOTAL', 'OTHERDISTRIBUTIONCATEGORY', 'OTHERDISTRIBUTIONSOURCE', 'OTHERENROLL', 'OTHEREVENTS', 'OTHERFILTERS', 'OTHERFULFILLMENT', 'OTHERHISTORYTAB', 'OTHERITEM', 'OTHERITEMS', 'OTHERLANDEDCOST', 'OTHERLINES', 'OTHERLOCATION', 'OTHERMEDIAITEM', 'OTHERNEWLINEITEMS', 'OTHEROPPORTUNITIES', 'OTHERORDER', 'OTHERPARTNERS', 'OTHERPLANNINGMESSAGE', 'OTHERRATECARDPRICING', 'OTHERRATECARDPRICINGMULTI', 'OTHERRATECARDPROJECTS', 'OTHERRATECARDVERSION', 'OTHERRECURRENCEST', 'OTHERRELATEDSUBSCR', 'OTHERRENEWALHISTORY', 'OTHERRENEWALSTEPS', 'OTHERRESOURCERATEOVERRIDE', 'OTHERREVELEMENTS', 'OTHERROUTINGCOMPONENT', 'OTHERROUTINGSTEP', 'OTHERSUBLINE', 'OTHERSUBLINEFROMPLAN', 'OTHERSUBSCRIPTIONS', 'OTHERSYSTEMNOTES', 'OTHERSYSTEMNOTES', 'OTHERSYSTEMNOTES', 'OTHERSYSTEMNOTES', 'OTHERTASKS', 'OTHERTASKSFIXEDAMOUNT', 'OTHERTASKSPCTFROMTOTAL', 'OTHERTRANCODEMAPPING', 'OTHERTRANSACTIONS', 'OTHERTRANSLATIONS', 'OTHERUSERNOTES', 'OTHERWORKFLOWHISTORY', 'OTHERWORKFLOWHISTORY', 'TIMEACTIVEWORKFLOWS', 'TIMECHARGES', 'TIMESYSTEMNOTES', 'TIMEWORKFLOWHISTORY'] }),
+    },
+    path: [...enumsFolderPath, entryform_sublistidElemID.name],
+  }),
+  entryform_subtabid: new PrimitiveType({
+    elemID: entryform_subtabidElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CRMCONTACTS', 'ENTITYCURJURISDICTIONS', 'ENTITYEDUCATION', 'ENTITYEXPREPTCURRENCIES', 'ENTITYHRPERSONAL', 'ENTITYHRWORKSTATUS', 'ENTITYJURISDICTIONS', 'ENTITYPAYFED', 'ENTITYPROMOCODES', 'ENTITYQUALIFICATION', 'ENTITYSUBSCRIPTIONS', 'ENTITYSUBTAB_BBUDGET', 'ENTITYSUBTAB_CBUDGET', 'ENTITYWORKFLOW', 'EVENTFILE', 'EVENTMEDIA', 'EVENTSUBTAB_BBUDGET', 'EVENTSUBTAB_CBUDGET', 'EVENTSUPPORT', 'EVENTWORKFLOW', 'ITEMINVENTORYNUMBERS', 'ITEMLOCATIONS', 'ITEMMATRIX', 'ITEMMEMBERS', 'ITEMPROJECTS', 'ITEMPROJECTS', 'ITEMRELITEMS', 'ITEMTRANSLATION', 'ITEMVENDORS', 'ITEMWORKFLOW', 'ITEMWORKFLOW'] }),
+    },
+    path: [...enumsFolderPath, entryform_subtabidElemID.name],
+  }),
+  entryform_tabid: new PrimitiveType({
+    elemID: entryform_tabidElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ADDRESSCUSTOM', 'ADDRESSMAIN', 'BOMCOMMUNICATION', 'BOMCOMPONENTS', 'BOMHISTORY', 'BOMMAIN', 'CRMBUDGET', 'CRMKEYWORD', 'CRMMAIN', 'CRMMESSAGE', 'CRMRELATEDINFO', 'CRMRELATEDRECORDS', 'CRMSYSTEMINFORMATION', 'ENTITYACCESS', 'ENTITYACCOUNTING', 'ENTITYADDRESS', 'ENTITYADDRESS', 'ENTITYBILLACCNTS', 'ENTITYBUDGET', 'ENTITYCOMMISSION', 'ENTITYCOMMISSION', 'ENTITYCOMMUNICATION', 'ENTITYCOMPENSATIONTRACKING', 'ENTITYCUSTOM', 'ENTITYDD', 'ENTITYEDUCATION', 'ENTITYEFFECTIVEDATEHIST', 'ENTITYFINANCIAL', 'ENTITYGENERAL', 'ENTITYGOVID', 'ENTITYHUMANRESOURCES', 'ENTITYINFO', 'ENTITYMAIN', 'ENTITYMARKETING', 'ENTITYOUTSOURCEDMFG', 'ENTITYPAYROLL', 'ENTITYPL', 'ENTITYPREFERENCES', 'ENTITYPROMOCODES', 'ENTITYQUALIFICATION', 'ENTITYRELATEDRECORDS', 'ENTITYRELATIONSHIPS', 'ENTITYRESOURCES', 'ENTITYSALES', 'ENTITYSCHEDULE', 'ENTITYSUBSCRIPTIONS', 'ENTITYSUBSCRIPTIONSTAB', 'ENTITYSUBSIDIARIES', 'ENTITYSUBSIDIARIES', 'ENTITYSUPPORT', 'ENTITYS_SYSINFO', 'ENTITYTAB_WBS', 'ENTITYTIMEOFF', 'ENTITYTIMETRACKING', 'ENTITYTIMETRACKING', 'ENTITYWORKFLOW', 'EVENTASSIGNEES', 'EVENTCASE', 'EVENTCOMMUNICATION', 'EVENTCOSTDETAILS', 'EVENTCUSTOM', 'EVENTDETAIL', 'EVENTESCALATION', 'EVENTEVENTS', 'EVENTEXTERNAL', 'EVENTFILE', 'EVENTGENERAL', 'EVENTICALENDAR', 'EVENTINTERACTIONS', 'EVENTISTATUS', 'EVENTMETRICS', 'EVENTNOTES', 'EVENTPREDECESSORS', 'EVENTRECURRENCE', 'EVENTRESOURCES', 'EVENTRSTATUS', 'EVENTSOLUTION', 'EVENTSTATISTICS', 'EVENTTIME', 'EVENTTIMEOFF', 'EVENTTOPIC', 'EVENTVERSION', 'EVENTWORKFLOW', 'INVENTORYDETAILMAIN', 'ITEMACCOUNTING', 'ITEMACCOUNTING', 'ITEMCOMMUNICATION', 'ITEMCOMMUNICATION', 'ITEMCUSTOM', 'ITEMCUSTOM', 'ITEMFILESINTERNAL', 'ITEMHAZMATDGOODS', 'ITEMHISTORY', 'ITEMINVENTORY', 'ITEMINVENTORYDETAIL', 'ITEMINVENTORYNUMBERS', 'ITEMMAIN', 'ITEMMAIN', 'ITEMMANUFACTURING', 'ITEMMATRIX', 'ITEMMEMBERS', 'ITEMMERCHANDISEHIERARCHY', 'ITEMPREFERENCES', 'ITEMPREFERENCES', 'ITEMPRICEBOOKS', 'ITEMPRICING', 'ITEMPURCHASINGINVENTORY', 'ITEMRELRECORDS', 'ITEMRELRECORDS', 'ITEMRENEWAL', 'ITEMREVRECORAMORTIZATION', 'ITEMSPECIALS', 'ITEMSTORE', 'ITEMSYSTEMINFORMATION', 'ITEMSYSTEMINFORMATION', 'OTHERADDRESS', 'OTHERAUDIENCESETTINGS', 'OTHERCAMPAIGN', 'OTHERCHARGERULES', 'OTHERCHGORDERS', 'OTHERCODE', 'OTHERCOMMUNICATION', 'OTHERCONN_CONFIG_TAB', 'OTHERCOSTDETAILS', 'OTHERCOSTING', 'OTHERCREDENTIALFIELDS', 'OTHERCRMGROUPSETTINGS', 'OTHERCUSTOM', 'OTHERDEMAND', 'OTHERENROLL_FS_TAB', 'OTHEREXISTINGLINES', 'OTHERFILTERSTAB', 'OTHERFULFILLLOCPRIORITY', 'OTHERHISTORYTAB', 'OTHERIAM_FS_TAB', 'OTHERINVENTORYCOUNT', 'OTHERINVTLOCCUSTRETURN', 'OTHERINVTLOCFULFILLMENT', 'OTHERITEM', 'OTHERITEMS_TAB', 'OTHERLANDEDCOST_TAB', 'OTHERLINES', 'OTHERLINES_TAB', 'OTHERLOCATIONSTAB', 'OTHERMAIN', 'OTHERMINIMUMORDERAMOUNT', 'OTHERNEWLINES', 'OTHERORDERMANAGEMENT', 'OTHERORDERS', 'OTHEROTHER', 'OTHERPARTNER', 'OTHERPLANNING', 'OTHERPLANNINGMESSAGES', 'OTHERPLANNINGTIMES', 'OTHERPREFERENCES', 'OTHERPRICING', 'OTHERRATES', 'OTHERRELATEDRECORDS', 'OTHERRELRECORDS', 'OTHERRENEWAL', 'OTHERREVENUEPLAN', 'OTHERROUTINGCOMPONENTS', 'OTHERROUTINGSTEPS', 'OTHERSALESCHANNELS', 'OTHERSAVEDSEARCHES', 'OTHERSOURCE', 'OTHERSUBSCRIPTION', 'OTHERSYSTEMINFO', 'OTHERSYSTEMNOTES_FS_TAB', 'OTHERS_SYSINFO', 'OTHERS_SYSINFO', 'OTHERTTC_FS_TAB', 'OTHERUSAGELIMITS', 'OTHERVERSION', 'OTHERWORKFLOW', 'TIMEMAIN'] }),
+    },
+    path: [...enumsFolderPath, entryform_tabidElemID.name],
+  }),
+  execution_context: new PrimitiveType({
+    elemID: execution_contextElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACTION', 'ADVANCEDREVREC', 'BANKCONNECTIVITY', 'BANKSTATEMENTPARSER', 'BUNDLEINSTALLATION', 'CLIENT', 'CONSOLRATEADJUSTOR', 'CSVIMPORT', 'CUSTOMGLLINES', 'CUSTOMMASSUPDATE', 'DEBUGGER', 'EMAILCAPTURE', 'FICONNECTIVITY', 'MAPREDUCE', 'OFFLINECLIENT', 'OTHER', 'PAYMENTGATEWAY', 'PAYMENTPOSTBACK', 'PLATFORMEXTENSION', 'PORTLET', 'PROMOTIONS', 'RESTLET', 'RESTWEBSERVICES', 'SCHEDULED', 'SDFINSTALLATION', 'SHIPPINGPARTNERS', 'SUITELET', 'TAXCALCULATION', 'USEREVENT', 'USERINTERFACE', 'WEBAPPLICATION', 'WEBSERVICES', 'WEBSTORE', 'WORKFLOW'] }),
+    },
+    path: [...enumsFolderPath, execution_contextElemID.name],
+  }),
+  feature_status: new PrimitiveType({
+    elemID: feature_statusElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['DISABLED', 'ENABLED'] }),
+    },
+    path: [...enumsFolderPath, feature_statusElemID.name],
+  }),
+  features: new PrimitiveType({
+    elemID: featuresElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNTING', 'ACCOUNTINGPERIODS', 'ACHVEND', 'ADDRESSCUSTOMIZATION', 'ADVANCEDBILLOFMATERIALS', 'ADVANCEDEMPLOYEEPERMISSIONS', 'ADVANCEDGVMNTISSUEDIDTRACKING', 'ADVANCEDJOBS', 'ADVANCEDPRINTING', 'ADVANCEDPROCUREMENTAPPROVALS', 'ADVANCEDPROJECTACCOUNTING', 'ADVANCEDPROMOTIONS', 'ADVANCEDREVENUERECOGNITION', 'ADVANCEDREVENUERECOGNITIONAPP', 'ADVANCEDSITECUST', 'ADVANCEDSITEMANAGEMENT', 'ADVBILLING', 'ADVBINSERIALLOTMGMT', 'ADVFORECASTING', 'ADVINVENTORYMGMT', 'ADVPARTNERACCESS', 'ADVRECEIVING', 'ADVSHIPPING', 'ADVSUBSCRIPTIONBILLING', 'ADVTAXENGINE', 'ADVWEBREPORTS', 'ADVWEBSEARCH', 'ALTSALESAMOUNT', 'AMORTIZATION', 'APPDEFPKG', 'APPROVALROUTING', 'ASSEMBLIES', 'ASYNCCUSTOMER', 'ASYNCSALESORDER', 'AUTOAPPLYPROMOTIONS', 'AUTOLOCATIONASSIGNMENT', 'AVAILABLETOPROMISE', 'BARCODES', 'BASICGVMNTISSUEDIDTRACKING', 'BILLINGACCOUNTS', 'BILLINGCLASSES', 'BILLINGRATECARDS', 'BILLINGWORKCENTER', 'BILLPAY', 'BILLSCOSTS', 'BINMANAGEMENT', 'BLANKETPURCHASEORDERS', 'BOXNET', 'BUSINESS', 'CAMPAIGNASSISTANT', 'CAMPAIGNSUBSCRIPTIONS', 'CCTRACKING', 'CHARGEBASEDBILLING', 'CHECKOUTSUBDOMAIN', 'CLASSES', 'COACLASSIFICATIONMANAGEMENT', 'COMMERCECATEGORIES', 'COMMISSIONONCUSTOMFIELDS', 'COMMISSIONS', 'COMMITABLEORDERS', 'COMPENSATIONTRACKING', 'CONSOLPAYMENTS', 'CREATECONSOLIDATEDRATEPLUGINS', 'CREATEPAYMENTGATEWAYPLUGINS', 'CREATEPROMOTIONSPLUGINS', 'CREATESUITEBUNDLES', 'CRM', 'CRMTIME', 'CRM_TEMPLATE_CATEGORIES', 'CROSSSUBSIDIARYFULFILLMENT', 'CUSTOMCODE', 'CUSTOMERACCESS', 'CUSTOMGLLINES', 'CUSTOMRECORDS', 'CUSTOMSEGMENTS', 'CUSTOMTRANSACTIONS', 'DEPARTMENTS', 'DIRECTDEPOSIT', 'DISTRIBUTIONRESOURCEPLANNING', 'DOCUMENTPUBLISHING', 'DOCUMENTSANTIVIRUS', 'DOWNLOADITEMS', 'DROPSHIPMENTS', 'DUPLICATES', 'DYNALLOCATION', 'EBAY', 'EFFECTIVEDATING', 'EFT', 'EMAILINTEGRATION', 'EMPLOYEECENTERPUBLISHING', 'EMPLOYEECHANGEREQUESTS', 'EMPPERMS', 'ENHANCEDINVENTORYLOCATION', 'ENHANCEDPREMIERPAYROLL', 'ESCALATIONRULES', 'ESTIMATES', 'EXPENSEALLOCATION', 'EXPREPORTS', 'EXPREPORTS', 'EXTCRM', 'EXTREMELIST', 'EXTSTORE', 'FULFILLMENTREQUEST', 'FXRATEUPDATES', 'GAINLOSSACCTMAPPING', 'GCO', 'GIFTCERTIFICATES', 'GLAUDITNUMBERING', 'GRIDORDERMANAGEMENT', 'GROSSPROFIT', 'GROUPAVERAGECOSTING', 'HELPDESK', 'HISTORICALMETRICS', 'HRANALYSIS', 'I18NTAXREPORTS', 'INBOUNDCASEEMAIL', 'INBOUNDSHIPMENT', 'INTERCOMPANYAUTODROPSHIP', 'INTERCOMPANYAUTOELIMINATION', 'INTERCOMPANYTIMEEXPENSE', 'INTRANET', 'INTRANSITPAYMENTS', 'INVENTORY', 'INVENTORYCOUNT', 'INVENTORYSTATUS', 'IPADDRESSRULES', 'ISSUEDB', 'ITEMDEMANDPLANNING', 'ITEMOPTIONS', 'JOBCOSTING', 'JOBMANAGEMENT', 'JOBREQUISITION', 'JOBS', 'KNOWLEDGEBASE', 'KPIREPORTS', 'KUDOS', 'LANDEDCOST', 'LEADMANAGEMENT', 'LOCATIONS', 'LOTNUMBEREDINVENTORY', 'MAILMERGE', 'MARKETING', 'MATRIXITEMS', 'MERCHANDISEHIERARCHY', 'MFGROUTING', 'MFGWORKINPROCESS', 'MOBILEPUSHNTF', 'MOSS', 'MULTIBOOK', 'MULTIBOOKV2', 'MULTICURRENCY', 'MULTICURRENCYCUSTOMER', 'MULTICURRENCYVENDOR', 'MULTILANGUAGE', 'MULTILOCINVT', 'MULTIPARTNER', 'MULTIPLEBUDGETS', 'MULTIPLECALENDARS', 'MULTISHIPTO', 'MULTISITE', 'MULTISUBSIDIARYCUSTOMER', 'MULTIVENDOR', 'MULTPRICE', 'NETSUITEAPPROVALSWORKFLOW', 'NUMBEREDINVENTORY', 'NUMBEREDINVENTORYORGIFTCERTS', 'OFFLINECLIENT', 'ONLINEORDERING', 'OPENIDSSO', 'OPPORTUNITIES', 'OUTLOOKINTEGRATION_V3', 'PARTNERACCESS', 'PARTNERCOMMISSIONS', 'PARTNEREMPLOYEECOMMISSN', 'PAYABLES', 'PAYCHECKJOURNAL', 'PAYPALINTEGRATION', 'PAYROLL', 'PAYROLLSERVICE', 'PERIODENDJOURNALENTRIES', 'PICKPACKSHIP', 'PLANNEDWORK', 'POSITIONMANAGEMENT', 'PRM', 'PROJECTTASKMANAGER', 'PROMOCODES', 'PURCHASECARDDATA', 'PURCHASECONTRACTS', 'PURCHASEORDERS', 'PURCHASEREQS', 'QUANTITYPRICING', 'RECEIVABLES', 'REQUISITIONS', 'RESOURCEALLOCATIONAPPROVAL', 'RESOURCEALLOCATIONCHART', 'RESOURCEALLOCATIONS', 'RESOURCESKILLSETS', 'RETURNAUTHS', 'REVENUECOMMITMENTS', 'REVENUERECOGNITION', 'REVEXPMGMTANDAMORTIZATION', 'REVEXPMGMTANDREVREC', 'REVRECSALESORDERFORECASTING', 'REVRECVSOE', 'RFQ', 'ROUTINGORSTANDARDORLANDEDCOST', 'RUM', 'SALESCAMPAIGNS', 'SALESORDERS', 'SAMLSSO', 'SERIALIZEDINVENTORY', 'SERVERSIDESCRIPTING', 'SERVICEPRINTEDCHECKS', 'SERVICEPRINTEDW2S', 'SFA', 'SHIPPINGLABELS', 'SHIPPINGPARTNERS', 'SHIPPINGPARTNERSDEVELOPMENT', 'SITELOCATIONALIASES', 'SOFTDESCRIPTORS', 'STACKABLEPROMOTIONS', 'STANDARDCOSTING', 'STANDARDCOSTINGANDASSEMBLIES', 'STANDARDRECORDCUSTOMIZATION', 'STATACCOUNTING', 'STOREPICKUP', 'SUBSCRIPTIONBILLING', 'SUBSIDIARIES', 'SUBSIDIARIESANDMULTICURRENCY', 'SUITEANALYTICSCONNECT', 'SUITECOMMERCEENTERPRISE', 'SUITESIGNON', 'SUITESOCIAL', 'SUPPLTAXCALC', 'SUPPLYCHAINCONTROLTOWER', 'SUPPLYCHAINMANAGEMENT', 'SUPPORT', 'TABLEAU', 'TAXAUDITFILES', 'TAX_OVERHAULINGDEV', 'TBA', 'TEAMSELLING', 'TELEPHONY', 'TERMINATIONREASONTRACKING', 'TIMEBASEDPRICING', 'TIMEBASEDPRICINGSUITEAPP', 'TIMEOFFMANAGEMENT', 'TIMESHEETS', 'TIMETRACKING', 'TIMETRACKINGANY', 'TRANDELETIONREASONCODE', 'UNIFIEDREVENUERECOGNITION', 'UNITSOFMEASURE', 'UPSELL', 'URLCOMPONENTALIASES', 'USR', 'VENDORACCESS', 'VENDORRETURNAUTHS', 'WARRANTYANDREPAIRSMANAGEMENT', 'WEBAPPLICATIONS', 'WEBAPPLICATIONVERSIONING', 'WEBDUPLICATEEMAILMANAGEMENT', 'WEBHOSTING', 'WEBSERVICES', 'WEBSERVICESEXTERNAL', 'WEBSITE', 'WEBSTORE', 'WEEKLYTIMESHEETS', 'WEEKLYTIMESHEETSNEWUI', 'WITHHOLDINGTAX', 'WORKFLOW', 'WORKORDERS'] }),
+    },
+    path: [...enumsFolderPath, featuresElemID.name],
+  }),
+  forbidden_features: new PrimitiveType({
+    elemID: forbidden_featuresElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['DOCUMENTS', 'SUITEAPPDEVELOPMENTFRAMEWORK'] }),
+    },
+    path: [...enumsFolderPath, forbidden_featuresElemID.name],
+  }),
+  form_buttonstyle: new PrimitiveType({
+    elemID: form_buttonstyleElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BUTTON', 'MENU'] }),
+    },
+    path: [...enumsFolderPath, form_buttonstyleElemID.name],
+  }),
+  form_displaytype: new PrimitiveType({
+    elemID: form_displaytypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['DISABLED', 'INLINETEXT', 'NORMAL'] }),
+    },
+    path: [...enumsFolderPath, form_displaytypeElemID.name],
+  }),
+  form_fieldposition: new PrimitiveType({
+    elemID: form_fieldpositionElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BOTTOM', 'MIDDLE', 'TOP'] }),
+    },
+    path: [...enumsFolderPath, form_fieldpositionElemID.name],
+  }),
+  generic_accesslevel_searchlevel: new PrimitiveType({
+    elemID: generic_accesslevel_searchlevelElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['0', '1', '2'] }),
+    },
+    path: [...enumsFolderPath, generic_accesslevel_searchlevelElemID.name],
+  }),
+  generic_body_tab: new PrimitiveType({
+    elemID: generic_body_tabElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['TRANSACTIONACCOUNTING', 'TRANSACTIONADDRESS', 'TRANSACTIONBILLING', 'TRANSACTIONBUILDS', 'TRANSACTIONCOMMUNICATION', 'TRANSACTIONFULFILLMENTSANDCREDITS', 'TRANSACTIONFULFILLMENTSANDRECEIPTS', 'TRANSACTIONGENERAL', 'TRANSACTIONHISTORY', 'TRANSACTIONITEMS', 'TRANSACTIONJOURNAL', 'TRANSACTIONMAIN', 'TRANSACTIONOUTPUTOPTIONS', 'TRANSACTIONPAYMENT', 'TRANSACTIONQUALIFICATION', 'TRANSACTIONRECEIPTSANDREFUNDS', 'TRANSACTIONRELATEDRECORDS', 'TRANSACTIONRELATIONSHIPS', 'TRANSACTIONSALES', 'TRANSACTIONSHIPPING', 'TRANSACTIONSYSTEMINFORMATION'] }),
+    },
+    path: [...enumsFolderPath, generic_body_tabElemID.name],
+  }),
+  generic_centercategory: new PrimitiveType({
+    elemID: generic_centercategoryElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNTCENTERCUSTOMERSACCOUNTSRECEIVABLE', 'ACCOUNTCENTERCUSTOMERSCREDITSANDRETURNS', 'ACCOUNTCENTERCUSTOMERSCUSTOM', 'ACCOUNTCENTERCUSTOMERSCUSTOMERRECEIVABLESREPORTS', 'ACCOUNTCENTERCUSTOMERSCUSTOMERSERVICE', 'ACCOUNTCENTERCUSTOMERSLISTS', 'ACCOUNTCENTERCUSTOMERSMARKETING', 'ACCOUNTCENTERCUSTOMERSOTHER', 'ACCOUNTCENTERCUSTOMERSSALES', 'ACCOUNTCENTERCUSTOMERSSALESORDERREPORTS', 'ACCOUNTCENTERCUSTOMERSSALESREPORTS', 'ACCOUNTCENTERCUSTOMERSUBSRIPTIONS', 'ACCOUNTCENTERFINANCIALBANKING', 'ACCOUNTCENTERFINANCIALBILLING', 'ACCOUNTCENTERFINANCIALCOSTACCOUNTING', 'ACCOUNTCENTERFINANCIALCUSTOM', 'ACCOUNTCENTERFINANCIALDEMANDPLANNING', 'ACCOUNTCENTERFINANCIALINVENTORY', 'ACCOUNTCENTERFINANCIALLISTS', 'ACCOUNTCENTERFINANCIALMANUFACTURING', 'ACCOUNTCENTERFINANCIALOTHER', 'ACCOUNTCENTERFINANCIALOTHERTRANSACTIONS', 'ACCOUNTCENTERFINANCIALREPORTS', 'ACCOUNTCENTERFINANCIALSUBSCRIPTIONS', 'ACCOUNTCENTERPAYROLLANDHRCOMMISSIONREPORTS', 'ACCOUNTCENTERPAYROLLANDHRCOMMISSIONS', 'ACCOUNTCENTERPAYROLLANDHRCUSTOM', 'ACCOUNTCENTERPAYROLLANDHREXPENSEREPORTS', 'ACCOUNTCENTERPAYROLLANDHRLISTS', 'ACCOUNTCENTERPAYROLLANDHROTHER', 'ACCOUNTCENTERPAYROLLANDHRPAYROLL', 'ACCOUNTCENTERPAYROLLANDHRPAYROLLFORMS', 'ACCOUNTCENTERPAYROLLANDHRPAYROLLREPORTS', 'ACCOUNTCENTERPAYROLLANDHRTIMETRACKING', 'ACCOUNTCENTERPAYROLLANDHRTIMETRACKINGREPORTS', 'ACCOUNTCENTERSETUPACCOUNTING', 'ACCOUNTCENTERSETUPCOMPANY', 'ACCOUNTCENTERSETUPCUSTOM', 'ACCOUNTCENTERSETUPCUSTOMIZATION', 'ACCOUNTCENTERSETUPENTEROPENINGBALANCES', 'ACCOUNTCENTERSETUPHRINFORMATIONSYSTEM', 'ACCOUNTCENTERSETUPIMPORTEXPORT', 'ACCOUNTCENTERSETUPINTEGRATION', 'ACCOUNTCENTERSETUPMERCHANDISEHIERARCHY', 'ACCOUNTCENTERSETUPOTHERSETUP', 'ACCOUNTCENTERSETUPPERFORMANCEMANAGEMENT', 'ACCOUNTCENTERSETUPTAX', 'ACCOUNTCENTERSETUPUSERPREFERENCES', 'ACCOUNTCENTERSETUPUSERSROLES', 'ACCOUNTCENTERVENDORSACCOUNTSPAYABLE', 'ACCOUNTCENTERVENDORSCUSTOM', 'ACCOUNTCENTERVENDORSLISTS', 'ACCOUNTCENTERVENDORSOTHER', 'ACCOUNTCENTERVENDORSPURCHASES', 'ACCOUNTCENTERVENDORSSCHEDULEMANAGEMENT', 'ACCOUNTCENTERVENDORSVENDORPAYABLESREPORTS', 'BASICLISTICAUTOMATION', 'BASICLISTMAILING', 'BASICLISTOUTBOUNDREQUEST', 'BASICLISTSACCOUNTING', 'BASICLISTSBILLING', 'BASICLISTSCOMMISSIONS', 'BASICLISTSCUSTOM', 'BASICLISTSCUSTOMIZATION', 'BASICLISTSEMPLOYEES', 'BASICLISTSINTERCOMPANY', 'BASICLISTSMARKETING', 'BASICLISTSMASSUPDATE', 'BASICLISTSNETLEDGERSYSTEM', 'BASICLISTSNETTING', 'BASICLISTSRELATIONSHIPS', 'BASICLISTSSEARCH', 'BASICLISTSSUBSCRIPTIONS', 'BASICLISTSSUPPLYCHAIN', 'BASICLISTSSUPPORT', 'BASICLISTSWEBSITE', 'BASICREPORTSBANKINGBUDGETING', 'BASICREPORTSCOMMISSIONS', 'BASICREPORTSCOSTACCOUNTING', 'BASICREPORTSCUSTOM', 'BASICREPORTSCUSTOMERRECEIVABLES', 'BASICREPORTSCUSTOMERSERVICE', 'BASICREPORTSDEMANDPLANNING', 'BASICREPORTSEMPLOYEESHR', 'BASICREPORTSFINANCIAL', 'BASICREPORTSFORECAST', 'BASICREPORTSINTEGRATION', 'BASICREPORTSINVENTORYITEMS', 'BASICREPORTSISSUEMANAGEMENT', 'BASICREPORTSMARKETING', 'BASICREPORTSNEWBANKINGBUDGETING', 'BASICREPORTSNEWFINANCIAL', 'BASICREPORTSNEWREPORT', 'BASICREPORTSNEWSEARCH', 'BASICREPORTSOLDFINANCIAL', 'BASICREPORTSORDERMANAGEMENT', 'BASICREPORTSPAYROLL', 'BASICREPORTSPIPELINEANALYSIS', 'BASICREPORTSPROJECTS', 'BASICREPORTSPURCHASES', 'BASICREPORTSRECENTREPORTS', 'BASICREPORTSREVENUE', 'BASICREPORTSSALES', 'BASICREPORTSSALESORDERS', 'BASICREPORTSSALESTAXCANADA', 'BASICREPORTSSALESTAXUS', 'BASICREPORTSSAVEDREPORTS', 'BASICREPORTSSAVEDSEARCHES', 'BASICREPORTSSCHEDULEDREPORTS', 'BASICREPORTSSCHEDULEDSEARCHES', 'BASICREPORTSSUBSCRIPTIONS', 'BASICREPORTSTAX', 'BASICREPORTSTAXAUDITFILES', 'BASICREPORTSTIMEBILLABLES', 'BASICREPORTSVAT', 'BASICREPORTSVATGST', 'BASICREPORTSVENDORSPAYABLES', 'BASICREPORTSWEBPRESENCE', 'BASICREPORTSWITHHOLDINGTAX', 'BASICSETUPACCOUNTING', 'BASICSETUPCOMPANY', 'BASICSETUPCUSTOM', 'BASICSETUPCUSTOMIZATION', 'BASICSETUPHRINFORMATIONSYSTEM', 'BASICSETUPIMPORTEXPORT', 'BASICSETUPINTEGRATION', 'BASICSETUPISSUES', 'BASICSETUPMARKETING', 'BASICSETUPMERCHANDISEHIERARCHY', 'BASICSETUPORDERMANAGEMENT', 'BASICSETUPPAYROLL', 'BASICSETUPPERFORMANCEMANAGEMENT', 'BASICSETUPSALES', 'BASICSETUPSITEBUILDER', 'BASICSETUPSUITECOMMERCEADVANCED', 'BASICSETUPSUPPORT', 'BASICSETUPTAX', 'BASICSETUPUSERSROLES', 'BASICSETUPWAREHOUSEMANAGEMENT', 'BASICSUPPORTCOMMUNITIES', 'BASICSUPPORTCUSTOM', 'BASICSUPPORTCUSTOMERSERVICE', 'BASICSUPPORTDIRECTORIES', 'BASICSUPPORTFEEDBACK', 'BASICSUPPORTHELP', 'BASICTRANSACTIONSBANK', 'BASICTRANSACTIONSBILLING', 'BASICTRANSACTIONSCOMMISSIONS', 'BASICTRANSACTIONSCUSTOM', 'BASICTRANSACTIONSCUSTOMERS', 'BASICTRANSACTIONSDEMANDPLANNING', 'BASICTRANSACTIONSEMPLOYEES', 'BASICTRANSACTIONSFINANCIAL', 'BASICTRANSACTIONSINVENTORY', 'BASICTRANSACTIONSMANAGEMENT', 'BASICTRANSACTIONSMANUFACTURING', 'BASICTRANSACTIONSPURCHASESVENDORS', 'BASICTRANSACTIONSQUOTAFORECAST', 'BASICTRANSACTIONSSALES', 'BASICTRANSACTIONSSUBSCRIPTIONS', 'BASICTRANSACTIONSVENDORS', 'CUSTOMERHOMEBILLING', 'CUSTOMERHOMECUSTOM', 'CUSTOMERHOMEORDERS', 'CUSTOMERHOMESUPPORT', 'EMPLOYEEHOMEACTIVITIES', 'EMPLOYEEHOMECHANGEREQUESTS', 'EMPLOYEEHOMECUSTOM', 'EMPLOYEEHOMEDOCUMENTS', 'EMPLOYEEHOMEEXPENSEREPORTS', 'EMPLOYEEHOMEHELPDESK', 'EMPLOYEEHOMEMYINFORMATION', 'EMPLOYEEHOMEPURCHASEREQUESTS', 'EMPLOYEEHOMERELATIONSHIPS', 'EMPLOYEEHOMEREPORTS', 'EMPLOYEEHOMESEARCH', 'EMPLOYEEHOMETIMEOFFREQUEST', 'EMPLOYEEHOMETIMETRACKING', 'EMPLOYEEMYCOMPANY', 'ENGINEERCENTERISSUESCUSTOM', 'ENGINEERCENTERISSUESISSUES', 'ENGINEERCENTERISSUESRELATIONSHIPS', 'ENGINEERCENTERISSUESSEARCH', 'ENGINEERCENTERISSUESSETUP', 'EXECUTIVEEXPENSESACCOUNTSPAYABLE', 'EXECUTIVEEXPENSESCUSTOM', 'EXECUTIVEEXPENSESLISTS', 'EXECUTIVEEXPENSESOTHER', 'EXECUTIVEEXPENSESPURCHASES', 'EXECUTIVEEXPENSESVENDORPAYABLESREPORTS', 'EXECUTIVEFINANCIALADJUSTMENTS', 'EXECUTIVEFINANCIALBANKACCOUNTS', 'EXECUTIVEFINANCIALCOSTACCOUNTING', 'EXECUTIVEFINANCIALCUSTOM', 'EXECUTIVEFINANCIALLISTS', 'EXECUTIVEFINANCIALMANUFACTURING', 'EXECUTIVEFINANCIALOTHER', 'EXECUTIVEFINANCIALREPORTS', 'EXECUTIVEHRCOMMISSIONS', 'EXECUTIVEHRCUSTOM', 'EXECUTIVEHREXPENSEREPORTS', 'EXECUTIVEHRHR', 'EXECUTIVEHROTHER', 'EXECUTIVEHRPAYROLLFORMS', 'EXECUTIVEHRPAYROLLREPORTS', 'EXECUTIVEHRTIMETRACKING', 'EXECUTIVEHRTIMETRACKINGREPORTS', 'EXECUTIVESALESMARKETINGACCOUNTSRECEIVABLE', 'EXECUTIVESALESMARKETINGBILLING', 'EXECUTIVESALESMARKETINGCREDITSANDRETURNS', 'EXECUTIVESALESMARKETINGCUSTOM', 'EXECUTIVESALESMARKETINGCUSTOMERRECEIVABLESREPORTS', 'EXECUTIVESALESMARKETINGCUSTOMERSERVICE', 'EXECUTIVESALESMARKETINGFORECASTREPORTS', 'EXECUTIVESALESMARKETINGLISTS', 'EXECUTIVESALESMARKETINGMARKETING', 'EXECUTIVESALESMARKETINGMARKETINGREPORTS', 'EXECUTIVESALESMARKETINGOTHER', 'EXECUTIVESALESMARKETINGPIPELINEREPORTS', 'EXECUTIVESALESMARKETINGSALES', 'EXECUTIVESALESMARKETINGSALESORDERREPORTS', 'EXECUTIVESALESMARKETINGSALESREPORTS', 'EXECUTIVESETUPACCOUNTING', 'EXECUTIVESETUPCOMPANY', 'EXECUTIVESETUPCUSTOM', 'EXECUTIVESETUPCUSTOMIZATION', 'EXECUTIVESETUPENTEROPENINGBALANCES', 'EXECUTIVESETUPIMPORTEXPORT', 'EXECUTIVESETUPINTEGRATION', 'EXECUTIVESETUPMERCHANDISEHIERARCHY', 'EXECUTIVESETUPOTHERSETUP', 'EXECUTIVESETUPTAX', 'EXECUTIVESETUPUSERPREFERENCES', 'EXECUTIVESETUPUSERSROLES', 'MARKETCENTERCAMPAIGNSCUSTOM', 'MARKETCENTERCAMPAIGNSCUSTOMERSERVICE', 'MARKETCENTERCAMPAIGNSMARKETING', 'MARKETCENTERCAMPAIGNSOTHER', 'MARKETCENTERCAMPAIGNSOTHERLISTS', 'MARKETCENTERCAMPAIGNSOTHERTRANSACTIONS', 'MARKETCENTERCAMPAIGNSPRODUCTSSERVICES', 'MARKETCENTERCAMPAIGNSREPORTS', 'MARKETCENTERLEADSCUSTOM', 'MARKETCENTERLEADSCUSTOMERSERVICE', 'MARKETCENTERLEADSRELATIONSHIPS', 'MARKETCENTERLEADSREPORTS', 'MARKETCENTERLEADSTRANSACTIONS', 'MARKETCENTERSETUPCOMPANY', 'MARKETCENTERSETUPCUSTOM', 'MARKETCENTERSETUPCUSTOMIZATION', 'MARKETCENTERSETUPIMPORTEXPORT', 'MARKETCENTERSETUPINTEGRATION', 'MARKETCENTERSETUPMERCHANDISEHIERARCHY', 'MARKETCENTERSETUPOTHERSETUP', 'MARKETCENTERSETUPSALESMARKETINGAUTOMATION', 'MARKETCENTERSETUPUSERSROLES', 'OFFLINESALESCENTERACTIVITIESCUSTOM', 'OFFLINESALESCENTERACTIVITIESSCHEDULING', 'OFFLINESALESCENTERCUSTOMERSCUSTOM', 'OFFLINESALESCENTERCUSTOMERSRELATIONSHIPS', 'OFFLINESALESCENTERLEADSCUSTOM', 'OFFLINESALESCENTERLEADSRELATIONSHIPS', 'OFFLINESALESCENTEROPPORTUNITIESCUSTOM', 'OFFLINESALESCENTEROPPORTUNITIESRELATIONSHIPS', 'OFFLINESALESCENTEROPPORTUNITIESTRANSACTIONS', 'OFFLINESALESCENTERPROSPECTSCUSTOM', 'OFFLINESALESCENTERPROSPECTSRELATIONSHIPS', 'PARTNERCENTERCASESCUSTOM', 'PARTNERCENTERCASESCUSTOMERSERVICE', 'PARTNERCENTERCASESOTHER', 'PARTNERCENTERCASESOTHERLISTS', 'PARTNERCENTERCASESREPORTS', 'PARTNERCENTERCUSTOMERSCUSTOM', 'PARTNERCENTERCUSTOMERSMARKETING', 'PARTNERCENTERCUSTOMERSOTHER', 'PARTNERCENTERCUSTOMERSOTHERTRANSACTIONS', 'PARTNERCENTERCUSTOMERSRELATIONSHIPS', 'PARTNERCENTERCUSTOMERSREPORTS', 'PARTNERCENTERCUSTOMERSTRANSACTIONS', 'PARTNERCENTERCUSTOMERSTRIALTEMPLATETYPES', 'PARTNERCENTERSETUPCUSTOM', 'PARTNERCENTERSETUPMERCHANDISEHIERARCHY', 'PARTNERCENTERSETUPOTHERSETUP', 'SALESCENTERCUSTOMERSCUSTOM', 'SALESCENTERCUSTOMERSCUSTOMERREPORTS', 'SALESCENTERCUSTOMERSCUSTOMERSERVICE', 'SALESCENTERCUSTOMERSMARKETING', 'SALESCENTERCUSTOMERSOTHER', 'SALESCENTERCUSTOMERSOTHERLISTS', 'SALESCENTERCUSTOMERSOTHERTRANSACTIONS', 'SALESCENTERCUSTOMERSRELATIONSHIPS', 'SALESCENTERCUSTOMERSSUBSCRIPTIONS', 'SALESCENTERCUSTOMERSTRANSACTIONS', 'SALESCENTERFORECASTCOMMISSIONS', 'SALESCENTERFORECASTCUSTOM', 'SALESCENTERFORECASTREPORTS', 'SALESCENTERFORECASTSETUP', 'SALESCENTERFORECASTTRANSACTIONS', 'SALESCENTERLEADSCUSTOM', 'SALESCENTERLEADSLEADREPORTS', 'SALESCENTERLEADSOTHER', 'SALESCENTERLEADSRELATIONSHIPS', 'SALESCENTERLEADSTRANSACTIONS', 'SALESCENTEROPPORTUNITIESCUSTOM', 'SALESCENTEROPPORTUNITIESOTHER', 'SALESCENTEROPPORTUNITIESRELATIONSHIPS', 'SALESCENTEROPPORTUNITIESREPORTS', 'SALESCENTEROPPORTUNITIESTRANSACTIONS', 'SALESCENTERPROSPECTSCUSTOM', 'SALESCENTERPROSPECTSOTHER', 'SALESCENTERPROSPECTSPROSPECTREPORTS', 'SALESCENTERPROSPECTSRELATIONSHIPS', 'SALESCENTERPROSPECTSTRANSACTIONS', 'SHIPPINGCENTERINVENTORYCUSTOM', 'SHIPPINGCENTERINVENTORYINVENTORY', 'SHIPPINGCENTERINVENTORYLISTS', 'SHIPPINGCENTERINVENTORYMANUFACTURING', 'SHIPPINGCENTERINVENTORYOTHER', 'SHIPPINGCENTERINVENTORYREPORTS', 'SHIPPINGCENTERINVENTORYSCHEDULEMANAGEMENT', 'SHIPPINGCENTERRECEIVINGCUSTOM', 'SHIPPINGCENTERRECEIVINGLISTS', 'SHIPPINGCENTERRECEIVINGOTHER', 'SHIPPINGCENTERRECEIVINGRECEIVING', 'SHIPPINGCENTERRECEIVINGREPORTS', 'SHIPPINGCENTERRECEIVINGSCHEDULEMANAGEMENT', 'SHIPPINGCENTERRECEIVINGSEARCH', 'SHIPPINGCENTERSETUPCUSTOM', 'SHIPPINGCENTERSETUPMERCHANDISEHIERARCHY', 'SHIPPINGCENTERSETUPOTHERSETUP', 'SHIPPINGCENTERSETUPWAREHOUSEMANAGEMENT', 'SHIPPINGCENTERSHIPPINGCUSTOM', 'SHIPPINGCENTERSHIPPINGLISTS', 'SHIPPINGCENTERSHIPPINGOTHER', 'SHIPPINGCENTERSHIPPINGREPORTS', 'SHIPPINGCENTERSHIPPINGSCHEDULEMANAGEMENT', 'SHIPPINGCENTERSHIPPINGSHIPPING', 'STOREMANAGERCONTACTSCONTACTS', 'STOREMANAGERCONTACTSCUSTOM', 'STOREMANAGERCONTACTSREPORTS', 'STOREMANAGERSALESCUSTOM', 'STOREMANAGERSALESDEMANDPLANNING', 'STOREMANAGERSALESORDERS', 'STOREMANAGERSALESOTHER', 'STOREMANAGERSALESOTHERTRANSACTIONS', 'STOREMANAGERSALESREPORTS', 'STOREMANAGERSALESSEARCH', 'STOREMANAGERSETUPCUSTOM', 'STOREMANAGERSETUPCUSTOMIZATION', 'STOREMANAGERSETUPMERCHANDISEHIERARCHY', 'STOREMANAGERSETUPOTHERLISTS', 'STOREMANAGERSETUPOTHERSETUP', 'STOREMANAGERSETUPSEARCHUPDATES', 'STOREMANAGERSETUPSITEBUILDER', 'STOREMANAGERSETUPSUITECOMMERCEADVANCED', 'SUPPORTCENTERCASESCASECAPTURE', 'SUPPORTCENTERCASESCUSTOM', 'SUPPORTCENTERCASESCUSTOMERSERVICE', 'SUPPORTCENTERCASESOTHER', 'SUPPORTCENTERCASESOTHERLISTS', 'SUPPORTCENTERCASESOTHERTRANSACTIONS', 'SUPPORTCENTERCASESREPORTS', 'SUPPORTCENTERCUSTOMERSCUSTOM', 'SUPPORTCENTERCUSTOMERSMARKETING', 'SUPPORTCENTERCUSTOMERSRELATIONSHIPS', 'SUPPORTCENTERCUSTOMERSREPORTS', 'SUPPORTCENTERCUSTOMERSTRANSACTIONS', 'SUPPORTCENTERISSUESCUSTOM', 'SUPPORTCENTERISSUESISSUES', 'SUPPORTCENTERISSUESSEARCH', 'SUPPORTCENTERSETUPCOMPANY', 'SUPPORTCENTERSETUPCUSTOM', 'SUPPORTCENTERSETUPCUSTOMIZATION', 'SUPPORTCENTERSETUPIMPORTEXPORT', 'SUPPORTCENTERSETUPINTEGRATION', 'SUPPORTCENTERSETUPMERCHANDISEHIERARCHY', 'SUPPORTCENTERSETUPOTHERSETUP', 'SUPPORTCENTERSETUPSALESMARKETINGAUTOMATION', 'SUPPORTCENTERSETUPSUPPORT', 'SUPPORTCENTERSETUPUSERPREFERENCES', 'SUPPORTCENTERSETUPUSERSROLES', 'SYSADMINCENTERSETUPCOMPANY', 'SYSADMINCENTERSETUPCUSTOM', 'SYSADMINCENTERSETUPCUSTOMIZATION', 'SYSADMINCENTERSETUPENTEROPENINGBALANCES', 'SYSADMINCENTERSETUPIMPORTEXPORT', 'SYSADMINCENTERSETUPINTEGRATION', 'SYSADMINCENTERSETUPLISTS', 'SYSADMINCENTERSETUPMERCHANDISEHIERARCHY', 'SYSADMINCENTERSETUPOTHERLISTS', 'SYSADMINCENTERSETUPUSERPREFERENCES', 'SYSADMINCENTERSETUPUSERSROLES'] }),
+    },
+    path: [...enumsFolderPath, generic_centercategoryElemID.name],
+  }),
+  generic_centertab: new PrimitiveType({
+    elemID: generic_centertabElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNTCENTERCENTERCUSTOMERS', 'ACCOUNTCENTERCENTERFINANCIAL', 'ACCOUNTCENTERCENTERPAYROLLANDHR', 'ACCOUNTCENTERCENTERREPORTS', 'ACCOUNTCENTERCENTERREVENUE', 'ACCOUNTCENTERCENTERSETUP', 'ACCOUNTCENTERCENTERVENDORS', 'BASICCENTERACTIVITIES', 'BASICCENTERCUSTOMERDASHBOARD', 'BASICCENTERCUSTOMIZATION', 'BASICCENTERDOCUMENTS', 'BASICCENTERHOMEHOME', 'BASICCENTERLISTS', 'BASICCENTERPROJECTDASHBOARD', 'BASICCENTERREPORTS', 'BASICCENTERSETUP', 'BASICCENTERSUPPORT', 'BASICCENTERTRANSACTIONS', 'BASICCONTROLTOWERDASHBOARD', 'BASICVENDORDASHBOARD', 'CUSTCENTERTAB-100', 'CUSTCENTERTAB-120', 'CUSTCENTERTAB-121', 'CUSTCENTERTAB-122', 'CUSTCENTERTAB-123', 'CUSTCENTERTAB-125', 'CUSTCENTERTAB-130', 'CUSTCENTERTAB-131', 'CUSTCENTERTAB-141', 'CUSTCENTERTAB-142', 'CUSTCENTERTAB-143', 'CUSTCENTERTAB-144', 'CUSTCENTERTAB-145', 'CUSTCENTERTAB-148', 'CUSTOMERCENTERHOMEHOME', 'EMPLOYEECENTERHOMEHOME', 'ENGINEERCENTERCENTERISSUES', 'ENGINEERCENTERCENTERREPORTS', 'EXECUTIVECENTEREXPENSES', 'EXECUTIVECENTERFINANCIAL', 'EXECUTIVECENTERHR', 'EXECUTIVECENTERREPORTS', 'EXECUTIVECENTERSALESMARKETING', 'EXECUTIVECENTERSETUP', 'MARKETCENTERCENTERCAMPAIGNS', 'MARKETCENTERCENTERLEADS', 'MARKETCENTERCENTERREPORTS', 'MARKETCENTERCENTERSETUP', 'OFFLINESALESCENTERCENTERACTIVITIES', 'OFFLINESALESCENTERCENTERCUSTOMERS', 'OFFLINESALESCENTERCENTERHOME', 'OFFLINESALESCENTERCENTERLEADS', 'OFFLINESALESCENTERCENTEROPPORTUNITIES', 'OFFLINESALESCENTERCENTERPROSPECTS', 'PARTNERCENTERCENTERCASES', 'PARTNERCENTERCENTERCUSTOMERS', 'PARTNERCENTERCENTERREPORTS', 'PARTNERCENTERCENTERSETUP', 'PARTNERCENTERHOMEHOME', 'PROJECTCENTERCENTERACTIVITIES', 'PROJECTCENTERCENTERCRM', 'PROJECTCENTERCENTERHOMEHOME', 'PROJECTCENTERCENTERPROJECTS', 'PROJECTCENTERCENTERREPORTS', 'PROJECTCENTERCENTERRESOURCES', 'PROJECTCENTERCENTERTIMEEXPENSES', 'SALESCENTERCENTERCUSTOMERS', 'SALESCENTERCENTERFORECAST', 'SALESCENTERCENTERLEADS', 'SALESCENTERCENTEROPPORTUNITIES', 'SALESCENTERCENTERPROSPECTS', 'SALESCENTERCENTERREPORTS', 'SALESCENTERCENTERSETUP', 'SHIPPINGCENTERCENTERINVENTORY', 'SHIPPINGCENTERCENTERRECEIVING', 'SHIPPINGCENTERCENTERREPORTS', 'SHIPPINGCENTERCENTERSETUP', 'SHIPPINGCENTERCENTERSHIPPING', 'STOREMANAGERCENTERCONTACTS', 'STOREMANAGERCENTERREPORTS', 'STOREMANAGERCENTERSALES', 'STOREMANAGERCENTERSETUP', 'STOREMANAGERCENTERWEBSITE', 'SUPPORTCENTERCENTERCASES', 'SUPPORTCENTERCENTERCUSTOMERS', 'SUPPORTCENTERCENTERISSUES', 'SUPPORTCENTERCENTERREPORTS', 'SUPPORTCENTERCENTERSETUP', 'SYSADMINCENTERCENTERLISTS', 'SYSADMINCENTERCENTERSETUP', 'VENDORCENTERHOMEHOME'] }),
+    },
+    path: [...enumsFolderPath, generic_centertabElemID.name],
+  }),
+  generic_centertype: new PrimitiveType({
+    elemID: generic_centertypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNTCENTER', 'ALL', 'BASIC', 'CUSTOMER', 'EMPLOYEE', 'ENGINEERCENTER', 'EXECUTIVE', 'HR', 'MARKETCENTER', 'OFFLINESALESCENTER', 'PARTNER', 'PARTNERCENTER', 'PROJECTCENTER', 'SALESCENTER', 'SHIPPINGCENTER', 'STOREMANAGER', 'SUITEAPPCONTROLCENTER', 'SUPPORTCENTER', 'SYSADMINCENTER', 'VENDOR', 'WEBSITE'] }),
+    },
+    path: [...enumsFolderPath, generic_centertypeElemID.name],
+  }),
+  generic_crm_tab: new PrimitiveType({
+    elemID: generic_crm_tabElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CRMBUDGET', 'CRMCONTACTS', 'CRMKEYWORD', 'CRMMAIN', 'CRMMESSAGE', 'CRMRELATEDINFO', 'CRMRELATEDRECORDS', 'CRMSYSTEMINFORMATION'] }),
+    },
+    path: [...enumsFolderPath, generic_crm_tabElemID.name],
+  }),
+  generic_custom_record_icon: new PrimitiveType({
+    elemID: generic_custom_record_iconElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['1', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '2', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '3', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '4', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '5', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '6', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '7', '70', '8', '9'] }),
+    },
+    path: [...enumsFolderPath, generic_custom_record_iconElemID.name],
+  }),
+  generic_customfield_displaytype: new PrimitiveType({
+    elemID: generic_customfield_displaytypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['HIDDEN', 'LOCKED', 'NORMAL', 'SHOWASLIST', 'STATICTEXT'] }),
+    },
+    path: [...enumsFolderPath, generic_customfield_displaytypeElemID.name],
+  }),
+  generic_customfield_dynamicdefault: new PrimitiveType({
+    elemID: generic_customfield_dynamicdefaultElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['DEPARTMENT', 'LOCATION', 'ME', 'NOW', 'SUBSIDIARY', 'SUPERVISOR'] }),
+    },
+    path: [...enumsFolderPath, generic_customfield_dynamicdefaultElemID.name],
+  }),
+  generic_customfield_fieldtype: new PrimitiveType({
+    elemID: generic_customfield_fieldtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CHECKBOX', 'CLOBTEXT', 'CURRENCY', 'DATE', 'DATETIMETZ', 'DOCUMENT', 'EMAIL', 'FLOAT', 'HELP', 'IMAGE', 'INLINEHTML', 'INTEGER', 'MULTISELECT', 'PASSWORD', 'PERCENT', 'PHONE', 'RICHTEXT', 'SELECT', 'TEXT', 'TEXTAREA', 'TIMEOFDAY', 'URL'] }),
+    },
+    path: [...enumsFolderPath, generic_customfield_fieldtypeElemID.name],
+  }),
+  generic_customfield_fldfiltercomparetype: new PrimitiveType({
+    elemID: generic_customfield_fldfiltercomparetypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['EQ', 'GT', 'GTE', 'LIKE', 'LT', 'LTE', 'NE', 'NOTLIKE'] }),
+    },
+    path: [...enumsFolderPath, generic_customfield_fldfiltercomparetypeElemID.name],
+  }),
+  generic_customfield_onparentdelete: new PrimitiveType({
+    elemID: generic_customfield_onparentdeleteElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['NO_ACTION', 'SET_NULL'] }),
+    },
+    path: [...enumsFolderPath, generic_customfield_onparentdeleteElemID.name],
+  }),
+  generic_customfield_parentsubtab: new PrimitiveType({
+    elemID: generic_customfield_parentsubtabElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CRMBUDGET', 'CRMCONTACTS', 'CRMKEYWORD', 'CRMMAIN', 'CRMMESSAGE', 'CRMRELATEDINFO', 'CRMRELATEDRECORDS', 'CRMSYSTEMINFORMATION', 'ENTITYACCESS', 'ENTITYACCOUNTING', 'ENTITYBUDGET', 'ENTITYCOMMUNICATION', 'ENTITYCOMPENSATIONTRACKING', 'ENTITYFINANCIAL', 'ENTITYGENERAL', 'ENTITYHUMANRESOURCES', 'ENTITYINFO', 'ENTITYMAIN', 'ENTITYMARKETING', 'ENTITYPL', 'ENTITYPREFERENCES', 'ENTITYQUALIFICATION', 'ENTITYRELATEDRECORDS', 'ENTITYRELATIONSHIPS', 'ENTITYSALES', 'ENTITYSUBSCRIPTIONS', 'ENTITYSUPPORT', 'ENTITYTIMEOFF', 'ENTITYTIMETRACKING', 'ITEMBASIC', 'ITEMCOMMUNICATION', 'ITEMINVENTORY', 'ITEMLOCATIONS', 'ITEMMAIN', 'ITEMMATRIX', 'ITEMPURCHASINGINVENTORY', 'ITEMSYSTEMINFORMATION', 'ITEMVENDORS', 'TRANSACTIONACCOUNTING', 'TRANSACTIONADDRESS', 'TRANSACTIONBILLING', 'TRANSACTIONBUILDS', 'TRANSACTIONCOMMUNICATION', 'TRANSACTIONFULFILLMENTSANDCREDITS', 'TRANSACTIONFULFILLMENTSANDRECEIPTS', 'TRANSACTIONGENERAL', 'TRANSACTIONHISTORY', 'TRANSACTIONITEMS', 'TRANSACTIONJOURNAL', 'TRANSACTIONMAIN', 'TRANSACTIONOUTPUTOPTIONS', 'TRANSACTIONPAYMENT', 'TRANSACTIONQUALIFICATION', 'TRANSACTIONRECEIPTSANDREFUNDS', 'TRANSACTIONRELATEDRECORDS', 'TRANSACTIONRELATIONSHIPS', 'TRANSACTIONSALES', 'TRANSACTIONSHIPPING', 'TRANSACTIONSYSTEMINFORMATION'] }),
+    },
+    path: [...enumsFolderPath, generic_customfield_parentsubtabElemID.name],
+  }),
+  generic_customfield_selectrecordtype: new PrimitiveType({
+    elemID: generic_customfield_selectrecordtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['-10', '-100', '-101', '-102', '-103', '-104', '-105', '-106', '-108', '-109', '-110', '-111', '-112', '-113', '-114', '-115', '-116', '-117', '-118', '-119', '-120', '-121', '-122', '-123', '-124', '-125', '-126', '-127', '-128', '-129', '-131', '-132', '-133', '-134', '-135', '-136', '-137', '-138', '-139', '-140', '-1403', '-141', '-142', '-143', '-144', '-145', '-146', '-147', '-148', '-149', '-150', '-1501', '-1502', '-1503', '-151', '-152', '-153', '-154', '-155', '-1553', '-156', '-157', '-158', '-159', '-160', '-161', '-162', '-163', '-164', '-165', '-166', '-167', '-168', '-169', '-170', '-171', '-172', '-173', '-174', '-175', '-176', '-177', '-178', '-179', '-180', '-181', '-182', '-183', '-184', '-185', '-186', '-187', '-188', '-189', '-190', '-191', '-192', '-193', '-194', '-195', '-196', '-197', '-198', '-199', '-2', '-20', '-200', '-201', '-202', '-203', '-204', '-205', '-206', '-207', '-208', '-209', '-21', '-210', '-211', '-212', '-213', '-214', '-215', '-216', '-217', '-218', '-219', '-22', '-220', '-221', '-222', '-223', '-224', '-225', '-226', '-227', '-228', '-229', '-23', '-230', '-231', '-232', '-233', '-234', '-235', '-236', '-237', '-238', '-239', '-24', '-240', '-241', '-242', '-243', '-244', '-245', '-246', '-247', '-248', '-249', '-25', '-250', '-251', '-252', '-253', '-256', '-257', '-258', '-259', '-26', '-261', '-262', '-263', '-264', '-265', '-266', '-268', '-269', '-27', '-270', '-271', '-276', '-278', '-28', '-280', '-281', '-282', '-283', '-284', '-285', '-286', '-287', '-288', '-289', '-290', '-292', '-293', '-294', '-295', '-296', '-297', '-298', '-3', '-30', '-301', '-302', '-304', '-309', '-31', '-310', '-311', '-314', '-315', '-316', '-317', '-319', '-320', '-321', '-322', '-324', '-325', '-326', '-327', '-330', '-331', '-332', '-333', '-335', '-336', '-337', '-338', '-340', '-341', '-342', '-343', '-344', '-345', '-347', '-348', '-349', '-35', '-350', '-353', '-355', '-356', '-357', '-359', '-36', '-360', '-361', '-362', '-364', '-365', '-366', '-367', '-368', '-369', '-37', '-371', '-372', '-373', '-374', '-375', '-376', '-377', '-378', '-379', '-38', '-380', '-381', '-382', '-383', '-385', '-386', '-387', '-388', '-39', '-391', '-392', '-395', '-396', '-4', '-40', '-400', '-4006', '-4007', '-4009', '-4010', '-4011', '-4012', '-402', '-4021', '-4027', '-4028', '-403', '-4032', '-4033', '-404', '-405', '-406', '-407', '-408', '-409', '-41', '-410', '-411', '-412', '-413', '-414', '-417', '-418', '-419', '-420', '-422', '-423', '-425', '-426', '-427', '-428', '-430', '-431', '-432', '-434', '-435', '-436', '-437', '-438', '-440', '-441', '-450', '-451', '-452', '-460', '-461', '-494', '-495', '-496', '-497', '-5', '-505', '-506', '-507', '-508', '-514', '-517', '-520', '-522', '-523', '-524', '-528', '-530', '-531', '-532', '-533', '-537', '-538', '-539', '-540', '-543', '-544', '-546', '-547', '-548', '-549', '-550', '-551', '-553', '-554', '-555', '-556', '-560', '-6', '-7', '-8', '-851', '-856', '-861', '-862', '-863', '-864', '-865', '-867', '-868', '-869', '-896', '-897', '-898', '-899', '-9', '-900', '-901', '-904', '-905', '-906', '-907', '-908', '-910', '-911', '-970', '-997', '-998', '-999'] }),
+    },
+    path: [...enumsFolderPath, generic_customfield_selectrecordtypeElemID.name],
+  }),
+  generic_customrecordothercustomfield_field: new PrimitiveType({
+    elemID: generic_customrecordothercustomfield_fieldElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CREATED', 'CUSTOMFORM', 'ISINACTIVE', 'ISMATRIXOPTION', 'LASTMODIFIED', 'NAME', 'NKEY', 'OWNER', 'RECORDID'] }),
+    },
+    path: [...enumsFolderPath, generic_customrecordothercustomfield_fieldElemID.name],
+  }),
+  generic_customrecordothercustomfield_rectype: new PrimitiveType({
+    elemID: generic_customrecordothercustomfield_rectypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['-101', '-102', '-103', '-107', '-108', '-112', '-113', '-115', '-117', '-118', '-121', '-126', '-128', '-129', '-1500', '-196', '-242', '-246', '-247', '-248', '-249', '-250', '-251', '-252', '-253', '-257', '-258', '-259', '-265', '-276', '-278', '-288', '-289', '-290', '-292', '-294', '-295', '-298', '-303', '-304', '-309', '-316', '-317', '-325', '-326', '-327', '-330', '-331', '-332', '-333', '-335', '-336', '-341', '-342', '-347', '-348', '-350', '-353', '-355', '-357', '-359', '-362', '-369', '-376', '-377', '-379', '-381', '-382', '-383', '-385', '-386', '-388', '-4006', '-4007', '-4011', '-4012', '-4014', '-4021', '-4028', '-409', '-410', '-411', '-412', '-419', '-422', '-423', '-424', '-425', '-427', '-428', '-432', '-434', '-435', '-438', '-505', '-506', '-507', '-508', '-513', '-520', '-522', '-530', '-531', '-543', '-546', '-549', '-550', '-551', '-553', '-557', '-863', '-864', '-867', '-900', '-901', '-903', '-906', '-907', '-909'] }),
+    },
+    path: [...enumsFolderPath, generic_customrecordothercustomfield_rectypeElemID.name],
+  }),
+  generic_day_of_month: new PrimitiveType({
+    elemID: generic_day_of_monthElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['1', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '2', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '3', '30', '31', '4', '5', '6', '7', '8', '9'] }),
+    },
+    path: [...enumsFolderPath, generic_day_of_monthElemID.name],
+  }),
+  generic_day_of_week: new PrimitiveType({
+    elemID: generic_day_of_weekElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['FRIDAY', 'MONDAY', 'SATURDAY', 'SUNDAY', 'THURSDAY', 'TUESDAY', 'WEDNESDAY'] }),
+    },
+    path: [...enumsFolderPath, generic_day_of_weekElemID.name],
+  }),
+  generic_entity_tab: new PrimitiveType({
+    elemID: generic_entity_tabElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ENTITYACCESS', 'ENTITYACCOUNTING', 'ENTITYBUDGET', 'ENTITYCOMMUNICATION', 'ENTITYCOMPENSATIONTRACKING', 'ENTITYFINANCIAL', 'ENTITYGENERAL', 'ENTITYHUMANRESOURCES', 'ENTITYINFO', 'ENTITYMAIN', 'ENTITYMARKETING', 'ENTITYPL', 'ENTITYPREFERENCES', 'ENTITYQUALIFICATION', 'ENTITYRELATEDRECORDS', 'ENTITYRELATIONSHIPS', 'ENTITYSALES', 'ENTITYSUBSCRIPTIONS', 'ENTITYSUPPORT', 'ENTITYTIMEOFF', 'ENTITYTIMETRACKING'] }),
+    },
+    path: [...enumsFolderPath, generic_entity_tabElemID.name],
+  }),
+  generic_item_tab: new PrimitiveType({
+    elemID: generic_item_tabElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ITEMBASIC', 'ITEMCOMMUNICATION', 'ITEMINVENTORY', 'ITEMLOCATIONS', 'ITEMMAIN', 'ITEMMATRIX', 'ITEMPURCHASINGINVENTORY', 'ITEMSYSTEMINFORMATION', 'ITEMVENDORS'] }),
+    },
+    path: [...enumsFolderPath, generic_item_tabElemID.name],
+  }),
+  generic_itemoptionitemcol_field: new PrimitiveType({
+    elemID: generic_itemoptionitemcol_fieldElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ADJUSTQTYBY', 'ALTSALESAMT', 'AMORTIZATIONENDDATE', 'AMORTIZATIONRESIDUAL', 'AMORTIZATIONSCHED', 'AMORTIZSTARTDATE', 'AMOUNT', 'AMOUNTORDERED', 'AMOUNTRECOGNIZED', 'AMOUNTREMAINING', 'AVERAGECOST', 'BALANCE', 'BILLEDDATE', 'BILLINGSCHEDULE', 'BILLRECEIPTS', 'BILLVARIANCESTATUS', 'BINNUMBERS', 'BINNUMBERSSTOCK', 'BOMQUANTITY', 'CATCHUPPERIOD', 'CHARGE', 'CHARGES', 'CHARGETYPE', 'CLASS', 'COMMITINVENTORY', 'COMMITMENTFIRM', 'COMPONENTYIELD', 'COSTESTIMATE', 'COSTESTIMATERATE', 'COSTESTIMATETYPE', 'COUNTRYOFMANUFACTURE', 'CREATEDFROM', 'CREATEPO', 'CREATEWO', 'CURRENCY', 'CURRENTPERCENT', 'CURRENTVALUE', 'CUSTOMER', 'DATECOL', 'DEFERREVREC', 'DEPARTMENT', 'DESCRIPTION', 'DISCOUNT', 'DROPSHIP', 'DUEDATE', 'EMPLOYEE', 'EMPLOYEEFULLNAME', 'ENDDATE', 'ESTGROSSPROFIT', 'ESTGROSSPROFITFIELDS', 'ESTGROSSPROFITPERCENT', 'ESTIMATEDAMOUNT', 'ESTIMATEDRATE', 'EVENT', 'EXCLUDEFROMRATEREQUEST', 'EXPECTEDRECEIPTDATE', 'EXPECTEDSHIPDATE', 'FROMJOB', 'GIFTCERTFIELDS', 'GLNUMBER', 'GLSEQUENCE', 'GROSSAMT', 'INVENTORYDETAIL', 'INVENTORYDETAILSTOCK', 'ISBILLABLE', 'ISCLOSED', 'ISDROPSHIPMENT', 'ISESTIMATE', 'ISTAXABLE', 'ITEM', 'ITEMPRICING', 'ITEMTAX', 'JOB', 'LANDEDCOST', 'LANDEDCOSTCATEGORY', 'LASTPURCHASEPRICE', 'LICENSECODE', 'LINKEDORDER', 'LINKEDORDERSTATUS', 'LOCATION', 'MANUFACTURER', 'MATCHBILLTORECEIPT', 'MEMO', 'MPN', 'NEWQUANTITY', 'OPTIONS', 'ORDERPRIORITY', 'ORDERSCHEDULE', 'ORIGINALAMOUNT', 'OTHERREFNUM', 'PARENTITEM', 'PAYMENT', 'PAYMENTMETHOD', 'PERCENTCOMPLETE', 'PORATE', 'POVENDOR', 'PRICE', 'PROCESSEDBYREVCOMMIT', 'PURCHASECONTRACT', 'QUANTITY', 'QUANTITYAVAILABLE', 'QUANTITYBACKORDERED', 'QUANTITYCOMMITTED', 'QUANTITYFULFILLED', 'QUANTITYONHAND', 'QUANTITYORDERED', 'QUANTITYRECEIVED', 'QUANTITYREMAINING', 'RATE', 'RATE10', 'RATE2', 'RATE3', 'RATE4', 'RATE5', 'RATE6', 'RATE7', 'RATE8', 'RATE9', 'REASON', 'RESTOCK', 'REVRECENDDATE', 'REVRECSCHEDULE', 'REVRECSTARTDATE', 'SERIALNUMBERS', 'SHIPADDRESS', 'SHIPCARRIER', 'SHIPMETHOD', 'SHIPPINGCOST', 'SPECIALORDER', 'STARTDATE', 'SUBNAME', 'TAX1AMT', 'TAXAMOUNT', 'TAXCODE', 'TAXRATE1', 'TAXRATE2', 'TERMINMONTHS', 'TERMS', 'TRANSACTIONNO', 'UNITCOST', 'UNITCOSTOVERRIDE', 'UNITPRICE', 'UNITS', 'UPCCODE', 'VENDORNAME', 'VSOEDELIVERED', 'VSOEFIELDS', 'WEIGHT'] }),
+    },
+    path: [...enumsFolderPath, generic_itemoptionitemcol_fieldElemID.name],
+  }),
+  generic_itemoptionitemcol_fieldtype: new PrimitiveType({
+    elemID: generic_itemoptionitemcol_fieldtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CHECKBOX', 'CURRENCY', 'DATE', 'DATETIMETZ', 'DOCUMENT', 'EMAIL', 'FLOAT', 'INLINEHTML', 'INTEGER', 'PASSWORD', 'PERCENT', 'PHONE', 'SELECT', 'TEXT', 'TEXTAREA', 'TIMEOFDAY', 'URL'] }),
+    },
+    path: [...enumsFolderPath, generic_itemoptionitemcol_fieldtypeElemID.name],
+  }),
+  generic_itemoptionitemcol_searchcomparefield: new PrimitiveType({
+    elemID: generic_itemoptionitemcol_searchcomparefieldElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['STDCOLACCOUNT', 'STDCOLCALL', 'STDCOLCASE', 'STDCOLCHARGE', 'STDCOLCLASS', 'STDCOLCUSTOMER', 'STDCOLDEPARTMENT', 'STDCOLEMPLOYEE', 'STDCOLENTITY', 'STDCOLEVENT', 'STDCOLITEM', 'STDCOLJOB', 'STDCOLLOCATION', 'STDCOLSUBSIDIARY', 'STDCOLTASK'] }),
+    },
+    path: [...enumsFolderPath, generic_itemoptionitemcol_searchcomparefieldElemID.name],
+  }),
+  generic_month: new PrimitiveType({
+    elemID: generic_monthElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['APRIL', 'AUGUST', 'DECEMBER', 'FEBRUARY', 'JANUARY', 'JULY', 'JUNE', 'MARCH', 'MAY', 'NOVEMBER', 'OCTOBER', 'SEPTEMBER'] }),
+    },
+    path: [...enumsFolderPath, generic_monthElemID.name],
+  }),
+  generic_order_of_week: new PrimitiveType({
+    elemID: generic_order_of_weekElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['FIRST', 'FOURTH', 'LAST', 'SECOND', 'THIRD'] }),
+    },
+    path: [...enumsFolderPath, generic_order_of_weekElemID.name],
+  }),
+  generic_permission: new PrimitiveType({
+    elemID: generic_permissionElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ADMI_ACCOUNTING', 'ADMI_ACCOUNTINGBOOK', 'ADMI_ACCOUNTINGLIST', 'ADMI_ACCTPERIODS', 'ADMI_ACCTSETUP', 'ADMI_ACH', 'ADMI_ADMINDOCSEU', 'ADMI_ADMINDOCSNA', 'ADMI_ADMINDOCSOTHER', 'ADMI_ADVANCED_ORDER_MANAGEMENT', 'ADMI_ADVANCED_TEMPLATES', 'ADMI_ALLOWNONGLCHANGES', 'ADMI_ALLOW_JS_HTML_UPLOAD', 'ADMI_ANALYTICS', 'ADMI_APPDEFPKG', 'ADMI_APPPUBLISHER', 'ADMI_APP_DEPLOYMENT', 'ADMI_AUDITLOGIN', 'ADMI_BACKUPEXPORT', 'ADMI_BALANCE_TRX_BY_SEGMENTS', 'ADMI_BANK_CONNECTIVITY_CONFIG', 'ADMI_BILLINGINFO', 'ADMI_BILLPAYSETUP', 'ADMI_BLCGA', 'ADMI_BUNDLER', 'ADMI_BUNDLERAUDITTRAIL', 'ADMI_BUNDLERMANUP', 'ADMI_CAMPAIGNEMAIL', 'ADMI_CAMPAIGNSETUP', 'ADMI_CASEALERT', 'ADMI_CASEFORM', 'ADMI_CASEISSUE', 'ADMI_CASEORIGIN', 'ADMI_CASEPRIORITY', 'ADMI_CASERULE', 'ADMI_CASESTATUS', 'ADMI_CASETERRITORY', 'ADMI_CASETYPE', 'ADMI_CERTIFICATES', 'ADMI_CLASSESTOLOCS', 'ADMI_CLASSSEGMENTMAPPING', 'ADMI_CLOSE', 'ADMI_CLOSEPERIOD', 'ADMI_COMMERCECATEGORY', 'ADMI_COMMISSIONSETUP', 'ADMI_COMPANY', 'ADMI_CONSOLIDATED', 'ADMI_CONVERTCLASSES', 'ADMI_CONVERTLEAD', 'ADMI_COPYPROJECTTASK', 'ADMI_CREATEJOBSFROMSALESTRANS', 'ADMI_CREATEPEER', 'ADMI_CREDITCARD', 'ADMI_CRMLIST', 'ADMI_CSP_SETUP', 'ADMI_CSVIMPORTPREF', 'ADMI_CUSTADDRESSFORM', 'ADMI_CUSTBODYFIELD', 'ADMI_CUSTCATEGORY', 'ADMI_CUSTCENTER', 'ADMI_CUSTCOLUMNFIELD', 'ADMI_CUSTEMAILLAYOUT', 'ADMI_CUSTENTITYFIELD', 'ADMI_CUSTENTRYFORM', 'ADMI_CUSTEVENTFIELD', 'ADMI_CUSTFIELD', 'ADMI_CUSTFIELDTAB', 'ADMI_CUSTFORM', 'ADMI_CUSTITEMFIELD', 'ADMI_CUSTITEMNUMBERFIELD', 'ADMI_CUSTLAYOUT', 'ADMI_CUSTLIST', 'ADMI_CUSTOMERFORM', 'ADMI_CUSTOMERRULE', 'ADMI_CUSTOMER_SEGMENTS', 'ADMI_CUSTOMIZEDFIELDLEVELHELP', 'ADMI_CUSTOMSCRIPT', 'ADMI_CUSTOMSUBLIST', 'ADMI_CUSTOTHERFIELD', 'ADMI_CUSTPAGE', 'ADMI_CUSTRECORD', 'ADMI_CUSTRECORDFORM', 'ADMI_CUSTSECTION', 'ADMI_CUSTTASKS', 'ADMI_CUSTTRANFIELD', 'ADMI_CUSTTRANSACTION', 'ADMI_DELETEDRECORD', 'ADMI_DEPTSEGMENTMAPPING', 'ADMI_DEVICE_ID', 'ADMI_DOMAINS', 'ADMI_DUPLICATESETUP', 'ADMI_EMAILPWD', 'ADMI_EMPLCATEGORY', 'ADMI_EMPLOYEECENTERPUBLISHING', 'ADMI_EMPLOYEELIST', 'ADMI_ENABLEFEATURES', 'ADMI_ENTITYACCOUNTMAPPING', 'ADMI_ENTITYSTATUS', 'ADMI_ESCALATIONRULE', 'ADMI_ESCALATIONTERRITORY', 'ADMI_EXPORTIIF', 'ADMI_FFTEXCEPTIONREASON', 'ADMI_FINANCIALINSTITUTION', 'ADMI_FINCHARGEPREF', 'ADMI_GAINLOSSACCTMAPPING', 'ADMI_GLOBALACCOUNTMAPPING', 'ADMI_IMPORTCSVFILE', 'ADMI_IMPORTDEFAULT', 'ADMI_IMPORTOVERRIDESSTRIG', 'ADMI_IMPORTXML', 'ADMI_INTEGRAPP', 'ADMI_ISSUESETUP', 'ADMI_ISSUESHOWSTOPPER', 'ADMI_ITEMACCOUNTMAPPING', 'ADMI_KERNEL', 'ADMI_KEYS', 'ADMI_KNOWLEDGEBASE', 'ADMI_KPIREPORT', 'ADMI_LOCATIONCOSTINGGROUP', 'ADMI_LOCSEGMENTMAPPING', 'ADMI_LOGIN_OAUTH', 'ADMI_LOGIN_OAUTH2', 'ADMI_MANAGECUSTOMSEGMENTS', 'ADMI_MANAGEPERMISSIONS', 'ADMI_MANAGEROLES', 'ADMI_MANAGEUSERS', 'ADMI_MANAGE_OAUTH2', 'ADMI_MANAGE_OAUTH_TOKENS', 'ADMI_MANAGE_OWN_OAUTH_TOKENS', 'ADMI_MANAGE_RESTRICTIONS', 'ADMI_MHLEVEL', 'ADMI_MHNODE', 'ADMI_MHVERSION', 'ADMI_MIGRATEREVARRNGANDPLAN', 'ADMI_MOBILE_ACCESS', 'ADMI_OIDC', 'ADMI_OIDCSETUP', 'ADMI_OPENIDSSO', 'ADMI_OPENIDSSOSETUP', 'ADMI_ORDERALLOCATIONSTRATEGY', 'ADMI_OUTLOOKINTEGRATION', 'ADMI_OUTLOOKINTEGRATION_V3', 'ADMI_PARTNERCONTRIBUTION', 'ADMI_PAYROLL', 'ADMI_PENDINGBOOKJOURNAL', 'ADMI_PERIODCLOSING', 'ADMI_PERIODOVERRIDE', 'ADMI_PI_REMOVAL_CREATE', 'ADMI_PI_REMOVAL_RUN', 'ADMI_PROJECTTEMPLATE', 'ADMI_PROJECT_ACCOUNTING_SETUP', 'ADMI_PROVISION', 'ADMI_PROVSN_NEW_TSTDRV', 'ADMI_PROVSN_QA', 'ADMI_PROVSN_TSTDRV', 'ADMI_REMINDERS', 'ADMI_REPOGROUPS', 'ADMI_REPOLAYOUTS', 'ADMI_RESTWEBSERVICES', 'ADMI_REVIEW_CUSTOM_GL_RUNS', 'ADMI_SAC_READALL', 'ADMI_SALESTERRITORY', 'ADMI_SAMLSSO', 'ADMI_SAMLSSOSETUP', 'ADMI_SAVEDASHBOARD', 'ADMI_SETUPCOMPANY', 'ADMI_SETUPIMAGERESIZE', 'ADMI_SETUPYEARSTATUS', 'ADMI_SFASETUP', 'ADMI_SITEMANAGEMENT', 'ADMI_SNAPSHOTS', 'ADMI_SS_NLCORP', 'ADMI_SS_SCHEDULING', 'ADMI_STATETAXIMPORT', 'ADMI_STORESEARCH', 'ADMI_STORESETUP', 'ADMI_SUBLIST', 'ADMI_SUBSIDIARYHIERARCHYMOD', 'ADMI_SUBSIDIARYSETTINGSMANAGER', 'ADMI_SUITEANALYTICSCONNECT', 'ADMI_SUITEAPP_MANAGEMENT', 'ADMI_SUITESIGNON', 'ADMI_SUPPLYALLOCATIONSETUP', 'ADMI_SUPPORTSETUP', 'ADMI_SWAPPRICES', 'ADMI_TAXMIGRATION', 'ADMI_TAXPERIODS', 'ADMI_TEAMSELLINGCONTRIBUTION', 'ADMI_TELEPHONY_SETUP', 'ADMI_TIMEMODIFICATION', 'ADMI_TRANSITEMTXT', 'ADMI_TRANSLATION', 'ADMI_TSTDRV_MASTER', 'ADMI_TWOFACTORAUTH', 'ADMI_TWOFACTORAUTHBASE', 'ADMI_TYPE', 'ADMI_UNCATSITEITEMS', 'ADMI_UNLOCKEDTIMEPERIOD', 'ADMI_UPDATEPRICES', 'ADMI_UPSELLSETUP', 'ADMI_USER', 'ADMI_USERPREF', 'ADMI_VIEWCREDITCARDS', 'ADMI_WEBSERVICES', 'ADMI_WEBSERVICESLOG', 'ADMI_WEBSERVICESOVERRIDESSTRIG', 'ADMI_WEBSERVICESSETUP', 'ADMI_WORKFLOW', 'ADMI_XMLADPSETUP', 'EDIT_FISCALCALENDAR', 'GRAP_AP', 'GRAP_AR', 'GRAP_EXP', 'GRAP_INC', 'GRAP_NETWORTH', 'LIST_ACCOUNT', 'LIST_ADDRESS', 'LIST_ALLGOVERNMENTISSUEDIDS', 'LIST_ALLOCSCHEDULE', 'LIST_AMORTIZATION', 'LIST_BASICGOVERNMENTISSUEDIDS', 'LIST_BIG_SEARCH', 'LIST_BILLINBOUNDSHIPMENT', 'LIST_BILLINGSCHEDULE', 'LIST_BILLOFDISTRIBUTION', 'LIST_BILLOFMATERIALSINQUIRY', 'LIST_BIN', 'LIST_BOM', 'LIST_BONUS', 'LIST_BONUSTYPE', 'LIST_CALENDAR', 'LIST_CALL', 'LIST_CAMPAIGN', 'LIST_CAMPAIGNHISTORY', 'LIST_CARDHOLDERAUTHENTICATION', 'LIST_CARDHOLDERAUTHEVENT', 'LIST_CASE', 'LIST_CASE_DUPLICATES', 'LIST_CATEGORY', 'LIST_CERTIFICATES', 'LIST_CHECKITEMAVAILABILITY', 'LIST_CLASS', 'LIST_COLORTHEME', 'LIST_COMMISSIONRULES', 'LIST_COMPANY', 'LIST_COMPETITOR', 'LIST_COMPONENTWHEREUSEDINQUIRY', 'LIST_CONTACT', 'LIST_CONTACTROLE', 'LIST_CONVERTLEAD', 'LIST_COSTEDBOMINQUIRY', 'LIST_CRMGROUP', 'LIST_CRMMESSAGE', 'LIST_CRMTEMPLATE', 'LIST_CURRENCY', 'LIST_CUSTJOB', 'LIST_CUSTPROFILE', 'LIST_CUSTRECORDENTRY', 'LIST_DEPARTMENT', 'LIST_DISTRIBUTIONNETWORK', 'LIST_EMAILTEMPLATE', 'LIST_EMPLOYEE', 'LIST_EMPLOYEECHANGEREASON', 'LIST_EMPLOYEECHANGEREQUEST', 'LIST_EMPLOYEECHANGETYPE', 'LIST_EMPLOYEEEFFECTIVEDATING', 'LIST_EMPLOYEESEPARATION', 'LIST_EMPLOYEESSN', 'LIST_EMPLOYEE_ACCESS', 'LIST_EMPLOYEE_ADMINISTRATION', 'LIST_EMPLOYEE_CONFIDENTIAL', 'LIST_EMPLOYEE_PUBLIC', 'LIST_EMPLOYEE_RECORD', 'LIST_EMPLOYEE_SELF', 'LIST_ENTITY_DUPLICATES', 'LIST_EVENT', 'LIST_EXPENSEAMORTIZATIONRULE', 'LIST_EXPENSEPLAN', 'LIST_EXPORT', 'LIST_FAIRVALUEDIMENSION', 'LIST_FAIRVALUEFORMULA', 'LIST_FAIRVALUEPRICE', 'LIST_FAXMESSAGE', 'LIST_FAXTEMPLATE', 'LIST_FILECABINET', 'LIST_FIND', 'LIST_FINHISTORY', 'LIST_FISCALCALENDAR', 'LIST_GENERAL_TOKEN', 'LIST_GENERICRESOURCE', 'LIST_GLLINESAUDITLOG', 'LIST_GLLINESAUDITLOGSEG', 'LIST_GLOBALINVTRELATIONSHIP', 'LIST_GOVERNMENTISSUEDIDTYPE', 'LIST_HCMJOB', 'LIST_HCMPOSITION', 'LIST_HISTORY', 'LIST_INBOUNDSHIPMENT', 'LIST_INFOCATEGORY', 'LIST_INFOITEM', 'LIST_INFOITEMFORM', 'LIST_INTEGRAPP', 'LIST_INTERNALPUBLISH', 'LIST_INVCOSTTEMPLATE', 'LIST_INVENTORYSTATUS', 'LIST_ISSUE', 'LIST_ITEM', 'LIST_ITEMDEMANDPLAN', 'LIST_ITEMPROCESSFAMILY', 'LIST_ITEMPROCESSGROUP', 'LIST_ITEMREVENUECATEGORY', 'LIST_ITEMSUPPLYPLAN', 'LIST_ITEMTEMPLATE', 'LIST_ITEM_COLLECTION', 'LIST_ITEM_REVISION', 'LIST_JOB', 'LIST_JOBREQUISITION', 'LIST_KEYS', 'LIST_KNOWLEDGEBASE', 'LIST_KUDOS', 'LIST_LOCATION', 'LIST_MAILMERGE', 'LIST_MAILMESSAGE', 'LIST_MAILTEMPLATE', 'LIST_MASSUPDATES', 'LIST_MEDIAITEMFOLDER', 'LIST_MEMDOC', 'LIST_MFGCOSTTEMPLATE', 'LIST_MFGROUTING', 'LIST_MYROLES', 'LIST_NEWSITEM', 'LIST_NOTIFICATION', 'LIST_ORDER_REALLOCATION', 'LIST_ORGANIZATIONVALUE', 'LIST_OTHERNAME', 'LIST_OUTBOUNDREQUEST', 'LIST_PARTNER', 'LIST_PARTNERCOMMISSNRULES', 'LIST_PAYCHECK', 'LIST_PAYMENT_CARD', 'LIST_PAYMENT_CARD_TOKEN', 'LIST_PAYMENT_INSTRUMENTS', 'LIST_PAYMETH', 'LIST_PAYROLLITEM', 'LIST_PDFMESSAGE', 'LIST_PDFTEMPLATE', 'LIST_PHASEDPROCESS', 'LIST_PICKSTRATEGY', 'LIST_PICKTASK', 'LIST_PLANNEDREVENUE', 'LIST_PLANNEDSTANDARDCOST', 'LIST_PRESCATEGORY', 'LIST_PRICEBOOK', 'LIST_PRICEPLAN', 'LIST_PROJECTREVENUERULE', 'LIST_PROJECTTASK', 'LIST_PROJECTTEMPLATE', 'LIST_PROJECT_BUDGET', 'LIST_PROMOTIONCODE', 'LIST_PUBLIC_TEMPLATE_CATEGORY', 'LIST_PUBLISHSEARCH', 'LIST_QUANTITYPRICINGSCHEDULE', 'LIST_REALLOCATE_ORDER_ITEM', 'LIST_RECOGNITIONEVENTTYPE', 'LIST_RECORDCUSTFIELD', 'LIST_RELATEDITEMS', 'LIST_RESOURCE', 'LIST_RESOURCEGROUP', 'LIST_REVENUEELEMENT', 'LIST_REVENUEPLAN', 'LIST_REVENUERECOGNITIONRULE', 'LIST_REVRECFIELDMAPPING', 'LIST_REVRECSCHEDULE', 'LIST_REVRECTREATMENT', 'LIST_REVRECTREATMENTRULE', 'LIST_REVRECVSOE', 'LIST_RSRCALLOCATION', 'LIST_RSRCALLOCATIONAPPRV', 'LIST_RSSFEED', 'LIST_SALESCAMPAIGN', 'LIST_SALESROLE', 'LIST_SCHEDULEMASSUPDATES', 'LIST_SCSNAPSHOT', 'LIST_SENTEMAIL', 'LIST_SHIPITEM', 'LIST_SHIPPARTPACKAGE', 'LIST_SHIPPARTREGISTRATION', 'LIST_SHIPPARTSHIPMENT', 'LIST_SHORTCUT', 'LIST_SITEEMAILTEMPLATE', 'LIST_STANDARDCOSTVERSION', 'LIST_STORECATEGORY', 'LIST_STOREITEMLISTLA', 'LIST_STORETAB', 'LIST_SUBSCRIPTION', 'LIST_SUBSCRIPTIONCHANGEORDER', 'LIST_SUBSCRIPTIONPLAN', 'LIST_SUBSIDIARY', 'LIST_SUPPLY_REALLOCATION', 'LIST_SYSTEMEMAILTEMPLATE', 'LIST_TABLEAU_WORKBOOK_EXPORT', 'LIST_TALENT_ADMINISTRATION', 'LIST_TASK', 'LIST_TAXDETAILSTAB', 'LIST_TAXENGINESELECTION', 'LIST_TAXITEM', 'LIST_TAXSCHEDULE', 'LIST_TEGATAACCOUNT', 'LIST_TEMPLATE_CATEGORY', 'LIST_TIMEOFFADMIN', 'LIST_TRANNUMBERAUDITLOG', 'LIST_UNDELIVEREDEMAIL', 'LIST_UNIT', 'LIST_UPSELL', 'LIST_UPSELLWIZARD', 'LIST_USAGE', 'LIST_VENDOR', 'LIST_WBS', 'LIST_WEBSITE', 'LIST_WORKCALENDAR', 'LIST_WORKPLACE', 'LIST_ZONE', 'NONE_NEEDED', 'REGT_ACCTPAY', 'REGT_ACCTREC', 'REGT_BANK', 'REGT_COGS', 'REGT_CREDCARD', 'REGT_DEFEREXPENSE', 'REGT_DEFERREVENUE', 'REGT_EQUITY', 'REGT_EXPENSE', 'REGT_FIXEDASSET', 'REGT_INCOME', 'REGT_LONGTERMLIAB', 'REGT_NONPOSTING', 'REGT_OTHASSET', 'REGT_OTHCURRASSET', 'REGT_OTHCURRLIAB', 'REGT_OTHEXPENSE', 'REGT_OTHINCOME', 'REGT_PAYROLL', 'REGT_STAT', 'REGT_UNBILLEDREC', 'REPO_1099', 'REPO_940', 'REPO_941', 'REPO_ACCOUNTDETAIL', 'REPO_AMORTIZATION', 'REPO_ANALYTICS', 'REPO_AP', 'REPO_AR', 'REPO_AUTHPARTNERCOMMISSION', 'REPO_BALANCESHEET', 'REPO_BOOKINGS', 'REPO_BUDGET', 'REPO_CASHFLOW', 'REPO_COMMISSION', 'REPO_CUSTOMIZATION', 'REPO_DEFERREDEXPENSE', 'REPO_EMAIL', 'REPO_FINANCIALS', 'REPO_GL', 'REPO_GRANT_ACCESS', 'REPO_GSTSUMMARY', 'REPO_INTEGRATION', 'REPO_INVENTORY', 'REPO_ISSUE', 'REPO_MARKETING', 'REPO_NONPOSTING', 'REPO_PANDL', 'REPO_PARTNERCOMMISSION', 'REPO_PAYCHECKDETAIL', 'REPO_PAYROLL', 'REPO_PAYROLLHIDEFINEMPINFO', 'REPO_PAYROLLHOURSEARNING', 'REPO_PAYROLLJOURNAL', 'REPO_PAYROLLLIAB', 'REPO_PAYROLLSTATEWITHHOLD', 'REPO_PAYROLLW2', 'REPO_PERIODENDFINANCIALS', 'REPO_PROJECT_ACCOUNTING', 'REPO_PSTSUMMARY', 'REPO_PURCHASEORDER', 'REPO_PURCHASES', 'REPO_QUOTA', 'REPO_RECONCILE', 'REPO_REMINDEREMPLOYEE', 'REPO_RETURNAUTH', 'REPO_REVREC', 'REPO_RSRCALLOCATION', 'REPO_SALES', 'REPO_SALESORDER', 'REPO_SALES_PARTNER', 'REPO_SALES_PROMO', 'REPO_SCHEDULE', 'REPO_SFA', 'REPO_SNAPSHOTCASE', 'REPO_SNAPSHOTLEAD', 'REPO_SUPPORT', 'REPO_TAX', 'REPO_TAXREPORTS', 'REPO_TIME', 'REPO_TRAN', 'REPO_TRIALBALANCE', 'REPO_UNBILLED', 'REPO_W4', 'REPO_WEBSITE', 'REPO_WEBSTORE', 'REPO_WORKFORCEANALYTICS', 'TRAN_ADJUSTMENTJOURNAL', 'TRAN_ALLOCSCHEDULE', 'TRAN_AMENDW4', 'TRAN_APPROVECOMMISSN', 'TRAN_APPROVEDD', 'TRAN_APPROVEEFT', 'TRAN_APPROVEPARTNERCOMM', 'TRAN_APPROVEVP', 'TRAN_AUDIT', 'TRAN_AUTO_CASH', 'TRAN_BALANCEOVERVIEW', 'TRAN_BALJRNAL', 'TRAN_BILLPAY_APPROVE', 'TRAN_BILLPAY_STATUS', 'TRAN_BINTRNFR', 'TRAN_BINWKSHT', 'TRAN_BLANKORD', 'TRAN_BLANKORDAPPRV', 'TRAN_BUDGET', 'TRAN_BUILD', 'TRAN_CARDCHRG', 'TRAN_CARDHOLDERAUTHENTICATION', 'TRAN_CARDHOLDERAUTHEVENT', 'TRAN_CARDRFND', 'TRAN_CASHRFND', 'TRAN_CASHSALE', 'TRAN_CHARGE', 'TRAN_CHARGERULE', 'TRAN_CHECK', 'TRAN_CLEARHOLD', 'TRAN_COMMISSN', 'TRAN_COMMITPAYROLL', 'TRAN_COPY_BUDGET', 'TRAN_CREATEINVCOUNT', 'TRAN_CROSSCHARGE', 'TRAN_CUSTAUTH', 'TRAN_CUSTCHRG', 'TRAN_CUSTCRED', 'TRAN_CUSTDEP', 'TRAN_CUSTINVC', 'TRAN_CUSTINVCAPPRV', 'TRAN_CUSTPYMT', 'TRAN_CUSTRFND', 'TRAN_DEPAPPL', 'TRAN_DEPOSIT', 'TRAN_EDITBANKINGINFO', 'TRAN_EDITPROFILE', 'TRAN_ESTIMATE', 'TRAN_ESTIMATEDCOSTOVERRIDE', 'TRAN_EXPREPT', 'TRAN_FFTREQ', 'TRAN_FINCHRG', 'TRAN_FIND', 'TRAN_FORECAST', 'TRAN_FXREVAL', 'TRAN_GATEWAYNOTIFICATION', 'TRAN_GENERATECHARGES', 'TRAN_GST_REFUND', 'TRAN_IMPORTOLBFILE', 'TRAN_INTERCOADJ', 'TRAN_INVADJST', 'TRAN_INVCOUNT', 'TRAN_INVDISTR', 'TRAN_INVREVAL', 'TRAN_INVTRNFR', 'TRAN_INVWKSHT', 'TRAN_ITEMRCPT', 'TRAN_ITEMSHIP', 'TRAN_JOURNAL', 'TRAN_JOURNALAPPRV', 'TRAN_LIABPYMT', 'TRAN_MANAGEPAYROLL', 'TRAN_MATCHING_RULES', 'TRAN_MGRFORECAST', 'TRAN_OPENBAL', 'TRAN_OPPRTNTY', 'TRAN_OWNTRNSF', 'TRAN_PARTNERCOMMISSN', 'TRAN_PAYCHECK', 'TRAN_PAYMENTAUDIT', 'TRAN_PAYMENTEVENT', 'TRAN_PAYMENTRESULTPREVIEW', 'TRAN_PAYROLLRUN', 'TRAN_PCHKJRNL', 'TRAN_PEJRNL', 'TRAN_POSTPERIODS', 'TRAN_POSTVENDORBILLVARIANCE', 'TRAN_PRICELIST', 'TRAN_PRINT', 'TRAN_PRINTCHECKSFORMS', 'TRAN_PRINTSHIPMENTDOCS', 'TRAN_PROJECT_IC_CHARGE_REQUEST', 'TRAN_PURCHCON', 'TRAN_PURCHCONAPPRV', 'TRAN_PURCHORD', 'TRAN_PURCHORDBILL', 'TRAN_PURCHORDRECEIVE', 'TRAN_PURCHREQ', 'TRAN_PURCHREQAPPRV', 'TRAN_QUOTA', 'TRAN_RECEIVEINBOUND', 'TRAN_RECOG_GIFTCERT_INCOME', 'TRAN_RECONCILE', 'TRAN_REVARRNG', 'TRAN_REVARRNGAPPRV', 'TRAN_REVCOMM', 'TRAN_REVCOMRV', 'TRAN_REVCONTR', 'TRAN_RFQ', 'TRAN_RTNAUTH', 'TRAN_RTNAUTHAPPRV', 'TRAN_RTNAUTHCREDIT', 'TRAN_RTNAUTHRECEIVE', 'TRAN_RTNAUTHREVERSEREVCOMMIT', 'TRAN_SALESORD', 'TRAN_SALESORDAPPRV', 'TRAN_SALESORDCOMMITREVENUE', 'TRAN_SALESORDFULFILL', 'TRAN_SALESORDINVOICE', 'TRAN_SALESORDREVENUECONTRACT', 'TRAN_STATCHNG', 'TRAN_STATEMENT', 'TRAN_STATUSDD', 'TRAN_STATUSEFT', 'TRAN_STATUSVP', 'TRAN_STPICKUP', 'TRAN_SYSJRNL', 'TRAN_TAXLIAB', 'TRAN_TAXPYMT', 'TRAN_TEGPYBL', 'TRAN_TEGRCVBL', 'TRAN_TIMEBILL', 'TRAN_TIMECALC', 'TRAN_TIMEPOST', 'TRAN_TIMER', 'TRAN_TRANSFER', 'TRAN_TRNFRORD', 'TRAN_TRNFRORDAPPRV', 'TRAN_UNBUILD', 'TRAN_VENDAUTH', 'TRAN_VENDAUTHAPPRV', 'TRAN_VENDAUTHCREDIT', 'TRAN_VENDAUTHRETURN', 'TRAN_VENDBILL', 'TRAN_VENDBILLAPPRV', 'TRAN_VENDCRED', 'TRAN_VENDPYMT', 'TRAN_VENDPYMTAPPRV', 'TRAN_VENDRFQ', 'TRAN_VPREP', 'TRAN_VPREPAPP', 'TRAN_WAVE', 'TRAN_WOCLOSE', 'TRAN_WOCOMPL', 'TRAN_WOISSUE', 'TRAN_WORKORD', 'TRAN_WORKORDBUILD', 'TRAN_WORKORDCLOSE', 'TRAN_WORKORDCOMPLETE', 'TRAN_WORKORDISSUE', 'TRAN_WORKORDMARKBUILT', 'TRAN_WORKORDMARKFIRMED', 'TRAN_WORKORDMARKRELEASED', 'TRAN_XMLDETAIL', 'TRAN_YTDADJST'] }),
+    },
+    path: [...enumsFolderPath, generic_permissionElemID.name],
+  }),
+  generic_permission_level: new PrimitiveType({
+    elemID: generic_permission_levelElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CREATE', 'EDIT', 'FULL', 'NONE', 'VIEW'] }),
+    },
+    path: [...enumsFolderPath, generic_permission_levelElemID.name],
+  }),
+  generic_portlet: new PrimitiveType({
+    elemID: generic_portletElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ANALYTICS', 'CALENDAR', 'DASHBOARD_APP', 'KPIMETER', 'KPIREPORT', 'LASTLOGIN', 'LIST', 'QUICKADD', 'QUICKSEARCH', 'RECENTRECORDS', 'RECENTREPORTS', 'REMINDERS', 'RSSSOURCE', 'SCHEDULER', 'SCRIPTPORTLET', 'SEARCHFORM', 'SEARCHRESULTS', 'SETTINGS', 'SHORTCUTS', 'SNAPSHOTS', 'SYSTEMSTATUS', 'TASKLINKS', 'TIMELINE'] }),
+    },
+    path: [...enumsFolderPath, generic_portletElemID.name],
+  }),
+  generic_portletcolumn: new PrimitiveType({
+    elemID: generic_portletcolumnElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['1', '2', '3'] }),
+    },
+    path: [...enumsFolderPath, generic_portletcolumnElemID.name],
+  }),
+  generic_repeat_time: new PrimitiveType({
+    elemID: generic_repeat_timeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['PT12H', 'PT15M', 'PT1H', 'PT2H', 'PT30M', 'PT4H', 'PT6H', 'PT8H'] }),
+    },
+    path: [...enumsFolderPath, generic_repeat_timeElemID.name],
+  }),
+  generic_repeat_time_in_minutes: new PrimitiveType({
+    elemID: generic_repeat_time_in_minutesElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['120', '15', '240', '30', '360', '480', '60', '720'] }),
+    },
+    path: [...enumsFolderPath, generic_repeat_time_in_minutesElemID.name],
+  }),
+  generic_role: new PrimitiveType({
+    elemID: generic_roleElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNTANT', 'ACCOUNTANT__REVIEWER', 'ADMINISTRATOR', 'ADVANCED_PARTNER_CENTER', 'AP_CLERK', 'AR_CLERK', 'BOOKKEEPER', 'BUYER', 'CEO', 'CEO_HANDS_OFF', 'CHIEF_PEOPLE_OFFICER_CPO', 'CONSULTANT', 'CUSTOMER_CENTER', 'CUSTOMROLE41', 'CUSTOMROLE42', 'CUSTOMROLE43', 'CUSTOMROLE56', 'DEVELOPER', 'EMPLOYEE_CENTER', 'ENGINEER', 'ENGINEERING_MANAGER', 'FULL_ACCESS', 'HUMAN_RESOURCES_ADMINISTRATOR', 'HUMAN_RESOURCES_GENERALIST', 'INTRANET_MANAGER', 'ISSUE_ADMINISTRATOR', 'MARKETING_ADMINISTRATOR', 'MARKETING_ASSISTANT', 'MARKETING_MANAGER', 'NETSUITE_SUPPORT_CENTER', 'NETSUITE_SUPPORT_CENTER__BASIC', 'ONLINE_FORM_USER', 'PARTNER_CENTER', 'PAYROLL_MANAGER', 'PAYROLL_SETUP', 'PM_MANAGER', 'PRODUCT_MANAGER', 'QA_ENGINEER', 'QA_MANAGER', 'RESOURCE_MANAGER', 'REVENUE_ACCOUNTANT', 'REVENUE_MANAGER', 'SALES_ADMINISTRATOR', 'SALES_MANAGER', 'SALES_PERSON', 'SALES_VICE_PRESIDENT', 'SHOPPER', 'STORE_MANAGER', 'SUITEAPPRELEASEMANAGER', 'SUPPORT_ADMINISTRATOR', 'SUPPORT_MANAGER', 'SUPPORT_PERSON', 'SYSTEM_ADMINISTRATOR', 'TAX_ENGINE', 'VENDOR_CENTER', 'WAREHOUSE_MANAGER', '_ALL_ROLES'] }),
+    },
+    path: [...enumsFolderPath, generic_roleElemID.name],
+  }),
+  generic_savedsearches_daterange: new PrimitiveType({
+    elemID: generic_savedsearches_daterangeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACTIVITIES', 'BONUSES', 'FULFILLMENT_EXCEPTION_REASON_DEFAULT_VIEW', 'GENERIC_TAX_REPORT_DETAIL', 'GENERIC_TAX_REPORT_SUMMARY', 'NEWS_ITEM_LIST', 'REVENUE_RECOGNITION_ERRORS'] }),
+    },
+    path: [...enumsFolderPath, generic_savedsearches_daterangeElemID.name],
+  }),
+  generic_savedsearches_period: new PrimitiveType({
+    elemID: generic_savedsearches_periodElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['GL_AUDIT_NUMBERING_REVIEW'] }),
+    },
+    path: [...enumsFolderPath, generic_savedsearches_periodElemID.name],
+  }),
+  generic_standard_field: new PrimitiveType({
+    elemID: generic_standard_fieldElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['STDBILLINGACCOUNTAUTONAME', 'STDBILLINGACCOUNTBILLADDRESS', 'STDBILLINGACCOUNTBILLADDRESSLIST', 'STDBILLINGACCOUNTBILLINGSCHEDULE', 'STDBILLINGACCOUNTCASHSALEFORM', 'STDBILLINGACCOUNTCLASS', 'STDBILLINGACCOUNTCREATEDBY', 'STDBILLINGACCOUNTCREATEDDATE', 'STDBILLINGACCOUNTCURRENCY', 'STDBILLINGACCOUNTCUSTOMER', 'STDBILLINGACCOUNTCUSTOMERDEFAULT', 'STDBILLINGACCOUNTCUSTOMFORM', 'STDBILLINGACCOUNTDEPARTMENT', 'STDBILLINGACCOUNTEXTERNALID', 'STDBILLINGACCOUNTFREQUENCY', 'STDBILLINGACCOUNTIDNUMBER', 'STDBILLINGACCOUNTINACTIVE', 'STDBILLINGACCOUNTINVOICEFORM', 'STDBILLINGACCOUNTLASTBILLCYCLEDATE', 'STDBILLINGACCOUNTLASTBILLDATE', 'STDBILLINGACCOUNTLOCATION', 'STDBILLINGACCOUNTMEMO', 'STDBILLINGACCOUNTNAME', 'STDBILLINGACCOUNTNEXTBILLCYCLEDATE', 'STDBILLINGACCOUNTSHIPADDRESS', 'STDBILLINGACCOUNTSHIPADDRESSLIST', 'STDBILLINGACCOUNTSTARTDATE', 'STDBILLINGACCOUNTSUBSIDIARY', 'STDBODYACCOUNT', 'STDBODYACCOUNTINGAPPROVAL', 'STDBODYACCOUNTINGBOOK', 'STDBODYACCTCORPCARDEXP', 'STDBODYACTIONITEM', 'STDBODYADDRESS', 'STDBODYADJLOCATION', 'STDBODYADVANCE', 'STDBODYADVANCEACCOUNT', 'STDBODYALACONFIGURATION', 'STDBODYALTSALESRANGEHIGH', 'STDBODYALTSALESRANGELOW', 'STDBODYALTSALESTOTAL', 'STDBODYALTSHIPPINGCOST', 'STDBODYAMOUNT', 'STDBODYAPACCT', 'STDBODYAPPLIED', 'STDBODYAPPROVALSTATUS', 'STDBODYAPPROVED', 'STDBODYARACCT', 'STDBODYASSEMBLYITEM', 'STDBODYAUTHCODE', 'STDBODYAVAILABLEBALANCE', 'STDBODYBALANCE', 'STDBODYBIDCLOSEDATE', 'STDBODYBIDOPENDATE', 'STDBODYBILLADDRESS', 'STDBODYBILLINGACCOUNT', 'STDBODYBILLINGADDRESS_TEXT', 'STDBODYBILLINGINSTRUCTIONS', 'STDBODYBILLINGSCHEDULE', 'STDBODYBINNUMBERS', 'STDBODYBUILDABLE', 'STDBODYBUILT', 'STDBODYBUYINGREASON', 'STDBODYBUYINGTIMEFRAME', 'STDBODYCARRIER', 'STDBODYCCAPPROVED', 'STDBODYCCEXPIREDATE', 'STDBODYCCISPURCHASECARDBIN', 'STDBODYCCNAME', 'STDBODYCCNUMBER', 'STDBODYCCSECURITYCODE', 'STDBODYCCSTREET', 'STDBODYCCZIPCODE', 'STDBODYCHECKNUM', 'STDBODYCLASS', 'STDBODYCOMPLETE', 'STDBODYCREATEDFROM', 'STDBODYCREDITLIMIT', 'STDBODYCURRENCY', 'STDBODYCURRENCYNAME', 'STDBODYCUSTOMER', 'STDBODYCUSTOMFORM', 'STDBODYDATEELIGIBLE', 'STDBODYDECISIONMAKER', 'STDBODYDEFERREDREVENUE', 'STDBODYDEPARTMENT', 'STDBODYDEPOSIT', 'STDBODYDEPOSITDATE', 'STDBODYDISCOUNTAMOUNT', 'STDBODYDISCOUNTDATE', 'STDBODYDISCOUNTITEM', 'STDBODYDISCOUNTRATE', 'STDBODYDISCOUNTTOTAL', 'STDBODYDOCUMENTSTATUS', 'STDBODYDRACCOUNT', 'STDBODYDUEDATE', 'STDBODYEFFECTIVITYBASEDON', 'STDBODYEMAIL', 'STDBODYEMPLOYEE', 'STDBODYENDDATE', 'STDBODYENTITY', 'STDBODYENTITYEMPLOYEE', 'STDBODYENTITYSTATUS', 'STDBODYESTGROSSPROFIT', 'STDBODYESTGROSSPROFITPERCENT', 'STDBODYESTIMATEDBUDGET', 'STDBODYESTIMATEDTOTAL', 'STDBODYESTIMATEDTOTALVALUE', 'STDBODYEXCHANGERATE', 'STDBODYEXCLUDECOMMISSION', 'STDBODYEXCLUDEFROMGLNUMBERING', 'STDBODYEXPANDASSEMBLY', 'STDBODYEXPECTEDCLOSE', 'STDBODYEXPENSEACCOUNT', 'STDBODYEXPENSEREPORTCURRENCY', 'STDBODYEXPENSEREPORTEXCHANGERATE', 'STDBODYEXTERNALID', 'STDBODYFIRMED', 'STDBODYFOB', 'STDBODYFORECASTTYPE', 'STDBODYFXACCOUNT', 'STDBODYGENERATETRANIDONSAVE', 'STDBODYHANDLINGCOST', 'STDBODYHANDLINGTAXAMOUNT', 'STDBODYINCOTERM', 'STDBODYISBUDGETAPPROVED', 'STDBODYISCROSSSUBTRANSACTION', 'STDBODYISCUSTOMAPPROVAL', 'STDBODYISINTRANSITPAYMENT', 'STDBODYISRECURRINGPAYMENT', 'STDBODYISTAXABLE', 'STDBODYITEM', 'STDBODYITEMFULFILLMENT', 'STDBODYJOB', 'STDBODYLEADSOURCE', 'STDBODYLINKEDTRACKINGNUMBERS', 'STDBODYLOCATION', 'STDBODYMAXIMUMAMOUNT', 'STDBODYMEMO', 'STDBODYMESSAGE', 'STDBODYMINIMUMAMOUNT', 'STDBODYNEXTAPPROVER', 'STDBODYONETIME', 'STDBODYOPPORTUNITY', 'STDBODYORDERSTATUS', 'STDBODYOTHERREFNUM', 'STDBODYPACKINGLISTINSTRUCTIONS', 'STDBODYPARENTEXPENSEALLOC', 'STDBODYPARTNER', 'STDBODYPAYMENT', 'STDBODYPAYMENTCUSTOMER', 'STDBODYPAYMENTHOLD', 'STDBODYPAYMENTMETHOD', 'STDBODYPAYMENTSESSIONAMOUNT', 'STDBODYPAYPALAUTHID', 'STDBODYPAYPALORDERID', 'STDBODYPAYPALPROCESS', 'STDBODYPAYPALSTATUS', 'STDBODYPAYPALTRANID', 'STDBODYPAYROLLITEM', 'STDBODYPNREFNUM', 'STDBODYPOSTINGPERIOD', 'STDBODYPRINTVOUCHER', 'STDBODYPROBABILITY', 'STDBODYPRODUCTLABELINGINSTRUCTIONS', 'STDBODYPROJALTSALESAMT', 'STDBODYPROJECTEDTOTAL', 'STDBODYPROMOCODE', 'STDBODYPURCHASECONTRACT', 'STDBODYPURCHASEORDERINSTRUCTIONS', 'STDBODYQUANTITY', 'STDBODYRANGEHIGH', 'STDBODYRANGELOW', 'STDBODYRECOGNIZEDREVENUE', 'STDBODYRECURANNUALLY', 'STDBODYRECURMONTHLY', 'STDBODYRECURQUARTERLY', 'STDBODYRECURWEEKLY', 'STDBODYREFUNDCHECK', 'STDBODYREIMBURSABLEAMOUNT', 'STDBODYRETURNTRACKINGNUMBERS', 'STDBODYREVCOMMITSTATUS', 'STDBODYREVENUESTATUS', 'STDBODYREVERSALDATE', 'STDBODYREVERSALDEFER', 'STDBODYREVERSALENTRY', 'STDBODYREVISION', 'STDBODYREVISIONMEMO', 'STDBODYREVRECONREVCOMMITMENT', 'STDBODYSALESEFFECTIVEDATE', 'STDBODYSALESORDER', 'STDBODYSALESREADINESS', 'STDBODYSALESREP', 'STDBODYSERIALNUMBERS', 'STDBODYSHIPADDR1', 'STDBODYSHIPADDR2', 'STDBODYSHIPADDRESS', 'STDBODYSHIPADDRESSLIST', 'STDBODYSHIPATTENTION', 'STDBODYSHIPCITY', 'STDBODYSHIPCOMPANY', 'STDBODYSHIPCOMPLETE', 'STDBODYSHIPCOUNTRY', 'STDBODYSHIPDATE', 'STDBODYSHIPISRESIDENTIAL', 'STDBODYSHIPMETHOD', 'STDBODYSHIPOVERRIDE', 'STDBODYSHIPPHONE', 'STDBODYSHIPPINGADDRESS_TEXT', 'STDBODYSHIPPINGCOST', 'STDBODYSHIPPINGTAX1RATE', 'STDBODYSHIPPINGTAXAMOUNT', 'STDBODYSHIPPINGTAXCODE', 'STDBODYSHIPSTATE', 'STDBODYSHIPSTATUS', 'STDBODYSHIPTO', 'STDBODYSHIPZIP', 'STDBODYSOFTDESCRIPTOR', 'STDBODYSOURCE', 'STDBODYSOURCETRANSACTIONNUMBER', 'STDBODYSTARTDATE', 'STDBODYSTATUS', 'STDBODYSUBSIDIARY', 'STDBODYSUPERVISOR', 'STDBODYSUPERVISORAPPROVAL', 'STDBODYTAXITEM', 'STDBODYTAXPERIOD', 'STDBODYTAXPOINTDATE', 'STDBODYTAXPOINTDATEOVERRIDE', 'STDBODYTAXRATE', 'STDBODYTAXTOTAL', 'STDBODYTERMS', 'STDBODYTITLE', 'STDBODYTOACH', 'STDBODYTOBEEMAILED', 'STDBODYTOBEFAXED', 'STDBODYTOBEPRINTED', 'STDBODYTOLOCATION', 'STDBODYTOSUBSIDIARY', 'STDBODYTOTAL', 'STDBODYTOTALALLOCATIONAMOUNT', 'STDBODYTOTALCOSTESTIMATE', 'STDBODYTOTALREVENUEAMOUNT', 'STDBODYTOTALSELLINGAMOUNT', 'STDBODYTRACKINGNUMBERS', 'STDBODYTRANDATE', 'STDBODYTRANID', 'STDBODYTRANISVSOEBUNDLE', 'STDBODYTRANSACTIONNUMBER', 'STDBODYTRANSFERLOCATION', 'STDBODYTRANSTATUS', 'STDBODYTRANTYPE', 'STDBODYUNAPPLIED', 'STDBODYUNDEPFUNDS', 'STDBODYUSEITEMCOSTASTRANSFERCOST', 'STDBODYUSEMULTICURRENCY', 'STDBODYUSERAMOUNT', 'STDBODYUSERTOTAL', 'STDBODYVENDOR', 'STDBODYVISIBLETOCUSTOMER', 'STDBODYVSOEAUTOCALC', 'STDBODYWAVEINTERNALID', 'STDBODYWAVEISINACTIVE', 'STDBODYWAVENAME', 'STDBODYWAVEPRIORITY', 'STDBODYWEIGHTEDTOTAL', 'STDBODYWHICHCHARGESTOADD', 'STDBODYWINLOSSREASON', 'STDCHARGEAMOUNT', 'STDCHARGEBILLDATE', 'STDCHARGEBILLINGMODE', 'STDCHARGEBILLINGSCHEDULE', 'STDCHARGECHARGERULE', 'STDCHARGECLASS', 'STDCHARGECURRENCY', 'STDCHARGECUSTOMER', 'STDCHARGEDATE', 'STDCHARGEDEPARTMENT', 'STDCHARGEEMPLOYEE', 'STDCHARGEFIXEDCHARGERULE', 'STDCHARGEGROUPORDER', 'STDCHARGEITEM', 'STDCHARGELOCATION', 'STDCHARGENOTES', 'STDCHARGEPROJECTTASKSOURCE', 'STDCHARGEQUANTITY', 'STDCHARGERATE', 'STDCHARGERULEBILLINGRATECARD', 'STDCHARGERULECAPHOURS', 'STDCHARGERULECAPMONEY', 'STDCHARGERULECAPTYPE', 'STDCHARGERULECHARGERULETYPE', 'STDCHARGERULECHARGESTAGE', 'STDCHARGERULEDESCRIPTION', 'STDCHARGERULEEXPAMTMULTIPLIER', 'STDCHARGERULEEXPSAVEDSEARCH', 'STDCHARGERULEISINACTIVE', 'STDCHARGERULEITEM', 'STDCHARGERULENAME', 'STDCHARGERULEORDER', 'STDCHARGERULEPROJECT', 'STDCHARGERULERATEMULTIPLIER', 'STDCHARGERULERATEROUNDINGTYPE', 'STDCHARGERULERATESOURCETYPE', 'STDCHARGERULESALEUNIT', 'STDCHARGERULESAVEDSEARCH', 'STDCHARGERULESTOPIFCAPPED', 'STDCHARGERULEUNITSTYPE', 'STDCHARGERUNID', 'STDCHARGESALESORDER', 'STDCHARGESERVICEEND', 'STDCHARGESERVICESTART', 'STDCHARGESOLINE', 'STDCHARGESTAGE', 'STDCHARGESUBSCRIPTIONLINE', 'STDCHARGETIMESOURCE', 'STDCHARGETRANSACTION', 'STDCHARGETYPE', 'STDCHARGETYPENAME', 'STDCHARGETYPESCRIPTID', 'STDCHARGTRANSACTIONLINE', 'STDCOLACCOUNT', 'STDCOLAMOUNT', 'STDCOLBOMREVISIONCOMPONENT', 'STDCOLCALL', 'STDCOLCASE', 'STDCOLCASETASKEVENT', 'STDCOLCHARGE', 'STDCOLCLASS', 'STDCOLCREATEDFROM', 'STDCOLCUSTOMER', 'STDCOLDEPARTMENT', 'STDCOLDESCRIPTION', 'STDCOLEMPLOYEE', 'STDCOLENTITY', 'STDCOLEVENT', 'STDCOLEXPECTEDRECEIPTDATE', 'STDCOLEXPECTEDSHIPDATE', 'STDCOLGLNUMBER', 'STDCOLGLSEQUENCE', 'STDCOLISBILLABLE', 'STDCOLISCLOSED', 'STDCOLISTAXABLE', 'STDCOLITEM', 'STDCOLJOB', 'STDCOLLINE', 'STDCOLLOCATION', 'STDCOLONHAND', 'STDCOLPRICEINTERVALFREQUENCYNAME', 'STDCOLPRICEINTERVALREPEATEVERY', 'STDCOLPROJECTTASK', 'STDCOLQUANTITY', 'STDCOLQUANTITYBILLED', 'STDCOLQUANTITYCOMMITTED', 'STDCOLQUANTITYFULFILLED', 'STDCOLQUANTITYINVOICED', 'STDCOLQUANTITYRECEIVED', 'STDCOLQUANTITYREFUNDED', 'STDCOLRATE', 'STDCOLSUBSCRIPTION', 'STDCOLSUBSCRIPTIONLINE', 'STDCOLSUBSCRIPTIONLINEPERIODAMOUNT', 'STDCOLSUBSCRIPTIONLINERATE', 'STDCOLSUBSIDIARY', 'STDCOLTASK', 'STDCOLUNITS', 'STDENTITYACCESSROLE', 'STDENTITYACCOUNTNUMBER', 'STDENTITYACTUALTIME', 'STDENTITYADDRESS1', 'STDENTITYADDRESS2', 'STDENTITYALIENNUMBER', 'STDENTITYALLOCATEDTIME', 'STDENTITYALLOWALLRESOURCESFORTASKS', 'STDENTITYALLOWEXPENSES', 'STDENTITYALLOWTIME', 'STDENTITYALLOWTIMEFORRSRCALLOC', 'STDENTITYALTCONTACT', 'STDENTITYALTEMAIL', 'STDENTITYALTPHONE', 'STDENTITYAPPLYPROJECTEXPENSETYPETOALL', 'STDENTITYAPPROVALLIMIT', 'STDENTITYAPPROVER', 'STDENTITYASSIGNEDWEBSITE', 'STDENTITYASSISTANT', 'STDENTITYASSISTANTPHONE', 'STDENTITYAUTHWORKDATE', 'STDENTITYBALANCE', 'STDENTITYBALANCEPRIMARY', 'STDENTITYBALANCEPRIMARYCURRENCY', 'STDENTITYBASEWAGE', 'STDENTITYBASEWAGETYPE', 'STDENTITYBCN', 'STDENTITYBILLADDRESS', 'STDENTITYBILLINGACCOUNT', 'STDENTITYBILLINGCLASS', 'STDENTITYBILLINGPHONE', 'STDENTITYBILLINGRATECARD', 'STDENTITYBILLINGSCHEDULE', 'STDENTITYBILLPAY', 'STDENTITYBIRTHDATE', 'STDENTITYBONUSTARGET', 'STDENTITYBONUSTARGETCOMMENT', 'STDENTITYBONUSTARGETPAYFREQUENCY', 'STDENTITYBONUSTARGETTYPE', 'STDENTITYBUYINGREASON', 'STDENTITYBUYINGTIMEFRAME', 'STDENTITYCALCULATEDENDDATE', 'STDENTITYCALCULATEDSTARTDATE', 'STDENTITYCALCULATEDSTARTDATEBASELINE', 'STDENTITYCALCULATEDWORK', 'STDENTITYCALCULATEDWORKBASELINE', 'STDENTITYCAMPAIGNCATEGORY', 'STDENTITYCAMPAIGNEVENT', 'STDENTITYCHANGEDETAILS', 'STDENTITYCHARGEAMOUNTBILLED', 'STDENTITYCHARGEAMOUNTHOLDFORBILLING', 'STDENTITYCHARGEAMOUNTPENDING', 'STDENTITYCHARGEAMOUNTREADYFORBILLING', 'STDENTITYCHARGEAMOUNTREMAINING', 'STDENTITYCHARGEEXPENSEAMOUNT', 'STDENTITYCHARGELABORAMOUNT', 'STDENTITYCITY', 'STDENTITYCLASS', 'STDENTITYCLICKSTREAM', 'STDENTITYCOMMENTS', 'STDENTITYCOMMISSIONPAYMENTPREFERENCE', 'STDENTITYCOMPANY', 'STDENTITYCOMPANYNAME', 'STDENTITYCOMPENSATIONCURRENCY', 'STDENTITYCONCURRENTWEBSERVICESUSER', 'STDENTITYCONSOLBALANCE', 'STDENTITYCONSOLDAYSOVERDUE', 'STDENTITYCONSOLOVERDUEBALANCE', 'STDENTITYCONSOLUNBILLEDORDERS', 'STDENTITYCONTACT', 'STDENTITYCONTACTCAMPAIGNEVENT', 'STDENTITYCONTACTSOURCE', 'STDENTITYCONTACTSOURCECAMPAIGNCATEGORY', 'STDENTITYCOUNTRY', 'STDENTITYCOUNTRYNAME', 'STDENTITYCREDITHOLDOVERRIDE', 'STDENTITYCREDITLIMIT', 'STDENTITYCREDITLIMITCURRENCY', 'STDENTITYCURRENCY', 'STDENTITYCUSTOMERCUSTOMFORM', 'STDENTITYCUSTTYPE', 'STDENTITYDATECREATED', 'STDENTITYDAYSOVERDUE', 'STDENTITYDEFAULTACCTCORPCARDEXP', 'STDENTITYDEFAULTADDRESS', 'STDENTITYDEFAULTEXPENSEREPORTCURRENCY', 'STDENTITYDEFAULTJOBRESOURCEROLE', 'STDENTITYDEFAULTORDERPRIORITY', 'STDENTITYDEPARTMENT', 'STDENTITYDIRECTDEPOSIT', 'STDENTITYDISPLAYSYMBOL', 'STDENTITYDRACCOUNT', 'STDENTITYDRIVERSLICENSENUMBER', 'STDENTITYELIGIBLEFORCOMMISSION', 'STDENTITYEMAIL', 'STDENTITYEMAILPREFERENCE', 'STDENTITYEMAILTRANSACTIONS', 'STDENTITYEMPLOYEECHANGEREASON', 'STDENTITYEMPLOYEEFTESTATUS', 'STDENTITYEMPLOYEEHCMJOB', 'STDENTITYEMPLOYEEHCMJOBID', 'STDENTITYEMPLOYEESTATUS', 'STDENTITYEMPLOYEETERMINATIONCATEGORY', 'STDENTITYEMPLOYEETERMINATIONREGRETTED', 'STDENTITYEMPLOYEEWORKASSIGNMENT', 'STDENTITYEMPTYPE', 'STDENTITYENDDATE', 'STDENTITYENTITYFIRSTNAME', 'STDENTITYENTITYID', 'STDENTITYENTITYLASTNAME', 'STDENTITYENTITYMIDDLENAME', 'STDENTITYENTITYSALUTATION', 'STDENTITYESTIMATEDBUDGET', 'STDENTITYESTIMATEDGROSSPROFIT', 'STDENTITYESTIMATEDGROSSPROFITPERCENT', 'STDENTITYESTIMATEDLABORCOST', 'STDENTITYESTIMATEDLABORREVENUE', 'STDENTITYESTIMATEDTIMEOVERRIDE', 'STDENTITYESTIMATEREVRECTEMPLATE', 'STDENTITYETHNICITY', 'STDENTITYEXPENSEACCOUNT', 'STDENTITYEXPENSELIMIT', 'STDENTITYEXTERNALID', 'STDENTITYFAX', 'STDENTITYFAXTRANSACTIONS', 'STDENTITYFIRSTVISIT', 'STDENTITYFORECASTCHARGERUNONDEMAND', 'STDENTITYFXACCOUNT', 'STDENTITYFXRATE', 'STDENTITYGENDER', 'STDENTITYGIVEACCESS', 'STDENTITYGLOBALSUBSCRIPTIONSTATUS', 'STDENTITYHASOFFLINEACCESS', 'STDENTITYHIREDATE', 'STDENTITYHOMEPHONE', 'STDENTITYI9VERIFIED', 'STDENTITYIMAGE', 'STDENTITYINCLUDECRMTASKSINTOTALS', 'STDENTITYINCOTERM', 'STDENTITYINHERITIPRULES', 'STDENTITYINITIALS', 'STDENTITYINTRANSITBALANCE', 'STDENTITYIPADDRESSRULE', 'STDENTITYIS1099ELIGIBLE', 'STDENTITYISBUDGETAPPROVED', 'STDENTITYISEXEMPTTIME', 'STDENTITYISINACTIVE', 'STDENTITYISJOB', 'STDENTITYISJOBMANAGER', 'STDENTITYISJOBRESOURCE', 'STDENTITYISJOBRESOURCEVEND', 'STDENTITYISJOBRESOURCEVENDOR', 'STDENTITYISPERSON', 'STDENTITYISPRIVATE', 'STDENTITYISPRODUCTIVETIME', 'STDENTITYISSALESREP', 'STDENTITYISSUPPORTREP', 'STDENTITYISUTILIZEDTIME', 'STDENTITYJOBBILLINGTYPE', 'STDENTITYJOBDESCRIPTION', 'STDENTITYJOBEMPLOYMENTCATEGORY', 'STDENTITYJOBITEM', 'STDENTITYJOBPRICE', 'STDENTITYJOBTYPE', 'STDENTITYJURISDICTIONCOUNTY', 'STDENTITYJURISDICTIONFEDERAL', 'STDENTITYJURISDICTIONLOCAL', 'STDENTITYJURISDICTIONSCHOOL', 'STDENTITYJURISDICTIONSTATE', 'STDENTITYKEYWORDS', 'STDENTITYLABORCOST', 'STDENTITYLABORPRICE', 'STDENTITYLANGUAGE', 'STDENTITYLASTBASELINEDATE', 'STDENTITYLASTPAGEVISITED', 'STDENTITYLASTPAIDDATE', 'STDENTITYLASTREVIEWDATE', 'STDENTITYLASTVISIT', 'STDENTITYLEADSOURCE', 'STDENTITYLEGALNAME', 'STDENTITYLIMITTIMETOASSIGNEES', 'STDENTITYLOCATION', 'STDENTITYMARITALSTATUS', 'STDENTITYMATERIALIZETIME', 'STDENTITYMOBILEPHONE', 'STDENTITYNEGATIVENUMBERFORMAT', 'STDENTITYNEXTREVIEWDATE', 'STDENTITYNUMBERFORMAT', 'STDENTITYOFFICEPHONE', 'STDENTITYOVERDUEBALANCE', 'STDENTITYOVERRIDECURRENCYFORMAT', 'STDENTITYPARENT', 'STDENTITYPARENTPARTNER', 'STDENTITYPARTNER', 'STDENTITYPARTNERCODE', 'STDENTITYPARTNERCUSTOMFORM', 'STDENTITYPASSPORTNUMBER', 'STDENTITYPASSWORD', 'STDENTITYPASSWORD2', 'STDENTITYPAYABLESACCOUNT', 'STDENTITYPAYFREQUENCY', 'STDENTITYPERCENTCOMPLETE', 'STDENTITYPERCENTCOMPLETEBYRSRCALLOC', 'STDENTITYPERCENTTIMECOMPLETE', 'STDENTITYPHONE', 'STDENTITYPLANNEDWORK', 'STDENTITYPLANNEDWORKBASELINE', 'STDENTITYPREDCONFIDENCE', 'STDENTITYPREDICTEDDAYS', 'STDENTITYPREFCCPROCESSOR', 'STDENTITYPRICELEVEL', 'STDENTITYPRINTONCHECKAS', 'STDENTITYPRINTTRANSACTIONS', 'STDENTITYPROBABILITY', 'STDENTITYPROJECTCOMPLETELYBILLED', 'STDENTITYPROJECTEXPENSETYPE', 'STDENTITYPROJECTMANAGER', 'STDENTITYPURCHASEORDERAMOUNT', 'STDENTITYPURCHASEORDERAPPROVALLIMIT', 'STDENTITYPURCHASEORDERAPPROVER', 'STDENTITYPURCHASEORDERLIMIT', 'STDENTITYPURCHASEORDERQUANTITY', 'STDENTITYPURCHASEORDERQUANTITYDIFF', 'STDENTITYRATE', 'STDENTITYRECEIPTAMOUNT', 'STDENTITYRECEIPTQUANTITY', 'STDENTITYRECEIPTQUANTITYDIFF', 'STDENTITYRECEIVABLESACCOUNT', 'STDENTITYREFERRER', 'STDENTITYRELEASEDATE', 'STDENTITYREMINDERDAYS', 'STDENTITYREQUIREPWDCHANGE', 'STDENTITYRESALENUMBER', 'STDENTITYRESIDENTSTATUS', 'STDENTITYSALESREADINESS', 'STDENTITYSALESREP', 'STDENTITYSALESROLE', 'STDENTITYSCHEDULEDENDDATE', 'STDENTITYSCHEDULEDENDDATEBASELINE', 'STDENTITYSCHEDULINGMETHOD', 'STDENTITYSHIPADDRESS', 'STDENTITYSHIPCOMPLETE', 'STDENTITYSHIPPINGITEM', 'STDENTITYSHIPPINGPHONE', 'STDENTITYSOCIALSECURITYNUMBER', 'STDENTITYSOURCEWEBSITE', 'STDENTITYSTAGE', 'STDENTITYSTAGENAME', 'STDENTITYSTARTDATE', 'STDENTITYSTARTDATETIMEOFFCALC', 'STDENTITYSTATE', 'STDENTITYSTATENAME', 'STDENTITYSTATUS', 'STDENTITYSUBPARTNERLOGIN', 'STDENTITYSUBSIDIARY', 'STDENTITYSUPERVISOR', 'STDENTITYSUPERVISORPHONE', 'STDENTITYSYMBOLPLACEMENT', 'STDENTITYTARGETUTILIZATION', 'STDENTITYTAXABLE', 'STDENTITYTAXEXEMPT', 'STDENTITYTAXIDNUM', 'STDENTITYTAXITEM', 'STDENTITYTAXROUNDING', 'STDENTITYTERMINATIONDETAILS', 'STDENTITYTERMINATIONREASON', 'STDENTITYTERMS', 'STDENTITYTERRITORY', 'STDENTITYTIMEAPPROVAL', 'STDENTITYTIMEAPPROVER', 'STDENTITYTIMEOFFPLAN', 'STDENTITYTIMEREMAINING', 'STDENTITYTITLE', 'STDENTITYTYPE', 'STDENTITYUNBILLEDORDERS', 'STDENTITYUNBILLEDORDERSPRIMARY', 'STDENTITYUNBILLEDORDERSPRIMARYCURRENCY', 'STDENTITYURL', 'STDENTITYUSEALLOCATEDTIMEFORFORECAST', 'STDENTITYUSEPERQUEST', 'STDENTITYUSETIMEDATA', 'STDENTITYVATREGNUMBER', 'STDENTITYVENDORCUSTOMFORM', 'STDENTITYVENDORTIMEAPPROVER', 'STDENTITYVENDTYPE', 'STDENTITYVISAEXPDATE', 'STDENTITYVISATYPE', 'STDENTITYVISITS', 'STDENTITYWEBLEAD', 'STDENTITYWORKCALENDAR', 'STDENTITYWORKPLACE', 'STDENTITYZIP', 'STDEVENTACCESSLEVEL', 'STDEVENTACTUALTIME', 'STDEVENTACTUALWORK', 'STDEVENTALLDAYEVENT', 'STDEVENTALLOCATEDWORK', 'STDEVENTALLOCATIONAMOUNT', 'STDEVENTALLOCATIONPROJECT', 'STDEVENTALLOCATIONPROJECTTASK', 'STDEVENTALLOCATIONTYPE', 'STDEVENTALLOCATIONUNIT', 'STDEVENTAPPROVALSTATUS', 'STDEVENTASSIGNED', 'STDEVENTAUDIENCE', 'STDEVENTBASECOST', 'STDEVENTCALCULATEDWORK', 'STDEVENTCALCULATEDWORKBASELINE', 'STDEVENTCALLSTATUS', 'STDEVENTCAMPAIGNCATEGORY', 'STDEVENTCAMPAIGNID', 'STDEVENTCASECATEGORY', 'STDEVENTCASENUMBER', 'STDEVENTCASEPRIORITY', 'STDEVENTCASEPROFILE', 'STDEVENTCASESTATUS', 'STDEVENTCOMPANY', 'STDEVENTCOMPLETEDDATE', 'STDEVENTCONSTRAINTTYPE', 'STDEVENTCONTACT', 'STDEVENTCONVCOSTPERCUSTOMER', 'STDEVENTCONVERSIONS', 'STDEVENTCOST', 'STDEVENTCOSTPERCUSTOMER', 'STDEVENTCREATEDDATE', 'STDEVENTCUSTOMER', 'STDEVENTCUSTOMFORM', 'STDEVENTDISPLAYONLINE', 'STDEVENTDUEDATE', 'STDEVENTDUPLICATEOF', 'STDEVENTEMAIL', 'STDEVENTEMAILASSIGNEE', 'STDEVENTENDBYDATE', 'STDEVENTENDDATE', 'STDEVENTENDTIME', 'STDEVENTESTIMATEDTIME', 'STDEVENTESTIMATEDTIMEOVERRIDE', 'STDEVENTESTIMATEDWORK', 'STDEVENTEXPECTEDREVENUE', 'STDEVENTEXTERNALABSTRACT', 'STDEVENTEXTERNALDETAILS', 'STDEVENTEXTERNALID', 'STDEVENTFAMILY', 'STDEVENTFINISHBYDATE', 'STDEVENTHELPDESK', 'STDEVENTHELPDESKEMPLOYEE', 'STDEVENTINBOUNDEMAIL', 'STDEVENTINCOMINGMESSAGE', 'STDEVENTISINACTIVE', 'STDEVENTISMILESTONE', 'STDEVENTISOWNER', 'STDEVENTISREVIEWED', 'STDEVENTISSHOWSTOPPER', 'STDEVENTISSUE', 'STDEVENTISSUEABSTRACT', 'STDEVENTISSUENUMBER', 'STDEVENTISSUESTATUS', 'STDEVENTISSUETYPE', 'STDEVENTITEM', 'STDEVENTJOB', 'STDEVENTKEYWORD', 'STDEVENTLASTMESSAGEDATE', 'STDEVENTLASTMODIFIEDDATE', 'STDEVENTLASTREOPENEDDATE', 'STDEVENTLEADSGENERATED', 'STDEVENTLOCATION', 'STDEVENTLONGDESCRIPTION', 'STDEVENTMESSAGE', 'STDEVENTMILESTONE', 'STDEVENTMODULE', 'STDEVENTNEXTAPPROVER', 'STDEVENTNOENDDATE', 'STDEVENTNONBILLABLETASK', 'STDEVENTNOTES', 'STDEVENTNUMBER', 'STDEVENTNUMBERTEXT', 'STDEVENTNUMHOURS', 'STDEVENTOFFER', 'STDEVENTOPPORTUNITY', 'STDEVENTORDER', 'STDEVENTORGANIZER', 'STDEVENTORIGIN', 'STDEVENTOWNER', 'STDEVENTPARENT', 'STDEVENTPERCENTCOMPLETE', 'STDEVENTPERCENTCOMPLETEBYRSRCALLOC', 'STDEVENTPERCENTOFTIME', 'STDEVENTPERCENTTIMECOMPLETE', 'STDEVENTPHONE', 'STDEVENTPLANNEDWORK', 'STDEVENTPLANNEDWORKBASELINE', 'STDEVENTPRIORITY', 'STDEVENTPRIORITYNAME', 'STDEVENTPRODUCT', 'STDEVENTPRODUCTTEAM', 'STDEVENTPROFIT', 'STDEVENTPROMOTIONCODE', 'STDEVENTREMAININGWORK', 'STDEVENTREMINDERMINUTES', 'STDEVENTREMINDERTYPE', 'STDEVENTREPORTEDBY', 'STDEVENTREPRODUCE', 'STDEVENTREQUESTEDBY', 'STDEVENTRESOURCE', 'STDEVENTREVIEWER', 'STDEVENTROI', 'STDEVENTSEARCHENGINE', 'STDEVENTSENDEMAIL', 'STDEVENTSERIESSTARTDATE', 'STDEVENTSEVERITY', 'STDEVENTSOLUTIONCODE', 'STDEVENTSOURCE', 'STDEVENTSTARTDATE', 'STDEVENTSTARTTIME', 'STDEVENTSTATUS', 'STDEVENTSTATUSNAME', 'STDEVENTSUBSIDIARY', 'STDEVENTSUPPORTCASE', 'STDEVENTTASKSTATUS', 'STDEVENTTIMEDEVENT', 'STDEVENTTIMEREMAINING', 'STDEVENTTITLE', 'STDEVENTTOTALREVENUE', 'STDEVENTTRANSACTION', 'STDEVENTUNIQUEVISITORS', 'STDEVENTURL', 'STDEVENTVERTICAL', 'STDGLSEQUENCEINACTIVE', 'STDGLSEQUENCEINITNUM', 'STDGLSEQUENCEINVALIDNUMCOUNT', 'STDGLSEQUENCELASTRUN', 'STDGLSEQUENCEMINDIGITS', 'STDGLSEQUENCENAME', 'STDGLSEQUENCENUMASSIGNEDCOUNT', 'STDGLSEQUENCEORDERTYPE', 'STDGLSEQUENCEPERIOD', 'STDGLSEQUENCEPREFIX', 'STDGLSEQUENCERUNAUTHOR', 'STDGLSEQUENCESUBSIDIARIES', 'STDGLSEQUENCESUFFIX', 'STDINVENTORYNUMBERITEM', 'STDITEMACCOUNT', 'STDITEMADVANCERENEWALPERIODNUMBER', 'STDITEMADVANCERENEWALPERIODUNIT', 'STDITEMAMORTIZATIONPERIOD', 'STDITEMAMORTIZATIONTEMPLATE', 'STDITEMASSETACCOUNT', 'STDITEMAUTOLEADTIME', 'STDITEMAUTOPREFERREDSTOCKLEVEL', 'STDITEMAUTORENEWAL', 'STDITEMAUTOREORDERPOINT', 'STDITEMAVAILABLE', 'STDITEMAVAILABLETOPARTNERS', 'STDITEMAVERAGECOST', 'STDITEMBACKORDERED', 'STDITEMBILLEXCHRATEVARIANCEACCT', 'STDITEMBILLINGSCHEDULE', 'STDITEMBILLPRICEVARIANCEACCT', 'STDITEMBILLQTYVARIANCEACCT', 'STDITEMBUILDENTIREASSEMBLY', 'STDITEMCITY', 'STDITEMCLASS', 'STDITEMCOGSACCOUNT', 'STDITEMCOPYDESCRIPTION', 'STDITEMCOST', 'STDITEMCOSTESTIMATE', 'STDITEMCOSTESTIMATETYPE', 'STDITEMCOSTINGMETHOD', 'STDITEMCOUNTRYOFMANUFACTURE', 'STDITEMCOUNTY', 'STDITEMCREATEDDATE', 'STDITEMCREATEJOB', 'STDITEMCREATEREVENUEPLANSON', 'STDITEMCURRENCY', 'STDITEMCUSTOMFORM', 'STDITEMCUSTRETURNVARIANCEACCOUNT', 'STDITEMDAYSBEFOREEXPIRATION', 'STDITEMDEFAULTRENEWALMETHOD', 'STDITEMDEFAULTRENEWALPLAN', 'STDITEMDEFAULTRENEWALTERM', 'STDITEMDEFAULTRENEWALTRANTYPE', 'STDITEMDEFAULTRETURNCOST', 'STDITEMDEFAULTREVISION', 'STDITEMDEFERRALACCOUNT', 'STDITEMDEFERREDREVENUEACCOUNT', 'STDITEMDEFERREVREC', 'STDITEMDEMANDMODIFIER', 'STDITEMDEPARTMENT', 'STDITEMDESCRIPTION', 'STDITEMDISPLAYNAME', 'STDITEMDONTSHOWPRICE', 'STDITEMDROPSHIPEXPENSEACCOUNT', 'STDITEMEFFECTIVEBOMCONTROL', 'STDITEMENFORCEMINQTYINTERNALLY', 'STDITEMEXCLUDEFROMSITEMAP', 'STDITEMEXPENSEACCOUNT', 'STDITEMEXTERNALID', 'STDITEMFEATUREDDESCRIPTION', 'STDITEMFRAUDRISK', 'STDITEMFUTUREHORIZON', 'STDITEMGAINLOSSACCOUNT', 'STDITEMGCOCOMPLIANT', 'STDITEMGENERATEACCRUALS', 'STDITEMHANDLINGCOST', 'STDITEMIMMEDIATEDOWNLOAD', 'STDITEMINCLUDECHILDREN', 'STDITEMINCLUDESTARTENDLINES', 'STDITEMINCOMEACCOUNT', 'STDITEMINITIALTERM', 'STDITEMINTERNALID', 'STDITEMISDONATIONITEM', 'STDITEMISDROPSHIPITEM', 'STDITEMISFULFILLABLE', 'STDITEMISINACTIVE', 'STDITEMISONLINE', 'STDITEMISPRETAX', 'STDITEMISSPECIALORDERITEM', 'STDITEMISSPECIALWORKORDERITEM', 'STDITEMISSTOREPICKUPALLOWED', 'STDITEMISSUEPRODUCT', 'STDITEMISTAXABLE', 'STDITEMISVSOEBUNDLE', 'STDITEMITEMREVENUECATEGORY', 'STDITEMITEMTYPE', 'STDITEMLASTPURCHASEPRICE', 'STDITEMLEADTIME', 'STDITEMLIABILITYACCOUNT', 'STDITEMLOCATION', 'STDITEMMANUFACTURER', 'STDITEMMATCHBILLTORECEIPT', 'STDITEMMATRIXITEMNAMETEMPLATE', 'STDITEMMAXDONATIONAMOUNT', 'STDITEMMAXIMUMQUANTITY', 'STDITEMMETATAGHTML', 'STDITEMMINIMUMQUANTITY', 'STDITEMMOSS', 'STDITEMMPN', 'STDITEMNAME', 'STDITEMNEXTAGCATEGORY', 'STDITEMNONPOSTING', 'STDITEMNOPRICEMESSAGE', 'STDITEMNUMOFALLOWEDDOWNLOADS', 'STDITEMOFFERSUPPORT', 'STDITEMONHAND', 'STDITEMONLINENAME', 'STDITEMONORDER', 'STDITEMONSPECIAL', 'STDITEMOUTOFSTOCKBEHAVIOR', 'STDITEMOUTOFSTOCKMESSAGE', 'STDITEMOVERALLQUANTITYPRICINGTYPE', 'STDITEMPAGETITLE', 'STDITEMPARENT', 'STDITEMPAYMENTMETHOD', 'STDITEMPREFERREDLOCATION', 'STDITEMPREFERREDSTOCKLEVEL', 'STDITEMPREFERREDSTOCKLEVELDAYS', 'STDITEMPRICINGGROUP', 'STDITEMPRINTITEMS', 'STDITEMPROCESSFAMILY', 'STDITEMPROCESSGROUP', 'STDITEMPROJECTEXPENSETYPE', 'STDITEMPROJECTTEMPLATE', 'STDITEMPURCHASEDESCRIPTION', 'STDITEMPURCHASEORDERAMOUNT', 'STDITEMPURCHASEORDERQUANTITY', 'STDITEMPURCHASEORDERQUANTITYDIFF', 'STDITEMPURCHASEUNIT', 'STDITEMQUANTITYCOMMITTED', 'STDITEMQUANTITYPRICINGSCHEDULE', 'STDITEMRATE', 'STDITEMRECEIPTAMOUNT', 'STDITEMRECEIPTQUANTITY', 'STDITEMRECEIPTQUANTITYDIFF', 'STDITEMRELATEDITEMSDESCRIPTION', 'STDITEMREORDERMULTIPLE', 'STDITEMREORDERPOINT', 'STDITEMRESIDUAL', 'STDITEMREVENUEALLOCATIONGROUP', 'STDITEMREVENUERECOGNITIONRULE', 'STDITEMREVRECSCHEDULE', 'STDITEMROUNDUPASCOMPONENT', 'STDITEMSAFETYSTOCKLEVEL', 'STDITEMSAFETYSTOCKLEVELDAYS', 'STDITEMSALESDESCRIPTION', 'STDITEMSALEUNIT', 'STDITEMSEARCHKEYWORDS', 'STDITEMSEASONALDEMAND', 'STDITEMSHIPINDIVIDUALLY', 'STDITEMSHIPPACKAGE', 'STDITEMSHIPPINGCOST', 'STDITEMSHOPPINGDOTCOMCATEGORY', 'STDITEMSHOPZILLACATEGORYID', 'STDITEMSHOWDEFAULTDONATIONAMOUNT', 'STDITEMSOFTDESCRIPTOR', 'STDITEMSPECIALSDESCRIPTION', 'STDITEMSTATE', 'STDITEMSTOCKDESCRIPTION', 'STDITEMSTOCKUNIT', 'STDITEMSTOREDESCRIPTION', 'STDITEMSTOREDETAILEDDESCRIPTION', 'STDITEMSTOREDISPLAYIMAGE', 'STDITEMSTOREDISPLAYTHUMBNAIL', 'STDITEMSTOREITEMTEMPLATE', 'STDITEMSUBSIDIARY', 'STDITEMTAXACCOUNT', 'STDITEMTAXAGENCY', 'STDITEMTAXSCHEDULE', 'STDITEMTAXTYPE', 'STDITEMTOTALVALUE', 'STDITEMTRACKLANDEDCOST', 'STDITEMTRANSFERPRICE', 'STDITEMUNBUILDVARIANCEACCOUNT', 'STDITEMUNDEPFUNDS', 'STDITEMUNITSTYPE', 'STDITEMUPCCODE', 'STDITEMUSEBINS', 'STDITEMUSECOMPONENTYIELD', 'STDITEMUSEMARGINALRATES', 'STDITEMVENDOR', 'STDITEMVENDORCOST', 'STDITEMVENDORNAME', 'STDITEMVENDRETURNVARIANCEACCOUNT', 'STDITEMVSOEDEFERRAL', 'STDITEMVSOEDELIVERED', 'STDITEMVSOEPERMITDISCOUNT', 'STDITEMVSOEPRICE', 'STDITEMVSOESOPGROUP', 'STDITEMWEIGHT', 'STDITEMWEIGHTUNITS', 'STDITEMZIP', 'STDLOCASSIGNCONFNAME', 'STDRECORDACCOUNTACCTNAME', 'STDRECORDACCOUNTACCTNUMBER', 'STDRECORDACCOUNTACCTTYPE', 'STDRECORDACCOUNTBAI2CUSTACCTNUM', 'STDRECORDACCOUNTBAI2ORIGID', 'STDRECORDACCOUNTBILLABLEEXPENSESACCT', 'STDRECORDACCOUNTCASHFLOWRATE', 'STDRECORDACCOUNTCATEGORY1099MISC', 'STDRECORDACCOUNTCLASS', 'STDRECORDACCOUNTCURRENCY', 'STDRECORDACCOUNTDEFERRALACCT', 'STDRECORDACCOUNTDEPARTMENT', 'STDRECORDACCOUNTDESCRIPTION', 'STDRECORDACCOUNTELIMINATE', 'STDRECORDACCOUNTEXCHANGERATE', 'STDRECORDACCOUNTEXTERNALID', 'STDRECORDACCOUNTGENERALRATE', 'STDRECORDACCOUNTIBANACCTNUM', 'STDRECORDACCOUNTINCLUDECHILDREN', 'STDRECORDACCOUNTINGBOOKEFFECTIVEPERIOD', 'STDRECORDACCOUNTINGBOOKEXTERNALID', 'STDRECORDACCOUNTINGBOOKINCLUDECHILDREN', 'STDRECORDACCOUNTINGBOOKISCONSOLIDATED', 'STDRECORDACCOUNTINGBOOKISPRIMARY', 'STDRECORDACCOUNTINGBOOKNAME', 'STDRECORDACCOUNTINGBOOKSTATUS', 'STDRECORDACCOUNTINGBOOKSUBSIDIARY', 'STDRECORDACCOUNTINGCONTEXTEXTERNALID', 'STDRECORDACCOUNTINGCONTEXTNAME', 'STDRECORDACCOUNTINGPERIODALLOWNONGLCHANGES', 'STDRECORDACCOUNTINGPERIODCLOSED', 'STDRECORDACCOUNTINGPERIODEND', 'STDRECORDACCOUNTINGPERIODISADJUST', 'STDRECORDACCOUNTINGPERIODISQUARTER', 'STDRECORDACCOUNTINGPERIODISYEAR', 'STDRECORDACCOUNTINGPERIODOPEN', 'STDRECORDACCOUNTINGPERIODPARENT', 'STDRECORDACCOUNTINGPERIODPERIODNAME', 'STDRECORDACCOUNTINGPERIODSTART', 'STDRECORDACCOUNTINVENTORY', 'STDRECORDACCOUNTISINACTIVE', 'STDRECORDACCOUNTISSUMMARY', 'STDRECORDACCOUNTLEGALNAME', 'STDRECORDACCOUNTLOCATION', 'STDRECORDACCOUNTOPENINGBALANCE', 'STDRECORDACCOUNTPARENT', 'STDRECORDACCOUNTRECONCILEWITHMATCHING', 'STDRECORDACCOUNTREVAL', 'STDRECORDADDRESSBOOKENTITY', 'STDRECORDADDRESSCOUNTRY', 'STDRECORDALLOCSCHEDDESTLINECLASS', 'STDRECORDALLOCSCHEDDESTLINEDEPARTMENT', 'STDRECORDALLOCSCHEDDESTLINELOCATION', 'STDRECORDALLOCSCHEDSRCLINECLASS', 'STDRECORDALLOCSCHEDSRCLINEDEPARTMENT', 'STDRECORDALLOCSCHEDSRCLINELOCATION', 'STDRECORDAPPROVEDBY', 'STDRECORDASCHARGEDPROJECTREVENUERULEDESCRIPTION', 'STDRECORDASCHARGEDPROJECTREVENUERULEISINACTIVE', 'STDRECORDASCHARGEDPROJECTREVENUERULENAME', 'STDRECORDASCHARGEDPROJECTREVENUERULEPROJECT', 'STDRECORDASCHARGEDPROJECTREVENUERULEREVENUERECONCILED', 'STDRECORDASCHARGEDPROJECTREVENUERULETOTALAMOUNTTORECOGNIZE', 'STDRECORDBILLINGCLASSCOST', 'STDRECORDBILLINGCLASSDESCRIPTION', 'STDRECORDBILLINGCLASSEXTERNALID', 'STDRECORDBILLINGCLASSISINACTIVE', 'STDRECORDBILLINGCLASSNAME', 'STDRECORDBILLINGCLASSPRICE', 'STDRECORDBILLINGCLASSSALEUNIT', 'STDRECORDBILLINGCLASSUNITSTYPE', 'STDRECORDBILLINGRATECARDCUSTOMER', 'STDRECORDBILLINGRATECARDISINACTIVE', 'STDRECORDBILLINGRATECARDNAME', 'STDRECORDBILLINGSCHEDULEAPPLYTOSUBTOTAL', 'STDRECORDBILLINGSCHEDULEEXTERNALID', 'STDRECORDBILLINGSCHEDULEFREQUENCY', 'STDRECORDBILLINGSCHEDULEINARREARS', 'STDRECORDBILLINGSCHEDULEINITIALAMOUNT', 'STDRECORDBILLINGSCHEDULEINITIALTERMS', 'STDRECORDBILLINGSCHEDULEISINACTIVE', 'STDRECORDBILLINGSCHEDULEISPUBLIC', 'STDRECORDBILLINGSCHEDULENAME', 'STDRECORDBILLINGSCHEDULENUMBERREMAINING', 'STDRECORDBILLINGSCHEDULERECURRENCETERMS', 'STDRECORDBILLINGSCHEDULESCHEDULETYPE', 'STDRECORDBILLINGSCHEDULETRANSACTION', 'STDRECORDBINNUMBERBINNUMBER', 'STDRECORDBINNUMBERISINACTIVE', 'STDRECORDBINNUMBERLOCATION', 'STDRECORDBINNUMBERMEMO', 'STDRECORDBINNUMBERSEQUENCENUMBER', 'STDRECORDBINNUMBERTYPE', 'STDRECORDBINNUMBERZONE', 'STDRECORDBOMAVAILABLEFORALLASSEMBLIES', 'STDRECORDBOMAVAILABLEFORALLLOCATIONS', 'STDRECORDBOMEXTERNALID', 'STDRECORDBOMID', 'STDRECORDBOMISINACTIVE', 'STDRECORDBOMMEMO', 'STDRECORDBOMNAME', 'STDRECORDBOMREVISIONBILLOFMATERIALS', 'STDRECORDBOMREVISIONCOMPONENTBOMREVISION', 'STDRECORDBOMREVISIONCOMPONENTID', 'STDRECORDBOMREVISIONCOMPONENTITEM', 'STDRECORDBOMREVISIONCOMPONENTLINENUMBER', 'STDRECORDBOMREVISIONCOMPONENTQUANTITY', 'STDRECORDBOMREVISIONCOMPONENTSOURCE', 'STDRECORDBOMREVISIONEFFECTIVEENDDATE', 'STDRECORDBOMREVISIONEFFECTIVESTARTDATE', 'STDRECORDBOMREVISIONEXTERNALID', 'STDRECORDBOMREVISIONID', 'STDRECORDBOMREVISIONISINACTIVE', 'STDRECORDBOMREVISIONMEMO', 'STDRECORDBOMREVISIONNAME', 'STDRECORDBONUSBONUSAMOUNTABSOLUTE', 'STDRECORDBONUSBONUSAWARDDATE', 'STDRECORDBONUSBONUSCOMMENT', 'STDRECORDBONUSBONUSCURRENCY', 'STDRECORDBONUSBONUSEMPLOYEE', 'STDRECORDBONUSBONUSSTATUS', 'STDRECORDBONUSBONUSTYPE', 'STDRECORDBONUSEXTERNALID', 'STDRECORDBONUSINTERNALID', 'STDRECORDBONUSTYPEEXTERNALID', 'STDRECORDBONUSTYPEINTERNALID', 'STDRECORDBONUSTYPEISINACTIVE', 'STDRECORDBONUSTYPENAME', 'STDRECORDBONUSTYPEPAYROLLITEM', 'STDRECORDBONUSTYPESUBSIDIARY', 'STDRECORDBUDGETACCOUNT', 'STDRECORDBUDGETAMOUNT', 'STDRECORDBUDGETCLASS', 'STDRECORDBUDGETCUSTOMER', 'STDRECORDBUDGETDEPARTMENT', 'STDRECORDBUDGETITEM', 'STDRECORDBUDGETLOCATION', 'STDRECORDBUDGETSUBSIDIARY', 'STDRECORDBUYINGREASONISINACTIVE', 'STDRECORDBUYINGREASONNAME', 'STDRECORDBUYINGTIMEFRAMEISINACTIVE', 'STDRECORDBUYINGTIMEFRAMENAME', 'STDRECORDCAMPAIGNAUDIENCEDESCRIPTION', 'STDRECORDCAMPAIGNAUDIENCEEXTERNALID', 'STDRECORDCAMPAIGNAUDIENCEISINACTIVE', 'STDRECORDCAMPAIGNAUDIENCENAME', 'STDRECORDCAMPAIGNCATEGORYDESCRIPTION', 'STDRECORDCAMPAIGNCATEGORYEXTERNALID', 'STDRECORDCAMPAIGNCATEGORYISEXTERNAL', 'STDRECORDCAMPAIGNCATEGORYISINACTIVE', 'STDRECORDCAMPAIGNCATEGORYLEADSOURCE', 'STDRECORDCAMPAIGNCATEGORYNAME', 'STDRECORDCAMPAIGNCATEGORYPARENT', 'STDRECORDCAMPAIGNCHANNELDESCRIPTION', 'STDRECORDCAMPAIGNCHANNELEVENTTYPE', 'STDRECORDCAMPAIGNCHANNELEXTERNALID', 'STDRECORDCAMPAIGNCHANNELISINACTIVE', 'STDRECORDCAMPAIGNCHANNELNAME', 'STDRECORDCAMPAIGNFAMILYDESCRIPTION', 'STDRECORDCAMPAIGNFAMILYEXTERNALID', 'STDRECORDCAMPAIGNFAMILYISINACTIVE', 'STDRECORDCAMPAIGNFAMILYNAME', 'STDRECORDCAMPAIGNOFFERDESCRIPTION', 'STDRECORDCAMPAIGNOFFEREXTERNALID', 'STDRECORDCAMPAIGNOFFERISINACTIVE', 'STDRECORDCAMPAIGNOFFERNAME', 'STDRECORDCAMPAIGNRESPONSECAMPAIGNEVENT', 'STDRECORDCAMPAIGNRESPONSECAMPAIGNRESPONSEDATE', 'STDRECORDCAMPAIGNRESPONSECHANNEL', 'STDRECORDCAMPAIGNRESPONSEENTITY', 'STDRECORDCAMPAIGNRESPONSEEXTERNALID', 'STDRECORDCAMPAIGNRESPONSELEADSOURCE', 'STDRECORDCAMPAIGNRESPONSENEWRESPONSEDATE', 'STDRECORDCAMPAIGNRESPONSENEWRESPONSETIME', 'STDRECORDCAMPAIGNRESPONSERESPONSE', 'STDRECORDCAMPAIGNRESPONSERESPONSETYPE', 'STDRECORDCAMPAIGNSEARCHENGINEDESCRIPTION', 'STDRECORDCAMPAIGNSEARCHENGINEEXTERNALID', 'STDRECORDCAMPAIGNSEARCHENGINEISINACTIVE', 'STDRECORDCAMPAIGNSEARCHENGINENAME', 'STDRECORDCAMPAIGNSUBSCRIPTIONDESCRIPTION', 'STDRECORDCAMPAIGNSUBSCRIPTIONEXTERNALDESCRIPTION', 'STDRECORDCAMPAIGNSUBSCRIPTIONEXTERNALNAME', 'STDRECORDCAMPAIGNSUBSCRIPTIONISINACTIVE', 'STDRECORDCAMPAIGNSUBSCRIPTIONNAME', 'STDRECORDCAMPAIGNSUBSCRIPTIONSUBSCRIBEDBYDEFAULT', 'STDRECORDCAMPAIGNVERTICALDESCRIPTION', 'STDRECORDCAMPAIGNVERTICALEXTERNALID', 'STDRECORDCAMPAIGNVERTICALISINACTIVE', 'STDRECORDCAMPAIGNVERTICALNAME', 'STDRECORDCASEISSUEDESCRIPTION', 'STDRECORDCASEISSUEEXTERNALID', 'STDRECORDCASEISSUEISINACTIVE', 'STDRECORDCASEISSUENAME', 'STDRECORDCASEORIGINDESCRIPTION', 'STDRECORDCASEORIGINEXTERNALID', 'STDRECORDCASEORIGINISINACTIVE', 'STDRECORDCASEORIGINNAME', 'STDRECORDCASEPRIORITYDESCRIPTION', 'STDRECORDCASEPRIORITYEXTERNALID', 'STDRECORDCASEPRIORITYISINACTIVE', 'STDRECORDCASEPRIORITYNAME', 'STDRECORDCASESTATUSAUTOCLOSECASE', 'STDRECORDCASESTATUSCASEONHOLD', 'STDRECORDCASESTATUSDESCRIPTION', 'STDRECORDCASESTATUSEXTERNALID', 'STDRECORDCASESTATUSISINACTIVE', 'STDRECORDCASESTATUSNAME', 'STDRECORDCASESTATUSSHOWAWAITINGREPLY', 'STDRECORDCASESTATUSSTAGE', 'STDRECORDCASETYPEDESCRIPTION', 'STDRECORDCASETYPEEXTERNALID', 'STDRECORDCASETYPEISINACTIVE', 'STDRECORDCASETYPENAME', 'STDRECORDCATCHUPPERIOD', 'STDRECORDCHARGERULEEXTERNALID', 'STDRECORDCLASS', 'STDRECORDCLASSEXTERNALID', 'STDRECORDCLASSINCLUDECHILDREN', 'STDRECORDCLASSISINACTIVE', 'STDRECORDCLASSNAME', 'STDRECORDCLASSPARENT', 'STDRECORDCLOSEDATE', 'STDRECORDCMSCONTENTAREANAME', 'STDRECORDCMSCONTENTCHANGEURL', 'STDRECORDCMSCONTENTCMSCONTENTTYPE', 'STDRECORDCMSCONTENTCREATED', 'STDRECORDCMSCONTENTCREATEDBY', 'STDRECORDCMSCONTENTDESCRIPTION', 'STDRECORDCMSCONTENTENDDATE', 'STDRECORDCMSCONTENTEXTERNALID', 'STDRECORDCMSCONTENTGLOBAL', 'STDRECORDCMSCONTENTHIDDEN', 'STDRECORDCMSCONTENTID', 'STDRECORDCMSCONTENTINTERNALID', 'STDRECORDCMSCONTENTLASTMODIFIED', 'STDRECORDCMSCONTENTLASTMODIFIEDBY', 'STDRECORDCMSCONTENTMATCHCOUNT', 'STDRECORDCMSCONTENTMATCHTYPE', 'STDRECORDCMSCONTENTNAME', 'STDRECORDCMSCONTENTPAGETYPE', 'STDRECORDCMSCONTENTPATH', 'STDRECORDCMSCONTENTSEQUENCENUMBER', 'STDRECORDCMSCONTENTSETTINGSID', 'STDRECORDCMSCONTENTSITE', 'STDRECORDCMSCONTENTSTARTDATE', 'STDRECORDCMSCONTENTTAGS', 'STDRECORDCMSCONTENTTEMPLATE', 'STDRECORDCMSCONTENTTYPECUSTOMRECORDID', 'STDRECORDCMSCONTENTTYPECUSTOMRECORDSCRIPTID', 'STDRECORDCMSCONTENTTYPEDESCRIPTION', 'STDRECORDCMSCONTENTTYPEEXTERNALID', 'STDRECORDCMSCONTENTTYPEICONIMAGEPATH', 'STDRECORDCMSCONTENTTYPEID', 'STDRECORDCMSCONTENTTYPEINTERNALID', 'STDRECORDCMSCONTENTTYPELABEL', 'STDRECORDCMSCONTENTTYPENAME', 'STDRECORDCMSCTSITEMAPPINGCMSCONTENTTYPE', 'STDRECORDCMSCTSITEMAPPINGDISPLAYINADMIN', 'STDRECORDCMSCTSITEMAPPINGEXTERNALID', 'STDRECORDCMSCTSITEMAPPINGID', 'STDRECORDCMSCTSITEMAPPINGINTERNALID', 'STDRECORDCMSCTSITEMAPPINGSITE', 'STDRECORDCMSPAGEADDTOHEAD', 'STDRECORDCMSPAGECREATED', 'STDRECORDCMSPAGECREATEDBY', 'STDRECORDCMSPAGEENDDATE', 'STDRECORDCMSPAGEEXTERNALID', 'STDRECORDCMSPAGEID', 'STDRECORDCMSPAGEINTERNALID', 'STDRECORDCMSPAGELASTMODIFIED', 'STDRECORDCMSPAGELASTMODIFIEDBY', 'STDRECORDCMSPAGEMETADESCRIPTION', 'STDRECORDCMSPAGEMETAKEYWORDS', 'STDRECORDCMSPAGENAME', 'STDRECORDCMSPAGEPAGEHEADER', 'STDRECORDCMSPAGEPAGETITLE', 'STDRECORDCMSPAGEPAGETYPE', 'STDRECORDCMSPAGESITE', 'STDRECORDCMSPAGESTARTDATE', 'STDRECORDCMSPAGETAGS', 'STDRECORDCMSPAGETEMPLATE', 'STDRECORDCMSPAGETYPEBASEURLPATH', 'STDRECORDCMSPAGETYPECMSCREATABLE', 'STDRECORDCMSPAGETYPECREATED', 'STDRECORDCMSPAGETYPECREATEDBY', 'STDRECORDCMSPAGETYPECUSTOMRECORDTYPE', 'STDRECORDCMSPAGETYPEDESCRIPTION', 'STDRECORDCMSPAGETYPEDISPLAYNAME', 'STDRECORDCMSPAGETYPEEXTERNALID', 'STDRECORDCMSPAGETYPEINACTIVE', 'STDRECORDCMSPAGETYPEINTERNALID', 'STDRECORDCMSPAGETYPELASTMODIFIED', 'STDRECORDCMSPAGETYPELASTMODIFIEDBY', 'STDRECORDCMSPAGETYPENAME', 'STDRECORDCMSPAGEURL', 'STDRECORDCOMMERCECATALOGDESCRIPTION', 'STDRECORDCOMMERCECATALOGEXTERNALID', 'STDRECORDCOMMERCECATALOGID', 'STDRECORDCOMMERCECATALOGINTERNALID', 'STDRECORDCOMMERCECATALOGNAME', 'STDRECORDCOMMERCECATALOGSITE', 'STDRECORDCOMMERCECATEGORYADDTOHEAD', 'STDRECORDCOMMERCECATEGORYCATALOG', 'STDRECORDCOMMERCECATEGORYCREATED', 'STDRECORDCOMMERCECATEGORYDESCRIPTION', 'STDRECORDCOMMERCECATEGORYDISPLAYINSITE', 'STDRECORDCOMMERCECATEGORYENDDATE', 'STDRECORDCOMMERCECATEGORYEXTERNALID', 'STDRECORDCOMMERCECATEGORYID', 'STDRECORDCOMMERCECATEGORYINTERNALID', 'STDRECORDCOMMERCECATEGORYISINACTIVE', 'STDRECORDCOMMERCECATEGORYITEMS', 'STDRECORDCOMMERCECATEGORYLASTMODIFIED', 'STDRECORDCOMMERCECATEGORYLASTMODIFIEDBY', 'STDRECORDCOMMERCECATEGORYMETADESCRIPTION', 'STDRECORDCOMMERCECATEGORYMETAKEYWORDS', 'STDRECORDCOMMERCECATEGORYNAME', 'STDRECORDCOMMERCECATEGORYPAGEBANNER', 'STDRECORDCOMMERCECATEGORYPAGEHEADING', 'STDRECORDCOMMERCECATEGORYPAGETITLE', 'STDRECORDCOMMERCECATEGORYPRIMARYPARENT', 'STDRECORDCOMMERCECATEGORYSEQUENCENUMBER', 'STDRECORDCOMMERCECATEGORYSITEMAPPRIORITY', 'STDRECORDCOMMERCECATEGORYSTARTDATE', 'STDRECORDCOMMERCECATEGORYSUBCATEGORIES', 'STDRECORDCOMMERCECATEGORYTHUMBNAIL', 'STDRECORDCOMMERCECATEGORYTITLE', 'STDRECORDCOMMERCECATEGORYURLFRAGMENT', 'STDRECORDCOMMERCECATEGORYVERSION', 'STDRECORDCOMMISSIONPLANDESCR', 'STDRECORDCOMMISSIONPLANINACTIVE', 'STDRECORDCOMMISSIONPLANPLANNAME', 'STDRECORDCOMMISSIONSCHEDULECURRENCYSYMBOL', 'STDRECORDCOMMISSIONSCHEDULEFORMGR', 'STDRECORDCOMMISSIONSCHEDULEFULLYPAIDELIGIBILITY', 'STDRECORDCOMMISSIONSCHEDULEINACTIVE', 'STDRECORDCOMMISSIONSCHEDULELINEITEMMAPPING', 'STDRECORDCOMMISSIONSCHEDULENAME', 'STDRECORDCOMMISSIONSCHEDULESUBSIDIARY', 'STDRECORDCOMMISSIONSCHEDULETARGET', 'STDRECORDCOMPETITORDESCRIPTION', 'STDRECORDCOMPETITOREXTERNALID', 'STDRECORDCOMPETITORISINACTIVE', 'STDRECORDCOMPETITORNAME', 'STDRECORDCOMPETITORPRODUCTSERVICE', 'STDRECORDCOMPETITORSTRATEGY', 'STDRECORDCOMPETITORSTRENGTHS', 'STDRECORDCOMPETITORURL', 'STDRECORDCOMPETITORWEAKNESSES', 'STDRECORDCONTACTCATEGORYEXTERNALID', 'STDRECORDCONTACTCATEGORYISINACTIVE', 'STDRECORDCONTACTCATEGORYNAME', 'STDRECORDCONTACTCATEGORYPRIVATE', 'STDRECORDCONTACTCATEGORYSYNC', 'STDRECORDCONTACTROLEDESCRIPTION', 'STDRECORDCONTACTROLEEXTERNALID', 'STDRECORDCONTACTROLEISINACTIVE', 'STDRECORDCONTACTROLENAME', 'STDRECORDCOSTCATEGORYACCOUNT', 'STDRECORDCOSTCATEGORYISINACTIVE', 'STDRECORDCOSTCATEGORYNAME', 'STDRECORDCREATED', 'STDRECORDCURRENCYCURRENCYFORMATSAMPLE', 'STDRECORDCURRENCYCURRENCYPRECISION', 'STDRECORDCURRENCYDISPLAYSYMBOL', 'STDRECORDCURRENCYEXCHANGERATE', 'STDRECORDCURRENCYEXTERNALID', 'STDRECORDCURRENCYINCLUDEINFXRATEUPDATES', 'STDRECORDCURRENCYISINACTIVE', 'STDRECORDCURRENCYLOCALE', 'STDRECORDCURRENCYNAME', 'STDRECORDCURRENCYOVERRIDECURRENCYFORMAT', 'STDRECORDCURRENCYSYMBOL', 'STDRECORDCURRENCYSYMBOLPLACEMENT', 'STDRECORDCUSTOMERCATEGORYEXTERNALID', 'STDRECORDCUSTOMERCATEGORYISINACTIVE', 'STDRECORDCUSTOMERCATEGORYNAME', 'STDRECORDCUSTOMERMESSAGEDESCRIPTION', 'STDRECORDCUSTOMERMESSAGEEXTERNALID', 'STDRECORDCUSTOMERMESSAGEISINACTIVE', 'STDRECORDCUSTOMERMESSAGENAME', 'STDRECORDCUSTOMERMESSAGEPREFERRED', 'STDRECORDCUSTOMERSUBSIDIARYRELATIONSHIPCUSTOMER', 'STDRECORDCUSTOMERSUBSIDIARYRELATIONSHIPENTITY', 'STDRECORDCUSTOMERSUBSIDIARYRELATIONSHIPISPRIMARYSUB', 'STDRECORDCUSTOMERSUBSIDIARYRELATIONSHIPSUBSIDIARY', 'STDRECORDCUSTOMFORM', 'STDRECORDDEPARTMENT', 'STDRECORDDEPARTMENTEXTERNALID', 'STDRECORDDEPARTMENTINCLUDECHILDREN', 'STDRECORDDEPARTMENTISINACTIVE', 'STDRECORDDEPARTMENTNAME', 'STDRECORDDEPARTMENTPARENT', 'STDRECORDDOCUMENTSTATUSTRANSACTIONTYPE', 'STDRECORDDOMAINWEBSITE', 'STDRECORDDRIVERSLICENSECLASS', 'STDRECORDDRIVERSLICENSEDATEOFISSUE', 'STDRECORDDRIVERSLICENSEDESCRIPTION', 'STDRECORDDRIVERSLICENSEEMPLOYEE', 'STDRECORDDRIVERSLICENSEEXPIRATIONDATE', 'STDRECORDDRIVERSLICENSEISINACTIVE', 'STDRECORDDRIVERSLICENSEISSUER', 'STDRECORDDRIVERSLICENSENAMEONDOCUMENT', 'STDRECORDDRIVERSLICENSENUMBERVALUE', 'STDRECORDEMAILTEMPLATEDESCRIPTION', 'STDRECORDEMAILTEMPLATEEMAILASSALESREP', 'STDRECORDEMAILTEMPLATEFROMEMAIL', 'STDRECORDEMAILTEMPLATEFROMNAME', 'STDRECORDEMAILTEMPLATEISINACTIVE', 'STDRECORDEMAILTEMPLATEISPRIVATE', 'STDRECORDEMAILTEMPLATENAME', 'STDRECORDEMAILTEMPLATERECORDTYPE', 'STDRECORDEMAILTEMPLATEREPLYEMAIL', 'STDRECORDEMAILTEMPLATERESTRICTGROUP', 'STDRECORDEMAILTEMPLATESHOWCOMPANYINFO', 'STDRECORDEMAILTEMPLATESUBSCRIPTION', 'STDRECORDEMAILTEMPLATETRACKEMAIL', 'STDRECORDEMAILTEMPLATEUNSUBSCRIBE', 'STDRECORDEMPLOYEECHANGEREQUESTAPPROVALSTATUS', 'STDRECORDEMPLOYEECHANGEREQUESTDECLINEDBY', 'STDRECORDEMPLOYEECHANGEREQUESTEMPLOYEE', 'STDRECORDEMPLOYEECHANGEREQUESTEMPLOYEECHANGEREQUESTTYPE', 'STDRECORDEMPLOYEECHANGEREQUESTEMPLOYEECHANGETYPE', 'STDRECORDEMPLOYEECHANGEREQUESTEXTERNALID', 'STDRECORDEMPLOYEECHANGEREQUESTFINALAPPROVER', 'STDRECORDEMPLOYEECHANGEREQUESTINTERNALID', 'STDRECORDEMPLOYEECHANGEREQUESTISINACTIVE', 'STDRECORDEMPLOYEECHANGEREQUESTJUSTIFICATION', 'STDRECORDEMPLOYEECHANGEREQUESTNEXTAPPROVER', 'STDRECORDEMPLOYEECHANGEREQUESTPROPOSEDDATE', 'STDRECORDEMPLOYEECHANGEREQUESTREQUESTER', 'STDRECORDEMPLOYEECHANGEREQUESTREQUESTSTATUS', 'STDRECORDEMPLOYEECHANGETYPECHANGEREASON', 'STDRECORDEMPLOYEECHANGETYPEDESCRIPTION', 'STDRECORDEMPLOYEECHANGETYPEEXTERNALID', 'STDRECORDEMPLOYEECHANGETYPEGUIDELINES', 'STDRECORDEMPLOYEECHANGETYPEINTERNALID', 'STDRECORDEMPLOYEECHANGETYPEISINACTIVE', 'STDRECORDEMPLOYEECHANGETYPENAME', 'STDRECORDENTITYSTATUSDESCRIPTION', 'STDRECORDENTITYSTATUSEXTERNALID', 'STDRECORDENTITYSTATUSINCLUDEINLEADREPORTS', 'STDRECORDENTITYSTATUSISINACTIVE', 'STDRECORDENTITYSTATUSNAME', 'STDRECORDENTITYSTATUSPROBABILITY', 'STDRECORDENTITYSTATUSSTAGE', 'STDRECORDENTITYSTATUSSTAGENAME', 'STDRECORDEREXPLINEAMOUNT', 'STDRECORDEREXPLINEBILLINGSUBSIDIARY', 'STDRECORDEREXPLINECATEGORY', 'STDRECORDEREXPLINECLASS', 'STDRECORDEREXPLINECORPORATECREDITCARD', 'STDRECORDEREXPLINECURRENCY', 'STDRECORDEREXPLINECUSTOMER', 'STDRECORDEREXPLINEDEPARTMENT', 'STDRECORDEREXPLINEEXCHANGERATE', 'STDRECORDEREXPLINEEXPENSEACCOUNT', 'STDRECORDEREXPLINEEXPENSEDATE', 'STDRECORDEREXPLINEFOREIGNAMOUNT', 'STDRECORDEREXPLINEGROSSAMT', 'STDRECORDEREXPLINEISBILLABLE', 'STDRECORDEREXPLINELOCATION', 'STDRECORDEREXPLINEMEMO', 'STDRECORDEREXPLINEPROJECTTASK', 'STDRECORDEREXPLINEQUANTITY', 'STDRECORDEREXPLINERATE', 'STDRECORDEREXPLINEREFNUMBER', 'STDRECORDEREXPLINETAX1AMT', 'STDRECORDEREXPLINETAXAMOUNT', 'STDRECORDEREXPLINETAXCODE', 'STDRECORDEREXPLINETAXRATE1', 'STDRECORDEREXPLINETAXRATE2', 'STDRECORDEXPCATCHUPPERIOD', 'STDRECORDEXPENSECATEGORYDEFAULTRATE', 'STDRECORDEXPENSECATEGORYDESCRIPTION', 'STDRECORDEXPENSECATEGORYEXPENSEACCT', 'STDRECORDEXPENSECATEGORYEXPENSEITEM', 'STDRECORDEXPENSECATEGORYEXTERNALID', 'STDRECORDEXPENSECATEGORYISINACTIVE', 'STDRECORDEXPENSECATEGORYNAME', 'STDRECORDEXPENSECATEGORYPERSONALCORPORATECARDEXPENSE', 'STDRECORDEXPENSECATEGORYRATEREQUIRED', 'STDRECORDEXPHOLDREVENUERECOGNITION', 'STDRECORDEXPRECALCADJUSTPERIODOFFSET', 'STDRECORDEXPREFORECASTMETHOD', 'STDRECORDEXPREVENUERECOGNITIONRULE', 'STDRECORDEXPREVRECENDDATE', 'STDRECORDEXPREVRECSTARTDATE', 'STDRECORDEXTERNALID', 'STDRECORDFIELDDATATYPE', 'STDRECORDFIELDDATATYPENAME', 'STDRECORDFIELDLISTRECORD', 'STDRECORDFIELDRECORDTYPE', 'STDRECORDFIELDSCRIPTID', 'STDRECORDFIELDSTOREVALUE', 'STDRECORDFIELDTYPE', 'STDRECORDFISCALCALENDAREXTERNALID', 'STDRECORDFISCALCALENDARISDEFAULT', 'STDRECORDFISCALCALENDARNAME', 'STDRECORDFIXEDAMOUNTPROJECTREVENUERULEDESCRIPTION', 'STDRECORDFIXEDAMOUNTPROJECTREVENUERULEFIXEDAMOUNTTYPE', 'STDRECORDFIXEDAMOUNTPROJECTREVENUERULEFIXEDSCHEDULETYPE', 'STDRECORDFIXEDAMOUNTPROJECTREVENUERULEISINACTIVE', 'STDRECORDFIXEDAMOUNTPROJECTREVENUERULENAME', 'STDRECORDFIXEDAMOUNTPROJECTREVENUERULEPROJECT', 'STDRECORDFIXEDAMOUNTPROJECTREVENUERULEREVENUERECONCILED', 'STDRECORDFIXEDAMOUNTPROJECTREVENUERULESERVICEITEM', 'STDRECORDFIXEDAMOUNTPROJECTREVENUERULETOTALAMOUNTTORECOGNIZE', 'STDRECORDFORMATPROFILECREATEDBY', 'STDRECORDFORMATPROFILECREATEDDATE', 'STDRECORDFORMATPROFILEDESCRIPTION', 'STDRECORDFORMATPROFILEFINANCIALINSTITUTION', 'STDRECORDFORMATPROFILEFORMATPROFILE', 'STDRECORDFORMATPROFILEINTERNALID', 'STDRECORDFORMATPROFILEISINACTIVE', 'STDRECORDFORMATPROFILELASTMODIFIEDDATE', 'STDRECORDFORMATPROFILEMODIFIEDBY', 'STDRECORDFORMATPROFILETRANSACTIONPARSER', 'STDRECORDFULFILLMENTEXCEPTIONREASONDESCRIPTION', 'STDRECORDFULFILLMENTEXCEPTIONREASONEXCEPTIONTYPE', 'STDRECORDFULFILLMENTEXCEPTIONREASONEXTERNALID', 'STDRECORDFULFILLMENTEXCEPTIONREASONISINACTIVE', 'STDRECORDFULFILLMENTEXCEPTIONREASONNAME', 'STDRECORDGLOBALACCOUNTMAPPINGACCOUNTINGBOOK', 'STDRECORDGLOBALACCOUNTMAPPINGCLASS', 'STDRECORDGLOBALACCOUNTMAPPINGDEPARTMENT', 'STDRECORDGLOBALACCOUNTMAPPINGDESTINATIONACCOUNT', 'STDRECORDGLOBALACCOUNTMAPPINGEFFECTIVEDATE', 'STDRECORDGLOBALACCOUNTMAPPINGENDDATE', 'STDRECORDGLOBALACCOUNTMAPPINGEXTERNALID', 'STDRECORDGLOBALACCOUNTMAPPINGLOCATION', 'STDRECORDGLOBALACCOUNTMAPPINGSOURCEACCOUNT', 'STDRECORDGLOBALACCOUNTMAPPINGSUBSIDIARY', 'STDRECORDGLOBALINVENTORYRELATIONSHIPALLLOCATIONSCUSTOMERRETURN', 'STDRECORDGLOBALINVENTORYRELATIONSHIPALLLOCATIONSFULFILLMENT', 'STDRECORDGLOBALINVENTORYRELATIONSHIPALLOWCROSSSUBCUSTOMERRETURN', 'STDRECORDGLOBALINVENTORYRELATIONSHIPALLOWCROSSSUBFULFILLMENT', 'STDRECORDGLOBALINVENTORYRELATIONSHIPINVENTORYSUBSIDIARY', 'STDRECORDGLOBALINVENTORYRELATIONSHIPISINACTIVE', 'STDRECORDGLOBALINVENTORYRELATIONSHIPORIGINATINGSUBSIDIARY', 'STDRECORDGOALCLOSEDDATE', 'STDRECORDGOALDETAILS', 'STDRECORDGOALEMPLOYEE', 'STDRECORDGOALGOALSTATUS', 'STDRECORDGOALINTERNALID', 'STDRECORDGOALISINACTIVE', 'STDRECORDGOALMOOD', 'STDRECORDGOALNAME', 'STDRECORDGOALTARGETDATE', 'STDRECORDGOVERNMENTISSUEDIDTYPEDESCRIPTION', 'STDRECORDGOVERNMENTISSUEDIDTYPEISALLOWMULTIPLE', 'STDRECORDGOVERNMENTISSUEDIDTYPEISINACTIVE', 'STDRECORDGOVERNMENTISSUEDIDTYPENAME', 'STDRECORDHCMJOBDESCRIPTION', 'STDRECORDHCMJOBINTERNALID', 'STDRECORDHCMJOBJOBID', 'STDRECORDHCMJOBTITLE', 'STDRECORDHEADCOUNT', 'STDRECORDHIRINGMANAGER', 'STDRECORDHOLDREVENUERECOGNITION', 'STDRECORDID', 'STDRECORDINCOTERMDESCRIPTION', 'STDRECORDINCOTERMISINACTIVE', 'STDRECORDINCOTERMNAME', 'STDRECORDINVENTORYSTATUSDESCRIPTION', 'STDRECORDINVENTORYSTATUSEXTERNALID', 'STDRECORDINVENTORYSTATUSINTERNALID', 'STDRECORDINVENTORYSTATUSINVENTORYAVAILABLE', 'STDRECORDINVENTORYSTATUSISINACTIVE', 'STDRECORDINVENTORYSTATUSNAME', 'STDRECORDISACTUALDELIVERYDATE', 'STDRECORDISACTUALSHIPPINGDATE', 'STDRECORDISBILLOFLADING', 'STDRECORDISCREATEDDATE', 'STDRECORDISEXPECTEDDELIVERYDATE', 'STDRECORDISEXPECTEDSHIPPINGDATE', 'STDRECORDISEXTERNALDOCUMENTNUMBER', 'STDRECORDISINACTIVE', 'STDRECORDISMEMO', 'STDRECORDISSHIPMENTBASECURRENCY', 'STDRECORDISSHIPMENTNUMBER', 'STDRECORDISSTATUS', 'STDRECORDISVESSELNUMBER', 'STDRECORDITEMACCOUNTMAPPINGACCOUNTINGBOOK', 'STDRECORDITEMACCOUNTMAPPINGCLASS', 'STDRECORDITEMACCOUNTMAPPINGDEPARTMENT', 'STDRECORDITEMACCOUNTMAPPINGDESTINATIONACCOUNT', 'STDRECORDITEMACCOUNTMAPPINGEFFECTIVEDATE', 'STDRECORDITEMACCOUNTMAPPINGENDDATE', 'STDRECORDITEMACCOUNTMAPPINGEXTERNALID', 'STDRECORDITEMACCOUNTMAPPINGITEMACCOUNT', 'STDRECORDITEMACCOUNTMAPPINGLOCATION', 'STDRECORDITEMACCOUNTMAPPINGSOURCEACCOUNT', 'STDRECORDITEMACCOUNTMAPPINGSUBSIDIARY', 'STDRECORDITEMCOLLECTIONDESCRIPTION', 'STDRECORDITEMCOLLECTIONEXTERNALID', 'STDRECORDITEMCOLLECTIONINTERNALID', 'STDRECORDITEMCOLLECTIONISINACTIVE', 'STDRECORDITEMCOLLECTIONITEMMAPEXTERNALID', 'STDRECORDITEMCOLLECTIONITEMMAPINTERNALID', 'STDRECORDITEMCOLLECTIONITEMMAPITEM', 'STDRECORDITEMCOLLECTIONITEMMAPITEMCOLLECTION', 'STDRECORDITEMCOLLECTIONNAME', 'STDRECORDITEMCOLLECTIONSAVEDSEARCH', 'STDRECORDITEMLOCATIONCONFIGURATIONLOCATION', 'STDRECORDITEMLOCATIONCONFIGURATIONMEMO', 'STDRECORDITEMLOCATIONCONFIGURATIONNAME', 'STDRECORDITEMLOCATIONCONFIGURATIONSUBSIDIARY', 'STDRECORDITEMPROCESSFAMILYDESCRIPTION', 'STDRECORDITEMPROCESSFAMILYEXTERNALID', 'STDRECORDITEMPROCESSFAMILYINTERNALID', 'STDRECORDITEMPROCESSFAMILYISINACTIVE', 'STDRECORDITEMPROCESSFAMILYNAME', 'STDRECORDITEMPROCESSGROUPDESCRIPTION', 'STDRECORDITEMPROCESSGROUPEXTERNALID', 'STDRECORDITEMPROCESSGROUPINTERNALID', 'STDRECORDITEMPROCESSGROUPISINACTIVE', 'STDRECORDITEMPROCESSGROUPNAME', 'STDRECORDITEMREVISIONEFFECTIVEDATE', 'STDRECORDITEMREVISIONEXTERNALID', 'STDRECORDITEMREVISIONINACTIVE', 'STDRECORDITEMREVISIONITEM', 'STDRECORDITEMREVISIONMEMO', 'STDRECORDITEMREVISIONNAME', 'STDRECORDITEMREVISIONOBSOLETEDATE', 'STDRECORDJOB', 'STDRECORDJOBID', 'STDRECORDJOBREQUISITIONID', 'STDRECORDLABORBASEDPROJECTREVENUERULEBILLINGRATECARD', 'STDRECORDLABORBASEDPROJECTREVENUERULEDESCRIPTION', 'STDRECORDLABORBASEDPROJECTREVENUERULEISINACTIVE', 'STDRECORDLABORBASEDPROJECTREVENUERULENAME', 'STDRECORDLABORBASEDPROJECTREVENUERULEPROJECT', 'STDRECORDLABORBASEDPROJECTREVENUERULERATEMULTIPLIER', 'STDRECORDLABORBASEDPROJECTREVENUERULERATEROUNDINGTYPE', 'STDRECORDLABORBASEDPROJECTREVENUERULERATESOURCETYPE', 'STDRECORDLABORBASEDPROJECTREVENUERULEREVENUERECONCILED', 'STDRECORDLABORBASEDPROJECTREVENUERULESAVEDSEARCH', 'STDRECORDLABORBASEDPROJECTREVENUERULESERVICEITEM', 'STDRECORDLABORBASEDPROJECTREVENUERULETOTALAMOUNTTORECOGNIZE', 'STDRECORDLOCATION', 'STDRECORDLOCATIONADDRESS1', 'STDRECORDLOCATIONADDRESS2', 'STDRECORDLOCATIONADDRESSEE', 'STDRECORDLOCATIONADDRTEXT', 'STDRECORDLOCATIONALLOWSTOREPICKUP', 'STDRECORDLOCATIONATTENTION', 'STDRECORDLOCATIONBUFFERSTOCK', 'STDRECORDLOCATIONCITY', 'STDRECORDLOCATIONCOSTINGGROUPCOSTINGGROUPCURRENCY', 'STDRECORDLOCATIONCOSTINGGROUPMEMO', 'STDRECORDLOCATIONCOSTINGGROUPNAME', 'STDRECORDLOCATIONCOUNTRY', 'STDRECORDLOCATIONCOUNTRYNAME', 'STDRECORDLOCATIONENDTIME', 'STDRECORDLOCATIONEXTERNALID', 'STDRECORDLOCATIONINCLUDECHILDREN', 'STDRECORDLOCATIONINCLUDEINCT', 'STDRECORDLOCATIONINCLUDEINSUPPLYPLANNING', 'STDRECORDLOCATIONINVTTURNOVERVEL', 'STDRECORDLOCATIONISFRIDAY', 'STDRECORDLOCATIONISINACTIVE', 'STDRECORDLOCATIONISMONDAY', 'STDRECORDLOCATIONISSATURDAY', 'STDRECORDLOCATIONISSUNDAY', 'STDRECORDLOCATIONISTHURSDAY', 'STDRECORDLOCATIONISTUESDAY', 'STDRECORDLOCATIONISWEDNESDAY', 'STDRECORDLOCATIONLOCATIONCOSTINGGROUP', 'STDRECORDLOCATIONLOCATIONTYPE', 'STDRECORDLOCATIONLOGO', 'STDRECORDLOCATIONMAINADDRESS', 'STDRECORDLOCATIONMAINADDRESS_TEXT', 'STDRECORDLOCATIONMAKEINVENTORYAVAILABLE', 'STDRECORDLOCATIONMAKEINVENTORYAVAILABLESTORE', 'STDRECORDLOCATIONMAXSHIPPERDAY', 'STDRECORDLOCATIONNAME', 'STDRECORDLOCATIONNEXTPICKUPCUTOFFTIME', 'STDRECORDLOCATIONOVERRIDE', 'STDRECORDLOCATIONPARENT', 'STDRECORDLOCATIONPHONE', 'STDRECORDLOCATIONPICKUPALERTEMAIL', 'STDRECORDLOCATIONRETURNADDR', 'STDRECORDLOCATIONRETURNADDRESS', 'STDRECORDLOCATIONRETURNADDRESS1', 'STDRECORDLOCATIONRETURNADDRESS2', 'STDRECORDLOCATIONRETURNADDRESS_TEXT', 'STDRECORDLOCATIONRETURNCITY', 'STDRECORDLOCATIONRETURNCOUNTRY', 'STDRECORDLOCATIONRETURNSTATE', 'STDRECORDLOCATIONRETURNZIP', 'STDRECORDLOCATIONSAMEDAYPICKUPCUTOFFTIME', 'STDRECORDLOCATIONSHIPCUTOFF', 'STDRECORDLOCATIONSTARTTIME', 'STDRECORDLOCATIONSTATE', 'STDRECORDLOCATIONSTATENAME', 'STDRECORDLOCATIONSTOREFULFILLMENTMEMO', 'STDRECORDLOCATIONSTOREPICKUPBUFFERSTOCK', 'STDRECORDLOCATIONSUBSIDIARY', 'STDRECORDLOCATIONTIMEZONE', 'STDRECORDLOCATIONTOTALSHIPPINGCAPACITY', 'STDRECORDLOCATIONTRANINTERNALPREFIX', 'STDRECORDLOCATIONTRANPREFIX', 'STDRECORDLOCATIONZIP', 'STDRECORDMERCHANDISEHIERARCHYLEVELDESCRIPTION', 'STDRECORDMERCHANDISEHIERARCHYLEVELEXTERNALID', 'STDRECORDMERCHANDISEHIERARCHYLEVELINTERNALID', 'STDRECORDMERCHANDISEHIERARCHYLEVELNAME', 'STDRECORDMERCHANDISEHIERARCHYLEVELRANK', 'STDRECORDMERCHANDISEHIERARCHYNODEDESCRIPTION', 'STDRECORDMERCHANDISEHIERARCHYNODEEXTERNALID', 'STDRECORDMERCHANDISEHIERARCHYNODEINTERNALID', 'STDRECORDMERCHANDISEHIERARCHYNODENAME', 'STDRECORDMERCHANDISEHIERARCHYVERSIONDESCRIPTION', 'STDRECORDMERCHANDISEHIERARCHYVERSIONENDDATE', 'STDRECORDMERCHANDISEHIERARCHYVERSIONEXTERNALID', 'STDRECORDMERCHANDISEHIERARCHYVERSIONINTERNALID', 'STDRECORDMERCHANDISEHIERARCHYVERSIONNAME', 'STDRECORDMERCHANDISEHIERARCHYVERSIONSTARTDATE', 'STDRECORDMODULEPRODUCT', 'STDRECORDNAME', 'STDRECORDNOTEDIRECTION', 'STDRECORDNOTEEXTERNALID', 'STDRECORDNOTENOTE', 'STDRECORDNOTENOTEDATE', 'STDRECORDNOTENOTETYPE', 'STDRECORDNOTETIME', 'STDRECORDNOTETITLE', 'STDRECORDNOTETYPEDESCRIPTION', 'STDRECORDNOTETYPEEXTERNALID', 'STDRECORDNOTETYPEISINACTIVE', 'STDRECORDNOTETYPENAME', 'STDRECORDOPENDATE', 'STDRECORDORDERSTATUSCOUNTRY', 'STDRECORDORDERSTATUSDESCRIPTION', 'STDRECORDORDERSTATUSSTATE', 'STDRECORDOTHERGOVERNMENTISSUEDIDDESCRIPTION', 'STDRECORDOTHERGOVERNMENTISSUEDIDEMPLOYEE', 'STDRECORDOTHERGOVERNMENTISSUEDIDEXPIRATIONDATE', 'STDRECORDOTHERGOVERNMENTISSUEDIDIDTYPE', 'STDRECORDOTHERGOVERNMENTISSUEDIDISINACTIVE', 'STDRECORDOTHERGOVERNMENTISSUEDIDNAMEONDOCUMENT', 'STDRECORDOTHERGOVERNMENTISSUEDIDNUMBERVALUE', 'STDRECORDOTHERNAMECATEGORYEXTERNALID', 'STDRECORDOTHERNAMECATEGORYISINACTIVE', 'STDRECORDOTHERNAMECATEGORYNAME', 'STDRECORDOWNER', 'STDRECORDPARENT', 'STDRECORDPARTERCATEGORYISINACTIVE', 'STDRECORDPARTERCATEGORYNAME', 'STDRECORDPARTERCATEGORYPARENT', 'STDRECORDPARTNERCATEGORYEXTERNALID', 'STDRECORDPASSPORTDATEOFISSUE', 'STDRECORDPASSPORTDESCRIPTION', 'STDRECORDPASSPORTEMPLOYEE', 'STDRECORDPASSPORTEXPIRATIONDATE', 'STDRECORDPASSPORTISINACTIVE', 'STDRECORDPASSPORTISSUER', 'STDRECORDPASSPORTNAMEONDOCUMENT', 'STDRECORDPASSPORTNATIONALITY', 'STDRECORDPASSPORTNUMBERVALUE', 'STDRECORDPAYMENTMETHODACCOUNT', 'STDRECORDPAYMENTMETHODCREDITCARD', 'STDRECORDPAYMENTMETHODEXTERNALID', 'STDRECORDPAYMENTMETHODISEMV', 'STDRECORDPAYMENTMETHODISINACTIVE', 'STDRECORDPAYMENTMETHODISONLINE', 'STDRECORDPAYMENTMETHODNAME', 'STDRECORDPAYMENTMETHODTOKENIZED', 'STDRECORDPAYMENTMETHODVISUALTAGS', 'STDRECORDPAYROLLBATCHSUBSIDIARY', 'STDRECORDPAYROLLITEMALLOWBULKENTRY', 'STDRECORDPAYROLLITEMAPPLYLIMIT', 'STDRECORDPAYROLLITEMAPPLYRATE', 'STDRECORDPAYROLLITEMBASEDONQUANTITY', 'STDRECORDPAYROLLITEMDEFAULTRATE', 'STDRECORDPAYROLLITEMEMPLOYEEPAID', 'STDRECORDPAYROLLITEMEXPENSEACCOUNT', 'STDRECORDPAYROLLITEMEXTERNALID', 'STDRECORDPAYROLLITEMINACTIVE', 'STDRECORDPAYROLLITEMLIABILITYACCOUNT', 'STDRECORDPAYROLLITEMLIMIT', 'STDRECORDPAYROLLITEMNAME', 'STDRECORDPAYROLLITEMSHOWINEMPLOYEECENTER', 'STDRECORDPAYROLLITEMSUBSIDIARY', 'STDRECORDPAYROLLITEMUSEDEFAULTS', 'STDRECORDPAYROLLITEMVENDOR', 'STDRECORDPCTCOMPLETEPROJECTREVENUERULEDESCRIPTION', 'STDRECORDPCTCOMPLETEPROJECTREVENUERULEISINACTIVE', 'STDRECORDPCTCOMPLETEPROJECTREVENUERULENAME', 'STDRECORDPCTCOMPLETEPROJECTREVENUERULEPROJECT', 'STDRECORDPCTCOMPLETEPROJECTREVENUERULEREVENUERECONCILED', 'STDRECORDPCTCOMPLETEPROJECTREVENUERULESERVICEITEM', 'STDRECORDPCTCOMPLETEPROJECTREVENUERULETOTALAMOUNTTORECOGNIZE', 'STDRECORDPERFORMANCEREVIEWCLOSEDATE', 'STDRECORDPERFORMANCEREVIEWCOMMENTS', 'STDRECORDPERFORMANCEREVIEWEMPLOYEE', 'STDRECORDPERFORMANCEREVIEWENDDATE', 'STDRECORDPERFORMANCEREVIEWINTERNALID', 'STDRECORDPERFORMANCEREVIEWISINACTIVE', 'STDRECORDPERFORMANCEREVIEWREVIEWSTATUS', 'STDRECORDPERFORMANCEREVIEWSCHEDULECLOSEDATE', 'STDRECORDPERFORMANCEREVIEWSCHEDULEENDDATE', 'STDRECORDPERFORMANCEREVIEWSCHEDULELAUNCHDATE', 'STDRECORDPERFORMANCEREVIEWSCHEDULENAME', 'STDRECORDPERFORMANCEREVIEWSCHEDULESTARTDATE', 'STDRECORDPERFORMANCEREVIEWSTARTDATE', 'STDRECORDPERFORMANCEREVIEWTEMPLATE', 'STDRECORDPICKSTRATEGYCUSTOMER', 'STDRECORDPICKSTRATEGYDESCRIPTION', 'STDRECORDPICKSTRATEGYEXTERNALID', 'STDRECORDPICKSTRATEGYINCLUDEINBOUNDSTAGINGBINS', 'STDRECORDPICKSTRATEGYINTERNALID', 'STDRECORDPICKSTRATEGYISINACTIVE', 'STDRECORDPICKSTRATEGYITEM', 'STDRECORDPICKSTRATEGYITEMCLASSIFICATION', 'STDRECORDPICKSTRATEGYITEMPROCESSFAMILY', 'STDRECORDPICKSTRATEGYITEMPROCESSGROUP', 'STDRECORDPICKSTRATEGYLOCATION', 'STDRECORDPICKSTRATEGYNAME', 'STDRECORDPICKSTRATEGYORDERTYPE', 'STDRECORDPICKSTRATEGYPRIORITY', 'STDRECORDPICKSTRATEGYTRANSACTIONTYPE', 'STDRECORDPICKSTRATEGYUNITSTYPE', 'STDRECORDPICKTASKEXTERNALID', 'STDRECORDPICKTASKINTERNALID', 'STDRECORDPICKTASKINVENTORYNUMBER', 'STDRECORDPICKTASKISINACTIVE', 'STDRECORDPICKTASKITEM', 'STDRECORDPICKTASKLOCATION', 'STDRECORDPICKTASKMEMO', 'STDRECORDPICKTASKPICKER', 'STDRECORDPICKTASKQUANTITY', 'STDRECORDPICKTASKTOTALPICKEDQUANTITY', 'STDRECORDPICKTASKTOTALREMAININGQUANTITY', 'STDRECORDPICKTASKUNITS', 'STDRECORDPICKTASKWAVE', 'STDRECORDPOSITIONBUDGETSTATUS', 'STDRECORDPOSITIONCLASS', 'STDRECORDPOSITIONDEPARTMENT', 'STDRECORDPOSITIONDESCRIPTION', 'STDRECORDPOSITIONFULLTIMEEQUIVALENT', 'STDRECORDPOSITIONHCMJOB', 'STDRECORDPOSITIONHEADCOUNTSTATUS', 'STDRECORDPOSITIONINACTIVE', 'STDRECORDPOSITIONINCUMBENTSHEADCOUNT', 'STDRECORDPOSITIONINTERNALID', 'STDRECORDPOSITIONLOCATION', 'STDRECORDPOSITIONMAXIMUMHEADCOUNT', 'STDRECORDPOSITIONOPENREQUISITION', 'STDRECORDPOSITIONPOSITIONID', 'STDRECORDPOSITIONSUBSIDIARY', 'STDRECORDPOSITIONTITLE', 'STDRECORDPOSTINGDESCRIPTION', 'STDRECORDPOSTINGTYPE', 'STDRECORDPRICEBOOKCURRENCY', 'STDRECORDPRICEBOOKNAME', 'STDRECORDPRICEBOOKSUBSCRIPTIONPLAN', 'STDRECORDPRICELEVELDISCOUNTPCT', 'STDRECORDPRICELEVELEXTERNALID', 'STDRECORDPRICELEVELISINACTIVE', 'STDRECORDPRICELEVELISONLINE', 'STDRECORDPRICELEVELNAME', 'STDRECORDPRICEPLANCURRENCY', 'STDRECORDPRICEPLANINCLUDEDQUANTITY', 'STDRECORDPRICEPLANPRICEMODELTYPE', 'STDRECORDPRICINGGROUPEXTERNALID', 'STDRECORDPRICINGGROUPISINACTIVE', 'STDRECORDPRICINGGROUPNAME', 'STDRECORDPRODUCTBUILDVERSION', 'STDRECORDPROJECTTYPEEXTERNALID', 'STDRECORDPROJECTTYPEISINACTIVE', 'STDRECORDPROJECTTYPENAME', 'STDRECORDPROJECTTYPEPARENT', 'STDRECORDPROMOTIONCODEAPPLYDISCOUNTTO', 'STDRECORDPROMOTIONCODECANNOTBECOMBINED', 'STDRECORDPROMOTIONCODECODE', 'STDRECORDPROMOTIONCODECODEPATTERN', 'STDRECORDPROMOTIONCODEDESCRIPTION', 'STDRECORDPROMOTIONCODEDISCOUNT', 'STDRECORDPROMOTIONCODEDISPLAYLINEDISCOUNTS', 'STDRECORDPROMOTIONCODEENDDATE', 'STDRECORDPROMOTIONCODEEXCLUDEITEMS', 'STDRECORDPROMOTIONCODEEXTERNALID', 'STDRECORDPROMOTIONCODEFREESHIPMETHOD', 'STDRECORDPROMOTIONCODEISINACTIVE', 'STDRECORDPROMOTIONCODEISPUBLIC', 'STDRECORDPROMOTIONCODEMINIMUMORDERAMOUNT', 'STDRECORDPROMOTIONCODENAME', 'STDRECORDPROMOTIONCODERATE', 'STDRECORDPROMOTIONCODESTARTDATE', 'STDRECORDQUANTITYPRICINGSCHEDULEINACTIVE', 'STDRECORDQUANTITYPRICINGSCHEDULENAME', 'STDRECORDQUANTITYPRICINGSCHEDULEOVERALLQUANTITYPRICINGTYPE', 'STDRECORDQUANTITYPRICINGSCHEDULEUSEMARGINALRATES', 'STDRECORDRECALCADJUSTPERIODOFFSET', 'STDRECORDRECORDFIELDTYPE', 'STDRECORDRECORDISLIST', 'STDRECORDRECORDSEARCHTYPE', 'STDRECORDRECRUITER', 'STDRECORDREFORECASTMETHOD', 'STDRECORDREQUISITIONSTATUS', 'STDRECORDREVENUEELEMENTALTERNATEQUANTITY', 'STDRECORDREVENUEELEMENTALTERNATEUNITS', 'STDRECORDREVENUEELEMENTCREATEREVENUEPLANSON', 'STDRECORDREVENUEELEMENTFORECASTENDDATE', 'STDRECORDREVENUEELEMENTFORECASTSTARTDATE', 'STDRECORDREVENUEELEMENTREFERENCEID', 'STDRECORDREVENUEELEMENTREVENUEALLOCATIONGROUP', 'STDRECORDREVENUEELEMENTREVRECENDDATE', 'STDRECORDREVENUEELEMENTREVRECSTARTDATE', 'STDRECORDREVENUEELEMENTTERMINDAYS', 'STDRECORDREVENUEELEMENTTERMINMONTHS', 'STDRECORDREVENUERECOGNITIONRULE', 'STDRECORDREVENUERECOGNITIONSCHEDULEAMORTIZATIONPERIOD', 'STDRECORDREVENUERECOGNITIONSCHEDULEAMORTIZATIONTYPE', 'STDRECORDREVENUERECOGNITIONSCHEDULEINITIALAMOUNT', 'STDRECORDREVENUERECOGNITIONSCHEDULEISINACTIVE', 'STDRECORDREVENUERECOGNITIONSCHEDULEISPUBLIC', 'STDRECORDREVENUERECOGNITIONSCHEDULEJOB', 'STDRECORDREVENUERECOGNITIONSCHEDULENAME', 'STDRECORDREVENUERECOGNITIONSCHEDULEPERIODOFFSET', 'STDRECORDREVENUERECOGNITIONSCHEDULERECURRENCETYPE', 'STDRECORDREVENUERECOGNITIONSCHEDULEREVRECOFFSET', 'STDRECORDREVRECENDDATE', 'STDRECORDREVRECSTARTDATE', 'STDRECORDSALESREADINESSISINACTIVE', 'STDRECORDSALESREADINESSNAME', 'STDRECORDSALESROLEDESCRIPTION', 'STDRECORDSALESROLEEXTERNALID', 'STDRECORDSALESROLEISINACTIVE', 'STDRECORDSALESROLEISSALESREP', 'STDRECORDSALESROLENAME', 'STDRECORDSAVEDSEARCHRECORDTYPE', 'STDRECORDSAVEDSEARCHSCRIPTEDRECORDTYPE', 'STDRECORDSAVEDSEARCHTYPE', 'STDRECORDSCRIPTEDRECORDBASETYPE', 'STDRECORDSCRIPTEDRECORDLISTRECORD', 'STDRECORDSCRIPTEDRECORDSCRIPTID', 'STDRECORDSCRIPTEDRECORDSEARCHTYPE', 'STDRECORDSTATECOUNTRY', 'STDRECORDSTUDENTRECORDADDRESS', 'STDRECORDSTUDENTRECORDCITYZIP', 'STDRECORDSTUDENTRECORDCLEVEL', 'STDRECORDSTUDENTRECORDCSCHOOL', 'STDRECORDSTUDENTRECORDDOB', 'STDRECORDSTUDENTRECORDFANAME', 'STDRECORDSTUDENTRECORDFEE', 'STDRECORDSTUDENTRECORDFEMAIL', 'STDRECORDSTUDENTRECORDFNAME', 'STDRECORDSTUDENTRECORDGDATE', 'STDRECORDSTUDENTRECORDGPATOTAL', 'STDRECORDSTUDENTRECORDID', 'STDRECORDSTUDENTRECORDINACTIVE', 'STDRECORDSTUDENTRECORDLNAME', 'STDRECORDSTUDENTRECORDMNAME', 'STDRECORDSTUDENTRECORDSEMESTER', 'STDRECORDSTUDENTRECORDSSCORE', 'STDRECORDSTUDENTRECORDSTARTDATE', 'STDRECORDSTUDENTRECORDSTUDENTID', 'STDRECORDSTUDENTRECORDSTUDEPARTMENT', 'STDRECORDSTUDENTRECORDSTUEMAIL', 'STDRECORDSTUDENTRECORDSTUNATIONALITY', 'STDRECORDSTUDENTRECORDTSCORE', 'STDRECORDSUBSCRIPTIONADVANCERENEWALPERIODNUMBER', 'STDRECORDSUBSCRIPTIONADVANCERENEWALPERIODUNIT', 'STDRECORDSUBSCRIPTIONAUTONAME', 'STDRECORDSUBSCRIPTIONAUTORENEWAL', 'STDRECORDSUBSCRIPTIONBILLINGACCOUNT', 'STDRECORDSUBSCRIPTIONBILLINGACCOUNTSTARTDATE', 'STDRECORDSUBSCRIPTIONBILLINGSCHEDULE', 'STDRECORDSUBSCRIPTIONCURRENCY', 'STDRECORDSUBSCRIPTIONCUSTOMER', 'STDRECORDSUBSCRIPTIONCUSTOMFORM', 'STDRECORDSUBSCRIPTIONDEFAULTRENEWALMETHOD', 'STDRECORDSUBSCRIPTIONDEFAULTRENEWALPLAN', 'STDRECORDSUBSCRIPTIONDEFAULTRENEWALTERM', 'STDRECORDSUBSCRIPTIONDEFAULTRENEWALTRANTYPE', 'STDRECORDSUBSCRIPTIONENDDATE', 'STDRECORDSUBSCRIPTIONESTIMATEDREVRECENDDATE', 'STDRECORDSUBSCRIPTIONFREQUENCY', 'STDRECORDSUBSCRIPTIONIDNUMBER', 'STDRECORDSUBSCRIPTIONINITIALTERM', 'STDRECORDSUBSCRIPTIONLASTBILLCYCLEDATE', 'STDRECORDSUBSCRIPTIONLASTBILLDATE', 'STDRECORDSUBSCRIPTIONLINECUSTOMFORM', 'STDRECORDSUBSCRIPTIONLINEDISCOUNT', 'STDRECORDSUBSCRIPTIONLINEENDDATE', 'STDRECORDSUBSCRIPTIONLINEESTIMATEDREVRECENDDATE', 'STDRECORDSUBSCRIPTIONLINEINCLUDEDUSAGE', 'STDRECORDSUBSCRIPTIONLINEITEM', 'STDRECORDSUBSCRIPTIONLINELINENUMBER', 'STDRECORDSUBSCRIPTIONLINEPLANLINE', 'STDRECORDSUBSCRIPTIONLINEPRICEINTERVALFREQUENCY', 'STDRECORDSUBSCRIPTIONLINEPRICEPLAN', 'STDRECORDSUBSCRIPTIONLINEPRORATEENDDATE', 'STDRECORDSUBSCRIPTIONLINEPRORATESTARTDATE', 'STDRECORDSUBSCRIPTIONLINEQUANTITY', 'STDRECORDSUBSCRIPTIONLINERECURRENCESTARTDATE', 'STDRECORDSUBSCRIPTIONLINEREVRECOPTION', 'STDRECORDSUBSCRIPTIONLINESTARTDATE', 'STDRECORDSUBSCRIPTIONLINESTATUS', 'STDRECORDSUBSCRIPTIONLINESUBSCRIPTION', 'STDRECORDSUBSCRIPTIONLINESUBSCRIPTIONLINETYPE', 'STDRECORDSUBSCRIPTIONLINESUBSCRIPTIONPLAN', 'STDRECORDSUBSCRIPTIONLINETOTAL', 'STDRECORDSUBSCRIPTIONLINEUSAGEMULTIPLIERLINE', 'STDRECORDSUBSCRIPTIONNAME', 'STDRECORDSUBSCRIPTIONNEXTBILLCYCLEDATE', 'STDRECORDSUBSCRIPTIONNEXTRENEWALSTARTDATE', 'STDRECORDSUBSCRIPTIONPLAN', 'STDRECORDSUBSCRIPTIONSTARTDATE', 'STDRECORDSUBSCRIPTIONSTATUS', 'STDRECORDSUBSCRIPTIONSUBSIDIARY', 'STDRECORDSUBSIDIARY', 'STDRECORDSUBSIDIARYADDR1', 'STDRECORDSUBSIDIARYADDR2', 'STDRECORDSUBSIDIARYADDRESSEE', 'STDRECORDSUBSIDIARYADDRPHONE', 'STDRECORDSUBSIDIARYADDRTEXT', 'STDRECORDSUBSIDIARYATTENTION', 'STDRECORDSUBSIDIARYCITY', 'STDRECORDSUBSIDIARYCOUNTRY', 'STDRECORDSUBSIDIARYCURRENCY', 'STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP', 'STDRECORDSUBSIDIARYEDITION', 'STDRECORDSUBSIDIARYEMAIL', 'STDRECORDSUBSIDIARYEXTERNALID', 'STDRECORDSUBSIDIARYFAX', 'STDRECORDSUBSIDIARYFEDERALIDNUMBER', 'STDRECORDSUBSIDIARYFISCALCALENDAR', 'STDRECORDSUBSIDIARYGLIMPACTLOCKING', 'STDRECORDSUBSIDIARYINTERNALTRANPREFIX', 'STDRECORDSUBSIDIARYISELIMINATION', 'STDRECORDSUBSIDIARYISINACTIVE', 'STDRECORDSUBSIDIARYLANGUAGELOCALE', 'STDRECORDSUBSIDIARYLEGALNAME', 'STDRECORDSUBSIDIARYLOGO', 'STDRECORDSUBSIDIARYMAINADDRESS', 'STDRECORDSUBSIDIARYMAINADDRESS_TEXT', 'STDRECORDSUBSIDIARYNAME', 'STDRECORDSUBSIDIARYOVERRIDE', 'STDRECORDSUBSIDIARYPAGELOGO', 'STDRECORDSUBSIDIARYPARENT', 'STDRECORDSUBSIDIARYPURCHASEORDERAMOUNT', 'STDRECORDSUBSIDIARYPURCHASEORDERQUANTITY', 'STDRECORDSUBSIDIARYPURCHASEORDERQUANTITYDIFF', 'STDRECORDSUBSIDIARYRECEIPTAMOUNT', 'STDRECORDSUBSIDIARYRECEIPTQUANTITY', 'STDRECORDSUBSIDIARYRECEIPTQUANTITYDIFF', 'STDRECORDSUBSIDIARYRETURNADDR', 'STDRECORDSUBSIDIARYRETURNADDRESS', 'STDRECORDSUBSIDIARYRETURNADDRESS1', 'STDRECORDSUBSIDIARYRETURNADDRESS2', 'STDRECORDSUBSIDIARYRETURNADDRESS_TEXT', 'STDRECORDSUBSIDIARYRETURNCITY', 'STDRECORDSUBSIDIARYRETURNCOUNTRY', 'STDRECORDSUBSIDIARYRETURNSTATE', 'STDRECORDSUBSIDIARYRETURNZIP', 'STDRECORDSUBSIDIARYSHIPADDR', 'STDRECORDSUBSIDIARYSHIPADDRESS1', 'STDRECORDSUBSIDIARYSHIPADDRESS2', 'STDRECORDSUBSIDIARYSHIPCITY', 'STDRECORDSUBSIDIARYSHIPCOUNTRY', 'STDRECORDSUBSIDIARYSHIPPINGADDRESS', 'STDRECORDSUBSIDIARYSHIPPINGADDRESS_TEXT', 'STDRECORDSUBSIDIARYSHIPSTATE', 'STDRECORDSUBSIDIARYSHIPZIP', 'STDRECORDSUBSIDIARYSHOWSUBSIDIARYNAME', 'STDRECORDSUBSIDIARYSSNORTIN', 'STDRECORDSUBSIDIARYSTATE', 'STDRECORDSUBSIDIARYSTATE1TAXNUMBER', 'STDRECORDSUBSIDIARYTAXFISCALCALENDAR', 'STDRECORDSUBSIDIARYTRANPREFIX', 'STDRECORDSUBSIDIARYURL', 'STDRECORDSUBSIDIARYZIP', 'STDRECORDSUPPLYCHAINSNAPSHOTDATERUN', 'STDRECORDSUPPLYCHAINSNAPSHOTFUTUREHORIZON', 'STDRECORDSUPPLYCHAINSNAPSHOTFUTUREHORIZONDATE', 'STDRECORDSUPPLYCHAINSNAPSHOTITEM', 'STDRECORDSUPPLYCHAINSNAPSHOTMEMO', 'STDRECORDSUPPLYCHAINSNAPSHOTPASTHORIZON', 'STDRECORDSUPPLYCHAINSNAPSHOTPASTHORIZONDATE', 'STDRECORDSUPPLYCHAINSNAPSHOTREPLENISHMENTMETHOD', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONDEMANDLOCATION', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONDEMANDLOCATIONDATE', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONDEMANDLOCATIONSUBSIDIARY', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONDOCNUMCREATEDFROM', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONISFORRESCHEDULE', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONITEMNAMENUMBER', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONMEMO', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONOWNER', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONQUANTITY', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONSIMULATIONNUMBER', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONSTATUS', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONSUPPLYLOCATION', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONSUPPLYLOCATIONDATE', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONSUPPLYLOCATIONSUBSIDIARY', 'STDRECORDSUPPLYCHAINSNAPSHOTSIMULATIONTRANSACTIONTYPE', 'STDRECORDSUPPLYCHAINSNAPSHOTSTOCKUNIT', 'STDRECORDTARGETHIREDATE', 'STDRECORDTAXPERIODCLOSED', 'STDRECORDTAXPERIODEND', 'STDRECORDTAXPERIODISADJUST', 'STDRECORDTAXPERIODISQUARTER', 'STDRECORDTAXPERIODISYEAR', 'STDRECORDTAXPERIODOPEN', 'STDRECORDTAXPERIODPARENT', 'STDRECORDTAXPERIODPERIODNAME', 'STDRECORDTAXPERIODSTART', 'STDRECORDTERMDAYDISCOUNTEXPIRES', 'STDRECORDTERMDAYOFMONTHNETDUE', 'STDRECORDTERMDAYSUNTILEXPIRY', 'STDRECORDTERMDAYSUNTILNETDUE', 'STDRECORDTERMDISCOUNTPERCENT', 'STDRECORDTERMDISCOUNTPERCENTDATEDRIVEN', 'STDRECORDTERMDUENEXTMONTHIFWITHINDAYS', 'STDRECORDTERMEXTERNALID', 'STDRECORDTERMINATIONCATEGORY', 'STDRECORDTERMINATIONREASON', 'STDRECORDTERMINATIONREASONINACTIVE', 'STDRECORDTERMISINACTIVE', 'STDRECORDTERMNAME', 'STDRECORDTERMPREFERRED', 'STDRECORDTIMEENTRYBILLABLE', 'STDRECORDTIMEENTRYCASETASKEVENT', 'STDRECORDTIMEENTRYCLASS', 'STDRECORDTIMEENTRYCUSTOMER', 'STDRECORDTIMEENTRYCUSTOMFORM', 'STDRECORDTIMEENTRYDAY', 'STDRECORDTIMEENTRYDEPARTMENT', 'STDRECORDTIMEENTRYDURATION', 'STDRECORDTIMEENTRYEMPLOYEE', 'STDRECORDTIMEENTRYEXEMPT', 'STDRECORDTIMEENTRYEXTERNALID', 'STDRECORDTIMEENTRYITEM', 'STDRECORDTIMEENTRYLOCATION', 'STDRECORDTIMEENTRYLOCKRATE', 'STDRECORDTIMEENTRYMEMO', 'STDRECORDTIMEENTRYNEXTAPPROVER', 'STDRECORDTIMEENTRYPAIDEXTERNALLY', 'STDRECORDTIMEENTRYPAYROLLITEM', 'STDRECORDTIMEENTRYPAYROLLWORKPLACE', 'STDRECORDTIMEENTRYPOSTED', 'STDRECORDTIMEENTRYPRODUCTIVE', 'STDRECORDTIMEENTRYRATE', 'STDRECORDTIMEENTRYREMAININGTIMETOCHARGE', 'STDRECORDTIMEENTRYSTATUS', 'STDRECORDTIMEENTRYSUBSIDIARY', 'STDRECORDTIMEENTRYTYPE', 'STDRECORDTIMEENTRYUTILIZED', 'STDRECORDTIMEOFFCHANGEAMOUNT', 'STDRECORDTIMEOFFCHANGEDATEAPPLIED', 'STDRECORDTIMEOFFCHANGEDESCRIPTION', 'STDRECORDTIMEOFFCHANGEEMPLOYEE', 'STDRECORDTIMEOFFCHANGEHOURLYACCRUALRATE', 'STDRECORDTIMEOFFCHANGEINTERNALID', 'STDRECORDTIMEOFFCHANGETIMEOFFTIMEUNIT', 'STDRECORDTIMEOFFCHANGETIMEOFFTYPE', 'STDRECORDTIMEOFFPLANCLASS', 'STDRECORDTIMEOFFPLANDEPARTMENT', 'STDRECORDTIMEOFFPLANINTERNALID', 'STDRECORDTIMEOFFPLANISINACTIVE', 'STDRECORDTIMEOFFPLANISINCLUDEFUTUREACCRUALS', 'STDRECORDTIMEOFFPLANLOCATION', 'STDRECORDTIMEOFFPLANNAME', 'STDRECORDTIMEOFFPLANSTARTMONTH', 'STDRECORDTIMEOFFPLANSUBSIDIARY', 'STDRECORDTIMEOFFREQUESTAPPROVALSTATUS', 'STDRECORDTIMEOFFREQUESTEMPLOYEE', 'STDRECORDTIMEOFFREQUESTENDDATE', 'STDRECORDTIMEOFFREQUESTINTERNALID', 'STDRECORDTIMEOFFREQUESTMESSAGE', 'STDRECORDTIMEOFFREQUESTSTARTDATE', 'STDRECORDTIMEOFFRULEACCRUALFREQUENCY', 'STDRECORDTIMEOFFRULEACCRUALLIMIT', 'STDRECORDTIMEOFFRULEACCRUALTYPE', 'STDRECORDTIMEOFFRULEACCRUESBASEDON', 'STDRECORDTIMEOFFRULEALLOWCARRYOVER', 'STDRECORDTIMEOFFRULECARRYOVEREXPIRYMONTH', 'STDRECORDTIMEOFFRULEDAYOFNEXTACCRUAL', 'STDRECORDTIMEOFFRULEDAYOFWEEKOFNEXTACCRUAL', 'STDRECORDTIMEOFFRULEENTITLEMENT', 'STDRECORDTIMEOFFRULEEXPIREUNUSEDCARRYOVER', 'STDRECORDTIMEOFFRULEHOURLYACCRUALRATE', 'STDRECORDTIMEOFFRULEINTERNALID', 'STDRECORDTIMEOFFRULEISAUTOMATICALLYACCRUE', 'STDRECORDTIMEOFFRULEMAXIMUMCARRYOVER', 'STDRECORDTIMEOFFRULEMINIMUMTENURE', 'STDRECORDTIMEOFFRULERESETNEGATIVEBALANCES', 'STDRECORDTIMEOFFRULESETACCRUALLIMIT', 'STDRECORDTIMEOFFRULESHOULDLIMITCARRYOVER', 'STDRECORDTIMEOFFRULETIMEOFFPLAN', 'STDRECORDTIMEOFFRULETIMEOFFTYPE', 'STDRECORDTIMEOFFTYPECOLOR', 'STDRECORDTIMEOFFTYPEDISPLAYNAME', 'STDRECORDTIMEOFFTYPEINTERNALID', 'STDRECORDTIMEOFFTYPEISINACTIVE', 'STDRECORDTIMEOFFTYPEISTRACKONLY', 'STDRECORDTIMEOFFTYPEMINIMUMINCREMENT', 'STDRECORDTIMEOFFTYPENAME', 'STDRECORDTIMEOFFTYPEPAYROLLITEM', 'STDRECORDTIMEOFFTYPEPROJECT', 'STDRECORDTIMEOFFTYPEPROJECTTASK', 'STDRECORDTIMESHEETALLOCATEDHOURS', 'STDRECORDTIMESHEETAPPROVALSTATUS', 'STDRECORDTIMESHEETCUSTOMFORM', 'STDRECORDTIMESHEETEMPLOYEE', 'STDRECORDTIMESHEETENDDATE', 'STDRECORDTIMESHEETLOCKSTATUS', 'STDRECORDTIMESHEETPLANNEDHOURS', 'STDRECORDTIMESHEETREJECTEDHOURS', 'STDRECORDTIMESHEETSTARTDATE', 'STDRECORDTIMESHEETSUBMITTEDHOURS', 'STDRECORDTIMESHEETTOTALHOURS', 'STDRECORDTIMESHEETWORKCALENDARHOURS', 'STDRECORDTITLE', 'STDRECORDUNITSTYPEISINACTIVE', 'STDRECORDUNITSTYPENAME', 'STDRECORDUNLOCKEDTIMEPERIODENDDATE', 'STDRECORDUNLOCKEDTIMEPERIODENTITY', 'STDRECORDUNLOCKEDTIMEPERIODISINACTIVE', 'STDRECORDUNLOCKEDTIMEPERIODSTARTDATE', 'STDRECORDUNLOCKEDTIMEPERIODVALIDUNTIL', 'STDRECORDUSAGECUSTOMER', 'STDRECORDUSAGEDATE', 'STDRECORDUSAGEEXTERNALID', 'STDRECORDUSAGEITEM', 'STDRECORDUSAGEMEMO', 'STDRECORDUSAGEQUANTITY', 'STDRECORDUSAGESUBSCRIPTION', 'STDRECORDUSAGESUBSCRIPTIONLINE', 'STDRECORDUSAGESUBSCRIPTIONPLAN', 'STDRECORDVENDORCATEGORYEXTERNALID', 'STDRECORDVENDORCATEGORYISINACTIVE', 'STDRECORDVENDORCATEGORYISTAXAGENCY', 'STDRECORDVENDORCATEGORYNAME', 'STDRECORDVENDORSUBSIDIARYRELATIONSHIPCREDITLIMIT', 'STDRECORDVENDORSUBSIDIARYRELATIONSHIPENTITY', 'STDRECORDVENDORSUBSIDIARYRELATIONSHIPISPRIMARYSUB', 'STDRECORDVENDORSUBSIDIARYRELATIONSHIPSUBSIDIARY', 'STDRECORDVENDORSUBSIDIARYRELATIONSHIPTAXITEM', 'STDRECORDVENDORSUBSIDIARYRELATIONSHIPVENDOR', 'STDRECORDVERSIONPRODUCT', 'STDRECORDWEBSITESITETYPE', 'STDRECORDWINLOSSREASONEXTERNALID', 'STDRECORDWINLOSSREASONISINACTIVE', 'STDRECORDWINLOSSREASONNAME', 'STDRECORDWORKCALENDARCOMMENTS', 'STDRECORDWORKCALENDARFRIDAY', 'STDRECORDWORKCALENDARISDEFAULT', 'STDRECORDWORKCALENDARMONDAY', 'STDRECORDWORKCALENDARNAME', 'STDRECORDWORKCALENDARSATURDAY', 'STDRECORDWORKCALENDARSTARTHOUR', 'STDRECORDWORKCALENDARSUNDAY', 'STDRECORDWORKCALENDARTHURSDAY', 'STDRECORDWORKCALENDARTUESDAY', 'STDRECORDWORKCALENDARWEDNESDAY', 'STDRECORDWORKCALENDARWORKHOURSPERDAY', 'STDRECORDWORKFLOWDESCRIPTION', 'STDRECORDWORKFLOWISINACTIVE', 'STDRECORDWORKFLOWOWNER', 'STDRECORDWORKFLOWRECORDTYPE', 'STDRECORDWORKFLOWRELEASESTATUS', 'STDRECORDWORKFLOWRUNASADMIN', 'STDRECORDWORKFLOWSAVEDSEARCH', 'STDRECORDWORKFLOWSCRIPTID', 'STDRECORDWORKFLOWTRIGGERCONDITIONTEXT', 'STDRECORDWORKFLOWTRIGGERONCREATE', 'STDRECORDWORKFLOWTRIGGERONUPDATE', 'STDRECORDWORKFLOWTRIGGERTYPE', 'STDRECORDWORKFLOWWORKFLOWNAME', 'STDRECORDWORKPLACEADDR1', 'STDRECORDWORKPLACEADDR2', 'STDRECORDWORKPLACEADDRESSEE', 'STDRECORDWORKPLACEADDRPHONE', 'STDRECORDWORKPLACEADDRTEXT', 'STDRECORDWORKPLACEATTENTION', 'STDRECORDWORKPLACECITY', 'STDRECORDWORKPLACECOUNTRY', 'STDRECORDWORKPLACEEXTERNALID', 'STDRECORDWORKPLACEISINACTIVE', 'STDRECORDWORKPLACEMAINADDRESS_TEXT', 'STDRECORDWORKPLACENAME', 'STDRECORDWORKPLACEOVERRIDE', 'STDRECORDWORKPLACEPARENT', 'STDRECORDWORKPLACESTATE', 'STDRECORDWORKPLACESUBSIDIARY', 'STDRECORDWORKPLACEZIP', 'STDRECORDZONEDESCRIPTION', 'STDRECORDZONEEXTERNALID', 'STDRECORDZONEINTERNALID', 'STDRECORDZONEISINACTIVE', 'STDRECORDZONELOCATION', 'STDRECORDZONENAME', 'STDRECURRINGBILL', 'STDREGIONFULFILLMENTPRIORITYLEVEL', 'STDREGIONINACTIVE', 'STDREGIONNAME', 'STDSUBSCRCHANGEORDERACTION', 'STDSUBSCRCHANGEORDERAPPROVALDATE', 'STDSUBSCRCHANGEORDERAPPROVALSTATUS', 'STDSUBSCRCHANGEORDERAUTONAME', 'STDSUBSCRCHANGEORDERBILLINGACCOUNT', 'STDSUBSCRCHANGEORDERCREATEDBY', 'STDSUBSCRCHANGEORDERCUSTOMER', 'STDSUBSCRCHANGEORDERCUSTOMFORM', 'STDSUBSCRCHANGEORDERDATECREATED', 'STDSUBSCRCHANGEORDEREFFECTIVEDATE', 'STDSUBSCRCHANGEORDEREXTERNALID', 'STDSUBSCRCHANGEORDERIDNUMBER', 'STDSUBSCRCHANGEORDERMEMO', 'STDSUBSCRCHANGEORDERREACTIVATIONOPTION', 'STDSUBSCRCHANGEORDERRENEWALENDDATE', 'STDSUBSCRCHANGEORDERRENEWALMETHOD', 'STDSUBSCRCHANGEORDERRENEWALPLAN', 'STDSUBSCRCHANGEORDERRENEWALSTARTDATE', 'STDSUBSCRCHANGEORDERRENEWALTERM', 'STDSUBSCRCHANGEORDERRENEWALTRANTYPE', 'STDSUBSCRCHANGEORDERREQUESTOFFCYCLEINVOICE', 'STDSUBSCRCHANGEORDERREQUESTOR', 'STDSUBSCRCHANGEORDERSUBSCRIPTION', 'STDSUBSCRCHANGEORDERSUBSCRIPTIONPLAN', 'STDSUBSCRCHANGEORDERSUBSIDIARY', 'STDTIMEAPPROVALSTATUS', 'STDTIMEBILLABLE', 'STDTIMEBILLINGSUBSIDIARY', 'STDTIMECLASS', 'STDTIMECUSTOMER', 'STDTIMECUSTOMFORM', 'STDTIMEDATE', 'STDTIMEDEPARTMENT', 'STDTIMEDURATION', 'STDTIMEEMPLOYEE', 'STDTIMEEVENT', 'STDTIMEEXEMPT', 'STDTIMEEXTERNALID', 'STDTIMEITEM', 'STDTIMELOCATION', 'STDTIMELOCKRATE', 'STDTIMEMEMO', 'STDTIMENEXTAPPROVER', 'STDTIMEOUTSIDEPROJECTPLAN', 'STDTIMEPAIDEXTERNALLY', 'STDTIMEPAYROLLITEM', 'STDTIMEPAYROLLWORKPLACE', 'STDTIMEPOSTED', 'STDTIMEPRODUCTIVE', 'STDTIMERATE', 'STDTIMEREJECTIONNOTE', 'STDTIMEREMAININGTIMETOCHARGE', 'STDTIMESUBSIDIARY', 'STDTIMESUPERVISORAPPROVAL', 'STDTIMETIMEMODIFIED', 'STDTIMETIMEOFFTYPE', 'STDTIMEUTILIZED', 'STDTIMEVENDOR', 'STDUSERCLASS', 'STDUSERDEPARTMENT', 'STDUSERLOCATION', 'STDUSERROLE', 'STDUSERSUBSIDIARY', 'STDUSERUSER'] }),
+    },
+    path: [...enumsFolderPath, generic_standard_fieldElemID.name],
+  }),
+  generic_standard_recordtype: new PrimitiveType({
+    elemID: generic_standard_recordtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNT', 'ACCOUNTINGBOOK', 'ACCOUNTINGCONTEXT', 'ACCOUNTINGPERIOD', 'ADVINTERCOMPANYJOURNALENTRY', 'ALLOCATIONSCHEDULE', 'AMORTIZATIONSCHEDULE', 'AMORTIZATIONTEMPLATE', 'ASSEMBLYBUILD', 'ASSEMBLYITEM', 'ASSEMBLYUNBUILD', 'BALANCETRXBYSEGMENTS', 'BILLINGACCOUNT', 'BILLINGCLASS', 'BILLINGRATECARD', 'BILLINGREVENUEEVENT', 'BILLINGSCHEDULE', 'BIN', 'BINTRANSFER', 'BINWORKSHEET', 'BLANKETPURCHASEORDER', 'BOM', 'BOMREVISION', 'BONUS', 'BONUSTYPE', 'BUDGETEXCHANGERATE', 'BULKOWNERSHIPTRANSFER', 'BUNDLEINSTALLATIONSCRIPT', 'CALENDAREVENT', 'CAMPAIGN', 'CAMPAIGNRESPONSE', 'CAMPAIGNTEMPLATE', 'CASHREFUND', 'CASHSALE', 'CHARGE', 'CHARGERULE', 'CHECK', 'CLASSIFICATION', 'CLIENTSCRIPT', 'CMSCONTENT', 'CMSCONTENTTYPE', 'CMSPAGE', 'CMSPAGETYPE', 'COMMERCECATEGORY', 'COMMERCESEARCHBOOST', 'COMMERCESEARCHBOOSTTYPE', 'COMPETITOR', 'CONSOLIDATEDEXCHANGERATE', 'CONTACT', 'CONTACTCATEGORY', 'CONTACTROLE', 'COSTCATEGORY', 'COUPONCODE', 'CREDITCARDCHARGE', 'CREDITCARDREFUND', 'CREDITMEMO', 'CURRENCY', 'CUSTOMER', 'CUSTOMERCATEGORY', 'CUSTOMERDEPOSIT', 'CUSTOMERMESSAGE', 'CUSTOMERPAYMENT', 'CUSTOMERPAYMENTAUTHORIZATION', 'CUSTOMERREFUND', 'CUSTOMERSTATUS', 'CUSTOMERSUBSIDIARYRELATIONSHIP', 'DEPARTMENT', 'DEPOSIT', 'DEPOSITAPPLICATION', 'DESCRIPTIONITEM', 'DISCOUNTITEM', 'DOWNLOADITEM', 'DRIVERSLICENSE', 'EMAILTEMPLATE', 'EMPLOYEE', 'EMPLOYEECHANGEREQUEST', 'EMPLOYEECHANGEREQUESTTYPE', 'EMPLOYEESTATUS', 'EMPLOYEETYPE', 'ENTITYACCOUNTMAPPING', 'ESTIMATE', 'EXPENSEAMORTIZATIONEVENT', 'EXPENSECATEGORY', 'EXPENSEPLAN', 'EXPENSEREPORT', 'FAIRVALUEPRICE', 'FINANCIALINSTITUTION', 'FIXEDAMOUNTPROJECTREVENUERULE', 'FOLDER', 'FORMATPROFILE', 'FULFILLMENTREQUEST', 'GENERALTOKEN', 'GENERICRESOURCE', 'GIFTCERTIFICATE', 'GIFTCERTIFICATEITEM', 'GLNUMBERINGSEQUENCE', 'GLOBALACCOUNTMAPPING', 'GLOBALINVENTORYRELATIONSHIP', 'GOAL', 'GOVERNMENTISSUEDIDTYPE', 'HCMJOB', 'INBOUNDSHIPMENT', 'INTERCOMPALLOCATIONSCHEDULE', 'INTERCOMPANYJOURNALENTRY', 'INTERCOMPANYTRANSFERORDER', 'INVENTORYADJUSTMENT', 'INVENTORYCOSTREVALUATION', 'INVENTORYCOUNT', 'INVENTORYDETAIL', 'INVENTORYITEM', 'INVENTORYNUMBER', 'INVENTORYSTATUS', 'INVENTORYSTATUSCHANGE', 'INVENTORYTRANSFER', 'INVOICE', 'INVOICEGROUP', 'ISSUE', 'ISSUEPRODUCT', 'ISSUEPRODUCTVERSION', 'ITEMACCOUNTMAPPING', 'ITEMCOLLECTION', 'ITEMCOLLECTIONITEMMAP', 'ITEMDEMANDPLAN', 'ITEMFULFILLMENT', 'ITEMGROUP', 'ITEMLOCATIONCONFIGURATION', 'ITEMPROCESSFAMILY', 'ITEMPROCESSGROUP', 'ITEMRECEIPT', 'ITEMREVISION', 'ITEMSUPPLYPLAN', 'JOB', 'JOBREQUISITION', 'JOBSTATUS', 'JOBTYPE', 'JOURNALENTRY', 'KITITEM', 'KUDOS', 'LABORBASEDPROJECTREVENUERULE', 'LEAD', 'LOCATION', 'LOTNUMBEREDASSEMBLYITEM', 'LOTNUMBEREDINVENTORYITEM', 'MANUFACTURINGCOSTTEMPLATE', 'MANUFACTURINGOPERATIONTASK', 'MANUFACTURINGROUTING', 'MAPREDUCESCRIPT', 'MARKUPITEM', 'MASSUPDATESCRIPT', 'MEMDOC', 'MERCHANDISEHIERARCHYLEVEL', 'MERCHANDISEHIERARCHYNODE', 'MERCHANDISEHIERARCHYVERSION', 'MESSAGE', 'MFGPLANNEDTIME', 'NEXUS', 'NONINVENTORYITEM', 'NOTE', 'NOTETYPE', 'OPPORTUNITY', 'ORDERSCHEDULE', 'ORDERTYPE', 'ORGANIZATIONVALUE', 'OTHERCHARGEITEM', 'OTHERGOVERNMENTISSUEDID', 'OTHERNAME', 'OTHERNAMECATEGORY', 'PARTNER', 'PARTNERCATEGORY', 'PASSPORT', 'PAYCHECK', 'PAYCHECKJOURNAL', 'PAYMENTCARD', 'PAYMENTCARDTOKEN', 'PAYMENTITEM', 'PAYMENTMETHOD', 'PAYROLLBATCH', 'PAYROLLBATCHADDEMPLOYEES', 'PAYROLLITEM', 'PCTCOMPLETEPROJECTREVENUERULE', 'PERFORMANCEMETRIC', 'PERFORMANCEREVIEW', 'PERFORMANCEREVIEWSCHEDULE', 'PERIODENDJOURNAL', 'PHONECALL', 'PICKSTRATEGY', 'PORTLET', 'POSITION', 'PRICEBOOK', 'PRICELEVEL', 'PRICEPLAN', 'PRICINGGROUP', 'PROJECTEXPENSETYPE', 'PROJECTTASK', 'PROJECTTEMPLATE', 'PROMOTIONCODE', 'PROSPECT', 'PURCHASECONTRACT', 'PURCHASEORDER', 'PURCHASEREQUISITION', 'REALLOCATEITEM', 'RECEIVEINBOUNDSHIPMENT', 'RESOURCEALLOCATION', 'RESTLET', 'RETURNAUTHORIZATION', 'REVENUEARRANGEMENT', 'REVENUECOMMITMENT', 'REVENUECOMMITMENTREVERSAL', 'REVENUEPLAN', 'REVRECSCHEDULE', 'REVRECTEMPLATE', 'SALESORDER', 'SALESROLE', 'SALESTAXITEM', 'SCHEDULEDSCRIPT', 'SCHEDULEDSCRIPTINSTANCE', 'SERIALIZEDASSEMBLYITEM', 'SERIALIZEDINVENTORYITEM', 'SERVICEITEM', 'SHIPITEM', 'SHIPPINGPARTNERPACKAGE', 'SHIPPINGPARTNERREGISTRATION', 'SHIPPINGPARTNERSHIPMENT', 'SOLUTION', 'STATISTICALJOURNALENTRY', 'STOREPICKUPFULFILLMENT', 'SUBSCRIPTION', 'SUBSCRIPTIONCHANGEORDER', 'SUBSCRIPTIONLINE', 'SUBSCRIPTIONPLAN', 'SUBSIDIARY', 'SUBSIDIARYSETTINGS', 'SUBTOTALITEM', 'SUITELET', 'SUPPLYCHAINSNAPSHOT', 'SUPPLYCHAINSNAPSHOTSIMULATION', 'SUPPORTCASE', 'TASK', 'TAXACCT', 'TAXGROUP', 'TAXPERIOD', 'TAXSCHEDULE', 'TAXTYPE', 'TERM', 'TERMINATIONREASON', 'TIMEBILL', 'TIMEENTRY', 'TIMEOFFCHANGE', 'TIMEOFFPLAN', 'TIMEOFFREQUEST', 'TIMEOFFRULE', 'TIMEOFFTYPE', 'TIMESHEET', 'TOPIC', 'TRANSFERORDER', 'UNITSTYPE', 'UNLOCKEDTIMEPERIOD', 'USAGE', 'USEREVENTSCRIPT', 'VENDOR', 'VENDORBILL', 'VENDORCATEGORY', 'VENDORCREDIT', 'VENDORPAYMENT', 'VENDORPREPAYMENT', 'VENDORPREPAYMENTAPPLICATION', 'VENDORRETURNAUTHORIZATION', 'VENDORSUBSIDIARYRELATIONSHIP', 'WAVE', 'WBS', 'WEBSITE', 'WINLOSSREASON', 'WORKFLOWACTIONSCRIPT', 'WORKORDER', 'WORKORDERCLOSE', 'WORKORDERCOMPLETION', 'WORKORDERISSUE', 'WORKPLACE', 'ZONE'] }),
+    },
+    path: [...enumsFolderPath, generic_standard_recordtypeElemID.name],
+  }),
+  generic_standard_task: new PrimitiveType({
+    elemID: generic_standard_taskElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ADMI_ACCOUNTCLOSE', 'ADMI_ACCOUNTMOBILITY', 'ADMI_ACCTSETUP', 'ADMI_ACHSETUP', 'ADMI_ACTIVATEBANKACCOUNT', 'ADMI_ADP', 'ADMI_ADVINVENTORYSETUP', 'ADMI_ALLOW_LOGIN', 'ADMI_BACKUP', 'ADMI_BASSETUP', 'ADMI_BILLINGEVENTS', 'ADMI_BILLINGTERMS', 'ADMI_BILLING_QEST', 'ADMI_BOUNCEDADDRESS', 'ADMI_BUDGET', 'ADMI_BUNDLEDETAILS', 'ADMI_CACHEINVALIDATIONREQUESTADV', 'ADMI_CACHEINVALIDATIONREQUESTLISTADV', 'ADMI_CLASSESTOLOCS', 'ADMI_CLEARACCOUNT', 'ADMI_CLOSEPERIOD', 'ADMI_COMMISSIONSETUP', 'ADMI_COMPANY', 'ADMI_CONVERTCLASSES', 'ADMI_COPYCOA', 'ADMI_CREATECONSOLCOMPANY', 'ADMI_CSVIMPORTPREF', 'ADMI_CUSTAPPTEXT', 'ADMI_DUPLICATESETUP', 'ADMI_EBAY', 'ADMI_EBAY_END_AUCTIONS', 'ADMI_EBAY_END_AUCTIONS_LOG', 'ADMI_EBAY_EXPORT', 'ADMI_EBAY_EXPORT_LOG', 'ADMI_EBAY_IMPORT', 'ADMI_EBAY_IMPORT_LOG', 'ADMI_EBAY_STATUS', 'ADMI_EDITNEXUSES', 'ADMI_EDITTAXACCTS', 'ADMI_EDITTAXTYPES', 'ADMI_EDITTEGATA', 'ADMI_EXPORTIIF', 'ADMI_EXPORTPRODUCTFEEDS', 'ADMI_EXPORTPRODUCTFEEDSADV', 'ADMI_FEATURES', 'ADMI_FEDEXREG', 'ADMI_FINCHARGEPREF', 'ADMI_FISCALPERIODS', 'ADMI_GENERAL', 'ADMI_HEADING', 'ADMI_IMAGERESIZE', 'ADMI_IMPORTADP', 'ADMI_IMPORTCSV', 'ADMI_IMPORTCSV_LOG', 'ADMI_IMPORTOLB', 'ADMI_IMPORT_COUPONCODE_STATUS', 'ADMI_INVOICESETUP', 'ADMI_ISSUEBUILD', 'ADMI_ISSUEEXTSTATUS', 'ADMI_ISSUEIMPORT', 'ADMI_ISSUEMODULE', 'ADMI_ISSUEPRIORITY', 'ADMI_ISSUEPRODUCT', 'ADMI_ISSUERELEASEUPDATE', 'ADMI_ISSUEREPRODUCE', 'ADMI_ISSUESETUP', 'ADMI_ISSUESEVERITY', 'ADMI_ISSUESOURCE', 'ADMI_ISSUESTATUS', 'ADMI_ISSUESTATUSFLOW', 'ADMI_ISSUETAGS', 'ADMI_ISSUETYPE', 'ADMI_ISSUEUSERTYPE', 'ADMI_ISSUEVERSION', 'ADMI_ITEMATTRGROUP', 'ADMI_LEADCUSTOMFIELDMAPPING', 'ADMI_LOGINAUDIT', 'ADMI_LOGINRESTRICT', 'ADMI_MAINTENANCEDOMAIN', 'ADMI_MAINTENANCEDOMAINADV', 'ADMI_MAINTENANCEDOMAINLIST', 'ADMI_MAINTENANCEDOMAINLISTADV', 'ADMI_MANAGEPAYROLL', 'ADMI_MANAGE_PLUGINS', 'ADMI_NAMING', 'ADMI_NETANSWERS', 'ADMI_NEXUSES', 'ADMI_NOTIFICATIONS', 'ADMI_NUMBERING', 'ADMI_OPENIDSSO', 'ADMI_OTHERSTUB', 'ADMI_OUTLOOKINTEGRATION', 'ADMI_OUTLOOKINTEGRATION_V3', 'ADMI_PAYROLL', 'ADMI_PAYROLLMAP', 'ADMI_PAYROLLREP', 'ADMI_PRINTING', 'ADMI_REDIRECT', 'ADMI_REDIRECTADV', 'ADMI_REDIRECTS', 'ADMI_REDIRECTSADV', 'ADMI_RELEASEPREVIEW', 'ADMI_SAMLSSO', 'ADMI_SANDBOXACCOUNTS', 'ADMI_SAVEDASH', 'ADMI_SAVEDIMPORTS', 'ADMI_SCRIPTDEBUGGER', 'ADMI_SETUPMANAGER', 'ADMI_SETUPURLS', 'ADMI_SETUPURLSADV', 'ADMI_SETUPURLSADV_LOG', 'ADMI_SETUPURLS_LOG', 'ADMI_SETUPYEARSTATUS', 'ADMI_SFASETUP', 'ADMI_SHIPPING', 'ADMI_SITEMAPGENERATOR', 'ADMI_SITEMAPGENERATORADV', 'ADMI_SITEMAP_MANAGER', 'ADMI_SOFTDESCRIPTORS', 'ADMI_STATETAXIMPORT', 'ADMI_STOREADMIN', 'ADMI_STOREADMINADV', 'ADMI_STOREASSISTANT', 'ADMI_STORELIST', 'ADMI_STORELISTADV', 'ADMI_STOREPREVIEW', 'ADMI_STOREPREVIEWADV', 'ADMI_SUITESIGNON', 'ADMI_SUPPORTSETUP', 'ADMI_SWAPPRICES', 'ADMI_TAX', 'ADMI_TAXACCTS', 'ADMI_TAXTYPES', 'ADMI_TDCLRPOOL', 'ADMI_TDMKMSTR', 'ADMI_TEGATA', 'ADMI_TEXTCUST', 'ADMI_TEXTCUSTADV', 'ADMI_TEXTCUSTGROUP', 'ADMI_TEXTCUSTGROUPADV', 'ADMI_TRANSETUP', 'ADMI_TRANSITEMTXT', 'ADMI_TWOFACTORDEVICES', 'ADMI_TWOFACTORROLES', 'ADMI_UPDATEPRICES', 'ADMI_UPSELLSETUP', 'ADMI_UPSWIZ', 'ADMI_URLCOMPONENTS', 'ADMI_WEBSERVICEPREFS', 'ADMI_WEBSERVICES_STATUS', 'ADMI_WEBSERVICES_USAGE_LOG', 'ADMI_XML_ADP_SETUP', 'ADMI_XML_PAYTRUST_APPROVE', 'ADMI_XML_PAYTRUST_SETUP', 'ADMI_XML_PAYTRUST_STATUS', 'ADMI_YTDTAXLIBANDPYMTS', 'CARD_-10', 'CARD_-11', 'CARD_-12', 'CARD_-13', 'CARD_-14', 'CARD_-15', 'CARD_-16', 'CARD_-17', 'CARD_-18', 'CARD_-19', 'CARD_-20', 'CARD_-21', 'CARD_-22', 'CARD_-23', 'CARD_-24', 'CARD_-25', 'CARD_-26', 'CARD_-27', 'CARD_-28', 'CARD_-29', 'CARD_-30', 'CARD_-31', 'CARD_-32', 'CARD_-33', 'CARD_-34', 'CARD_-35', 'CARD_-36', 'CARD_-37', 'CARD_-38', 'CARD_-39', 'CARD_-40', 'CARD_-41', 'CARD_-42', 'CARD_-43', 'CARD_-44', 'CARD_-45', 'CARD_-46', 'CARD_-47', 'CARD_-48', 'CARD_-49', 'CARD_-50', 'CARD_-51', 'CARD_-52', 'CARD_-54', 'CARD_-55', 'CARD_-56', 'CARD_-58', 'CARD_-59', 'CARD_-60', 'CARD_-61', 'CARD_-62', 'CARD_-63', 'CARD_-7', 'CARD_-8', 'CARD_-9', 'CARD_-91', 'DUMM_SEPARATOR', 'EDIT_ACCOUNT', 'EDIT_ACCOUNTINGBOOK', 'EDIT_ACCOUNTINGOTHERLIST', 'EDIT_ACTIVITY', 'EDIT_ALLOCATION', 'EDIT_ALLOCATIONBATCH', 'EDIT_AMENDW4', 'EDIT_AMORTIZATIONSCHEDULE', 'EDIT_APPDEF', 'EDIT_APPPKG', 'EDIT_APPPKG_UPGRADE', 'EDIT_APPPUBLISHER', 'EDIT_BILLINGCLASS', 'EDIT_BILLINGRULE', 'EDIT_BILLINGSCHEDULE', 'EDIT_BILLOFDISTRIBUTION', 'EDIT_BILLRUNSCHEDULE', 'EDIT_BILLRUNSCHEDULES', 'EDIT_BINNUMBERRECORD', 'EDIT_BULKOP', 'EDIT_BUNDLE', 'EDIT_BUNDLEAUDITTRAIL', 'EDIT_CALENDARPREFERENCE', 'EDIT_CALL', 'EDIT_CAMPAIGN', 'EDIT_CAMPAIGNAUDIENCE', 'EDIT_CAMPAIGNBULK', 'EDIT_CAMPAIGNBULKIMPORT', 'EDIT_CAMPAIGNCATEGORY', 'EDIT_CAMPAIGNCHANNEL', 'EDIT_CAMPAIGNEMAIL', 'EDIT_CAMPAIGNFAMILY', 'EDIT_CAMPAIGNOFFER', 'EDIT_CAMPAIGNSEARCHENGINE', 'EDIT_CAMPAIGNSUBSCRIPTION', 'EDIT_CAMPAIGNVERTICAL', 'EDIT_CASEFIELDRULE', 'EDIT_CASEFORM', 'EDIT_CASEISSUE', 'EDIT_CASEORIGIN', 'EDIT_CASEPRIORITY', 'EDIT_CASEPROFILE', 'EDIT_CASESTATUS', 'EDIT_CASETERRITORY', 'EDIT_CASETYPE', 'EDIT_CHARGE', 'EDIT_CHARGERULE', 'EDIT_CLASS', 'EDIT_CLASSSEGMENTMAPPING', 'EDIT_COLORTHEME', 'EDIT_COMMISSIONSCHEDULE', 'EDIT_COMPETITOR', 'EDIT_CONTACT', 'EDIT_CRMGROUP', 'EDIT_CRMMESSAGE', 'EDIT_CRMOTHERLIST', 'EDIT_CRMTEMPLATE', 'EDIT_CURRENCY', 'EDIT_CURRENCYRATE', 'EDIT_CUSTADDRESSENTRYFORM', 'EDIT_CUSTADDRESSFORM', 'EDIT_CUSTBODYFIELD', 'EDIT_CUSTCATEGORY', 'EDIT_CUSTCENTER', 'EDIT_CUSTCOLUMNFIELD', 'EDIT_CUSTEMAILLAYOUT', 'EDIT_CUSTENTITYFIELD', 'EDIT_CUSTENTRYFORM', 'EDIT_CUSTEVENTFIELD', 'EDIT_CUSTFORM', 'EDIT_CUSTITEMFIELD', 'EDIT_CUSTITEMNUMBERFIELD', 'EDIT_CUSTJOB', 'EDIT_CUSTLAYOUT', 'EDIT_CUSTLIST', 'EDIT_CUSTOMERFIELDRULE', 'EDIT_CUSTOMERFORM', 'EDIT_CUSTOMERSTATUS', 'EDIT_CUSTOTHERFIELD', 'EDIT_CUSTPROFILE', 'EDIT_CUSTRECORD', 'EDIT_CUSTRECORDFIELD', 'EDIT_CUSTRECORDFORM', 'EDIT_CUSTSCRIPTFIELD', 'EDIT_CUSTSECTION', 'EDIT_CUSTTASKS', 'EDIT_CUSTWFSTATEFIELD', 'EDIT_CUSTWORKFLOWFIELD', 'EDIT_CUST_', 'EDIT_DEPARTMENT', 'EDIT_DEPTSEGMENTMAPPING', 'EDIT_DISTRIBUTIONNETWORK', 'EDIT_EDITPROFILE', 'EDIT_EMAILTEMPLATE', 'EDIT_EMPLCATEGORY', 'EDIT_EMPLOYEE', 'EDIT_EMPLOYEESFA', 'EDIT_EMPOTHERLIST', 'EDIT_ENTITYACCOUNTMAPPING', 'EDIT_ESCALATIONRULE', 'EDIT_ESCALATIONTERRITORY', 'EDIT_EVENT', 'EDIT_EXPCATEGORY', 'EDIT_FAXMESSAGE', 'EDIT_FAXTEMPLATE', 'EDIT_FISCALCALENDAR', 'EDIT_FISCALPERIOD', 'EDIT_GENERICRESOURCE', 'EDIT_GLOBALACCOUNTMAPPING', 'EDIT_HCMJOB', 'EDIT_IC_ALLOCATION', 'EDIT_IMPORT_COUPONCODE', 'EDIT_INFOITEM', 'EDIT_INFOITEMFORM', 'EDIT_INSTALLBUNDLE', 'EDIT_INVCOSTTEMPLATE', 'EDIT_ISSUE', 'EDIT_ISSUEPRODUCT', 'EDIT_ISSUETAG', 'EDIT_ISSUEUSERTYPE', 'EDIT_ITEM', 'EDIT_ITEMACCOUNTMAPPING', 'EDIT_ITEMDEMANDPLAN', 'EDIT_ITEMOPTION', 'EDIT_ITEMSUPPLYPLAN', 'EDIT_ITEM_REVISION', 'EDIT_JOB', 'EDIT_KBCATEGORY', 'EDIT_KPIREPORT', 'EDIT_LEAD', 'EDIT_LOCATION', 'EDIT_LOCSEGMENTMAPPING', 'EDIT_MAILMERGE', 'EDIT_MAILMESSAGE', 'EDIT_MAILTEMPLATE', 'EDIT_MEDIAITEM', 'EDIT_MEDIAITEMFOLDER', 'EDIT_MEMDOC', 'EDIT_MFGCOSTTEMPLATE', 'EDIT_MFGROUTING', 'EDIT_NEXUS', 'EDIT_OPENIDSSO', 'EDIT_OTHERNAME', 'EDIT_PARTNER', 'EDIT_PARTNERCOMMISSIONSCHED', 'EDIT_PARTNERPLANASSIGN', 'EDIT_PAYPALACCOUNT', 'EDIT_PAYROLLBATCH2', 'EDIT_PAYROLLITEM', 'EDIT_PDFMESSAGE', 'EDIT_PDFTEMPLATE', 'EDIT_PERIOD', 'EDIT_PLANASSIGN', 'EDIT_PLANNEDSTANDARDCOST', 'EDIT_PLUGIN', 'EDIT_PLUGINTYPE', 'EDIT_POSITION', 'EDIT_PRESCATEGORY', 'EDIT_PROCESSHISTTXN', 'EDIT_PROJECTEXPENSETYPE', 'EDIT_PROJECTTASK', 'EDIT_PROJECTTEMPLATE', 'EDIT_PROSPECT', 'EDIT_PUBLISHER', 'EDIT_PUBLISHERAPP', 'EDIT_QUANTITYPRICINGSCHEDULE', 'EDIT_REDIRECT', 'EDIT_REDIRECTADV', 'EDIT_REFERRALCODE', 'EDIT_REGISTERPUBLISHER', 'EDIT_RELATEDITEM', 'EDIT_RELATEDITEMADV', 'EDIT_REPORT', 'EDIT_RESOLVECONFLICTS', 'EDIT_RESOURCE', 'EDIT_RESOURCEGROUP', 'EDIT_REVRECSCHEDULE', 'EDIT_ROLE', 'EDIT_RSRCALLOCATION', 'EDIT_RSSFEED', 'EDIT_SALESCAMPAIGN', 'EDIT_SALESTEAM', 'EDIT_SALESTERRITORY', 'EDIT_SAVEDSEARCH', 'EDIT_SCRIPT', 'EDIT_SCRIPTEDRECORD', 'EDIT_SCRIPTRECORD', 'EDIT_SEARCH', 'EDIT_SHIPITEM', 'EDIT_SHIPPARTREGISTRATION', 'EDIT_SITEEMAILTEMPLATE', 'EDIT_SITEITEMTEMPLAT', 'EDIT_SITEMEDIA', 'EDIT_SITETAG', 'EDIT_SITETHEME', 'EDIT_SOLUTION', 'EDIT_SSCATEGORY', 'EDIT_STANDARDCOSTVERSION', 'EDIT_STATE', 'EDIT_STOREITEMLISTLAYOUT', 'EDIT_STORETAB', 'EDIT_SUBSIDIARY', 'EDIT_SUITEAPPLIST', 'EDIT_SUITESIGNON', 'EDIT_SUPPORTCASE', 'EDIT_SYSALERT', 'EDIT_TASK', 'EDIT_TAXACCT', 'EDIT_TAXGROUP', 'EDIT_TAXITEM', 'EDIT_TAXPERIOD', 'EDIT_TAXSCHEDULE', 'EDIT_TAXTYPE', 'EDIT_TEMPLATECATEGORY', 'EDIT_TERMINATIONREASON', 'EDIT_TIMESHEET', 'EDIT_TOPIC', 'EDIT_TRANSACTIONLIST', 'EDIT_TRAN_ADJJOURNAL', 'EDIT_TRAN_BINTRNFR', 'EDIT_TRAN_BINWKSHT', 'EDIT_TRAN_BLANKORD', 'EDIT_TRAN_BOOKICJOURNAL', 'EDIT_TRAN_BOOKICJOURNALIMPORT', 'EDIT_TRAN_BOOKJOURNAL', 'EDIT_TRAN_BOOKJOURNALIMPORT', 'EDIT_TRAN_BUILD', 'EDIT_TRAN_CARDCHRG', 'EDIT_TRAN_CASHRFND', 'EDIT_TRAN_CASHSALE', 'EDIT_TRAN_CHECK', 'EDIT_TRAN_COMMISSN', 'EDIT_TRAN_CUSTCHRG', 'EDIT_TRAN_CUSTCRED', 'EDIT_TRAN_CUSTDEP', 'EDIT_TRAN_CUSTINVC', 'EDIT_TRAN_CUSTPYMT', 'EDIT_TRAN_CUSTRFND', 'EDIT_TRAN_DEPAPPL', 'EDIT_TRAN_DEPOSIT', 'EDIT_TRAN_ESTIMATE', 'EDIT_TRAN_EXPREPT', 'EDIT_TRAN_FXREVAL', 'EDIT_TRAN_ICJOURNAL', 'EDIT_TRAN_ICJOURNALIMPORT', 'EDIT_TRAN_ICTRNFRORD', 'EDIT_TRAN_INVADJST', 'EDIT_TRAN_INVCOUNT', 'EDIT_TRAN_INVDISTR', 'EDIT_TRAN_INVREVAL', 'EDIT_TRAN_INVTRNFR', 'EDIT_TRAN_INVWKSHT', 'EDIT_TRAN_INVWKSHTIMPORT', 'EDIT_TRAN_ITEMRCPT', 'EDIT_TRAN_ITEMSHIP', 'EDIT_TRAN_JOURNAL', 'EDIT_TRAN_JOURNALIMPORT', 'EDIT_TRAN_LIAADJST', 'EDIT_TRAN_LIABPYMT', 'EDIT_TRAN_OPPRTNTY', 'EDIT_TRAN_ORDERPURCHREQ', 'EDIT_TRAN_PARTNERCOMMISSN', 'EDIT_TRAN_PAYCHECK', 'EDIT_TRAN_PAYCHECK2', 'EDIT_TRAN_PCHKJRNL', 'EDIT_TRAN_PEJRNL', 'EDIT_TRAN_PURCHCON', 'EDIT_TRAN_PURCHORD', 'EDIT_TRAN_PURCHORD_REQ', 'EDIT_TRAN_PURCHREQ', 'EDIT_TRAN_REPLENISHLOC', 'EDIT_TRAN_REVCOMM', 'EDIT_TRAN_REVCOMRV', 'EDIT_TRAN_REVCONTR', 'EDIT_TRAN_RFQ', 'EDIT_TRAN_RTNAUTH', 'EDIT_TRAN_SALESORD', 'EDIT_TRAN_STATJOURNAL', 'EDIT_TRAN_STATJOURNALIMPORT', 'EDIT_TRAN_STATSCHEDULE', 'EDIT_TRAN_TAXLIAB', 'EDIT_TRAN_TAXLIAB2', 'EDIT_TRAN_TAXPYMT', 'EDIT_TRAN_TAXPYMT2', 'EDIT_TRAN_TAXPYMTCA', 'EDIT_TRAN_TEGCOLLECT', 'EDIT_TRAN_TEGPAY', 'EDIT_TRAN_TEGPYBL', 'EDIT_TRAN_TEGRCVBL', 'EDIT_TRAN_TRANSFER', 'EDIT_TRAN_TRNFRORD', 'EDIT_TRAN_UNBUILD', 'EDIT_TRAN_VATLIABAU', 'EDIT_TRAN_VENDAUTH', 'EDIT_TRAN_VENDBILL', 'EDIT_TRAN_VENDCRED', 'EDIT_TRAN_VENDPYMT', 'EDIT_TRAN_VENDRFQ', 'EDIT_TRAN_WOCLOSE', 'EDIT_TRAN_WOCOMPL', 'EDIT_TRAN_WOISSUE', 'EDIT_TRAN_WORKORD', 'EDIT_TRAN_YTDADJST', 'EDIT_UNITSTYPE', 'EDIT_UPGRADEBUNDLE', 'EDIT_URLALIAS', 'EDIT_VENDOR', 'EDIT_WEBAPPS', 'EDIT_WEBAPPSADV', 'EDIT_WORKCALENDAR', 'EDIT_WORKFLOW', 'EDIT_WORKPLACE', 'EXTL_0', 'EXTL_10', 'EXTL_10_1', 'EXTL_12', 'EXTL_9', 'EXTL_9_1', 'INTL_SECTION', 'INTL_SECTIONS', 'INTL_TASKLINK', 'INTL_TASKLINKS', 'LIST_ACCOUNT', 'LIST_ACCOUNTINGBOOK', 'LIST_ACCOUNTINGOTHERLIST', 'LIST_ACTIVITY', 'LIST_ADP_BATCHES', 'LIST_ADP_PAYCHECK', 'LIST_ADVPDFTEMPLATE', 'LIST_ALLOCATION', 'LIST_ALLOCATIONBATCH', 'LIST_AMORTIZATION', 'LIST_AMORTIZATIONSCHEDULE', 'LIST_APPDEF', 'LIST_APPPKG', 'LIST_APPPUBLISHERS', 'LIST_APPROVEACH', 'LIST_APPROVEEFT', 'LIST_APPROVERSRCALLOCATION', 'LIST_APPROVERTIMEENTRY', 'LIST_APPROVEVP', 'LIST_BILLINGCLASS', 'LIST_BILLINGRULE', 'LIST_BILLINGRUNRESULTS', 'LIST_BILLINGSCHEDULE', 'LIST_BILLING_GROUPS', 'LIST_BILLING_WORK_CENTER', 'LIST_BILLOFDISTRIBUTION', 'LIST_BILLRUN', 'LIST_BILLRUNSCHEDULE', 'LIST_BIN', 'LIST_BUDGET', 'LIST_BUDGETRATES', 'LIST_BULKOP', 'LIST_BULKRESULTS', 'LIST_BUNDLE', 'LIST_CALENDAR', 'LIST_CALL', 'LIST_CAMPAIGN', 'LIST_CAMPAIGNAUDIENCE', 'LIST_CAMPAIGNCATEGORY', 'LIST_CAMPAIGNCHANNEL', 'LIST_CAMPAIGNEMAIL', 'LIST_CAMPAIGNFAMILY', 'LIST_CAMPAIGNOFFER', 'LIST_CAMPAIGNSEARCHENGINE', 'LIST_CAMPAIGNSUBSCRIPTION', 'LIST_CAMPAIGNVERTICAL', 'LIST_CASEFIELDRULE', 'LIST_CASEFORM', 'LIST_CASEISSUE', 'LIST_CASEORIGIN', 'LIST_CASEPRIORITY', 'LIST_CASEPROFILE', 'LIST_CASESTATUS', 'LIST_CASETERRITORIES', 'LIST_CASETERRITORY', 'LIST_CASETERRITORYASSIGN', 'LIST_CASETYPE', 'LIST_CCTRAN', 'LIST_CHARGE', 'LIST_CHARGERULE', 'LIST_CHARGERUNRESULTS', 'LIST_CHART_ACCOUNT', 'LIST_CLASS', 'LIST_CLASSSEGMENTMAPPING', 'LIST_COLORTHEME', 'LIST_COMMCAT', 'LIST_COMMISSIONSCHEDULE', 'LIST_COMPETITOR', 'LIST_CONSOLRATES', 'LIST_CONTACT', 'LIST_COUNTRY', 'LIST_CRMGROUP', 'LIST_CRMOTHERLIST', 'LIST_CRMTEMPLATE', 'LIST_CURRENCY', 'LIST_CURRENCYRATE', 'LIST_CUSTADDRESSENTRYFORM', 'LIST_CUSTBODYFIELD', 'LIST_CUSTCATEGORY', 'LIST_CUSTCENTER', 'LIST_CUSTCOLUMNFIELD', 'LIST_CUSTEMAILLAYOUT', 'LIST_CUSTENTITYFIELD', 'LIST_CUSTENTRYFORM', 'LIST_CUSTEVENTFIELD', 'LIST_CUSTFIELDTAB', 'LIST_CUSTFORM', 'LIST_CUSTITEMFIELD', 'LIST_CUSTITEMNUMBERFIELD', 'LIST_CUSTJOB', 'LIST_CUSTLAYOUT', 'LIST_CUSTLIST', 'LIST_CUSTOMCODEFILES', 'LIST_CUSTOMERFIELDRULE', 'LIST_CUSTOMERFORM', 'LIST_CUSTOMERSTATUS', 'LIST_CUSTOMSUBLIST', 'LIST_CUSTOTHERFIELD', 'LIST_CUSTRECORD', 'LIST_CUSTRECORDFORM', 'LIST_CUSTSECTION', 'LIST_DEPARTMENT', 'LIST_DEPTSEGMENTMAPPING', 'LIST_DIFFROLE', 'LIST_DISTRIBUTIONNETWORK', 'LIST_DUPLICATE_RESOLUTION_STATUS', 'LIST_EMAILTEMPLATE', 'LIST_EMPLCATEGORY', 'LIST_EMPLOYEE', 'LIST_EMPOTHERLIST', 'LIST_ENTITY', 'LIST_ENTITYACCOUNTMAPPING', 'LIST_ENTITY_DUPLICATES', 'LIST_ESCALATIONRULE', 'LIST_ESCALATIONTERRITORY', 'LIST_EVENT', 'LIST_EXPCATEGORY', 'LIST_FAXTEMPLATE', 'LIST_FCSITEFOLDER', 'LIST_FCSITEFOLDERADV', 'LIST_FILECABINET', 'LIST_FINCHRG', 'LIST_FISCALCALENDAR', 'LIST_FORECAST', 'LIST_GENERICRESOURCE', 'LIST_GIFTCERTIFICATES', 'LIST_GLNUMHISTORY', 'LIST_GLOBALACCOUNTMAPPING', 'LIST_HCMJOB', 'LIST_IMAGE', 'LIST_INFOITEM', 'LIST_INFOITEMFORM', 'LIST_INSTALLEDBUNDLE', 'LIST_INVCOSTTEMPLATE', 'LIST_ISSUE', 'LIST_ITEM', 'LIST_ITEMACCOUNTMAPPING', 'LIST_ITEMATTRGROUP', 'LIST_ITEMDEMANDPLAN', 'LIST_ITEMOPTION', 'LIST_ITEMSUPPLYPLAN', 'LIST_ITEM_REVISION', 'LIST_JOB', 'LIST_KBCATEGORY', 'LIST_KPIREPORT', 'LIST_LEAD', 'LIST_LOCATION', 'LIST_LOCSEGMENTMAPPING', 'LIST_MAILMERGE', 'LIST_MAILTEMPLATE', 'LIST_MEDIAITEMFOLDER', 'LIST_MEDIAITEMFOLDER_LOG', 'LIST_MEMDOC', 'LIST_MEMDOCRESULTS', 'LIST_MFGCOSTTEMPLATE', 'LIST_MFGOPERATIONTASK', 'LIST_MFGROUTING', 'LIST_MGRFORECAST', 'LIST_MYROLES', 'LIST_OTHERNAME', 'LIST_PARTNER', 'LIST_PARTNERCOMMISSIONSCHED', 'LIST_PARTNERPLANASSIGN', 'LIST_PARTNERPLANASSIGNS', 'LIST_PAYMENTEVENT', 'LIST_PAYPALACCOUNT', 'LIST_PAYROLLBATCH', 'LIST_PAYROLLISSUES', 'LIST_PAYROLLITEM', 'LIST_PDFTEMPLATE', 'LIST_PERIOD', 'LIST_PLANASSIGN', 'LIST_PLANASSIGNS', 'LIST_PLANNEDSTANDARDCOST', 'LIST_PLUGIN', 'LIST_PLUGINTYPE', 'LIST_POSITION', 'LIST_PRESCATEGORY', 'LIST_PROCESSHISTTXNSTATUS', 'LIST_PROJECTEXPENSETYPE', 'LIST_PROJECTTASK', 'LIST_PROJECTTASKIMPORT', 'LIST_PROJECTTEMPLATE', 'LIST_PROSPECT', 'LIST_PUBLISHERAPP', 'LIST_QUANTITYPRICINGSCHEDULE', 'LIST_QUOTA', 'LIST_RECENTRECORDS', 'LIST_RECVDFILES', 'LIST_REFERRALCODE', 'LIST_RELATEDITEM', 'LIST_RELATEDITEMADV', 'LIST_REPORESULT', 'LIST_REPOSCHEDULE', 'LIST_RESOURCE', 'LIST_RESOURCEGROUP', 'LIST_REVRECSCHEDS', 'LIST_REVRECSCHEDULE', 'LIST_ROLE', 'LIST_RSRCALLOCATION', 'LIST_RSSFEED', 'LIST_SALESCAMPAIGN', 'LIST_SALESTEAM', 'LIST_SALESTERRITORIES', 'LIST_SALESTERRITORY', 'LIST_SALESTERRITORYASSIGN', 'LIST_SAVEDASHBOARD', 'LIST_SAVEDBULKOP', 'LIST_SAVEDSEARCH', 'LIST_SCRIPT', 'LIST_SCRIPTEDRECORD', 'LIST_SCRIPTRECORD', 'LIST_SCRIPTSTATUS', 'LIST_SEARCHRESULTS', 'LIST_SEARCHRESULTSARCHIVE', 'LIST_SENTFILES', 'LIST_SHIPITEM', 'LIST_SHIPPARTREGISTRATION', 'LIST_SHIPPINGMANIFEST', 'LIST_SITEEMAILTEMPLATE', 'LIST_SITEITEMTEMPLAT', 'LIST_SITETAGS', 'LIST_SITETHEMES', 'LIST_SMBIMPORT', 'LIST_SOLUTION', 'LIST_SSCATEGORY', 'LIST_STANDARDCOSTVERSION', 'LIST_STATE', 'LIST_STATUSACH', 'LIST_STATUSEFT', 'LIST_STATUSVP', 'LIST_STOREITEMLISTLAYOUT', 'LIST_STORETAB', 'LIST_SUBSIDIARY', 'LIST_SUPPORTCASE', 'LIST_SYSALERT', 'LIST_SYSTEMEMAILTEMPLATE', 'LIST_TASK', 'LIST_TAXGROUP', 'LIST_TAXITEM', 'LIST_TAXPERIOD', 'LIST_TAXSCHEDULE', 'LIST_TEMPLATEFILES', 'LIST_TEMPLATE_CATEGORY', 'LIST_TERMINATIONREASON', 'LIST_TIMESHEET', 'LIST_TOPIC', 'LIST_TRANNUMBERAUDITLOG', 'LIST_TRANSACTION', 'LIST_TRAN_BINTRNFR', 'LIST_TRAN_BINWKSHT', 'LIST_TRAN_BLANKORD', 'LIST_TRAN_BOOKICJOURNAL', 'LIST_TRAN_BOOKJOURNAL', 'LIST_TRAN_BUILD', 'LIST_TRAN_CARDCHRG', 'LIST_TRAN_CASHRFND', 'LIST_TRAN_CASHSALE', 'LIST_TRAN_CHECK', 'LIST_TRAN_COMMISSN', 'LIST_TRAN_CUSTCHRG', 'LIST_TRAN_CUSTCRED', 'LIST_TRAN_CUSTDEP', 'LIST_TRAN_CUSTINVC', 'LIST_TRAN_CUSTPYMT', 'LIST_TRAN_CUSTRFND', 'LIST_TRAN_DEPAPPL', 'LIST_TRAN_DEPOSIT', 'LIST_TRAN_DOWNLOAD', 'LIST_TRAN_ESTIMATE', 'LIST_TRAN_EXPREPT', 'LIST_TRAN_FXREVAL', 'LIST_TRAN_ICJOURNAL', 'LIST_TRAN_ICTRNFRORD', 'LIST_TRAN_INVADJST', 'LIST_TRAN_INVCOUNT', 'LIST_TRAN_INVDISTR', 'LIST_TRAN_INVREVAL', 'LIST_TRAN_INVTRNFR', 'LIST_TRAN_INVWKSHT', 'LIST_TRAN_ITEMRCPT', 'LIST_TRAN_ITEMSHIP', 'LIST_TRAN_JOURNAL', 'LIST_TRAN_LIABPYMT', 'LIST_TRAN_OPPRTNTY', 'LIST_TRAN_PARTNERCOMMISSN', 'LIST_TRAN_PAYCHECK', 'LIST_TRAN_PCHKJRNL', 'LIST_TRAN_PEJRNL', 'LIST_TRAN_PURCHCON', 'LIST_TRAN_PURCHORD', 'LIST_TRAN_PURCHORD_REQ', 'LIST_TRAN_PURCHREQ', 'LIST_TRAN_REORDER', 'LIST_TRAN_REVCOMM', 'LIST_TRAN_REVCOMRV', 'LIST_TRAN_REVCONTR', 'LIST_TRAN_RFQ', 'LIST_TRAN_RTNAUTH', 'LIST_TRAN_SALESORD', 'LIST_TRAN_STATJOURNAL', 'LIST_TRAN_STATSCHEDULE', 'LIST_TRAN_TAXLIAB', 'LIST_TRAN_TAXPYMT', 'LIST_TRAN_TEGPYBL', 'LIST_TRAN_TEGRCVBL', 'LIST_TRAN_TRANSFER', 'LIST_TRAN_TRNFRORD', 'LIST_TRAN_UNBUILD', 'LIST_TRAN_VATLIAB', 'LIST_TRAN_VATLIABAU', 'LIST_TRAN_VATLIABUK', 'LIST_TRAN_VENDAUTH', 'LIST_TRAN_VENDBILL', 'LIST_TRAN_VENDCRED', 'LIST_TRAN_VENDPYMT', 'LIST_TRAN_VENDRFQ', 'LIST_TRAN_WOCLOSE', 'LIST_TRAN_WOCOMPL', 'LIST_TRAN_WOISSUE', 'LIST_TRAN_WORKORD', 'LIST_TRAN_YTDADJST', 'LIST_UNCATSITEITEM', 'LIST_UNCATSITEITEMADV', 'LIST_UNITSTYPE', 'LIST_UPSELLPOPUP', 'LIST_UPSELLWIZARD', 'LIST_URLALIASES', 'LIST_USER', 'LIST_VENDOR', 'LIST_WEBAPPS', 'LIST_WEBAPPSADV', 'LIST_WORKCALENDAR', 'LIST_WORKFLOW', 'LIST_WORKPLACE', 'REPO_10', 'REPO_100', 'REPO_101', 'REPO_102', 'REPO_103', 'REPO_104', 'REPO_105', 'REPO_106', 'REPO_107', 'REPO_108', 'REPO_109', 'REPO_11', 'REPO_110', 'REPO_111', 'REPO_112', 'REPO_113', 'REPO_114', 'REPO_115', 'REPO_116', 'REPO_118', 'REPO_119', 'REPO_12', 'REPO_121', 'REPO_122', 'REPO_123', 'REPO_126', 'REPO_127', 'REPO_128', 'REPO_13', 'REPO_130', 'REPO_131', 'REPO_132', 'REPO_133', 'REPO_134', 'REPO_135', 'REPO_14', 'REPO_141', 'REPO_142', 'REPO_143', 'REPO_144', 'REPO_145', 'REPO_146', 'REPO_147', 'REPO_148', 'REPO_149', 'REPO_15', 'REPO_150', 'REPO_151', 'REPO_152', 'REPO_16', 'REPO_161', 'REPO_162', 'REPO_163', 'REPO_164', 'REPO_165', 'REPO_169', 'REPO_17', 'REPO_170', 'REPO_171', 'REPO_172', 'REPO_173', 'REPO_174', 'REPO_175', 'REPO_176', 'REPO_177', 'REPO_178', 'REPO_179', 'REPO_18', 'REPO_180', 'REPO_183', 'REPO_184', 'REPO_185', 'REPO_188', 'REPO_189', 'REPO_19', 'REPO_191', 'REPO_192', 'REPO_193', 'REPO_194', 'REPO_195', 'REPO_196', 'REPO_197', 'REPO_198', 'REPO_199', 'REPO_2', 'REPO_20', 'REPO_203', 'REPO_204', 'REPO_205', 'REPO_206', 'REPO_209', 'REPO_21', 'REPO_210', 'REPO_211', 'REPO_214', 'REPO_215', 'REPO_218', 'REPO_219', 'REPO_22', 'REPO_220', 'REPO_221', 'REPO_222', 'REPO_223', 'REPO_225', 'REPO_226', 'REPO_227', 'REPO_229', 'REPO_23', 'REPO_230', 'REPO_231', 'REPO_232', 'REPO_233', 'REPO_234', 'REPO_235', 'REPO_239', 'REPO_24', 'REPO_240', 'REPO_241', 'REPO_242', 'REPO_243', 'REPO_246', 'REPO_248', 'REPO_249', 'REPO_25', 'REPO_250', 'REPO_251', 'REPO_256', 'REPO_257', 'REPO_258', 'REPO_26', 'REPO_261', 'REPO_262', 'REPO_264', 'REPO_266', 'REPO_267', 'REPO_268', 'REPO_269', 'REPO_27', 'REPO_270', 'REPO_271', 'REPO_272', 'REPO_273', 'REPO_274', 'REPO_277', 'REPO_278', 'REPO_279', 'REPO_28', 'REPO_280', 'REPO_281', 'REPO_282', 'REPO_283', 'REPO_284', 'REPO_285', 'REPO_286', 'REPO_29', 'REPO_292', 'REPO_293', 'REPO_3', 'REPO_30', 'REPO_31', 'REPO_32', 'REPO_33', 'REPO_34', 'REPO_35', 'REPO_36', 'REPO_37', 'REPO_38', 'REPO_39', 'REPO_4', 'REPO_41', 'REPO_42', 'REPO_43', 'REPO_44', 'REPO_48', 'REPO_49', 'REPO_5', 'REPO_50', 'REPO_51', 'REPO_53', 'REPO_54', 'REPO_55', 'REPO_56', 'REPO_57', 'REPO_58', 'REPO_59', 'REPO_6', 'REPO_60', 'REPO_61', 'REPO_62', 'REPO_63', 'REPO_64', 'REPO_65', 'REPO_66', 'REPO_67', 'REPO_68', 'REPO_69', 'REPO_7', 'REPO_71', 'REPO_72', 'REPO_73', 'REPO_74', 'REPO_77', 'REPO_78', 'REPO_79', 'REPO_8', 'REPO_80', 'REPO_81', 'REPO_82', 'REPO_83', 'REPO_84', 'REPO_85', 'REPO_87', 'REPO_88', 'REPO_9', 'REPO_90', 'REPO_91', 'REPO_93', 'REPO_94', 'REPO_95', 'REPO_96', 'REPO_97', 'REPO_98', 'REPO_99', 'REPO_ASSIGNFINANCIALLAYOUTS', 'REPO_BANKREGISTER', 'REPO_CUSTOMIZATION', 'REPO_CUST_10', 'REPO_CUST_100', 'REPO_CUST_101', 'REPO_CUST_102', 'REPO_CUST_103', 'REPO_CUST_104', 'REPO_CUST_105', 'REPO_CUST_106', 'REPO_CUST_107', 'REPO_CUST_11', 'REPO_CUST_111', 'REPO_CUST_112', 'REPO_CUST_113', 'REPO_CUST_114', 'REPO_CUST_115', 'REPO_CUST_116', 'REPO_CUST_118', 'REPO_CUST_119', 'REPO_CUST_12', 'REPO_CUST_121', 'REPO_CUST_122', 'REPO_CUST_123', 'REPO_CUST_126', 'REPO_CUST_127', 'REPO_CUST_128', 'REPO_CUST_129', 'REPO_CUST_13', 'REPO_CUST_130', 'REPO_CUST_131', 'REPO_CUST_132', 'REPO_CUST_133', 'REPO_CUST_134', 'REPO_CUST_135', 'REPO_CUST_137', 'REPO_CUST_138', 'REPO_CUST_139', 'REPO_CUST_14', 'REPO_CUST_140', 'REPO_CUST_141', 'REPO_CUST_142', 'REPO_CUST_143', 'REPO_CUST_144', 'REPO_CUST_145', 'REPO_CUST_146', 'REPO_CUST_147', 'REPO_CUST_148', 'REPO_CUST_149', 'REPO_CUST_15', 'REPO_CUST_150', 'REPO_CUST_151', 'REPO_CUST_16', 'REPO_CUST_161', 'REPO_CUST_162', 'REPO_CUST_169', 'REPO_CUST_17', 'REPO_CUST_170', 'REPO_CUST_171', 'REPO_CUST_172', 'REPO_CUST_173', 'REPO_CUST_174', 'REPO_CUST_175', 'REPO_CUST_176', 'REPO_CUST_177', 'REPO_CUST_178', 'REPO_CUST_179', 'REPO_CUST_18', 'REPO_CUST_180', 'REPO_CUST_183', 'REPO_CUST_184', 'REPO_CUST_185', 'REPO_CUST_188', 'REPO_CUST_189', 'REPO_CUST_19', 'REPO_CUST_191', 'REPO_CUST_192', 'REPO_CUST_193', 'REPO_CUST_194', 'REPO_CUST_195', 'REPO_CUST_196', 'REPO_CUST_197', 'REPO_CUST_198', 'REPO_CUST_199', 'REPO_CUST_2', 'REPO_CUST_20', 'REPO_CUST_203', 'REPO_CUST_204', 'REPO_CUST_205', 'REPO_CUST_206', 'REPO_CUST_209', 'REPO_CUST_21', 'REPO_CUST_210', 'REPO_CUST_211', 'REPO_CUST_214', 'REPO_CUST_215', 'REPO_CUST_218', 'REPO_CUST_219', 'REPO_CUST_22', 'REPO_CUST_220', 'REPO_CUST_221', 'REPO_CUST_222', 'REPO_CUST_223', 'REPO_CUST_225', 'REPO_CUST_226', 'REPO_CUST_227', 'REPO_CUST_229', 'REPO_CUST_230', 'REPO_CUST_231', 'REPO_CUST_232', 'REPO_CUST_233', 'REPO_CUST_234', 'REPO_CUST_235', 'REPO_CUST_239', 'REPO_CUST_240', 'REPO_CUST_241', 'REPO_CUST_242', 'REPO_CUST_243', 'REPO_CUST_246', 'REPO_CUST_248', 'REPO_CUST_249', 'REPO_CUST_25', 'REPO_CUST_250', 'REPO_CUST_251', 'REPO_CUST_256', 'REPO_CUST_257', 'REPO_CUST_258', 'REPO_CUST_26', 'REPO_CUST_261', 'REPO_CUST_262', 'REPO_CUST_264', 'REPO_CUST_266', 'REPO_CUST_267', 'REPO_CUST_268', 'REPO_CUST_269', 'REPO_CUST_27', 'REPO_CUST_270', 'REPO_CUST_271', 'REPO_CUST_272', 'REPO_CUST_273', 'REPO_CUST_274', 'REPO_CUST_277', 'REPO_CUST_278', 'REPO_CUST_279', 'REPO_CUST_28', 'REPO_CUST_280', 'REPO_CUST_281', 'REPO_CUST_282', 'REPO_CUST_283', 'REPO_CUST_284', 'REPO_CUST_285', 'REPO_CUST_286', 'REPO_CUST_29', 'REPO_CUST_292', 'REPO_CUST_293', 'REPO_CUST_3', 'REPO_CUST_30', 'REPO_CUST_31', 'REPO_CUST_32', 'REPO_CUST_33', 'REPO_CUST_34', 'REPO_CUST_35', 'REPO_CUST_36', 'REPO_CUST_37', 'REPO_CUST_38', 'REPO_CUST_39', 'REPO_CUST_4', 'REPO_CUST_40', 'REPO_CUST_41', 'REPO_CUST_42', 'REPO_CUST_43', 'REPO_CUST_44', 'REPO_CUST_48', 'REPO_CUST_49', 'REPO_CUST_5', 'REPO_CUST_51', 'REPO_CUST_53', 'REPO_CUST_54', 'REPO_CUST_55', 'REPO_CUST_56', 'REPO_CUST_57', 'REPO_CUST_58', 'REPO_CUST_59', 'REPO_CUST_6', 'REPO_CUST_60', 'REPO_CUST_61', 'REPO_CUST_62', 'REPO_CUST_63', 'REPO_CUST_64', 'REPO_CUST_65', 'REPO_CUST_66', 'REPO_CUST_67', 'REPO_CUST_68', 'REPO_CUST_69', 'REPO_CUST_7', 'REPO_CUST_71', 'REPO_CUST_72', 'REPO_CUST_73', 'REPO_CUST_74', 'REPO_CUST_8', 'REPO_CUST_80', 'REPO_CUST_81', 'REPO_CUST_82', 'REPO_CUST_83', 'REPO_CUST_84', 'REPO_CUST_85', 'REPO_CUST_87', 'REPO_CUST_88', 'REPO_CUST_9', 'REPO_CUST_90', 'REPO_CUST_91', 'REPO_CUST_94', 'REPO_CUST_95', 'REPO_CUST_96', 'REPO_CUST_97', 'REPO_CUST_98', 'REPO_CUST_99', 'REPO_CUST_NEG100', 'REPO_CUST_NEG101', 'REPO_CUST_NEG105', 'REPO_CUST_NEG106', 'REPO_CUST_NEG108', 'REPO_CUST_NEG109', 'REPO_CUST_NEG110', 'REPO_CUST_NEG111', 'REPO_CUST_NEG112', 'REPO_CUST_NEG113', 'REPO_CUST_NEG114', 'REPO_CUST_NEG115', 'REPO_CUST_NEG116', 'REPO_CUST_NEG118', 'REPO_CUST_NEG120', 'REPO_CUST_NEG121', 'REPO_CUST_NEG122', 'REPO_CUST_NEG123', 'REPO_CUST_NEG124', 'REPO_CUST_NEG125', 'REPO_CUST_NEG126', 'REPO_CUST_NEG127', 'REPO_CUST_NEG128', 'REPO_CUST_NEG130', 'REPO_CUST_NEG131', 'REPO_CUST_NEG132', 'REPO_CUST_NEG133', 'REPO_CUST_NEG134', 'REPO_CUST_NEG135', 'REPO_CUST_NEG136', 'REPO_CUST_NEG137', 'REPO_CUST_NEG138', 'REPO_CUST_NEG139', 'REPO_CUST_NEG140', 'REPO_CUST_NEG141', 'REPO_CUST_NEG144', 'REPO_CUST_NEG145', 'REPO_CUST_NEG146', 'REPO_CUST_NEG147', 'REPO_CUST_NEG148', 'REPO_CUST_NEG149', 'REPO_CUST_NEG150', 'REPO_CUST_NEG151', 'REPO_CUST_NEG152', 'REPO_CUST_NEG153', 'REPO_CUST_NEG154', 'REPO_CUST_NEG155', 'REPO_CUST_NEG156', 'REPO_CUST_NEG157', 'REPO_CUST_NEG158', 'REPO_CUST_NEG159', 'REPO_CUST_NEG160', 'REPO_CUST_NEG161', 'REPO_CUST_NEG162', 'REPO_CUST_NEG175', 'REPO_CUST_NEG178', 'REPO_CUST_NEG179', 'REPO_CUST_NEG180', 'REPO_CUST_NEG181', 'REPO_CUST_NEG182', 'REPO_CUST_NEG183', 'REPO_CUST_NEG184', 'REPO_CUST_NEG185', 'REPO_CUST_NEG186', 'REPO_CUST_NEG187', 'REPO_CUST_NEG188', 'REPO_CUST_NEG195', 'REPO_CUST_NEG196', 'REPO_CUST_NEG197', 'REPO_CUST_NEG198', 'REPO_CUST_NEG199', 'REPO_CUST_NEG200', 'REPO_CUST_NEG201', 'REPO_CUST_NEG202', 'REPO_CUST_NEG203', 'REPO_CUST_NEG204', 'REPO_CUST_NEG205', 'REPO_CUST_NEG206', 'REPO_CUST_NEG209', 'REPO_CUST_NEG210', 'REPO_CUST_NEG211', 'REPO_CUST_NEG212', 'REPO_CUST_NEG213', 'REPO_CUST_NEG214', 'REPO_CUST_NEG215', 'REPO_CUST_NEG216', 'REPO_CUST_NEG221', 'REPO_CUST_NEG222', 'REPO_CUST_NEG223', 'REPO_CUST_NEG224', 'REPO_CUST_NEG225', 'REPO_CUST_NEG226', 'REPO_CUST_NEG227', 'REPO_CUST_NEG228', 'REPO_CUST_NEG231', 'REPO_CUST_NEG232', 'REPO_CUST_NEG233', 'REPO_CUST_NEG234', 'REPO_CUST_NEG235', 'REPO_CUST_NEG236', 'REPO_CUST_NEG239', 'REPO_CUST_NEG240', 'REPO_CUST_NEG241', 'REPO_CUST_NEG242', 'REPO_CUST_NEG245', 'REPO_CUST_NEG246', 'REPO_CUST_NEG247', 'REPO_CUST_NEG248', 'REPO_CUST_NEG249', 'REPO_CUST_NEG250', 'REPO_CUST_NEG251', 'REPO_CUST_NEG252', 'REPO_CUST_NEG253', 'REPO_CUST_NEG254', 'REPO_CUST_NEG255', 'REPO_CUST_NEG256', 'REPO_CUST_NEG257', 'REPO_CUST_NEG258', 'REPO_CUST_NEG259', 'REPO_CUST_NEG260', 'REPO_CUST_NEG261', 'REPO_CUST_NEG262', 'REPO_CUST_NEG263', 'REPO_CUST_NEG264', 'REPO_CUST_NEG265', 'REPO_CUST_NEG266', 'REPO_CUST_NEG267', 'REPO_CUST_NEG268', 'REPO_CUST_NEG269', 'REPO_CUST_NEG273', 'REPO_CUST_NEG274', 'REPO_CUST_NEG275', 'REPO_CUST_NEG277', 'REPO_CUST_NEG278', 'REPO_CUST_NEG279', 'REPO_CUST_NEG280', 'REPO_CUST_NEG281', 'REPO_CUST_NEG284', 'REPO_CUST_NEG285', 'REPO_CUST_PAGE', 'REPO_EMAIL', 'REPO_FINANCIALLAYOUTS', 'REPO_GST34', 'REPO_NEG100', 'REPO_NEG101', 'REPO_NEG105', 'REPO_NEG106', 'REPO_NEG108', 'REPO_NEG109', 'REPO_NEG110', 'REPO_NEG111', 'REPO_NEG112', 'REPO_NEG113', 'REPO_NEG114', 'REPO_NEG115', 'REPO_NEG116', 'REPO_NEG118', 'REPO_NEG119', 'REPO_NEG120', 'REPO_NEG121', 'REPO_NEG122', 'REPO_NEG123', 'REPO_NEG124', 'REPO_NEG125', 'REPO_NEG126', 'REPO_NEG127', 'REPO_NEG128', 'REPO_NEG129', 'REPO_NEG130', 'REPO_NEG131', 'REPO_NEG132', 'REPO_NEG133', 'REPO_NEG134', 'REPO_NEG135', 'REPO_NEG136', 'REPO_NEG137', 'REPO_NEG138', 'REPO_NEG139', 'REPO_NEG140', 'REPO_NEG141', 'REPO_NEG144', 'REPO_NEG145', 'REPO_NEG146', 'REPO_NEG147', 'REPO_NEG148', 'REPO_NEG149', 'REPO_NEG150', 'REPO_NEG151', 'REPO_NEG152', 'REPO_NEG153', 'REPO_NEG154', 'REPO_NEG155', 'REPO_NEG156', 'REPO_NEG157', 'REPO_NEG158', 'REPO_NEG159', 'REPO_NEG160', 'REPO_NEG161', 'REPO_NEG162', 'REPO_NEG175', 'REPO_NEG178', 'REPO_NEG179', 'REPO_NEG180', 'REPO_NEG181', 'REPO_NEG182', 'REPO_NEG183', 'REPO_NEG184', 'REPO_NEG185', 'REPO_NEG186', 'REPO_NEG187', 'REPO_NEG188', 'REPO_NEG195', 'REPO_NEG196', 'REPO_NEG197', 'REPO_NEG198', 'REPO_NEG199', 'REPO_NEG200', 'REPO_NEG201', 'REPO_NEG202', 'REPO_NEG203', 'REPO_NEG204', 'REPO_NEG205', 'REPO_NEG206', 'REPO_NEG209', 'REPO_NEG210', 'REPO_NEG211', 'REPO_NEG212', 'REPO_NEG213', 'REPO_NEG214', 'REPO_NEG215', 'REPO_NEG216', 'REPO_NEG221', 'REPO_NEG222', 'REPO_NEG223', 'REPO_NEG224', 'REPO_NEG225', 'REPO_NEG226', 'REPO_NEG227', 'REPO_NEG228', 'REPO_NEG231', 'REPO_NEG232', 'REPO_NEG233', 'REPO_NEG234', 'REPO_NEG235', 'REPO_NEG236', 'REPO_NEG237', 'REPO_NEG239', 'REPO_NEG240', 'REPO_NEG241', 'REPO_NEG242', 'REPO_NEG245', 'REPO_NEG246', 'REPO_NEG247', 'REPO_NEG248', 'REPO_NEG249', 'REPO_NEG250', 'REPO_NEG251', 'REPO_NEG252', 'REPO_NEG253', 'REPO_NEG254', 'REPO_NEG255', 'REPO_NEG256', 'REPO_NEG257', 'REPO_NEG258', 'REPO_NEG259', 'REPO_NEG260', 'REPO_NEG261', 'REPO_NEG262', 'REPO_NEG263', 'REPO_NEG264', 'REPO_NEG265', 'REPO_NEG266', 'REPO_NEG267', 'REPO_NEG268', 'REPO_NEG269', 'REPO_NEG271', 'REPO_NEG273', 'REPO_NEG274', 'REPO_NEG275', 'REPO_NEG277', 'REPO_NEG278', 'REPO_NEG279', 'REPO_NEG280', 'REPO_NEG281', 'REPO_NEG284', 'REPO_NEG285', 'REPO_NEG322', 'REPO_NEG324', 'REPO_NEWFINANCIALREPORT', 'REPO_QUICKREPORT', 'REPO_RECENT', 'REPO_REGISTER_ACCTPAY', 'REPO_REGISTER_ACCTREC', 'REPO_REGISTER_BANK', 'REPO_REGISTER_COGS', 'REPO_REGISTER_CREDCARD', 'REPO_REGISTER_DEFEREXPENSE', 'REPO_REGISTER_DEFERREVENUE', 'REPO_REGISTER_EQUITY', 'REPO_REGISTER_EXPENSE', 'REPO_REGISTER_FIXEDASSET', 'REPO_REGISTER_INCOME', 'REPO_REGISTER_LONGTERMLIAB', 'REPO_REGISTER_NONPOSTING', 'REPO_REGISTER_OTHASSET', 'REPO_REGISTER_OTHCURRASSET', 'REPO_REGISTER_OTHCURRLIAB', 'REPO_REGISTER_OTHEXPENSE', 'REPO_REGISTER_OTHINCOME', 'REPO_REGISTER_UNBILLEDREC', 'SRCH_ACCOUNT', 'SRCH_ACCOUNTINGBOOK', 'SRCH_ACCOUNTINGPERIOD', 'SRCH_ACCOUNTINGTRANSACTION', 'SRCH_ACTIVITY', 'SRCH_AMORTIZATIONSCHEDULE', 'SRCH_APPDEF', 'SRCH_APPPKG', 'SRCH_AUDITTRAIL', 'SRCH_BILLINGCLASS', 'SRCH_BILLINGRULE', 'SRCH_BILLINGSCHEDULE', 'SRCH_BILLOFDISTRIBUTION', 'SRCH_BILLRUN', 'SRCH_BILLRUNSCHEDULE', 'SRCH_BIN', 'SRCH_BINNUMBER', 'SRCH_BUDGET', 'SRCH_BUDGETRATES', 'SRCH_CALENDAR', 'SRCH_CALL', 'SRCH_CAMPAIGN', 'SRCH_CASE', 'SRCH_CHARGE', 'SRCH_CHARGERULE', 'SRCH_CLASS', 'SRCH_CLASSSEGMENTMAPPING', 'SRCH_COMMISSIONABLEITEM', 'SRCH_COMMISSIONOVERVIEW', 'SRCH_COMPANY', 'SRCH_COMPETITOR', 'SRCH_CONSOLEXCHANGERATE', 'SRCH_CONSOLRATES', 'SRCH_CONTACT', 'SRCH_COUPONCODE', 'SRCH_CRMGROUP', 'SRCH_CUSTOMER', 'SRCH_DELETEDRECORD', 'SRCH_DEPARTMENT', 'SRCH_DEPTSEGMENTMAPPING', 'SRCH_DISTRIBUTIONNETWORK', 'SRCH_DOCUMENT', 'SRCH_EMPLOYEE', 'SRCH_EMPLOYEEPAYROLLITEM', 'SRCH_ENTITY', 'SRCH_ENTITYACCOUNTMAPPING', 'SRCH_FIRSTVISIT', 'SRCH_FISCALCALENDAR', 'SRCH_FOLDER', 'SRCH_GENERICRESOURCE', 'SRCH_GIFTCERTIFICATE', 'SRCH_GLOBALACCOUNTMAPPING', 'SRCH_INFOITEM', 'SRCH_INFOITEMFORM', 'SRCH_INVCOSTTEMPLATE', 'SRCH_INVENTORYNUMBER', 'SRCH_INVENTORYNUMBERBIN', 'SRCH_ISSUE', 'SRCH_ITEM', 'SRCH_ITEMACCOUNTMAPPING', 'SRCH_ITEMDEMANDPLAN', 'SRCH_ITEMSUPPLYPLAN', 'SRCH_ITEM_REVISION', 'SRCH_JOB', 'SRCH_LEAD', 'SRCH_LOCATION', 'SRCH_LOCSEGMENTMAPPING', 'SRCH_LOGINAUDIT', 'SRCH_MEDIAITEM', 'SRCH_MEMDOC', 'SRCH_MESSAGE', 'SRCH_MFGCOSTTEMPLATE', 'SRCH_MFGOPERATIONTASK', 'SRCH_MFGPLANNEDTIME', 'SRCH_MFGROUTING', 'SRCH_NEXUS', 'SRCH_ONLINECASEFORM', 'SRCH_ONLINELEADFORM', 'SRCH_PARTNER', 'SRCH_PAYMENTEVENT', 'SRCH_PAYROLLITEM', 'SRCH_PLANNEDSTANDARDCOST', 'SRCH_PRESCATEGORY', 'SRCH_PRICING', 'SRCH_PROJECTEXPENSETYPE', 'SRCH_PROJECTRESOURCE', 'SRCH_PROJECTTASK', 'SRCH_PROJECTTASKANDCRMTASK', 'SRCH_PROJECTTEMPLATE', 'SRCH_PROMOTION', 'SRCH_PROSPECT', 'SRCH_QUOTA', 'SRCH_REPORT', 'SRCH_RESOURCEGROUP', 'SRCH_REVREC', 'SRCH_REVRECOGNITIONSCHED', 'SRCH_ROLE', 'SRCH_RSRCALLOCATION', 'SRCH_SALESCAMPAIGN', 'SRCH_SALESTERRITORIES', 'SRCH_SAVEDSEARCH', 'SRCH_SCHEDULEDSCRIPTINSTANCE', 'SRCH_SCRIPT', 'SRCH_SCRIPTDEPLOYMENT', 'SRCH_SCRIPTNOTE', 'SRCH_SHIPITEM', 'SRCH_SHIPMENTPACKAGE', 'SRCH_SHIPPARTPACKAGE', 'SRCH_SHIPPARTREGISTRATION', 'SRCH_SHIPPARTSHIPMENT', 'SRCH_SHOPPINGCART', 'SRCH_SOLUTION', 'SRCH_STANDARDCOSTVERSION', 'SRCH_SUBSIDIARY', 'SRCH_SYSTEMNOTE', 'SRCH_TASK', 'SRCH_TAXGROUP', 'SRCH_TAXITEM', 'SRCH_TIME', 'SRCH_TIMEENTRY', 'SRCH_TIMESHEET', 'SRCH_TOPIC', 'SRCH_TRANNUMBERAUDITLOG', 'SRCH_TRANSACTION', 'SRCH_TRAN_BINTRNFR', 'SRCH_TRAN_BINWKSHT', 'SRCH_TRAN_BLANKORD', 'SRCH_TRAN_BOOKJOURNAL', 'SRCH_TRAN_BUILD', 'SRCH_TRAN_CARDCHRG', 'SRCH_TRAN_CASHRFND', 'SRCH_TRAN_CASHSALE', 'SRCH_TRAN_CHECK', 'SRCH_TRAN_COMMISSN', 'SRCH_TRAN_CUSTCHRG', 'SRCH_TRAN_CUSTCRED', 'SRCH_TRAN_CUSTDEP', 'SRCH_TRAN_CUSTINVC', 'SRCH_TRAN_CUSTPYMT', 'SRCH_TRAN_CUSTRFND', 'SRCH_TRAN_DEPAPPL', 'SRCH_TRAN_DEPOSIT', 'SRCH_TRAN_ESTIMATE', 'SRCH_TRAN_EXPREPT', 'SRCH_TRAN_FXREVAL', 'SRCH_TRAN_INVADJST', 'SRCH_TRAN_INVCOUNT', 'SRCH_TRAN_INVDISTR', 'SRCH_TRAN_INVREVAL', 'SRCH_TRAN_INVTRNFR', 'SRCH_TRAN_INVWKSHT', 'SRCH_TRAN_ITEMRCPT', 'SRCH_TRAN_ITEMSHIP', 'SRCH_TRAN_JOURNAL', 'SRCH_TRAN_LIABPYMT', 'SRCH_TRAN_OPPRTNTY', 'SRCH_TRAN_PAYCHECK', 'SRCH_TRAN_PCHKJRNL', 'SRCH_TRAN_PURCHCON', 'SRCH_TRAN_PURCHORD', 'SRCH_TRAN_PURCHREQ', 'SRCH_TRAN_REVCOMM', 'SRCH_TRAN_REVCOMRV', 'SRCH_TRAN_REVCONTR', 'SRCH_TRAN_RFQ', 'SRCH_TRAN_RTNAUTH', 'SRCH_TRAN_SALESORD', 'SRCH_TRAN_STATJOURNAL', 'SRCH_TRAN_TAXLIAB', 'SRCH_TRAN_TAXPYMT', 'SRCH_TRAN_TEGPYBL', 'SRCH_TRAN_TEGRCVBL', 'SRCH_TRAN_TRANSFER', 'SRCH_TRAN_TRNFRORD', 'SRCH_TRAN_UNBUILD', 'SRCH_TRAN_VENDAUTH', 'SRCH_TRAN_VENDBILL', 'SRCH_TRAN_VENDCRED', 'SRCH_TRAN_VENDPYMT', 'SRCH_TRAN_VENDRFQ', 'SRCH_TRAN_WOCLOSE', 'SRCH_TRAN_WOCOMPL', 'SRCH_TRAN_WOISSUE', 'SRCH_TRAN_WORKORD', 'SRCH_TRAN_YTDADJST', 'SRCH_UNITSTYPE', 'SRCH_USERNOTE', 'SRCH_VENDOR', 'SRCH_WORKCALENDAR', 'SRCH_WORKFLOW', 'SRCH_WORKFLOWINSTANCE', 'SRCH_WORKPLACE', 'SUPT_ALLOW_LOGIN', 'SUPT_BUG_BILLING', 'SUPT_BUG_SUPPORT', 'SUPT_BUG_SUPPORT_POPUP', 'SUPT_CENTER_ROLE', 'SUPT_GENERICHELP', 'SUPT_GLOSSARY', 'SUPT_GUIDES', 'SUPT_HELP', 'SUPT_MENUOPTIONS', 'SUPT_NSCENTRAL', 'SUPT_POLICYFORM', 'SUPT_RELEASENOTES', 'SUPT_SNEAKPEAK9_5', 'SUPT_VERSION_10_5', 'TRAN_ACTIVITY', 'TRAN_ADDCONTENT', 'TRAN_ADDSHORTCUT', 'TRAN_ALLOCATEPAYCHECKSTOJOBS', 'TRAN_ALLOCATIONBATCH', 'TRAN_APPROVAL_EXPREPT', 'TRAN_APPROVAL_PURCHORD', 'TRAN_APPROVECOMMISSN', 'TRAN_APPROVEPARTNERCOMMISSN', 'TRAN_AUDIT', 'TRAN_BANKRECON', 'TRAN_BANKVIEW', 'TRAN_BAS', 'TRAN_BATCHCHECK', 'TRAN_BILLOFMATERIALSINQUIRY', 'TRAN_BILLPAY_LOG', 'TRAN_BILLRUN', 'TRAN_BILLRUNRESULT', 'TRAN_BLANKORDAPPRV', 'TRAN_BUDGET', 'TRAN_BULKAUTHCOMMISSN_LOG', 'TRAN_BULKAUTHPARTNERCOMMISSN_LOG', 'TRAN_BULKBILL_LOG', 'TRAN_BULKCOMMITREVENUE_LOG', 'TRAN_BULKFULFILL_LOG', 'TRAN_BULKINVOICE_LOG', 'TRAN_BULKITEMSHIPSTATUSPACK_LOG', 'TRAN_BULKITEMSHIPSTATUSSHIP_LOG', 'TRAN_BULKRECEIVE_LOG', 'TRAN_BULKREVENUECONTRACT_LOG', 'TRAN_CALCULATEITEMDEMANDPLAN', 'TRAN_CALCULATEITEMDEMANDPLAN_STATUS', 'TRAN_CALENDARPREFERENCE', 'TRAN_CAMPAIGNSETUP', 'TRAN_CHARGEMANAGER', 'TRAN_CHECKITEMAVAILABILITY', 'TRAN_CLEARHOLD', 'TRAN_CLOSEWORKORDERS_LOG', 'TRAN_COMPLETEWORKORDERS_LOG', 'TRAN_COMPONENTWHEREUSEDINQUIRY', 'TRAN_COPY_BUDGET', 'TRAN_COSTEDBOMINQUIRY', 'TRAN_CREATEAMORTIZATIONJE', 'TRAN_CREATEAMORTIZATIONJE_LOG', 'TRAN_CREATEDEGROSSJE', 'TRAN_CREATEDEGROSSJE_LOG', 'TRAN_CREATEINTERCOADJJE', 'TRAN_CREATEINTERCOADJJE_LOG', 'TRAN_CREATEREVRECJE', 'TRAN_CREATEREVRECJE_LOG', 'TRAN_CREATE_INVCOUNT', 'TRAN_CREATE_JOBS_FROM_ORDERS', 'TRAN_CREATE_WORK_ORDERS_FOR_STOCK', 'TRAN_CREATE_WORK_ORDERS_FOR_STOCK_DEMAND_PLANNING', 'TRAN_CREATE_WORK_ORDERS_FOR_STOCK_LOG', 'TRAN_CUSTCATEGORY', 'TRAN_CUSTINVCAPPRV', 'TRAN_CUSTOMIZEITEMLIST', 'TRAN_CUSTOMIZETRANLIST', 'TRAN_DEPOSITSUMMARY', 'TRAN_DOMAINS', 'TRAN_DOMAINSADV', 'TRAN_EMAILPWD', 'TRAN_EMPLOYEESFA', 'TRAN_FINCHRG', 'TRAN_FORECAST', 'TRAN_FXREVAL_STATUS', 'TRAN_GENERATEFISCALPERIODS', 'TRAN_GENERATEITEMSUPPLYPLAN', 'TRAN_GENERATEITEMSUPPLYPLAN_STATUS', 'TRAN_GENERATETAXPERIODS', 'TRAN_GIFTCERTCREATEJE', 'TRAN_GLNUMSTATUS', 'TRAN_GSTREFUND', 'TRAN_HISTORY', 'TRAN_IMPACT', 'TRAN_INVOICECUSTOMERS', 'TRAN_ISSUEWORKORDERS_LOG', 'TRAN_ITEMGROSSREQUIREMENTS', 'TRAN_ITEMSHIPPACK', 'TRAN_ITEMSHIPSHIP', 'TRAN_JOURNALAPPROVAL', 'TRAN_LASTLOGIN', 'TRAN_LOGINAUDIT', 'TRAN_MARKBUILTWORKORDERS_LOG', 'TRAN_MARKVSOEDELIVERED', 'TRAN_MARKVSOEDELIVERED_LOG', 'TRAN_MATCHING_RULES', 'TRAN_MGRFORECAST', 'TRAN_NLVENDOR', 'TRAN_OPENBAL', 'TRAN_ORDERDEMANDPLANITEMS', 'TRAN_ORDERITEMS', 'TRAN_ORDER_REALLOCATION_LOG', 'TRAN_PAYMENTS', 'TRAN_PAYROLLBATCH', 'TRAN_PAYROLLRUN', 'TRAN_PAYROLLSTATUS', 'TRAN_PDF_F940', 'TRAN_PDF_F941', 'TRAN_PLANNEDSTANDARDCOSTROLLUP', 'TRAN_PLANNEDSTANDARDCOSTROLLUP_STATUS', 'TRAN_POSTVENDORBILLVARIANCES', 'TRAN_POSTVENDORBILLVARIANCES_STATUS', 'TRAN_PREVIEWW2', 'TRAN_PRINT', 'TRAN_PRINT1096', 'TRAN_PRINT1099', 'TRAN_PRINTBARCODES', 'TRAN_PRINTMAILINGLABELS', 'TRAN_PRINTPRICELIST', 'TRAN_PRINTSTATEMENT', 'TRAN_PRINTW2', 'TRAN_PRINTW2AUDIT', 'TRAN_PRINTW3', 'TRAN_PRINT_BOM', 'TRAN_PRINT_CASHSALE', 'TRAN_PRINT_CHECK', 'TRAN_PRINT_COMMERCIALINVOICE', 'TRAN_PRINT_CUSTCRED', 'TRAN_PRINT_CUSTINVC', 'TRAN_PRINT_ESTIMATE', 'TRAN_PRINT_INTEGRATEDSHIPPINGLABEL', 'TRAN_PRINT_ITEM_DETAIL_STATEMENT', 'TRAN_PRINT_ONE_ITEM_DETAIL_STATEMENT', 'TRAN_PRINT_PACKINGSLIP', 'TRAN_PRINT_PAYCHECK', 'TRAN_PRINT_PAYMENTVOUCHER', 'TRAN_PRINT_PICKINGTICKET', 'TRAN_PRINT_PRICELIST', 'TRAN_PRINT_PURCHORD', 'TRAN_PRINT_RTNAUTH', 'TRAN_PRINT_SALESORD', 'TRAN_PRINT_SHIPPINGLABEL', 'TRAN_PRINT_STATEMENT', 'TRAN_PROCESSCOMMISSN', 'TRAN_PROCESSICRTNAUTHS', 'TRAN_PROCESSICSALESORDERS', 'TRAN_PROCESSORDER', 'TRAN_PROCESSPARTNERCOMMISSN', 'TRAN_PURCHCONAPPRV', 'TRAN_PURCHORDPROC', 'TRAN_PURCHORDRECEIVE', 'TRAN_PURCHREQAPPRV', 'TRAN_QUOTA', 'TRAN_REALLOCITEMS', 'TRAN_RECONCILE', 'TRAN_RECONCILE_CC', 'TRAN_REIMBURSEMENTS', 'TRAN_REMINDERS', 'TRAN_REVALUESTANDARDCOSTINVENTORY', 'TRAN_REVALUESTANDARDCOSTINVENTORY_STATUS', 'TRAN_REVIEWNEGATIVEINVENTORY', 'TRAN_REVRECCREATEJE', 'TRAN_RTNAUTHAPPRV', 'TRAN_RTNAUTHCREDIT', 'TRAN_RTNAUTHRECEIVE', 'TRAN_RTNAUTHREVERSEREVCOMMITMENT', 'TRAN_SALESORDAPPRV', 'TRAN_SALESORDCOMMITREVENUE', 'TRAN_SALESORDFULFILL', 'TRAN_SALESORDPROC', 'TRAN_SALESORDREVENUECONTRACT', 'TRAN_SCHEDULE_ORDER_REALLOCATION', 'TRAN_SEARCH', 'TRAN_SHORTCUTS', 'TRAN_SNAPSHOTCOMPOSER', 'TRAN_SNAPSHOTS', 'TRAN_STATSCHEDULE', 'TRAN_TAXPERIODS', 'TRAN_TIMEAPPROVAL', 'TRAN_TIMEBILL', 'TRAN_TIMEBILL_WEEKLY', 'TRAN_TIMECALC', 'TRAN_TIMEENTRYAPPROVAL', 'TRAN_TIMEPOST', 'TRAN_TIMER', 'TRAN_TIMESHEETAPPROVAL', 'TRAN_TIMEVOID', 'TRAN_TRNFRORDAPPRV', 'TRAN_USERPREFS', 'TRAN_VENDAUTHAPPRV', 'TRAN_VENDAUTHCREDIT', 'TRAN_VENDAUTHRETURN', 'TRAN_VENDBILLAPPRV', 'TRAN_VENDBILLPURCHORD', 'TRAN_VENDPYMTS', 'TRAN_VENDPYMT_LOG', 'TRAN_WORKORDBUILD', 'TRAN_WORKORDBUILD_LOG', 'TRAN_WORKORDCLOSE', 'TRAN_WORKORDCOMPLETE', 'TRAN_WORKORDISSUE', 'TRAN_WORKORDMARKBUILT', 'TRAN_WORKORDMARKFIRMED', 'TRAN_WORKORDMARKRELEASED'] }),
+    },
+    path: [...enumsFolderPath, generic_standard_taskElemID.name],
+  }),
+  generic_standard_template: new PrimitiveType({
+    elemID: generic_standard_templateElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['-200', '-201', '-202', '-203', '-204', '-205', '-206', '-207', '-208', '-209', '-210', '-211', '-212', '-213', '-214', '-215', '-216', '-217', '-218', '-219', '-220', '-221', '-222', '-223', '-224', '-225', '-226', '-600', '-683', '-684'] }),
+    },
+    path: [...enumsFolderPath, generic_standard_templateElemID.name],
+  }),
+  generic_standard_transactions: new PrimitiveType({
+    elemID: generic_standard_transactionsElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ADVINTERCOMPANYJOURNALENTRY', 'ASSEMBLYBUILD', 'ASSEMBLYUNBUILD', 'BINTRANSFER', 'BINWORKSHEET', 'BLANKETPURCHASEORDER', 'CASHREFUND', 'CASHSALE', 'CHECK', 'CREDITCARDCHARGE', 'CREDITCARDREFUND', 'CREDITMEMO', 'CUSTOMERDEPOSIT', 'CUSTOMERPAYMENT', 'CUSTOMERPAYMENTAUTHORIZATION', 'CUSTOMERREFUND', 'DEPOSIT', 'DEPOSITAPPLICATION', 'ESTIMATE', 'EXPENSEREPORT', 'FULFILLMENTREQUEST', 'INTERCOMPANYJOURNALENTRY', 'INTERCOMPANYTRANSFERORDER', 'INVENTORYADJUSTMENT', 'INVENTORYCOSTREVALUATION', 'INVENTORYCOUNT', 'INVENTORYSTATUSCHANGE', 'INVENTORYTRANSFER', 'INVOICE', 'ITEMFULFILLMENT', 'ITEMRECEIPT', 'JOURNALENTRY', 'PAYCHECK', 'PAYCHECKJOURNAL', 'PERIODENDJOURNAL', 'PURCHASECONTRACT', 'PURCHASEORDER', 'PURCHASEREQUISITION', 'RETURNAUTHORIZATION', 'REVENUEARRANGEMENT', 'REVENUECOMMITMENT', 'REVENUECOMMITMENTREVERSAL', 'SALESORDER', 'STATISTICALJOURNALENTRY', 'STOREPICKUPFULFILLMENT', 'TRANSFERORDER', 'VENDORBILL', 'VENDORCREDIT', 'VENDORPAYMENT', 'VENDORPREPAYMENT', 'VENDORPREPAYMENTAPPLICATION', 'VENDORRETURNAUTHORIZATION', 'WAVE', 'WORKORDER', 'WORKORDERCLOSE', 'WORKORDERCOMPLETION', 'WORKORDERISSUE'] }),
+    },
+    path: [...enumsFolderPath, generic_standard_transactionsElemID.name],
+  }),
+  generic_tab_parent: new PrimitiveType({
+    elemID: generic_tab_parentElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CRMBUDGET', 'CRMCONTACTS', 'CRMKEYWORD', 'CRMMAIN', 'CRMMESSAGE', 'CRMRELATEDINFO', 'CRMRELATEDRECORDS', 'CRMSYSTEMINFORMATION', 'ENTITYACCESS', 'ENTITYACCOUNTING', 'ENTITYBUDGET', 'ENTITYCOMMUNICATION', 'ENTITYCOMPENSATIONTRACKING', 'ENTITYFINANCIAL', 'ENTITYGENERAL', 'ENTITYHUMANRESOURCES', 'ENTITYINFO', 'ENTITYMAIN', 'ENTITYMARKETING', 'ENTITYPL', 'ENTITYPREFERENCES', 'ENTITYQUALIFICATION', 'ENTITYRELATEDRECORDS', 'ENTITYRELATIONSHIPS', 'ENTITYSALES', 'ENTITYSUBSCRIPTIONS', 'ENTITYSUPPORT', 'ENTITYTIMEOFF', 'ENTITYTIMETRACKING', 'ITEMBASIC', 'ITEMCOMMUNICATION', 'ITEMINVENTORY', 'ITEMLOCATIONS', 'ITEMMAIN', 'ITEMMATRIX', 'ITEMPURCHASINGINVENTORY', 'ITEMSYSTEMINFORMATION', 'ITEMVENDORS', 'TRANSACTIONACCOUNTING', 'TRANSACTIONADDRESS', 'TRANSACTIONBILLING', 'TRANSACTIONBUILDS', 'TRANSACTIONCOMMUNICATION', 'TRANSACTIONFULFILLMENTSANDCREDITS', 'TRANSACTIONFULFILLMENTSANDRECEIPTS', 'TRANSACTIONGENERAL', 'TRANSACTIONHISTORY', 'TRANSACTIONITEMS', 'TRANSACTIONJOURNAL', 'TRANSACTIONMAIN', 'TRANSACTIONOUTPUTOPTIONS', 'TRANSACTIONPAYMENT', 'TRANSACTIONQUALIFICATION', 'TRANSACTIONRECEIPTSANDREFUNDS', 'TRANSACTIONRELATEDRECORDS', 'TRANSACTIONRELATIONSHIPS', 'TRANSACTIONSALES', 'TRANSACTIONSHIPPING', 'TRANSACTIONSYSTEMINFORMATION'] }),
+    },
+    path: [...enumsFolderPath, generic_tab_parentElemID.name],
+  }),
+  generic_tab_type: new PrimitiveType({
+    elemID: generic_tab_typeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CRM', 'ENTITY', 'ITEM', 'TRANSACTION'] }),
+    },
+    path: [...enumsFolderPath, generic_tab_typeElemID.name],
+  }),
+  generic_task: new PrimitiveType({
+    elemID: generic_taskElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ADMI_ACCOUNTCLOSE', 'ADMI_ACCOUNTMOBILITY', 'ADMI_ACCTSETUP', 'ADMI_ACHSETUP', 'ADMI_ACTIVATEBANKACCOUNT', 'ADMI_ADP', 'ADMI_ADVINVENTORYSETUP', 'ADMI_ALLOW_LOGIN', 'ADMI_BACKUP', 'ADMI_BALANCE_TRX_BY_SEGMENTS', 'ADMI_BASSETUP', 'ADMI_BILLINGEVENTS', 'ADMI_BILLINGTERMS', 'ADMI_BILLING_QEST', 'ADMI_BOUNCEDADDRESS', 'ADMI_CACHEINVALIDATIONREQUESTLISTADV', 'ADMI_CERTIFICATES', 'ADMI_CLASSESTOLOCS', 'ADMI_CLEARACCOUNT', 'ADMI_CLOSEPERIOD', 'ADMI_COMMISSIONSETUP', 'ADMI_COMPANY', 'ADMI_COMSEARCHBOOSTING', 'ADMI_CONVERTCLASSES', 'ADMI_CSVIMPORTPREF', 'ADMI_CUSTAPPTEXT', 'ADMI_CUSTOMER_SEGMENTS_MANAGER', 'ADMI_DUPLICATESETUP', 'ADMI_EMAIL', 'ADMI_EXPORTPRODUCTFEEDS', 'ADMI_EXPORTPRODUCTFEEDSADV', 'ADMI_FEATURES', 'ADMI_FINCHARGEPREF', 'ADMI_GENERAL', 'ADMI_GOVERNANCE', 'ADMI_HEADING', 'ADMI_HIERARCHYMANAGER', 'ADMI_IMAGERESIZE', 'ADMI_IMPORTADP', 'ADMI_IMPORTCSV', 'ADMI_IMPORTCSV_LOG', 'ADMI_IMPORTOLB', 'ADMI_INTEGR_APP', 'ADMI_INTERCOMPANY_SETUP', 'ADMI_INVENTORYCOSTINGSETUP', 'ADMI_INVOICESETUP', 'ADMI_ISSUEEXTSTATUS', 'ADMI_ISSUEIMPORT', 'ADMI_ISSUEPRIORITY', 'ADMI_ISSUEPRODUCT', 'ADMI_ISSUERELEASEUPDATE', 'ADMI_ISSUEREPRODUCE', 'ADMI_ISSUESETUP', 'ADMI_ISSUESEVERITY', 'ADMI_ISSUESOURCE', 'ADMI_ISSUESTATUS', 'ADMI_ISSUESTATUSFLOW', 'ADMI_ISSUETAGS', 'ADMI_ISSUETYPE', 'ADMI_ISSUEUSERTYPE', 'ADMI_KEYS', 'ADMI_LEADCUSTOMFIELDMAPPING', 'ADMI_LOGINAUDIT', 'ADMI_LOGINRESTRICT', 'ADMI_MAINTENANCEDOMAINLIST', 'ADMI_MAINTENANCEDOMAINLISTADV', 'ADMI_MANAGEPAYROLL', 'ADMI_MANAGE_PLUGINS', 'ADMI_NAMING', 'ADMI_NATIVESITEMAPGENERATOR', 'ADMI_NEXUSES', 'ADMI_NEXUSES2', 'ADMI_NOTIFICATIONS', 'ADMI_NUMBERING', 'ADMI_OAUTH_TOKENS', 'ADMI_OIDC', 'ADMI_OPENIDSSO', 'ADMI_OTHERSTUB', 'ADMI_PAYROLL', 'ADMI_PAYROLLMAP', 'ADMI_PAYROLLREP', 'ADMI_PI_REMOVAL_CREATE', 'ADMI_PI_REMOVAL_RUN', 'ADMI_PRINTING', 'ADMI_PROJECT_ACCOUNTING_SETUP', 'ADMI_REDIRECTS', 'ADMI_REDIRECTSADV', 'ADMI_RELEASEPREVIEW', 'ADMI_REVIEW_CUSTOM_GL', 'ADMI_SAMLSSO', 'ADMI_SANDBOXACCOUNTS', 'ADMI_SAVEDIMPORTS', 'ADMI_SCCONTROLTOWERSETUP', 'ADMI_SCRIPTDEBUGGER', 'ADMI_SETUPURLS', 'ADMI_SETUPURLSADV', 'ADMI_SFASETUP', 'ADMI_SHIPPING', 'ADMI_SITEMAPGENERATOR', 'ADMI_SITEMAPGENERATORADV', 'ADMI_SITEMAP_MANAGER', 'ADMI_SOFTDESCRIPTORS', 'ADMI_STATETAXIMPORT', 'ADMI_STAXMIGRATION', 'ADMI_STOREASSISTANT', 'ADMI_STORELIST', 'ADMI_STORELISTADV', 'ADMI_STOREPREVIEW', 'ADMI_STOREPREVIEWADV', 'ADMI_SUBSIDIARYSETTINGSMANAGER', 'ADMI_SUITEPROCESSORS', 'ADMI_SUITESIGNON', 'ADMI_SUPPLYALLOCATIONSETUP', 'ADMI_SUPPORTSETUP', 'ADMI_SWAPPRICES', 'ADMI_TALENT', 'ADMI_TAX', 'ADMI_TAXACCTS', 'ADMI_TAXTYPES', 'ADMI_TAXTYPES2', 'ADMI_TDCLRPOOL', 'ADMI_TDMKMSTR', 'ADMI_TEGATA', 'ADMI_TEXTCUST', 'ADMI_TEXTCUSTADV', 'ADMI_TIMEMODIFICATION', 'ADMI_TRAFFICHEALTH', 'ADMI_TRANSETUP', 'ADMI_TRANSITEMTXT', 'ADMI_TRANSLATION', 'ADMI_TWOFACTORDEVICES', 'ADMI_TWOFACTORPHONERESET', 'ADMI_TWOFACTORROLES', 'ADMI_UPDATEPRICES', 'ADMI_UPSELLSETUP', 'ADMI_URLCOMPONENTS', 'ADMI_USERACCESSRESET', 'ADMI_WEBSERVICEPREFS', 'ADMI_WEBSERVICES_STATUS', 'ADMI_WEBSERVICES_USAGE_LOG', 'ADMI_XML_ADP_SETUP', 'ADMI_XML_PAYTRUST_APPROVE', 'ADMI_XML_PAYTRUST_SETUP', 'ADMI_XML_PAYTRUST_STATUS', 'ADMI_YTDTAXLIBANDPYMTS', 'DUMM_SEPARATOR', 'EDIT_ADVANCEDORDERMANAGEMENTSETUP', 'EDIT_ALLOCATION', 'EDIT_ALLOCATIONBATCH', 'EDIT_AMORTJESCHEDULE', 'EDIT_APPPKG', 'EDIT_APPPKG_UPGRADE', 'EDIT_BILLINGACCOUNT', 'EDIT_BILLRUNSCHEDULE', 'EDIT_BUNDLE', 'EDIT_BUNDLEAUDITTRAIL', 'EDIT_CALENDARPREFERENCE', 'EDIT_CAMPAIGNBULK', 'EDIT_CHARGE', 'EDIT_CUSTADDRESSFORM', 'EDIT_CUSTPROFILE', 'EDIT_CUSTTASKS', 'EDIT_DEPLOYMENTAUDITTRAIL', 'EDIT_EDITPROFILE', 'EDIT_EMPLOYEESELF', 'EDIT_FINANCIALINSTITUTION', 'EDIT_IC_ALLOCATION', 'EDIT_IMPORT_COUPONCODE', 'EDIT_INBOUNDSHIPMENT', 'EDIT_INSTALLBUNDLE', 'EDIT_LOCASSIGNRULES_AUDIT_TRAIL', 'EDIT_MAILMERGE', 'EDIT_MEMDOC', 'EDIT_PROCESSHISTTXN', 'EDIT_PROJECTICCHARGEREQUEST', 'EDIT_RECLASSJESCHEDULE', 'EDIT_REVRECJESCHEDULE', 'EDIT_SUBSCRIPTION', 'EDIT_SUITEAPPLIST', 'EDIT_SUPPORTCASE', 'EDIT_TIMEOFFREQUEST', 'EDIT_TIMESHEET', 'EDIT_TRAN_ADJJOURNAL', 'EDIT_TRAN_ADVICJOURNAL', 'EDIT_TRAN_BINTRNFR', 'EDIT_TRAN_BINWKSHT', 'EDIT_TRAN_BLANKORD', 'EDIT_TRAN_BOOKADVICJOURNAL', 'EDIT_TRAN_BOOKICJOURNAL', 'EDIT_TRAN_BOOKJOURNAL', 'EDIT_TRAN_BUILD', 'EDIT_TRAN_CARDCHRG', 'EDIT_TRAN_CASHRFND', 'EDIT_TRAN_CASHSALE', 'EDIT_TRAN_CHECK', 'EDIT_TRAN_COMMISSN', 'EDIT_TRAN_CUSTAUTH', 'EDIT_TRAN_CUSTCHRG', 'EDIT_TRAN_CUSTCRED', 'EDIT_TRAN_CUSTDEP', 'EDIT_TRAN_CUSTINVC', 'EDIT_TRAN_CUSTPYMT', 'EDIT_TRAN_CUSTRFND', 'EDIT_TRAN_DEPOSIT', 'EDIT_TRAN_ESTIMATE', 'EDIT_TRAN_EXPREPT', 'EDIT_TRAN_FXREVAL', 'EDIT_TRAN_ICJOURNAL', 'EDIT_TRAN_ICTRNFRORD', 'EDIT_TRAN_INVADJST', 'EDIT_TRAN_INVCOUNT', 'EDIT_TRAN_INVDISTR', 'EDIT_TRAN_INVREVAL', 'EDIT_TRAN_INVTRNFR', 'EDIT_TRAN_INVWKSHT', 'EDIT_TRAN_JOURNAL', 'EDIT_TRAN_LIABPYMT', 'EDIT_TRAN_OPPRTNTY', 'EDIT_TRAN_ORDERPURCHREQ', 'EDIT_TRAN_PARTNERCOMMISSN', 'EDIT_TRAN_PCHKJRNL', 'EDIT_TRAN_PURCHCON', 'EDIT_TRAN_PURCHORD', 'EDIT_TRAN_PURCHREQ', 'EDIT_TRAN_REPLENISHINVENTORY', 'EDIT_TRAN_REPLENISHLOC', 'EDIT_TRAN_RFQ', 'EDIT_TRAN_RTNAUTH', 'EDIT_TRAN_SALESORD', 'EDIT_TRAN_STATCHNG', 'EDIT_TRAN_STATJOURNAL', 'EDIT_TRAN_STATSCHEDULE', 'EDIT_TRAN_TAXLIAB', 'EDIT_TRAN_TAXLIAB2', 'EDIT_TRAN_TAXPYMT', 'EDIT_TRAN_TAXPYMT2', 'EDIT_TRAN_TAXPYMTCA', 'EDIT_TRAN_TEGCOLLECT', 'EDIT_TRAN_TEGPAY', 'EDIT_TRAN_TEGPYBL', 'EDIT_TRAN_TEGRCVBL', 'EDIT_TRAN_TRANSFER', 'EDIT_TRAN_TRNFRORD', 'EDIT_TRAN_UNBUILD', 'EDIT_TRAN_VATLIABAU', 'EDIT_TRAN_VENDAUTH', 'EDIT_TRAN_VENDBILL', 'EDIT_TRAN_VENDCRED', 'EDIT_TRAN_VENDORPREPAYMENT', 'EDIT_TRAN_VENDPYMT', 'EDIT_TRAN_WAVE', 'EDIT_TRAN_WITHDRAWINVENTORY', 'EDIT_TRAN_WORKORD', 'EDIT_TRAN_YTDADJST', 'EDIT_UNLOCKEDTIMEPERIOD', 'EDIT_UPGRADEBUNDLE', 'EDIT_USAGE', 'EXTL_10', 'EXTL_10_1', 'EXTL_12', 'EXTL_2', 'EXTL_9', 'EXTL_9_1', 'INTL_SECTIONS', 'INTL_TASKLINKS', 'LIST_ACCOUNT', 'LIST_ACCOUNTINGBOOK', 'LIST_ACCOUNTINGOTHERLIST', 'LIST_ACTIVITY', 'LIST_ADP_BATCHES', 'LIST_ADP_PAYCHECK', 'LIST_ADVPDFTEMPLATE', 'LIST_ADVRECORDCUST', 'LIST_ALLOCATEORDERS', 'LIST_AMORTIZATION', 'LIST_AMORTIZATIONSCHEDULE', 'LIST_APPDEF', 'LIST_APPPUBLISHERS', 'LIST_APPROVEACH', 'LIST_APPROVEEFT', 'LIST_APPROVERTIMEENTRY', 'LIST_APPROVEVP', 'LIST_AUTHORIZATIONCONSENT', 'LIST_BALANCE_OVERVIEW', 'LIST_BILLINGACCOUNT', 'LIST_BILLINGCLASS', 'LIST_BILLINGRATECARD', 'LIST_BILLINGREVENUEEVENT', 'LIST_BILLINGREVENUEEVENTTYPE', 'LIST_BILLINGSCHEDULE', 'LIST_BILLING_GROUPS', 'LIST_BILLOFDISTRIBUTION', 'LIST_BILLRUN', 'LIST_BILLRUNSCHEDULE', 'LIST_BIN', 'LIST_BOM', 'LIST_BONUSTYPE', 'LIST_BUDGETRATES', 'LIST_BULKOP', 'LIST_BULKPROCSUBMISSION', 'LIST_CALENDAR', 'LIST_CALL', 'LIST_CAMPAIGN', 'LIST_CAMPAIGNAUDIENCE', 'LIST_CAMPAIGNCATEGORY', 'LIST_CAMPAIGNCHANNEL', 'LIST_CAMPAIGNEMAIL', 'LIST_CAMPAIGNFAMILY', 'LIST_CAMPAIGNOFFER', 'LIST_CAMPAIGNSEARCHENGINE', 'LIST_CAMPAIGNSUBSCRIPTION', 'LIST_CAMPAIGNVERTICAL', 'LIST_CASEALERT', 'LIST_CASEFIELDRULE', 'LIST_CASEFORM', 'LIST_CASEISSUE', 'LIST_CASEORIGIN', 'LIST_CASEPRIORITY', 'LIST_CASEPROFILE', 'LIST_CASESTATUS', 'LIST_CASETERRITORY', 'LIST_CASETERRITORYASSIGN', 'LIST_CASETYPE', 'LIST_CCTRAN', 'LIST_CHARGE', 'LIST_CHARGERULE', 'LIST_CHART_ACCOUNT', 'LIST_CLASS', 'LIST_CLASSSEGMENTMAPPING', 'LIST_CMSCONTENT', 'LIST_CMSCONTENTTYPE', 'LIST_CMSPAGE', 'LIST_CMSPAGETYPE', 'LIST_COLORTHEME', 'LIST_COMMERCECATALOG', 'LIST_COMMERCECATEGORY', 'LIST_COMMISSIONSCHEDULE', 'LIST_COMPETITOR', 'LIST_COMSEARCHBOOST', 'LIST_COMSEARCHBOOSTTYPE', 'LIST_COMSEARCHGROUPSYNONYM', 'LIST_COMSEARCHONEWAYSYNONYM', 'LIST_CONSOLRATES', 'LIST_CONTACT', 'LIST_COUNTRY', 'LIST_CRMGROUP', 'LIST_CRMOTHERLIST', 'LIST_CRMTEMPLATE', 'LIST_CSPSETUP', 'LIST_CURRENCY', 'LIST_CURRENCYRATE', 'LIST_CURRENCYRATETYPE', 'LIST_CUSTADDRESSENTRYFORM', 'LIST_CUSTBODYFIELD', 'LIST_CUSTCATEGORY', 'LIST_CUSTCENTER', 'LIST_CUSTCOLUMNFIELD', 'LIST_CUSTEMAILLAYOUT', 'LIST_CUSTENTITYFIELD', 'LIST_CUSTENTRYFORM', 'LIST_CUSTEVENTFIELD', 'LIST_CUSTFIELDTAB', 'LIST_CUSTFORM', 'LIST_CUSTITEMFIELD', 'LIST_CUSTITEMNUMBERFIELD', 'LIST_CUSTJOB', 'LIST_CUSTLAYOUT', 'LIST_CUSTLIST', 'LIST_CUSTOMCODEFILES', 'LIST_CUSTOMERFIELDRULE', 'LIST_CUSTOMERFORM', 'LIST_CUSTOMERSTATUS', 'LIST_CUSTOMIZEDFIELDLEVELHELP', 'LIST_CUSTOMSEGMENT', 'LIST_CUSTOMSUBLIST', 'LIST_CUSTOTHERFIELD', 'LIST_CUSTRECORD', 'LIST_CUSTSECTION', 'LIST_CUSTSUBLISTFIELD', 'LIST_CUSTTRANSACTION', 'LIST_DEPARTMENT', 'LIST_DEPTSEGMENTMAPPING', 'LIST_DEVICE_ID', 'LIST_DIFFROLE', 'LIST_DISTRIBUTIONNETWORK', 'LIST_DRIVERSLICENSE', 'LIST_DUPLICATE_RESOLUTION_STATUS', 'LIST_EMAILTEMPLATE', 'LIST_EMPLCATEGORY', 'LIST_EMPLOYEECHANGEREASON', 'LIST_EMPLOYEECHANGEREQUEST', 'LIST_EMPLOYEECHANGETYPE', 'LIST_EMPLOYEE_RECORD', 'LIST_EMPOTHERLIST', 'LIST_ENTITYACCOUNTMAPPING', 'LIST_ENTITY_DUPLICATES', 'LIST_ESCALATIONRULE', 'LIST_ESCALATIONTERRITORY', 'LIST_EVENT', 'LIST_EXPCATEGORY', 'LIST_EXPENSEAMORTIZATIONEVENT', 'LIST_EXPENSEAMORTIZATIONRULE', 'LIST_EXPENSEPLAN', 'LIST_FAIRVALUEDIMENSION', 'LIST_FAIRVALUEFORMULA', 'LIST_FAIRVALUEPRICE', 'LIST_FAXTEMPLATE', 'LIST_FCSITEFOLDER', 'LIST_FCSITEFOLDERADV', 'LIST_FISCALCALENDAR', 'LIST_FULFILLMENTEXCEPTIONREASON', 'LIST_GAINLOSSACCTMAPPING', 'LIST_GATEWAYNOTIFICATION', 'LIST_GENERICRESOURCE', 'LIST_GIFTCERTIFICATES', 'LIST_GLNUMBERING', 'LIST_GLOBALACCOUNTMAPPING', 'LIST_GLOBALINVTRELATIONSHIP', 'LIST_GOAL', 'LIST_GOVERNMENTISSUEDIDTYPE', 'LIST_HCMJOB', 'LIST_IMAGE', 'LIST_INFOITEM', 'LIST_INFOITEMFORM', 'LIST_INVCOSTTEMPLATE', 'LIST_INVENTORYSTATUS', 'LIST_ISSUE', 'LIST_ITEM', 'LIST_ITEMACCOUNTMAPPING', 'LIST_ITEMCOLLECTION', 'LIST_ITEMDEMANDPLAN', 'LIST_ITEMLOCCONFIG_LOG', 'LIST_ITEMOPTION', 'LIST_ITEMPROCESSFAMILY', 'LIST_ITEMPROCESSGROUP', 'LIST_ITEMREVENUECATEGORY', 'LIST_ITEMSUPPLYPLAN', 'LIST_ITEM_REVISION', 'LIST_JOB', 'LIST_JOBREQUISITION', 'LIST_JOBRESOURCEROLE', 'LIST_KBCATEGORY', 'LIST_KPIREPORT', 'LIST_KUDOS', 'LIST_LEAD', 'LIST_LOCASSIGNCONF', 'LIST_LOCATION', 'LIST_LOCATIONCOSTINGGROUP', 'LIST_LOCSEGMENTMAPPING', 'LIST_MAILMERGE', 'LIST_MAILTEMPLATE', 'LIST_MAPREDUCESCRIPTSTATUS', 'LIST_MEDIAITEMFOLDER', 'LIST_MERCHANDISEHIERARCHYLEVEL', 'LIST_MERCHANDISEHIERARCHYNODE', 'LIST_MERCHANDISEHIERARCHYVERSION', 'LIST_MFGCOSTTEMPLATE', 'LIST_MFGOPERATIONTASK', 'LIST_MFGROUTING', 'LIST_MYSUITEAPPS', 'LIST_NETTINGBALANCE', 'LIST_NETTINGTRX', 'LIST_NEWSITEM', 'LIST_NOTIFICATION', 'LIST_ORDERALLOCATIONSTRATEGY', 'LIST_ORGANIZATIONVALUE', 'LIST_OTHERGOVERNMENTISSUEDID', 'LIST_OTHERNAME', 'LIST_OUTBOUNDEMAILLOG', 'LIST_OUTBOUNDREQUEST', 'LIST_PARTNER', 'LIST_PARTNERCOMMISSIONSCHED', 'LIST_PARTNERPLANASSIGN', 'LIST_PARTNERPLANASSIGNS', 'LIST_PASSPORT', 'LIST_PAYMENTEVENT', 'LIST_PAYMENTPROFILE', 'LIST_PAYMETHODS', 'LIST_PAYPALACCOUNT', 'LIST_PAYROLLITEM', 'LIST_PAYTERMS', 'LIST_PDFTEMPLATE', 'LIST_PERFORMANCEMETRIC', 'LIST_PERFORMANCEREVIEW', 'LIST_PERFORMANCEREVIEWQUESTION', 'LIST_PERFORMANCEREVIEWRATINGSCALE', 'LIST_PERFORMANCEREVIEWSCHEDULE', 'LIST_PERFORMANCEREVIEWTEMPLATE', 'LIST_PERIOD', 'LIST_PERMISSION', 'LIST_PICKSTRATEGY', 'LIST_PICKTASK', 'LIST_PLANASSIGN', 'LIST_PLANASSIGNS', 'LIST_PLANNEDSTANDARDCOST', 'LIST_PLUGIN', 'LIST_PLUGINTYPE', 'LIST_POSITION', 'LIST_PRESCATEGORY', 'LIST_PRIORITYSETTINGS', 'LIST_PROJECTEXPENSETYPE', 'LIST_PROJECTTASK', 'LIST_PROJECTTEMPLATE', 'LIST_PROJECT_PROFITABILITY', 'LIST_PROSPECT', 'LIST_QUANTITYPRICINGSCHEDULE', 'LIST_RECVDFILES', 'LIST_REFERRALCODE', 'LIST_REGION', 'LIST_RELATEDITEM', 'LIST_RELATEDITEMADV', 'LIST_REPORESULT', 'LIST_REPOSCHEDULE', 'LIST_RESOURCE', 'LIST_RESOURCEGROUP', 'LIST_RESTRICTION', 'LIST_REVENUEALLOCATIONGROUP', 'LIST_REVENUEELEMENT', 'LIST_REVENUEPLAN', 'LIST_REVENUERECOGNITIONRULE', 'LIST_REVRECFIELDMAPPING', 'LIST_REVRECSCHEDS', 'LIST_REVRECSCHEDULE', 'LIST_REVRECTREATMENT', 'LIST_REVRECTREATMENTRULE', 'LIST_ROLE', 'LIST_RSRCALLOCATION', 'LIST_RSSFEED', 'LIST_SALESCAMPAIGN', 'LIST_SALESTEAM', 'LIST_SALESTERRITORIES', 'LIST_SALESTERRITORY', 'LIST_SALESTERRITORYASSIGN', 'LIST_SAVEDBULKOP', 'LIST_SAVEDSEARCH', 'LIST_SCHEDULEDSUPPLYCHAINSNAPSHOTREFRESH', 'LIST_SCRIPT', 'LIST_SCRIPTEDRECORD', 'LIST_SCRIPTLOGS', 'LIST_SCRIPTRECORD', 'LIST_SCRIPTSTATUS', 'LIST_SC_CONTROLTOWERDASHBRD', 'LIST_SC_SNAPSHOTS', 'LIST_SEARCHRESULTS', 'LIST_SEARCHRESULTSARCHIVE', 'LIST_SENTFILES', 'LIST_SHIPITEM', 'LIST_SITEEMAILTEMPLATE', 'LIST_SITEITEMTEMPLAT', 'LIST_SITETAGS', 'LIST_SITETHEMES', 'LIST_SOLUTION', 'LIST_SPA', 'LIST_SSCATEGORY', 'LIST_STANDARDCOSTVERSION', 'LIST_STATE', 'LIST_STATUSACH', 'LIST_STATUSEFT', 'LIST_STATUSVP', 'LIST_STOREITEMLISTLAYOUT', 'LIST_STORETAB', 'LIST_SUBSCRIPTION', 'LIST_SUBSCRIPTIONCHANGEORDER', 'LIST_SUBSCRIPTIONCHANGEORDER2', 'LIST_SUBSCRIPTIONPLAN', 'LIST_SUBSCRIPTIONRENEWALHISTORY', 'LIST_SUBSCRIPTIONRENEWALHISTORY2', 'LIST_SUBSIDIARY', 'LIST_SUITEAPPS_MARKET', 'LIST_SUPPLYCHAINSNAPSHOTSIMULATION', 'LIST_SUPPORTCASE', 'LIST_SYSALERT', 'LIST_SYSTEMEMAILTEMPLATE', 'LIST_TASK', 'LIST_TAXGROUP', 'LIST_TAXITEM', 'LIST_TAXITEM2', 'LIST_TAXPERIOD', 'LIST_TAXREPORT', 'LIST_TAXSCHEDULE', 'LIST_TEMPLATEFILES', 'LIST_TEMPLATE_CATEGORY', 'LIST_TERMINATIONREASON', 'LIST_TIMEOFFCHANGE', 'LIST_TIMEOFFPLAN', 'LIST_TIMEOFFREQUEST', 'LIST_TIMEOFFTYPE', 'LIST_TOPIC', 'LIST_TRANNUMBERAUDITLOG', 'LIST_TRANSACTION', 'LIST_TRAN_BALJRNAL', 'LIST_TRAN_BINTRNFR', 'LIST_TRAN_BINWKSHT', 'LIST_TRAN_BLANKORD', 'LIST_TRAN_CARDCHRG', 'LIST_TRAN_CASHRFND', 'LIST_TRAN_CASHSALE', 'LIST_TRAN_CHECK', 'LIST_TRAN_COMMISSN', 'LIST_TRAN_CUSTAUTH', 'LIST_TRAN_CUSTCHRG', 'LIST_TRAN_CUSTCRED', 'LIST_TRAN_CUSTDEP', 'LIST_TRAN_CUSTINVC', 'LIST_TRAN_CUSTPYMT', 'LIST_TRAN_CUSTRFND', 'LIST_TRAN_DEPOSIT', 'LIST_TRAN_DOWNLOAD', 'LIST_TRAN_ESTIMATE', 'LIST_TRAN_EXPREPT', 'LIST_TRAN_FFTREQ', 'LIST_TRAN_FXREVAL', 'LIST_TRAN_INVADJST', 'LIST_TRAN_INVDISTR', 'LIST_TRAN_INVTRNFR', 'LIST_TRAN_INVWKSHT', 'LIST_TRAN_JOURNAL', 'LIST_TRAN_LIABPYMT', 'LIST_TRAN_OPPRTNTY', 'LIST_TRAN_OWNTRNSF', 'LIST_TRAN_PAYCHECK2', 'LIST_TRAN_PEJRNL', 'LIST_TRAN_PURCHCON', 'LIST_TRAN_PURCHORD', 'LIST_TRAN_PURCHORD_REQ', 'LIST_TRAN_PURCHREQ', 'LIST_TRAN_REORDER', 'LIST_TRAN_REVARRNG', 'LIST_TRAN_RFQ', 'LIST_TRAN_RTNAUTH', 'LIST_TRAN_SALESORD', 'LIST_TRAN_TAXLIAB', 'LIST_TRAN_TAXPYMT', 'LIST_TRAN_TRANSFER', 'LIST_TRAN_VENDAUTH', 'LIST_TRAN_VENDBILL', 'LIST_TRAN_VENDCRED', 'LIST_TRAN_VENDPYMT', 'LIST_UNCATSITEITEM', 'LIST_UNCATSITEITEMADV', 'LIST_UNDELIVEREDEMAIL', 'LIST_UNITSTYPE', 'LIST_UPSELLWIZARD', 'LIST_URLALIASES', 'LIST_USAGE', 'LIST_USER', 'LIST_VENDOR', 'LIST_WEBAPPS', 'LIST_WEBAPPSADV', 'LIST_WORKCALENDAR', 'LIST_WORKFLOW', 'LIST_WORKPLACE', 'LIST_ZONE', 'REPO_10', 'REPO_100', 'REPO_103', 'REPO_104', 'REPO_105', 'REPO_106', 'REPO_107', 'REPO_11', 'REPO_111', 'REPO_113', 'REPO_114', 'REPO_118', 'REPO_121', 'REPO_126', 'REPO_127', 'REPO_128', 'REPO_13', 'REPO_131', 'REPO_133', 'REPO_134', 'REPO_14', 'REPO_141', 'REPO_143', 'REPO_145', 'REPO_147', 'REPO_148', 'REPO_15', 'REPO_150', 'REPO_151', 'REPO_152', 'REPO_16', 'REPO_162', 'REPO_170', 'REPO_172', 'REPO_174', 'REPO_176', 'REPO_178', 'REPO_179', 'REPO_18', 'REPO_180', 'REPO_183', 'REPO_184', 'REPO_185', 'REPO_188', 'REPO_19', 'REPO_191', 'REPO_193', 'REPO_194', 'REPO_196', 'REPO_197', 'REPO_199', 'REPO_2', 'REPO_20', 'REPO_203', 'REPO_205', 'REPO_209', 'REPO_21', 'REPO_210', 'REPO_211', 'REPO_215', 'REPO_219', 'REPO_22', 'REPO_221', 'REPO_222', 'REPO_223', 'REPO_225', 'REPO_229', 'REPO_230', 'REPO_231', 'REPO_232', 'REPO_233', 'REPO_234', 'REPO_235', 'REPO_240', 'REPO_241', 'REPO_242', 'REPO_243', 'REPO_246', 'REPO_249', 'REPO_250', 'REPO_256', 'REPO_257', 'REPO_26', 'REPO_261', 'REPO_262', 'REPO_266', 'REPO_267', 'REPO_269', 'REPO_270', 'REPO_271', 'REPO_272', 'REPO_273', 'REPO_274', 'REPO_277', 'REPO_278', 'REPO_28', 'REPO_281', 'REPO_282', 'REPO_283', 'REPO_284', 'REPO_286', 'REPO_292', 'REPO_293', 'REPO_30', 'REPO_32', 'REPO_34', 'REPO_36', 'REPO_37', 'REPO_38', 'REPO_39', 'REPO_4', 'REPO_40', 'REPO_41', 'REPO_42', 'REPO_43', 'REPO_44', 'REPO_49', 'REPO_5', 'REPO_51', 'REPO_53', 'REPO_54', 'REPO_55', 'REPO_57', 'REPO_58', 'REPO_59', 'REPO_6', 'REPO_60', 'REPO_63', 'REPO_64', 'REPO_65', 'REPO_67', 'REPO_68', 'REPO_69', 'REPO_72', 'REPO_74', 'REPO_78', 'REPO_79', 'REPO_8', 'REPO_80', 'REPO_81', 'REPO_84', 'REPO_85', 'REPO_9', 'REPO_90', 'REPO_91', 'REPO_94', 'REPO_95', 'REPO_96', 'REPO_98', 'REPO_99', 'REPO_ASSIGNFINANCIALLAYOUTS', 'REPO_BANKREGISTER', 'REPO_CUST_PAGE', 'REPO_FINANCIALLAYOUTS', 'REPO_GST34', 'REPO_HEADCOUNT_ANALYSIS', 'REPO_NEG100', 'REPO_NEG105', 'REPO_NEG106', 'REPO_NEG108', 'REPO_NEG110', 'REPO_NEG112', 'REPO_NEG113', 'REPO_NEG114', 'REPO_NEG116', 'REPO_NEG118', 'REPO_NEG120', 'REPO_NEG122', 'REPO_NEG124', 'REPO_NEG127', 'REPO_NEG128', 'REPO_NEG129', 'REPO_NEG130', 'REPO_NEG131', 'REPO_NEG132', 'REPO_NEG133', 'REPO_NEG135', 'REPO_NEG137', 'REPO_NEG138', 'REPO_NEG140', 'REPO_NEG144', 'REPO_NEG146', 'REPO_NEG148', 'REPO_NEG150', 'REPO_NEG151', 'REPO_NEG152', 'REPO_NEG153', 'REPO_NEG154', 'REPO_NEG155', 'REPO_NEG156', 'REPO_NEG157', 'REPO_NEG158', 'REPO_NEG159', 'REPO_NEG160', 'REPO_NEG161', 'REPO_NEG162', 'REPO_NEG175', 'REPO_NEG178', 'REPO_NEG179', 'REPO_NEG180', 'REPO_NEG181', 'REPO_NEG182', 'REPO_NEG183', 'REPO_NEG184', 'REPO_NEG185', 'REPO_NEG186', 'REPO_NEG187', 'REPO_NEG188', 'REPO_NEG196', 'REPO_NEG197', 'REPO_NEG198', 'REPO_NEG199', 'REPO_NEG200', 'REPO_NEG201', 'REPO_NEG202', 'REPO_NEG203', 'REPO_NEG209', 'REPO_NEG210', 'REPO_NEG211', 'REPO_NEG212', 'REPO_NEG213', 'REPO_NEG215', 'REPO_NEG221', 'REPO_NEG222', 'REPO_NEG223', 'REPO_NEG224', 'REPO_NEG225', 'REPO_NEG226', 'REPO_NEG227', 'REPO_NEG228', 'REPO_NEG231', 'REPO_NEG232', 'REPO_NEG233', 'REPO_NEG236', 'REPO_NEG237', 'REPO_NEG239', 'REPO_NEG240', 'REPO_NEG241', 'REPO_NEG242', 'REPO_NEG245', 'REPO_NEG246', 'REPO_NEG247', 'REPO_NEG248', 'REPO_NEG249', 'REPO_NEG250', 'REPO_NEG253', 'REPO_NEG254', 'REPO_NEG255', 'REPO_NEG256', 'REPO_NEG257', 'REPO_NEG258', 'REPO_NEG259', 'REPO_NEG260', 'REPO_NEG265', 'REPO_NEG271', 'REPO_NEG277', 'REPO_NEG281', 'REPO_NEG282', 'REPO_NEG284', 'REPO_NEG285', 'REPO_NEG289', 'REPO_NEG291', 'REPO_NEG292', 'REPO_NEG295', 'REPO_NEG296', 'REPO_NEG297', 'REPO_NEG298', 'REPO_NEG299', 'REPO_NEG305', 'REPO_NEG306', 'REPO_NEG307', 'REPO_NEG308', 'REPO_NEG309', 'REPO_NEG310', 'REPO_NEG311', 'REPO_NEG314', 'REPO_NEG316', 'REPO_NEG320', 'REPO_NEG326', 'REPO_NEG330', 'REPO_REGISTER_ACCTPAY', 'REPO_REGISTER_ACCTREC', 'REPO_TURNOVER_ANALYSIS', 'SRCH_CUSTBAL', 'SRCH_CUSTOVDBAL', 'SRCH_EMPLOYEECHANGEREQUEST_MYREQ', 'SRCH_EMPLOYEECHANGEREQUEST_PENDINGREQ', 'SRCH_SAVEDSEARCH', 'SRCH_TRANSACTION', 'SRCH_UNBILLORDERS', 'SUPT_ALLOW_LOGIN', 'SUPT_BUG_BILLING', 'SUPT_BUG_SUPPORT', 'SUPT_BUG_SUPPORT_POPUP', 'SUPT_CENTER_ROLE', 'SUPT_GLOSSARY', 'SUPT_HELP', 'SUPT_MENUOPTIONS', 'SUPT_POLICYFORM', 'SUPT_RELEASENOTES', 'SUPT_VERSION_10_5', 'TRAN_ALLOCATEPAYCHECKSTOJOBS', 'TRAN_ALLOCATEREVENUEARRANGEMENTS', 'TRAN_APPROVAL_EXPREPT', 'TRAN_APPROVAL_PURCHORD', 'TRAN_APPROVECOMMISSN', 'TRAN_APPROVEPARTNERCOMMISSN', 'TRAN_AUDIT', 'TRAN_AUTO_CASH', 'TRAN_BALANCELCGACCOUNTS', 'TRAN_BAS', 'TRAN_BILLOFMATERIALSINQUIRY', 'TRAN_BILLRUN', 'TRAN_BLANKORDAPPRV', 'TRAN_BUDGET', 'TRAN_CALCULATEITEMDEMANDPLAN', 'TRAN_CAMPAIGNSETUP', 'TRAN_CHARGEMANAGER', 'TRAN_CHECKITEMAVAILABILITY', 'TRAN_CLEARHOLD', 'TRAN_COMPONENTWHEREUSEDINQUIRY', 'TRAN_CONFIRMTRANSACTIONS', 'TRAN_COPY_BUDGET', 'TRAN_COSTEDBOMINQUIRY', 'TRAN_CREATEAMORTIZATIONJE', 'TRAN_CREATEDEGROSSJE', 'TRAN_CREATEINTERCOADJJE', 'TRAN_CREATEREVRECJE', 'TRAN_CREATE_INVCOUNT', 'TRAN_CREATE_JOBS_FROM_ORDERS', 'TRAN_CREATE_WORK_ORDERS_FOR_STOCK', 'TRAN_CREATE_WORK_ORDERS_FOR_STOCK_DEMAND_PLANNING', 'TRAN_CUSTINVCAPPRV', 'TRAN_DOMAINS', 'TRAN_DOMAINSADV', 'TRAN_EDITREVENUEARRANGEMENTS', 'TRAN_FINCHRG', 'TRAN_FORECAST', 'TRAN_GENERATEITEMSUPPLYPLAN', 'TRAN_GIFTCERTCREATEJE', 'TRAN_GSTREFUND', 'TRAN_INVOICECUSTOMERS', 'TRAN_INVOICEGROUP', 'TRAN_ITEMGROSSREQUIREMENTS', 'TRAN_ITEMSHIPPACK', 'TRAN_ITEMSHIPSHIP', 'TRAN_JOURNALAPPROVAL', 'TRAN_MANAGEARRANGEMENTS', 'TRAN_MANAGEEXPENSEPLANS', 'TRAN_MANAGEREVENUEARRANGEMENTS', 'TRAN_MANAGEREVENUEPLANS', 'TRAN_MARKVSOEDELIVERED', 'TRAN_MATCHING_RULES', 'TRAN_MERGEREVENUEARRANGEMENTS', 'TRAN_MGRFORECAST', 'TRAN_MIGRATEOPENREVENUETRANSACTIONS', 'TRAN_OPENBAL', 'TRAN_ORDERDEMANDPLANITEMS', 'TRAN_ORDERITEMS', 'TRAN_ORDER_REALLOCATION', 'TRAN_PAYROLLRUN', 'TRAN_PAYROLLSTATUS', 'TRAN_PDF_F940', 'TRAN_PDF_F941', 'TRAN_PLANNEDSTANDARDCOSTROLLUP', 'TRAN_POSTVENDORBILLVARIANCES', 'TRAN_PRINT', 'TRAN_PRINTPRICELIST', 'TRAN_PRINTSTATEMENT', 'TRAN_PRINTW2', 'TRAN_PRINTW2AUDIT', 'TRAN_PRINTW3', 'TRAN_PRINT_PACKINGSLIP', 'TRAN_PRINT_PICKINGTICKET', 'TRAN_PRINT_PRICELIST', 'TRAN_PRINT_STATEMENT', 'TRAN_PROCESSCOMMISSN', 'TRAN_PROCESSICRTNAUTHS', 'TRAN_PROCESSICSALESORDERS', 'TRAN_PROCESSORDER', 'TRAN_PROCESSPARTNERCOMMISSN', 'TRAN_PROMOTIONS_PREFERENCES', 'TRAN_PURCHCONAPPRV', 'TRAN_PURCHORDPROC', 'TRAN_PURCHORDRECEIVE', 'TRAN_PURCHREQAPPRV', 'TRAN_QUOTA', 'TRAN_REALLOCITEMS', 'TRAN_RECALCULATEEXPENSEFORECASTPLANS', 'TRAN_RECALCULATEREVENUEFORECASTPLANS', 'TRAN_RECONCILE', 'TRAN_RECONCILEACCOUNTSTATEMENT', 'TRAN_RECONCILE_CC', 'TRAN_REVALUESTANDARDCOSTINVENTORY', 'TRAN_REVARRNGAPPRV', 'TRAN_REVIEWNEGATIVEINVENTORY', 'TRAN_RTNAUTHAPPRV', 'TRAN_RTNAUTHCREDIT', 'TRAN_RTNAUTHRECEIVE', 'TRAN_RTNAUTHREVERSEREVCOMMITMENT', 'TRAN_SALESORDAPPRV', 'TRAN_SALESORDCOMMITREVENUE', 'TRAN_SALESORDFULFILL', 'TRAN_SALESORDPROC', 'TRAN_SALESORDREVENUECONTRACT', 'TRAN_SEARCH', 'TRAN_STPICKUP', 'TRAN_TIMEAPPROVAL', 'TRAN_TIMEBILL', 'TRAN_TIMEBILL_WEEKLY', 'TRAN_TIMEPOST', 'TRAN_TIMESHEETAPPROVAL', 'TRAN_TIMEVOID', 'TRAN_TRNFRORDAPPRV', 'TRAN_UPDATEEXPENSEPLANS', 'TRAN_UPDATEREVENUERECOGNITIONPLANS', 'TRAN_VENDAUTHAPPRV', 'TRAN_VENDAUTHCREDIT', 'TRAN_VENDAUTHRETURN', 'TRAN_VENDBILLAPPRV', 'TRAN_VENDPYMTAPPRV', 'TRAN_VENDPYMTS', 'TRAN_WEEKLY_TIMESHEET', 'TRAN_WORKORDBUILD', 'TRAN_WORKORDCLOSE', 'TRAN_WORKORDCOMPLETE', 'TRAN_WORKORDISSUE', 'TRAN_WORKORDMARKBUILT', 'TRAN_WORKORDMARKFIRMED', 'TRAN_WORKORDMARKRELEASED'] }),
+    },
+    path: [...enumsFolderPath, generic_taskElemID.name],
+  }),
+  generic_year_month: new PrimitiveType({
+    elemID: generic_year_monthElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['1', '10', '11', '12', '2', '3', '4', '5', '6', '7', '8', '9'] }),
+    },
+    path: [...enumsFolderPath, generic_year_monthElemID.name],
+  }),
+  hiding_actions: new PrimitiveType({
+    elemID: hiding_actionsElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['HIDE', 'UNHIDE'] }),
+    },
+    path: [...enumsFolderPath, hiding_actionsElemID.name],
+  }),
+  itemcustomfield_itemsubtype: new PrimitiveType({
+    elemID: itemcustomfield_itemsubtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BOTH', 'PURCHASE', 'SALE'] }),
+    },
+    path: [...enumsFolderPath, itemcustomfield_itemsubtypeElemID.name],
+  }),
+  itemnumbercustomfield_field: new PrimitiveType({
+    elemID: itemnumbercustomfield_fieldElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ADJUSTQTYBY', 'ALTSALESAMT', 'AMORTIZATIONENDDATE', 'AMORTIZATIONRESIDUAL', 'AMORTIZATIONSCHED', 'AMORTIZSTARTDATE', 'AMOUNT', 'AMOUNTORDERED', 'AMOUNTRECOGNIZED', 'AMOUNTREMAINING', 'AVERAGECOST', 'BALANCE', 'BILLEDDATE', 'BILLINGSCHEDULE', 'BILLRECEIPTS', 'BILLVARIANCESTATUS', 'BINNUMBERS', 'BINNUMBERSSTOCK', 'BOMQUANTITY', 'CATCHUPPERIOD', 'CHARGE', 'CHARGES', 'CHARGETYPE', 'CLASS', 'COMMITINVENTORY', 'COMMITMENTFIRM', 'COMPONENTYIELD', 'COSTESTIMATE', 'COSTESTIMATERATE', 'COSTESTIMATETYPE', 'COUNTRYOFMANUFACTURE', 'CREATEDFROM', 'CREATEPO', 'CREATEWO', 'CURRENCY', 'CURRENTPERCENT', 'CURRENTVALUE', 'CUSTOMER', 'DATECOL', 'DEFERREVREC', 'DEPARTMENT', 'DESCRIPTION', 'DISCOUNT', 'DROPSHIP', 'DUEDATE', 'EMPLOYEE', 'EMPLOYEEFULLNAME', 'ENDDATE', 'ESTGROSSPROFIT', 'ESTGROSSPROFITFIELDS', 'ESTGROSSPROFITPERCENT', 'ESTIMATEDAMOUNT', 'ESTIMATEDRATE', 'EVENT', 'EXCLUDEFROMRATEREQUEST', 'EXPECTEDRECEIPTDATE', 'EXPECTEDSHIPDATE', 'FROMJOB', 'GIFTCERTFIELDS', 'GLNUMBER', 'GLSEQUENCE', 'GROSSAMT', 'INVENTORYDETAIL', 'INVENTORYDETAILSTOCK', 'ISBILLABLE', 'ISCLOSED', 'ISDROPSHIPMENT', 'ISESTIMATE', 'ISTAXABLE', 'ITEM', 'ITEMPRICING', 'ITEMTAX', 'JOB', 'LANDEDCOST', 'LANDEDCOSTCATEGORY', 'LASTPURCHASEPRICE', 'LICENSECODE', 'LINKEDORDER', 'LINKEDORDERSTATUS', 'LOCATION', 'MANUFACTURER', 'MATCHBILLTORECEIPT', 'MEMO', 'MPN', 'NEWQUANTITY', 'OPTIONS', 'ORDERPRIORITY', 'ORDERSCHEDULE', 'ORIGINALAMOUNT', 'OTHERREFNUM', 'PARENTITEM', 'PAYMENT', 'PAYMENTMETHOD', 'PERCENTCOMPLETE', 'PORATE', 'POVENDOR', 'PRICE', 'PROCESSEDBYREVCOMMIT', 'PURCHASECONTRACT', 'QUANTITY', 'QUANTITYAVAILABLE', 'QUANTITYBACKORDERED', 'QUANTITYCOMMITTED', 'QUANTITYFULFILLED', 'QUANTITYONHAND', 'QUANTITYORDERED', 'QUANTITYRECEIVED', 'QUANTITYREMAINING', 'RATE', 'RATE10', 'RATE2', 'RATE3', 'RATE4', 'RATE5', 'RATE6', 'RATE7', 'RATE8', 'RATE9', 'REASON', 'RESTOCK', 'REVRECENDDATE', 'REVRECSCHEDULE', 'REVRECSTARTDATE', 'SERIALNUMBERS', 'SHIPADDRESS', 'SHIPCARRIER', 'SHIPMETHOD', 'SHIPPINGCOST', 'SPECIALORDER', 'STARTDATE', 'SUBNAME', 'TAX1AMT', 'TAXAMOUNT', 'TAXCODE', 'TAXRATE1', 'TAXRATE2', 'TERMINMONTHS', 'TERMS', 'TRANSACTIONNO', 'UNITCOST', 'UNITCOSTOVERRIDE', 'UNITPRICE', 'UNITS', 'UPCCODE', 'VENDORNAME', 'VSOEDELIVERED', 'VSOEFIELDS', 'WEIGHT'] }),
+    },
+    path: [...enumsFolderPath, itemnumbercustomfield_fieldElemID.name],
+  }),
+  kpi_ranges_daterange: new PrimitiveType({
+    elemID: kpi_ranges_daterangeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['FISCAL_HALF_BEFORE_LAST', 'FISCAL_HALF_BEFORE_LAST_TO_DATE', 'FISCAL_QUARTER_BEFORE_LAST', 'FISCAL_QUARTER_BEFORE_LAST_TO_DATE', 'FISCAL_YEAR_BEFORE_LAST_TO_DATE', 'FIVE_DAYS_AGO', 'FIVE_DAYS_FROM_NOW', 'FOUR_DAYS_AGO', 'FOUR_DAYS_FROM_NOW', 'FOUR_WEEKS_STARTING_THIS_WEEK', 'LAST_BUSINESS_WEEK', 'LAST_FISCAL_HALF', 'LAST_FISCAL_HALF_ONE_FISCAL_YEAR_AGO', 'LAST_FISCAL_HALF_TO_DATE', 'LAST_FISCAL_QUARTER', 'LAST_FISCAL_QUARTER_ONE_FISCAL_YEAR_AGO', 'LAST_FISCAL_QUARTER_TO_DATE', 'LAST_FISCAL_QUARTER_TWO_FISCAL_YEARS_AGO', 'LAST_FISCAL_YEAR_TO_DATE', 'LAST_MONTH', 'LAST_MONTH_ONE_FISCAL_QUARTER_AGO', 'LAST_MONTH_ONE_FISCAL_YEAR_AGO', 'LAST_MONTH_TO_DATE', 'LAST_MONTH_TWO_FISCAL_QUARTERS_AGO', 'LAST_MONTH_TWO_FISCAL_YEARS_AGO', 'LAST_ROLLING_HALF', 'LAST_ROLLING_QUARTER', 'LAST_ROLLING_YEAR', 'LAST_WEEK', 'LAST_WEEK_TO_DATE', 'LAST_YEAR', 'LAST_YEAR_TO_DATE', 'MONTH_AFTER_NEXT', 'MONTH_AFTER_NEXT_TO_DATE', 'MONTH_BEFORE_LAST', 'MONTH_BEFORE_LAST_TO_DATE', 'NEXT_BUSINESS_WEEK', 'NEXT_FISCAL_HALF', 'NEXT_FISCAL_QUARTER', 'NEXT_FISCAL_YEAR', 'NEXT_FOUR_WEEKS', 'NEXT_MONTH', 'NEXT_ONE_HALF', 'NEXT_ONE_MONTH', 'NEXT_ONE_QUARTER', 'NEXT_ONE_WEEK__7_ROLLING_DAYS', 'NEXT_ONE_YEAR', 'NEXT_WEEK', 'NINETY_DAYS_AGO', 'NINETY_DAYS_FROM_NOW', 'ONE_YEAR_BEFORE_LAST', 'PREVIOUS_FISCAL_QUARTERS_LAST_FISCAL_YEAR', 'PREVIOUS_FISCAL_QUARTERS_THIS_FISCAL_YEAR', 'PREVIOUS_MONTHS_LAST_FISCAL_HALF', 'PREVIOUS_MONTHS_LAST_FISCAL_QUARTER', 'PREVIOUS_MONTHS_LAST_FISCAL_YEAR', 'PREVIOUS_MONTHS_SAME_FISCAL_HALF_LAST_FISCAL_YEAR', 'PREVIOUS_MONTHS_SAME_FISCAL_QUARTER_LAST_FISCAL_YEAR', 'PREVIOUS_MONTHS_THIS_FISCAL_HALF', 'PREVIOUS_MONTHS_THIS_FISCAL_QUARTER', 'PREVIOUS_MONTHS_THIS_FISCAL_YEAR', 'PREVIOUS_ONE_DAY', 'PREVIOUS_ONE_HALF', 'PREVIOUS_ONE_MONTH', 'PREVIOUS_ONE_QUARTER', 'PREVIOUS_ONE_WEEK', 'PREVIOUS_ONE_YEAR', 'PREVIOUS_ROLLING_HALF', 'PREVIOUS_ROLLING_QUARTER', 'PREVIOUS_ROLLING_YEAR', 'SAME_DAY_FISCAL_QUARTER_BEFORE_LAST', 'SAME_DAY_FISCAL_YEAR_BEFORE_LAST', 'SAME_DAY_LAST_FISCAL_QUARTER', 'SAME_DAY_LAST_FISCAL_YEAR', 'SAME_DAY_LAST_MONTH', 'SAME_DAY_LAST_WEEK', 'SAME_DAY_MONTH_BEFORE_LAST', 'SAME_DAY_WEEK_BEFORE_LAST', 'SAME_FISCAL_HALF_LAST_FISCAL_YEAR', 'SAME_FISCAL_HALF_LAST_FISCAL_YEAR_TO_DATE', 'SAME_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST', 'SAME_FISCAL_QUARTER_LAST_FISCAL_YEAR', 'SAME_FISCAL_QUARTER_LAST_FISCAL_YEAR_TO_DATE', 'SAME_MONTH_FISCAL_QUARTER_BEFORE_LAST', 'SAME_MONTH_FISCAL_YEAR_BEFORE_LAST', 'SAME_MONTH_LAST_FISCAL_QUARTER', 'SAME_MONTH_LAST_FISCAL_QUARTER_TO_DATE', 'SAME_MONTH_LAST_FISCAL_YEAR', 'SAME_MONTH_LAST_FISCAL_YEAR_TO_DATE', 'SAME_WEEK_FISCAL_YEAR_BEFORE_LAST', 'SAME_WEEK_LAST_FISCAL_YEAR', 'SIXTY_DAYS_AGO', 'SIXTY_DAYS_FROM_NOW', 'TEN_DAYS_AGO', 'TEN_DAYS_FROM_NOW', 'THIRTY_DAYS_AGO', 'THIRTY_DAYS_FROM_NOW', 'THIS_BUSINESS_WEEK', 'THIS_FISCAL_HALF', 'THIS_FISCAL_HALF_TO_DATE', 'THIS_FISCAL_QUARTER', 'THIS_FISCAL_QUARTER_TO_DATE', 'THIS_FISCAL_YEAR_TO_DATE', 'THIS_MONTH', 'THIS_MONTH_TO_DATE', 'THIS_ROLLING_HALF', 'THIS_ROLLING_QUARTER', 'THIS_ROLLING_YEAR', 'THIS_WEEK', 'THIS_WEEK_TO_DATE', 'THIS_YEAR', 'THIS_YEAR_TO_DATE', 'THREE_DAYS_AGO', 'THREE_DAYS_FROM_NOW', 'THREE_FISCAL_QUARTERS_AGO', 'THREE_FISCAL_QUARTERS_AGO_TO_DATE', 'THREE_FISCAL_YEARS_AGO', 'THREE_FISCAL_YEARS_AGO_TO_DATE', 'THREE_MONTHS_AGO', 'THREE_MONTHS_AGO_TO_DATE', 'TODAY', 'TODAY_TO_END_OF_THIS_MONTH', 'TOMORROW', 'TWO_DAYS_AGO', 'TWO_DAYS_FROM_NOW', 'WEEK_AFTER_NEXT', 'WEEK_AFTER_NEXT_TO_DATE', 'WEEK_BEFORE_LAST', 'WEEK_BEFORE_LAST_TO_DATE', 'YESTERDAY'] }),
+    },
+    path: [...enumsFolderPath, kpi_ranges_daterangeElemID.name],
+  }),
+  kpi_ranges_daterange_or_period: new PrimitiveType({
+    elemID: kpi_ranges_daterange_or_periodElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['FISCAL_YEAR_BEFORE_LAST', 'LAST_FISCAL_YEAR', 'THIS_FISCAL_YEAR'] }),
+    },
+    path: [...enumsFolderPath, kpi_ranges_daterange_or_periodElemID.name],
+  }),
+  kpi_ranges_daterange_report: new PrimitiveType({
+    elemID: kpi_ranges_daterange_reportElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['10_MONTHS_AGO', '11_MONTHS_AGO', '12_MONTHS_AGO', '1_DAY_AGO', '1_FISCAL_HALF_AGO', '1_FISCAL_QUARTER_AGO', '1_FISCAL_YEAR_AGO', '1_MONTH_AGO', '1_WEEK_AGO', '2_DAYS_AGO', '2_FISCAL_HALVES_AGO', '2_FISCAL_QUARTERS_AGO', '2_FISCAL_YEARS_AGO', '2_MONTHS_AGO', '2_WEEKS_AGO', '3_DAYS_AGO', '3_FISCAL_HALVES_AGO', '3_FISCAL_QUARTERS_AGO', '3_FISCAL_YEARS_AGO', '3_MONTHS_AGO', '3_WEEKS_AGO', '4_DAYS_AGO', '4_FISCAL_HALVES_AGO', '4_FISCAL_QUARTERS_AGO', '4_FISCAL_YEARS_AGO', '4_MONTHS_AGO', '4_WEEKS_AGO', '5_DAYS_AGO', '5_FISCAL_HALVES_AGO', '5_FISCAL_QUARTERS_AGO', '5_FISCAL_YEARS_AGO', '5_MONTHS_AGO', '5_WEEKS_AGO', '6_DAYS_AGO', '6_FISCAL_HALVES_AGO', '6_FISCAL_QUARTERS_AGO', '6_FISCAL_YEARS_AGO', '6_MONTHS_AGO', '6_WEEKS_AGO', '7_DAYS_AGO', '7_FISCAL_HALVES_AGO', '7_FISCAL_QUARTERS_AGO', '7_FISCAL_YEARS_AGO', '7_MONTHS_AGO', '7_WEEKS_AGO', '8_FISCAL_HALVES_AGO', '8_FISCAL_QUARTERS_AGO', '8_FISCAL_YEARS_AGO', '8_MONTHS_AGO', '8_WEEKS_AGO', '9_MONTHS_AGO', 'APRIL_LAST_YEAR', 'APRIL_LAST_YEAR_TO_DATE', 'APRIL_THIS_YEAR', 'APRIL_THIS_YEAR_TO_DATE', 'AUGUST_LAST_YEAR', 'AUGUST_LAST_YEAR_TO_DATE', 'AUGUST_THIS_YEAR', 'AUGUST_THIS_YEAR_TO_DATE', 'CALENDAR_WEEK_2_LAST_MONTH', 'CALENDAR_WEEK_2_SAME_MONTH_LAST_FISCAL_QUARTER', 'CALENDAR_WEEK_2_SAME_MONTH_LAST_FISCAL_YEAR', 'CALENDAR_WEEK_2_THIS_MONTH', 'CALENDAR_WEEK_3_LAST_MONTH', 'CALENDAR_WEEK_3_SAME_MONTH_LAST_FISCAL_QUARTER', 'CALENDAR_WEEK_3_SAME_MONTH_LAST_FISCAL_YEAR', 'CALENDAR_WEEK_3_THIS_MONTH', 'CALENDAR_WEEK_4_LAST_MONTH', 'CALENDAR_WEEK_4_SAME_MONTH_LAST_FISCAL_QUARTER', 'CALENDAR_WEEK_4_SAME_MONTH_LAST_FISCAL_YEAR', 'CALENDAR_WEEK_4_THIS_MONTH', 'DECEMBER_LAST_YEAR', 'DECEMBER_LAST_YEAR_TO_DATE', 'DECEMBER_THIS_YEAR', 'DECEMBER_THIS_YEAR_TO_DATE', 'FEBRUARY_LAST_YEAR', 'FEBRUARY_LAST_YEAR_TO_DATE', 'FEBRUARY_THIS_YEAR', 'FEBRUARY_THIS_YEAR_TO_DATE', 'FIRST_2_WEEKS_LAST_MONTH__FIRST_14_DAYS', 'FIRST_2_WEEKS_SAME_MONTH_LAST_FISCAL_QUARTER__FIRST_14_DAYS', 'FIRST_2_WEEKS_SAME_MONTH_LAST_FISCAL_YEAR__FIRST_14_DAYS', 'FIRST_2_WEEKS_THIS_MONTH__FIRST_14_DAYS', 'FIRST_3_WEEKS_LAST_MONTH__FIRST_21_DAYS', 'FIRST_3_WEEKS_SAME_MONTH_LAST_FISCAL_QUARTER__FIRST_21_DAYS', 'FIRST_3_WEEKS_SAME_MONTH_LAST_FISCAL_YEAR__FIRST_21_DAYS', 'FIRST_3_WEEKS_THIS_MONTH__FIRST_21_DAYS', 'FIRST_4_WEEKS_LAST_MONTH__FIRST_28_DAYS', 'FIRST_4_WEEKS_SAME_MONTH_LAST_FISCAL_QUARTER__FIRST_28_DAYS', 'FIRST_4_WEEKS_SAME_MONTH_LAST_FISCAL_YEAR__FIRST_28_DAYS', 'FIRST_4_WEEKS_THIS_MONTH__FIRST_28_DAYS', 'FIRST_FISCAL_HALF_FISCAL_YEAR_BEFORE_LAST', 'FIRST_FISCAL_HALF_FISCAL_YEAR_BEFORE_LAST_TO_DATE', 'FIRST_FISCAL_HALF_LAST_FISCAL_YEAR', 'FIRST_FISCAL_HALF_LAST_FISCAL_YEAR_TO_DATE', 'FIRST_FISCAL_HALF_THIS_FISCAL_YEAR', 'FIRST_FISCAL_HALF_THIS_FISCAL_YEAR_TO_DATE', 'FIRST_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST', 'FIRST_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST_TO_DATE', 'FIRST_FISCAL_QUARTER_LAST_FISCAL_YEAR', 'FIRST_FISCAL_QUARTER_LAST_FISCAL_YEAR_TO_DATE', 'FIRST_FISCAL_QUARTER_THIS_FISCAL_YEAR', 'FIRST_FISCAL_QUARTER_THIS_FISCAL_YEAR_TO_DATE', 'FIRST_MONTH_FISCAL_QUARTER_BEFORE_LAST', 'FIRST_MONTH_FISCAL_QUARTER_BEFORE_LAST_TO_DATE', 'FIRST_MONTH_LAST_FISCAL_QUARTER', 'FIRST_MONTH_LAST_FISCAL_QUARTER_TO_DATE', 'FIRST_MONTH_SAME_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST', 'FIRST_MONTH_SAME_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST_TO_DATE', 'FIRST_MONTH_SAME_FISCAL_QUARTER_LAST_FISCAL_YEAR', 'FIRST_MONTH_SAME_FISCAL_QUARTER_LAST_FISCAL_YEAR_TO_DATE', 'FIRST_MONTH_THIS_FISCAL_QUARTER', 'FIRST_MONTH_THIS_FISCAL_QUARTER_TO_DATE', 'FIRST_THREE_FISCAL_QUARTERS_FISCAL_YEAR_BEFORE_LAST', 'FIRST_THREE_FISCAL_QUARTERS_LAST_FISCAL_YEAR', 'FIRST_THREE_FISCAL_QUARTERS_THIS_FISCAL_YEAR', 'FIRST_TWO_FISCAL_QUARTERS_FISCAL_YEAR_BEFORE_LAST', 'FIRST_TWO_FISCAL_QUARTERS_LAST_FISCAL_YEAR', 'FIRST_TWO_FISCAL_QUARTERS_THIS_FISCAL_YEAR', 'FIRST_TWO_MONTHS_FISCAL_QUARTER_BEFORE_LAST', 'FIRST_TWO_MONTHS_LAST_FISCAL_QUARTER', 'FIRST_TWO_MONTHS_SAME_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST', 'FIRST_TWO_MONTHS_SAME_FISCAL_QUARTER_LAST_FISCAL_YEAR', 'FIRST_TWO_MONTHS_THIS_FISCAL_QUARTER', 'FOURTH_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST', 'FOURTH_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST_TO_DATE', 'FOURTH_FISCAL_QUARTER_LAST_FISCAL_YEAR', 'FOURTH_FISCAL_QUARTER_LAST_FISCAL_YEAR_TO_DATE', 'FOURTH_FISCAL_QUARTER_THIS_FISCAL_YEAR', 'FOURTH_FISCAL_QUARTER_THIS_FISCAL_YEAR_TO_DATE', 'JANUARY_LAST_YEAR', 'JANUARY_LAST_YEAR_TO_DATE', 'JANUARY_THIS_YEAR', 'JANUARY_THIS_YEAR_TO_DATE', 'JANUARY_THROUGH_APRIL_LAST_YEAR', 'JANUARY_THROUGH_APRIL_THIS_YEAR', 'JANUARY_THROUGH_AUGUST_LAST_YEAR', 'JANUARY_THROUGH_AUGUST_THIS_YEAR', 'JANUARY_THROUGH_FEBRUARY_LAST_YEAR', 'JANUARY_THROUGH_FEBRUARY_THIS_YEAR', 'JANUARY_THROUGH_JULY_LAST_YEAR', 'JANUARY_THROUGH_JULY_THIS_YEAR', 'JANUARY_THROUGH_JUNE_LAST_YEAR', 'JANUARY_THROUGH_JUNE_THIS_YEAR', 'JANUARY_THROUGH_MARCH_LAST_YEAR', 'JANUARY_THROUGH_MARCH_THIS_YEAR', 'JANUARY_THROUGH_MAY_LAST_YEAR', 'JANUARY_THROUGH_MAY_THIS_YEAR', 'JANUARY_THROUGH_NOVEMBER_LAST_YEAR', 'JANUARY_THROUGH_NOVEMBER_THIS_YEAR', 'JANUARY_THROUGH_OCTOBER_LAST_YEAR', 'JANUARY_THROUGH_OCTOBER_THIS_YEAR', 'JANUARY_THROUGH_SEPTEMBER_LAST_YEAR', 'JANUARY_THROUGH_SEPTEMBER_THIS_YEAR', 'JULY_LAST_YEAR', 'JULY_LAST_YEAR_TO_DATE', 'JULY_THIS_YEAR', 'JULY_THIS_YEAR_TO_DATE', 'JUNE_LAST_YEAR', 'JUNE_LAST_YEAR_TO_DATE', 'JUNE_THIS_YEAR', 'JUNE_THIS_YEAR_TO_DATE', 'MARCH_LAST_YEAR', 'MARCH_LAST_YEAR_TO_DATE', 'MARCH_THIS_YEAR', 'MARCH_THIS_YEAR_TO_DATE', 'MAY_LAST_YEAR', 'MAY_LAST_YEAR_TO_DATE', 'MAY_THIS_YEAR', 'MAY_THIS_YEAR_TO_DATE', 'NOVEMBER_LAST_YEAR', 'NOVEMBER_LAST_YEAR_TO_DATE', 'NOVEMBER_THIS_YEAR', 'NOVEMBER_THIS_YEAR_TO_DATE', 'OCTOBER_LAST_YEAR', 'OCTOBER_LAST_YEAR_TO_DATE', 'OCTOBER_THIS_YEAR', 'OCTOBER_THIS_YEAR_TO_DATE', 'SECOND_FISCAL_HALF_FISCAL_YEAR_BEFORE_LAST', 'SECOND_FISCAL_HALF_FISCAL_YEAR_BEFORE_LAST_TO_DATE', 'SECOND_FISCAL_HALF_LAST_FISCAL_YEAR', 'SECOND_FISCAL_HALF_LAST_FISCAL_YEAR_TO_DATE', 'SECOND_FISCAL_HALF_THIS_FISCAL_YEAR', 'SECOND_FISCAL_HALF_THIS_FISCAL_YEAR_TO_DATE', 'SECOND_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST', 'SECOND_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST_TO_DATE', 'SECOND_FISCAL_QUARTER_LAST_FISCAL_YEAR', 'SECOND_FISCAL_QUARTER_LAST_FISCAL_YEAR_TO_DATE', 'SECOND_FISCAL_QUARTER_THIS_FISCAL_YEAR', 'SECOND_FISCAL_QUARTER_THIS_FISCAL_YEAR_TO_DATE', 'SECOND_MONTH_FISCAL_QUARTER_BEFORE_LAST', 'SECOND_MONTH_FISCAL_QUARTER_BEFORE_LAST_TO_DATE', 'SECOND_MONTH_LAST_FISCAL_QUARTER', 'SECOND_MONTH_LAST_FISCAL_QUARTER_TO_DATE', 'SECOND_MONTH_SAME_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST', 'SECOND_MONTH_SAME_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST_TO_DATE', 'SECOND_MONTH_SAME_FISCAL_QUARTER_LAST_FISCAL_YEAR', 'SECOND_MONTH_SAME_FISCAL_QUARTER_LAST_FISCAL_YEAR_TO_DATE', 'SECOND_MONTH_THIS_FISCAL_QUARTER', 'SECOND_MONTH_THIS_FISCAL_QUARTER_TO_DATE', 'SEPTEMBER_LAST_YEAR', 'SEPTEMBER_LAST_YEAR_TO_DATE', 'SEPTEMBER_THIS_YEAR', 'SEPTEMBER_THIS_YEAR_TO_DATE', 'START_OF_LAST_MONTH_TO_END_OF_ITS_FIRST_WEEK', 'START_OF_LAST_MONTH_TO_END_OF_ITS_FOURTH_WEEK', 'START_OF_LAST_MONTH_TO_END_OF_ITS_SECOND_WEEK', 'START_OF_LAST_MONTH_TO_END_OF_ITS_THIRD_WEEK', 'START_OF_SAME_MONTH_LAST_FISCAL_QUARTER_TO_END_OF_ITS_FIRST_WEEK', 'START_OF_SAME_MONTH_LAST_FISCAL_QUARTER_TO_END_OF_ITS_FOURTH_WEEK', 'START_OF_SAME_MONTH_LAST_FISCAL_QUARTER_TO_END_OF_ITS_SECOND_WEEK', 'START_OF_SAME_MONTH_LAST_FISCAL_QUARTER_TO_END_OF_ITS_THIRD_WEEK', 'START_OF_SAME_MONTH_LAST_FISCAL_YEAR_TO_END_OF_ITS_FIRST_WEEK', 'START_OF_SAME_MONTH_LAST_FISCAL_YEAR_TO_END_OF_ITS_FOURTH_WEEK', 'START_OF_SAME_MONTH_LAST_FISCAL_YEAR_TO_END_OF_ITS_SECOND_WEEK', 'START_OF_SAME_MONTH_LAST_FISCAL_YEAR_TO_END_OF_ITS_THIRD_WEEK', 'START_OF_THIS_MONTH_TO_END_OF_ITS_FIRST_WEEK', 'START_OF_THIS_MONTH_TO_END_OF_ITS_FOURTH_WEEK', 'START_OF_THIS_MONTH_TO_END_OF_ITS_SECOND_WEEK', 'START_OF_THIS_MONTH_TO_END_OF_ITS_THIRD_WEEK', 'START_OF_WEEK_5_LAST_MONTH_TO_END_OF_LAST_MONTH', 'START_OF_WEEK_5_SAME_MONTH_LAST_FISCAL_QUARTER_TO_END_OF_THAT_MONTH', 'START_OF_WEEK_5_SAME_MONTH_LAST_FISCAL_YEAR_TO_END_OF_THAT_MONTH', 'START_OF_WEEK_5_THIS_MONTH_TO_END_OF_THIS_MONTH', 'THIRD_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST', 'THIRD_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST_TO_DATE', 'THIRD_FISCAL_QUARTER_LAST_FISCAL_YEAR', 'THIRD_FISCAL_QUARTER_LAST_FISCAL_YEAR_TO_DATE', 'THIRD_FISCAL_QUARTER_THIS_FISCAL_YEAR', 'THIRD_FISCAL_QUARTER_THIS_FISCAL_YEAR_TO_DATE', 'THIRD_MONTH_FISCAL_QUARTER_BEFORE_LAST', 'THIRD_MONTH_FISCAL_QUARTER_BEFORE_LAST_TO_DATE', 'THIRD_MONTH_LAST_FISCAL_QUARTER', 'THIRD_MONTH_LAST_FISCAL_QUARTER_TO_DATE', 'THIRD_MONTH_SAME_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST', 'THIRD_MONTH_SAME_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST_TO_DATE', 'THIRD_MONTH_SAME_FISCAL_QUARTER_LAST_FISCAL_YEAR', 'THIRD_MONTH_SAME_FISCAL_QUARTER_LAST_FISCAL_YEAR_TO_DATE', 'THIRD_MONTH_THIS_FISCAL_QUARTER', 'THIRD_MONTH_THIS_FISCAL_QUARTER_TO_DATE', 'WEEK_1_LAST_MONTH__DAYS_1_TO_7', 'WEEK_1_SAME_MONTH_LAST_FISCAL_QUARTER__DAYS_1_TO_7', 'WEEK_1_SAME_MONTH_LAST_FISCAL_YEAR__DAYS_1_TO_7', 'WEEK_1_THIS_MONTH__DAYS_1_TO_7', 'WEEK_2_LAST_MONTH__DAYS_8_TO_14', 'WEEK_2_SAME_MONTH_LAST_FISCAL_QUARTER__DAYS_8_TO_14', 'WEEK_2_SAME_MONTH_LAST_FISCAL_YEAR__DAYS_8_TO_14', 'WEEK_2_THIS_MONTH__DAYS_8_TO_14', 'WEEK_3_LAST_MONTH__DAYS_15_TO_21', 'WEEK_3_SAME_MONTH_LAST_FISCAL_QUARTER__DAYS_15_TO_21', 'WEEK_3_SAME_MONTH_LAST_FISCAL_YEAR__DAYS_15_TO_21', 'WEEK_3_THIS_MONTH__DAYS_15_TO_21', 'WEEK_4_LAST_MONTH__DAYS_22_TO_28', 'WEEK_4_SAME_MONTH_LAST_FISCAL_QUARTER__DAYS_22_TO_28', 'WEEK_4_SAME_MONTH_LAST_FISCAL_YEAR__DAYS_22_TO_28', 'WEEK_4_THIS_MONTH__DAYS_22_TO_28', 'WEEK_5_LAST_MONTH__DAY_29_TO_MONTHS_END', 'WEEK_5_SAME_MONTH_LAST_FISCAL_QUARTER__DAY_29_TO_MONTHS_END', 'WEEK_5_SAME_MONTH_LAST_FISCAL_YEAR__DAY_29_TO_MONTHS_END', 'WEEK_5_THIS_MONTH__DAY_29_TO_MONTHS_END'] }),
+    },
+    path: [...enumsFolderPath, kpi_ranges_daterange_reportElemID.name],
+  }),
+  kpi_ranges_period: new PrimitiveType({
+    elemID: kpi_ranges_periodElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['FIRST_FISCAL_QUARTER_LAST_FY', 'FIRST_FISCAL_QUARTER_THIS_FY', 'FISCAL_QUARTER_BEFORE_LAST', 'FOURTH_FISCAL_QUARTER_LAST_FY', 'FOURTH_FISCAL_QUARTER_THIS_FY', 'LAST_FISCAL_QUARTER', 'LAST_FISCAL_QUARTER_ONE_FISCAL_YEAR_AGO', 'LAST_FISCAL_QUARTER_TO_PERIOD', 'LAST_FISCAL_YEAR_TO_PERIOD', 'LAST_PERIOD', 'LAST_PERIOD_ONE_FISCAL_QUARTER_AGO', 'LAST_PERIOD_ONE_FISCAL_YEAR_AGO', 'LAST_ROLLING_18_PERIODS', 'LAST_ROLLING_6_FISCAL_QUARTERS', 'PERIOD_BEFORE_LAST', 'SAME_FISCAL_QUARTER_LAST_FY', 'SAME_FISCAL_QUARTER_LAST_FY_TO_PERIOD', 'SAME_PERIOD_LAST_FISCAL_QUARTER', 'SAME_PERIOD_LAST_FY', 'SECOND_FISCAL_QUARTER_LAST_FY', 'SECOND_FISCAL_QUARTER_THIS_FY', 'THIRD_FISCAL_QUARTER_LAST_FY', 'THIRD_FISCAL_QUARTER_THIS_FY', 'THIS_FISCAL_QUARTER', 'THIS_FISCAL_QUARTER_TO_PERIOD', 'THIS_FISCAL_YEAR_TO_PERIOD', 'THIS_PERIOD'] }),
+    },
+    path: [...enumsFolderPath, kpi_ranges_periodElemID.name],
+  }),
+  kpi_snapshots_custom: new PrimitiveType({
+    elemID: kpi_snapshots_customElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CUSTOM', 'CUSTOM10', 'CUSTOM2', 'CUSTOM3', 'CUSTOM4', 'CUSTOM5', 'CUSTOM6', 'CUSTOM7', 'CUSTOM8', 'CUSTOM9'] }),
+    },
+    path: [...enumsFolderPath, kpi_snapshots_customElemID.name],
+  }),
+  kpi_snapshots_daterange: new PrimitiveType({
+    elemID: kpi_snapshots_daterangeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCTUPTIME', 'AGGREGATEDBOOKINGS', 'AVERAGEINVENTORY', 'BOOKINGS', 'BOOKINGSALT', 'CARTABANDON', 'CHECKOUTABANDON', 'CLOSEDCASES', 'CLOSEDISSUES', 'COMMISSIONS', 'COMMISSIONSPARTNER', 'CURRENTLOGGEDINUSERS', 'CUSTOMERSWON', 'ECOMMISSIONS', 'ECOMMISSIONSPARTNER', 'EMPLOYEES', 'ESCALATEDCASES', 'ESTIMATES', 'ESTIMATESRANGE', 'ETECASEEOVERFIVE', 'ETECASEEOVERTWO', 'ETECASEVOVERFIVE', 'ETECASEVOVERTWO', 'ETECUSTEOVERFIVE', 'ETECUSTEOVERTWO', 'ETECUSTVOVERFIVE', 'ETECUSTVOVERTWO', 'ETESOEOVERFIVE', 'ETESOEOVERTWO', 'ETESOVOVERFIVE', 'ETESOVOVERTWO', 'FORECAST', 'FORECASTASA', 'FORECASTOVERRIDE', 'FORECASTOVERRIDEASA', 'HOSTEDSITETRAFFIC', 'NEWBUSINESSORD', 'NEWBUSINESSORDALT', 'NEWCASES', 'NEWCUSTOMERSORD', 'NEWISSUES', 'NEWLEADS', 'NEWLEADSGROSS', 'NEWOPPORTUNITIES', 'NEWVISITORS', 'OPENCASES', 'OPENISSUES', 'OPPORTUNITIES', 'OPPORTUNITIESLOST', 'OPPORTUNITIESRANGE', 'OPPORTUNITIESWON', 'ORDERS', 'PAGETIMESOVERFIVE', 'PAGETIMESOVERTWO', 'PCOMMISSIONS', 'PCOMMISSIONSPARTNER', 'PIPELINE', 'PIPELINEASA', 'PIPELINEDEALS', 'PIPELINEWEIGHTED', 'PIPELINEWEIGHTEDASA', 'PROSPECTS', 'PURCHASES', 'QUOTA', 'QUOTAASA', 'QUOTAREPS', 'RPAGETIMESOVERFIVE', 'RPAGETIMESOVERTWO', 'SITETRAFFIC', 'SPAGETIMESOVERFIVE', 'SPAGETIMESOVERTWO', 'TOTALBOOKINGS', 'TOTALORDERS', 'TOTALPIPEDEALS', 'TOTALPIPELINE', 'TOTALPIPELINEASA', 'TOTALPIPEWEIGHTED', 'TOTALPIPEWEIGHTEDASA', 'VENDOROPENPO', 'VISITORTRAFFIC', 'WEBORDERS', 'WEBREVENUE'] }),
+    },
+    path: [...enumsFolderPath, kpi_snapshots_daterangeElemID.name],
+  }),
+  kpi_snapshots_daterange_or_period: new PrimitiveType({
+    elemID: kpi_snapshots_daterange_or_periodElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BANKBAL', 'COGS', 'CREDITCARDBAL', 'DEFERREDREVENUE', 'EQUITY', 'EXPENSES', 'FIXEDASSET', 'INCOME', 'INTTURNOVRPERPERIOD', 'INVENTORY', 'LONGTERMLIAB', 'NETCASHFLOW', 'NEWBUSINESS', 'NEWCUSTOMERS', 'ONTIMERECEIPTS', 'ONTIMESHIPMENTS', 'OPERATINGEXPENSES', 'OPERCASHFLOW', 'OTHERASSET', 'OTHERCURRENTASSET', 'OTHERCURRENTLIAB', 'PAYABLES', 'PAYROLL', 'PROFIT', 'RECEIVABLES', 'REVENUE', 'SALES', 'SALESCASHBASIS', 'UTILIZATION', 'VENDORBALANCE'] }),
+    },
+    path: [...enumsFolderPath, kpi_snapshots_daterange_or_periodElemID.name],
+  }),
+  kpi_snapshots_formula: new PrimitiveType({
+    elemID: kpi_snapshots_formulaElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['FORMULACURRENCY', 'FORMULANUMERIC', 'FORMULAPERCENT'] }),
+    },
+    path: [...enumsFolderPath, kpi_snapshots_formulaElemID.name],
+  }),
+  kpi_snapshots_internal: new PrimitiveType({
+    elemID: kpi_snapshots_internalElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCTUPTIME', 'AGGREGATEDBOOKINGS', 'BOOKINGS', 'CURRENTLOGGEDINUSERS', 'CUSTOMERSWON', 'EMPLOYEES', 'ETECASEEOVERFIVE', 'ETECASEEOVERTWO', 'ETECASEVOVERFIVE', 'ETECASEVOVERTWO', 'ETECUSTEOVERFIVE', 'ETECUSTEOVERTWO', 'ETECUSTVOVERFIVE', 'ETECUSTVOVERTWO', 'ETESOEOVERFIVE', 'ETESOEOVERTWO', 'ETESOVOVERFIVE', 'ETESOVOVERTWO', 'NEWBUSINESS', 'NEWBUSINESSORD', 'NEWCUSTOMERS', 'NEWCUSTOMERSORD', 'ORDERS', 'PAGETIMESOVERFIVE', 'PAGETIMESOVERTWO', 'RPAGETIMESOVERFIVE', 'RPAGETIMESOVERTWO', 'SPAGETIMESOVERFIVE', 'SPAGETIMESOVERTWO', 'VENDORBALANCE'] }),
+    },
+    path: [...enumsFolderPath, kpi_snapshots_internalElemID.name],
+  }),
+  kpiscorecards_comparisons: new PrimitiveType({
+    elemID: kpiscorecards_comparisonsElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['RATIO_ABSOLUTE', 'RATIO_PERCENT', 'SUM', 'VARIANCE_ABSOLUTE', 'VARIANCE_PERCENT'] }),
+    },
+    path: [...enumsFolderPath, kpiscorecards_comparisonsElemID.name],
+  }),
+  kpiscorecards_highlight_conditions: new PrimitiveType({
+    elemID: kpiscorecards_highlight_conditionsElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ALWAYS', 'GREATER_THAN', 'LESS_THAN', 'MAGNITUDE_GREATER_THAN', 'MAGNITUDE_LESS_THAN'] }),
+    },
+    path: [...enumsFolderPath, kpiscorecards_highlight_conditionsElemID.name],
+  }),
+  kpiscorecards_highlight_icons: new PrimitiveType({
+    elemID: kpiscorecards_highlight_iconsElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BLUE_FLAG', 'BLUE_NEW', 'CHECKMARK', 'DOLLAR_SIGN_1', 'DOLLAR_SIGN_2', 'DOLLAR_SIGN_3', 'EXCLAMATION_MARK', 'FIREBALL', 'GREEN_FLAG', 'HEART', 'ORANGE_FLAG', 'RED_ARROW_LEFT', 'RED_ARROW_RIGHT', 'RED_FLAG', 'RED_NEW', 'STARBURST', 'STARBURST_NEW', 'X_MARK', 'YELLOW_FLAG'] }),
+    },
+    path: [...enumsFolderPath, kpiscorecards_highlight_iconsElemID.name],
+  }),
+  kpiscorecards_useperiods: new PrimitiveType({
+    elemID: kpiscorecards_useperiodsElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['F', 'T'] }),
+    },
+    path: [...enumsFolderPath, kpiscorecards_useperiodsElemID.name],
+  }),
+  locking_actions: new PrimitiveType({
+    elemID: locking_actionsElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['LOCK', 'UNLOCK'] }),
+    },
+    path: [...enumsFolderPath, locking_actionsElemID.name],
+  }),
+  plugintype_deployment_model: new PrimitiveType({
+    elemID: plugintype_deployment_modelElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ALLOW_MULTIPLE', 'ALLOW_SINGLE'] }),
+    },
+    path: [...enumsFolderPath, plugintype_deployment_modelElemID.name],
+  }),
+  plugintype_loglevel: new PrimitiveType({
+    elemID: plugintype_loglevelElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['AUDIT', 'DEBUG', 'EMERGENCY', 'ERROR'] }),
+    },
+    path: [...enumsFolderPath, plugintype_loglevelElemID.name],
+  }),
+  plugintype_status: new PrimitiveType({
+    elemID: plugintype_statusElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['RELEASED', 'TESTING'] }),
+    },
+    path: [...enumsFolderPath, plugintype_statusElemID.name],
+  }),
+  portlet_calendar_agenda: new PrimitiveType({
+    elemID: portlet_calendar_agendaElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['TODAY_ONLY', 'UPCOMING'] }),
+    },
+    path: [...enumsFolderPath, portlet_calendar_agendaElemID.name],
+  }),
+  portlet_customsearch_backgroundtype: new PrimitiveType({
+    elemID: portlet_customsearch_backgroundtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BANDS', 'GLOBAL_BACKGROUND', 'GRID', 'LINES'] }),
+    },
+    path: [...enumsFolderPath, portlet_customsearch_backgroundtypeElemID.name],
+  }),
+  portlet_customsearch_charttheme: new PrimitiveType({
+    elemID: portlet_customsearch_chartthemeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BASIC', 'COLORFUL', 'GLOBAL_THEME', 'MATCH_COLOR_THEME_BOLD', 'MATCH_COLOR_THEME_LIGHT'] }),
+    },
+    path: [...enumsFolderPath, portlet_customsearch_chartthemeElemID.name],
+  }),
+  portlet_customsearch_drilldown: new PrimitiveType({
+    elemID: portlet_customsearch_drilldownElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['IN_PORTLET', 'NEW_PAGE'] }),
+    },
+    path: [...enumsFolderPath, portlet_customsearch_drilldownElemID.name],
+  }),
+  portlet_customsearch_savedsearch: new PrimitiveType({
+    elemID: portlet_customsearch_savedsearchElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ALLOCATEORDER', 'ANALYTICSAUDITTRAILDETAILVIEW', 'COMMITORDER', 'CUSTOMERDASHBOARDVIEW', 'CUSTOMERSBYOSBALANCE', 'CUSTOMERSEARCH', 'CUSTOMERSTHISWEEKBYLEADSOURCE', 'CUSTOMERSTORENEWTHISMONTH', 'CUSTOMSEARCH61', 'CUSTOMTRANSACTIONSEARCH', 'DEFAULTSCRIPTNOTESPORTLETVIEW', 'DEPOSITSUMMARY', 'ESCALATEDCASES', 'FAILEDRECORDS', 'GLAUDITNUMBERINGHISTORY', 'GLIPGLIMPACT', 'GLIPTRANSACTION', 'GOOGLEBASE', 'HIGHPRIORITYCASES', 'INFORMATIONITEMSVIEW', 'INVENTORYADJUSTMENTS', 'INVENTORYSTATUS', 'ISSUEDASHBOARDVIEW', 'LEADSTHISWEEKBYLEADSOURCE', 'MOBILEEXPENSEREPORTAWAITINGMYAPPROVAL', 'MOBILEEXPENSEREPORTNOTSUBMITTED', 'MOBILEEXPENSEREPORTOUTSTANDING', 'MOBILEEXPENSEREPORTREJECTED', 'MOBILETIMEENTRIES', 'MOBILETIMEENTRIES2', 'MYACTIVECUSTOMERS', 'MYACTIVELEADS', 'MYACTIVEPROSPECTS', 'MYCALLSTOCOMPLETE', 'MYNEWLEADSTHISWEEK', 'MYNEWPROSPECTSTHISWEEK', 'MYOPENORRECENTLYCLOSEDOPPORTUNITIES', 'MYOPPORTUNITIESTOCLOSE', 'MYTEAMSACTIVECUSTOMERS', 'MYTEAMSACTIVELEADS', 'MYTEAMSACTIVEPROSPECTS', 'MYUNCOMPLETEDTASKS', 'NEWCASESTODAY', 'NEWHIRESTHISMONTHBYHIREDATE', 'NEWHIRESTHISMONTHBYNAME', 'NEXTAG', 'OPENAPBALANCES', 'OPENARBALANCES', 'OPENESTIMATESANDORDERS', 'OPENSALESORDERS', 'OPPORTUNITYDASHBOARDVIEW', 'PARALLELBOOKSTRANSACTIONIMPACT', 'PHONECALLDASHBOARDVIEW', 'PRICEBOOKLIST', 'PRICELISTHISTORYBASESEARCH', 'PRICELISTHISTORYNOQUANTITYORPRICETYPE', 'PROSPECTSTHISWEEKBYLEADSOURCE', 'PURCHASEORDERRECEIPTPASTDUE', 'PURCHASEORDERSTORECEIVE', 'RECENTORUPCOMING', 'RESOURCEALLOCATIONSFORAPPROVAL', 'REVENUEARRANGEMENTSPENDINGAPPROVAL', 'REVENUERECOGNITIONERRORS', 'SALESORDERSHIPMENTPASTDUE', 'SALESORDERSTOFULFILL', 'SHOPPINGCOM', 'SHOPZILLA', 'STANDARDTASKPORTLETSEARCHDUEDATE', 'STANDARDTASKPORTLETSEARCHORDER', 'STATISTICALJOURNALIMPACTHISTORY', 'TASKDASHBOARDVIEW', 'TASKSTOREPLACE', 'THIRDPARTYCONVERSIONTRACKINGURL', 'TIMEBILLINGRULEFILTER', 'TIMEENTRIES', 'TIMEENTRYCHARGERULEFILTER', 'TODAYSSALESORDERS', 'TOPOPENESTIMATESTHISMONTH', 'TOPSALESREPTHISMONTH', 'TRANSACTIONIMPACT', 'TRANSACTIONIMPACTHISTORY', 'TRANSFERORDERRECEIPTPASTDUE', 'TRANSFERORDERSHIPMENTPASTDUE', 'USAGECHARGES', 'VENDORDASHBOARDVIEW', 'VENDORSBYOSBALANCE', 'WORKORDERBUILDPASTDUE', 'YAHOOSHOPPING'] }),
+    },
+    path: [...enumsFolderPath, portlet_customsearch_savedsearchElemID.name],
+  }),
+  portlet_kpi_employees: new PrimitiveType({
+    elemID: portlet_kpi_employeesElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ALL', 'ME_ONLY', 'MY_TEAM'] }),
+    },
+    path: [...enumsFolderPath, portlet_kpi_employeesElemID.name],
+  }),
+  portlet_kpi_highlightif: new PrimitiveType({
+    elemID: portlet_kpi_highlightifElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ALWAYS', 'GREATER_THAN', 'LESS_THAN', 'VARIANCE_GREATER_THAN', 'VARIANCE_LESS_THAN'] }),
+    },
+    path: [...enumsFolderPath, portlet_kpi_highlightifElemID.name],
+  }),
+  portlet_kpimeter_combined_snapshots: new PrimitiveType({
+    elemID: portlet_kpimeter_combined_snapshotsElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACTUAL_VS_FORECAST', 'ACTUAL_VS_QUOTA', 'FORECAST_VS_QUOTA', 'FORECAST_VS_QUOTA_ASA'] }),
+    },
+    path: [...enumsFolderPath, portlet_kpimeter_combined_snapshotsElemID.name],
+  }),
+  portlet_list_type: new PrimitiveType({
+    elemID: portlet_list_typeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNTINGBOOK', 'ACCOUNTINGCONTEXT', 'ACCOUNTINGRULE', 'ACCOUNTINGTRANSACTION', 'ACTIVITY', 'ADVANCEDNUMBERINGSEQUENCE', 'ALLOC', 'ALLOCATEORDERSCHEDULE', 'AMORTIZATIONSCHEDULE', 'AMORTIZATIONTEMPLATE', 'ASCHARGEDPROJECTREVENUERULE', 'BALANCETRXBYSEGMENTS', 'BANKIMPORTHISTORY', 'BILLINGACCOUNT', 'BILLINGACCOUNTBILLCYCLE', 'BILLINGACCOUNTBILLREQUEST', 'BILLINGRATECARD', 'BILLINGREVENUEEVENT', 'BILLOFDISTRIBUTION', 'BILLRUN', 'BILLRUNSCHEDULE', 'BINNUMBER', 'BOM', 'BUDGET', 'BUDGETEXCHANGERATE', 'BULKPROCERRORS', 'BUSINESSEVENTHISTORY', 'BUSINESSEVENTPROCESSINGDETAILS', 'CALENDAR', 'CALL', 'CAMPAIGN', 'CARDHOLDERAUTHENTICATIONEVENT', 'CASE', 'CCTRAN', 'CHARGE', 'CHARGERULE', 'CHARGERUN', 'CLASS', 'CLASSSEGMENTMAPPING', 'CMSCONTENT', 'CMSPAGE', 'CMSPAGETYPE', 'COMMERCECATALOG', 'COMMITORDERSCHEDULE', 'COMPETITOR', 'COMSEARCHBOOST', 'COMSEARCHBOOSTTYPE', 'COMSEARCHGROUPSYN', 'COMSEARCHONEWAYSYN', 'CONSOLEXCHANGERATE', 'CONTACT', 'CURRENCYRATETYPE', 'CUSTOMER', 'DEPARTMENT', 'DEPTSEGMENTMAPPING', 'DISTRIBUTIONNETWORK', 'DOCUMENT', 'DRIVERSLICENSE', 'EMPLOYEE', 'EMPLOYEECHANGE', 'EMPLOYEECHANGEREASON', 'EMPLOYEECHANGEREQUEST', 'EMPLOYEECHANGETYPE', 'EMPLOYEESTATUS', 'EMPLOYEETYPE', 'ENTITYACCOUNTMAPPING', 'ENTITYMSESUBSIDIARY', 'EXPENSEAMORTIZATIONEVENT', 'EXPENSEAMORTIZATIONRULE', 'EXPENSEPLAN', 'FAIRVALUEFORMULA', 'FAIRVALUEPRICE', 'FINANCIALINSTITUTION', 'FIXEDAMOUNTPROJECTREVENUERULE', 'FORECAST', 'FULFILLMENTEXCEPTIONREASON', 'GATEWAYNOTIFICATION', 'GENERICRESOURCE', 'GIFTCERTIFICATE', 'GLOBALACCOUNTMAPPING', 'GOAL', 'GOVERNMENTISSUEDIDTYPE', 'GROUPINGRULE', 'HCMJOB', 'INBOUNDSHIPMENT', 'INFOITEM', 'INVCOSTTEMPLATE', 'INVENTORYSTATUS', 'ISSUE', 'ITEM', 'ITEMACCOUNTMAPPING', 'ITEMCOLLECTION', 'ITEMDEMANDPLAN', 'ITEMPROCESSFAMILY', 'ITEMPROCESSGROUP', 'ITEMREVENUECATEGORY', 'ITEMSUPPLYPLAN', 'JOB', 'JOBREQUISITION', 'KUDOS', 'LABORBASEDPROJECTREVENUERULE', 'LATEORDERALLOCATION', 'LOCASSIGNCONF', 'LOCATION', 'LOCATIONCOSTINGGROUP', 'LOCSEGMENTMAPPING', 'MEMDOC', 'MEMDOCRESULTS', 'MERCHANDISEHIERARCHYLEVEL', 'MERCHANDISEHIERARCHYNODE', 'MERCHANDISEHIERARCHYVERSION', 'MFGCOSTTEMPLATE', 'MFGOPERATIONTASK', 'MFGROUTING', 'MSESUBSIDIARY', 'NEWSITEM', 'NEXUS', 'NOTIFICATION', 'OAUTHTOKEN', 'ONLINECASEFORM', 'ONLINELEADFORM', 'OPPRTNTY', 'ORDERALLOCATIONSTRATEGY', 'ORGANIZATIONVALUE', 'ORIGINATINGLEAD', 'OTHERGOVERNMENTISSUEDID', 'OUTBOUNDEMAILLOG', 'OUTBOUNDREQUEST', 'PARTNER', 'PASSPORT', 'PAYMENTEVENT', 'PAYMENTPROCESSINGPROFILE', 'PAYROLLBATCH', 'PAYROLLBATCH2', 'PCTCOMPLETEPROJECTREVENUERULE', 'PERFORMANCEMETRIC', 'PERFORMANCEREVIEW', 'PERFORMANCEREVIEWQUESTION', 'PERFORMANCEREVIEWRATINGSCALE', 'PERFORMANCEREVIEWSCHEDULE', 'PERFORMANCEREVIEWTEMPLATE', 'PICKSTRATEGY', 'PICKTASK', 'PLANNEDREVENUE', 'PLANNEDSTANDARDCOST', 'POSITION', 'PROJECTEXPENSETYPE', 'PROJECTREVENUERULE', 'PROJECTREVENUERULELIST', 'PROJECTTASK', 'PROJECTTASKANDCRMTASK', 'PROJECTTEMPLATE', 'PROMOTION', 'QUOTA', 'REGION', 'REPORT', 'REPORTRESULTS', 'REPORTSCHEDULE', 'RESALLOCATIONTIMEOFFCONFLICT', 'RESOURCEGROUP', 'RESTRICTION', 'REVENUEELEMENT', 'REVENUEPLAN', 'REVREC', 'REVRECOGNITIONSCHED', 'REVRECRULE', 'REVRECSCHEDULE', 'REVRECTEMPLATE', 'RSRCALLOCATION', 'SALESCAMPAIGN', 'SALESTERRITORY', 'SCRIPTNOTE', 'SCSnapshotRefreshSchedule', 'SOLUTION', 'STANDARDCOSTVERSION', 'SUBSCRIPTION', 'SUBSCRIPTIONCHANGEORDER', 'SUBSCRIPTIONLINE', 'SUBSCRIPTIONLINEREVISION', 'SUBSIDIARY', 'SUPPLYCHAINSNAPSHOT', 'SUPPORTTERRITORY', 'TASK', 'TAXTYPE', 'TERMINATIONREASON', 'TIME', 'TIMEAPPROVAL', 'TIMEOFFCHANGE', 'TIMEOFFPLAN', 'TIMEOFFREQUEST', 'TIMEOFFTYPE', 'TIMESHEET', 'TRANSACTION', 'UNDELIVEREDEMAIL', 'UNLOCKEDTIMEPERIOD', 'USAGE', 'USEROAUTHTOKEN', 'VENDOR', 'WAVE', 'WORKPLACE', 'ZONE'] }),
+    },
+    path: [...enumsFolderPath, portlet_list_typeElemID.name],
+  }),
+  portlet_quicksearch_generic: new PrimitiveType({
+    elemID: portlet_quicksearch_genericElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACTIVITY', 'CAMPAIGN', 'CASE_NUMBER', 'CONTACT', 'CUSTOMER', 'DOCUMENT', 'DOCUMENT_NUMBER', 'EMAIL', 'EMPLOYEE', 'EVENT', 'ISSUE_NUMBER', 'ITEM', 'JOB', 'NAME', 'NAME_ID', 'PARTNER', 'PHONE', 'PHONE_CALL', 'PO_CHECK_NUMBER', 'PRODUCT_PAGE', 'PROJECT_TASK', 'SOLUTION', 'TASK', 'TRACKING_NUMBER', 'TRANSACTION_NUMBER', 'VENDOR', 'ZIP_POSTAL_CODE'] }),
+    },
+    path: [...enumsFolderPath, portlet_quicksearch_genericElemID.name],
+  }),
+  portlet_quicksearch_transaction: new PrimitiveType({
+    elemID: portlet_quicksearch_transactionElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ASSEMBLY_BUILD', 'ASSEMBLY_UNBUILD', 'BALANCING_JOURNAL', 'BILL', 'BILL_CREDIT', 'BILL_PAYMENT', 'BIN_PUTAWAY_WORKSHEET', 'BIN_TRANSFER', 'BLANKET_PURCHASE_ORDER', 'CASH_REFUND', 'CASH_SALE', 'CCARD_REFUND', 'CHECK', 'COMMISSION', 'CREDIT_CARD', 'CREDIT_MEMO', 'CURRENCY_REVALUATION', 'CUSTOM', 'CUSTOMER_DEPOSIT', 'CUSTOMER_PAYMENT_AUTHORIZATION', 'CUSTOMER_REFUND', 'DEPOSIT', 'DEPOSIT_APPLICATION', 'DEPRECATED_CUSTOM_TRANSACTION', 'ESTIMATE', 'EXPENSE_REPORT', 'FINANCE_CHARGE', 'FULFILLMENT_REQUEST', 'GL_IMPACT_ADJUSTMENT', 'INBOUND_SHIPMENT', 'INVENTORY_ADJUSTMENT', 'INVENTORY_COST_REVALUATION', 'INVENTORY_COUNT', 'INVENTORY_DISTRIBUTION', 'INVENTORY_STATUS_CHANGE', 'INVENTORY_TRANSFER', 'INVENTORY_WORKSHEET', 'INVOICE', 'ITEM_FULFILLMENT', 'ITEM_RECEIPT', 'JOURNAL', 'LIABILITY_ADJUSTMENT', 'OPPORTUNITY', 'OWNERSHIP_TRANSFER', 'PAYCHECK', 'PAYCHECK_JOURNAL', 'PAYMENT', 'PAYROLL_ADJUSTMENT', 'PAYROLL_LIABILITY_CHECK', 'PERIOD_END_JOURNAL', 'PURCHASE-TYPE_CUSTOM_TRANSACTION', 'PURCHASE_CONTRACT', 'PURCHASE_ORDER', 'REQUEST_FOR_QUOTE', 'REQUISITION', 'RETURN_AUTHORIZATION', 'REVENUE_ARRANGEMENT', 'REVENUE_COMMITMENT', 'REVENUE_COMMITMENT_REVERSAL', 'REVENUE_CONTRACT', 'SALES-TYPE_CUSTOM_TRANSACTION', 'SALES_ORDER', 'SALES_TAX_PAYMENT', 'STATEMENT_CHARGE', 'STORE_PICKUP_FULFILLMENT', 'SYSTEM_JOURNAL', 'TAX_LIABILITY_CHEQUE', 'TEGATA_PAYABLE', 'TEGATA_RECEIVABLE', 'TRANSFER', 'TRANSFER_ORDER', 'VENDOR_PREPAYMENT', 'VENDOR_PREPAYMENT_APPLICATION', 'VENDOR_REQUEST_FOR_QUOTE', 'VENDOR_RETURN_AUTHORIZATION', 'WAVE', 'WORK_ORDER', 'WORK_ORDER_CLOSE', 'WORK_ORDER_COMPLETION', 'WORK_ORDER_ISSUE'] }),
+    },
+    path: [...enumsFolderPath, portlet_quicksearch_transactionElemID.name],
+  }),
+  portlet_quicksearch_type: new PrimitiveType({
+    elemID: portlet_quicksearch_typeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['GENERIC', 'TRANSACTION'] }),
+    },
+    path: [...enumsFolderPath, portlet_quicksearch_typeElemID.name],
+  }),
+  portlet_trendgraph_backgroundtype: new PrimitiveType({
+    elemID: portlet_trendgraph_backgroundtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BANDS', 'GLOBAL_BACKGROUND', 'GRID', 'LINES'] }),
+    },
+    path: [...enumsFolderPath, portlet_trendgraph_backgroundtypeElemID.name],
+  }),
+  portlet_trendgraph_charttheme: new PrimitiveType({
+    elemID: portlet_trendgraph_chartthemeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BASIC', 'COLORFUL', 'GLOBAL_THEME', 'MATCH_COLOR_THEME___BOLD', 'MATCH_COLOR_THEME___LIGHT'] }),
+    },
+    path: [...enumsFolderPath, portlet_trendgraph_chartthemeElemID.name],
+  }),
+  portlet_trendgraph_charttype: new PrimitiveType({
+    elemID: portlet_trendgraph_charttypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['AREA', 'BAR', 'COLUMN', 'LINE'] }),
+    },
+    path: [...enumsFolderPath, portlet_trendgraph_charttypeElemID.name],
+  }),
+  portlet_trendgraph_trendtype: new PrimitiveType({
+    elemID: portlet_trendgraph_trendtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['DAILY', 'MONTHLY', 'QUARTERLY', 'WEEKLY', 'YEARLY'] }),
+    },
+    path: [...enumsFolderPath, portlet_trendgraph_trendtypeElemID.name],
+  }),
+  reminders_highlighting_rules_colors: new PrimitiveType({
+    elemID: reminders_highlighting_rules_colorsElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BLUE', 'BROWN', 'CYAN', 'DARKGREEN', 'DARKRED', 'GOLDENROD', 'GREEN', 'LIGHTBLUE', 'LIMEGREEN', 'MAROON', 'ORANGE', 'PASTELGREEN', 'PINK', 'PURPLE', 'RED', 'YELLOW'] }),
+    },
+    path: [...enumsFolderPath, reminders_highlighting_rules_colorsElemID.name],
+  }),
+  reminders_standard_reminders_with_days: new PrimitiveType({
+    elemID: reminders_standard_reminders_with_daysElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ALLOCATIONSCHEDULESDUE', 'BILLPAYMENTSTOAPPROVE', 'BILLSTOPAY', 'EMPLOYEESTOPAY', 'EMPLOYEESTOREVIEW', 'EMPLOYEESWITHEXPIRINGAUTHORIZATION', 'EMPLOYEESWITHEXPIRINGVISA', 'EMPLOYEESWITHUPCOMINGANNIVERSARY', 'EMPLOYEESWITHUPCOMINGBIRTHDAY', 'MEMORIZEDTRANSACTIONSDUE', 'OPPORTUNITIESTOCLOSE', 'OVERDUEADVANCEDJOBS', 'OVERDUECALLS', 'OVERDUEINVOICES', 'OVERDUESTANDARDJOBS', 'OVERDUETASKS', 'PERIODSTOCLOSE', 'SALESORDERSTOBILL', 'SALESORDERSTOPROCESSINVOICE'] }),
+    },
+    path: [...enumsFolderPath, reminders_standard_reminders_with_daysElemID.name],
+  }),
+  reminders_standard_reminders_without_days: new PrimitiveType({
+    elemID: reminders_standard_reminders_without_daysElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['AMORTIZATIONENTRIESPENDING', 'ASSEMBLIESTOBUILD', 'ASSEMBLIESTOORDER', 'BILLSTOAPPROVE', 'BUNDLESTOUPDATE', 'CAMPAIGNSTOEMAIL', 'CAMPAIGNSTOPRINT', 'CASESTORESPOND', 'CHECKSTOPRINT', 'COMMISSIONSREJECTED', 'CREDITCARDSTOAPPROVE', 'CREDITMEMOSTOPRINT', 'CUSTOMERSTOBILL', 'CUSTOMERSTORENEW', 'DIRECTDEPOSITSRETURNED', 'DIRECTDEPOSITSTOAPPROVE', 'DIRECTDEPOSITSTOPRINT', 'DOMAINCONFIGALERTS', 'EFTSRETURNED', 'EFTSTOAPPROVE', 'EMPLOYEESWITHFAILEDDIRECTDEPOSIT', 'EMPLOYEESWITHPENDINGDIRECTDEPOSIT', 'ESTIMATESTOPRINT', 'EVENTSTORESPOND', 'EXPENSEPLANSONHOLD', 'EXPENSEREPORTSTOAPPROVE', 'IMPORTSTOPROCESS', 'INCOMPLETECALLS', 'INCOMPLETETASKS', 'INVOICESREJECTED', 'INVOICESTOAPPROVE', 'INVOICESTOAPPROVECREDITHOLD', 'INVOICESTOAPPROVEPAYMENTTERMS', 'INVOICESTOAPPROVEUNKNOWNTAX', 'INVOICESTOPRINT', 'ITEMSTOORDER', 'JOURNALSTOAPPROVE', 'JOURNALSTOAPPROVEBYYOU', 'MISSINGTIMESHEETS', 'MISSINGTIMESHEETSLM', 'PAYCHECKSTOPRINT', 'PAYMENTSTODEPOSIT', 'PAYROLLBATCHESTOCOMMIT', 'PAYROLLTRANSACTIONISSUESTOACKNOWLEDGE', 'PAYROLLUPDATESTOCOMMIT', 'PURCHASEORDERSRECEIPTPASTDUE', 'PURCHASEORDERSTOBILL', 'PURCHASEORDERSTOPRINT', 'PURCHASEORDERSTORECEIVE', 'PURCHASEREQUESTSTOAPPROVE', 'RECEIPTSTOPRINT', 'REJECTEDPURCHASEORDERS', 'REJECTEDVENDORRETURNS', 'REQUISITIONSTOAPPROVE', 'RESOURCEALLOCATIONSTOAPPROVE', 'RETURNAUTHNSTOPRINT', 'RETURNAUTHSREQUIRINGREVENUECOMMITMENTREVERSALS', 'RETURNAUTHSTOAPPROVE', 'RETURNAUTHSTORECEIVE', 'RETURNAUTHSTOREFUND', 'REVENUEARRANGEMENTSNOTCOMPLIANT', 'REVENUEARRANGEMENTSPENDINGAPPROVAL', 'REVRECENTRIESPENDING', 'REVRECPLANSONHOLD', 'SALESORDERSHIPMENTPASTDUE', 'SALESORDERSREQUIRINGREVENUECOMMITMENTS', 'SALESORDERSTOAPPROVE', 'SALESORDERSTOFULFULL', 'SALESORDERSTOPRINT', 'SALESORDERSTOPROCESS', 'SHIPMENTSTOPACK', 'SHIPMENTSTOSHIP', 'SOLUTIONSTOAPPROVE', 'SYSTEMALERTSTOACKNOWLEDGE', 'TASKSDUETODAY', 'TEAMMISSINGWEEKLYTIMESHEETS', 'TEAMMISSINGWEEKLYTIMESHEETSLASTMONTH', 'TIMEENTRIESTOAPPROVE', 'TIMERECORDSREJECTED', 'TIMERECORDSTOAPPROVE', 'TIMESHEETSTOAPPROVE', 'TRANSFERORDERRECEIPTPASTDUE', 'TRANSFERORDERSHIPMENTPASTDUE', 'TRANSFERORDERSTOAPPROVE', 'VENDORRETURNAUTHSTOAPPROVE', 'VENDORRETURNAUTHSTOREFUND', 'VENDORRETURNAUTHSTORETURN', 'WORKORDERBUILDPASTDUE', 'WORKORDERSTOBUILD', 'WORKORDERSTOCLOSE'] }),
+    },
+    path: [...enumsFolderPath, reminders_standard_reminders_without_daysElemID.name],
+  }),
+  report_date_range: new PrimitiveType({
+    elemID: report_date_rangeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['FISCAL_HALF_BEFORE_LAST', 'FISCAL_HALF_BEFORE_LAST_TO_DATE', 'FISCAL_QUARTER_BEFORE_LAST', 'FISCAL_QUARTER_BEFORE_LAST_TO_DATE', 'FISCAL_YEAR_BEFORE_LAST', 'FISCAL_YEAR_BEFORE_LAST_TO_DATE', 'FIVE_DAYS_AGO', 'FIVE_DAYS_FROM_NOW', 'FOUR_DAYS_AGO', 'FOUR_DAYS_FROM_NOW', 'FOUR_WEEKS_STARTING_THIS_WEEK', 'LAST_BUSINESS_WEEK', 'LAST_FISCAL_HALF', 'LAST_FISCAL_HALF_ONE_FISCAL_YEAR_AGO', 'LAST_FISCAL_HALF_TO_DATE', 'LAST_FISCAL_QUARTER', 'LAST_FISCAL_QUARTER_ONE_FISCAL_YEAR_AGO', 'LAST_FISCAL_QUARTER_TO_DATE', 'LAST_FISCAL_QUARTER_TWO_FISCAL_YEARS_AGO', 'LAST_FISCAL_YEAR', 'LAST_FISCAL_YEAR_TO_DATE', 'LAST_MONTH', 'LAST_MONTH_ONE_FISCAL_QUARTER_AGO', 'LAST_MONTH_ONE_FISCAL_YEAR_AGO', 'LAST_MONTH_TO_DATE', 'LAST_MONTH_TWO_FISCAL_QUARTERS_AGO', 'LAST_MONTH_TWO_FISCAL_YEARS_AGO', 'LAST_ROLLING_HALF', 'LAST_ROLLING_QUARTER', 'LAST_ROLLING_YEAR', 'LAST_WEEK', 'LAST_WEEK_TO_DATE', 'LAST_YEAR', 'LAST_YEAR_TO_DATE', 'MONTH_AFTER_NEXT', 'MONTH_AFTER_NEXT_TO_DATE', 'MONTH_BEFORE_LAST', 'MONTH_BEFORE_LAST_TO_DATE', 'NEXT_BUSINESS_WEEK', 'NEXT_FISCAL_HALF', 'NEXT_FISCAL_QUARTER', 'NEXT_FISCAL_YEAR', 'NEXT_FOUR_WEEKS', 'NEXT_MONTH', 'NEXT_ONE_HALF', 'NEXT_ONE_MONTH', 'NEXT_ONE_QUARTER', 'NEXT_ONE_WEEK__7_ROLLING_DAYS', 'NEXT_ONE_YEAR', 'NEXT_WEEK', 'NINETY_DAYS_AGO', 'NINETY_DAYS_FROM_NOW', 'ONE_YEAR_BEFORE_LAST', 'PREVIOUS_FISCAL_QUARTERS_LAST_FISCAL_YEAR', 'PREVIOUS_FISCAL_QUARTERS_THIS_FISCAL_YEAR', 'PREVIOUS_MONTHS_LAST_FISCAL_HALF', 'PREVIOUS_MONTHS_LAST_FISCAL_QUARTER', 'PREVIOUS_MONTHS_LAST_FISCAL_YEAR', 'PREVIOUS_MONTHS_SAME_FISCAL_HALF_LAST_FISCAL_YEAR', 'PREVIOUS_MONTHS_SAME_FISCAL_QUARTER_LAST_FISCAL_YEAR', 'PREVIOUS_MONTHS_THIS_FISCAL_HALF', 'PREVIOUS_MONTHS_THIS_FISCAL_QUARTER', 'PREVIOUS_MONTHS_THIS_FISCAL_YEAR', 'PREVIOUS_ONE_DAY', 'PREVIOUS_ONE_HALF', 'PREVIOUS_ONE_MONTH', 'PREVIOUS_ONE_QUARTER', 'PREVIOUS_ONE_WEEK', 'PREVIOUS_ONE_YEAR', 'PREVIOUS_ROLLING_HALF', 'PREVIOUS_ROLLING_QUARTER', 'PREVIOUS_ROLLING_YEAR', 'SAME_DAY_FISCAL_QUARTER_BEFORE_LAST', 'SAME_DAY_FISCAL_YEAR_BEFORE_LAST', 'SAME_DAY_LAST_FISCAL_QUARTER', 'SAME_DAY_LAST_FISCAL_YEAR', 'SAME_DAY_LAST_MONTH', 'SAME_DAY_LAST_WEEK', 'SAME_DAY_MONTH_BEFORE_LAST', 'SAME_DAY_WEEK_BEFORE_LAST', 'SAME_FISCAL_HALF_LAST_FISCAL_YEAR', 'SAME_FISCAL_HALF_LAST_FISCAL_YEAR_TO_DATE', 'SAME_FISCAL_QUARTER_FISCAL_YEAR_BEFORE_LAST', 'SAME_FISCAL_QUARTER_LAST_FISCAL_YEAR', 'SAME_FISCAL_QUARTER_LAST_FISCAL_YEAR_TO_DATE', 'SAME_MONTH_FISCAL_QUARTER_BEFORE_LAST', 'SAME_MONTH_FISCAL_YEAR_BEFORE_LAST', 'SAME_MONTH_LAST_FISCAL_QUARTER', 'SAME_MONTH_LAST_FISCAL_QUARTER_TO_DATE', 'SAME_MONTH_LAST_FISCAL_YEAR', 'SAME_MONTH_LAST_FISCAL_YEAR_TO_DATE', 'SAME_WEEK_FISCAL_YEAR_BEFORE_LAST', 'SAME_WEEK_LAST_FISCAL_YEAR', 'SIXTY_DAYS_AGO', 'SIXTY_DAYS_FROM_NOW', 'TEN_DAYS_AGO', 'TEN_DAYS_FROM_NOW', 'THIRTY_DAYS_AGO', 'THIRTY_DAYS_FROM_NOW', 'THIS_BUSINESS_WEEK', 'THIS_FISCAL_HALF', 'THIS_FISCAL_HALF_TO_DATE', 'THIS_FISCAL_QUARTER', 'THIS_FISCAL_QUARTER_TO_DATE', 'THIS_FISCAL_YEAR', 'THIS_FISCAL_YEAR_TO_DATE', 'THIS_MONTH', 'THIS_MONTH_TO_DATE', 'THIS_ROLLING_HALF', 'THIS_ROLLING_QUARTER', 'THIS_ROLLING_YEAR', 'THIS_WEEK', 'THIS_WEEK_TO_DATE', 'THIS_YEAR', 'THIS_YEAR_TO_DATE', 'THREE_DAYS_AGO', 'THREE_DAYS_FROM_NOW', 'THREE_FISCAL_QUARTERS_AGO', 'THREE_FISCAL_QUARTERS_AGO_TO_DATE', 'THREE_FISCAL_YEARS_AGO', 'THREE_FISCAL_YEARS_AGO_TO_DATE', 'THREE_MONTHS_AGO', 'THREE_MONTHS_AGO_TO_DATE', 'TODAY', 'TODAY_TO_END_OF_THIS_MONTH', 'TOMORROW', 'TWO_DAYS_AGO', 'TWO_DAYS_FROM_NOW', 'WEEK_AFTER_NEXT', 'WEEK_AFTER_NEXT_TO_DATE', 'WEEK_BEFORE_LAST', 'WEEK_BEFORE_LAST_TO_DATE', 'YESTERDAY'] }),
+    },
+    path: [...enumsFolderPath, report_date_rangeElemID.name],
+  }),
+  report_period_range: new PrimitiveType({
+    elemID: report_period_rangeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['FIRST_FISCAL_QUARTER_LAST_FY', 'FIRST_FISCAL_QUARTER_THIS_FY', 'FISCAL_QUARTER_BEFORE_LAST', 'FISCAL_YEAR_BEFORE_LAST', 'FOURTH_FISCAL_QUARTER_LAST_FY', 'FOURTH_FISCAL_QUARTER_THIS_FY', 'LAST_FISCAL_QUARTER', 'LAST_FISCAL_QUARTER_ONE_FISCAL_YEAR_AGO', 'LAST_FISCAL_QUARTER_TO_PERIOD', 'LAST_FISCAL_YEAR', 'LAST_FISCAL_YEAR_TO_PERIOD', 'LAST_PERIOD', 'LAST_PERIOD_ONE_FISCAL_QUARTER_AGO', 'LAST_PERIOD_ONE_FISCAL_YEAR_AGO', 'LAST_ROLLING_18_PERIODS', 'LAST_ROLLING_6_FISCAL_QUARTERS', 'PERIOD_BEFORE_LAST', 'SAME_FISCAL_QUARTER_LAST_FY', 'SAME_FISCAL_QUARTER_LAST_FY_TO_PERIOD', 'SAME_PERIOD_LAST_FISCAL_QUARTER', 'SAME_PERIOD_LAST_FY', 'SECOND_FISCAL_QUARTER_LAST_FY', 'SECOND_FISCAL_QUARTER_THIS_FY', 'THIRD_FISCAL_QUARTER_LAST_FY', 'THIRD_FISCAL_QUARTER_THIS_FY', 'THIS_FISCAL_QUARTER', 'THIS_FISCAL_QUARTER_TO_PERIOD', 'THIS_FISCAL_YEAR', 'THIS_FISCAL_YEAR_TO_PERIOD', 'THIS_PERIOD'] }),
+    },
+    path: [...enumsFolderPath, report_period_rangeElemID.name],
+  }),
+  role_centertype: new PrimitiveType({
+    elemID: role_centertypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNTCENTER', 'BASIC', 'ENGINEERCENTER', 'EXECUTIVE', 'HR', 'MARKETCENTER', 'PARTNERCENTER', 'PROJECTCENTER', 'SALESCENTER', 'SHIPPINGCENTER', 'STOREMANAGER', 'SUPPORTCENTER', 'SYSADMINCENTER'] }),
+    },
+    path: [...enumsFolderPath, role_centertypeElemID.name],
+  }),
+  role_fullrestrictions: new PrimitiveType({
+    elemID: role_fullrestrictionsElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['DEFAULTTOOWN', 'NONE', 'OWNONLY', 'UNASSIGNED'] }),
+    },
+    path: [...enumsFolderPath, role_fullrestrictionsElemID.name],
+  }),
+  role_restrict: new PrimitiveType({
+    elemID: role_restrictElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['EDIT', 'VIEWANDEDIT'] }),
+    },
+    path: [...enumsFolderPath, role_restrictElemID.name],
+  }),
+  role_restrictions: new PrimitiveType({
+    elemID: role_restrictionsElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['DEFAULTTOOWN', 'OWNONLY', 'UNASSIGNED'] }),
+    },
+    path: [...enumsFolderPath, role_restrictionsElemID.name],
+  }),
+  role_restrictionsegment: new PrimitiveType({
+    elemID: role_restrictionsegmentElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CLASS', 'DEPARTMENT', 'LOCATION'] }),
+    },
+    path: [...enumsFolderPath, role_restrictionsegmentElemID.name],
+  }),
+  script_deploymentmodel: new PrimitiveType({
+    elemID: script_deploymentmodelElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['PLUGIN_TYPE_DEPLOYMENT_ALLOW_MULTIPLE', 'PLUGIN_TYPE_DEPLOYMENT_ALLOW_ONLY_ONE'] }),
+    },
+    path: [...enumsFolderPath, script_deploymentmodelElemID.name],
+  }),
+  script_eventtype: new PrimitiveType({
+    elemID: script_eventtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['APPROVE', 'CANCEL', 'CHANGEPASSWORD', 'COPY', 'CREATE', 'DELETE', 'DROPSHIP', 'EDIT', 'EDITFORECAST', 'EMAIL', 'GET', 'MARKCOMPLETE', 'ORDERITEMS', 'PACK', 'PAYBILLS', 'POST', 'PRINT', 'QUICKVIEW', 'REASSIGN', 'REJECT', 'SHIP', 'SPECIALORDER', 'TRANSFORM', 'VIEW', 'XEDIT'] }),
+    },
+    path: [...enumsFolderPath, script_eventtypeElemID.name],
+  }),
+  script_frequency: new PrimitiveType({
+    elemID: script_frequencyElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['DAY', 'MONTH', 'MWF', 'NONE', 'TTH', 'WEEK', 'WEEKDAY', 'WEEKEND', 'YEAR'] }),
+    },
+    path: [...enumsFolderPath, script_frequencyElemID.name],
+  }),
+  script_loglevel: new PrimitiveType({
+    elemID: script_loglevelElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['AUDIT', 'DEBUG', 'EMERGENCY', 'ERROR', 'INTERNAL', 'SYSTEM'] }),
+    },
+    path: [...enumsFolderPath, script_loglevelElemID.name],
+  }),
+  script_portlettype: new PrimitiveType({
+    elemID: script_portlettypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['FORM', 'HTML', 'LINKS', 'LIST'] }),
+    },
+    path: [...enumsFolderPath, script_portlettypeElemID.name],
+  }),
+  script_recurrenceminutes: new PrimitiveType({
+    elemID: script_recurrenceminutesElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['120', '15', '240', '30', '360', '480', '60', '720'] }),
+    },
+    path: [...enumsFolderPath, script_recurrenceminutesElemID.name],
+  }),
+  script_returnrecordtype: new PrimitiveType({
+    elemID: script_returnrecordtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['-10', '-100', '-101', '-102', '-103', '-104', '-105', '-106', '-107', '-108', '-109', '-110', '-111', '-112', '-113', '-114', '-115', '-116', '-117', '-118', '-119', '-120', '-121', '-122', '-123', '-124', '-125', '-126', '-127', '-128', '-129', '-130', '-131', '-132', '-133', '-134', '-135', '-136', '-137', '-138', '-139', '-140', '-1403', '-141', '-142', '-143', '-144', '-145', '-146', '-147', '-148', '-149', '-150', '-1500', '-1501', '-1502', '-1503', '-151', '-152', '-153', '-154', '-155', '-1553', '-156', '-157', '-158', '-159', '-160', '-161', '-162', '-163', '-164', '-165', '-166', '-167', '-168', '-169', '-170', '-171', '-172', '-173', '-174', '-175', '-176', '-177', '-178', '-179', '-180', '-181', '-182', '-183', '-184', '-185', '-186', '-187', '-188', '-189', '-190', '-191', '-192', '-193', '-194', '-195', '-196', '-197', '-198', '-199', '-2', '-20', '-200', '-201', '-202', '-203', '-204', '-205', '-206', '-207', '-208', '-209', '-21', '-210', '-211', '-212', '-213', '-214', '-215', '-216', '-217', '-218', '-219', '-22', '-220', '-221', '-222', '-223', '-224', '-225', '-226', '-227', '-228', '-229', '-23', '-230', '-231', '-232', '-233', '-234', '-235', '-236', '-237', '-238', '-239', '-24', '-240', '-241', '-242', '-243', '-244', '-245', '-246', '-247', '-248', '-249', '-25', '-250', '-251', '-252', '-253', '-256', '-257', '-258', '-259', '-26', '-260', '-261', '-262', '-263', '-264', '-265', '-266', '-268', '-269', '-27', '-270', '-271', '-272', '-273', '-274', '-276', '-278', '-279', '-28', '-280', '-281', '-282', '-283', '-284', '-285', '-286', '-287', '-288', '-289', '-290', '-292', '-293', '-294', '-295', '-296', '-297', '-298', '-3', '-30', '-301', '-302', '-303', '-304', '-305', '-306', '-309', '-31', '-310', '-311', '-314', '-315', '-316', '-317', '-319', '-320', '-321', '-322', '-324', '-325', '-326', '-327', '-328', '-330', '-331', '-332', '-333', '-335', '-336', '-337', '-338', '-340', '-341', '-342', '-343', '-344', '-345', '-346', '-347', '-348', '-349', '-35', '-350', '-351', '-352', '-353', '-354', '-355', '-356', '-357', '-359', '-36', '-360', '-361', '-362', '-364', '-365', '-366', '-367', '-368', '-369', '-37', '-371', '-372', '-373', '-374', '-375', '-376', '-377', '-378', '-379', '-38', '-380', '-381', '-382', '-383', '-385', '-386', '-387', '-388', '-39', '-390', '-391', '-392', '-393', '-394', '-395', '-396', '-4', '-40', '-400', '-4006', '-4007', '-4009', '-401', '-4010', '-4011', '-4012', '-4014', '-402', '-4021', '-4027', '-4028', '-403', '-4032', '-4033', '-404', '-405', '-406', '-407', '-408', '-409', '-41', '-410', '-411', '-412', '-413', '-414', '-417', '-418', '-419', '-420', '-422', '-423', '-424', '-425', '-426', '-427', '-428', '-430', '-431', '-432', '-434', '-435', '-436', '-437', '-438', '-440', '-441', '-450', '-451', '-452', '-460', '-461', '-494', '-495', '-496', '-497', '-5', '-505', '-506', '-507', '-508', '-513', '-514', '-517', '-520', '-522', '-523', '-524', '-528', '-530', '-531', '-532', '-533', '-537', '-538', '-539', '-540', '-543', '-544', '-546', '-547', '-548', '-549', '-550', '-551', '-552', '-553', '-554', '-555', '-556', '-557', '-558', '-560', '-6', '-7', '-8', '-851', '-856', '-861', '-862', '-863', '-864', '-865', '-867', '-868', '-869', '-896', '-897', '-898', '-899', '-9', '-900', '-901', '-903', '-904', '-905', '-906', '-907', '-908', '-909', '-910', '-911', '-970', '-997', '-998', '-999'] }),
+    },
+    path: [...enumsFolderPath, script_returnrecordtypeElemID.name],
+  }),
+  script_scripttype: new PrimitiveType({
+    elemID: script_scripttypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACTION', 'APPPKGINSTALL', 'BUNDLEINSTALLATION', 'CLIENT', 'CONSOLRATEADJUSTOR', 'CUSTOMGLLINES', 'EMAILCAPTURE', 'MASSUPDATE', 'PAYMENTGATEWAY', 'PLUGINTYPE', 'PLUGINTYPEIMPL', 'PORTLET', 'PROMOTIONS', 'RESTLET', 'SCHEDULED', 'SCRIPTLET', 'SHIPPINGPARTNERS', 'TAXCALCULATION', 'TESTPLUGIN', 'USEREVENT', 'WEBAPP'] }),
+    },
+    path: [...enumsFolderPath, script_scripttypeElemID.name],
+  }),
+  script_setting: new PrimitiveType({
+    elemID: script_settingElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['COMPANY', 'PORTLET', 'USER'] }),
+    },
+    path: [...enumsFolderPath, script_settingElemID.name],
+  }),
+  script_starttime: new PrimitiveType({
+    elemID: script_starttimeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['0000', '0030', '0100', '0130', '0200', '0230', '0300', '0330', '0400', '0430', '0500', '0530', '0600', '0630', '0700', '0730', '0800', '0830', '0900', '0930', '1000', '1030', '1100', '1130', '1200', '1230', '1300', '1330', '1400', '1430', '1500', '1530', '1600', '1630', '1700', '1730', '1800', '1830', '1900', '1930', '2000', '2030', '2100', '2130', '2200', '2230', '2300', '2330'] }),
+    },
+    path: [...enumsFolderPath, script_starttimeElemID.name],
+  }),
+  script_status: new PrimitiveType({
+    elemID: script_statusElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['COMPLETED', 'INPROGRESS', 'INQUEUE', 'NOTSCHEDULED', 'RELEASED', 'SCHEDULED', 'TESTING'] }),
+    },
+    path: [...enumsFolderPath, script_statusElemID.name],
+  }),
+  scriptdeployment_recordtype: new PrimitiveType({
+    elemID: scriptdeployment_recordtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNT', 'ACCOUNTINGBOOK', 'ACCOUNTINGCONTEXT', 'ACCOUNTINGPERIOD', 'ADVINTERCOMPANYJOURNALENTRY', 'ALLOCATIONSCHEDULE', 'AMORTIZATIONSCHEDULE', 'AMORTIZATIONTEMPLATE', 'APPDEFINITION', 'APPPACKAGE', 'ASSEMBLYBUILD', 'ASSEMBLYITEM', 'ASSEMBLYUNBUILD', 'BALANCETRXBYSEGMENTS', 'BILLINGACCOUNT', 'BILLINGCLASS', 'BILLINGRATECARD', 'BILLINGREVENUEEVENT', 'BILLINGSCHEDULE', 'BIN', 'BINTRANSFER', 'BINWORKSHEET', 'BLANKETPURCHASEORDER', 'BOM', 'BOMREVISION', 'BONUS', 'BONUSTYPE', 'BUDGETEXCHANGERATE', 'BULKOWNERSHIPTRANSFER', 'BUNDLEINSTALLATIONSCRIPT', 'CALENDAREVENT', 'CAMPAIGN', 'CAMPAIGNRESPONSE', 'CAMPAIGNTEMPLATE', 'CASHREFUND', 'CASHSALE', 'CHARGE', 'CHARGERULE', 'CHECK', 'CLASSIFICATION', 'CLIENTSCRIPT', 'CMSCONTENT', 'CMSCONTENTTYPE', 'CMSPAGE', 'CMSPAGETYPE', 'COMMERCECATEGORY', 'COMMERCESEARCHBOOST', 'COMMERCESEARCHBOOSTTYPE', 'COMPETITOR', 'CONSOLIDATEDEXCHANGERATE', 'CONTACT', 'CONTACTCATEGORY', 'CONTACTROLE', 'COSTCATEGORY', 'COUPONCODE', 'CREDITCARDCHARGE', 'CREDITCARDREFUND', 'CREDITMEMO', 'CURRENCY', 'CUSTOMER', 'CUSTOMERCATEGORY', 'CUSTOMERDEPOSIT', 'CUSTOMERMESSAGE', 'CUSTOMERPAYMENT', 'CUSTOMERPAYMENTAUTHORIZATION', 'CUSTOMERREFUND', 'CUSTOMERSTATUS', 'CUSTOMERSUBSIDIARYRELATIONSHIP', 'DEPARTMENT', 'DEPOSIT', 'DEPOSITAPPLICATION', 'DESCRIPTIONITEM', 'DISCOUNTITEM', 'DOWNLOADITEM', 'DRIVERSLICENSE', 'EMAILTEMPLATE', 'EMPLOYEE', 'EMPLOYEECHANGEREQUEST', 'EMPLOYEECHANGEREQUESTTYPE', 'EMPLOYEESTATUS', 'EMPLOYEETYPE', 'ENTITYACCOUNTMAPPING', 'ESTIMATE', 'EXPENSEAMORTIZATIONEVENT', 'EXPENSECATEGORY', 'EXPENSEPLAN', 'EXPENSEREPORT', 'FAIRVALUEPRICE', 'FINANCIALINSTITUTION', 'FIXEDAMOUNTPROJECTREVENUERULE', 'FOLDER', 'FORMATPROFILE', 'FULFILLMENTREQUEST', 'GENERALTOKEN', 'GENERICRESOURCE', 'GIFTCERTIFICATE', 'GIFTCERTIFICATEITEM', 'GLNUMBERINGSEQUENCE', 'GLOBALACCOUNTMAPPING', 'GLOBALINVENTORYRELATIONSHIP', 'GOAL', 'GOVERNMENTISSUEDIDTYPE', 'HCMJOB', 'INBOUNDSHIPMENT', 'INTERCOMPALLOCATIONSCHEDULE', 'INTERCOMPANYJOURNALENTRY', 'INTERCOMPANYTRANSFERORDER', 'INVENTORYADJUSTMENT', 'INVENTORYCOSTREVALUATION', 'INVENTORYCOUNT', 'INVENTORYITEM', 'INVENTORYNUMBER', 'INVENTORYSTATUS', 'INVENTORYSTATUSCHANGE', 'INVENTORYTRANSFER', 'INVOICE', 'INVOICEGROUP', 'ISSUE', 'ISSUEPRODUCT', 'ISSUEPRODUCTVERSION', 'ITEMACCOUNTMAPPING', 'ITEMCOLLECTION', 'ITEMCOLLECTIONITEMMAP', 'ITEMDEMANDPLAN', 'ITEMFULFILLMENT', 'ITEMGROUP', 'ITEMLOCATIONCONFIGURATION', 'ITEMPROCESSFAMILY', 'ITEMPROCESSGROUP', 'ITEMRECEIPT', 'ITEMREVISION', 'ITEMSUPPLYPLAN', 'JOB', 'JOBREQUISITION', 'JOBSTATUS', 'JOBTYPE', 'JOURNALENTRY', 'KITITEM', 'KUDOS', 'LABORBASEDPROJECTREVENUERULE', 'LEAD', 'LOCATION', 'LOTNUMBEREDASSEMBLYITEM', 'LOTNUMBEREDINVENTORYITEM', 'MANUFACTURINGCOSTTEMPLATE', 'MANUFACTURINGOPERATIONTASK', 'MANUFACTURINGROUTING', 'MAPREDUCESCRIPT', 'MARKUPITEM', 'MASSUPDATESCRIPT', 'MEMDOC', 'MERCHANDISEHIERARCHYLEVEL', 'MERCHANDISEHIERARCHYNODE', 'MERCHANDISEHIERARCHYVERSION', 'MESSAGE', 'MFGPLANNEDTIME', 'NEXUS', 'NONINVENTORYITEM', 'NOTE', 'NOTETYPE', 'OPPORTUNITY', 'ORDERTYPE', 'ORGANIZATIONVALUE', 'OTHERCHARGEITEM', 'OTHERGOVERNMENTISSUEDID', 'OTHERNAME', 'OTHERNAMECATEGORY', 'PARTNER', 'PARTNERCATEGORY', 'PASSPORT', 'PAYCHECK', 'PAYCHECKJOURNAL', 'PAYMENTCARD', 'PAYMENTCARDTOKEN', 'PAYMENTITEM', 'PAYMENTMETHOD', 'PAYROLLBATCH', 'PAYROLLBATCHADDEMPLOYEES', 'PAYROLLITEM', 'PCTCOMPLETEPROJECTREVENUERULE', 'PERFORMANCEMETRIC', 'PERFORMANCEREVIEW', 'PERFORMANCEREVIEWSCHEDULE', 'PERIODENDJOURNAL', 'PHONECALL', 'PICKSTRATEGY', 'PORTLET', 'POSITION', 'PRICEBOOK', 'PRICELEVEL', 'PRICEPLAN', 'PRICINGGROUP', 'PROJECTEXPENSETYPE', 'PROJECTTASK', 'PROJECTTEMPLATE', 'PROMOTIONCODE', 'PROSPECT', 'PURCHASECONTRACT', 'PURCHASEORDER', 'PURCHASEREQUISITION', 'REALLOCATEITEM', 'RECEIVEINBOUNDSHIPMENT', 'RESOURCEALLOCATION', 'RESTLET', 'RETURNAUTHORIZATION', 'REVENUEARRANGEMENT', 'REVENUECOMMITMENT', 'REVENUECOMMITMENTREVERSAL', 'REVENUEPLAN', 'REVRECSCHEDULE', 'REVRECTEMPLATE', 'SALESORDER', 'SALESROLE', 'SALESTAXITEM', 'SCHEDULEDSCRIPT', 'SCHEDULEDSCRIPTINSTANCE', 'SERIALIZEDASSEMBLYITEM', 'SERIALIZEDINVENTORYITEM', 'SERVICEITEM', 'SHIPITEM', 'SHIPPINGPARTNERREGISTRATION', 'SOLUTION', 'STATISTICALJOURNALENTRY', 'STOREPICKUPFULFILLMENT', 'SUBSCRIPTION', 'SUBSCRIPTIONCHANGEORDER', 'SUBSCRIPTIONLINE', 'SUBSCRIPTIONPLAN', 'SUBSIDIARY', 'SUBSIDIARYSETTINGS', 'SUBTOTALITEM', 'SUITELET', 'SUPPLYCHAINSNAPSHOT', 'SUPPLYCHAINSNAPSHOTSIMULATION', 'SUPPORTCASE', 'TASK', 'TAXACCT', 'TAXGROUP', 'TAXPERIOD', 'TAXSCHEDULE', 'TAXTYPE', 'TERM', 'TERMINATIONREASON', 'TIMEBILL', 'TIMEOFFCHANGE', 'TIMEOFFPLAN', 'TIMEOFFREQUEST', 'TIMEOFFRULE', 'TIMEOFFTYPE', 'TIMESHEET', 'TOPIC', 'TRANSFERORDER', 'UNITSTYPE', 'UNLOCKEDTIMEPERIOD', 'USAGE', 'USEREVENTSCRIPT', 'VENDOR', 'VENDORBILL', 'VENDORCATEGORY', 'VENDORCREDIT', 'VENDORPAYMENT', 'VENDORPREPAYMENT', 'VENDORPREPAYMENTAPPLICATION', 'VENDORRETURNAUTHORIZATION', 'VENDORSUBSIDIARYRELATIONSHIP', 'WAVE', 'WBS', 'WEBSITE', 'WINLOSSREASON', 'WORKFLOWACTIONSCRIPT', 'WORKORDER', 'WORKORDERCLOSE', 'WORKORDERCOMPLETION', 'WORKORDERISSUE', 'WORKPLACE', 'ZONE'] }),
+    },
+    path: [...enumsFolderPath, scriptdeployment_recordtypeElemID.name],
+  }),
+  snapshot_type_custom: new PrimitiveType({
+    elemID: snapshot_type_customElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CUSTOM', 'CUSTOM10', 'CUSTOM2', 'CUSTOM3', 'CUSTOM4', 'CUSTOM5', 'CUSTOM6', 'CUSTOM7', 'CUSTOM8', 'CUSTOM9'] }),
+    },
+    path: [...enumsFolderPath, snapshot_type_customElemID.name],
+  }),
+  snapshot_type_date_range_comparable: new PrimitiveType({
+    elemID: snapshot_type_date_range_comparableElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCTUPTIME', 'AGGREGATEDBOOKINGS', 'AVERAGEINVENTORY', 'BOOKINGS', 'BOOKINGSALT', 'CARTABANDON', 'CHECKOUTABANDON', 'CLOSEDCASES', 'CLOSEDISSUES', 'CURRENTLOGGEDINUSERS', 'CUSTOMERSWON', 'ECOMMISSIONS', 'ECOMMISSIONSPARTNER', 'EMPLOYEES', 'ESCALATEDCASES', 'ESTIMATES', 'ESTIMATESRANGE', 'ETECASEEOVERFIVE', 'ETECASEEOVERTWO', 'ETECASEVOVERFIVE', 'ETECASEVOVERTWO', 'ETECUSTEOVERFIVE', 'ETECUSTEOVERTWO', 'ETECUSTVOVERFIVE', 'ETECUSTVOVERTWO', 'ETESOEOVERFIVE', 'ETESOEOVERTWO', 'ETESOVOVERFIVE', 'ETESOVOVERTWO', 'FORECAST', 'FORECASTASA', 'FORECASTOVERRIDE', 'FORECASTOVERRIDEASA', 'HOSTEDSITETRAFFIC', 'NEWBUSINESSORD', 'NEWBUSINESSORDALT', 'NEWCASES', 'NEWCUSTOMERSORD', 'NEWISSUES', 'NEWLEADS', 'NEWLEADSGROSS', 'NEWOPPORTUNITIES', 'NEWVISITORS', 'OPENCASES', 'OPENISSUES', 'OPPORTUNITIES', 'OPPORTUNITIESLOST', 'OPPORTUNITIESRANGE', 'OPPORTUNITIESWON', 'ORDERS', 'PAGETIMESOVERFIVE', 'PAGETIMESOVERTWO', 'PCOMMISSIONS', 'PCOMMISSIONSPARTNER', 'PIPELINE', 'PIPELINEASA', 'PIPELINEDEALS', 'PIPELINEWEIGHTED', 'PIPELINEWEIGHTEDASA', 'PROSPECTS', 'QUOTA', 'QUOTAASA', 'QUOTAREPS', 'RPAGETIMESOVERFIVE', 'RPAGETIMESOVERTWO', 'SITETRAFFIC', 'SPAGETIMESOVERFIVE', 'SPAGETIMESOVERTWO', 'TOTALBOOKINGS', 'TOTALORDERS', 'TOTALPIPEDEALS', 'TOTALPIPELINE', 'TOTALPIPELINEASA', 'TOTALPIPEWEIGHTED', 'TOTALPIPEWEIGHTEDASA', 'VISITORTRAFFIC', 'WEBORDERS', 'WEBREVENUE'] }),
+    },
+    path: [...enumsFolderPath, snapshot_type_date_range_comparableElemID.name],
+  }),
+  snapshot_type_date_range_not_comparable: new PrimitiveType({
+    elemID: snapshot_type_date_range_not_comparableElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['COMMISSIONS', 'COMMISSIONSPARTNER'] }),
+    },
+    path: [...enumsFolderPath, snapshot_type_date_range_not_comparableElemID.name],
+  }),
+  snapshot_type_period_range_comparable: new PrimitiveType({
+    elemID: snapshot_type_period_range_comparableElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['BANKBAL', 'COGS', 'CREDITCARDBAL', 'DEFERREDREVENUE', 'EQUITY', 'EXPENSES', 'FIXEDASSET', 'INCOME', 'INTTURNOVRPERPERIOD', 'INVENTORY', 'LONGTERMLIAB', 'NETCASHFLOW', 'NEWBUSINESS', 'NEWCUSTOMERS', 'ONTIMERECEIPTS', 'ONTIMESHIPMENTS', 'OPERATINGEXPENSES', 'OPERCASHFLOW', 'OTHERASSET', 'OTHERCURRENTASSET', 'OTHERCURRENTLIAB', 'PAYABLES', 'PAYROLL', 'PROFIT', 'RECEIVABLES', 'REVENUE', 'SALES', 'SALESCASHBASIS'] }),
+    },
+    path: [...enumsFolderPath, snapshot_type_period_range_comparableElemID.name],
+  }),
+  snapshot_type_period_range_not_comparable: new PrimitiveType({
+    elemID: snapshot_type_period_range_not_comparableElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['UTILIZATION'] }),
+    },
+    path: [...enumsFolderPath, snapshot_type_period_range_not_comparableElemID.name],
+  }),
+  snapshot_type_trendgraph: new PrimitiveType({
+    elemID: snapshot_type_trendgraphElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCTUPTIME', 'AGGREGATEDBOOKINGS', 'AVERAGEINVENTORY', 'BANKBAL', 'BOOKINGS', 'BOOKINGSALT', 'CARTABANDON', 'CHECKOUTABANDON', 'CLOSEDCASES', 'CLOSEDISSUES', 'COGS', 'CREDITCARDBAL', 'CURRENTLOGGEDINUSERS', 'CUSTCONSOLAVGDL', 'CUSTCONSOLUNBLEDORDS', 'CUSTOMERAVGDAYSLATE', 'CUSTOMERAVGDAYSTOPAY', 'CUSTOMERRECEIVABLES', 'CUSTOMERSWON', 'CUSTUNBILLEDORDERS', 'DEFERREDREVENUE', 'ECOMMISSIONS', 'ECOMMISSIONSPARTNER', 'EMPLOYEES', 'EQUITY', 'ESCALATEDCASES', 'ESTIMATES', 'ESTIMATESRANGE', 'ETECASEEOVERFIVE', 'ETECASEEOVERTWO', 'ETECASEVOVERFIVE', 'ETECASEVOVERTWO', 'ETECUSTEOVERFIVE', 'ETECUSTEOVERTWO', 'ETECUSTVOVERFIVE', 'ETECUSTVOVERTWO', 'ETESOEOVERFIVE', 'ETESOEOVERTWO', 'ETESOVOVERFIVE', 'ETESOVOVERTWO', 'EXPENSES', 'FIXEDASSET', 'FORECAST', 'FORECASTASA', 'FORECASTOVERRIDE', 'FORECASTOVERRIDEASA', 'HOSTEDSITETRAFFIC', 'INCOME', 'INTTURNOVRPERPERIOD', 'INVENTORY', 'JOBAMOUNTRECOGNIZED', 'JOBFORECASTCHARGES', 'JOBINCURREDCOSTS', 'LONGTERMLIAB', 'NETCASHFLOW', 'NEWBUSINESS', 'NEWBUSINESSORD', 'NEWBUSINESSORDALT', 'NEWCASES', 'NEWCUSTOMERS', 'NEWCUSTOMERSORD', 'NEWISSUES', 'NEWLEADS', 'NEWLEADSGROSS', 'NEWOPPORTUNITIES', 'NEWVISITORS', 'ONTIMERECEIPTS', 'ONTIMESHIPMENTS', 'OPENCASES', 'OPENISSUES', 'OPERATINGEXPENSES', 'OPERCASHFLOW', 'OPPORTUNITIES', 'OPPORTUNITIESLOST', 'OPPORTUNITIESRANGE', 'OPPORTUNITIESWON', 'ORDERS', 'OTHERASSET', 'OTHERCURRENTASSET', 'OTHERCURRENTLIAB', 'PAGETIMESOVERFIVE', 'PAGETIMESOVERTWO', 'PAYABLES', 'PAYROLL', 'PCOMMISSIONS', 'PCOMMISSIONSPARTNER', 'PIPELINE', 'PIPELINEASA', 'PIPELINEDEALS', 'PIPELINEWEIGHTED', 'PIPELINEWEIGHTEDASA', 'PROFIT', 'PROJECTHOURSWORKED', 'PROJECTINVOICED', 'PROJECTPROFITABILITY', 'PROSPECTS', 'PURCHASES', 'QUOTA', 'QUOTAASA', 'QUOTAREPS', 'RECEIVABLES', 'REVENUE', 'RPAGETIMESOVERFIVE', 'RPAGETIMESOVERTWO', 'SALES', 'SALESCASHBASIS', 'SITETRAFFIC', 'SPAGETIMESOVERFIVE', 'SPAGETIMESOVERTWO', 'TOTALBOOKINGS', 'TOTALORDERS', 'TOTALPIPEDEALS', 'TOTALPIPELINE', 'TOTALPIPELINEASA', 'TOTALPIPEWEIGHTED', 'TOTALPIPEWEIGHTEDASA', 'VENDORBALANCE', 'VENDOROPENPO', 'VISITORTRAFFIC', 'WEBORDERS', 'WEBREVENUE'] }),
+    },
+    path: [...enumsFolderPath, snapshot_type_trendgraphElemID.name],
+  }),
+  sublist_standard_fields: new PrimitiveType({
+    elemID: sublist_standard_fieldsElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['STDBODYACCOUNT', 'STDBODYACCOUNTINGBOOK', 'STDBODYACCTCORPCARDEXP', 'STDBODYADJLOCATION', 'STDBODYADVANCEACCOUNT', 'STDBODYALACONFIGURATION', 'STDBODYAPACCT', 'STDBODYAPPROVALSTATUS', 'STDBODYARACCT', 'STDBODYASSEMBLYITEM', 'STDBODYBILLINGACCOUNT', 'STDBODYBILLINGSCHEDULE', 'STDBODYBUYINGREASON', 'STDBODYBUYINGTIMEFRAME', 'STDBODYCLASS', 'STDBODYCREATEDFROM', 'STDBODYCURRENCY', 'STDBODYCUSTOMER', 'STDBODYCUSTOMFORM', 'STDBODYDECISIONMAKER', 'STDBODYDEPARTMENT', 'STDBODYDEPOSIT', 'STDBODYDISCOUNTITEM', 'STDBODYDRACCOUNT', 'STDBODYEFFECTIVITYBASEDON', 'STDBODYEMPLOYEE', 'STDBODYENTITY', 'STDBODYENTITYEMPLOYEE', 'STDBODYENTITYSTATUS', 'STDBODYEXPENSEACCOUNT', 'STDBODYEXPENSEREPORTCURRENCY', 'STDBODYFORECASTTYPE', 'STDBODYFXACCOUNT', 'STDBODYINCOTERM', 'STDBODYITEM', 'STDBODYITEMFULFILLMENT', 'STDBODYJOB', 'STDBODYLEADSOURCE', 'STDBODYLOCATION', 'STDBODYNEXTAPPROVER', 'STDBODYOPPORTUNITY', 'STDBODYORDERSTATUS', 'STDBODYPARENTEXPENSEALLOC', 'STDBODYPARTNER', 'STDBODYPAYMENTCUSTOMER', 'STDBODYPAYMENTMETHOD', 'STDBODYPAYROLLITEM', 'STDBODYPOSTINGPERIOD', 'STDBODYPROMOCODE', 'STDBODYPURCHASECONTRACT', 'STDBODYREVCOMMITSTATUS', 'STDBODYREVENUESTATUS', 'STDBODYREVERSALENTRY', 'STDBODYREVISION', 'STDBODYSALESORDER', 'STDBODYSALESREADINESS', 'STDBODYSALESREP', 'STDBODYSHIPADDRESSLIST', 'STDBODYSHIPCOUNTRY', 'STDBODYSHIPMETHOD', 'STDBODYSHIPPINGTAXCODE', 'STDBODYSHIPSTATUS', 'STDBODYSHIPTO', 'STDBODYSTATUS', 'STDBODYSUBSIDIARY', 'STDBODYTAXITEM', 'STDBODYTAXPERIOD', 'STDBODYTERMS', 'STDBODYTOLOCATION', 'STDBODYTOSUBSIDIARY', 'STDBODYTRANSFERLOCATION', 'STDBODYTRANSTATUS', 'STDBODYTRANTYPE', 'STDBODYVENDOR', 'STDBODYWINLOSSREASON', 'STDCOLACCOUNT', 'STDCOLBOMREVISIONCOMPONENT', 'STDCOLCALL', 'STDCOLCASE', 'STDCOLCASETASKEVENT', 'STDCOLCHARGE', 'STDCOLCLASS', 'STDCOLCREATEDFROM', 'STDCOLCUSTOMER', 'STDCOLDEPARTMENT', 'STDCOLEMPLOYEE', 'STDCOLENTITY', 'STDCOLEVENT', 'STDCOLITEM', 'STDCOLJOB', 'STDCOLLOCATION', 'STDCOLPROJECTTASK', 'STDCOLSUBSCRIPTION', 'STDCOLSUBSCRIPTIONLINE', 'STDCOLSUBSIDIARY', 'STDCOLTASK', 'STDCOLUNITS', 'STDENTITYACCESSROLE', 'STDENTITYAPPROVER', 'STDENTITYASSIGNEDWEBSITE', 'STDENTITYASSISTANT', 'STDENTITYBILLINGACCOUNT', 'STDENTITYBILLINGCLASS', 'STDENTITYBILLINGRATECARD', 'STDENTITYBILLINGSCHEDULE', 'STDENTITYBUYINGREASON', 'STDENTITYBUYINGTIMEFRAME', 'STDENTITYCAMPAIGNCATEGORY', 'STDENTITYCAMPAIGNEVENT', 'STDENTITYCLASS', 'STDENTITYCOMMISSIONPAYMENTPREFERENCE', 'STDENTITYCOMPANY', 'STDENTITYCONTACTCAMPAIGNEVENT', 'STDENTITYCONTACTSOURCE', 'STDENTITYCONTACTSOURCECAMPAIGNCATEGORY', 'STDENTITYCOUNTRY', 'STDENTITYCREDITHOLDOVERRIDE', 'STDENTITYCURRENCY', 'STDENTITYCUSTOMERCUSTOMFORM', 'STDENTITYCUSTTYPE', 'STDENTITYDEFAULTACCTCORPCARDEXP', 'STDENTITYDEFAULTEXPENSEREPORTCURRENCY', 'STDENTITYDEFAULTJOBRESOURCEROLE', 'STDENTITYDEPARTMENT', 'STDENTITYDRACCOUNT', 'STDENTITYEMAILPREFERENCE', 'STDENTITYEMPLOYEECHANGEREASON', 'STDENTITYEMPLOYEEHCMJOB', 'STDENTITYEMPLOYEESTATUS', 'STDENTITYEMPLOYEETERMINATIONCATEGORY', 'STDENTITYEMPLOYEETERMINATIONREGRETTED', 'STDENTITYEMPTYPE', 'STDENTITYESTIMATEREVRECTEMPLATE', 'STDENTITYETHNICITY', 'STDENTITYEXPENSEACCOUNT', 'STDENTITYFXACCOUNT', 'STDENTITYGLOBALSUBSCRIPTIONSTATUS', 'STDENTITYINCOTERM', 'STDENTITYJOBBILLINGTYPE', 'STDENTITYJOBEMPLOYMENTCATEGORY', 'STDENTITYJOBITEM', 'STDENTITYJOBTYPE', 'STDENTITYLANGUAGE', 'STDENTITYLEADSOURCE', 'STDENTITYLOCATION', 'STDENTITYMARITALSTATUS', 'STDENTITYNEGATIVENUMBERFORMAT', 'STDENTITYNUMBERFORMAT', 'STDENTITYPARENT', 'STDENTITYPARENTPARTNER', 'STDENTITYPARTNER', 'STDENTITYPARTNERCUSTOMFORM', 'STDENTITYPAYABLESACCOUNT', 'STDENTITYPAYFREQUENCY', 'STDENTITYPREFCCPROCESSOR', 'STDENTITYPRICELEVEL', 'STDENTITYPROJECTEXPENSETYPE', 'STDENTITYPROJECTMANAGER', 'STDENTITYPURCHASEORDERAPPROVER', 'STDENTITYRECEIVABLESACCOUNT', 'STDENTITYRESIDENTSTATUS', 'STDENTITYSALESREADINESS', 'STDENTITYSALESREP', 'STDENTITYSALESROLE', 'STDENTITYSCHEDULINGMETHOD', 'STDENTITYSHIPPINGITEM', 'STDENTITYSOURCEWEBSITE', 'STDENTITYSTAGE', 'STDENTITYSTATE', 'STDENTITYSTATUS', 'STDENTITYSUBSIDIARY', 'STDENTITYSUPERVISOR', 'STDENTITYSYMBOLPLACEMENT', 'STDENTITYTAXITEM', 'STDENTITYTAXROUNDING', 'STDENTITYTERMINATIONREASON', 'STDENTITYTERMS', 'STDENTITYTERRITORY', 'STDENTITYTIMEAPPROVAL', 'STDENTITYTIMEAPPROVER', 'STDENTITYTIMEOFFPLAN', 'STDENTITYTYPE', 'STDENTITYVENDORCUSTOMFORM', 'STDENTITYVENDORTIMEAPPROVER', 'STDENTITYVENDTYPE', 'STDENTITYVISATYPE', 'STDENTITYWORKCALENDAR', 'STDENTITYWORKPLACE', 'STDEVENTALLOCATIONPROJECT', 'STDEVENTALLOCATIONPROJECTTASK', 'STDEVENTALLOCATIONTYPE', 'STDEVENTAPPROVALSTATUS', 'STDEVENTASSIGNED', 'STDEVENTAUDIENCE', 'STDEVENTCALLSTATUS', 'STDEVENTCAMPAIGNCATEGORY', 'STDEVENTCASECATEGORY', 'STDEVENTCASEPRIORITY', 'STDEVENTCASEPROFILE', 'STDEVENTCASESTATUS', 'STDEVENTCOMPANY', 'STDEVENTCONSTRAINTTYPE', 'STDEVENTCONTACT', 'STDEVENTCUSTOMER', 'STDEVENTCUSTOMFORM', 'STDEVENTDUPLICATEOF', 'STDEVENTFAMILY', 'STDEVENTHELPDESKEMPLOYEE', 'STDEVENTISSUE', 'STDEVENTISSUESTATUS', 'STDEVENTISSUETYPE', 'STDEVENTITEM', 'STDEVENTJOB', 'STDEVENTMILESTONE', 'STDEVENTMODULE', 'STDEVENTNEXTAPPROVER', 'STDEVENTOFFER', 'STDEVENTOPPORTUNITY', 'STDEVENTORDER', 'STDEVENTORGANIZER', 'STDEVENTORIGIN', 'STDEVENTOWNER', 'STDEVENTPARENT', 'STDEVENTPRIORITY', 'STDEVENTPRODUCT', 'STDEVENTPRODUCTTEAM', 'STDEVENTPROMOTIONCODE', 'STDEVENTREMINDERMINUTES', 'STDEVENTREMINDERTYPE', 'STDEVENTREPORTEDBY', 'STDEVENTREPRODUCE', 'STDEVENTREQUESTEDBY', 'STDEVENTRESOURCE', 'STDEVENTREVIEWER', 'STDEVENTSEARCHENGINE', 'STDEVENTSEVERITY', 'STDEVENTSOURCE', 'STDEVENTSTATUS', 'STDEVENTSUBSIDIARY', 'STDEVENTSUPPORTCASE', 'STDEVENTTASKSTATUS', 'STDEVENTTRANSACTION', 'STDEVENTVERTICAL', 'STDITEMACCOUNT', 'STDITEMAMORTIZATIONTEMPLATE', 'STDITEMASSETACCOUNT', 'STDITEMBILLEXCHRATEVARIANCEACCT', 'STDITEMBILLINGSCHEDULE', 'STDITEMBILLPRICEVARIANCEACCT', 'STDITEMBILLQTYVARIANCEACCT', 'STDITEMCLASS', 'STDITEMCOGSACCOUNT', 'STDITEMCOSTESTIMATETYPE', 'STDITEMCOSTINGMETHOD', 'STDITEMCREATEREVENUEPLANSON', 'STDITEMCURRENCY', 'STDITEMCUSTOMFORM', 'STDITEMCUSTRETURNVARIANCEACCOUNT', 'STDITEMDEFAULTRENEWALPLAN', 'STDITEMDEFAULTRENEWALTRANTYPE', 'STDITEMDEFERRALACCOUNT', 'STDITEMDEFERREDREVENUEACCOUNT', 'STDITEMDEPARTMENT', 'STDITEMDROPSHIPEXPENSEACCOUNT', 'STDITEMEFFECTIVEBOMCONTROL', 'STDITEMEXPENSEACCOUNT', 'STDITEMFRAUDRISK', 'STDITEMGAINLOSSACCOUNT', 'STDITEMINCOMEACCOUNT', 'STDITEMINITIALTERM', 'STDITEMISSUEPRODUCT', 'STDITEMITEMREVENUECATEGORY', 'STDITEMITEMTYPE', 'STDITEMLIABILITYACCOUNT', 'STDITEMLOCATION', 'STDITEMOUTOFSTOCKBEHAVIOR', 'STDITEMOVERALLQUANTITYPRICINGTYPE', 'STDITEMPARENT', 'STDITEMPAYMENTMETHOD', 'STDITEMPREFERREDLOCATION', 'STDITEMPRICINGGROUP', 'STDITEMPROJECTEXPENSETYPE', 'STDITEMPROJECTTEMPLATE', 'STDITEMPURCHASEUNIT', 'STDITEMQUANTITYPRICINGSCHEDULE', 'STDITEMREVENUEALLOCATIONGROUP', 'STDITEMREVENUERECOGNITIONRULE', 'STDITEMREVRECSCHEDULE', 'STDITEMSALEUNIT', 'STDITEMSHIPPACKAGE', 'STDITEMSOFTDESCRIPTOR', 'STDITEMSTATE', 'STDITEMSTOCKUNIT', 'STDITEMSTOREITEMTEMPLATE', 'STDITEMTAXACCOUNT', 'STDITEMTAXAGENCY', 'STDITEMTAXSCHEDULE', 'STDITEMTAXTYPE', 'STDITEMUNBUILDVARIANCEACCOUNT', 'STDITEMUNITSTYPE', 'STDITEMVENDOR', 'STDITEMVENDRETURNVARIANCEACCOUNT', 'STDITEMVSOEDEFERRAL', 'STDITEMVSOEPERMITDISCOUNT', 'STDITEMVSOESOPGROUP', 'STDUSERCLASS', 'STDUSERDEPARTMENT', 'STDUSERLOCATION', 'STDUSERROLE', 'STDUSERSUBSIDIARY', 'STDUSERUSER'] }),
+    },
+    path: [...enumsFolderPath, sublist_standard_fieldsElemID.name],
+  }),
+  suiteletdeployment_tasktype: new PrimitiveType({
+    elemID: suiteletdeployment_tasktypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['SCRIPT'] }),
+    },
+    path: [...enumsFolderPath, suiteletdeployment_tasktypeElemID.name],
+  }),
+  transactionform_advancedtemplate: new PrimitiveType({
+    elemID: transactionform_advancedtemplateElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['OLDSTDTMPLPACKINGSLIP', 'STDTMPLAUVENDPYMT', 'STDTMPLAUVOUCHERCHECK', 'STDTMPLBCUSTTRAN', 'STDTMPLBOM', 'STDTMPLCASHRFND', 'STDTMPLCASHRFNDST', 'STDTMPLCASHSALE', 'STDTMPLCASHSALEST', 'STDTMPLCHECK', 'STDTMPLCUSTCRED', 'STDTMPLCUSTCREDST', 'STDTMPLCUSTDEP', 'STDTMPLCUSTINVC', 'STDTMPLCUSTINVCST', 'STDTMPLCUSTPYMT', 'STDTMPLEMPTY', 'STDTMPLEXPREPT', 'STDTMPLFRPICKINGTICKET', 'STDTMPLGLIMPACT', 'STDTMPLHCUSTTRAN', 'STDTMPLINVCGROUP2ST', 'STDTMPLINVCGROUPST', 'STDTMPLITEMLABEL', 'STDTMPLJCUSTTRAN', 'STDTMPLJOURNAL', 'STDTMPLMAILINGLABEL', 'STDTMPLMULTICURRSTMT', 'STDTMPLPACKINGSLIP', 'STDTMPLPAYCHECK', 'STDTMPLPAYMENTVOUCHER', 'STDTMPLPCUSTTRAN', 'STDTMPLPERIODENDJOURNAL', 'STDTMPLPICKINGTICKET', 'STDTMPLPRICELIST', 'STDTMPLPURCHORD', 'STDTMPLPURCHORDST', 'STDTMPLQUOTE', 'STDTMPLQUOTEST', 'STDTMPLRTNAUTH', 'STDTMPLRTNAUTHST', 'STDTMPLSALESORD', 'STDTMPLSALESORDST', 'STDTMPLSCUSTTRAN', 'STDTMPLSHIPPINGLABEL', 'STDTMPLSTATEMENT', 'STDTMPLSVPREP', 'STDTMPLUKCHECK', 'STDTMPLUKVENDPYMT', 'STDTMPLUKVOUCHERCHECK', 'STDTMPLUSVENDPYMT', 'STDTMPLUSVOUCHERCHECK', 'STDTMPLWAVE'] }),
+    },
+    path: [...enumsFolderPath, transactionform_advancedtemplateElemID.name],
+  }),
+  transactionform_buttonid: new PrimitiveType({
+    elemID: transactionform_buttonidElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCEPTPAYMENT', 'ACTIVITYHISTORY', 'APPROVE', 'AUTOFILL', 'BILL', 'BILLREMAINING', 'CANCELORDER', 'CLEARSPLITS', 'CLOSEREMAINING', 'CREATEAUTHORIZATION', 'CREATECASHSALE', 'CREATEDEPOSIT', 'CREATEINVOICE', 'CREATEPICKUP', 'CREATESALESORD', 'CREDIT', 'DELETE', 'EMAIL', 'ENTERPREPAYMENT', 'FAX', 'GLIMPACT', 'GOTOREGISTER', 'ITEM_ADDPROJECTITEMS', 'MAKECOPY', 'MAKESTANDALONECOPY', 'MEMORIZE', 'NEW', 'NEXTBILL', 'PRINT', 'PRINTLABEL', 'PRINTPICKTICK', 'PROCESS', 'RECEIVE', 'REFUND', 'REJECT', 'RENEWAL', 'REQUESTFULFILLMENT', 'RESETTER', 'RETURN', 'REVCOMM', 'REVCOMRV', 'SAVEEMAIL', 'SAVEPRINT', 'SUBMITACCEPTDEPOSIT', 'SUBMITACCEPTPAYMENTAUTHORIZATION', 'SUBMITFULFILL', 'SUBMITNEW', 'UPDATEREVREC', 'UPDATEVSOE', 'VIEWEXPENSEPLANS', 'VOID'] }),
+    },
+    path: [...enumsFolderPath, transactionform_buttonidElemID.name],
+  }),
+  transactionform_checkboxdefault: new PrimitiveType({
+    elemID: transactionform_checkboxdefaultElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CHECKED', 'UNCHECKED', 'USE_FIELD_DEFAULT'] }),
+    },
+    path: [...enumsFolderPath, transactionform_checkboxdefaultElemID.name],
+  }),
+  transactionform_columnid: new PrimitiveType({
+    elemID: transactionform_columnidElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNT', 'ALLOCATIONALERT', 'ALTSALESAMT', 'AMOUNT', 'AMOUNTORDERED', 'AMOUNTRECOGNIZED', 'AMOUNTREMAINING', 'ASSEMBLY', 'ASSEMBLYUNITS', 'AVERAGECOST', 'BILLEDDATE', 'BILLINGSCHEDULE', 'BILLOFMATERIALS', 'BILLOFMATERIALSREVISION', 'BILLVARIANCESTATUS', 'BINNUMBERS', 'CATCHUPPERIOD', 'CATEGORY', 'CHARGERULE', 'CHARGES', 'CHARGETYPE', 'CLASS', 'COMMITINVENTORY', 'COMMITMENTFIRM', 'COSTESTIMATE', 'COSTESTIMATERATE', 'COSTESTIMATETYPE', 'CREATEDFROM', 'CREATEDFROM', 'CREATEEXPENSEPLANSON', 'CREATEOUTSOURCEDWO', 'CREATEPO', 'CREATEWO', 'CREDIT', 'CREDITTAX', 'CURRENTPERCENT', 'CUSTOMER', 'DATECOL', 'DAYSLATE', 'DEBIT', 'DEBITTAX', 'DEFERREVREC', 'DEPARTMENT', 'DESCRIPTION', 'DISCOUNT', 'DONOTCREATEREVENUEELEMENT', 'DUEDATE', 'ELIMINATE', 'EMPLOYEE', 'EMPLOYEEFULLNAME', 'ENDDATE', 'ENTITY', 'ESTGROSSPROFIT', 'ESTGROSSPROFITPERCENT', 'EVENT', 'EXCLUDEFROMRATEREQUEST', 'EXPECTEDDELIVERYDATE', 'EXPECTEDRECEIPTDATE', 'EXPECTEDSHIPDATE', 'EXPENSEAMORTIZATIONRULE', 'EXPENSEPLAN', 'EXPENSEPLANSTATUS', 'FREEGIFTPROMOTION', 'FROMJOB', 'GENERATEACCRUALS', 'GIFTCERTFIELDS', 'GLNUMBER', 'GLSEQUENCE', 'GROSSAMT', 'INVENTORYDETAIL', 'INVENTORYLOCATION', 'INVENTORYSUBSIDIARY', 'ISBILLABLE', 'ISCLOSED', 'ISESTIMATE', 'ISTAXABLE', 'ITEM', 'ITEMFULFILLMENTCHOICE', 'JOB', 'LANDEDCOSTCATEGORY', 'LASTPURCHASEPRICE', 'LICENSECODE', 'LINETAXCODE', 'LINETAXRATE', 'LINKEDORDER', 'LOCATION', 'LOCATIONAUTOASSIGNED', 'MATCHBILLTORECEIPT', 'MEMO', 'NOAUTOASSIGNLOCATION', 'OPTIONS', 'ORDERALLOCATIONSTRATEGY', 'ORDERPRIORITY', 'PAYMENT', 'PERCENTCOMPLETE', 'PORATE', 'POVENDOR', 'PRICE', 'PRICEINTERVALFREQUENCYNAME', 'PRICEINTERVALREPEATEVERY', 'PROCESSEDBYREVCOMMIT', 'PRODUCTIONENDDATE', 'PRODUCTIONSTARTDATE', 'PROJECTTASK', 'PROMISEDATE', 'PURCHASECONTRACT', 'QUANTITY', 'QUANTITYALLOCATED', 'QUANTITYAVAILABLE', 'QUANTITYBACKORDERED', 'QUANTITYCOMMITTED', 'QUANTITYDEMANDALLOCATED', 'QUANTITYFULFILLED', 'QUANTITYONHAND', 'QUANTITYONSHIPMENTS', 'QUANTITYORDERED', 'QUANTITYRECEIVED', 'QUANTITYREMAINING', 'RATE', 'REQUESTEDDATE', 'REQUESTEDDELIVERYDATE', 'RESIDUAL', 'REVENUERECOGNITIONRULE', 'REVRECENDDATE', 'REVRECSCHEDULE', 'REVRECSTARTDATE', 'SCHEDULE', 'SCHEDULENUM', 'SERIALNUMBERS', 'SHIPADDRESS', 'SHIPCARRIER', 'SHIPMETHOD', 'SOURCEEXPENSEDOC', 'SOURCEREVENUEPLAN', 'STARTDATE', 'SUBNAME', 'SUBSCRIPTION', 'SUBSCRIPTIONLINE', 'SUBSCRIPTIONLINEPERIODAMOUNT', 'SUBSCRIPTIONLINERATE', 'SUBSIDIARY', 'TAX1AMT', 'TAXACCOUNT', 'TAXAMOUNT', 'TAXBASIS', 'TAXCODE', 'TAXRATE1', 'TAXRATE2', 'TERMINMONTHS', 'TERMS', 'TOBEFULFILLED', 'TOBERECEIVED', 'TOTALAMOUNT', 'UNITS', 'VSOEFIELDS'] }),
+    },
+    path: [...enumsFolderPath, transactionform_columnidElemID.name],
+  }),
+  transactionform_fieldid: new PrimitiveType({
+    elemID: transactionform_fieldidElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCOUNT', 'ACCOUNTINGBOOK', 'ACCOUNTNUMBER', 'ACTUALSHIPDATE', 'ADDRESS', 'AGING1', 'AGING2', 'AGING3', 'AGING4', 'AGING5', 'AGINGBAL', 'ALACONFIGURATION', 'ALTERNATIVEPICKUPCONTACT', 'AMOUNTPAID', 'AMOUNTREMAINING', 'APACCT', 'APPROVALSTATUS', 'APPROVED', 'ARACCT', 'ASOFDATE', 'AUTHCODE', 'AUTOAPPLY', 'AUTOMATICALLYAPPLYPROMOTIONS', 'AVAILABLEBALANCE', 'AVAILABLEVENDORCREDIT', 'BALANCE', 'BARCODE', 'BILLADDRESS', 'BILLADDRESSLIST', 'BILLINGACCOUNT', 'BILLINGSCHEDULE', 'BULKSUBMISSIONID', 'CANHAVESTACKABLE', 'CARDDATAPROVIDED', 'CCAPPROVED', 'CCAVSSTREETMATCH', 'CCAVSZIPMATCH', 'CCDEFAULT', 'CCEXPIREDATE', 'CCISPURCHASECARDBIN', 'CCNAME', 'CCNUMBER', 'CCPROCESSASPURCHASECARD', 'CCSAVE', 'CCSECURITYCODE', 'CCSECURITYCODEMATCH', 'CCSTREET', 'CCZIPCODE', 'CHARGEIT', 'CHECKNUM', 'CHECKNUMBER', 'CLASS', 'COMPANYADDRESS', 'COMPANYFEDNUM', 'COMPANYLOGO', 'COMPANYNAME', 'COMPANYPHONE', 'COMPANYURL', 'CONSOLIDATEBALANCE', 'COUPONCODE', 'CREATEDFROM', 'CREDITCARD', 'CREDITCARDPROCESSOR', 'CREDITTOTAL', 'CURRENCY', 'CUSTOMER', 'CUSTOMERCODE', 'CUSTOMERPAYMENTAUTHORIZATION', 'CUSTOMFORM', 'DEBITTOTAL', 'DEFERREDREVENUE', 'DEPARTMENT', 'DISCOUNTAMOUNT', 'DISCOUNTDATE', 'DISCOUNTITEM', 'DISCOUNTRATE', 'DOCUMENTSEQUENCE', 'DRACCOUNT', 'DUEDATE', 'DYNAMICDESCRIPTOR', 'EMPLOYEE', 'ENDDATE', 'ENTITY', 'ENTITYSTATUS', 'ENTITYTAXREGNUM', 'ESTGROSSPROFIT', 'ESTGROSSPROFITPERCENT', 'EXCHANGERATE', 'EXCLUDECOMMISSION', 'EXCLUDEFROMGLNUMBERING', 'EXPECTEDCLOSEDATE', 'EXPENSEPLANSTATUS', 'FILE', 'FOB', 'FORECASTTYPE', 'FORINVOICEGROUPING', 'FORMTITLE', 'FXACCOUNT', 'GENERATETRANIDONSAVE', 'GETAUTH', 'GIFTCERT', 'GROUPEDTO', 'HANDLINGCOST', 'HANDLINGMODE', 'HANDLINGTAX1RATE', 'HANDLINGTAX2RATE', 'HANDLINGTAXAMOUNT', 'HANDLINGTAXCODE', 'IGNOREAVS', 'IGNORECSC', 'INCLUDEINFORECAST', 'INCOTERM', 'INPUTAUTHCODE', 'INPUTREFERENCECODE', 'INTERCOSTATUS', 'INTERCOTRANSACTION', 'IPADDRESS', 'IPADDRESSCOUNTRY', 'ISAOMAUTOMATED', 'ISCROSSSUBTRANSACTION', 'ISINTRANSITPAYMENT', 'ISMULTISHIPTO', 'ISRECURRINGPAYMENT', 'ISTAXABLE', 'JOB', 'LEADSOURCE', 'LOCATION', 'MEMO', 'MESSAGE', 'MESSAGESEL', 'MOSSCOUNTRY', 'MOSSCOUNTRYDETAIL', 'NEXTAPPROVER', 'NEXUS', 'OFFSETACCOUNT', 'ONETIME', 'OPPORTUNITY', 'ORDERFULFILLMENTCHOICE', 'ORDERSTATUS', 'OTHERREFNUM', 'OUTOFBALANCEBY', 'OUTPUTAUTHCODE', 'OUTPUTREFERENCECODE', 'OVERRIDEINSTALLMENTS', 'PAGENUMBER', 'PARENTEXPENSEALLOC', 'PARTNER', 'PAYEEADDRESSLIST', 'PAYMENT', 'PAYMENTCARDCSC', 'PAYMENTMETHOD', 'PAYMENTOPERATION', 'PAYMENTOPTION', 'PAYMENTPROCESSINGPROFILE', 'PAYMENTSESSIONAMOUNT', 'PAYPALAUTHID', 'PAYPALORDERID', 'PAYPALSTATUS', 'PAYPALTRANID', 'PENDING', 'PNREFNUM', 'POSTINGPERIOD', 'PRINTVOUCHER', 'PROBABILITY', 'PROJECT', 'PROMOCODE', 'PURCHASECONTRACT', 'RECOGNIZEDREVENUE', 'RECURANNUALLY', 'RECURMONTHLY', 'RECURQUARTERLY', 'RECURRENCEFREQUENCY', 'RECURRINGBILL', 'RECURWEEKLY', 'REFUNDCHECK', 'REPEATEVERY', 'REPEATUNIT', 'REVCOMMITSTATUS', 'REVENUESTATUS', 'REVERSALDATE', 'REVERSALDEFER', 'REVERSALENTRY', 'REVRECENDDATE', 'REVRECONREVCOMMITMENT', 'REVRECSCHEDULE', 'REVRECSTARTDATE', 'SALESEFFECTIVEDATE', 'SALESREP', 'SHIPADDRESS', 'SHIPADDRESSLIST', 'SHIPCARRIER', 'SHIPCOMPLETE', 'SHIPDATE', 'SHIPMETHOD', 'SHIPPINGCOST', 'SHIPPINGTAX1RATE', 'SHIPPINGTAX2RATE', 'SHIPPINGTAXAMOUNT', 'SHIPPINGTAXCODE', 'SHIPTO', 'SOFTDESCRIPTOR', 'SOURCE', 'STARTDATE', 'SUBSIDIARY', 'SUBSIDIARYTAXREGNUM', 'SUBTOTAL', 'SUPERVISORAPPROVAL', 'TAXDETAILSOVERRIDE', 'TAXITEM', 'TAXPOINTDATE', 'TAXPOINTDATEOVERRIDE', 'TAXRATE', 'TAXREGOVERRIDE', 'TAXTOTAL', 'TERMS', 'TITLE', 'TOBEEMAILED', 'TOBEFAXED', 'TOBEPRINTED', 'TOPRINT2', 'TOSUBSIDIARY', 'TOTAL', 'TOTALAFTERTAXES', 'TOTALCOSTESTIMATE', 'TRACKINGNUMBERS', 'TRANDATE', 'TRANID', 'TRANISVSOEBUNDLE', 'TRANSACTIONNUMBER', 'UNBILLEDORDERS', 'VATREGNUM', 'VISIBLETOCUSTOMER', 'VOIDJOURNAL', 'VSOEAUTOCALC', 'WHICHCHARGESTOADD'] }),
+    },
+    path: [...enumsFolderPath, transactionform_fieldidElemID.name],
+  }),
+  transactionform_htmllayout: new PrimitiveType({
+    elemID: transactionform_htmllayoutElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CLASSICHTMLBOMLAYOUT', 'CLASSICHTMLPACKINGSLIPLAYOUT', 'CLASSICHTMLPICKINGTICKETLAYOUT', 'CLASSICHTMLPRICELISTLAYOUT', 'CLASSICHTMLREMITTANCESLIPLAYOUT', 'CLASSICHTMLRETURNFORMLAYOUT', 'CLASSICHTMLSTATEMENTLAYOUT', 'CLASSICHTMLTRANSACTIONLAYOUT', 'STANDARDHTMLBOMLAYOUT', 'STANDARDHTMLPACKINGSLIPLAYOUT', 'STANDARDHTMLPICKINGTICKETLAYOUT', 'STANDARDHTMLPRICELISTLAYOUT', 'STANDARDHTMLREMITTANCESLIPLAYOUT', 'STANDARDHTMLRETURNFORMLAYOUT', 'STANDARDHTMLSTATEMENTLAYOUT', 'STANDARDHTMLTRANSACTIONLAYOUT'] }),
+    },
+    path: [...enumsFolderPath, transactionform_htmllayoutElemID.name],
+  }),
+  transactionform_pdflayout: new PrimitiveType({
+    elemID: transactionform_pdflayoutElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CLASSICBOMLAYOUT', 'CLASSICDISCLAIMERPRICELISTLAYOUT', 'CLASSICDISCLAIMERTRANSACTIONLAYOUT', 'CLASSICPACKINGSLIPLAYOUT', 'CLASSICPICKINGTICKETLAYOUT', 'CLASSICPRICELISTLAYOUT', 'CLASSICREMITTANCESLIPLAYOUT', 'CLASSICRETURNFORMLAYOUT', 'CLASSICSHIPPINGLABELLAYOUT', 'CLASSICTRANSACTIONLAYOUT', 'CLASSICTRANSACTIONLAYOUTLARGELOGO', 'CLASSICTRANSACTIONLAYOUTWBARCODE', 'FEDEXDISCLAIMERLAYOUT', 'STANDARDBOMLAYOUT', 'STANDARDDISCLAIMERPRICELISTLAYOUT', 'STANDARDDISCLAIMERTRANSACTIONLAYOUT', 'STANDARDPACKINGSLIPLAYOUT', 'STANDARDPICKINGTICKETLAYOUT', 'STANDARDPRICELISTLAYOUT', 'STANDARDREMITTANCESLIPLAYOUT', 'STANDARDRETURNFORMLAYOUT', 'STANDARDSHIPPINGLABELLAYOUT', 'STANDARDTRANSACTIONLAYOUT', 'TRANSACTIONLAYOUTWITHTAXSUMMARY'] }),
+    },
+    path: [...enumsFolderPath, transactionform_pdflayoutElemID.name],
+  }),
+  transactionform_standard: new PrimitiveType({
+    elemID: transactionform_standardElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['STANDARDBILLPAYMENT', 'STANDARDCASHREFUND', 'STANDARDCASHSALE', 'STANDARDCUSTOMERPAYMENT', 'STANDARDDROPSHIPPURCHASEORDER', 'STANDARDESTIMATE', 'STANDARDFINANCECHARGE', 'STANDARDJOURNALENTRY', 'STANDARDONLINEORDERCASHSALE', 'STANDARDONLINEORDERINVOICE', 'STANDARDONLINEPAYMENT', 'STANDARDPRODUCTINVOICE', 'STANDARDPROFESSIONALINVOICE', 'STANDARDPROGRESSINVOICE', 'STANDARDPURCHASEORDER', 'STANDARDSALESORDER', 'STANDARDSALESORDERCASHSALE', 'STANDARDSALESORDERINVOICE', 'STANDARDSALESORDERPROGRESSBILLING', 'STANDARDSERVICEINVOICE'] }),
+    },
+    path: [...enumsFolderPath, transactionform_standardElemID.name],
+  }),
+  transactionform_sublistid: new PrimitiveType({
+    elemID: transactionform_sublistidElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACTIVEWORKFLOWS', 'ACTIVITIES', 'APPROVALS', 'ARRNGRLRCDS', 'BILLINGSCHEDULE', 'BIZEVTHISTORY', 'CALLS', 'CASES', 'EVENTS', 'EXPCOST', 'EXPENSE', 'EXPENSEPLANMESSAGE', 'GIFTCERTREDEMPTION', 'GLIMPACTCHANGES', 'INSTALLMENTS', 'ITEM', 'ITEMCOST', 'ITPRLRCDS', 'LINKS', 'MEDIAITEM', 'MESSAGES', 'PARTNERS', 'PROMOTIONS', 'SALESTEAM', 'SYSTEMNOTES', 'TASKS', 'TIME', 'USERNOTES', 'WORKFLOWHISTORY'] }),
+    },
+    path: [...enumsFolderPath, transactionform_sublistidElemID.name],
+  }),
+  transactionform_subtabid: new PrimitiveType({
+    elemID: transactionform_subtabidElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['COVERAGE', 'TRANSACTIONOUTPUTOPTIONS', 'TRANSACTIONPAYMENT', 'WORKFLOW'] }),
+    },
+    path: [...enumsFolderPath, transactionform_subtabidElemID.name],
+  }),
+  transactionform_tabid: new PrimitiveType({
+    elemID: transactionform_tabidElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['APPLICATIONS', 'CHARGES', 'CUSTOM', 'GLIMPACTTAB', 'LINES', 'MILESTONES', 'MULTIBOOK', 'MULTIPARTNER', 'PAYEEADDRESS', 'PROMOTIONSTAB', 'STOREPICKUP', 'TAXES', 'TEAMSELLING', 'TRANSACTIONACCOUNTING', 'TRANSACTIONADDRESS', 'TRANSACTIONBILLING', 'TRANSACTIONCOMMUNICATION', 'TRANSACTIONITEMS', 'TRANSACTIONOUTPUTOPTIONS', 'TRANSACTIONPAYMENT', 'TRANSACTIONRELATEDRECORDS', 'TRANSACTIONRELATIONSHIPS', 'TRANSACTIONSHIPPING', 'TRANSACTIONSYSTEMINFORMATION', 'WORKFLOW'] }),
+    },
+    path: [...enumsFolderPath, transactionform_tabidElemID.name],
+  }),
+  translationcollection_defaultlanguage: new PrimitiveType({
+    elemID: translationcollection_defaultlanguageElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['af-ZA', 'ar', 'bg-BG', 'bn-BD', 'bs-BA', 'cs-CZ', 'da-DK', 'de-DE', 'el-GR', 'en', 'en-AU', 'en-CA', 'en-GB', 'en-US', 'es-AR', 'es-ES', 'et-EE', 'fa-IR', 'fi-FI', 'fr-CA', 'fr-FR', 'gu-IN', 'he-IL', 'hi-IN', 'hr-HR', 'hu-HU', 'hy-AM', 'id-ID', 'is-IS', 'it-IT', 'ja-JP', 'kn-IN', 'ko-KR', 'lb-LU', 'lt-LT', 'lv-LV', 'mr-IN', 'ms-MY', 'nl-NL', 'no-NO', 'pa-IN', 'pl-PL', 'pt-BR', 'pt-PT', 'ro-RO', 'ru-RU', 'sh-RS', 'sk-SK', 'sl-SI', 'sq-AL', 'sr-RS', 'sv-SE', 'ta-IN', 'te-IN', 'th-TH', 'tl-PH', 'tr-TR', 'uk-UA', 'vi-VN', 'zh-CN', 'zh-TW'] }),
+    },
+    path: [...enumsFolderPath, translationcollection_defaultlanguageElemID.name],
+  }),
+  webapp_entrytype: new PrimitiveType({
+    elemID: webapp_entrytypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['CART', 'CHECKOUT', 'CUSTCENTER', 'HOMEPAGE', 'LOGIN', 'LOGOUT', 'REGISTER'] }),
+    },
+    path: [...enumsFolderPath, webapp_entrytypeElemID.name],
+  }),
+  workflow_condition_type: new PrimitiveType({
+    elemID: workflow_condition_typeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['FORMULA', 'VISUAL_BUILDER'] }),
+    },
+    path: [...enumsFolderPath, workflow_condition_typeElemID.name],
+  }),
+  workflow_eventtype: new PrimitiveType({
+    elemID: workflow_eventtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['APPROVE', 'CANCEL', 'CHANGEPASSWORD', 'COPY', 'CREATE', 'DELETE', 'DROPSHIP', 'EDIT', 'EDITFORECAST', 'EMAIL', 'GET', 'MARKCOMPLETE', 'ORDERITEMS', 'PACK', 'PAYBILLS', 'POST', 'PRINT', 'QUICKVIEW', 'REASSIGN', 'REJECT', 'SHIP', 'SPECIALORDER', 'TRANSFORM', 'VIEW', 'XEDIT'] }),
+    },
+    path: [...enumsFolderPath, workflow_eventtypeElemID.name],
+  }),
+  workflow_keephistory: new PrimitiveType({
+    elemID: workflow_keephistoryElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ALWAYS', 'F', 'NEVER', 'ONLYWHENTESTING', 'T'] }),
+    },
+    path: [...enumsFolderPath, workflow_keephistoryElemID.name],
+  }),
+  workflow_order_of_week: new PrimitiveType({
+    elemID: workflow_order_of_weekElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['FIRST', 'FOURTH', 'LAST', 'SECOND', 'THIRD'] }),
+    },
+    path: [...enumsFolderPath, workflow_order_of_weekElemID.name],
+  }),
+  workflow_releasestatus: new PrimitiveType({
+    elemID: workflow_releasestatusElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['NOTINITIATING', 'NOTRUNNING', 'RELEASED', 'SUSPENDED', 'TESTING'] }),
+    },
+    path: [...enumsFolderPath, workflow_releasestatusElemID.name],
+  }),
+  workflow_sublists: new PrimitiveType({
+    elemID: workflow_sublistsElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['EXPENSEREPORT:EXPENSE', 'ITEM'] }),
+    },
+    path: [...enumsFolderPath, workflow_sublistsElemID.name],
+  }),
+  workflow_timeunit: new PrimitiveType({
+    elemID: workflow_timeunitElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['DAY', 'HOUR'] }),
+    },
+    path: [...enumsFolderPath, workflow_timeunitElemID.name],
+  }),
+  workflow_triggertype: new PrimitiveType({
+    elemID: workflow_triggertypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['AFTERSUBMIT', 'BEFORELOAD', 'BEFORESUBMIT'] }),
+    },
+    path: [...enumsFolderPath, workflow_triggertypeElemID.name],
+  }),
+  workflowaction_attachmenttype: new PrimitiveType({
+    elemID: workflowaction_attachmenttypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['FIELD', 'SPECIFIC'] }),
+    },
+    path: [...enumsFolderPath, workflowaction_attachmenttypeElemID.name],
+  }),
+  workflowaction_buttonid: new PrimitiveType({
+    elemID: workflowaction_buttonidElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ACCEPT', 'ACCEPTPAYMENT', 'ACTIVATE', 'ACTIVITYHISTORY', 'ADDMATRIX', 'APPLY', 'APPROVE', 'APPROVEALLPENDING', 'APPROVERETURN', 'AUTOFILL', 'BILL', 'BILLREMAINING', 'CANCEL', 'CANCELBILL', 'CANCELFULFILLMENT', 'CANCELORDER', 'CANCELREQUEST', 'CANCELRETURN', 'CAPTUREBYDEPOSIT', 'CAPTUREBYPAYMENT', 'CHANGECUSTOMER', 'CLEARREVISIONS', 'CLEARSPLITS', 'CLOSEREMAINING', 'COMPLETECOUNT', 'CONVERTINVT', 'CONVERTLEAD', 'CONVERTLOT', 'CONVERTSERIAL', 'COPY', 'COPYTIMESHEET', 'CREATEAUTHORIZATION', 'CREATEBUILD', 'CREATECASHSALE', 'CREATEDEPOSIT', 'CREATEINVOICE', 'CREATEMATRIX', 'CREATENEWVERSION', 'CREATEPICKUP', 'CREATEPO', 'CREATEPROJECT', 'CREATESALESORD', 'CREATEUNBUILD', 'CREATE_EMPLOYEE_CHANGE_REQUEST', 'CREDIT', 'DECLINE', 'DELETE', 'DELETELASTVERSION', 'DEPOSITSUMMARY', 'EDIT_CHANGE_REASON', 'EMAIL', 'ENTERCOMPLETION', 'ENTERCOMPLETIONWITHBACKFLUSH', 'ENTERPREPAYMENT', 'FAX', 'FULFILL', 'GENERATEPRICELIST', 'GENERATESTATEMENT', 'GLIMPACT', 'GOTOREGISTER', 'GRAB', 'IMPORTPLANNEDTIME', 'ISSUECOMPONENTS', 'ITEM_ADDPROJECTITEMS', 'MAKECOPY', 'MAKECOPYWITHOUTPRICINGTIERS', 'MAKECOPYWITHOUTSCHEDULES', 'MAKESTANDALONECOPY', 'MARKASPOSTED', 'MARKINPROGRESS', 'MARKPACKED', 'MARKPICKEDUP', 'MEMORIZE', 'MERGE', 'MODIFY_PRICING', 'NEW', 'NEWEVENTFIELD', 'NEXT', 'NEXTBILL', 'NEXTVERSION', 'PAYMENT', 'PREV', 'PREVIOUSVERSION', 'PRINT', 'PRINTBOM', 'PRINTETDCOPY', 'PRINTITEMLABELS', 'PRINTLABEL', 'PRINTPICKTICK', 'PROCESS', 'QUICKACCEPT', 'REACTIVATE', 'RECALC', 'RECALCULATEACCOUNTINGDATA', 'RECALCULATEPROJECTPLAN', 'RECEIVE', 'REFUND', 'REJECT', 'REJECTALLPENDING', 'REJECTALLPENDINGWITHNOTE', 'REJECTREQUEST', 'REJECTWITHNOTE', 'REMOVEMATRIXOPTIONS', 'RENEW', 'RENEWAL', 'REQUESTFULFILLMENT', 'RESETTER', 'RETURN', 'REVCOMM', 'REVCOMRV', 'SAVE', 'SAVEANDPRINTLABEL', 'SAVEBASELINE', 'SAVEEMAIL', 'SAVEPRINT', 'SAVEPRINTBOM', 'SAVESUBMIT', 'SEARCH', 'SELECT_EFFECTIVE_DATE', 'STARTCOUNT', 'SUBMITACCEPTDEPOSIT', 'SUBMITACCEPTPAYMENTAUTHORIZATION', 'SUBMITAS', 'SUBMITBILL', 'SUBMITCOPY', 'SUBMITEDIT', 'SUBMITFULFILL', 'SUBMITINV', 'SUBMITNEW', 'SUBMITNEXT', 'SUBMITREFUND', 'SUBMITSAME', 'SUSPEND', 'TENTATIVE', 'TERMINATE', 'TERMINATE_EMPLOYEE', 'UNLOCKTIMEPERIOD', 'UPDATEMATRIX', 'UPDATEREVENUEPLAN', 'UPDATEREVREC', 'UPDATEVSOE', 'VIEWALLTRANSACTIONS', 'VIEWEXPENSEPLANS', 'VIEWREVENUEPLANS', 'VIEW_EMPLOYEE_TIMELINE', 'VOID', 'W4DATA'] }),
+    },
+    path: [...enumsFolderPath, workflowaction_buttonidElemID.name],
+  }),
+  workflowaction_createline_position: new PrimitiveType({
+    elemID: workflowaction_createline_positionElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['AFTERLASTLINE', 'BEFOREFIRSTLINE'] }),
+    },
+    path: [...enumsFolderPath, workflowaction_createline_positionElemID.name],
+  }),
+  workflowaction_displaytype: new PrimitiveType({
+    elemID: workflowaction_displaytypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['DISABLED', 'HIDDEN', 'INLINE', 'NORMAL'] }),
+    },
+    path: [...enumsFolderPath, workflowaction_displaytypeElemID.name],
+  }),
+  workflowaction_eventtype: new PrimitiveType({
+    elemID: workflowaction_eventtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['APPROVE', 'CANCEL', 'COPY', 'CREATE', 'DELETE', 'DROPSHIP', 'EDIT', 'EDITFORECAST', 'EMAIL', 'MARKCOMPLETE', 'ORDERITEMS', 'PACK', 'PAYBILLS', 'PRINT', 'REASSIGN', 'REJECT', 'SHIP', 'SPECIALORDER', 'VIEW', 'XEDIT'] }),
+    },
+    path: [...enumsFolderPath, workflowaction_eventtypeElemID.name],
+  }),
+  workflowaction_radioschedulemode: new PrimitiveType({
+    elemID: workflowaction_radioschedulemodeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['DELAY', 'TIMEOFDAY'] }),
+    },
+    path: [...enumsFolderPath, workflowaction_radioschedulemodeElemID.name],
+  }),
+  workflowaction_recipienttype: new PrimitiveType({
+    elemID: workflowaction_recipienttypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['ADDRESS', 'CURRENTRECORD', 'FIELD', 'SPECIFIC'] }),
+    },
+    path: [...enumsFolderPath, workflowaction_recipienttypeElemID.name],
+  }),
+  workflowaction_sendertype: new PrimitiveType({
+    elemID: workflowaction_sendertypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['FIELD', 'SPECIFIC'] }),
+    },
+    path: [...enumsFolderPath, workflowaction_sendertypeElemID.name],
+  }),
+  workflowaction_transtatementtype: new PrimitiveType({
+    elemID: workflowaction_transtatementtypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['DEFAULT', 'HTML', 'INLINEABOVE', 'INLINEBELOW', 'PDF'] }),
+    },
+    path: [...enumsFolderPath, workflowaction_transtatementtypeElemID.name],
+  }),
+  workflowaction_triggertype: new PrimitiveType({
+    elemID: workflowaction_triggertypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['AFTERFIELDEDIT', 'AFTERFIELDSOURCING', 'AFTERSUBMIT', 'BEFOREFIELDEDIT', 'BEFORELOAD', 'BEFORESUBMIT', 'BEFOREUSEREDIT', 'BEFOREUSERSUBMIT', 'ONENTRY', 'ONEXIT', 'SCHEDULED'] }),
+    },
+    path: [...enumsFolderPath, workflowaction_triggertypeElemID.name],
+  }),
+  workflowaction_triggertype_client: new PrimitiveType({
+    elemID: workflowaction_triggertype_clientElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['AFTERFIELDEDIT', 'AFTERFIELDSOURCING', 'BEFOREFIELDEDIT'] }),
+    },
+    path: [...enumsFolderPath, workflowaction_triggertype_clientElemID.name],
+  }),
+  workflowaction_valuedate: new PrimitiveType({
+    elemID: workflowaction_valuedateElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['DAGO10', 'DAGO2', 'DAGO3', 'DAGO30', 'DAGO4', 'DAGO5', 'DAGO60', 'DAGO90', 'DFN10', 'DFN2', 'DFN3', 'DFN30', 'DFN4', 'DFN5', 'DFN60', 'DFN90', 'FHBL', 'FQB', 'FQBL', 'FQBLTD', 'FQBTD', 'FYB', 'FYBL', 'FYBLTD', 'FYBTD', 'LBW', 'LFH', 'LFHLFY', 'LFHTD', 'LFQ', 'LFQFYBL', 'LFQLFY', 'LFQTD', 'LFY', 'LFYTD', 'LM', 'LMFQBL', 'LMFYBL', 'LMLFQ', 'LMLFY', 'LMTD', 'LW', 'LWTD', 'LY', 'LYTD', 'MAN', 'MANTD', 'MB', 'MBL', 'MBLTD', 'MBTD', 'N4W', 'NBW', 'NFH', 'NFQ', 'NFY', 'NM', 'NOH', 'NOM', 'NOQ', 'NOW', 'NOY', 'NW', 'SDFQBL', 'SDFYBL', 'SDLFQ', 'SDLFY', 'SDLM', 'SDLW', 'SDMBL', 'SDWBL', 'SFHLFY', 'SFQFYBL', 'SFQLFY', 'SMFQBL', 'SMFYBL', 'SMLFQ', 'SMLFY', 'SOFHBL', 'SOFQBL', 'SOFYBL', 'SOLBW', 'SOLFH', 'SOLFHLFY', 'SOLFQ', 'SOLFQLFY', 'SOLFY', 'SOLM', 'SOLMLFQ', 'SOLMLFY', 'SOLRH', 'SOLRQ', 'SOLRY', 'SOLW', 'SOMBL', 'SONBW', 'SONFH', 'SONFQ', 'SONFY', 'SONM', 'SONW', 'SOPRH', 'SOPRQ', 'SOPRY', 'SOSFHLFY', 'SOSFQLFY', 'SOSMLFQ', 'SOSMLFY', 'SOTBW', 'SOTFH', 'SOTFQ', 'SOTFY', 'SOTM', 'SOTW', 'SOTY', 'SOWBL', 'SWFYBL', 'SWLFY', 'TBW', 'TFH', 'TFQ', 'TFY', 'TM', 'TODAY', 'TOMORROW', 'TRH', 'TRQ', 'TRY', 'TW', 'TWN3W', 'TY', 'WAN', 'WANTD', 'WBL', 'WBLTD', 'YESTERDAY'] }),
+    },
+    path: [...enumsFolderPath, workflowaction_valuedateElemID.name],
+  }),
+  workflowaction_valuetype: new PrimitiveType({
+    elemID: workflowaction_valuetypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['DATE', 'FIELD', 'FORMULA', 'STATIC'] }),
+    },
+    path: [...enumsFolderPath, workflowaction_valuetypeElemID.name],
+  }),
+  workflowtransition_triggertype: new PrimitiveType({
+    elemID: workflowtransition_triggertypeElemID,
+    primitive: PrimitiveTypes.STRING,
+    annotations: {
+      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values:
+        ['AFTERSUBMIT', 'BEFORELOAD', 'BEFORESUBMIT', 'ONENTRY', 'SCHEDULED'] }),
+    },
+    path: [...enumsFolderPath, workflowtransition_triggertypeElemID.name],
+  }),
+}

--- a/packages/netsuite-adapter/test/change_validators/remove_custom_object.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_custom_object.test.ts
@@ -15,14 +15,14 @@
 */
 import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import removeCustomObjectValidator from '../../src/change_validators/remove_custom_object'
-import { Types } from '../../src/types'
+import { customTypes } from '../../src/types'
 import { ENTITY_CUSTOM_FIELD } from '../../src/constants'
 
 
 describe('remove custom object change validator', () => {
   describe('onRemove', () => {
     it('should have change error when removing an instance with custom object type', async () => {
-      const instance = new InstanceElement('test', Types.customTypes[ENTITY_CUSTOM_FIELD.toLowerCase()])
+      const instance = new InstanceElement('test', customTypes[ENTITY_CUSTOM_FIELD])
       const changeErrors = await removeCustomObjectValidator.onRemove(instance)
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -18,7 +18,7 @@ import _ from 'lodash'
 import { readFile, readDir, writeFile } from '@salto-io/file'
 import { logger } from '@salto-io/logging'
 import mockClient, { DUMMY_CREDENTIALS } from './client'
-import NetsuiteClient, { COMMANDS } from '../../src/client/client'
+import NetsuiteClient, { COMMANDS, CustomizationInfo } from '../../src/client/client'
 
 
 jest.mock('@salto-io/file', () => ({
@@ -211,7 +211,7 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ status: 'SUCCESS' })
       })
-      await client.deployCustomObject('elementName', {})
+      await client.deployCustomObject('elementName', {} as CustomizationInfo)
       expect(writeFileMock).toHaveBeenCalledTimes(1)
       expect(mockExecuteAction).toHaveBeenCalledWith(createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenCalledWith(reuseAuthIdCommandMatcher)
@@ -222,7 +222,7 @@ describe('netsuite client', () => {
 
     it('should succeed', async () => {
       mockExecuteAction.mockResolvedValue({ status: 'SUCCESS' })
-      await client.deployCustomObject('elementName', {})
+      await client.deployCustomObject('elementName', {} as CustomizationInfo)
       expect(writeFileMock).toHaveBeenCalledTimes(1)
       expect(mockExecuteAction).toHaveBeenCalledWith(createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenCalledWith(reuseAuthIdCommandMatcher)

--- a/packages/netsuite-adapter/test/types.test.ts
+++ b/packages/netsuite-adapter/test/types.test.ts
@@ -14,20 +14,20 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS } from '@salto-io/adapter-api'
-import { Types } from '../src/types'
+import { customTypes } from '../src/types'
 import { IS_NAME, SCRIPT_ID, SCRIPT_ID_PREFIX } from '../src/constants'
 
 describe('Types', () => {
   describe('CustomTypes', () => {
     it('should have single name field for all custom types', () => {
-      Object.values(Types.customTypes)
+      Object.values(customTypes)
         .forEach(typeDef =>
           expect(Object.values(typeDef.fields)
             .filter(field => field.annotations[IS_NAME])).toHaveLength(1))
     })
 
     it('should have SCRIPT_ID_PREFIX defined correctly for all custom types', () => {
-      Object.values(Types.customTypes)
+      Object.values(customTypes)
         .forEach(typeDef => {
           expect(typeDef.annotations[SCRIPT_ID_PREFIX]).toBeDefined()
           expect(typeDef.annotations[SCRIPT_ID_PREFIX]).toMatch(/_$/)
@@ -35,7 +35,7 @@ describe('Types', () => {
     })
 
     it('should have a not required SCRIPT_ID field for all custom types', () => {
-      Object.values(Types.customTypes)
+      Object.values(customTypes)
         .forEach(typeDef => {
           expect(typeDef.fields[SCRIPT_ID]).toBeDefined()
           expect(typeDef.fields[SCRIPT_ID].annotations[CORE_ANNOTATIONS.REQUIRED]).toBeUndefined()

--- a/packages/salesforce-adapter/src/filters/convert_lists.ts
+++ b/packages/salesforce-adapter/src/filters/convert_lists.ts
@@ -18,7 +18,7 @@ import {
   ElemID, Element, isObjectType, Field, Values, Value, ObjectType, isInstanceElement,
   isListType, ListType, isElement,
 } from '@salto-io/adapter-api'
-import { resolvePath } from '@salto-io/adapter-utils'
+import { applyRecursive, resolvePath } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
 import { SALESFORCE } from '../constants'
 import hardcodedListsData from './hardcoded_lists.json'
@@ -78,27 +78,6 @@ const annotationsToSort: ReadonlyArray<UnorderedList> = [
     orderBy: 'fullName',
   },
 ]
-
-// This method iterate on types and corresponding values and run innerChange
-// on every "node".
-const applyRecursive = (type: ObjectType, value: Values,
-  innerChange: (field: Field, value: Value) => Value): void => {
-  if (!value) return
-  Object.keys(type.fields).forEach(key => {
-    if (value[key] === undefined) return
-    value[key] = innerChange(type.fields[key], value[key])
-    const fieldType = type.fields[key].type
-    if (!isListType(fieldType) && !isObjectType(fieldType)) return
-    const actualFieldType = isListType(fieldType) ? fieldType.innerType : fieldType
-    if (isObjectType(actualFieldType)) {
-      if (_.isArray(value[key])) {
-        value[key].forEach((val: Values) => applyRecursive(actualFieldType, val, innerChange))
-      } else {
-        applyRecursive(actualFieldType, value[key], innerChange)
-      }
-    }
-  })
-}
 
 const markListRecursively = (
   type: ObjectType,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11465,13 +11465,6 @@ wu@^2.1.0:
   resolved "https://registry.yarnpkg.com/wu/-/wu-2.1.0.tgz#7e72e3fba23e0ff669ddd537e1c857d3d4b1614f"
   integrity sha1-fnLj+6I+D/Zp3dU34chX09SxYU8=
 
-xml-js@^1.6.11:
-  version "1.6.11"
-  resolved "https://registry.yarnpkg.com/xml-js/-/xml-js-1.6.11.tgz#927d2f6947f7f1c19a316dd8eea3614e8b18f8e9"
-  integrity sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==
-  dependencies:
-    sax "^1.2.4"
-
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"


### PR DESCRIPTION
This PR contains 2 commits:
1. Automatic generation of types.
The logic is in types_generator.py while all other files are its output.
The only manual work that was done post the script run is to remove several unused imports in certain types (imports of subtypes and ListType).

2. Some code fixes after the generation of the types:
    - don't camelCase types and fields as was done before, leave the names as they are in the service (although sometimes there are weird naming conventions)
    - change to fast-xml-parser so we'll have a generic xml transformation
    - modify the transformer in both directions to convert xml attributes in a different way