### PR TITLE
Bump to version 0.1.15

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.1.14",
+  "version": "0.1.15",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "stream": true,

--- a/packages/adapter-api/package.json
+++ b/packages/adapter-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/adapter-api",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "description": "Salto Adapter API",
   "repository": {
@@ -32,8 +32,8 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/dag": "0.1.14",
-    "@salto-io/lowerdash": "0.1.14",
+    "@salto-io/dag": "0.1.15",
+    "@salto-io/lowerdash": "0.1.15",
     "lodash": "^4.17.11",
     "wu": "^2.1.0"
   },

--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/adapter-utils",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "description": "Salto Adapter Utils",
   "repository": {
@@ -32,10 +32,10 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.14",
-    "@salto-io/dag": "0.1.14",
-    "@salto-io/logging": "0.1.14",
-    "@salto-io/lowerdash": "0.1.14",
+    "@salto-io/adapter-api": "0.1.15",
+    "@salto-io/dag": "0.1.15",
+    "@salto-io/logging": "0.1.15",
+    "@salto-io/lowerdash": "0.1.15",
     "lodash": "^4.17.11",
     "wu": "^2.1.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "description": "cli on top of salto core",
   "repository": {
@@ -35,15 +35,15 @@
     "package": "node ./package_native.js"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.14",
-    "@salto-io/adapter-utils": "0.1.14",
-    "@salto-io/core": "0.1.14",
-    "@salto-io/dag": "0.1.14",
-    "@salto-io/e2e-credentials-store": "^0.1.14",
-    "@salto-io/file": "0.1.14",
-    "@salto-io/logging": "0.1.14",
-    "@salto-io/lowerdash": "0.1.14",
-    "@salto-io/salesforce-adapter": "0.1.14",
+    "@salto-io/adapter-api": "0.1.15",
+    "@salto-io/adapter-utils": "0.1.15",
+    "@salto-io/core": "0.1.15",
+    "@salto-io/dag": "0.1.15",
+    "@salto-io/e2e-credentials-store": "0.1.15",
+    "@salto-io/file": "0.1.15",
+    "@salto-io/logging": "0.1.15",
+    "@salto-io/lowerdash": "0.1.15",
+    "@salto-io/salesforce-adapter": "0.1.15",
     "chalk": "^2.4.2",
     "figlet": "^1.2.4",
     "glob": "^7.1.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/core",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "description": "Salto core",
   "repository": {
@@ -34,14 +34,14 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.14",
-    "@salto-io/adapter-utils": "0.1.14",
-    "@salto-io/dag": "0.1.14",
-    "@salto-io/file": "0.1.14",
-    "@salto-io/hubspot-adapter": "0.1.14",
-    "@salto-io/logging": "0.1.14",
-    "@salto-io/lowerdash": "0.1.14",
-    "@salto-io/salesforce-adapter": "0.1.14",
+    "@salto-io/adapter-api": "0.1.15",
+    "@salto-io/adapter-utils": "0.1.15",
+    "@salto-io/dag": "0.1.15",
+    "@salto-io/file": "0.1.15",
+    "@salto-io/hubspot-adapter": "0.1.15",
+    "@salto-io/logging": "0.1.15",
+    "@salto-io/lowerdash": "0.1.15",
+    "@salto-io/salesforce-adapter": "0.1.15",
     "axios": "^0.19.2",
     "fuse.js": "^3.4.5",
     "lodash": "^4.17.11",

--- a/packages/dag/package.json
+++ b/packages/dag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/dag",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "description": "directed acyclic graph implementation including - dag diff and node grouping",
   "repository": {
@@ -32,8 +32,8 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/logging": "0.1.14",
-    "@salto-io/lowerdash": "0.1.14",
+    "@salto-io/logging": "0.1.15",
+    "@salto-io/lowerdash": "0.1.15",
     "lodash": "^4.17.15",
     "wu": "^2.1.0"
   },

--- a/packages/e2e-credential-store/package.json
+++ b/packages/e2e-credential-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/e2e-credentials-store",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "description": "Salto E2E tests credentials store",
   "repository": {
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@jest/environment": "^24.0.0",
-    "@salto-io/logging": "0.1.14",
-    "@salto-io/lowerdash": "0.1.14",
-    "@salto-io/persistent-pool": "0.1.14",
+    "@salto-io/logging": "0.1.15",
+    "@salto-io/lowerdash": "0.1.15",
+    "@salto-io/persistent-pool": "0.1.15",
     "easy-table": "^1.1.1",
     "humanize-duration": "^3.21.0",
     "jest-circus": "^24.9.0",

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/file",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "description": "File System Utils",
   "repository": {
@@ -32,7 +32,7 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/lowerdash": "0.1.14",
+    "@salto-io/lowerdash": "0.1.15",
     "mkdirp": "^0.5.1",
     "rimraf": "^3.0.0"
   },

--- a/packages/hubspot-adapter/package.json
+++ b/packages/hubspot-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/hubspot-adapter",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "description": "Salto Hubspot adapter",
   "repository": {
@@ -32,20 +32,20 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.14",
-    "@salto-io/adapter-utils": "0.1.14",
-    "@salto-io/logging": "0.1.14",
-    "@salto-io/lowerdash": "0.1.14",
+    "@salto-io/adapter-api": "0.1.15",
+    "@salto-io/adapter-utils": "0.1.15",
+    "@salto-io/logging": "0.1.15",
+    "@salto-io/lowerdash": "0.1.15",
     "hubspot": "^2.3.8",
     "lodash": "^4.17.11",
     "request-promise": "^4.2.5",
     "requestretry": "^4.0.2"
   },
   "devDependencies": {
-    "@types/request-promise": "^4.1.45",
     "@types/jest": "^24.0.0",
     "@types/lodash": "^4.14.133",
     "@types/node": "^12.7.1",
+    "@types/request-promise": "^4.1.45",
     "@typescript-eslint/eslint-plugin": "2.21.0",
     "@typescript-eslint/parser": "2.21.0",
     "eslint": "^6.2.2",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/logging",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "description": "Salto Logging library",
   "repository": {
@@ -31,7 +31,7 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/lowerdash": "0.1.14",
+    "@salto-io/lowerdash": "0.1.15",
     "chalk": "^2.4.2",
     "lodash": "^4.17.11",
     "logform": "^2.1.2",

--- a/packages/lowerdash/package.json
+++ b/packages/lowerdash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/lowerdash",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "description": "Salto utils - stuff that isn't in lodash",
   "repository": {

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/netsuite-adapter",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "description": "Salto Netsuite adapter",
   "repository": {
@@ -27,11 +27,11 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.14",
-    "@salto-io/adapter-utils": "0.1.14",
-    "@salto-io/file": "0.1.14",
-    "@salto-io/logging": "0.1.14",
-    "@salto-io/lowerdash": "0.1.14",
+    "@salto-io/adapter-api": "0.1.15",
+    "@salto-io/adapter-utils": "0.1.15",
+    "@salto-io/file": "0.1.15",
+    "@salto-io/logging": "0.1.15",
+    "@salto-io/lowerdash": "0.1.15",
     "@salto-io/suitecloud-cli": "^1.0.2-salto-2",
     "lodash": "^4.17.11",
     "wu": "^2.1.0",

--- a/packages/persistent-pool/package.json
+++ b/packages/persistent-pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/persistent-pool",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "description": "Keeps a persistent pool of objects",
   "repository": {
@@ -26,7 +26,7 @@
     "lint-fix": "yarn lint --fix"
   },
   "dependencies": {
-    "@salto-io/lowerdash": "0.1.14",
+    "@salto-io/lowerdash": "0.1.15",
     "aws-sdk": "^2.573.0",
     "uuid": "^3.3.3"
   },

--- a/packages/salesforce-adapter/package.json
+++ b/packages/salesforce-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/salesforce-adapter",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "description": "Salto Salesforce adapter",
   "repository": {
@@ -34,11 +34,11 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.14",
-    "@salto-io/adapter-utils": "0.1.14",
-    "@salto-io/e2e-credentials-store": "0.1.14",
-    "@salto-io/logging": "0.1.14",
-    "@salto-io/lowerdash": "0.1.14",
+    "@salto-io/adapter-api": "0.1.15",
+    "@salto-io/adapter-utils": "0.1.15",
+    "@salto-io/e2e-credentials-store": "0.1.15",
+    "@salto-io/logging": "0.1.15",
+    "@salto-io/lowerdash": "0.1.15",
     "@types/requestretry": "^1.12.5",
     "fast-xml-parser": "^3.15.0",
     "humanize-duration": "^3.22.0",
@@ -52,7 +52,7 @@
     "wu": "^2.1.0"
   },
   "devDependencies": {
-    "@salto-io/persistent-pool": "0.1.14",
+    "@salto-io/persistent-pool": "0.1.15",
     "@types/jest": "^24.0.0",
     "@types/jszip": "^3.1.6",
     "@types/lodash": "^4.14.133",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "salto-vscode",
     "displayName": "Salto",
     "description": "Configure Salto patches in vscode.",
-    "version": "0.1.14",
+    "version": "0.1.15",
     "publishConfig": {
         "access": "public"
     },
@@ -116,10 +116,10 @@
         "generate-yarn-lock": "yarn workspaces run generate-lock-entry | sed '1,2d' | sed -n -e :a -e '1,1!{P;N;D;};N;ba' >> yarn.lock"
     },
     "dependencies": {
-        "@salto-io/adapter-api": "0.1.14",
-        "@salto-io/adapter-utils": "0.1.14",
-        "@salto-io/core": "0.1.14",
-        "@salto-io/file": "0.1.14",
+        "@salto-io/adapter-api": "0.1.15",
+        "@salto-io/adapter-utils": "0.1.15",
+        "@salto-io/core": "0.1.15",
+        "@salto-io/file": "0.1.15",
         "copy-paste": "^1.3.0",
         "diff": "^4.0.1",
         "diff2html": "^2.12.1",


### PR DESCRIPTION
### What's New in Version v0.1.15

Note: This version will modify the in which certain elements are written to the NaCL. As a result - some of the changes won't take effect until the fetching the services. For more details in which changes will require a fetch - see below.

**What's New**
* Added a new CLI command `rename` to rename an existing environment (https://github.com/salto-io/salto/blob/master/docs/user_guide.md#salto-env-command-name-new-name)
* Added variable support to NaCL (https://github.com/salto-io/salto/blob/master/docs/user_guide.md#variables)
* Added static files support to NaCL

_Hubspot adapter_
 * Auto generated attributes are no longer written to the NaCL files.
 * Emails are used in the NaCL files instead of internal user ids in order to improve readability. `Note that this may result in validation warnings if Hubspot is already fetched. To resolve this, please fetch Hubspot and ignore the warning prompt.`
 * Only elements for which the user has read permissions instances are fetched from Hubspot. 
 
 _Salesforce Adapter_
 * Changed default skip configuration to include Marketo email templates. 
 * Email Templates and Apex code are now saved as static files.
 * Use references to represent layout items in custom objects. (`fetch` is needed to apply this change.)

### Bug Fixes
* Elements that are moved to from the common folder into an environment specific folder are no longer written with wrong filenames.
* Parse errors when attempting to parse strings with special unicode characters.
* Added Salto template marker escaping to prevent parse errors on multiline strings that contains the `${` substring.