### PR TITLE
SALTO-286: remove field update syntax

### DIFF
--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -161,12 +161,12 @@ export class Field extends Element {
    * Note that the cloned field still has the same element ID so it cannot be used in a different
    * object
    */
-  clone(): Field {
+  clone(annotations?: Values): Field {
     return new Field(
       this.parentID,
       this.name,
       this.type,
-      _.cloneDeep(this.annotations),
+      annotations === undefined ? _.cloneDeep(this.annotations) : annotations,
     )
   }
 }

--- a/packages/core/src/core/merger/index.ts
+++ b/packages/core/src/core/merger/index.ts
@@ -29,7 +29,7 @@ export { MergeError, DuplicateAnnotationError } from './internal/common'
 export type MergeResult = InternalMergeResult<Element[]>
 
 export {
-  FieldDefinitionMergeError, NoBaseDefinitionMergeError, MultipleBaseDefinitionsMergeError,
+  FieldDefinitionMergeError, ConflictingFieldTypesError,
   DuplicateAnnotationFieldDefinitionError, DuplicateAnnotationTypeError,
 } from './internal/object_types'
 

--- a/packages/core/src/parser/language.ts
+++ b/packages/core/src/parser/language.ts
@@ -20,7 +20,6 @@ export enum Keywords {
   LIST_DEFINITION = 'list',
   TYPE_INHERITANCE_SEPARATOR = 'is',
   ANNOTATIONS_DEFINITION = 'annotations',
-  UPDATE_DEFINITION = 'update',
   NAMESPACE_SEPARATOR = '.',
 
   // Primitive types


### PR DESCRIPTION
---
This was annoying in #1018, was easier to remove support for `update` than make it work with #1018 