### PR TITLE
Move apply instances defaults to run after merging all env's active elements and apply the defaults based on the instance values to avoid applying defaults for inner undefined values

### DIFF
--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -17,8 +17,8 @@ import _ from 'lodash'
 import {
   ObjectType, Adapter, ElemIdGetter, AdapterCreatorOpts, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
+import { createDefaultInstanceFromType } from '@salto-io/adapter-utils'
 import adapterCreators from './creators'
-import { createDefaultInstanceFromType } from '../merger/internal/instances'
 
 export const getAdaptersCredentialsTypes = (
   names?: ReadonlyArray<string>

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -22,8 +22,7 @@ import {
   ADAPTER, ElemIdGetter,
 } from '@salto-io/adapter-api'
 import {
-  resolvePath,
-  flattenElementStr,
+  applyInstancesDefaults, resolvePath, flattenElementStr,
 } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { StepEvents } from './deploy'
@@ -246,6 +245,7 @@ const fetchAndProcessMergeErrors = async (
       .filter(c => !_.isUndefined(c)) as UpdatedConfig[]
     log.debug(`fetched ${serviceElements.length} elements from adapters`)
     const { errors: mergeErrors, merged: elements } = mergeElements(serviceElements)
+    applyInstancesDefaults(elements.filter(isInstanceElement))
     log.debug(`got ${serviceElements.length} from merge results and elements and to ${elements.length} elements [errors=${
       mergeErrors.length}]`)
 

--- a/packages/core/src/core/merger/index.ts
+++ b/packages/core/src/core/merger/index.ts
@@ -33,7 +33,7 @@ export {
   DuplicateAnnotationFieldDefinitionError, DuplicateAnnotationTypeError,
 } from './internal/object_types'
 
-export { DuplicateInstanceKeyError, createDefaultInstanceFromType } from './internal/instances'
+export { DuplicateInstanceKeyError } from './internal/instances'
 export { MultiplePrimitiveTypesUnsupportedError } from './internal/primitives'
 export { DuplicateVariableNameError } from './internal/variables'
 

--- a/packages/core/src/workspace/nacl_files/mutil_env/multi_env_source.ts
+++ b/packages/core/src/workspace/nacl_files/mutil_env/multi_env_source.ts
@@ -17,7 +17,8 @@ import _ from 'lodash'
 import path from 'path'
 import wu from 'wu'
 
-import { Element, ElemID, getChangeElement, Value } from '@salto-io/adapter-api'
+import { Element, ElemID, getChangeElement, isInstanceElement, Value } from '@salto-io/adapter-api'
+import { applyInstancesDefaults } from '@salto-io/adapter-utils'
 import { promises } from '@salto-io/lowerdash'
 import { ParseError, SourceMap, SourceRange } from 'src/parser/parse'
 import { ValidationError } from 'src/core/validator'
@@ -71,6 +72,7 @@ const buildMultiEnvSource = (
       _.values(getActiveSources()).map(s => s.getAll())
     ))
     const { errors, merged } = mergeElements(allActiveElements)
+    applyInstancesDefaults(merged.filter(isInstanceElement))
     return {
       elements: _.keyBy(merged, e => e.elemID.getFullName()),
       mergeErrors: errors,

--- a/packages/core/test/core/adapters/adapters.test.ts
+++ b/packages/core/test/core/adapters/adapters.test.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { InstanceElement, ElemID, ObjectType } from '@salto-io/adapter-api'
+import * as utils from '@salto-io/adapter-utils'
 import { creator } from '@salto-io/salesforce-adapter'
 import {
   initAdapters, getAdaptersCredentialsTypes, getAdaptersCreatorConfigs, getDefaultAdapterConfig,
@@ -46,6 +47,14 @@ describe('adapters.ts', () => {
       credentials = getAdaptersCredentialsTypes(services.concat('fake'))
       expect(credentials.salesforce).toEqual(credentialsType)
       expect(credentials.fake).toBeUndefined()
+    })
+  })
+
+  describe('getDefaultAdapterConfig', () => {
+    it('should call createDefaultInstanceFromType', () => {
+      jest.spyOn(utils, 'createDefaultInstanceFromType')
+      getDefaultAdapterConfig('salesforce')
+      expect(utils.createDefaultInstanceFromType).toHaveBeenCalled()
     })
   })
 

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -20,6 +20,7 @@ import {
   isModificationDiff,
   ListType,
 } from '@salto-io/adapter-api'
+import * as utils from '@salto-io/adapter-utils'
 import {
   fetchChanges, FetchChange, generateServiceIdToStateElemId,
   FetchChangesResult, FetchProgressEvents,
@@ -628,6 +629,22 @@ describe('fetch', () => {
         const fetchedInst = getChangeElement(changes[1].change)
         expect(fetchedInst.value.hidden).toBeUndefined()
         expect(fetchedInst.value.notHidden).toEqual('notHidden')
+      })
+    })
+
+    describe('instance defaults', () => {
+      it('should call applyInstancesDefaults', async () => {
+        jest.spyOn(utils, 'applyInstancesDefaults')
+        mockAdapters.dummy.fetch.mockResolvedValueOnce(
+          Promise.resolve({ elements: [workspaceInstance] })
+        )
+        await fetchChanges(
+          mockAdapters as unknown as Record<string, Adapter>,
+          [],
+          [],
+          [],
+        )
+        expect(utils.applyInstancesDefaults).toHaveBeenCalledWith([workspaceInstance])
       })
     })
   })

--- a/packages/core/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/core/test/workspace/multi_env/multi_env_source.test.ts
@@ -16,6 +16,7 @@
 import path from 'path'
 import { ElemID, Field, BuiltinTypes, ObjectType } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import * as utils from '@salto-io/adapter-utils'
 import { createMockNaclFileSource } from '../../common/nacl_file_source'
 import { multiEnvSource } from '../../../src/workspace/nacl_files/mutil_env/multi_env_source'
 import { Errors } from '../../../src/workspace/errors'
@@ -23,6 +24,8 @@ import { ValidationError } from '../../../src/core/validator'
 import { MergeError } from '../../../src/core/merger/internal/common'
 import { expectToContainAllItems } from '../../common/helpers'
 import { DetailedChange } from '../../../src/core/plan'
+
+jest.spyOn(utils, 'applyInstancesDefaults')
 
 const objectElemID = new ElemID('salto', 'object')
 const commonField = new Field(objectElemID, 'commonField', BuiltinTypes.STRING)
@@ -330,6 +333,11 @@ describe('multi env source', () => {
     it('should forward the getElements command to the common source', async () => {
       await source.getElements(path.join(commonPrefix, 'common.nacl'))
       expect(commonSource.getElements).toHaveBeenCalled()
+    })
+  })
+  describe('applyInstancesDefaults', () => {
+    it('should call applyInstancesDefaults', () => {
+      expect(utils.applyInstancesDefaults).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
@roironn Please LMK if you think that the fetch shouldn't call the applyInstancesDefaults directly