### PR TITLE
NOTICES github action: run once a week

### DIFF
--- a/.github/workflows/notices.yml
+++ b/.github/workflows/notices.yml
@@ -1,8 +1,9 @@
 name: Attribution NOTICES file
 
 on:
-  push:
-    branches: [ master ]
+  schedule:
+    # every saturday on 3 am
+    - cron: '0 3 * * 6'
 
 jobs:
   build:


### PR DESCRIPTION
Instead of every merge to `master`.
It runs on the latest commit in `master` in that point in time (see [docs](https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule))