### PR TITLE
fix default adapter config bug

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -239,9 +239,12 @@ export const addAdapter = async (
     throw new Error('No adapter available for this service')
   }
   await workspace.addService(adapterName)
-  const defaultConfig = getDefaultAdapterConfig(adapterName)
-  if (!_.isUndefined(defaultConfig)) {
-    await workspace.updateServiceConfig(adapterName, defaultConfig)
+
+  if (_.isUndefined((await workspace.servicesConfig([adapterName]))[adapterName])) {
+    const defaultConfig = getDefaultAdapterConfig(adapterName)
+    if (!_.isUndefined(defaultConfig)) {
+      await workspace.updateServiceConfig(adapterName, defaultConfig)
+    }
   }
   return adapterCredentials
 }


### PR DESCRIPTION
Currently, if you would create a new env and add a service, the service config would be changed to the default one. This PR fixes it.