### PR TITLE
SALTO-748-fix business process undefined in logs bug

### DIFF
--- a/packages/salesforce-adapter/src/filters/record_type.ts
+++ b/packages/salesforce-adapter/src/filters/record_type.ts
@@ -47,7 +47,7 @@ const filterCreator = (): FilterWith<'onFetch'> => ({
           ?.find(process => relativeApiName(process) === record.value[BUSINESS_PROCESS])
         if (businessProcess) {
           record.value[BUSINESS_PROCESS] = new ReferenceExpression(businessProcess.elemID)
-        } else {
+        } else if (record.value[BUSINESS_PROCESS]) {
           log.warn('failed to find business process %s', record.value[BUSINESS_PROCESS])
         }
       })


### PR DESCRIPTION
The bug was that the code assumes that each record type got a business process field, but its not true. 
as you can see here (taken from the documentation of RecordType):
![image](https://user-images.githubusercontent.com/16052578/82117335-de9db000-9777-11ea-8958-495a20fec96d.png)
This means that for records type for other types than lead, opportunity, solution, and case this log message will be written.
So I just added an `if` that checks if this field exists before it writes that log.