### PR TITLE
SALTO-769: Serialization without relying on constructor name

### DIFF
--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -121,8 +121,6 @@ export class ListType extends Element {
     })
   }
 
-  static get serializedTypeName(): string { return 'ListType' }
-
   isEqual(other: ListType): boolean {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return super.isEqual(other) && isEqualTypes(this.innerType, other.innerType)
@@ -147,8 +145,6 @@ export class Field extends Element {
   ) {
     super({ elemID: parentID.createNestedID('field', name), annotations })
   }
-
-  static get serializedTypeName(): string { return 'Field' }
 
   isEqual(other: Field): boolean {
     return _.isEqual(this.type.elemID, other.type.elemID)
@@ -193,8 +189,6 @@ export class PrimitiveType extends Element {
     super({ elemID, annotationTypes, annotations, path })
     this.primitive = primitive
   }
-
-  static get serializedTypeName(): string { return 'PrimitiveType' }
 
   isEqual(other: PrimitiveType): boolean {
     return super.isEqual(other)
@@ -243,8 +237,6 @@ export class ObjectType extends Element {
     this.fields = fields
     this.isSettings = isSettings
   }
-
-  static get serializedTypeName(): string { return 'ObjectType' }
 
   private cloneFields(): FieldMap {
     const clonedFields: FieldMap = {}
@@ -297,8 +289,6 @@ export class InstanceElement extends Element {
     super({ elemID: type.elemID.createNestedID('instance', name), annotations, path })
   }
 
-  static get serializedTypeName(): string { return 'InstanceElement' }
-
   isEqual(other: InstanceElement): boolean {
     return _.isEqual(this.type.elemID, other.type.elemID)
       && isEqualValues(this.value, other.value)
@@ -331,8 +321,6 @@ export class Variable extends Element {
     path?: ReadonlyArray<string>) {
     super({ elemID, path })
   }
-
-  static get serializedTypeName(): string { return 'Variable' }
 
   isEqual(other: Variable): boolean {
     return super.isEqual(other) && isEqualValues(this.value, other.value)

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -15,7 +15,6 @@
 */
 import _ from 'lodash'
 import { hash as hashUtils, types } from '@salto-io/lowerdash'
-
 import { ElemID } from './element_id'
 
 export type PrimitiveValue = string | boolean | number
@@ -48,8 +47,6 @@ export class StaticFile {
   public isEqual(other: StaticFile): boolean {
     return this.hash === other.hash
   }
-
-  static get serializedTypeName(): string { return 'StaticFile' }
 }
 
 export class ReferenceExpression {
@@ -67,8 +64,6 @@ export class ReferenceExpression {
     const ExpressionCtor = this.constructor as typeof ReferenceExpression
     return new ExpressionCtor(this.elemId, resValue)
   }
-
-  static get serializedTypeName(): string { return 'ReferenceExpression' }
 
   get traversalParts(): string[] {
     return this.elemId.getFullNameParts()
@@ -93,13 +88,9 @@ export class VariableExpression extends ReferenceExpression {
       } is a ${elemId.idType}`)
     }
   }
-
-  static get serializedTypeName(): string { return 'VariableExpression' }
 }
 
-export class TemplateExpression extends types.Bean<{ parts: TemplatePart[] }> {
-  static get serializedTypeName(): string { return 'TemplateExpression' }
-}
+export class TemplateExpression extends types.Bean<{ parts: TemplatePart[] }> { }
 
 export type Expression = ReferenceExpression | TemplateExpression
 

--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -50,9 +50,6 @@ describe('Values', () => {
   })
 
   describe('StaticFile', () => {
-    it('should have correct static serializedTypeName', () =>
-      expect(StaticFile.serializedTypeName).toEqual('StaticFile'))
-
     describe('equality (direct)', () => {
       it('equals', () => {
         const fileFunc1 = new StaticFile('some/path.ext', Buffer.from('ZOMG'))

--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -19,7 +19,7 @@ import { getChangeElement, isInstanceElement } from '@salto-io/adapter-api'
 import {
   fetch as apiFetch,
   Workspace,
-  fetchFunc,
+  FetchFunc,
   FetchChange,
   FetchProgressEvents,
   StepEmitter,
@@ -53,18 +53,18 @@ import { EnvironmentArgs } from './env'
 const log = logger(module)
 const { series } = promises.array
 
-type approveChangesFunc = (
+type ApproveChangesFunc = (
   changes: ReadonlyArray<FetchChange>,
   interactive: boolean
 ) => Promise<ReadonlyArray<FetchChange>>
 
-type shouldUpdateConfigFunc = (
+type ShouldUpdateConfigFunc = (
   { stdout }: CliOutput,
   introMessage: string,
   change: PlanItem
 ) => Promise<boolean>
 
-type approveIsolatedModeFunc = (
+type ApproveIsolatedModeFunc = (
   newServices: string[],
   oldServices: string[],
   inputIsolated: boolean
@@ -77,10 +77,10 @@ export type FetchCommandArgs = {
   inputIsolated: boolean
   cliTelemetry: CliTelemetry
   output: CliOutput
-  fetch: fetchFunc
-  getApprovedChanges: approveChangesFunc
-  shouldUpdateConfig: shouldUpdateConfigFunc
-  approveIsolatedMode: approveIsolatedModeFunc
+  fetch: FetchFunc
+  getApprovedChanges: ApproveChangesFunc
+  shouldUpdateConfig: ShouldUpdateConfigFunc
+  approveIsolatedMode: ApproveIsolatedModeFunc
   shouldCalcTotalSize: boolean
   inputServices?: string[]
 }
@@ -103,7 +103,7 @@ const getRelevantServicesAndIsolatedMode = async (
   workspace: Workspace,
   inputIsolated: boolean,
   force: boolean,
-  approveIsolatedMode: approveIsolatedModeFunc,
+  approveIsolatedMode: ApproveIsolatedModeFunc,
   outputLine: (text: string) => void
 ): Promise<{services: string[]; isolated: boolean}> => {
   const envNames = workspace.envs()

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -19,7 +19,7 @@ import { ElemID, ObjectType, Element, InstanceElement } from '@salto-io/adapter-
 import {
   Workspace, fetch, FetchChange,
   DetailedChange, FetchProgressEvents,
-  StepEmitter, fetchFunc,
+  StepEmitter, FetchFunc,
 } from '@salto-io/core'
 import { Spinner, SpinnerCreator, CliExitCode } from '../../src/types'
 import { command, fetchCommand, FetchCommandArgs } from '../../src/commands/fetch'
@@ -528,7 +528,7 @@ describe('fetch command', () => {
         })
       })
       describe('with merge errors', () => {
-        const mockFetchWithChanges = mocks.mockFunction<fetchFunc>().mockResolvedValue(
+        const mockFetchWithChanges = mocks.mockFunction<FetchFunc>().mockResolvedValue(
           {
             changes: [],
             mergeErrors: [

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -153,7 +153,7 @@ export const deploy = async (
   return { success: true, errors: [] }
 }
 
-export type fillConfigFunc = (configType: ObjectType) => Promise<InstanceElement>
+export type FillConfigFunc = (configType: ObjectType) => Promise<InstanceElement>
 
 export type FetchResult = {
   changes: Iterable<FetchChange>
@@ -162,13 +162,13 @@ export type FetchResult = {
   configChanges?: Plan
   adapterNameToConfigMessage?: Record<string, string>
 }
-export type fetchFunc = (
+export type FetchFunc = (
   workspace: Workspace,
   progressEmitter?: EventEmitter<FetchProgressEvents>,
   services?: string[],
 ) => Promise<FetchResult>
 
-export const fetch: fetchFunc = async (
+export const fetch: FetchFunc = async (
   workspace,
   progressEmitter?,
   services?,

--- a/packages/core/test/serializer/serializer.test.ts
+++ b/packages/core/test/serializer/serializer.test.ts
@@ -74,6 +74,16 @@ describe('State/cache serialization', () => {
     { test: 'annotation' },
   )
 
+  class SubInstanceElement extends InstanceElement { }
+
+  const subInstance = new SubInstanceElement(
+    'sub_me',
+    model,
+    { name: 'me', num: 7 },
+    ['path', 'test'],
+    { test: 'annotation' },
+  )
+
   const refInstance = new InstanceElement(
     'also_me',
     model,
@@ -135,7 +145,8 @@ describe('State/cache serialization', () => {
   )
 
   const elements = [strType, numType, boolType, model, strListType, variable, instance,
-    refInstance, refInstance2, refInstance3, templateRefInstance, functionRefInstance, config]
+    subInstance, refInstance, refInstance2, refInstance3, templateRefInstance, functionRefInstance,
+    config]
 
   it('should serialize and deserialize all element types', async () => {
     const serialized = serialize(elements)
@@ -143,6 +154,12 @@ describe('State/cache serialization', () => {
     const sortedElements = _.sortBy(elements, e => e.elemID.getFullName())
     expect(deserialized).toEqual(sortedElements)
   })
+
+  it('should serialize and deserialize without relying on the constructor name', async () => {
+    const serialized = serialize([subInstance])
+    expect(serialized).not.toMatch(subInstance.constructor.name)
+  })
+
 
   it('should not serialize resolved values', async () => {
     // TemplateExpressions are discarded

--- a/packages/lowerdash/src/types.ts
+++ b/packages/lowerdash/src/types.ts
@@ -36,6 +36,8 @@ export type FunctionPropertyNames<T> = {
   [K in keyof T]: T[K] extends Function ? K : never
 }[keyof T]
 
+export type ValueOf<T> = T[keyof T]
+
 /*
 
 --- Bean ---

--- a/packages/lowerdash/test/types.test.ts
+++ b/packages/lowerdash/test/types.test.ts
@@ -14,13 +14,34 @@
 * limitations under the License.
 */
 import {
-  AtLeastOne, RequiredMember, hasMember, filterHasMember,
+  AtLeastOne, RequiredMember, hasMember, filterHasMember, ValueOf,
   Bean,
 } from '../src/types'
 
 // Note: some of the tests here are compile-time, so the actual assertions may look weird.
 
 describe('types', () => {
+  describe('ValueOf', () => {
+    class A { constructor(public val: string) { } }
+    class B { constructor(public val: number) { } }
+    const map = {
+      a: A,
+      b: B,
+    }
+    type InstanceOfValueOfMap = InstanceType<ValueOf<typeof map>>
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function isValueOfMap(_obj: any): _obj is InstanceOfValueOfMap {
+      // Make sure the code will transpile, the return value of the type-guard should not matter
+      return false
+    }
+
+    it('should transpile', () => {
+      const c = new A('def') as unknown
+      const res = isValueOfMap(c) ? c.val : 'no'
+      expect(res).toEqual('no')
+    })
+  })
   describe('AtLeastOne, RequiredMember', () => {
     type TestType = AtLeastOne<{
       first: number


### PR DESCRIPTION
* Removed `serializedTypeName`
* We no longer rely on the value of `constructor.name`