### PR TITLE
Netsuite: Support additional files

### DIFF
--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -52,21 +52,30 @@ export const CDATA_TAG_NAME = '__cdata'
 
 const OBJECTS_DIR = 'Objects'
 const SRC_DIR = 'src'
+const FILE_SEPARATOR = '.'
+const ADDITIONAL_FILE_PATTERN = '.template.'
 
 const rootCLIPath = path.normalize(path.join(__dirname, ...Array(5).fill('..'), 'node_modules',
   '@salto-io', 'suitecloud-cli', 'src'))
 const baseExecutionPath = os.tmpdir()
 
+type FileContent = {
+  extension: string
+  content: string
+}
+
 export interface CustomizationInfo {
   typeName: string
   values: Values
+  fileContent?: FileContent
 }
 
-export const convertToCustomizationInfo = (xmlContent: string): CustomizationInfo => {
+export const convertToCustomizationInfo = (xmlContent: string, fileContent?: FileContent):
+  CustomizationInfo => {
   const parsedXmlValues = xmlParser.parse(xmlContent,
     { attributeNamePrefix: ATTRIBUTE_PREFIX, ignoreAttributes: false })
   const typeName = Object.keys(parsedXmlValues)[0]
-  return { typeName, values: parsedXmlValues[typeName] }
+  return { typeName, values: parsedXmlValues[typeName], fileContent }
 }
 
 export const convertToXmlContent = (customizationInfo: CustomizationInfo): string =>
@@ -210,27 +219,32 @@ export default class NetsuiteClient {
 
     const objectsDirPath = NetsuiteClient.getObjectsDirPath(project.projectName)
     const dirContent = await readDir(objectsDirPath)
-    // Todo: when we'll support more types (e.g. emailTemplates), there might be other file types
-    //  in the directory. remove the below row once these types are supported
-    const xmlFilesInDir = dirContent.filter(filename => filename.endsWith('xml'))
-    return Promise.all(xmlFilesInDir.map(async filename => {
-      const xmlContent = await readFile(path.resolve(objectsDirPath, filename))
-      return convertToCustomizationInfo(xmlContent.toString())
+    const scriptIdToFiles = _.groupBy(dirContent, filename => filename.split(FILE_SEPARATOR)[0])
+    return Promise.all(Object.values(scriptIdToFiles).map(async objectFileNames => {
+      const [[additionalFilename], [contentFilename]] = _.partition(objectFileNames,
+        filename => filename.includes(ADDITIONAL_FILE_PATTERN))
+      const xmlContent = readFile(path.resolve(objectsDirPath, contentFilename))
+      const fileContent = !_.isUndefined(additionalFilename) ? {
+        content: (await readFile(path.resolve(objectsDirPath, additionalFilename))).toString(),
+        extension: additionalFilename.split(FILE_SEPARATOR)[2],
+      } : undefined
+      return convertToCustomizationInfo((await xmlContent).toString(), fileContent)
     }))
   }
 
   @NetsuiteClient.logDecorator
   async deployCustomObject(filename: string, customizationInfo: CustomizationInfo): Promise<void> {
     const project = await this.initProject()
-    await NetsuiteClient.deploy(path.resolve(NetsuiteClient.getObjectsDirPath(project.projectName),
-      `${filename}.xml`), customizationInfo, project.executor)
-  }
-
-  private static async deploy(filePath: string, customizationInfo: CustomizationInfo,
-    executor: CommandActionExecutor): Promise<void> {
-    await writeFile(filePath, convertToXmlContent(customizationInfo))
-    await NetsuiteClient.executeProjectAction(COMMANDS.ADD_PROJECT_DEPENDENCIES, {}, executor)
-    await NetsuiteClient.executeProjectAction(COMMANDS.DEPLOY_PROJECT, {}, executor)
+    const dirPath = NetsuiteClient.getObjectsDirPath(project.projectName)
+    await writeFile(path.resolve(dirPath, `${filename}.xml`), convertToXmlContent(customizationInfo))
+    if (!_.isUndefined(customizationInfo.fileContent)) {
+      await writeFile(path.resolve(dirPath,
+        `${filename}${ADDITIONAL_FILE_PATTERN}${customizationInfo.fileContent.extension}`),
+      customizationInfo.fileContent.content)
+    }
+    await NetsuiteClient.executeProjectAction(COMMANDS.ADD_PROJECT_DEPENDENCIES, {},
+      project.executor)
+    await NetsuiteClient.executeProjectAction(COMMANDS.DEPLOY_PROJECT, {}, project.executor)
   }
 
   private static getProjectPath(projectName: string): string {

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -25,6 +25,7 @@ export const ENTITY_CUSTOM_FIELD = 'entitycustomfield'
 export const ADDRESS_FORM = 'addressForm'
 export const ENTRY_FORM = 'entryForm'
 export const TRANSACTION_FORM = 'transactionForm'
+export const EMAIL_TEMPLATE = 'emailtemplate'
 
 // Type Annotations
 export const SCRIPT_ID_PREFIX = 'scriptIdPrefix'

--- a/packages/netsuite-adapter/src/types/custom_types/advancedpdftemplate.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/advancedpdftemplate.ts
@@ -20,6 +20,7 @@ import {
 } from '@salto-io/adapter-api'
 import * as constants from '../../constants'
 import { enums } from '../enums'
+import { fieldTypes } from '../field_types'
 
 export const advancedpdftemplateInnerTypes: ObjectType[] = []
 
@@ -29,7 +30,6 @@ export const advancedpdftemplate = new ObjectType({
   elemID: advancedpdftemplateElemID,
   annotations: {
     [constants.SCRIPT_ID_PREFIX]: 'custtmpl_',
-    [constants.ADDITIONAL_FILE_SUFFIX]: '.template.xml',
   },
   fields: {
     scriptid: {
@@ -83,6 +83,12 @@ export const advancedpdftemplate = new ObjectType({
       annotations: {
       },
     }, /* Original description: This field accepts references to the following custom types:   customtransactiontype   customrecordtype */
+    content: {
+      type: fieldTypes.fileContent,
+      annotations: {
+        [constants.ADDITIONAL_FILE_SUFFIX]: 'xml',
+      },
+    },
   },
   path: [constants.NETSUITE, constants.TYPES_PATH, advancedpdftemplateElemID.name],
 })

--- a/packages/netsuite-adapter/src/types/custom_types/emailtemplate.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/emailtemplate.ts
@@ -20,6 +20,7 @@ import {
 } from '@salto-io/adapter-api'
 import * as constants from '../../constants'
 import { enums } from '../enums'
+import { fieldTypes } from '../field_types'
 
 export const emailtemplateInnerTypes: ObjectType[] = []
 
@@ -29,7 +30,6 @@ export const emailtemplate = new ObjectType({
   elemID: emailtemplateElemID,
   annotations: {
     [constants.SCRIPT_ID_PREFIX]: 'custemailtmpl_',
-    [constants.ADDITIONAL_FILE_SUFFIX]: '.template.html',
   },
   fields: {
     scriptid: {
@@ -93,6 +93,12 @@ export const emailtemplate = new ObjectType({
       annotations: {
       },
     }, /* Original description: The default value is F. */
+    content: {
+      type: fieldTypes.fileContent,
+      annotations: {
+        [constants.ADDITIONAL_FILE_SUFFIX]: 'html',
+      },
+    },
   },
   path: [constants.NETSUITE, constants.TYPES_PATH, emailtemplateElemID.name],
 })

--- a/packages/netsuite-adapter/src/types/field_types.ts
+++ b/packages/netsuite-adapter/src/types/field_types.ts
@@ -22,4 +22,9 @@ export const fieldTypes = {
     primitive: PrimitiveTypes.STRING,
     path: [NETSUITE, TYPES_PATH, SUBTYPES_PATH, FIELD_TYPES_PATH],
   }),
+  fileContent: new PrimitiveType({
+    elemID: new ElemID(NETSUITE, 'fileContent'),
+    primitive: PrimitiveTypes.STRING,
+    path: [NETSUITE, TYPES_PATH, SUBTYPES_PATH, FIELD_TYPES_PATH],
+  }),
 }

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -21,9 +21,15 @@ import mockClient, { DUMMY_CREDENTIALS } from './client'
 import NetsuiteClient, { COMMANDS, CustomizationInfo } from '../../src/client/client'
 
 
+const MOCK_TEMPLATE_CONTENT = 'Template Inner Content'
 jest.mock('@salto-io/file', () => ({
-  readDir: jest.fn().mockImplementation(() => ['a.xml', 'b.xml', 'c.html']),
-  readFile: jest.fn().mockImplementation(filePath => `<elementName filePath="${filePath}">`),
+  readDir: jest.fn().mockImplementation(() => ['a.xml', 'b.xml', 'a.template.html']),
+  readFile: jest.fn().mockImplementation(filePath => {
+    if (filePath.includes('.template.')) {
+      return MOCK_TEMPLATE_CONTENT
+    }
+    return `<elementName filename="${filePath.split('/').pop()}">`
+  }),
   writeFile: jest.fn(),
 }))
 const readFileMock = readFile as unknown as jest.Mock
@@ -177,10 +183,7 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ status: 'SUCCESS' })
       })
-      const xmlElements = await client.listCustomObjects()
-      expect(readDirMock).toHaveBeenCalledTimes(1)
-      expect(readFileMock).toHaveBeenCalledTimes(2)
-      expect(xmlElements).toHaveLength(2)
+      await client.listCustomObjects()
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, reuseAuthIdCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(3, saveTokenCommandMatcher)
@@ -189,10 +192,28 @@ describe('netsuite client', () => {
 
     it('should succeed', async () => {
       mockExecuteAction.mockResolvedValue({ status: 'SUCCESS' })
-      const xmlElements = await client.listCustomObjects()
+      const customizationInfos = await client.listCustomObjects()
       expect(readDirMock).toHaveBeenCalledTimes(1)
-      expect(readFileMock).toHaveBeenCalledTimes(2)
-      expect(xmlElements).toHaveLength(2)
+      expect(readFileMock).toHaveBeenCalledTimes(3)
+      expect(customizationInfos).toHaveLength(2)
+      expect(customizationInfos).toEqual([{
+        typeName: 'elementName',
+        values: {
+          '@_filename': 'a.xml',
+        },
+        fileContent: {
+          extension: 'html',
+          content: MOCK_TEMPLATE_CONTENT,
+        },
+      },
+      {
+        typeName: 'elementName',
+        values: {
+          '@_filename': 'b.xml',
+        },
+        fileContent: undefined,
+      }])
+
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, reuseAuthIdCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(3, importObjectsCommandMatcher)
@@ -222,10 +243,45 @@ describe('netsuite client', () => {
       expect(mockExecuteAction).toHaveBeenNthCalledWith(5, deployProjectCommandMatcher)
     })
 
-    it('should succeed', async () => {
+    it('should succeed for customizationInfo without additionalFile', async () => {
       mockExecuteAction.mockResolvedValue({ status: 'SUCCESS' })
-      await client.deployCustomObject('elementName', {} as CustomizationInfo)
+      const customizationInfo = {
+        typeName: 'typeName',
+        values: {
+          key: 'val',
+        },
+      }
+      const filename = 'filename'
+      await client.deployCustomObject(filename, customizationInfo)
       expect(writeFileMock).toHaveBeenCalledTimes(1)
+      expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining(`${filename}.xml`),
+        '<typeName><key>val</key></typeName>')
+      expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
+      expect(mockExecuteAction).toHaveBeenNthCalledWith(2, reuseAuthIdCommandMatcher)
+      expect(mockExecuteAction).toHaveBeenNthCalledWith(3, addDependenciesCommandMatcher)
+      expect(mockExecuteAction).toHaveBeenNthCalledWith(4, deployProjectCommandMatcher)
+      expect(mockExecuteAction).not.toHaveBeenCalledWith(saveTokenCommandMatcher)
+    })
+
+    it('should succeed for customizationInfo with additionalFile', async () => {
+      mockExecuteAction.mockResolvedValue({ status: 'SUCCESS' })
+      const filename = 'filename'
+      const customizationInfo = {
+        typeName: 'typeName',
+        values: {
+          key: 'val',
+        },
+        fileContent: {
+          extension: 'html',
+          content: MOCK_TEMPLATE_CONTENT,
+        },
+      }
+      await client.deployCustomObject(filename, customizationInfo)
+      expect(writeFileMock).toHaveBeenCalledTimes(2)
+      expect(writeFileMock)
+        .toHaveBeenCalledWith(expect.stringContaining(`${filename}.xml`), '<typeName><key>val</key></typeName>')
+      expect(writeFileMock)
+        .toHaveBeenCalledWith(expect.stringContaining(`${filename}.template.html`), MOCK_TEMPLATE_CONTENT)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, reuseAuthIdCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(3, addDependenciesCommandMatcher)

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -13,10 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement } from '@salto-io/adapter-api'
+import { InstanceElement, StaticFile } from '@salto-io/adapter-api'
 import { createInstanceElement, toCustomizationInfo } from '../src/transformer'
 import {
   ADDRESS_FORM, CUSTOM_RECORD_TYPE, ENTITY_CUSTOM_FIELD, SCRIPT_ID, TRANSACTION_FORM,
+  EMAIL_TEMPLATE,
 } from '../src/constants'
 import { customTypes } from '../src/types'
 import { convertToCustomizationInfo, convertToXmlContent } from '../src/client/client'
@@ -112,7 +113,7 @@ describe('Transformer', () => {
   describe('createInstanceElement', () => {
     const transformCustomFieldRecord = (xmlContent: string): InstanceElement => {
       const customFieldType = customTypes[ENTITY_CUSTOM_FIELD]
-      return createInstanceElement(convertToCustomizationInfo(xmlContent).values, customFieldType)
+      return createInstanceElement(convertToCustomizationInfo(xmlContent), customFieldType)
     }
 
     it('should create instance name correctly', () => {
@@ -125,7 +126,7 @@ describe('Transformer', () => {
       + '  <definition>BLA</definition>\n'
       + '</savedsearch>\n'
       const savedSearchType = customTypes.savedsearch
-      const result = createInstanceElement(convertToCustomizationInfo(savedSearchXmlContent).values,
+      const result = createInstanceElement(convertToCustomizationInfo(savedSearchXmlContent),
         savedSearchType)
       expect(result.elemID.name).toEqual('customsearch_my_search_script_id')
     })
@@ -134,7 +135,7 @@ describe('Transformer', () => {
       const customRecordTypeXmlContent = '<customrecordtype scriptid="customrecord__my_record_script_id">\n'
       + '</customrecordtype>\n'
       const result = createInstanceElement(
-        convertToCustomizationInfo(customRecordTypeXmlContent).values,
+        convertToCustomizationInfo(customRecordTypeXmlContent),
         customTypes[CUSTOM_RECORD_TYPE]
       )
       expect(result.elemID.name).toEqual('customrecord__my_record_script_id')
@@ -148,7 +149,7 @@ describe('Transformer', () => {
     it('should transform nested attributes', () => {
       const customRecordTypeXmlContent = XML_TEMPLATES.WITH_NESTED_ATTRIBUTE
       const result = createInstanceElement(
-        convertToCustomizationInfo(customRecordTypeXmlContent).values,
+        convertToCustomizationInfo(customRecordTypeXmlContent),
         customTypes[CUSTOM_RECORD_TYPE]
       )
       expect(result.value[SCRIPT_ID]).toEqual('customrecord_my_script_id')
@@ -234,6 +235,51 @@ describe('Transformer', () => {
     it('should ignore unknown fields', () => {
       const result = transformCustomFieldRecord(XML_TEMPLATES.WITH_UNKNOWN_FIELD)
       expect(result.value.unknownfield).toBeUndefined()
+    })
+
+    it('should add content value with additionalFile content as static file', () => {
+      const emailTemplateContent = 'Email template content'
+      const emailTemplateCustomizationInfo = {
+        typeName: EMAIL_TEMPLATE,
+        values: {
+          name: 'email template name',
+          [SCRIPT_ID]: 'custemailtmpl_my_script_id',
+        },
+        fileContent: {
+          extension: 'html',
+          content: emailTemplateContent,
+        },
+      }
+      const result = createInstanceElement(
+        emailTemplateCustomizationInfo,
+        customTypes[EMAIL_TEMPLATE]
+      )
+      expect(result.value).toEqual({
+        name: 'email template name',
+        [SCRIPT_ID]: 'custemailtmpl_my_script_id',
+        content: new StaticFile({
+          filepath: 'netsuite/emailtemplate/email_template_name.html',
+          content: Buffer.from(emailTemplateContent),
+        }),
+      })
+    })
+
+    it('should not add content value when there is no additionalFile', () => {
+      const emailTemplateCustomizationInfo = {
+        typeName: EMAIL_TEMPLATE,
+        values: {
+          name: 'email template name',
+          [SCRIPT_ID]: 'custemailtmpl_my_script_id',
+        },
+      }
+      const result = createInstanceElement(
+        emailTemplateCustomizationInfo,
+        customTypes[EMAIL_TEMPLATE]
+      )
+      expect(result.value).toEqual({
+        name: 'email template name',
+        [SCRIPT_ID]: 'custemailtmpl_my_script_id',
+      })
     })
   })
 
@@ -436,6 +482,42 @@ describe('Transformer', () => {
         + '  </mainFields>\n'
         + '  <address>my address</address>\n'
         + '</transactionForm>\n'))
+    })
+
+    it('should transform additionalFile content', () => {
+      const emailTemplateContent = 'email template content'
+      const elementName = 'elementName'
+      const emailTemplateInstance = new InstanceElement(elementName,
+        customTypes[EMAIL_TEMPLATE], {
+          name: elementName,
+          content: emailTemplateContent,
+        })
+      const customizationInfo = toCustomizationInfo(emailTemplateInstance)
+      expect(customizationInfo).toEqual({
+        typeName: EMAIL_TEMPLATE,
+        values: {
+          name: elementName,
+        },
+        fileContent: {
+          extension: 'html',
+          content: emailTemplateContent,
+        },
+      })
+    })
+
+    it('should not transform additionalFile content when content is undefined', () => {
+      const elementName = 'elementName'
+      const emailTemplateInstance = new InstanceElement(elementName,
+        customTypes[EMAIL_TEMPLATE], {
+          name: elementName,
+        })
+      const customizationInfo = toCustomizationInfo(emailTemplateInstance)
+      expect(customizationInfo).toEqual({
+        typeName: EMAIL_TEMPLATE,
+        values: {
+          name: elementName,
+        },
+      })
     })
   })
 })

--- a/packages/netsuite-adapter/test/types.test.ts
+++ b/packages/netsuite-adapter/test/types.test.ts
@@ -13,9 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, isPrimitiveType } from '@salto-io/adapter-api'
+import _ from 'lodash'
 import { customTypes } from '../src/types'
-import { IS_NAME, SCRIPT_ID, SCRIPT_ID_PREFIX } from '../src/constants'
+import { ADDITIONAL_FILE_SUFFIX, IS_NAME, SCRIPT_ID, SCRIPT_ID_PREFIX } from '../src/constants'
+import { fieldTypes } from '../src/types/field_types'
 
 describe('Types', () => {
   describe('CustomTypes', () => {
@@ -39,6 +41,18 @@ describe('Types', () => {
         .forEach(typeDef => {
           expect(typeDef.fields[SCRIPT_ID]).toBeDefined()
           expect(typeDef.fields[SCRIPT_ID].annotations[CORE_ANNOTATIONS.REQUIRED]).toBeUndefined()
+        })
+    })
+
+    it('should have at most 1 fileContent field with ADDITIONAL_FILE_SUFFIX annotation', () => {
+      Object.values(customTypes)
+        .forEach(typeDef => {
+          const fileContentFields = Object.values(typeDef.fields)
+            .filter(f => isPrimitiveType(f.type) && f.type.isEqual(fieldTypes.fileContent))
+          expect(fileContentFields.length).toBeLessThanOrEqual(1)
+          if (!_.isEmpty(fileContentFields)) {
+            expect(fileContentFields[0].annotations[ADDITIONAL_FILE_SUFFIX]).toBeDefined()
+          }
         })
     })
   })


### PR DESCRIPTION
Some context:
In SDF, emailtemplate & advancedpdftemplate types may have another file in the project containing the template's content. In the xml there is no mention for that content and the way to understand the connection between the content file and the xml is by the files names (e.g. `email_template_script_id.xml` & `email_template_script_id.template.html`).

In this PR:
- detect the additional files suffix
- add a 'content' field to types with additional file
- fetch the content from the additional file to the `content` field and set it as a `StaticFile`
- deploy the `content` value to a separate file in the project upon add & update
- support resolve & restore of static files in the adapter
