### PR TITLE
Bump to version 0.1.16

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.1.15",
+  "version": "0.1.16",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "stream": true,

--- a/packages/adapter-api/package.json
+++ b/packages/adapter-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/adapter-api",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "Apache-2.0",
   "description": "Salto Adapter API",
   "repository": {
@@ -32,8 +32,8 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/dag": "0.1.15",
-    "@salto-io/lowerdash": "0.1.15",
+    "@salto-io/dag": "0.1.16",
+    "@salto-io/lowerdash": "0.1.16",
     "lodash": "^4.17.15",
     "wu": "^2.1.0"
   },

--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/adapter-utils",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "Apache-2.0",
   "description": "Salto Adapter Utils",
   "repository": {
@@ -32,10 +32,10 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.15",
-    "@salto-io/dag": "0.1.15",
-    "@salto-io/logging": "0.1.15",
-    "@salto-io/lowerdash": "0.1.15",
+    "@salto-io/adapter-api": "0.1.16",
+    "@salto-io/dag": "0.1.16",
+    "@salto-io/logging": "0.1.16",
+    "@salto-io/lowerdash": "0.1.16",
     "lodash": "^4.17.15",
     "wu": "^2.1.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "Apache-2.0",
   "description": "cli on top of salto core",
   "repository": {
@@ -35,15 +35,15 @@
     "package": "node ./package_native.js"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.15",
-    "@salto-io/adapter-utils": "0.1.15",
-    "@salto-io/core": "0.1.15",
-    "@salto-io/dag": "0.1.15",
-    "@salto-io/e2e-credentials-store": "0.1.15",
-    "@salto-io/file": "0.1.15",
-    "@salto-io/logging": "0.1.15",
-    "@salto-io/lowerdash": "0.1.15",
-    "@salto-io/salesforce-adapter": "0.1.15",
+    "@salto-io/adapter-api": "0.1.16",
+    "@salto-io/adapter-utils": "0.1.16",
+    "@salto-io/core": "0.1.16",
+    "@salto-io/dag": "0.1.16",
+    "@salto-io/e2e-credentials-store": "0.1.16",
+    "@salto-io/file": "0.1.16",
+    "@salto-io/logging": "0.1.16",
+    "@salto-io/lowerdash": "0.1.16",
+    "@salto-io/salesforce-adapter": "0.1.16",
     "chalk": "^2.4.2",
     "figlet": "^1.2.4",
     "glob": "^7.1.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/core",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "Apache-2.0",
   "description": "Salto core",
   "repository": {
@@ -34,14 +34,14 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.15",
-    "@salto-io/adapter-utils": "0.1.15",
-    "@salto-io/dag": "0.1.15",
-    "@salto-io/file": "0.1.15",
-    "@salto-io/hubspot-adapter": "0.1.15",
-    "@salto-io/logging": "0.1.15",
-    "@salto-io/lowerdash": "0.1.15",
-    "@salto-io/salesforce-adapter": "0.1.15",
+    "@salto-io/adapter-api": "0.1.16",
+    "@salto-io/adapter-utils": "0.1.16",
+    "@salto-io/dag": "0.1.16",
+    "@salto-io/file": "0.1.16",
+    "@salto-io/hubspot-adapter": "0.1.16",
+    "@salto-io/logging": "0.1.16",
+    "@salto-io/lowerdash": "0.1.16",
+    "@salto-io/salesforce-adapter": "0.1.16",
     "axios": "^0.19.2",
     "fuse.js": "^3.4.5",
     "lodash": "^4.17.15",

--- a/packages/dag/package.json
+++ b/packages/dag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/dag",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "Apache-2.0",
   "description": "directed acyclic graph implementation including - dag diff and node grouping",
   "repository": {
@@ -32,8 +32,8 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/logging": "0.1.15",
-    "@salto-io/lowerdash": "0.1.15",
+    "@salto-io/logging": "0.1.16",
+    "@salto-io/lowerdash": "0.1.16",
     "lodash": "^4.17.15",
     "wu": "^2.1.0"
   },

--- a/packages/e2e-credential-store/package.json
+++ b/packages/e2e-credential-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/e2e-credentials-store",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "Apache-2.0",
   "description": "Salto E2E tests credentials store",
   "repository": {
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@jest/environment": "^24.0.0",
-    "@salto-io/logging": "0.1.15",
-    "@salto-io/lowerdash": "0.1.15",
-    "@salto-io/persistent-pool": "0.1.15",
+    "@salto-io/logging": "0.1.16",
+    "@salto-io/lowerdash": "0.1.16",
+    "@salto-io/persistent-pool": "0.1.16",
     "easy-table": "^1.1.1",
     "humanize-duration": "^3.22.0",
     "jest-circus": "^24.9.0",

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/file",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "Apache-2.0",
   "description": "File System Utils",
   "repository": {
@@ -32,7 +32,7 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/lowerdash": "0.1.15",
+    "@salto-io/lowerdash": "0.1.16",
     "mkdirp": "^0.5.1",
     "rimraf": "^3.0.0"
   },

--- a/packages/hubspot-adapter/package.json
+++ b/packages/hubspot-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/hubspot-adapter",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "Apache-2.0",
   "description": "Salto Hubspot adapter",
   "repository": {
@@ -32,10 +32,10 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.15",
-    "@salto-io/adapter-utils": "0.1.15",
-    "@salto-io/logging": "0.1.15",
-    "@salto-io/lowerdash": "0.1.15",
+    "@salto-io/adapter-api": "0.1.16",
+    "@salto-io/adapter-utils": "0.1.16",
+    "@salto-io/logging": "0.1.16",
+    "@salto-io/lowerdash": "0.1.16",
     "hubspot": "^2.3.8",
     "lodash": "^4.17.15",
     "request-promise": "^4.2.5",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/logging",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "Apache-2.0",
   "description": "Salto Logging library",
   "repository": {
@@ -31,7 +31,7 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/lowerdash": "0.1.15",
+    "@salto-io/lowerdash": "0.1.16",
     "chalk": "^2.4.2",
     "lodash": "^4.17.15",
     "logform": "^2.1.2",

--- a/packages/lowerdash/package.json
+++ b/packages/lowerdash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/lowerdash",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "Apache-2.0",
   "description": "Salto utils - stuff that isn't in lodash",
   "repository": {

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/netsuite-adapter",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "Apache-2.0",
   "description": "Salto Netsuite adapter",
   "repository": {
@@ -27,15 +27,15 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.15",
-    "@salto-io/adapter-utils": "0.1.15",
-    "@salto-io/file": "0.1.15",
-    "@salto-io/logging": "0.1.15",
-    "@salto-io/lowerdash": "0.1.15",
+    "@salto-io/adapter-api": "0.1.16",
+    "@salto-io/adapter-utils": "0.1.16",
+    "@salto-io/file": "0.1.16",
+    "@salto-io/logging": "0.1.16",
+    "@salto-io/lowerdash": "0.1.16",
     "@salto-io/suitecloud-cli": "^1.0.2-salto-3",
+    "fast-xml-parser": "^3.15.0",
     "lodash": "^4.17.15",
-    "wu": "^2.1.0",
-    "fast-xml-parser": "^3.15.0"
+    "wu": "^2.1.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.0",

--- a/packages/persistent-pool/package.json
+++ b/packages/persistent-pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/persistent-pool",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "Apache-2.0",
   "description": "Keeps a persistent pool of objects",
   "repository": {
@@ -26,7 +26,7 @@
     "lint-fix": "yarn lint --fix"
   },
   "dependencies": {
-    "@salto-io/lowerdash": "0.1.15",
+    "@salto-io/lowerdash": "0.1.16",
     "aws-sdk": "^2.573.0",
     "uuid": "^3.3.3"
   },

--- a/packages/salesforce-adapter/package.json
+++ b/packages/salesforce-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/salesforce-adapter",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "Apache-2.0",
   "description": "Salto Salesforce adapter",
   "repository": {
@@ -34,11 +34,11 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.15",
-    "@salto-io/adapter-utils": "0.1.15",
-    "@salto-io/e2e-credentials-store": "0.1.15",
-    "@salto-io/logging": "0.1.15",
-    "@salto-io/lowerdash": "0.1.15",
+    "@salto-io/adapter-api": "0.1.16",
+    "@salto-io/adapter-utils": "0.1.16",
+    "@salto-io/e2e-credentials-store": "0.1.16",
+    "@salto-io/logging": "0.1.16",
+    "@salto-io/lowerdash": "0.1.16",
     "@types/requestretry": "^1.12.5",
     "fast-xml-parser": "^3.15.0",
     "humanize-duration": "^3.22.0",
@@ -52,7 +52,7 @@
     "wu": "^2.1.0"
   },
   "devDependencies": {
-    "@salto-io/persistent-pool": "0.1.15",
+    "@salto-io/persistent-pool": "0.1.16",
     "@types/jest": "^24.0.0",
     "@types/jszip": "^3.1.6",
     "@types/lodash": "^4.14.133",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "salto-vscode",
     "displayName": "Salto",
     "description": "Configure Salto patches in vscode.",
-    "version": "0.1.15",
+    "version": "0.1.16",
     "publishConfig": {
         "access": "public"
     },
@@ -116,10 +116,10 @@
         "generate-yarn-lock": "yarn workspaces run generate-lock-entry | sed '1,2d' | sed -n -e :a -e '1,1!{P;N;D;};N;ba' >> yarn.lock"
     },
     "dependencies": {
-        "@salto-io/adapter-api": "0.1.15",
-        "@salto-io/adapter-utils": "0.1.15",
-        "@salto-io/core": "0.1.15",
-        "@salto-io/file": "0.1.15",
+        "@salto-io/adapter-api": "0.1.16",
+        "@salto-io/adapter-utils": "0.1.16",
+        "@salto-io/core": "0.1.16",
+        "@salto-io/file": "0.1.16",
         "copy-paste": "^1.3.0",
         "diff": "^4.0.1",
         "diff2html": "^2.12.1",


### PR DESCRIPTION
### What's New in Version v0.1.16

Note: This version will hide the types folder in the Hubspot directory after the first fetch. The elements data will remain in the state file.

**What's New**
* Improved NaCL files parsing speed. 
* Removed the `update` syntax from the NaCL language.
* Added a new workspace size telemetry. (See: https://salto.io/telemetry_c.html)
* The NaCL static file function will no longer allow access for files that are not located within the static files folders.
 
_Hubspot adapter_
 * Large JSON values are now saved in static files.
 * Elements from the Hubspot types folder are fetched to the state file, but are not written to the NaCL files.
 * Will no longer attempt to deploy changes to readonly fields.

### Bug Fixes
* Fixed default values are assigned for fields with no default values if the field type is an object type.
* Fixed current adapter configuration is overwritten when adding a new service.
* Fixed obscure log lines when fetching record types without a business process being defined.
* Fixed `delete env` attempting to delete non-existing files.