### PR TITLE
vscode - add tsc watch task for cli

### DIFF
--- a/packages/cli/.vscode/tasks.json
+++ b/packages/cli/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "cli watch-ts",
+      "command": "yarn watch-ts",
+      "type": "shell",
+      "args": [],
+      "problemMatcher": [
+        "$tsc-watch"
+      ],
+      "isBackground": true,
+      "group": "build"
+    },
+  ]
+}

--- a/packages/persistent-pool/test/lib/dynamodb/dynamodb_repo.e2e.test.ts
+++ b/packages/persistent-pool/test/lib/dynamodb/dynamodb_repo.e2e.test.ts
@@ -93,13 +93,9 @@ describe('when there are existing leases', () => {
   })
 
   describe('clear', () => {
-    beforeAll(async () => {
-      await pool.clear()
-    })
+    beforeAll(() => pool.clear())
 
-    afterAll(async () => {
-      await fillPool()
-    })
+    afterAll(fillPool, 30000)
 
     it('should clear the instances', async () => {
       expect(await asyncToArray(pool)).toHaveLength(0)


### PR DESCRIPTION
allows running the build in vscode the background