### PR TITLE
remove unused interface complexity

### DIFF
--- a/packages/core/src/workspace/local/state.ts
+++ b/packages/core/src/workspace/local/state.ts
@@ -68,16 +68,12 @@ export const localState = (filePath: string): State => {
     list: async (): Promise<ElemID[]> =>
       Object.keys((await stateData()).elements).map(n => ElemID.fromFullName(n)),
     get: async (id: ElemID): Promise<Element> => ((await stateData()).elements[id.getFullName()]),
-    set: async (element: Element | Element []): Promise<void> => {
-      makeArray(element).forEach(async e => {
-        (await stateData()).elements[e.elemID.getFullName()] = e
-      })
+    set: async (element: Element): Promise<void> => {
+      (await stateData()).elements[element.elemID.getFullName()] = element
       dirty = true
     },
-    remove: async (id: ElemID | ElemID[]): Promise<void> => {
-      makeArray(id).forEach(async i => {
-        delete (await stateData()).elements[i.getFullName()]
-      })
+    remove: async (id: ElemID): Promise<void> => {
+      delete (await stateData()).elements[id.getFullName()]
       dirty = true
     },
     rename: async (name: string): Promise<void> => {

--- a/packages/core/src/workspace/state.ts
+++ b/packages/core/src/workspace/state.ts
@@ -17,8 +17,8 @@ import { Element, ElemID } from '@salto-io/adapter-api'
 import { ElementsSource } from './elements_source'
 
 export default interface State extends ElementsSource {
-  set(element: Element | Element[]): Promise<void>
-  remove(id: ElemID | ElemID[]): Promise<void>
+  set(element: Element): Promise<void>
+  remove(id: ElemID): Promise<void>
   override(element: Element | Element[], services?: string[]): Promise<void>
   getServicesUpdateDates(): Promise<Record<string, Date>>
   existingServices(): Promise<string[]>

--- a/packages/core/test/workspace/local/state.test.ts
+++ b/packages/core/test/workspace/local/state.test.ts
@@ -60,7 +60,7 @@ describe('local state', () => {
 
     it('should override state successfully, retrieve it and get the same result', async () => {
       const newElem = new ObjectType({ elemID: new ElemID('mock_adapter', 'new') })
-      state.set([newElem])
+      state.set(newElem)
       await state.override([mockElement])
       const retrievedState = await state.getAll()
       expect(retrievedState.length).toBe(1)
@@ -69,7 +69,7 @@ describe('local state', () => {
     })
 
     it('should set state successfully, retrieve it and get the same result', async () => {
-      await state.set([mockElement])
+      await state.set(mockElement)
       const retrievedState = await state.getAll()
       expect(retrievedState.length).toBe(1)
       const retrievedStateObjectType = retrievedState[0] as ObjectType
@@ -77,21 +77,21 @@ describe('local state', () => {
     })
 
     it('should update state', async () => {
-      await state.set([mockElement])
+      await state.set(mockElement)
       const clone = mockElement.clone()
       const newField = Object.values(mockElement.fields)[0]
       newField.name = 'new_field'
       clone.fields.newfield = newField
-      state.set([clone])
+      state.set(clone)
 
       const fromState = await state.get(mockElement.elemID) as ObjectType
       expect(fromState.fields.newfield).toBeDefined()
     })
 
     it('should add to state', async () => {
-      await state.set([mockElement])
+      await state.set(mockElement)
       const newElem = new ObjectType({ elemID: new ElemID('mock_adapter', 'new') })
-      state.set([newElem])
+      state.set(newElem)
 
       const fromState = await state.getAll()
       expect(fromState.length).toBe(2)
@@ -99,7 +99,7 @@ describe('local state', () => {
     })
 
     it('should remove from state', async () => {
-      await state.set([mockElement])
+      await state.set(mockElement)
       let fromState = await state.getAll()
       expect(fromState.length).toBe(1)
 
@@ -125,7 +125,7 @@ describe('local state', () => {
 
   it('should write file on flush', async () => {
     const state = localState('on-flush')
-    await state.set([mockElement])
+    await state.set(mockElement)
     await state.flush()
     const onFlush = findReplaceContentCall('on-flush')
     expect(onFlush).toBeDefined()
@@ -187,18 +187,18 @@ describe('local state', () => {
       readTextFileMock.mockResolvedValueOnce(mockStateStr)
       const state = localState('filename')
 
-      await state.set([mockElement])
+      await state.set(mockElement)
       const overrideDate = await state.getServicesUpdateDates()
       expect(overrideDate.salto).toEqual(saltoModificationDate)
       expect(overrideDate.hubspot).toEqual(hubspotModificationDate)
-      await state.remove([mockElement.elemID])
+      await state.remove(mockElement.elemID)
       expect(overrideDate.salto).toEqual(saltoModificationDate)
       expect(overrideDate.hubspot).toEqual(hubspotModificationDate)
     })
     it('should ignore built in types in set ops', async () => {
       mockExists.mockResolvedValueOnce(true)
       const state = localState('empty')
-      await state.set([BuiltinTypes.STRING])
+      await state.set(BuiltinTypes.STRING)
       const overrideDate = await state.getServicesUpdateDates()
       expect(overrideDate).toEqual({})
     })


### PR DESCRIPTION
No code (except tests) used the "feature" of `State` that allowed passing in multiple elements to `set` and `remove`.
since this was a confusing interface (get/set/remove become asymmetric) and nothing actually needed it, I changed it to always work on a single element (as it is used in all cases in the core)