### PR TITLE
Bump to version 0.1.18

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.1.17",
+  "version": "0.1.18",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "stream": true,

--- a/packages/adapter-api/package.json
+++ b/packages/adapter-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/adapter-api",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "description": "Salto Adapter API",
   "repository": {
@@ -32,8 +32,8 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/dag": "0.1.17",
-    "@salto-io/lowerdash": "0.1.17",
+    "@salto-io/dag": "0.1.18",
+    "@salto-io/lowerdash": "0.1.18",
     "lodash": "^4.17.15",
     "wu": "^2.1.0"
   },

--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/adapter-utils",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "description": "Salto Adapter Utils",
   "repository": {
@@ -32,10 +32,10 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.17",
-    "@salto-io/dag": "0.1.17",
-    "@salto-io/logging": "0.1.17",
-    "@salto-io/lowerdash": "0.1.17",
+    "@salto-io/adapter-api": "0.1.18",
+    "@salto-io/dag": "0.1.18",
+    "@salto-io/logging": "0.1.18",
+    "@salto-io/lowerdash": "0.1.18",
     "lodash": "^4.17.15",
     "wu": "^2.1.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/cli",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "description": "cli on top of salto core",
   "repository": {
@@ -35,15 +35,15 @@
     "package": "node ./package_native.js"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.17",
-    "@salto-io/adapter-utils": "0.1.17",
-    "@salto-io/core": "0.1.17",
-    "@salto-io/dag": "0.1.17",
-    "@salto-io/e2e-credentials-store": "0.1.17",
-    "@salto-io/file": "0.1.17",
-    "@salto-io/logging": "0.1.17",
-    "@salto-io/lowerdash": "0.1.17",
-    "@salto-io/salesforce-adapter": "0.1.17",
+    "@salto-io/adapter-api": "0.1.18",
+    "@salto-io/adapter-utils": "0.1.18",
+    "@salto-io/core": "0.1.18",
+    "@salto-io/dag": "0.1.18",
+    "@salto-io/e2e-credentials-store": "0.1.18",
+    "@salto-io/file": "0.1.18",
+    "@salto-io/logging": "0.1.18",
+    "@salto-io/lowerdash": "0.1.18",
+    "@salto-io/salesforce-adapter": "0.1.18",
     "chalk": "^2.4.2",
     "figlet": "^1.2.4",
     "glob": "^7.1.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/core",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "description": "Salto core",
   "repository": {
@@ -34,15 +34,15 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.17",
-    "@salto-io/adapter-utils": "0.1.17",
-    "@salto-io/dag": "0.1.17",
-    "@salto-io/file": "0.1.17",
-    "@salto-io/hubspot-adapter": "0.1.17",
-    "@salto-io/netsuite-adapter": "0.1.17",
-    "@salto-io/logging": "0.1.17",
-    "@salto-io/lowerdash": "0.1.17",
-    "@salto-io/salesforce-adapter": "0.1.17",
+    "@salto-io/adapter-api": "0.1.18",
+    "@salto-io/adapter-utils": "0.1.18",
+    "@salto-io/dag": "0.1.18",
+    "@salto-io/file": "0.1.18",
+    "@salto-io/hubspot-adapter": "0.1.18",
+    "@salto-io/logging": "0.1.18",
+    "@salto-io/lowerdash": "0.1.18",
+    "@salto-io/netsuite-adapter": "0.1.18",
+    "@salto-io/salesforce-adapter": "0.1.18",
     "axios": "^0.19.2",
     "fuse.js": "^3.4.5",
     "lodash": "^4.17.15",

--- a/packages/dag/package.json
+++ b/packages/dag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/dag",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "description": "directed acyclic graph implementation including - dag diff and node grouping",
   "repository": {
@@ -32,8 +32,8 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/logging": "0.1.17",
-    "@salto-io/lowerdash": "0.1.17",
+    "@salto-io/logging": "0.1.18",
+    "@salto-io/lowerdash": "0.1.18",
     "lodash": "^4.17.15",
     "wu": "^2.1.0"
   },

--- a/packages/e2e-credentials-store/package.json
+++ b/packages/e2e-credentials-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/e2e-credentials-store",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "description": "Salto E2E tests credentials store",
   "repository": {
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@jest/environment": "^24.0.0",
-    "@salto-io/logging": "0.1.17",
-    "@salto-io/lowerdash": "0.1.17",
-    "@salto-io/persistent-pool": "0.1.17",
+    "@salto-io/logging": "0.1.18",
+    "@salto-io/lowerdash": "0.1.18",
+    "@salto-io/persistent-pool": "0.1.18",
     "easy-table": "^1.1.1",
     "humanize-duration": "^3.22.0",
     "jest-circus": "^24.9.0",

--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/file",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "description": "File System Utils",
   "repository": {
@@ -32,7 +32,7 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/lowerdash": "0.1.17",
+    "@salto-io/lowerdash": "0.1.18",
     "mkdirp": "^0.5.1",
     "rimraf": "^3.0.0"
   },

--- a/packages/hubspot-adapter/package.json
+++ b/packages/hubspot-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/hubspot-adapter",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "description": "Salto Hubspot adapter",
   "repository": {
@@ -32,10 +32,10 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.17",
-    "@salto-io/adapter-utils": "0.1.17",
-    "@salto-io/logging": "0.1.17",
-    "@salto-io/lowerdash": "0.1.17",
+    "@salto-io/adapter-api": "0.1.18",
+    "@salto-io/adapter-utils": "0.1.18",
+    "@salto-io/logging": "0.1.18",
+    "@salto-io/lowerdash": "0.1.18",
     "hubspot": "^2.3.8",
     "lodash": "^4.17.15",
     "request-promise": "^4.2.5",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/logging",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "description": "Salto Logging library",
   "repository": {
@@ -31,7 +31,7 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/lowerdash": "0.1.17",
+    "@salto-io/lowerdash": "0.1.18",
     "chalk": "^2.4.2",
     "lodash": "^4.17.15",
     "logform": "^2.1.2",

--- a/packages/lowerdash/package.json
+++ b/packages/lowerdash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/lowerdash",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "description": "Salto utils - stuff that isn't in lodash",
   "repository": {

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/netsuite-adapter",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "description": "Salto Netsuite adapter",
   "repository": {
@@ -27,11 +27,11 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.17",
-    "@salto-io/adapter-utils": "0.1.17",
-    "@salto-io/file": "0.1.17",
-    "@salto-io/logging": "0.1.17",
-    "@salto-io/lowerdash": "0.1.17",
+    "@salto-io/adapter-api": "0.1.18",
+    "@salto-io/adapter-utils": "0.1.18",
+    "@salto-io/file": "0.1.18",
+    "@salto-io/logging": "0.1.18",
+    "@salto-io/lowerdash": "0.1.18",
     "fast-xml-parser": "^3.15.0",
     "lodash": "^4.17.15",
     "wu": "^2.1.0"

--- a/packages/persistent-pool/package.json
+++ b/packages/persistent-pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/persistent-pool",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "description": "Keeps a persistent pool of objects",
   "repository": {
@@ -26,7 +26,7 @@
     "lint-fix": "yarn lint --fix"
   },
   "dependencies": {
-    "@salto-io/lowerdash": "0.1.17",
+    "@salto-io/lowerdash": "0.1.18",
     "aws-sdk": "^2.573.0",
     "uuid": "^3.3.3"
   },

--- a/packages/salesforce-adapter/package.json
+++ b/packages/salesforce-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salto-io/salesforce-adapter",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "license": "Apache-2.0",
   "description": "Salto Salesforce adapter",
   "repository": {
@@ -34,11 +34,11 @@
     "lint-fix": "yarn run lint --fix"
   },
   "dependencies": {
-    "@salto-io/adapter-api": "0.1.17",
-    "@salto-io/adapter-utils": "0.1.17",
-    "@salto-io/e2e-credentials-store": "0.1.17",
-    "@salto-io/logging": "0.1.17",
-    "@salto-io/lowerdash": "0.1.17",
+    "@salto-io/adapter-api": "0.1.18",
+    "@salto-io/adapter-utils": "0.1.18",
+    "@salto-io/e2e-credentials-store": "0.1.18",
+    "@salto-io/logging": "0.1.18",
+    "@salto-io/lowerdash": "0.1.18",
     "@types/requestretry": "^1.12.5",
     "fast-xml-parser": "^3.15.0",
     "humanize-duration": "^3.22.0",
@@ -52,7 +52,7 @@
     "wu": "^2.1.0"
   },
   "devDependencies": {
-    "@salto-io/persistent-pool": "0.1.17",
+    "@salto-io/persistent-pool": "0.1.18",
     "@types/jest": "^24.0.0",
     "@types/jszip": "^3.1.6",
     "@types/lodash": "^4.14.133",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "salto-vscode",
     "displayName": "Salto",
     "description": "Configure Salto patches in vscode.",
-    "version": "0.1.17",
+    "version": "0.1.18",
     "publishConfig": {
         "access": "public"
     },
@@ -116,10 +116,10 @@
         "generate-yarn-lock": "yarn workspaces run generate-lock-entry | sed '1,2d' | sed -n -e :a -e '1,1!{P;N;D;};N;ba' >> yarn.lock"
     },
     "dependencies": {
-        "@salto-io/adapter-api": "0.1.17",
-        "@salto-io/adapter-utils": "0.1.17",
-        "@salto-io/core": "0.1.17",
-        "@salto-io/file": "0.1.17",
+        "@salto-io/adapter-api": "0.1.18",
+        "@salto-io/adapter-utils": "0.1.18",
+        "@salto-io/core": "0.1.18",
+        "@salto-io/file": "0.1.18",
         "copy-paste": "^1.3.0",
         "diff": "^4.0.1",
         "diff2html": "^2.12.1",


### PR DESCRIPTION
### What's New in Version v0.1.18

**What's New**
 * Added a new fetch command flag `--state-only` to fetch service changes to the state file without applying them the the NaCL file.
 * Added a new flag `-d` to the preview command to display a more detailed deploy plan.
 * Added the abilty to define regex based restriction and validations.

_VScode extension_
 * Added goto defintion and goto references support for type level annotations
 * Added support for VScode version 1.36

 
_Salesforce adapter_
 * Added a configuration flag `hideTypesInNacls` to toggle the ability to store certain types in the state file and not in the NaCL files.
 * Added territory types to the default skip list.

### Bug Fixes
 * Fixed new elements are create in the NaCL files with an extra indentation level
 * Fixed references inside an array are not indented when dumped in the NaCL files.
 * Fixed the ability to deploy static file content for cached static files.
 * Fixed comments are in NaCL files cause parsing errors.