### PR TITLE
Change the Records Management configuration

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -328,7 +328,7 @@ export default class SalesforceAdapter implements AdapterOperations {
         instancesRegexSkippedList: this.instancesRegexSkippedList,
         metadataTypesSkippedList: this.metadataTypesSkippedList,
         unsupportedSystemFields,
-        namespacesToFetchInstancesFor: config.namespacesToFetchInstancesFor,
+        recordsManagement: config.recordsManagement,
       },
       filterCreators
     )

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -328,7 +328,7 @@ export default class SalesforceAdapter implements AdapterOperations {
         instancesRegexSkippedList: this.instancesRegexSkippedList,
         metadataTypesSkippedList: this.metadataTypesSkippedList,
         unsupportedSystemFields,
-        recordsManagement: config.recordsManagement,
+        dataManagement: config.dataManagement,
       },
       filterCreators
     )

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -41,7 +41,7 @@ SalesforceConfig => {
     maxConcurrentRetrieveRequests: config?.value?.maxConcurrentRetrieveRequests,
     maxItemsInRetrieveRequest: config?.value?.maxItemsInRetrieveRequest,
     hideTypesInNacls: config?.value?.hideTypesInNacls,
-    recordsManagement: config?.value?.recordsManagement,
+    dataManagement: config?.value?.dataManagement,
   }
   Object.keys(config?.value ?? {})
     .filter(k => !Object.keys(adapterConfig).includes(k))

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -41,7 +41,7 @@ SalesforceConfig => {
     maxConcurrentRetrieveRequests: config?.value?.maxConcurrentRetrieveRequests,
     maxItemsInRetrieveRequest: config?.value?.maxItemsInRetrieveRequest,
     hideTypesInNacls: config?.value?.hideTypesInNacls,
-    namespacesToFetchInstancesFor: config?.value?.namespacesToFetchInstancesFor,
+    recordsManagement: config?.value?.recordsManagement,
   }
   Object.keys(config?.value ?? {})
     .filter(k => !Object.keys(adapterConfig).includes(k))

--- a/packages/salesforce-adapter/src/config_change.ts
+++ b/packages/salesforce-adapter/src/config_change.ts
@@ -79,7 +79,7 @@ export const getConfigFromConfigChanges = (
       maxConcurrentRetrieveRequests: currentConfig.maxConcurrentRetrieveRequests,
       maxItemsInRetrieveRequest: currentConfig.maxItemsInRetrieveRequest,
       hideTypesInNacls: currentConfig.hideTypesInNacls,
-      recordsManagement: currentConfig.recordsManagement,
+      dataManagement: currentConfig.dataManagement,
     }
   )
 }

--- a/packages/salesforce-adapter/src/config_change.ts
+++ b/packages/salesforce-adapter/src/config_change.ts
@@ -79,7 +79,7 @@ export const getConfigFromConfigChanges = (
       maxConcurrentRetrieveRequests: currentConfig.maxConcurrentRetrieveRequests,
       maxItemsInRetrieveRequest: currentConfig.maxItemsInRetrieveRequest,
       hideTypesInNacls: currentConfig.hideTypesInNacls,
-      namespacesToFetchInstancesFor: currentConfig.namespacesToFetchInstancesFor,
+      recordsManagement: currentConfig.recordsManagement,
     }
   )
 }

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -22,7 +22,7 @@ import * as constants from './constants'
 
 export const METADATA_TYPES_SKIPPED_LIST = 'metadataTypesSkippedList'
 export const UNSUPPORTED_SYSTEM_FIELDS = 'unsupportedSystemFields'
-export const RECORDS_MANAGEÂENT = 'recordsManagement'
+export const DATA_MANAGEMENT = 'dataManagement'
 export const INSTANCES_REGEX_SKIPPED_LIST = 'instancesRegexSkippedList'
 export const MAX_CONCURRENT_RETRIEVE_REQUESTS = 'maxConcurrentRetrieveRequests'
 export const MAX_ITEMS_IN_RETRIEVE_REQUEST = 'maxItemsInRetrieveRequest'
@@ -32,10 +32,10 @@ export type FilterContext = {
   [METADATA_TYPES_SKIPPED_LIST]?: string[]
   [INSTANCES_REGEX_SKIPPED_LIST]?: RegExp[]
   [UNSUPPORTED_SYSTEM_FIELDS]?: string[]
-  [RECORDS_MANAGEÂENT]?: RecordsManegementConfig[]
+  [DATA_MANAGEMENT]?: DataManegementConfig[]
 }
 
-export type RecordsManegementConfig = {
+export type DataManegementConfig = {
   name: string
   enabled: boolean
   includeNamespaces?: string[]
@@ -49,7 +49,7 @@ export type SalesforceConfig = {
   [MAX_CONCURRENT_RETRIEVE_REQUESTS]?: number
   [MAX_ITEMS_IN_RETRIEVE_REQUEST]?: number
   [HIDE_TYPES_IN_NACLS]?: boolean
-  [RECORDS_MANAGEÂENT]?: RecordsManegementConfig[]
+  [DATA_MANAGEMENT]?: DataManegementConfig[]
 }
 
 export type ConfigChangeSuggestion = {
@@ -76,8 +76,8 @@ export const credentialsType = new ObjectType({
   },
 })
 
-const recordManagementType = new ObjectType({
-  elemID: new ElemID('salesforce', 'recordsManagement'),
+const dataManagementType = new ObjectType({
+  elemID: new ElemID(constants.SALESFORCE, DATA_MANAGEMENT),
   fields: {
     name: {
       type: BuiltinTypes.STRING,
@@ -138,8 +138,8 @@ export const configType = new ObjectType({
         [CORE_ANNOTATIONS.DEFAULT]: constants.DEFAULT_HIDE_TYPES_IN_NACLS,
       },
     },
-    [RECORDS_MANAGEÂENT]: {
-      type: new ListType(recordManagementType),
+    [DATA_MANAGEMENT]: {
+      type: new ListType(dataManagementType),
       annotations: {
         [CORE_ANNOTATIONS.DEFAULT]: [
           {

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -22,7 +22,7 @@ import * as constants from './constants'
 
 export const METADATA_TYPES_SKIPPED_LIST = 'metadataTypesSkippedList'
 export const UNSUPPORTED_SYSTEM_FIELDS = 'unsupportedSystemFields'
-export const NAMESPACES_TO_FETCH_INSTANCES_FOR = 'namespacesToFetchInstancesFor'
+export const RECORDS_MANAGEÂENT = 'recordsManagement'
 export const INSTANCES_REGEX_SKIPPED_LIST = 'instancesRegexSkippedList'
 export const MAX_CONCURRENT_RETRIEVE_REQUESTS = 'maxConcurrentRetrieveRequests'
 export const MAX_ITEMS_IN_RETRIEVE_REQUEST = 'maxItemsInRetrieveRequest'
@@ -32,7 +32,15 @@ export type FilterContext = {
   [METADATA_TYPES_SKIPPED_LIST]?: string[]
   [INSTANCES_REGEX_SKIPPED_LIST]?: RegExp[]
   [UNSUPPORTED_SYSTEM_FIELDS]?: string[]
-  [NAMESPACES_TO_FETCH_INSTANCES_FOR]?: string[]
+  [RECORDS_MANAGEÂENT]?: RecordsManegementConfig[]
+}
+
+export type RecordsManegementConfig = {
+  name: string
+  enabled: boolean
+  includeNamespaces?: string[]
+  includeObjects?: string[]
+  excludeObjects?: string[]
 }
 
 export type SalesforceConfig = {
@@ -41,7 +49,7 @@ export type SalesforceConfig = {
   [MAX_CONCURRENT_RETRIEVE_REQUESTS]?: number
   [MAX_ITEMS_IN_RETRIEVE_REQUEST]?: number
   [HIDE_TYPES_IN_NACLS]?: boolean
-  [NAMESPACES_TO_FETCH_INSTANCES_FOR]?: string[]
+  [RECORDS_MANAGEÂENT]?: RecordsManegementConfig[]
 }
 
 export type ConfigChangeSuggestion = {
@@ -65,6 +73,27 @@ export const credentialsType = new ObjectType({
       annotations: { message: 'Token (empty if your org uses IP whitelisting)' },
     },
     sandbox: { type: BuiltinTypes.BOOLEAN },
+  },
+})
+
+const recordManagementType = new ObjectType({
+  elemID: new ElemID('salesforce', 'recordsManagement'),
+  fields: {
+    name: {
+      type: BuiltinTypes.STRING,
+      annotations: {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    },
+    enabled: {
+      type: BuiltinTypes.BOOLEAN,
+      annotations: {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
+      },
+    },
+    includeNamespaces: { type: new ListType(BuiltinTypes.STRING) },
+    includeObjects: { type: new ListType(BuiltinTypes.STRING) },
+    excludeObjects: { type: new ListType(BuiltinTypes.STRING) },
   },
 })
 
@@ -109,10 +138,18 @@ export const configType = new ObjectType({
         [CORE_ANNOTATIONS.DEFAULT]: constants.DEFAULT_HIDE_TYPES_IN_NACLS,
       },
     },
-    [NAMESPACES_TO_FETCH_INSTANCES_FOR]: {
-      type: new ListType(BuiltinTypes.STRING),
+    [RECORDS_MANAGEÂENT]: {
+      type: new ListType(recordManagementType),
       annotations: {
-        [CORE_ANNOTATIONS.DEFAULT]: [],
+        [CORE_ANNOTATIONS.DEFAULT]: [
+          {
+            name: 'CPQ',
+            enabled: false,
+            includeNamespaces: ['SBQQ'],
+            includeObjects: ['Product2'],
+            excludeObjects: ['SBQQ__Quote__c'],
+          },
+        ],
       },
     },
   },


### PR DESCRIPTION
Change from namespaceList to a more advanced configuration with includeNamespace, excludeObject and includeObject to support the "right" CPQ configuration and allow fluidity