### PR TITLE
SALTO-800: refactor fetch to support additional types

### DIFF
--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -18,7 +18,7 @@ import { Element, TypeMap, ObjectType, PrimitiveType, PrimitiveTypes, ListType }
 
 export const GLOBAL_ADAPTER = ''
 
-export const BuiltinTypes: Record<string, PrimitiveType> = {
+export const BuiltinTypes = {
   STRING: new PrimitiveType({
     elemID: new ElemID(GLOBAL_ADAPTER, 'string'),
     primitive: PrimitiveTypes.STRING,

--- a/packages/adapter-utils/test/common.ts
+++ b/packages/adapter-utils/test/common.ts
@@ -18,6 +18,12 @@ import { ChangeDataType, Change, ChangeGroup, getChangeElement } from '@salto-io
 export type MockFunction<T extends (...args: never[]) => unknown> =
   jest.Mock<ReturnType<T>, Parameters<T>>
 
+export type MockInterface<T extends {}> = {
+  [k in keyof T]: T[k] extends (...args: never[]) => unknown
+    ? MockFunction<T[k]>
+    : MockInterface<T[k]>
+}
+
 export const mockFunction = <T extends (...args: never[]) => unknown>(): MockFunction<T> => (
   jest.fn()
 )

--- a/packages/adapter-utils/test/deploy.test.ts
+++ b/packages/adapter-utils/test/deploy.test.ts
@@ -15,11 +15,7 @@
 */
 import { ObjectType, ElemID, InstanceElement, DeployResult, getChangeElement } from '@salto-io/adapter-api'
 import { deployInstance, ChangeOperations } from '../src/deploy'
-import { mockFunction, toChangeGroup } from './common'
-
-type MockInterface<T extends { [key: string]: (...args: never[]) => unknown }> = {
-  [k in keyof T]: jest.Mock<ReturnType<T[k]>, Parameters<T[k]>>
-}
+import { mockFunction, toChangeGroup, MockInterface } from './common'
 
 describe('deployInstance', () => {
   const testType = new ObjectType({ elemID: new ElemID('test', 'type') })

--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -75,8 +75,13 @@ Promise<ObjectType[]> => {
   const baseTypeNames = new Set(types)
   const subTypes = new Map<string, TypeElement>()
   return _.flatten(await Promise.all(types.map(async type =>
-    createMetadataTypeElements(type, await client.describeMetadataType(type), subTypes,
-      baseTypeNames, client))))
+    createMetadataTypeElements({
+      name: type,
+      fields: (await client.describeMetadataType(type)).valueTypeFields,
+      knownTypes: subTypes,
+      baseTypeNames,
+      client,
+    }))))
 }
 
 export const createInstance = async (client: SalesforceClient, value: Values,

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -19,8 +19,8 @@ import requestretry, { RequestRetryOptions, RetryStrategies } from 'requestretry
 import { collections, decorators } from '@salto-io/lowerdash'
 import {
   Connection as RealConnection, MetadataObject, DescribeGlobalSObjectResult, FileProperties,
-  MetadataInfo, SaveResult, ValueTypeField, DescribeSObjectResult, DeployResult,
-  RetrieveRequest, RetrieveResult, ListMetadataQuery, UpsertResult, QueryResult,
+  MetadataInfo, SaveResult, DescribeSObjectResult, DeployResult, RetrieveRequest, RetrieveResult,
+  ListMetadataQuery, UpsertResult, QueryResult, DescribeValueTypeResult,
 } from 'jsforce'
 import { flatValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -309,10 +309,10 @@ export default class SalesforceClient {
    */
   @SalesforceClient.logDecorator
   @SalesforceClient.requiresLogin
-  public async describeMetadataType(type: string): Promise<ValueTypeField[]> {
+  public async describeMetadataType(type: string): Promise<DescribeValueTypeResult> {
     const fullName = `{${METADATA_NAMESPACE}}${type}`
     const describeResult = await this.conn.metadata.describeValueType(fullName)
-    return flatValues(describeResult.valueTypeFields)
+    return flatValues(describeResult)
   }
 
   @SalesforceClient.logDecorator

--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -15,7 +15,7 @@
 */
 import { Stream } from 'stream'
 import {
-  MetadataObject, ValueTypeField, MetadataInfo, SaveResult, UpsertResult,
+  MetadataObject, DescribeValueTypeResult, MetadataInfo, SaveResult, UpsertResult,
   ListMetadataQuery, FileProperties, DescribeSObjectResult,
   DescribeGlobalSObjectResult, DeployOptions, DeployResultLocator, DeployResult,
   RetrieveRequest, RetrieveResult, Callback, RetrieveResultLocator, UserInfo, QueryResult,
@@ -27,7 +27,7 @@ import { Value } from '@salto-io/adapter-api'
 
 export interface Metadata {
   describe(): Promise<{ metadataObjects: MetadataObject[] }>
-  describeValueType(type: string): Promise<{ valueTypeFields: ValueTypeField[] }>
+  describeValueType(type: string): Promise<DescribeValueTypeResult>
   read(type: string, fullNames: string | string[]): Promise<MetadataInfo | MetadataInfo[]>
   list(queries: ListMetadataQuery | ListMetadataQuery[]): Promise<FileProperties[]>
   upsert(

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -18,6 +18,7 @@ export const SALESFORCE = 'salesforce'
 export const CUSTOM_FIELD = 'CustomField'
 export const CUSTOM_OBJECT = 'CustomObject'
 export const INSTANCE_FULL_NAME_FIELD = 'fullName'
+export const METADATA_CONTENT_FIELD = 'content'
 export const FORMULA_TYPE_NAME = 'Formula'
 export const SALESFORCE_CUSTOM_SUFFIX = '__c'
 export const ADMIN_PROFILE = 'Admin'
@@ -109,6 +110,9 @@ export enum ANNOTATION_TYPE_NAMES {
 export const API_NAME = 'apiName'
 export const METADATA_TYPE = 'metadataType'
 export const TOPICS_FOR_OBJECTS_ANNOTATION = 'topicsForObjects'
+export const HAS_META_FILE = 'hasMetaFile'
+export const FOLDER_TYPE = 'folderType'
+export const IS_FOLDER = 'isFolder'
 
 // Salesforce annotations
 export const LABEL = 'label'

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -1,0 +1,139 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { FileProperties } from 'jsforce-types'
+import { InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { promises, values as lowerDashValues } from '@salto-io/lowerdash'
+import { FetchElements, ConfigChangeSuggestion } from './types'
+import { FOLDER_TYPE, METADATA_CONTENT_FIELD, HAS_META_FILE, IS_FOLDER } from './constants'
+import SalesforceClient from './client/client'
+import { createListMetadataObjectsConfigChange, createRetrieveConfigChange } from './config_change'
+import { apiName, createInstanceElement } from './transformers/transformer'
+import { fromRetrieveResult, toRetrieveRequest } from './transformers/xml_transformer'
+
+const { isDefined } = lowerDashValues
+
+const getTypesWithContent = (types: ReadonlyArray<ObjectType>): Set<string> => new Set(
+  types
+    .filter(t => Object.keys(t.fields).includes(METADATA_CONTENT_FIELD))
+    .map(t => apiName(t))
+)
+
+const getTypesWithMetaFile = (types: ReadonlyArray<ObjectType>): Set<string> => new Set(
+  types
+    .filter(t => t.annotations[HAS_META_FILE] === true)
+    .map(t => apiName(t))
+)
+
+type RetreiveMetadataInstancesArgs = {
+  client: SalesforceClient
+  types: ReadonlyArray<ObjectType>
+  maxItemsInRetrieveRequest: number
+  maxConcurrentRetrieveRequests: number
+  instancesRegexSkippedList: ReadonlyArray<RegExp>
+}
+
+export const retrieveMetadataInstances = async ({
+  client,
+  types,
+  maxItemsInRetrieveRequest,
+  maxConcurrentRetrieveRequests,
+  instancesRegexSkippedList,
+}: RetreiveMetadataInstancesArgs): Promise<FetchElements<InstanceElement[]>> => {
+  const configChanges: ConfigChangeSuggestion[] = []
+
+  const notInSkipList = (file: FileProperties): boolean => (
+    !instancesRegexSkippedList.some(re => re.test(`${file.type}.${file.fullName}`))
+  )
+
+  const getFolders = async (type: ObjectType): Promise<(FileProperties | undefined)[]> => {
+    const folderType = type.annotations[FOLDER_TYPE]
+    if (folderType === undefined) {
+      return [undefined]
+    }
+    const { result, errors } = await client.listMetadataObjects({ type: folderType })
+    configChanges.push(...errors.map(createListMetadataObjectsConfigChange))
+    return _(result)
+      .filter(notInSkipList)
+      .uniqBy(file => file.fullName)
+      .value()
+  }
+
+  const listFilesOfType = async (type: ObjectType): Promise<FileProperties[]> => {
+    if (type.annotations[IS_FOLDER] === true) {
+      // We get folders as part of getting the records inside them
+      return []
+    }
+    const folders = await getFolders(type)
+    const folderNames = folders.map(folder => (folder === undefined ? folder : folder.fullName))
+    const { result, errors } = await client.listMetadataObjects(
+      folderNames.map(folder => ({ type: apiName(type), folder }))
+    )
+    configChanges.push(...errors.map(createListMetadataObjectsConfigChange))
+    return [
+      ...folders.filter(isDefined),
+      ..._.uniqBy(result, file => file.fullName),
+    ]
+  }
+
+  const typesByName = _.keyBy(types, t => apiName(t))
+  const folderToChildType = _(types)
+    .filter(type => FOLDER_TYPE in type.annotations)
+    .map(type => [type.annotations[FOLDER_TYPE], apiName(type)])
+    .fromPairs()
+    .value()
+  const typesWithMetaFile = getTypesWithMetaFile(types)
+  const typesWithContent = getTypesWithContent(types)
+
+  const retrieveInstances = async (
+    fileProps: ReadonlyArray<FileProperties>
+  ): Promise<InstanceElement[]> => {
+    // Because of a salesforce quirk, in order to get folder instances we actually need to use the
+    // "child" type with the folder fullName
+    const filesToRetrieve = fileProps.map(inst => (
+      inst.type in folderToChildType
+        ? { ...inst, type: folderToChildType[inst.type] }
+        : inst
+    ))
+    const request = toRetrieveRequest(filesToRetrieve)
+    const result = await client.retrieve(request)
+    configChanges.push(...createRetrieveConfigChange(result))
+    const allValues = await fromRetrieveResult(
+      result,
+      fileProps,
+      typesWithMetaFile,
+      typesWithContent,
+    )
+    return allValues.map(({ file, values }) => (
+      createInstanceElement(values, typesByName[file.type], file.namespacePrefix)
+    ))
+  }
+
+  const filesToRetrieve = _.flatten(await Promise.all(types.map(listFilesOfType)))
+    .filter(notInSkipList)
+
+  const instances = await promises.array.withLimitedConcurrency(
+    _.chunk(filesToRetrieve, maxItemsInRetrieveRequest)
+      .filter(filesChunk => filesChunk.length > 0)
+      .map(filesChunk => () => retrieveInstances(filesChunk)),
+    maxConcurrentRetrieveRequests,
+  )
+
+  return {
+    elements: _.flatten(instances),
+    configChanges,
+  }
+}

--- a/packages/salesforce-adapter/src/filters/missing_fields.ts
+++ b/packages/salesforce-adapter/src/filters/missing_fields.ts
@@ -71,8 +71,12 @@ type MissingField = {
   isList?: boolean
 }
 
+const isBuiltinTypeName = (name: string): name is keyof typeof BuiltinTypes => (
+  name in BuiltinTypes
+)
+
 const generateType = (typeName: string): PrimitiveType | ElemID => {
-  if (Object.keys(BuiltinTypes).includes(typeName)) {
+  if (isBuiltinTypeName(typeName)) {
     return BuiltinTypes[typeName]
   }
   return new ElemID(SALESFORCE, typeName)

--- a/packages/salesforce-adapter/src/filters/settings_type.ts
+++ b/packages/salesforce-adapter/src/filters/settings_type.ts
@@ -42,8 +42,14 @@ const createSettingsType = async (
   knownTypes: Map<string, TypeElement>): Promise<ObjectType[]> => {
   const typeFields = await client.describeMetadataType(settingsTypesName)
   const baseTypeNames = new Set([settingsTypesName])
-  return createMetadataTypeElements(settingsTypesName, typeFields, knownTypes, baseTypeNames,
-    client, true)
+  return createMetadataTypeElements({
+    name: settingsTypesName,
+    fields: typeFields.valueTypeFields,
+    knownTypes,
+    baseTypeNames,
+    client,
+    isSettings: true,
+  })
 }
 
 const createSettingsTypes = async (

--- a/packages/salesforce-adapter/src/filters/workflow.ts
+++ b/packages/salesforce-adapter/src/filters/workflow.ts
@@ -25,7 +25,7 @@ import {
 } from '../constants'
 import { FilterCreator } from '../filter'
 import {
-  apiName, metadataType, createInstanceElementFromValues,
+  apiName, metadataType, createInstanceElement,
 } from '../transformers/transformer'
 import { fullApiName } from './utils'
 
@@ -74,7 +74,7 @@ const filterCreator: FilterCreator = () => ({
           .map(innerValue => {
             innerValue[INSTANCE_FULL_NAME_FIELD] = fullApiName(apiName(workflowInstance),
               innerValue[INSTANCE_FULL_NAME_FIELD])
-            return createInstanceElementFromValues(innerValue, objType)
+            return createInstanceElement(innerValue, objType)
           })
         if (!_.isEmpty(innerInstances)) {
           workflowInstance.value[fieldName] = innerInstances

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -63,10 +63,10 @@ describe('SalesforceAdapter CRUD', () => {
       success,
     })
 
-  const deployTypeNames = {
-    AssignmentRules: undefined,
-    UnsupportedType: undefined,
-  }
+  const deployTypeNames = [
+    'AssignmentRules',
+    'UnsupportedType',
+  ]
 
   let mockUpsert: jest.Mock
   let mockDelete: jest.Mock
@@ -77,7 +77,7 @@ describe('SalesforceAdapter CRUD', () => {
     ({ connection, adapter } = mockAdapter({
       adapterParams: {
         filterCreators: [],
-        metadataToRetrieveAndDeploy: deployTypeNames,
+        metadataToDeploy: deployTypeNames,
       },
     }))
 

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -18,11 +18,12 @@ import {
   ObjectType, InstanceElement, ServiceIds, ElemID, BuiltinTypes,
   Element, CORE_ANNOTATIONS, FetchResult, isListType, ListType, getRestriction,
 } from '@salto-io/adapter-api'
-import { MetadataInfo, ListMetadataQuery } from 'jsforce'
+import { MetadataInfo } from 'jsforce'
+import { values, collections } from '@salto-io/lowerdash'
 import SalesforceAdapter from '../src/adapter'
 import Connection from '../src/client/jsforce'
 import { Types } from '../src/transformers/transformer'
-import { createEncodedZipContent, findElements, ZipFile } from './utils'
+import { findElements, ZipFile, MockInterface } from './utils'
 import mockAdapter from './adapter'
 import { id } from '../src/filters/utils'
 import * as constants from '../src/constants'
@@ -32,15 +33,18 @@ import {
   HIDE_TYPES_IN_NACLS,
 } from '../src/types'
 import { LAYOUT_TYPE_ID } from '../src/filters/layouts'
+import { MockFilePropertiesInput, MockDescribeResultInput, MockDescribeValueResultInput, mockDescribeResult, mockDescribeValueResult, mockFileProperties, mockRetrieveResult } from './connection'
 
 describe('SalesforceAdapter fetch', () => {
-  let connection: Connection
+  let connection: MockInterface<Connection>
   let adapter: SalesforceAdapter
-  const defaultMetadataTypesSkippedList = ['Test1', 'Ignored1']
-  const defaultInstancesRegexSkippedList = ['Test2.instance1', 'SkippedList$', '^Report.skip$']
-  const defaultMaxConcurrentRetrieveRequests = 4
-  const defaultMaxItemsInRetrieveRequest = 3000
-  const defaultHideTypesInNacls = true
+  const testMetadataTypesSkippedList = ['Test1', 'Ignored1']
+  const testInstancesRegexSkippedList = [
+    'Test2.instance1', 'SkippedList$', '^ReportFolder.skip$', 'AssignmentRules.MyRules',
+  ]
+  const testMaxConcurrentRetrieveRequests = 4
+  const testMaxItemsInRetrieveRequest = 100
+  const testHideTypesInNacls = true
 
   const mockGetElemIdFunc = (adapterName: string, _serviceIds: ServiceIds, name: string):
     ElemID => new ElemID(adapterName, name)
@@ -51,11 +55,11 @@ describe('SalesforceAdapter fetch', () => {
         getElemIdFunc: mockGetElemIdFunc,
         metadataAdditionalTypes: [],
         config: {
-          metadataTypesSkippedList: defaultMetadataTypesSkippedList,
-          instancesRegexSkippedList: defaultInstancesRegexSkippedList,
-          maxConcurrentRetrieveRequests: defaultMaxConcurrentRetrieveRequests,
-          maxItemsInRetrieveRequest: defaultMaxItemsInRetrieveRequest,
-          hideTypesInNacls: defaultHideTypesInNacls,
+          metadataTypesSkippedList: testMetadataTypesSkippedList,
+          instancesRegexSkippedList: testInstancesRegexSkippedList,
+          maxConcurrentRetrieveRequests: testMaxConcurrentRetrieveRequests,
+          maxItemsInRetrieveRequest: testMaxItemsInRetrieveRequest,
+          hideTypesInNacls: testHideTypesInNacls,
         },
       },
     }))
@@ -66,72 +70,71 @@ describe('SalesforceAdapter fetch', () => {
   })
 
   describe('should fetch metadata types', () => {
-    const mockSingleMetadataType = (
-      xmlName: string,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      fields: Record<string, any>[],
-      asChild = false,
-    ): void => {
-      connection.describeGlobal = jest.fn()
-        .mockImplementation(async () => ({ sobjects: [] }))
-
-      connection.metadata.describe = jest.fn()
-        .mockImplementation(async () => ({
-          metadataObjects: [asChild ? { xmlName: 'Base', childXmlNames: [xmlName] } : { xmlName }],
-        }))
-
-      connection.metadata.describeValueType = jest.fn()
-        .mockImplementation(async () => ({ valueTypeFields: fields }))
-
-      connection.metadata.list = jest.fn()
-        .mockImplementation(async () => [])
-    }
-
-    const mockSingleMetadataInstance = (
-      name: string,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      data: Record<string, any>,
-      namespace?: string,
+    type MockInstanceParams = {
+      props: Omit<MockFilePropertiesInput, 'type'> & Partial<Pick<MockFilePropertiesInput, 'type'>>
+      values: MetadataInfo & Record<string, unknown>
       zipFiles?: ZipFile[]
+    }
+    const mockMetadataType = (
+      typeDef: MockDescribeResultInput,
+      valueDef: MockDescribeValueResultInput,
+      instances?: MockInstanceParams[],
     ): void => {
-      connection.metadata.list = jest.fn()
-        .mockImplementation(async () => [{ fullName: name, namespacePrefix: namespace }])
-
-      connection.metadata.read = jest.fn()
-        .mockImplementation(async () => data)
-
-      if (!_.isUndefined(zipFiles)) {
-        connection.metadata.retrieve = jest.fn().mockImplementation(() =>
-          ({ complete: async () => ({ zipFile: await createEncodedZipContent(zipFiles) }) }))
+      connection.metadata.describe.mockResolvedValue(
+        mockDescribeResult(typeDef)
+      )
+      connection.metadata.describeValueType.mockResolvedValue(
+        mockDescribeValueResult(valueDef)
+      )
+      if (instances !== undefined) {
+        connection.metadata.list.mockResolvedValue(
+          instances.map(inst => mockFileProperties({ type: typeDef.xmlName, ...inst.props }))
+        )
+        connection.metadata.read.mockResolvedValue(
+          instances.map(inst => inst.values)
+        )
+        const zipFiles = instances.map(inst => inst.zipFiles).filter(values.isDefined)
+        if (!_.isEmpty(zipFiles)) {
+          _.chunk(zipFiles, testMaxItemsInRetrieveRequest).forEach(
+            chunkFiles => connection.metadata.retrieve.mockReturnValueOnce(mockRetrieveResult({
+              zipFiles: _.flatten(chunkFiles),
+            })),
+          )
+        }
       }
     }
 
     it('should fetch basic metadata type', async () => {
-      mockSingleMetadataType('Flow', [
+      mockMetadataType(
+        { xmlName: 'Flow' },
         {
-          name: 'fullName',
-          soapType: 'string',
-          valueRequired: true,
-        },
-        {
-          name: 'description',
-          soapType: 'string',
-          valueRequired: true,
-        },
-        {
-          name: 'isTemplate',
-          soapType: 'boolean',
-          valueRequired: false,
-        },
-        {
-          name: 'enum',
-          soapType: 'SomeEnumType',
-          picklistValues: [
-            { value: 'yes', defaultValue: true },
-            { value: 'no', defaultValue: false },
+          valueTypeFields: [
+            {
+              name: 'fullName',
+              soapType: 'string',
+              valueRequired: true,
+            },
+            {
+              name: 'description',
+              soapType: 'string',
+              valueRequired: true,
+            },
+            {
+              name: 'isTemplate',
+              soapType: 'boolean',
+              valueRequired: false,
+            },
+            {
+              name: 'enum',
+              soapType: 'SomeEnumType',
+              picklistValues: [
+                { value: 'yes', defaultValue: true, active: true },
+                { value: 'no', defaultValue: false, active: true },
+              ],
+            },
           ],
-        },
-      ])
+        }
+      )
       const { elements: result } = await adapter.fetch()
 
       const describeMock = connection.metadata.describeValueType as jest.Mock<unknown>
@@ -153,38 +156,47 @@ describe('SalesforceAdapter fetch', () => {
       expect(flow.annotations[constants.METADATA_TYPE]).toEqual('Flow')
     })
     it('should fetch nested metadata types', async () => {
-      mockSingleMetadataType('NestingType', [
-        { // Nested field with multiple subfields returns fields as array
-          name: 'field',
-          soapType: 'NestedType',
-          fields: [
-            {
-              name: 'nestedStr',
-              soapType: 'string',
+      mockMetadataType(
+        { xmlName: 'NestingType' },
+        {
+          valueTypeFields: [
+            { // Nested field with multiple subfields returns fields as array
+              name: 'field',
+              soapType: 'NestedType',
+              fields: [
+                {
+                  name: 'nestedStr',
+                  soapType: 'string',
+                },
+                {
+                  name: 'nestedNum',
+                  soapType: 'double',
+                },
+                {
+                  name: 'doubleNested',
+                  soapType: 'SingleFieldType',
+                  fields: [
+                    {
+                      name: 'str',
+                      soapType: 'string',
+                    },
+                  ],
+                },
+              ],
             },
-            {
-              name: 'nestedNum',
-              soapType: 'double',
-            },
-            {
-              name: 'doubleNested',
+            { // Nested field with a single subfield returns fields as an object
+              name: 'otherField',
               soapType: 'SingleFieldType',
-              fields: {
-                name: 'str',
-                soapType: 'string',
-              },
+              fields: [
+                {
+                  name: 'str',
+                  soapType: 'string',
+                },
+              ],
             },
           ],
-        },
-        { // Nested field with a single subfield returns fields as an object
-          name: 'otherField',
-          soapType: 'SingleFieldType',
-          fields: {
-            name: 'str',
-            soapType: 'string',
-          },
-        },
-      ])
+        }
+      )
 
       const { elements: result } = await adapter.fetch()
 
@@ -220,238 +232,227 @@ describe('SalesforceAdapter fetch', () => {
       expect(singleField.fields.str.type.elemID).toEqual(BuiltinTypes.STRING.elemID)
     })
 
-    it('should fetch metadata instance', async () => {
-      mockSingleMetadataType('Flow', [
-        {
-          name: 'bla',
-          soapType: 'Bla',
-          fields: [
-            {
-              name: 'bla',
-              soapType: 'double',
-            },
-            {
-              name: 'bla2',
-              soapType: 'boolean',
-            },
-            {
-              name: 'bla3',
-              soapType: 'boolean',
-            },
-          ],
-        },
-        {
-          name: 'fullName',
-          soapType: 'string',
-        },
-      ])
-
-      mockSingleMetadataInstance('FlowInstance', {
-        fullName: 'FlowInstance',
-        bla: { bla: '55', bla2: 'false', bla3: 'true' },
-      })
-
-      const { elements: result } = await adapter.fetch()
-      const flow = findElements(result, 'Flow', 'FlowInstance').pop() as InstanceElement
-      expect(flow.type.elemID).toEqual(new ElemID(constants.SALESFORCE, 'Flow'))
-      expect(flow.value.bla.bla).toBe(55)
-      expect(flow.value.bla.bla2).toBe(false)
-      expect(flow.value.bla.bla3).toBe(true)
-    })
-
-    it('should use existing elemID when fetching metadata instance', async () => {
-      ({ connection, adapter } = mockAdapter({
-        adapterParams: {
-          getElemIdFunc: (adapterName: string, serviceIds: ServiceIds, name: string):
-            ElemID => new ElemID(adapterName, name === 'FlowInstance'
-            && serviceIds[constants.INSTANCE_FULL_NAME_FIELD] === 'FlowInstance'
-            ? 'my_FlowInstance' : name),
-        },
-      }))
-
-      mockSingleMetadataType('Flow', [
-        {
-          name: 'bla',
-          soapType: 'Bla',
-          fields: [
-            {
-              name: 'bla',
-              soapType: 'double',
-            },
-            {
-              name: 'bla2',
-              soapType: 'boolean',
-            },
-            {
-              name: 'bla3',
-              soapType: 'boolean',
-            },
-          ],
-        },
-        {
-          name: 'fullName',
-          soapType: 'string',
-        },
-      ])
-
-      mockSingleMetadataInstance('FlowInstance', {
-        fullName: 'FlowInstance',
-        bla: { bla: '55', bla2: 'false', bla3: 'true' },
-      })
-
-      const { elements: result } = await adapter.fetch()
-      const flow = findElements(result, 'Flow', 'my_FlowInstance').pop() as InstanceElement
-      expect(flow.type.elemID).toEqual(new ElemID(constants.SALESFORCE, 'Flow'))
-      expect(flow.value[constants.INSTANCE_FULL_NAME_FIELD]).toEqual('FlowInstance')
-    })
-
-    it('should fetch complicated metadata instance', async () => {
-      mockSingleMetadataType('Layout', [
-        {
-          name: 'fullName', soapType: 'string', valueRequired: true,
-        },
-        {
-          fields: [
-            {
-              name: 'label', soapType: 'string', valueRequired: true,
-            },
-            {
-              name: 'style', soapType: 'string', valueRequired: false,
-            },
-            {
-              fields: [{
+    describe('with metadata instance', () => {
+      const mockFlowType = (): void => {
+        mockMetadataType(
+          { xmlName: 'Flow' },
+          {
+            valueTypeFields: [
+              {
+                name: 'bla',
+                soapType: 'Bla',
                 fields: [
                   {
-                    name: 'field', soapType: 'string', valueRequired: 'true',
-                  }, {
-                    name: 'behavior', soapType: 'string', valueRequired: 'true',
+                    name: 'bla',
+                    soapType: 'double',
+                  },
+                  {
+                    name: 'bla2',
+                    soapType: 'boolean',
+                  },
+                  {
+                    name: 'bla3',
+                    soapType: 'boolean',
                   },
                 ],
-                name: 'layoutItems',
-                soapType: 'LayoutItem',
-                valueRequired: 'true',
-              }, {
-                name: 'reserved', soapType: 'string', valueRequired: 'true',
-              }],
-              name: 'layoutColumns',
-              soapType: 'LayoutColumn',
-              valueRequired: true,
-            }],
-          name: 'layoutSections',
-          soapType: 'LayoutSection',
-        },
-        {
-          fields: [
+              },
+              {
+                name: 'fullName',
+                soapType: 'string',
+              },
+            ],
+          },
+          [
             {
-              // This use her 'String' and not 'string' on purpose, we saw similar response.
-              name: 'name', soapType: 'String', valueRequired: true,
+              props: {
+                fullName: 'FlowInstance',
+                fileName: 'flows/FlowInstance.flow',
+              },
+              values: {
+                fullName: 'FlowInstance',
+                bla: { bla: '55', bla2: 'false', bla3: 'true' },
+              },
             },
-            {
-              fields: [
-                {
-                  name: 'stringValue', soapType: 'string', valueRequired: 'true',
-                }],
-              name: 'value',
-              soapType: 'Value',
-              valueRequired: true,
-            }],
-          name: 'processMetadataValues',
-          soapType: 'ProcessMetadataValue',
-        },
-      ])
+          ]
+        )
+      }
 
-      const layoutName = 'Order-Order Layout'
-      mockSingleMetadataInstance(layoutName, {
-        fullName: layoutName,
-        layoutSections: [{
-          label: 'Description Information',
-          layoutColumns: [
-            {
-              layoutItems: [{ behavior: 'Edit', field: 'Description' }],
-            },
-            {
-              layoutItems: [{ behavior: 'Edit2', field: 'Description2' }],
-            },
-          ],
-        }, {
-          label: 'Additional Information',
-          layoutColumns: ['', ''],
-        }, {
-          layoutColumns: ['', '', ''],
-          style: 'CustomLinks',
-        },
-        {
-          layoutColumns: '',
-        }],
-        processMetadataValues: [{ name: 'dataType', value: { stringValue: 'Boolean' } },
-          { name: 'leftHandSideReferenceTo', value: '' },
-          { name: 'leftHandSideReferenceTo2', value: { stringValue: '' } },
-          {
-            name: 'leftHandSideReferenceTo3',
-            value: { stringValue: { $: { 'xsi:nil': 'true' } } },
-          }],
+      it('should fetch metadata instance', async () => {
+        mockFlowType()
+        const { elements: result } = await adapter.fetch()
+        const flow = findElements(result, 'Flow', 'FlowInstance').pop() as InstanceElement
+        expect(flow.type.elemID).toEqual(new ElemID(constants.SALESFORCE, 'Flow'))
+        expect(flow.value.bla.bla).toBe(55)
+        expect(flow.value.bla.bla2).toBe(false)
+        expect(flow.value.bla.bla3).toBe(true)
       })
 
-      const { elements: result } = await adapter.fetch()
-      const layout = findElements(result, 'Layout', 'Order_Layout').pop() as InstanceElement
-      expect(layout.type.elemID).toEqual(LAYOUT_TYPE_ID)
-      expect(layout.value[constants.INSTANCE_FULL_NAME_FIELD]).toBe(layoutName)
-      expect(layout.value.layoutSections.length).toBe(3)
-      expect(layout.value.layoutSections[0].label).toBe('Description Information')
-      expect(layout.value.layoutSections[0].layoutColumns[0].layoutItems[0].behavior).toBe('Edit')
-      expect(layout.value.layoutSections[0].layoutColumns[1].layoutItems[0].field).toBe('Description2')
-      expect(layout.value.layoutSections[1].layoutColumns).toBeUndefined()
-      expect(layout.value.layoutSections[1].label).toBe('Additional Information')
-      expect(layout.value.layoutSections[2].style).toBe('CustomLinks')
-      expect(
-        ((layout.type.fields.processMetadataValues.type as ListType)
-          .innerType as ObjectType).fields.name.type.elemID.name
-      ).toBe('string')
-      expect(layout.value.processMetadataValues[1].name).toBe('leftHandSideReferenceTo')
-      expect(layout.value.processMetadataValues[1].value).toBeUndefined()
-      expect(layout.value.processMetadataValues[2].name).toBe('leftHandSideReferenceTo2')
-      expect(layout.value.processMetadataValues[2].value).toBeUndefined()
-      expect(layout.value.processMetadataValues[3].name).toBe('leftHandSideReferenceTo3')
-      expect(layout.value.processMetadataValues[3].value).toBeUndefined()
+      it('should use existing elemID when fetching metadata instance', async () => {
+        ({ connection, adapter } = mockAdapter({
+          adapterParams: {
+            getElemIdFunc: (adapterName: string, serviceIds: ServiceIds, name: string):
+              ElemID => new ElemID(adapterName, name === 'FlowInstance'
+              && serviceIds[constants.INSTANCE_FULL_NAME_FIELD] === 'FlowInstance'
+              ? 'my_FlowInstance' : name),
+          },
+        }))
+
+        mockFlowType()
+
+        const { elements: result } = await adapter.fetch()
+        const flow = findElements(result, 'Flow', 'my_FlowInstance').pop() as InstanceElement
+        expect(flow.type.elemID).toEqual(new ElemID(constants.SALESFORCE, 'Flow'))
+        expect(flow.value[constants.INSTANCE_FULL_NAME_FIELD]).toEqual('FlowInstance')
+      })
+    })
+
+    describe('with complicated metadata instance', () => {
+      const layoutName = 'Order-Order Layout'
+      beforeEach(() => {
+        mockMetadataType(
+          { xmlName: 'Layout' },
+          {
+            valueTypeFields: [
+              { name: 'fullName', soapType: 'string', valueRequired: true },
+              {
+                fields: [
+                  { name: 'label', soapType: 'string', valueRequired: true },
+                  { name: 'style', soapType: 'string', valueRequired: false },
+                  {
+                    fields: [
+                      {
+                        fields: [
+                          { name: 'field', soapType: 'string', valueRequired: true },
+                          { name: 'behavior', soapType: 'string', valueRequired: true },
+                        ],
+                        name: 'layoutItems',
+                        soapType: 'LayoutItem',
+                        valueRequired: true,
+                      },
+                      { name: 'reserved', soapType: 'string', valueRequired: true },
+                    ],
+                    name: 'layoutColumns',
+                    soapType: 'LayoutColumn',
+                    valueRequired: true,
+                  },
+                ],
+                name: 'layoutSections',
+                soapType: 'LayoutSection',
+              },
+              {
+                fields: [
+                  // This returns 'String' and not 'string' on purpose, we saw similar response.
+                  { name: 'name', soapType: 'String', valueRequired: true },
+                  {
+                    fields: [
+                      { name: 'stringValue', soapType: 'string', valueRequired: true },
+                    ],
+                    name: 'value',
+                    soapType: 'Value',
+                    valueRequired: true,
+                  },
+                ],
+                name: 'processMetadataValues',
+                soapType: 'ProcessMetadataValue',
+              },
+            ],
+          },
+          [
+            {
+              props: {
+                fullName: layoutName,
+                fileName: `layouts/${layoutName}.layout`,
+              },
+              values: {
+                fullName: layoutName,
+                layoutSections: [
+                  {
+                    label: 'Description Information',
+                    layoutColumns: [
+                      { layoutItems: [{ behavior: 'Edit', field: 'Description' }] },
+                      { layoutItems: [{ behavior: 'Edit2', field: 'Description2' }] },
+                    ],
+                  },
+                  { label: 'Additional Information', layoutColumns: ['', ''] },
+                  { layoutColumns: ['', '', ''], style: 'CustomLinks' },
+                  { layoutColumns: '' },
+                ],
+                processMetadataValues: [
+                  { name: 'dataType', value: { stringValue: 'Boolean' } },
+                  { name: 'leftHandSideReferenceTo', value: '' },
+                  { name: 'leftHandSideReferenceTo2', value: { stringValue: '' } },
+                  {
+                    name: 'leftHandSideReferenceTo3',
+                    value: { stringValue: { $: { 'xsi:nil': 'true' } } },
+                  },
+                ],
+              },
+            },
+          ],
+        )
+      })
+
+      it('should fetch complicated metadata instance', async () => {
+        const { elements: result } = await adapter.fetch()
+        const layout = findElements(result, 'Layout', 'Order_Layout').pop() as InstanceElement
+        expect(layout.type.elemID).toEqual(LAYOUT_TYPE_ID)
+        expect(layout.value[constants.INSTANCE_FULL_NAME_FIELD]).toBe(layoutName)
+        expect(layout.value.layoutSections.length).toBe(3)
+        expect(layout.value.layoutSections[0].label).toBe('Description Information')
+        expect(layout.value.layoutSections[0].layoutColumns[0].layoutItems[0].behavior).toBe('Edit')
+        expect(layout.value.layoutSections[0].layoutColumns[1].layoutItems[0].field).toBe('Description2')
+        expect(layout.value.layoutSections[1].layoutColumns).toBeUndefined()
+        expect(layout.value.layoutSections[1].label).toBe('Additional Information')
+        expect(layout.value.layoutSections[2].style).toBe('CustomLinks')
+        expect(
+          ((layout.type.fields.processMetadataValues.type as ListType)
+            .innerType as ObjectType).fields.name.type.elemID.name
+        ).toBe('string')
+        expect(layout.value.processMetadataValues[1].name).toBe('leftHandSideReferenceTo')
+        expect(layout.value.processMetadataValues[1].value).toBeUndefined()
+        expect(layout.value.processMetadataValues[2].name).toBe('leftHandSideReferenceTo2')
+        expect(layout.value.processMetadataValues[2].value).toBeUndefined()
+        expect(layout.value.processMetadataValues[3].name).toBe('leftHandSideReferenceTo3')
+        expect(layout.value.processMetadataValues[3].value).toBeUndefined()
+      })
     })
 
     it('should fetch metadata types lists', async () => {
-      mockSingleMetadataType('Flow', [
+      mockMetadataType(
+        { xmlName: 'Flow' },
         {
-          name: 'fullName',
-          soapType: 'string',
+          valueTypeFields: [
+            { name: 'fullName', soapType: 'string' },
+            {
+              name: 'listTest',
+              soapType: 'ListTest',
+              fields: [
+                { name: 'editable', soapType: 'boolean' },
+                { name: 'field', soapType: 'string' },
+              ],
+            },
+          ],
         },
-        {
-          name: 'listTest',
-          soapType: 'ListTest',
-          fields: [{
-            name: 'editable',
-            soapType: 'boolean',
+        [
+          {
+            props: { fullName: 'FlowInstance' },
+            values: {
+              fullName: 'FlowInstance',
+              listTest: [
+                { field: 'Field1', editable: 'true' },
+                { field: 'Field2', editable: 'false' },
+              ],
+            },
           },
           {
-            name: 'field',
-            soapType: 'string',
-          }],
-        },
-      ])
-
-      connection.metadata.list = jest.fn()
-        .mockImplementation(async () => [{ fullName: 'FlowInstance' }, { fullName: 'FlowInstance2' }])
-
-      connection.metadata.read = jest.fn()
-        .mockImplementation(async () => ([
-          {
-            fullName: 'FlowInstance',
-            listTest: [
-              { field: 'Field1', editable: 'true' },
-              { field: 'Field2', editable: 'false' },
-            ],
+            props: { fullName: 'FlowInstance2' },
+            values: {
+              fullName: 'FlowInstance2',
+              listTest: { field: 'Field11', editable: 'true' },
+            },
           },
-          {
-            fullName: 'FlowInstance2',
-            listTest: { field: 'Field11', editable: 'true' },
-          },
-        ]))
+        ]
+      )
 
       const { elements: result } = await adapter.fetch()
       const flow = findElements(result, 'Flow', 'FlowInstance').pop() as InstanceElement
@@ -470,8 +471,16 @@ describe('SalesforceAdapter fetch', () => {
     })
 
     it('should fetch settings instance', async () => {
-      mockSingleMetadataType('Settings', [])
-      mockSingleMetadataInstance('Quote', { fullName: 'QuoteSettings' })
+      mockMetadataType(
+        { xmlName: 'Settings' },
+        { valueTypeFields: [] },
+        [
+          {
+            props: { fullName: 'Quote' },
+            values: { fullName: 'Quote' },
+          },
+        ]
+      )
 
       await adapter.fetch()
 
@@ -479,13 +488,10 @@ describe('SalesforceAdapter fetch', () => {
     })
 
     it('should not fetch child metadata type', async () => {
-      mockSingleMetadataType('Child', [
-        {
-          name: 'description',
-          soapType: 'string',
-          valueRequired: true,
-        },
-      ], true)
+      mockMetadataType(
+        { xmlName: 'Base', childXmlNames: ['Child'] },
+        { valueTypeFields: [] },
+      )
       await adapter.fetch()
 
       const describeMock = connection.metadata.describeValueType as jest.Mock<unknown>
@@ -494,139 +500,89 @@ describe('SalesforceAdapter fetch', () => {
       expect(describeMock.mock.calls[0][0]).toBe('{http://soap.sforce.com/2006/04/metadata}Base')
     })
 
-    it('should fetch metadata instances using retrieve', async () => {
-      mockSingleMetadataType('EmailTemplate', [{
-        name: 'fullName',
-        soapType: 'string',
-        valueRequired: true,
-      },
-      {
-        name: 'name',
-        soapType: 'string',
-        valueRequired: false,
-      },
-      {
-        name: 'content',
-        soapType: 'string',
-        valueRequired: false,
-      }])
-
-      mockSingleMetadataInstance('MyFolder/MyEmailTemplate',
-        { fullName: 'MyFolder/MyEmailTemplate' }, undefined,
-        [{ path: 'unpackaged/email/MyFolder/MyEmailTemplate.email-meta.xml',
-          content: '<?xml version="1.0" encoding="UTF-8"?>\n'
-            + '<EmailTemplate xmlns="http://soap.sforce.com/2006/04/metadata">\n'
-            + '    <available>false</available>\n'
-            + '    <encodingKey>ISO-8859-1</encodingKey>\n'
-            + '    <name>My Email Template</name>\n'
-            + '    <style>none</style>\n'
-            + '    <subject>MySubject</subject>\n'
-            + '    <type>text</type>\n'
-            + '    <uiType>Aloha</uiType>\n'
-            + '</EmailTemplate>\n' },
-        { path: 'unpackaged/email/MyFolder/MyEmailTemplate.email',
-          content: 'Email Body' }])
-
-      const { elements: result } = await adapter.fetch()
-      const [testElem] = findElements(result, 'EmailTemplate', 'MyFolder_MyEmailTemplate')
-      const testInst = testElem as InstanceElement
-      expect(testInst).toBeDefined()
-      expect(testInst.path)
-        .toEqual([constants.SALESFORCE, constants.RECORDS_PATH, 'EmailTemplate', 'MyFolder_MyEmailTemplate'])
-      expect(testInst.value[constants.INSTANCE_FULL_NAME_FIELD]).toEqual('MyFolder/MyEmailTemplate')
-      expect(testInst.value.name).toEqual('My Email Template')
-      expect(testInst.value.content.content.toString()).toEqual('Email Body')
-    })
-
     it('should fetch metadata instances using retrieve in chunks', async () => {
-      mockSingleMetadataType('ApexClass', [{
-        name: 'fullName',
-        soapType: 'string',
-        valueRequired: true,
-      },
-      {
-        name: 'content',
-        soapType: 'string',
-        valueRequired: false,
-      }])
-
-      const generateInstancesMocks = (numberOfInstances: number): MetadataInfo[] =>
-        Array.from(Array(numberOfInstances), (_x, index) => ({ fullName: `dummy${index}` }))
-
-      const metadataInfos = generateInstancesMocks(
-        constants.DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST * 2
+      mockMetadataType(
+        { xmlName: 'ApexClass', metaFile: true, suffix: 'cls', directoryName: 'classes' },
+        {
+          valueTypeFields: [
+            { name: 'fullName', soapType: 'string', valueRequired: true },
+            { name: 'content', soapType: 'string', valueRequired: false },
+          ],
+        },
+        _.times(testMaxItemsInRetrieveRequest * 2).map(
+          index => ({
+            props: { fullName: `MyClass${index}`, fileName: `classes/MyClass${index}.cls` },
+            values: { fullName: `MyClass${index}` },
+            zipFiles: [
+              {
+                path: `unpackaged/classes/MyClass${index}.cls-meta.xml`,
+                content: `
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>47.0</apiVersion>
+  <status>Active</status>
+</ApexClass>
+`,
+              },
+              {
+                path: `unpackaged/classes/MyClass${index}.cls`,
+                content: `
+public class MyClass${index} {
+  public void printLog() {
+    System.debug('Instance${index}');
+  }'
+}
+`,
+              },
+            ],
+          })
+        )
       )
-      connection.metadata.list = jest.fn()
-        .mockImplementation(async () => metadataInfos)
-
-      const mockRetrieve = jest.fn().mockReturnValueOnce(
-        ({ complete: async () => ({ zipFile: await createEncodedZipContent(
-          [{ path: 'unpackaged/classes/MyApexClass.cls-meta.xml',
-            content: '<?xml version="1.0" encoding="UTF-8"?>\n'
-              + '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">\n'
-              + '    <apiVersion>47.0</apiVersion>\n'
-              + '    <status>Active</status>\n'
-              + '</ApexClass>\n' }, { path: 'unpackaged/classes/MyApexClass.cls',
-            content: 'public class MyApexClass {\n'
-              + '    public void printLog() {\n'
-              + '        System.debug(\'Instance1\');\n'
-              + '    }\n'
-              + '}' }]
-        ) }) })
-      ).mockReturnValueOnce(
-        ({ complete: async () => ({ zipFile: await createEncodedZipContent(
-          [{ path: 'unpackaged/classes/MyApexClass2.cls-meta.xml',
-            content: '<?xml version="1.0" encoding="UTF-8"?>\n'
-              + '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">\n'
-              + '    <apiVersion>47.0</apiVersion>\n'
-              + '    <status>Active</status>\n'
-              + '</ApexClass>\n' }, { path: 'unpackaged/classes/MyApexClass2.cls',
-            content: 'public class MyApexClass2 {\n'
-              + '    public void printLog() {\n'
-              + '        System.debug(\'Instance2\');\n'
-              + '    }\n'
-              + '}' }]
-        ) }) })
-      )
-      connection.metadata.retrieve = mockRetrieve
 
       const { elements: result } = await adapter.fetch()
-      expect(mockRetrieve.mock.calls.length).toBe(2)
-      const [first] = findElements(result, 'ApexClass', 'MyApexClass') as InstanceElement[]
-      const [second] = findElements(result, 'ApexClass', 'MyApexClass2') as InstanceElement[]
-      expect(first.value[constants.INSTANCE_FULL_NAME_FIELD]).toEqual('MyApexClass')
-      expect(second.value[constants.INSTANCE_FULL_NAME_FIELD]).toEqual('MyApexClass2')
-      expect(first.value.content.content.toString().includes('Instance1')).toBeTruthy()
-      expect(second.value.content.content.toString().includes('Instance2')).toBeTruthy()
+      expect(connection.metadata.retrieve).toHaveBeenCalledTimes(2)
+      const [first] = findElements(result, 'ApexClass', 'MyClass0') as InstanceElement[]
+      const [second] = findElements(result, 'ApexClass', 'MyClass1') as InstanceElement[]
+      expect(first.value[constants.INSTANCE_FULL_NAME_FIELD]).toEqual('MyClass0')
+      expect(second.value[constants.INSTANCE_FULL_NAME_FIELD]).toEqual('MyClass1')
+      expect(first.value.content.content.toString().includes('Instance0')).toBeTruthy()
+      expect(second.value.content.content.toString().includes('Instance1')).toBeTruthy()
     })
 
     it('should fetch metadata instances folders using retrieve', async () => {
-      connection.metadata.describe = jest.fn()
-        .mockImplementation(async () => ({
-          metadataObjects: [{ xmlName: 'EmailTemplate' }, { xmlName: 'EmailFolder' }],
-        }))
-
-      connection.metadata.describeValueType = jest.fn()
-        .mockImplementation(async () => ({ valueTypeFields: [{
-          name: 'fullName',
-          soapType: 'string',
-          valueRequired: true,
-        },
+      mockMetadataType(
+        { xmlName: 'EmailTemplate', inFolder: true, metaFile: true },
         {
-          name: 'name',
-          soapType: 'string',
-          valueRequired: false,
-        }] }))
-
-      mockSingleMetadataInstance('MyFolder',
-        { fullName: 'MyFolder' }, undefined,
-        [{ path: 'unpackaged/email/MyFolder-meta.xml',
-          content: '<?xml version="1.0" encoding="UTF-8"?>\n'
-            + '<EmailFolder xmlns="http://soap.sforce.com/2006/04/metadata">\n'
-            + '    <accessType>Public</accessType>\n'
-            + '    <name>My folder</name>\n'
-            + '    <publicFolderAccess>ReadWrite</publicFolderAccess>\n'
-            + '</EmailFolder>\n' }])
+          parentField: {
+            name: '',
+            soapType: 'string',
+            foreignKeyDomain: 'EmailFolder',
+          },
+          valueTypeFields: [
+            { name: 'fullName', soapType: 'string', valueRequired: true },
+            { name: 'name', soapType: 'string', valueRequired: false },
+          ],
+        },
+        [
+          {
+            props: { fullName: 'MyFolder', fileName: 'email/MyFolder', type: 'EmailFolder' },
+            values: { fullName: 'MyFolder' },
+            zipFiles: [
+              {
+                path: 'unpackaged/email/MyFolder-meta.xml',
+                content: `
+<?xml version="1.0" encoding="UTF-8"?>
+<EmailFolder xmlns="http://soap.sforce.com/2006/04/metadata">
+  <accessType>Public</accessType>
+  <name>My folder</name>
+  <publicFolderAccess>ReadWrite</publicFolderAccess>
+</EmailFolder>
+`,
+              },
+            ],
+          },
+        ]
+      )
 
       const { elements: result } = await adapter.fetch()
       const [testElem] = findElements(result, 'EmailFolder', 'MyFolder')
@@ -639,18 +595,39 @@ describe('SalesforceAdapter fetch', () => {
     })
 
     it('should fetch metadata instances with namespace using retrieve', async () => {
-      mockSingleMetadataType('ApexPage', [])
       const namespaceName = 'th_con_app'
-      mockSingleMetadataInstance('th_con_app__ThHomepage', { fullName: 'th_con_app__ThHomepage' },
-        namespaceName, [{ path: 'unpackaged/pages/th_con_app__ThHomepage.page-meta.xml',
-          content: '<?xml version="1.0" encoding="UTF-8"?>\n'
-          + '<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">\n'
-          + '    <apiVersion>38.0</apiVersion>\n'
-          + '    <availableInTouch>false</availableInTouch>\n'
-          + '    <confirmationTokenRequired>false</confirmationTokenRequired>\n'
-          + '    <label>ThHomepage</label>\n'
-          + '</ApexPage>\n' }, { path: 'unpackaged/pages/th_con_app__ThHomepage.page',
-          content: '<apex:page sidebar="false" standardStylesheets="false"/>' }])
+      mockMetadataType(
+        { xmlName: 'ApexPage', metaFile: true },
+        { valueTypeFields: [{ name: 'content', soapType: 'string' }] },
+        [
+          {
+            props: {
+              fullName: 'th_con_app__ThHomepage',
+              fileName: 'pages/th_con_app__ThHomepage.page',
+              namespacePrefix: namespaceName,
+            },
+            values: { fullName: 'th_con_app__ThHomepage' },
+            zipFiles: [
+              {
+                path: 'unpackaged/pages/th_con_app__ThHomepage.page-meta.xml',
+                content: `
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>38.0</apiVersion>
+  <availableInTouch>false</availableInTouch>
+  <confirmationTokenRequired>false</confirmationTokenRequired>
+  <label>ThHomepage</label>
+</ApexPage>
+`,
+              },
+              {
+                path: 'unpackaged/pages/th_con_app__ThHomepage.page',
+                content: '<apex:page sidebar="false" standardStylesheets="false"/>',
+              },
+            ],
+          },
+        ]
+      )
 
       const { elements: result } = await adapter.fetch()
       const [testInst] = findElements(result, 'ApexPage', 'th_con_app__ThHomepage')
@@ -661,9 +638,17 @@ describe('SalesforceAdapter fetch', () => {
     })
 
     it('should fetch metadata instances with namespace', async () => {
-      mockSingleMetadataType('Test', [])
       const namespaceName = 'asd'
-      mockSingleMetadataInstance('Test', { fullName: 'asd__Test' }, namespaceName)
+      mockMetadataType(
+        { xmlName: 'Test' },
+        { valueTypeFields: [] },
+        [
+          {
+            props: { fullName: 'Test', namespacePrefix: namespaceName },
+            values: { fullName: `${namespaceName}__Test` },
+          },
+        ]
+      )
 
       const { elements: result } = await adapter.fetch()
       const [testInst] = findElements(result, 'Test', 'asd__Test')
@@ -675,8 +660,16 @@ describe('SalesforceAdapter fetch', () => {
 
     it('should fetch metadata instances with namespace when fullname already includes the namespace', async () => {
       const namespaceName = 'asd'
-      mockSingleMetadataType('Test', [])
-      mockSingleMetadataInstance('asd__Test', { fullName: 'asd__Test' }, namespaceName)
+      mockMetadataType(
+        { xmlName: 'Test' },
+        { valueTypeFields: [] },
+        [
+          {
+            props: { fullName: `${namespaceName}__Test`, namespacePrefix: namespaceName },
+            values: { fullName: `${namespaceName}__Test` },
+          },
+        ]
+      )
 
       const { elements: result } = await adapter.fetch()
       const [testInst] = findElements(result, 'Test', 'asd__Test')
@@ -691,35 +684,44 @@ describe('SalesforceAdapter fetch', () => {
       let result: FetchResult
       let elements: Element[] = []
       beforeEach(async () => {
-        connection.describeGlobal = jest.fn().mockImplementation(async () => ({ sobjects: [] }))
-        connection.metadata.describe = jest.fn().mockImplementation(async () => ({
-          metadataObjects: [
-            { xmlName: 'Test1' },
-            { xmlName: 'Test2' },
-            { xmlName: 'Test3' },
-            { xmlName: 'Report' },
-          ],
-        }))
-        connection.metadata.describeValueType = jest.fn().mockImplementation(
+        connection.describeGlobal.mockImplementation(async () => ({ sobjects: [] }))
+        connection.metadata.describe.mockResolvedValue(mockDescribeResult(
+          { xmlName: 'Test1' },
+          { xmlName: 'Test2' },
+          { xmlName: 'Test3' },
+          { xmlName: 'Report', inFolder: true },
+        ))
+        connection.metadata.describeValueType.mockImplementation(
           async (typeName: string) => {
             if (typeName.endsWith('Test1')) {
               throw new Error('fake error')
             }
-            return { valueTypeFields: [] }
+            if (typeName.endsWith('Report')) {
+              return mockDescribeValueResult({
+                parentField: {
+                  name: '',
+                  soapType: 'string',
+                  foreignKeyDomain: 'ReportFolder',
+                },
+                valueTypeFields: [],
+              })
+            }
+            return mockDescribeValueResult({ valueTypeFields: [] })
           }
         )
-        connection.metadata.list = jest.fn().mockImplementation(
-          async (typeName: ListMetadataQuery[]) => {
-            if (typeName[0].type === 'ReportFolder') {
-              return [{ fullName: 'skip' }]
-            }
-            if (_.isEqual(typeName[0], { type: 'Report', folder: 'skip' })) {
+        connection.metadata.list.mockImplementation(
+          async inQuery => {
+            const query = collections.array.makeArray(inQuery)[0]
+            if (_.isEqual(query, { type: 'Report', folder: 'skip' })) {
               throw new Error('fake error')
             }
-            return [{ fullName: 'instance1' }]
+            const fullName = query.type === 'ReportFolder'
+              ? 'skip'
+              : 'instance1'
+            return [mockFileProperties({ fullName, type: query.type })]
           }
         )
-        connection.metadata.read = jest.fn().mockImplementation(
+        connection.metadata.read.mockImplementation(
           async (typeName: string, fullNames: string | string[]) => {
             if (typeName === 'Test2') {
               throw new Error('fake error')
@@ -752,37 +754,27 @@ describe('SalesforceAdapter fetch', () => {
     describe('should not fetch skippedlist retrieve instance', () => {
       let result: Element[] = []
       beforeEach(async () => {
-        mockSingleMetadataType('EmailTemplate', [{
-          name: 'fullName',
-          soapType: 'string',
-          valueRequired: true,
-        },
-        {
-          name: 'name',
-          soapType: 'string',
-          valueRequired: false,
-        },
-        {
-          name: 'content',
-          soapType: 'string',
-          valueRequired: false,
-        }])
-
-        mockSingleMetadataInstance('MyFolder/MyEmailTemplateSkippedList',
-          { fullName: 'MyFolder/MyEmailTemplateSkippedList' }, undefined,
-          [{ path: 'unpackaged/email/MyFolder/MyEmailTemplateSkippedList.email-meta.xml',
-            content: '<?xml version="1.0" encoding="UTF-8"?>\n'
-              + '<EmailTemplate xmlns="http://soap.sforce.com/2006/04/metadata">\n'
-              + '    <available>false</available>\n'
-              + '    <encodingKey>ISO-8859-1</encodingKey>\n'
-              + '    <name>My Email Template</name>\n'
-              + '    <style>none</style>\n'
-              + '    <subject>MySubject</subject>\n'
-              + '    <type>text</type>\n'
-              + '    <uiType>Aloha</uiType>\n'
-              + '</EmailTemplate>\n' },
-          { path: 'unpackaged/email/MyFolder/MyEmailTemplateSkippedList.email',
-            content: 'Email Body' }])
+        mockMetadataType(
+          { xmlName: 'AssignmentRules' },
+          { valueTypeFields: [] },
+          [
+            {
+              props: { fullName: 'MyRules', fileName: 'assignmentRules/MyRules.rules' },
+              values: { fullName: 'MyRules' },
+              zipFiles: [
+                {
+                  path: 'unpackaged/assignmentRules/MyRules.rules',
+                  content: `
+<?xml version="1.0" encoding="UTF-8"?>
+<AssignmentRules xmlns="http://soap.sforce.com/2006/04/metadata">
+  <dummy>true</dummy>
+</ApexPage>
+`,
+                },
+              ],
+            },
+          ]
+        )
 
         result = (await adapter.fetch()).elements
       })
@@ -804,52 +796,58 @@ describe('SalesforceAdapter fetch', () => {
       let config: InstanceElement
 
       beforeEach(async () => {
-        connection.describeGlobal = jest.fn().mockImplementation(async () => ({ sobjects: [] }))
-        connection.metadata.describe = jest.fn().mockImplementation(async () => ({
-          metadataObjects: [
-            { xmlName: 'MetadataTest1' },
-            { xmlName: 'MetadataTest2' },
-            { xmlName: 'InstalledPackage' },
-            { xmlName: 'Report' },
-          ],
+        connection.describeGlobal.mockImplementation(async () => ({ sobjects: [] }))
+        connection.metadata.describe.mockResolvedValue(mockDescribeResult(
+          { xmlName: 'MetadataTest1' },
+          { xmlName: 'MetadataTest2' },
+          { xmlName: 'InstalledPackage' },
+          { xmlName: 'Report', inFolder: true },
+        ))
+        connection.metadata.describeValueType.mockImplementation(
+          async (typeName: string) => {
+            if (typeName.endsWith('Report')) {
+              return mockDescribeValueResult({
+                parentField: {
+                  name: '',
+                  soapType: 'string',
+                  foreignKeyDomain: 'ReportFolder',
+                },
+                valueTypeFields: [],
+              })
+            }
+            return mockDescribeValueResult({ valueTypeFields: [] })
+          }
+        )
+        connection.metadata.list.mockImplementation(
+          async inQuery => {
+            const query = collections.array.makeArray(inQuery)[0]
+            const { type } = query
+            if (type === 'MetadataTest2') {
+              throw new SFError('sf:UNKNOWN_EXCEPTION')
+            }
+            if (_.isEqual(query, { type: 'Report', folder: 'testFolder' })) {
+              throw new SFError('sf:UNKNOWN_EXCEPTION')
+            }
+            const fullNames: Record<string, string> = {
+              MetadataTest1: 'instance1',
+              InstalledPackage: 'instance2',
+              ReportFolder: 'testFolder',
+            }
+            const fullName = fullNames[type]
+            return fullName === undefined ? [] : [mockFileProperties({ fullName, type })]
+          }
+        )
+        connection.metadata.read.mockRejectedValue(new SFError('sf:UNKNOWN_EXCEPTION'))
+
+        connection.metadata.retrieve.mockReturnValue(mockRetrieveResult({
+          messages: [{
+            fileName: 'unpackaged/package.xml',
+            problem: 'Metadata API received improper input.'
+              + 'Please ensure file name and capitalization is correct.'
+              + 'Load of metadata from db failed for metadata of '
+              + 'type:InstalledPackage and file name:Test2.',
+          }],
         }))
-        connection.metadata.describeValueType = jest.fn().mockImplementation(
-          async (_typeName: string) => ({ valueTypeFields: [] })
-        )
-        connection.metadata.list = jest.fn().mockImplementation(
-          async (typeName: ListMetadataQuery[]) => {
-            if (typeName[0].type === 'MetadataTest1') {
-              return [{ fullName: 'instance1' }]
-            }
-            if (typeName[0].type === 'InstalledPackage') {
-              return [{ fullName: 'instance2' }]
-            }
-            if (typeName[0].type === 'MetadataTest2') {
-              throw new SFError('sf:UNKNOWN_EXCEPTION')
-            }
-            if (typeName[0].type === 'ReportFolder') {
-              return [{ fullName: 'testFolder' }]
-            }
-            if (_.isEqual(typeName[0], { type: 'Report', folder: 'testFolder' })) {
-              throw new SFError('sf:UNKNOWN_EXCEPTION')
-            }
-            return []
-          }
-        )
-        connection.metadata.read = jest.fn().mockImplementation(
-          async (_typeName: string, _fullNames: string | string[]) => {
-            throw new SFError('sf:UNKNOWN_EXCEPTION')
-          }
-        )
-        connection.metadata.retrieve = jest.fn().mockImplementation(() =>
-          ({ complete: async () => ({ zipFile: await createEncodedZipContent([]),
-            messages: {
-              fileName: 'unpackaged/package.xml',
-              problem: 'Metadata API received improper input.'
-                + 'Please ensure file name and capitalization is correct.'
-                + 'Load of metadata from db failed for metadata of '
-                + 'type:InstalledPackage and file name:Test2.',
-            } }) }))
 
         result = await adapter.fetch()
         config = result?.updatedConfig?.config as InstanceElement
@@ -863,16 +861,16 @@ describe('SalesforceAdapter fetch', () => {
         expect(config.value).toEqual(
           {
             [INSTANCES_REGEX_SKIPPED_LIST]: [
-              '^MetadataTest1.instance1$',
-              '^InstalledPackage.Test2$',
               '^Report.testFolder$',
+              '^InstalledPackage.Test2$',
+              '^MetadataTest1.instance1$',
             ]
-              .concat(defaultInstancesRegexSkippedList),
+              .concat(testInstancesRegexSkippedList),
             [METADATA_TYPES_SKIPPED_LIST]: ['MetadataTest2']
-              .concat(defaultMetadataTypesSkippedList),
-            [MAX_CONCURRENT_RETRIEVE_REQUESTS]: defaultMaxConcurrentRetrieveRequests,
-            [MAX_ITEMS_IN_RETRIEVE_REQUEST]: defaultMaxItemsInRetrieveRequest,
-            [HIDE_TYPES_IN_NACLS]: defaultHideTypesInNacls,
+              .concat(testMetadataTypesSkippedList),
+            [MAX_CONCURRENT_RETRIEVE_REQUESTS]: testMaxConcurrentRetrieveRequests,
+            [MAX_ITEMS_IN_RETRIEVE_REQUEST]: testMaxItemsInRetrieveRequest,
+            [HIDE_TYPES_IN_NACLS]: testHideTypesInNacls,
           }
         )
       })

--- a/packages/salesforce-adapter/test/adapter.ts
+++ b/packages/salesforce-adapter/test/adapter.ts
@@ -17,9 +17,10 @@ import Connection from '../src/client/jsforce'
 import SalesforceClient from '../src/client/client'
 import SalesforceAdapter, { SalesforceAdapterParams } from '../src/adapter'
 import createClient from './client'
+import { MockInterface } from './utils'
 
 export type Mocks = {
-  connection: Connection
+  connection: MockInterface<Connection>
   client: SalesforceClient
   adapter: SalesforceAdapter
 }

--- a/packages/salesforce-adapter/test/client.ts
+++ b/packages/salesforce-adapter/test/client.ts
@@ -15,10 +15,11 @@
 */
 import Connection from '../src/client/jsforce'
 import SalesforceClient from '../src/client/client'
-import createConnection from './connection'
+import { mockJsforce } from './connection'
+import { MockInterface } from './utils'
 
-const mockClient = (): { connection: Connection; client: SalesforceClient } => {
-  const connection = createConnection()
+const mockClient = (): { connection: MockInterface<Connection>; client: SalesforceClient } => {
+  const connection = mockJsforce()
   const client = new SalesforceClient({
     credentials: {
       username: 'mockUser',

--- a/packages/salesforce-adapter/test/connection.ts
+++ b/packages/salesforce-adapter/test/connection.ts
@@ -13,36 +13,154 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
+import { Value } from '@salto-io/adapter-api'
+import { MetadataObject, DescribeMetadataResult, ValueTypeField, DescribeValueTypeResult, FileProperties, RetrieveResult, RetrieveResultLocator, DeployResultLocator, DeployResult, QueryResult } from 'jsforce-types'
 import Connection, { Metadata, Soap } from '../src/client/jsforce'
-import { createEncodedZipContent } from './utils'
+import { createEncodedZipContent, MockInterface, mockFunction, ZipFile } from './utils'
 
-const mockJsforce: () => Connection = () => ({
-  login: jest.fn().mockImplementation(
-    (_user: string, _password: string) =>
-      Promise.resolve({ id: '', organizationId: '', url: '' })
-  ),
-  metadata: {
-    describe: jest.fn().mockImplementation(() => Promise.resolve({ metadataObjects: [] })),
-    describeValueType: jest.fn().mockImplementation(() => Promise.resolve([])),
-    read: jest.fn().mockImplementation(() => Promise.resolve([])),
-    list: jest.fn().mockImplementation(() => Promise.resolve([])),
-    upsert: jest.fn().mockImplementation(() => Promise.resolve([])),
-    delete: jest.fn().mockImplementation(() => Promise.resolve([])),
-    update: jest.fn().mockImplementation(() => Promise.resolve([])),
-    retrieve: jest.fn().mockImplementation(() =>
-      ({ complete: async () => ({ zipFile: createEncodedZipContent([]) }) })),
-    deploy: jest.fn().mockImplementation(() => Promise.resolve({})),
-  } as Metadata,
-  soap: {
-    describeSObjects: jest.fn().mockImplementation(() => Promise.resolve([])),
-  } as Soap,
-
-  describeGlobal: jest.fn().mockImplementation(async () => Promise.resolve({ sobjects: [] })),
-  query: jest.fn().mockImplementation(() => Promise.resolve([])),
-  queryMore: jest.fn().mockImplementation(() => Promise.resolve([])),
-  limits: jest.fn().mockImplementation(() => Promise.resolve({
-    DailyApiRequests: { Remaining: 10000 },
+export type MockDescribeResultInput = Pick<MetadataObject, 'xmlName'> & Partial<MetadataObject>
+export const mockDescribeResult = (
+  ...objects: MockDescribeResultInput[]
+): DescribeMetadataResult => ({
+  metadataObjects: objects.map(props => ({
+    childXmlNames: [],
+    directoryName: _.lowerCase(props.xmlName),
+    inFolder: false,
+    metaFile: false,
+    suffix: '.file',
+    ...props,
   })),
+  organizationNamespace: '',
+  testRequired: false,
+  partialSaveAllowed: true,
 })
 
-export default mockJsforce
+export type MockValueTypeFieldInput =
+  Pick<ValueTypeField, 'name' | 'soapType'>
+  & Partial<Omit<ValueTypeField, 'fields'> & { fields: MockValueTypeFieldInput[] }>
+
+export const mockValueTypeField = (
+  props: MockValueTypeFieldInput,
+): ValueTypeField => ({
+  foreignKeyDomain: '',
+  isForeignKey: false,
+  isNameField: false,
+  minOccurs: 0,
+  picklistValues: [],
+  valueRequired: false,
+  ...props,
+  fields: props.fields === undefined ? [] : props.fields.map(mockValueTypeField),
+})
+
+export type MockDescribeValueResultInput =
+  Partial<Omit<DescribeValueTypeResult, 'valueTypeFields' | 'parentField'>> & {
+    parentField?: MockValueTypeFieldInput
+    valueTypeFields: MockValueTypeFieldInput[]
+  }
+
+export const mockDescribeValueResult = (
+  props: MockDescribeValueResultInput
+): DescribeValueTypeResult => ({
+  apiCreatable: true,
+  apiDeletable: true,
+  apiReadable: true,
+  apiUpdatable: true,
+  ...props,
+  parentField: props.parentField === undefined
+    ? undefined as unknown as ValueTypeField // The type says this is required but it isn't really
+    : mockValueTypeField(props.parentField),
+  valueTypeFields: props.valueTypeFields.map(mockValueTypeField),
+})
+
+export type MockFilePropertiesInput = Pick<FileProperties, 'type' | 'fullName'> & Partial<FileProperties>
+export const mockFileProperties = (
+  props: MockFilePropertiesInput
+): FileProperties => ({
+  createdById: '0054J000002KGspQAG',
+  createdByName: 'test',
+  createdDate: '2020-05-01T14:31:36.000Z',
+  fileName: `${_.camelCase(props.type)}/${props.fullName}.${_.snakeCase(props.type)}`,
+  id: _.uniqueId(),
+  lastModifiedById: '0054J000002KGspQAG',
+  lastModifiedByName: 'test',
+  lastModifiedDate: '2020-05-01T14:41:36.000Z',
+  manageableState: 'unmanaged',
+  ...props,
+})
+
+export type MockRetrieveResultInput = Partial<Omit<RetrieveResult, 'zipFile'>> &{
+  zipFiles?: ZipFile[]
+}
+export const mockRetrieveResult = (
+  props: MockRetrieveResultInput
+): RetrieveResultLocator<RetrieveResult> => ({
+  complete: async () => ({
+    fileProperties: [],
+    id: _.uniqueId(),
+    messages: [],
+    zipFile: await createEncodedZipContent(props.zipFiles ?? []),
+    ...props,
+  }),
+} as RetrieveResultLocator<RetrieveResult>)
+
+export const mockDeployResult = (
+  props: Partial<DeployResult>
+): DeployResultLocator<DeployResult> => ({
+  complete: () => Promise.resolve({
+    id: _.uniqueId(),
+    checkOnly: false,
+    completedDate: '2020-05-01T14:31:36.000Z',
+    createdDate: '2020-05-01T14:21:36.000Z',
+    done: true,
+    lastModifiedDate: '2020-05-01T14:31:36.000Z',
+    numberComponentErrors: 0,
+    numberComponentsDeployed: 0,
+    numberComponentsTotal: 0,
+    numberTestErrors: 0,
+    numberTestsCompleted: 0,
+    numberTestsTotal: 0,
+    startDate: '2020-05-01T14:21:36.000Z',
+    status: 'Succeeded',
+    success: true,
+    ...props,
+  }),
+} as DeployResultLocator<DeployResult>)
+
+const mockQueryResult = (
+  props: Partial<QueryResult<Value>>,
+): QueryResult<Value> => ({
+  done: true,
+  totalSize: 0,
+  records: [],
+  ...props,
+})
+
+export const mockJsforce: () => MockInterface<Connection> = () => ({
+  login: mockFunction<Connection['login']>().mockResolvedValue(
+    { id: '', organizationId: '', url: '' }
+  ),
+  metadata: {
+    describe: mockFunction<Metadata['describe']>().mockResolvedValue({ metadataObjects: [] }),
+    describeValueType: mockFunction<Metadata['describeValueType']>().mockResolvedValue(
+      mockDescribeValueResult({ valueTypeFields: [] })
+    ),
+    read: mockFunction<Metadata['read']>().mockResolvedValue([]),
+    list: mockFunction<Metadata['list']>().mockResolvedValue([]),
+    upsert: mockFunction<Metadata['upsert']>().mockResolvedValue([]),
+    delete: mockFunction<Metadata['delete']>().mockResolvedValue([]),
+    update: mockFunction<Metadata['update']>().mockResolvedValue([]),
+    retrieve: mockFunction<Metadata['retrieve']>().mockReturnValue(mockRetrieveResult({})),
+    deploy: mockFunction<Metadata['deploy']>().mockReturnValue(mockDeployResult({})),
+  },
+  soap: {
+    describeSObjects: mockFunction<Soap['describeSObjects']>().mockResolvedValue([]),
+  },
+
+  describeGlobal: mockFunction<Connection['describeGlobal']>().mockResolvedValue({ sobjects: [] }),
+  query: mockFunction<Connection['query']>().mockResolvedValue(mockQueryResult({})),
+  queryMore: mockFunction<Connection['queryMore']>().mockResolvedValue(mockQueryResult({})),
+  limits: mockFunction<Connection['limits']>().mockResolvedValue({
+    DailyApiRequests: { Remaining: 10000 },
+  }),
+})

--- a/packages/salesforce-adapter/test/utils.ts
+++ b/packages/salesforce-adapter/test/utils.ts
@@ -105,3 +105,16 @@ export const toChangeGroup = (...params: ChangeParams[]): ChangeGroup => {
     changes,
   }
 }
+
+export type MockFunction<T extends (...args: never[]) => unknown> =
+  jest.Mock<ReturnType<T>, Parameters<T>>
+
+export type MockInterface<T extends {}> = {
+  [k in keyof T]: T[k] extends (...args: never[]) => unknown
+    ? MockFunction<T[k]>
+    : MockInterface<T[k]>
+}
+
+export const mockFunction = <T extends (...args: never[]) => unknown>(): MockFunction<T> => (
+  jest.fn()
+)


### PR DESCRIPTION
Change the way fetch works for types that use the `retrieve` endpoint:
- rely on information from the metadata API instead of hard coded constants
- remove a heuristic that extracted an instance fullName from its fileName and use the fullName from the API instead