### PR TITLE
remove unneeded lib from tsconfig

### DIFF
--- a/packages/adapter-api/tsconfig.json
+++ b/packages/adapter-api/tsconfig.json
@@ -4,9 +4,6 @@
         "outDir": "dist",
         "baseUrl": ".",
         "declaration": true,
-        "lib": [
-            "esnext.asynciterable"
-        ],
         "resolveJsonModule": true
     },
     "include": [

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -12,10 +12,7 @@
             "@salto-io/suitecloud-cli": [
               "../netsuite-adapter/types/suitecloud-cli"
             ]
-        },
-        "lib": [
-            "esnext.asynciterable"
-          ]
+        }
     },
     "include": [
         "src/**/*",

--- a/packages/salesforce-adapter/tsconfig.json
+++ b/packages/salesforce-adapter/tsconfig.json
@@ -9,10 +9,7 @@
             "jsforce": [
                 "../../node_modules/jsforce-types"
             ]
-        },
-        "lib": [
-            "esnext.asynciterable"
-          ]
+        }
     },
     "include": [
         "src/**/*",


### PR DESCRIPTION
Now that the target is es2019, I think we do not need the extra "lib" for async iterable