### PR TITLE
Make system fields (^nameField) hidden, not required and editable

### DIFF
--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -952,7 +952,7 @@ describe('Salesforce adapter E2E with real account', () => {
 
         // Test true and false required
         expect(lead.fields.Description.annotations[CORE_ANNOTATIONS.REQUIRED]).toBe(false)
-        expect(lead.fields.CreatedDate.annotations[CORE_ANNOTATIONS.REQUIRED]).toBe(true)
+        expect(lead.fields.Company.annotations[CORE_ANNOTATIONS.REQUIRED]).toBe(true)
 
         // Test picklist restriction.enforce_value prop
         expect(lead.fields.Industry

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -322,6 +322,7 @@ export default class SalesforceAdapter implements AdapterOperations {
     this.metadataTypesToUseUpsertUponUpdate = metadataTypesToUseUpsertUponUpdate
     this.nestedMetadataTypes = nestedMetadataTypes
     this.client = client
+    this.systemFields = systemFields
     this.filtersRunner = filtersRunner(
       this.client,
       {
@@ -329,10 +330,10 @@ export default class SalesforceAdapter implements AdapterOperations {
         metadataTypesSkippedList: this.metadataTypesSkippedList,
         unsupportedSystemFields,
         dataManagement: config.dataManagement,
+        systemFields,
       },
       filterCreators
     )
-    this.systemFields = systemFields
     if (getElemIdFunc) {
       Types.setElemIdGetter(getElemIdFunc)
     }

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -922,8 +922,13 @@ const getDefaultValue = (field: SalesforceField): PrimitiveValue | undefined => 
 
 // The following method is used during the fetchy process and is used in building the objects
 // and their fields described in the Nacl file
-export const getSObjectFieldElement = (parent: ObjectType, field: SalesforceField,
-  parentServiceIds: ServiceIds, objCompoundFieldNames: string[] = []): Field => {
+export const getSObjectFieldElement = (
+  parent: ObjectType,
+  field: SalesforceField,
+  parentServiceIds: ServiceIds,
+  objCompoundFieldNames: string[] = [],
+  systemFields: string[] = []
+): Field => {
   const fieldApiName = [parentServiceIds[API_NAME], field.name].join(API_NAME_SEPERATOR)
   const serviceIds = {
     [ADAPTER]: SALESFORCE,
@@ -1047,6 +1052,16 @@ export const getSObjectFieldElement = (parent: ObjectType, field: SalesforceFiel
         Object.keys(naclFieldType.annotationTypes),
       )
     )
+  }
+
+  // System fields besides name should be hidden and not be creatable, updateable nor required
+  // Because they differ between envs and should not be editted through salto
+  // Name is an exception because it's editable and should be visible to the user
+  if (!field.nameField && systemFields.includes(field.name)) {
+    annotations[CORE_ANNOTATIONS.HIDDEN] = true
+    annotations[FIELD_ANNOTATIONS.UPDATEABLE] = false
+    annotations[FIELD_ANNOTATIONS.CREATABLE] = false
+    annotations[CORE_ANNOTATIONS.REQUIRED] = false
   }
 
   const fieldName = Types.getElemId(field.name, true, serviceIds).name

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -27,12 +27,14 @@ export const INSTANCES_REGEX_SKIPPED_LIST = 'instancesRegexSkippedList'
 export const MAX_CONCURRENT_RETRIEVE_REQUESTS = 'maxConcurrentRetrieveRequests'
 export const MAX_ITEMS_IN_RETRIEVE_REQUEST = 'maxItemsInRetrieveRequest'
 export const HIDE_TYPES_IN_NACLS = 'hideTypesInNacls'
+export const SYSTEM_FIELDS = 'systemFields'
 
 export type FilterContext = {
   [METADATA_TYPES_SKIPPED_LIST]?: string[]
   [INSTANCES_REGEX_SKIPPED_LIST]?: RegExp[]
   [UNSUPPORTED_SYSTEM_FIELDS]?: string[]
   [DATA_MANAGEMENT]?: DataManegementConfig[]
+  [SYSTEM_FIELDS]?: string[]
 }
 
 export type DataManegementConfig = {


### PR DESCRIPTION
Move system fields (besides nameField) to be saved only in the state and make them not required or editable. 

This is needed to make instances deploy work on create.