### PR TITLE
Revert "Netsuite: skip the fetch of custom types that are in the typesToSkip also in SDF"

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -84,8 +84,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
    * Account credentials were given in the constructor.
    */
   public async fetch(): Promise<FetchResult> {
-    const customTypesToFetch = _.pull(Object.keys(customTypes), ...this.typesToSkip)
-    const customObjects = this.client.listCustomObjects(customTypesToFetch).catch(e => {
+    const customObjects = this.client.listCustomObjects().catch(e => {
       log.error('failed to list custom objects. reason: %o', e)
       return [] as CustomizationInfo[]
     })

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -81,7 +81,6 @@ export type NetsuiteClientOpts = {
 export const COMMANDS = {
   CREATE_PROJECT: 'project:create',
   SETUP_ACCOUNT: 'account:setup',
-  LIST_OBJECTS: 'object:list',
   IMPORT_OBJECTS: 'object:import',
   LIST_FILES: 'file:list',
   IMPORT_FILES: 'file:import',
@@ -301,16 +300,12 @@ export default class NetsuiteClient {
   }
 
   @NetsuiteClient.logDecorator
-  async listCustomObjects(typeNames: string[]): Promise<CustomizationInfo[]> {
+  async listCustomObjects(): Promise<CustomizationInfo[]> {
     const project = await this.initProject()
-    const listObjectIdsResult = await NetsuiteClient.executeProjectAction(COMMANDS.LIST_OBJECTS, {
-      type: typeNames.join(' '),
-    }, project.executor)
-
     await NetsuiteClient.executeProjectAction(COMMANDS.IMPORT_OBJECTS, {
       destinationfolder: `${SDF_PATH_SEPARATOR}${OBJECTS_DIR}`,
       type: 'ALL',
-      scriptid: makeArray(listObjectIdsResult.data).map(objInfo => objInfo.scriptId).join(' '),
+      scriptid: 'ALL',
       excludefiles: true,
     }, project.executor)
 

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -18,7 +18,6 @@ import {
   ElemID, InstanceElement, ObjectType, StaticFile, ChangeDataType, DeployResult, getChangeElement,
   ServiceIds,
 } from '@salto-io/adapter-api'
-import _ from 'lodash'
 import createClient from './client/client'
 import NetsuiteAdapter from '../src/adapter'
 import { customTypes, fileCabinetTypes, getAllTypes } from '../src/types'
@@ -71,8 +70,6 @@ describe('Adapter', () => {
         .mockResolvedValue([folderCustomizationInfo, fileCustomizationInfo])
       client.listCustomObjects = jest.fn().mockResolvedValue([customizationInfo])
       const { elements } = await netsuiteAdapter.fetch()
-      expect(client.listCustomObjects)
-        .toHaveBeenCalledWith(_.pull(Object.keys(customTypes), SAVED_SEARCH, TRANSACTION_FORM))
       expect(elements).toHaveLength(getAllTypes().length + 3)
       const customFieldType = customTypes[ENTITY_CUSTOM_FIELD]
       expect(elements).toContainEqual(customFieldType)
@@ -120,14 +117,6 @@ describe('Adapter', () => {
       client.listCustomObjects = jest.fn().mockImplementation(async () => [customizationInfo])
       const { elements } = await netsuiteAdapter.fetch()
       expect(elements).toHaveLength(getAllTypes().length)
-    })
-
-    it('should call listCustomObjects only with types that are not in typesToSkip', async () => {
-      await netsuiteAdapter.fetch()
-      expect(client.listCustomObjects)
-        .toHaveBeenCalledWith(expect.arrayContaining([ENTITY_CUSTOM_FIELD]))
-      expect(client.listCustomObjects)
-        .not.toHaveBeenCalledWith(expect.arrayContaining([SAVED_SEARCH]))
     })
   })
 


### PR DESCRIPTION
since the Java CLI triggers API call per scriptId which makes it much less efficient

This reverts commit 956a2acf