### PR TITLE
SALTO-791: remove grouping from plan filter

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -53,7 +53,8 @@ export type ChangeError = SaltoElementError & {
   detailedMessage: string
 }
 
-export type ChangeValidator = (changes: ChangeGroup) => Promise<ReadonlyArray<ChangeError>>
+export type ChangeValidator = (changes: ReadonlyArray<Change>) =>
+  Promise<ReadonlyArray<ChangeError>>
 
 export type Adapter = {
   operations: (context: AdapterOperationsContext) => AdapterOperations

--- a/packages/adapter-utils/test/change_validator.test.ts
+++ b/packages/adapter-utils/test/change_validator.test.ts
@@ -14,15 +14,15 @@
 * limitations under the License.
 */
 
-import { ChangeValidator, ChangeError, ObjectType, ElemID, ChangeGroup } from '@salto-io/adapter-api'
+import { ChangeValidator, ChangeError, ObjectType, ElemID, Change } from '@salto-io/adapter-api'
 import { createChangeValidator } from '../src/change_validator'
-import { mockFunction, MockFunction, toChangeGroup } from './common'
+import { mockFunction, MockFunction, toChange } from './common'
 
 describe('change_validator', () => {
   const testElem = new ObjectType({ elemID: new ElemID('test', 'type') })
 
   let mockValidators: MockFunction<ChangeValidator>[]
-  let changes: ChangeGroup
+  let changes: ReadonlyArray<Change>
   let errors: ChangeError[]
   let result: ReadonlyArray<ChangeError>
 
@@ -45,7 +45,7 @@ describe('change_validator', () => {
       mockFunction<ChangeValidator>().mockResolvedValue(errors.slice(0, 1)),
       mockFunction<ChangeValidator>().mockResolvedValue(errors.slice(1)),
     ]
-    changes = toChangeGroup({ after: testElem })
+    changes = [toChange({ after: testElem })]
     const mainValidator = createChangeValidator(mockValidators)
     result = await mainValidator(changes)
   })

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -85,15 +85,15 @@ export const preview = async (
   services = workspace.services(),
 ): Promise<Plan> => {
   const stateElements = await workspace.state().getAll()
-  return getPlan(
-    filterElementsByServices(stateElements, services),
-    addHiddenValuesAndHiddenTypes(
+  return getPlan({
+    before: filterElementsByServices(stateElements, services),
+    after: addHiddenValuesAndHiddenTypes(
       filterElementsByServices(await workspace.elements(), services),
       stateElements
     ),
-    getAdapterChangeValidators(),
-    defaultDependencyChangers.concat(getAdapterDependencyChangers()),
-  )
+    changeValidators: getAdapterChangeValidators(),
+    dependencyChangers: defaultDependencyChangers.concat(getAdapterDependencyChangers()),
+  })
 }
 
 export interface DeployResult {

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -73,7 +73,7 @@ export const getDetailedChanges = async (
   after: ReadonlyArray<Element>,
   additionalResolveContext?: ReadonlyArray<Element>,
 ): Promise<Iterable<DetailedChange>> =>
-  wu((await getPlan(before, after, {}, [], additionalResolveContext)).itemsByEvalOrder())
+  wu((await getPlan({ before, after, additionalResolveContext })).itemsByEvalOrder())
     .map(item => item.detailedChanges())
     .flatten()
 
@@ -344,10 +344,10 @@ export const fetchChanges = async (
   }
   const configs = updatedConfigs.map(c => c.config)
   const updatedConfigNames = new Set(configs.map(c => c.elemID.getFullName()))
-  const configChanges = await getPlan(
-    currentConfigs.filter(config => updatedConfigNames.has(config.elemID.getFullName())),
-    configs,
-  )
+  const configChanges = await getPlan({
+    before: currentConfigs.filter(config => updatedConfigNames.has(config.elemID.getFullName())),
+    after: configs,
+  })
   const adapterNameToConfigMessage = _
     .fromPairs(updatedConfigs.map(c => [c.config.elemID.adapter, c.message]))
   return {

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -161,16 +161,23 @@ const addModifyNodes = (
   return runMergeStep
 }
 
-export const getPlan = async (
-  beforeElements: readonly Element[],
-  afterElements: readonly Element[],
-  changeValidators: Record<string, ChangeValidator> = {},
-  dependencyChangers: ReadonlyArray<DependencyChanger> = defaultDependencyChangers,
-  additionalResolveContext?: ReadonlyArray<Element>,
-): Promise<Plan> => log.time(async () => {
+type GetPlanParameters = {
+  before: ReadonlyArray<Element>
+  after: ReadonlyArray<Element>
+  changeValidators?: Record<string, ChangeValidator>
+  dependencyChangers?: ReadonlyArray<DependencyChanger>
+  additionalResolveContext?: ReadonlyArray<Element>
+}
+export const getPlan = async ({
+  before,
+  after,
+  changeValidators = {},
+  dependencyChangers = defaultDependencyChangers,
+  additionalResolveContext,
+}: GetPlanParameters): Promise<Plan> => log.time(async () => {
   // Resolve elements before adding them to the graph
-  const resolvedBefore = resolve(beforeElements, additionalResolveContext)
-  const resolvedAfter = resolve(afterElements, additionalResolveContext)
+  const resolvedBefore = resolve(before, additionalResolveContext)
+  const resolvedAfter = resolve(after, additionalResolveContext)
 
   const diffGraph = await buildDiffGraph(
     addElements(resolvedBefore, 'remove'),
@@ -198,4 +205,4 @@ export const getPlan = async (
     _.pick(beforeElementsMap, inGraphElementKeys),
     _.pick(filterResult.validAfterElementsMap, inGraphElementKeys)
   )
-}, 'get plan with %o -> %o elements', beforeElements.length, afterElements.length)
+}, 'get plan with %o -> %o elements', before.length, after.length)

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -209,12 +209,10 @@ describe('api.ts', () => {
       expect(mockedGetPlan).toHaveBeenCalledTimes(1)
 
       // check that we call get plan after adding hidden values and variables to workspace elements
-      expect(mockedGetPlan).toHaveBeenCalledWith(
-        stateElements,
-        stateElements,
-        expect.anything(),
-        expect.anything()
-      )
+      expect(mockedGetPlan).toHaveBeenCalledWith(expect.objectContaining({
+        before: stateElements,
+        after: stateElements,
+      }))
     })
 
     it('should not call flush', async () => {

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -145,7 +145,11 @@ describe('fetch', () => {
         const fetchChangesResult = await fetchChanges(
           mockAdapters, [], [], [],
         )
-        verifyPlan(fetchChangesResult.configChanges, await getPlan([], [configInstance]), 1)
+        verifyPlan(
+          fetchChangesResult.configChanges,
+          await getPlan({ before: [], after: [configInstance] }),
+          1,
+        )
       })
 
       it('should return config change plan when there is current config', async () => {
@@ -157,7 +161,7 @@ describe('fetch', () => {
         )
         verifyPlan(
           fetchChangesResult.configChanges,
-          await getPlan([currentInstanceConfig], [configInstance]),
+          await getPlan({ before: [currentInstanceConfig], after: [configInstance] }),
           1
         )
       })

--- a/packages/core/test/core/plan/filter.test.ts
+++ b/packages/core/test/core/plan/filter.test.ts
@@ -36,7 +36,11 @@ describe('filterInvalidChanges', () => {
   )
 
   it('should have no change errors when having no diffs', async () => {
-    const planResult = await getPlan(allElements, allElements, { salto: mockChangeValidator })
+    const planResult = await getPlan({
+      before: allElements,
+      after: allElements,
+      changeValidators: { salto: mockChangeValidator },
+    })
     expect(planResult.changeErrors).toHaveLength(0)
     expect(planResult.size).toBe(0)
   })
@@ -49,11 +53,11 @@ describe('filterInvalidChanges', () => {
       isSettings: true,
     })
     const newElements = [newValidObj, newValidInst, newValidSetting]
-    const planResult = await getPlan(
-      allElements,
-      [...allElements, ...newElements],
-      { salto: mockChangeValidator }
-    )
+    const planResult = await getPlan({
+      before: allElements,
+      after: [...allElements, ...newElements],
+      changeValidators: { salto: mockChangeValidator },
+    })
     expect(planResult.changeErrors).toHaveLength(0)
     expect(planResult.size).toBe(2)
     newElements.forEach(element => {
@@ -74,8 +78,11 @@ describe('filterInvalidChanges', () => {
       annotations: { value: 'value' },
     })
     const newInvalidInst = new InstanceElement('new_invalid_inst', newInvalidObj, {})
-    const planResult = await getPlan(allElements, [...allElements, newInvalidObj, newInvalidInst],
-      { salto: mockChangeValidator })
+    const planResult = await getPlan({
+      before: allElements,
+      after: [...allElements, newInvalidObj, newInvalidInst],
+      changeValidators: { salto: mockChangeValidator },
+    })
     expect(planResult.changeErrors).toHaveLength(3)
     expect(planResult.changeErrors.some(v => v.elemID.isEqual(newInvalidObj.elemID)))
       .toBeTruthy()
@@ -96,8 +103,11 @@ describe('filterInvalidChanges', () => {
       },
       annotations: { value: 'value' },
     })
-    const planResult = await getPlan(allElements, [...allElements, newValidObj],
-      { salto: mockChangeValidator })
+    const planResult = await getPlan({
+      before: allElements,
+      after: [...allElements, newValidObj],
+      changeValidators: { salto: mockChangeValidator },
+    })
     expect(planResult.changeErrors).toHaveLength(1)
     expect(planResult.changeErrors[0].elemID.isEqual(newValidObj.fields.invalid.elemID))
       .toBeTruthy()
@@ -115,7 +125,11 @@ describe('filterInvalidChanges', () => {
     const afterElements = mock.getAllElements()
     const saltoOffice = afterElements[2] as ObjectType
     saltoOffice.fields.invalid = new Field(saltoOffice, 'invalid', BuiltinTypes.STRING)
-    const planResult = await getPlan(allElements, afterElements, { salto: mockChangeValidator })
+    const planResult = await getPlan({
+      before: allElements,
+      after: afterElements,
+      changeValidators: { salto: mockChangeValidator },
+    })
     expect(planResult.changeErrors).toHaveLength(1)
     expect(planResult.changeErrors[0].severity).toEqual('Error')
     expect(planResult.changeErrors[0].elemID.isEqual(saltoOffice.fields.invalid.elemID))
@@ -128,7 +142,11 @@ describe('filterInvalidChanges', () => {
     const saltoOffice = afterElements[2] as ObjectType
     saltoOffice.fields.invalid = new Field(saltoOffice, 'invalid', BuiltinTypes.STRING)
     saltoOffice.fields.valid = new Field(saltoOffice, 'valid', BuiltinTypes.STRING)
-    const planResult = await getPlan(allElements, afterElements, { salto: mockChangeValidator })
+    const planResult = await getPlan({
+      before: allElements,
+      after: afterElements,
+      changeValidators: { salto: mockChangeValidator },
+    })
     expect(planResult.changeErrors).toHaveLength(1)
     expect(planResult.changeErrors[0].severity).toEqual('Error')
     expect(planResult.changeErrors[0].elemID.isEqual(saltoOffice.fields.invalid.elemID))
@@ -149,8 +167,11 @@ describe('filterInvalidChanges', () => {
     afterInvalidObj.annotations.new = 'value'
     afterInvalidObj.annotationTypes.new = BuiltinTypes.STRING
     afterInvalidObj.fields.valid = new Field(afterInvalidObj, 'valid', BuiltinTypes.STRING)
-    const planResult = await getPlan([...allElements, beforeInvalidObj],
-      [...allElements, afterInvalidObj], { salto: mockChangeValidator })
+    const planResult = await getPlan({
+      before: [...allElements, beforeInvalidObj],
+      after: [...allElements, afterInvalidObj],
+      changeValidators: { salto: mockChangeValidator },
+    })
     expect(planResult.changeErrors).toHaveLength(1)
     expect(planResult.changeErrors[0].severity).toEqual('Error')
     expect(planResult.changeErrors[0].elemID.isEqual(afterInvalidObj.elemID)).toBeTruthy()
@@ -166,7 +187,11 @@ describe('filterInvalidChanges', () => {
     const saltoOffice = beforeElements[2] as ObjectType
     saltoOffice.fields.invalid = new Field(saltoOffice, 'invalid', BuiltinTypes.STRING)
     saltoOffice.fields.valid = new Field(saltoOffice, 'valid', BuiltinTypes.STRING)
-    const planResult = await getPlan(beforeElements, allElements, { salto: mockChangeValidator })
+    const planResult = await getPlan({
+      before: beforeElements,
+      after: allElements,
+      changeValidators: { salto: mockChangeValidator },
+    })
     expect(planResult.changeErrors).toHaveLength(1)
     expect(planResult.changeErrors[0].severity).toEqual('Error')
     expect(planResult.changeErrors[0].elemID.isEqual(saltoOffice.fields.invalid.elemID))
@@ -189,8 +214,11 @@ describe('filterInvalidChanges', () => {
     const afterSaltoOffice = afterElements[2] as ObjectType
     afterSaltoOffice.fields.invalid = new Field(afterSaltoOffice, 'invalid',
       BuiltinTypes.STRING, { label: 'dummy annotation' })
-    const planResult = await getPlan(beforeElements, afterElements,
-      { salto: mockChangeValidator })
+    const planResult = await getPlan({
+      before: beforeElements,
+      after: afterElements,
+      changeValidators: { salto: mockChangeValidator },
+    })
     expect(planResult.changeErrors).toHaveLength(1)
     expect(planResult.changeErrors[0].severity).toEqual('Error')
     expect(planResult.changeErrors[0].elemID.isEqual(afterSaltoOffice.fields.invalid.elemID))
@@ -207,8 +235,11 @@ describe('filterInvalidChanges', () => {
     })
     const beforeInvalidField = beforeInvalidObj.fields.invalid
     const beforeInvalidInst = new InstanceElement('before_invalid_inst', beforeInvalidObj, {})
-    const planResult = await getPlan([...allElements, beforeInvalidObj, beforeInvalidInst],
-      allElements, { salto: mockChangeValidator })
+    const planResult = await getPlan({
+      before: [...allElements, beforeInvalidObj, beforeInvalidInst],
+      after: allElements,
+      changeValidators: { salto: mockChangeValidator },
+    })
     expect(planResult.changeErrors).toHaveLength(3)
     expect(planResult.changeErrors.some(v => v.elemID.isEqual(beforeInvalidObj.elemID)))
       .toBeTruthy()

--- a/packages/core/test/core/plan/filter.test.ts
+++ b/packages/core/test/core/plan/filter.test.ts
@@ -29,7 +29,7 @@ describe('filterInvalidChanges', () => {
 
 
   const mockChangeValidator = mockFunction<ChangeValidator>().mockImplementation(
-    async changes => changes.changes
+    async changes => changes
       .map(getChangeElement)
       .filter(elem => elem.elemID.name.includes('invalid'))
       .map(({ elemID }) => ({ elemID, severity: 'Error', message: 'msg', detailedMessage: '' }))

--- a/packages/core/test/core/plan/plan.test.ts
+++ b/packages/core/test/core/plan/plan.test.ts
@@ -40,7 +40,7 @@ export const planGenerators = (allElements: ReadonlyArray<Element>): PlanGenerat
     const saltoOffice = afterElements[2]
     saltoOffice.annotations.label = 'new label'
     saltoOffice.annotations.new = 'new annotation'
-    const plan = await getPlan(allElements, afterElements)
+    const plan = await getPlan({ before: allElements, after: afterElements })
     return [plan, saltoOffice]
   },
 
@@ -51,7 +51,7 @@ export const planGenerators = (allElements: ReadonlyArray<Element>): PlanGenerat
     saltoOffice.fields.new = new Field(saltoOffice, 'new', BuiltinTypes.STRING)
     // Sub element change
     saltoOffice.fields.location.annotations.label = 'new label'
-    const plan = await getPlan(allElements, afterElements)
+    const plan = await getPlan({ before: allElements, after: afterElements })
     return [plan, saltoOffice]
   },
 
@@ -60,7 +60,7 @@ export const planGenerators = (allElements: ReadonlyArray<Element>): PlanGenerat
       elemID: new ElemID('salto', 'additional'),
       primitive: PrimitiveTypes.STRING,
     })
-    const plan = await getPlan(allElements, [...allElements, newElement])
+    const plan = await getPlan({ before: allElements, after: [...allElements, newElement] })
     return [plan, newElement]
   },
 
@@ -69,7 +69,7 @@ export const planGenerators = (allElements: ReadonlyArray<Element>): PlanGenerat
     const updatedEmployee = afterElements[4]
     updatedEmployee.value.nicknames[1] = 'new'
     delete updatedEmployee.value.office.name
-    const plan = await getPlan(allElements, afterElements)
+    const plan = await getPlan({ before: allElements, after: afterElements })
     return [plan, updatedEmployee]
   },
 
@@ -77,7 +77,7 @@ export const planGenerators = (allElements: ReadonlyArray<Element>): PlanGenerat
     const afterElements = mock.getAllElements()
     const updatedEmployee = afterElements[4]
     updatedEmployee.value.nicknames.push('new')
-    const plan = await getPlan(allElements, afterElements)
+    const plan = await getPlan({ before: allElements, after: afterElements })
     return [plan, updatedEmployee]
   },
 
@@ -88,7 +88,7 @@ export const planGenerators = (allElements: ReadonlyArray<Element>): PlanGenerat
     // update annotation types
     saltoOffice.annotationTypes.new = BuiltinTypes.STRING
     saltoOffice.annotationTypes.address = saltoAddress.clone({ label: 'test label' })
-    const plan = await getPlan(allElements, afterElements)
+    const plan = await getPlan({ before: allElements, after: afterElements })
     return [plan, saltoOffice]
   },
 
@@ -97,7 +97,7 @@ export const planGenerators = (allElements: ReadonlyArray<Element>): PlanGenerat
     const saltoOffice = afterElements[2]
     saltoOffice.fields.name.type = new ListType(saltoOffice.fields.name.type)
     saltoOffice.fields.rooms.type = BuiltinTypes.STRING
-    const plan = await getPlan(allElements, afterElements)
+    const plan = await getPlan({ before: allElements, after: afterElements })
     return [plan, saltoOffice]
   },
 
@@ -121,8 +121,8 @@ export const planGenerators = (allElements: ReadonlyArray<Element>): PlanGenerat
       return []
     }
     const plan = isAdd
-      ? await getPlan([], afterElements, {}, [depChanger])
-      : await getPlan(afterElements, [], {}, [depChanger])
+      ? await getPlan({ before: [], after: afterElements, dependencyChangers: [depChanger] })
+      : await getPlan({ before: afterElements, after: [], dependencyChangers: [depChanger] })
     return [plan, saltoOffice]
   },
 })
@@ -138,7 +138,7 @@ describe('getPlan', () => {
   } = planGenerators(allElements)
 
   it('should create empty plan', async () => {
-    const plan = await getPlan(allElements, allElements)
+    const plan = await getPlan({ before: allElements, after: allElements })
     expect(plan.size).toBe(0)
   })
 
@@ -157,7 +157,7 @@ describe('getPlan', () => {
   it('should create plan with remove change', async () => {
     const pre = allElements
     const preFiltered = pre.filter(element => element.elemID.name !== 'instance')
-    const plan = await getPlan(pre, preFiltered)
+    const plan = await getPlan({ before: pre, after: preFiltered })
     expect(plan.size).toBe(1)
     const planItem = getFirstPlanItem(plan)
     const removed = _.find(pre, element => element.elemID.name === 'instance')
@@ -184,7 +184,7 @@ describe('getPlan', () => {
     const post = mock.getAllElements()
     const employee = post[4]
     employee.value.name = 'SecondEmployee'
-    const plan = await getPlan(allElements, post)
+    const plan = await getPlan({ before: allElements, after: post })
     expect(plan.size).toBe(1)
     const planItem = getFirstPlanItem(plan)
     expect(planItem.groupKey).toBe(employee.elemID.getFullName())

--- a/packages/hubspot-adapter/src/change_validators/form_field.ts
+++ b/packages/hubspot-adapter/src/change_validators/form_field.ts
@@ -62,7 +62,7 @@ const getFormInstanceFieldErrorsFromAfter = async (after: InstanceElement):
 
 const changeValidator: ChangeValidator = async changes => (
   _.flatten(await Promise.all(
-    changes.changes
+    changes
       .filter(isInstanceChange)
       .filter(isAdditionOrModificationDiff)
       .map(change => getFormInstanceFieldErrorsFromAfter(change.data.after))

--- a/packages/hubspot-adapter/src/change_validators/json_type.ts
+++ b/packages/hubspot-adapter/src/change_validators/json_type.ts
@@ -43,7 +43,7 @@ const getJsonValidationErrorsFromAfter = async (after: InstanceElement):
 
 const changeValidator: ChangeValidator = async changes => (
   _.flatten(await Promise.all(
-    changes.changes
+    changes
       .filter(isInstanceChange)
       .filter(isAdditionOrModificationDiff)
       .map(change => getJsonValidationErrorsFromAfter(change.data.after))

--- a/packages/hubspot-adapter/src/change_validators/readonly.ts
+++ b/packages/hubspot-adapter/src/change_validators/readonly.ts
@@ -56,7 +56,7 @@ const getReadonlyValidationError = async (before: InstanceElement, after: Instan
 
 const changeValidator: ChangeValidator = async changes => (
   _.flatten(await Promise.all(
-    changes.changes
+    changes
       .filter(isInstanceChange)
       .filter(isModificationDiff)
       .map(change => getReadonlyValidationError(change.data.before, change.data.after))

--- a/packages/hubspot-adapter/test/change_validators/form_field.test.ts
+++ b/packages/hubspot-adapter/test/change_validators/form_field.test.ts
@@ -16,7 +16,7 @@
 import { InstanceElement } from '@salto-io/adapter-api'
 import { Types } from '../../src/transformers/transformer'
 import { afterFormInstanceValuesMock } from '../common/mock_elements'
-import { toChangeGroup } from '../common/mock_changes'
+import { toChange } from '../common/mock_changes'
 import formFieldValidator from '../../src/change_validators/form_field'
 import { OBJECTS_NAMES } from '../../src/constants'
 
@@ -39,13 +39,13 @@ describe('form field change validator', () => {
     })
 
     it('should work when contactProperty are instances', async () => {
-      const changeErrors = await formFieldValidator(toChangeGroup({ after: addInstance }))
+      const changeErrors = await formFieldValidator([toChange({ after: addInstance })])
       expect(changeErrors).toHaveLength(0)
     })
 
     it('should have errors when not instance at field level', async () => {
       addInstance.value.formFieldGroups[0].fields[0].contactProperty = notInstanceStr
-      const changeErrors = await formFieldValidator(toChangeGroup({ after: addInstance }))
+      const changeErrors = await formFieldValidator([toChange({ after: addInstance })])
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(addInstance.elemID)
@@ -54,7 +54,7 @@ describe('form field change validator', () => {
     it('should have errors when not instance in dependent fields', async () => {
       addInstance.value.formFieldGroups[0].fields[0].dependentFieldFilters[0]
         .dependentFormField.contactProperty = notInstanceStr
-      const changeErrors = await formFieldValidator(toChangeGroup({ after: addInstance }))
+      const changeErrors = await formFieldValidator([toChange({ after: addInstance })])
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(addInstance.elemID)
@@ -67,12 +67,12 @@ describe('form field change validator', () => {
       after = formInstance.clone()
     })
     it('should work when contactProperty are instances', async () => {
-      const changeErrors = await formFieldValidator(toChangeGroup({ before: formInstance, after }))
+      const changeErrors = await formFieldValidator([toChange({ before: formInstance, after })])
       expect(changeErrors).toHaveLength(0)
     })
     it('should have errors when not instance at field level', async () => {
       after.value.formFieldGroups[0].fields[0].contactProperty = notInstanceStr
-      const changeErrors = await formFieldValidator(toChangeGroup({ before: formInstance, after }))
+      const changeErrors = await formFieldValidator([toChange({ before: formInstance, after })])
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(after.elemID)
@@ -81,7 +81,7 @@ describe('form field change validator', () => {
     it('should have errors when not instance in dependent fields', async () => {
       after.value.formFieldGroups[0].fields[0].dependentFieldFilters[0]
         .dependentFormField.contactProperty = notInstanceStr
-      const changeErrors = await formFieldValidator(toChangeGroup({ before: formInstance, after }))
+      const changeErrors = await formFieldValidator([toChange({ before: formInstance, after })])
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(after.elemID)

--- a/packages/hubspot-adapter/test/change_validators/json_type.test.ts
+++ b/packages/hubspot-adapter/test/change_validators/json_type.test.ts
@@ -15,7 +15,7 @@
 */
 import { InstanceElement, ObjectType, ElemID, BuiltinTypes, CORE_ANNOTATIONS, StaticFile, ChangeError } from '@salto-io/adapter-api'
 import jsonTypeValidator from '../../src/change_validators/json_type'
-import { toChangeGroup } from '../common/mock_changes'
+import { toChange } from '../common/mock_changes'
 
 const invalidJSON = '{'
 const validJSON = '{ "a": "bba" }'
@@ -52,7 +52,7 @@ describe('json type change validator', () => {
       })
 
       afterEach(async () => {
-        changeErrors = await jsonTypeValidator(toChangeGroup({ after: instance }))
+        changeErrors = await jsonTypeValidator([toChange({ after: instance })])
         expect(changeErrors).toHaveLength(1)
         expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(instance.elemID)
@@ -69,7 +69,7 @@ describe('json type change validator', () => {
       })
 
       afterEach(async () => {
-        changeErrors = await jsonTypeValidator(toChangeGroup({ after: instance }))
+        changeErrors = await jsonTypeValidator([toChange({ after: instance })])
         expect(changeErrors).toHaveLength(0)
       })
     })
@@ -91,7 +91,7 @@ describe('json type change validator', () => {
       })
 
       afterEach(async () => {
-        changeErrors = await jsonTypeValidator(toChangeGroup({ before: instance, after }))
+        changeErrors = await jsonTypeValidator([toChange({ before: instance, after })])
         expect(changeErrors).toHaveLength(1)
         expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(instance.elemID)
@@ -109,7 +109,7 @@ describe('json type change validator', () => {
       })
 
       afterEach(async () => {
-        changeErrors = await jsonTypeValidator(toChangeGroup({ before: instance, after }))
+        changeErrors = await jsonTypeValidator([toChange({ before: instance, after })])
         expect(changeErrors).toHaveLength(0)
       })
     })

--- a/packages/hubspot-adapter/test/change_validators/readonly.test.ts
+++ b/packages/hubspot-adapter/test/change_validators/readonly.test.ts
@@ -18,7 +18,7 @@ import readonlyValidator from '../../src/change_validators/readonly'
 import { Types } from '../../src/transformers/transformer'
 import { OBJECTS_NAMES } from '../../src/constants'
 import { contactPropertyMock } from '../common/mock_elements'
-import { toChangeGroup } from '../common/mock_changes'
+import { toChange } from '../common/mock_changes'
 
 describe('readonly change validator', () => {
   describe('onUpdate', () => {
@@ -37,23 +37,23 @@ describe('readonly change validator', () => {
     describe('change value of name in ContactProperty', () => {
       it('should have an error when different string', async () => {
         after.value.name = 'abc'
-        changeErrors = await readonlyValidator(
-          toChangeGroup({ before: contactPropertyInstance, after })
-        )
+        changeErrors = await readonlyValidator([
+          toChange({ before: contactPropertyInstance, after }),
+        ])
       })
 
       it('should have an error on static file with diff value', async () => {
         after.value.name = new StaticFile({ filepath: 'path', content: Buffer.from('abc') })
-        changeErrors = await readonlyValidator(
-          toChangeGroup({ before: contactPropertyInstance, after })
-        )
+        changeErrors = await readonlyValidator([
+          toChange({ before: contactPropertyInstance, after }),
+        ])
       })
 
       it('should have an error on reference with diff value', async () => {
         after.value.name = new ReferenceExpression(new ElemID('hubspot', 'str'), 'abc')
-        changeErrors = await readonlyValidator(
-          toChangeGroup({ before: contactPropertyInstance, after })
-        )
+        changeErrors = await readonlyValidator([
+          toChange({ before: contactPropertyInstance, after }),
+        ])
       })
 
       afterEach(() => {
@@ -66,23 +66,23 @@ describe('readonly change validator', () => {
     describe('keep resolved value of name in ContactProperty', () => {
       it('should not have an error when replacing name with static file with same value', async () => {
         after.value.name = new StaticFile({ filepath: 'path', content: Buffer.from(contactPropertyMock.name) })
-        changeErrors = await readonlyValidator(
-          toChangeGroup({ before: contactPropertyInstance, after })
-        )
+        changeErrors = await readonlyValidator([
+          toChange({ before: contactPropertyInstance, after }),
+        ])
       })
 
       it('should not have an error when replacing name with reference to the same value', async () => {
         after.value.name = new ReferenceExpression(new ElemID('hubspot', 'str'), contactPropertyMock.name)
-        changeErrors = await readonlyValidator(
-          toChangeGroup({ before: contactPropertyInstance, after })
-        )
+        changeErrors = await readonlyValidator([
+          toChange({ before: contactPropertyInstance, after }),
+        ])
       })
 
       it('should not have an error when modyfing other non-readonly value', async () => {
         after.value.label = 'new label'
-        changeErrors = await readonlyValidator(
-          toChangeGroup({ before: contactPropertyInstance, after })
-        )
+        changeErrors = await readonlyValidator([
+          toChange({ before: contactPropertyInstance, after }),
+        ])
       })
 
       afterEach(() => {

--- a/packages/hubspot-adapter/test/common/mock_changes.ts
+++ b/packages/hubspot-adapter/test/common/mock_changes.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeDataType, Change, ChangeGroup, getChangeElement } from '@salto-io/adapter-api'
+import { ChangeDataType, Change } from '@salto-io/adapter-api'
 
 // TODO: export to common test utils package
 export type ChangeParams = { before?: ChangeDataType; after?: ChangeDataType }
@@ -28,12 +28,4 @@ export const toChange = ({ before, after }: ChangeParams): Change => {
     return { action: 'add', data: { after } }
   }
   throw new Error('must provide before or after')
-}
-
-export const toChangeGroup = (...params: ChangeParams[]): ChangeGroup => {
-  const changes = params.map(toChange)
-  return {
-    groupID: getChangeElement(changes[0]).elemID.getFullName(),
-    changes,
-  }
 }

--- a/packages/lowerdash/src/collections/iterable.ts
+++ b/packages/lowerdash/src/collections/iterable.ts
@@ -17,12 +17,14 @@ import wu from 'wu'
 import { SetId } from './set'
 import { DefaultMap } from './map'
 
-export const groupBy = <T>(elements: Iterable<T>, groupFunc: (t: T) => SetId): Map<SetId, T[]> => (
-  new Map(wu(elements).reduce(
-    (groupMap, elem) => { groupMap.get(groupFunc(elem)).push(elem); return groupMap },
-    new DefaultMap<SetId, T[]>(() => []),
-  ))
-)
+export const groupBy = <K extends SetId, V>(
+  elements: Iterable<V>, groupFunc: (t: V) => K,
+): Map<K, V[]> => (
+    new Map(wu(elements).reduce(
+      (groupMap, elem) => { groupMap.get(groupFunc(elem)).push(elem); return groupMap },
+      new DefaultMap<K, V[]>(() => []),
+    ))
+  )
 
 export type Indexed<T> = [number, T]
 export type IndexedIterator<T> = Iterator<Indexed<T>>

--- a/packages/netsuite-adapter/src/change_validators/remove_customization.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_customization.ts
@@ -17,7 +17,7 @@ import { isInstanceElement, ChangeValidator, isRemovalDiff, getChangeElement } f
 import { isCustomType, isFileCabinetType } from '../types'
 
 const changeValidator: ChangeValidator = async changes => (
-  changes.changes
+  changes
     .filter(isRemovalDiff)
     .map(getChangeElement)
     .filter(isInstanceElement)

--- a/packages/netsuite-adapter/test/change_validators/remove_customization.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_customization.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, InstanceElement, ObjectType, ChangeDataType, Change, ChangeGroup, getChangeElement } from '@salto-io/adapter-api'
+import { ElemID, InstanceElement, ObjectType, ChangeDataType, Change } from '@salto-io/adapter-api'
 import removeCustomizationValidator from '../../src/change_validators/remove_customization'
 import { customTypes, fileCabinetTypes } from '../../src/types'
 import { ENTITY_CUSTOM_FIELD } from '../../src/constants'
@@ -34,19 +34,11 @@ export const toChange = ({ before, after }: ChangeParams): Change => {
   throw new Error('must provide before or after')
 }
 
-export const toChangeGroup = (...params: ChangeParams[]): ChangeGroup => {
-  const changes = params.map(toChange)
-  return {
-    groupID: getChangeElement(changes[0]).elemID.getFullName(),
-    changes,
-  }
-}
-
 describe('remove custom object change validator', () => {
   describe('onRemove', () => {
     it('should have change error when removing an instance with custom object type', async () => {
       const instance = new InstanceElement('test', customTypes[ENTITY_CUSTOM_FIELD])
-      const changeErrors = await removeCustomizationValidator(toChangeGroup({ before: instance }))
+      const changeErrors = await removeCustomizationValidator([toChange({ before: instance })])
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(instance.elemID)
@@ -54,7 +46,7 @@ describe('remove custom object change validator', () => {
 
     it('should have change error when removing an instance with file cabinet type', async () => {
       const instance = new InstanceElement('test', fileCabinetTypes.file)
-      const changeErrors = await removeCustomizationValidator(toChangeGroup({ before: instance }))
+      const changeErrors = await removeCustomizationValidator([toChange({ before: instance })])
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
       expect(changeErrors[0].elemID).toEqual(instance.elemID)
@@ -62,7 +54,7 @@ describe('remove custom object change validator', () => {
 
     it('should not have change error when removing an instance with non custom object type', async () => {
       const instance = new InstanceElement('test', new ObjectType({ elemID: new ElemID('bla') }))
-      const changeErrors = await removeCustomizationValidator(toChangeGroup({ before: instance }))
+      const changeErrors = await removeCustomizationValidator([toChange({ before: instance })])
       expect(changeErrors).toHaveLength(0)
     })
   })

--- a/packages/salesforce-adapter/src/change_validators/package.ts
+++ b/packages/salesforce-adapter/src/change_validators/package.ts
@@ -55,12 +55,12 @@ const isInstalledPackageVersionChange = (
 )
 
 const changeValidator: ChangeValidator = async changes => {
-  const addRemoveErrors = changes.changes
+  const addRemoveErrors = changes
     .filter(change => isAdditionDiff(change) || isRemovalDiff(change))
     .filter(change => hasNamespace(getChangeElement(change)))
     .map(change => packageChangeError(change.action, getChangeElement(change)))
 
-  const removeObjectWithPackageFieldsErrors = changes.changes
+  const removeObjectWithPackageFieldsErrors = changes
     .filter(isRemovalDiff)
     .map(getChangeElement)
     .filter(isObjectType)
@@ -71,7 +71,7 @@ const changeValidator: ChangeValidator = async changes => {
       'Cannot remove type because some of its fields belong to a managed package',
     ))
 
-  const packageVersionChangeErrors = changes.changes
+  const packageVersionChangeErrors = changes
     .filter(isInstanceChange)
     .filter(isModificationDiff)
     .filter(change => isInstalledPackageVersionChange(change.data))

--- a/packages/salesforce-adapter/src/change_validators/picklist_standard_field.ts
+++ b/packages/salesforce-adapter/src/change_validators/picklist_standard_field.ts
@@ -35,7 +35,7 @@ const createChangeError = (field: Field): ChangeError =>
  * It is forbidden to modify a picklist on a standard field. Only StandardValueSet is allowed.
  */
 const changeValidator: ChangeValidator = async changes => (
-  changes.changes
+  changes
     .filter(isModificationDiff)
     .map(getChangeElement)
     .filter(shouldCreateChangeError)

--- a/packages/salesforce-adapter/test/change_validators/package.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/package.test.ts
@@ -19,7 +19,7 @@ import packageValidator, {
   PACKAGE_VERSION_FIELD_NAME,
 } from '../../src/change_validators/package'
 import { API_NAME, INSTANCE_FULL_NAME_FIELD, METADATA_TYPE } from '../../src/constants'
-import { toChangeGroup } from '../utils'
+import { toChange } from '../utils'
 
 describe('package change validator', () => {
   let obj: ObjectType
@@ -41,7 +41,7 @@ describe('package change validator', () => {
     describe('Object', () => {
       it('should have change error when adding an object with namespace', async () => {
         obj.annotate({ [API_NAME]: 'MyNamespace__ObjectName__c' })
-        const changeErrors = await packageValidator(toChangeGroup({ after: obj }))
+        const changeErrors = await packageValidator([toChange({ after: obj })])
         expect(changeErrors).toHaveLength(1)
         expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(obj.elemID)
@@ -51,7 +51,7 @@ describe('package change validator', () => {
         obj.annotate({ [API_NAME]: 'ObjectName__c' })
         addField(`${obj.annotations[API_NAME]}.MyNamespace__FieldName__c`)
         const changeErrors = await packageValidator(
-          toChangeGroup({ after: obj }, { after: obj.fields.field })
+          [{ after: obj }, { after: obj.fields.field }].map(toChange)
         )
         expect(changeErrors).toHaveLength(1)
         expect(changeErrors[0].severity).toEqual('Error')
@@ -60,12 +60,12 @@ describe('package change validator', () => {
 
       it('should have no change errors when adding an object without namespace', async () => {
         obj.annotate({ [API_NAME]: 'ObjectName__c' })
-        const changeErrors = await packageValidator(toChangeGroup({ after: obj }))
+        const changeErrors = await packageValidator([toChange({ after: obj })])
         expect(changeErrors).toHaveLength(0)
       })
 
       it('should have no change errors when adding an object without apiName', async () => {
-        const changeErrors = await packageValidator(toChangeGroup({ after: obj }))
+        const changeErrors = await packageValidator([toChange({ after: obj })])
         expect(changeErrors).toHaveLength(0)
       })
     })
@@ -73,7 +73,7 @@ describe('package change validator', () => {
     describe('Instance', () => {
       it('should have change error when adding an instance with namespace', async () => {
         inst.value[INSTANCE_FULL_NAME_FIELD] = 'MyNamespace__InstanceName__c'
-        const changeErrors = await packageValidator(toChangeGroup({ after: inst }))
+        const changeErrors = await packageValidator([toChange({ after: inst })])
         expect(changeErrors).toHaveLength(1)
         expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(inst.elemID)
@@ -81,12 +81,12 @@ describe('package change validator', () => {
 
       it('should have no change errors when adding an instance without namespace', async () => {
         inst.value[INSTANCE_FULL_NAME_FIELD] = 'InstanceName__c'
-        const changeErrors = await packageValidator(toChangeGroup({ after: inst }))
+        const changeErrors = await packageValidator([toChange({ after: inst })])
         expect(changeErrors).toHaveLength(0)
       })
 
       it('should have no change errors when adding an instance without fullName', async () => {
-        const changeErrors = await packageValidator(toChangeGroup({ after: inst }))
+        const changeErrors = await packageValidator([toChange({ after: inst })])
         expect(changeErrors).toHaveLength(0)
       })
     })
@@ -96,7 +96,7 @@ describe('package change validator', () => {
     describe('Object', () => {
       it('should have change error when removing an object with namespace', async () => {
         obj.annotate({ [API_NAME]: 'MyNamespace__ObjectName__c' })
-        const changeErrors = await packageValidator(toChangeGroup({ before: obj }))
+        const changeErrors = await packageValidator([toChange({ before: obj })])
         expect(changeErrors).toHaveLength(1)
         expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(obj.elemID)
@@ -106,7 +106,7 @@ describe('package change validator', () => {
         obj.annotate({ [API_NAME]: 'ObjectName__c' })
         addField(`${obj.annotations[API_NAME]}.MyNamespace__FieldName__c`)
         const changeErrors = await packageValidator(
-          toChangeGroup({ before: obj }, { before: obj.fields.field })
+          [{ before: obj }, { before: obj.fields.field }].map(toChange)
         )
         expect(changeErrors).toHaveLength(2)
         expect(changeErrors[0].severity).toEqual('Error')
@@ -117,19 +117,19 @@ describe('package change validator', () => {
 
       it('should have no change errors when removing an object without namespace', async () => {
         obj.annotate({ [API_NAME]: 'ObjectName__c' })
-        const changeErrors = await packageValidator(toChangeGroup({ before: obj }))
+        const changeErrors = await packageValidator([toChange({ before: obj })])
         expect(changeErrors).toHaveLength(0)
       })
 
       it('should have no change errors when removing an object without apiName', async () => {
-        const changeErrors = await packageValidator(toChangeGroup({ before: obj }))
+        const changeErrors = await packageValidator([toChange({ before: obj })])
         expect(changeErrors).toHaveLength(0)
       })
     })
     describe('Instance', () => {
       it('should have change error when removing an instance with namespace', async () => {
         inst.value[INSTANCE_FULL_NAME_FIELD] = 'MyNamespace__InstanceName__c'
-        const changeErrors = await packageValidator(toChangeGroup({ before: inst }))
+        const changeErrors = await packageValidator([toChange({ before: inst })])
         expect(changeErrors).toHaveLength(1)
         expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(inst.elemID)
@@ -137,12 +137,12 @@ describe('package change validator', () => {
 
       it('should have no change errors when removing an instance without namespace', async () => {
         inst.value[INSTANCE_FULL_NAME_FIELD] = 'InstanceName__c'
-        const changeErrors = await packageValidator(toChangeGroup({ before: inst }))
+        const changeErrors = await packageValidator([toChange({ before: inst })])
         expect(changeErrors).toHaveLength(0)
       })
 
       it('should have no change errors when removing an instance without fullName', async () => {
-        const changeErrors = await packageValidator(toChangeGroup({ before: inst }))
+        const changeErrors = await packageValidator([toChange({ before: inst })])
         expect(changeErrors).toHaveLength(0)
       })
     })
@@ -152,7 +152,7 @@ describe('package change validator', () => {
     describe('add field', () => {
       it('should have change error when adding a field with namespace to an object', async () => {
         const newField = addField('ObjectName__c.MyNamespace__FieldName__c')
-        const changeErrors = await packageValidator(toChangeGroup({ after: newField }))
+        const changeErrors = await packageValidator([toChange({ after: newField })])
         expect(changeErrors).toHaveLength(1)
         expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(newField.elemID)
@@ -160,19 +160,19 @@ describe('package change validator', () => {
 
       it('should have no change error when adding a field without namespace to an object', async () => {
         const newField = addField('ObjectName__c.FieldName__c')
-        const changeErrors = await packageValidator(toChangeGroup({ after: newField }))
+        const changeErrors = await packageValidator([toChange({ after: newField })])
         expect(changeErrors).toHaveLength(0)
       })
 
       it('should have no change error when adding a field without namespace to a packaged object', async () => {
         const newField = addField('MyNamespace__ObjectName__c.FieldName')
-        const changeErrors = await packageValidator(toChangeGroup({ after: newField }))
+        const changeErrors = await packageValidator([toChange({ after: newField })])
         expect(changeErrors).toHaveLength(0)
       })
 
       it('should have no change error when adding a field without apiName to an object', async () => {
         const newField = addField()
-        const changeErrors = await packageValidator(toChangeGroup({ after: newField }))
+        const changeErrors = await packageValidator([toChange({ after: newField })])
         expect(changeErrors).toHaveLength(0)
       })
     })
@@ -180,7 +180,7 @@ describe('package change validator', () => {
     describe('remove field', () => {
       it('should have change error when removing a field with namespace from an object', async () => {
         const oldField = addField('ObjectName__c.MyNamespace__FieldName__c')
-        const changeErrors = await packageValidator(toChangeGroup({ before: oldField }))
+        const changeErrors = await packageValidator([toChange({ before: oldField })])
         expect(changeErrors).toHaveLength(1)
         expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(oldField.elemID)
@@ -188,19 +188,19 @@ describe('package change validator', () => {
 
       it('should have no change error when removing a field without namespace from an object', async () => {
         const oldField = addField('ObjectName__c.FieldName__c')
-        const changeErrors = await packageValidator(toChangeGroup({ before: oldField }))
+        const changeErrors = await packageValidator([toChange({ before: oldField })])
         expect(changeErrors).toHaveLength(0)
       })
 
       it('should have no change error when removing a custom field from a packaged object', async () => {
         const oldField = addField('MyNamespace__ObjectName__c.FieldName')
-        const changeErrors = await packageValidator(toChangeGroup({ before: oldField }))
+        const changeErrors = await packageValidator([toChange({ before: oldField })])
         expect(changeErrors).toHaveLength(0)
       })
 
       it('should have no change error when removing a field without apiName from an object', async () => {
         const oldField = addField()
-        const changeErrors = await packageValidator(toChangeGroup({ before: oldField }))
+        const changeErrors = await packageValidator([toChange({ before: oldField })])
         expect(changeErrors).toHaveLength(0)
       })
     })
@@ -212,7 +212,7 @@ describe('package change validator', () => {
         inst.value[PACKAGE_VERSION_FIELD_NAME] = '1.0'
         const after = inst.clone()
         after.value[PACKAGE_VERSION_FIELD_NAME] = '1.1'
-        const changeErrors = await packageValidator(toChangeGroup({ before: inst, after }))
+        const changeErrors = await packageValidator([toChange({ before: inst, after })])
         expect(changeErrors).toHaveLength(1)
         expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(after.elemID)

--- a/packages/salesforce-adapter/test/change_validators/picklist_standard_field.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/picklist_standard_field.test.ts
@@ -21,7 +21,7 @@ import picklistStandardFieldValidator from '../../src/change_validators/picklist
 import {
   API_NAME, FIELD_ANNOTATIONS, SALESFORCE, VALUE_SET_FIELDS,
 } from '../../src/constants'
-import { toChangeGroup } from '../utils'
+import { toChange } from '../utils'
 
 
 describe('picklist standard field change validator', () => {
@@ -50,7 +50,7 @@ describe('picklist standard field change validator', () => {
 
     const runChangeValidatorOnUpdate = (before: Field, after: Field):
       Promise<ReadonlyArray<ChangeError>> =>
-      picklistStandardFieldValidator(toChangeGroup({ before, after }))
+      picklistStandardFieldValidator([toChange({ before, after })])
 
     it('should have error for picklist standard field without API_NAME_SEPARATOR', async () => {
       const beforeField = createField(Types.primitiveDataTypes.Picklist, 'Standard')
@@ -108,9 +108,9 @@ describe('picklist standard field change validator', () => {
     })
 
     it('should have no error for object', async () => {
-      const changeErrors = await picklistStandardFieldValidator(
-        toChangeGroup({ before: obj, after: obj.clone() })
-      )
+      const changeErrors = await picklistStandardFieldValidator([
+        toChange({ before: obj, after: obj.clone() }),
+      ])
       expect(changeErrors).toHaveLength(0)
     })
   })

--- a/packages/salesforce-adapter/test/utils.ts
+++ b/packages/salesforce-adapter/test/utils.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  Element, ElemID, Values, ObjectType, ChangeDataType, Change, ChangeGroup, getChangeElement,
+  Element, ElemID, Values, ObjectType, ChangeDataType, Change,
 } from '@salto-io/adapter-api'
 import {
   findElements as findElementsByID,
@@ -96,14 +96,6 @@ export const toChange = ({ before, after }: ChangeParams): Change => {
     return { action: 'add', data: { after } }
   }
   throw new Error('must provide before or after')
-}
-
-export const toChangeGroup = (...params: ChangeParams[]): ChangeGroup => {
-  const changes = params.map(toChange)
-  return {
-    groupID: getChangeElement(changes[0]).elemID.getFullName(),
-    changes,
-  }
 }
 
 export type MockFunction<T extends (...args: never[]) => unknown> =


### PR DESCRIPTION
As preparation for grouping changes with custom logic, this PR removes the unnecessary use of change grouping before running change validators.