### PR TITLE
Ensure that static file content are NOT in state

### DIFF
--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -94,8 +94,8 @@ export const serialize = (elements: Element[],
     o[SALTO_CLASS_FIELD] = ctorNameToSerializedName[e.constructor.name]
     return o
   }
-  const staticFileReplacer = (e: StaticFile): Omit<StaticFile & SerializedClass, 'content'> => (
-    _.omit(saltoClassReplacer(e), 'content')
+  const staticFileReplacer = (e: StaticFile): Omit<Omit<StaticFile & SerializedClass, 'internalContent'>, 'content'> => (
+    _.omit(saltoClassReplacer(e), 'content', 'internalContent')
   )
   const referenceExpressionReplacer = (e: ReferenceExpression):
     ReferenceExpression & SerializedClass => {


### PR DESCRIPTION
Since we changed `content` to `internalContent`, we kept writing HUGE data to our state that isn't needed.

This change updates the serialize accordingly