### PR TITLE
Netsuite: overcome errors in importFiles & support filePathRegexSkipList

### DIFF
--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -21,7 +21,7 @@ import { logger } from '@salto-io/logging'
 import changeValidator from './change_validator'
 import NetsuiteClient, { Credentials } from './client/client'
 import NetsuiteAdapter, { NetsuiteConfig } from './adapter'
-import { NETSUITE, TYPES_TO_SKIP } from './constants'
+import { NETSUITE, TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST } from './constants'
 
 const log = logger(module)
 const { makeArray } = collections.array
@@ -45,6 +45,9 @@ const configType = new ObjectType({
     [TYPES_TO_SKIP]: {
       type: new ListType(BuiltinTypes.STRING),
     },
+    [FILE_PATHS_REGEX_SKIP_LIST]: {
+      type: new ListType(BuiltinTypes.STRING),
+    },
   },
 })
 
@@ -52,6 +55,7 @@ const netsuiteConfigFromConfig = (config: Readonly<InstanceElement> | undefined)
   NetsuiteConfig => {
   const netsuiteConfig = {
     [TYPES_TO_SKIP]: makeArray(config?.value?.[TYPES_TO_SKIP]),
+    [FILE_PATHS_REGEX_SKIP_LIST]: makeArray(config?.value?.[FILE_PATHS_REGEX_SKIP_LIST]),
   }
   Object.keys(config?.value ?? {})
     .filter(k => !Object.keys(netsuiteConfig).includes(k))

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -18,6 +18,7 @@ import {
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
+import _ from 'lodash'
 import changeValidator from './change_validator'
 import NetsuiteClient, { Credentials } from './client/client'
 import NetsuiteAdapter, { NetsuiteConfig } from './adapter'
@@ -53,9 +54,28 @@ const configType = new ObjectType({
 
 const netsuiteConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
   NetsuiteConfig => {
+  const validateRegularExpressions = (regularExpressions: string[]): void => {
+    const invalidRegularExpressions = regularExpressions
+      .filter(regex => {
+        try {
+          RegExp(regex)
+          return false
+        } catch (e) {
+          return true
+        }
+      })
+    if (!_.isEmpty(invalidRegularExpressions)) {
+      const errMessage = `Failed to load config due to an invalid ${FILE_PATHS_REGEX_SKIP_LIST} value. The following regular expressions are invalid: ${invalidRegularExpressions}`
+      log.error(errMessage)
+      throw Error(errMessage)
+    }
+  }
+
+  const filePathsRegexSkipList = makeArray(config?.value?.[FILE_PATHS_REGEX_SKIP_LIST])
+  validateRegularExpressions(filePathsRegexSkipList)
   const netsuiteConfig = {
     [TYPES_TO_SKIP]: makeArray(config?.value?.[TYPES_TO_SKIP]),
-    [FILE_PATHS_REGEX_SKIP_LIST]: makeArray(config?.value?.[FILE_PATHS_REGEX_SKIP_LIST]),
+    [FILE_PATHS_REGEX_SKIP_LIST]: filePathsRegexSkipList,
   }
   Object.keys(config?.value ?? {})
     .filter(k => !Object.keys(netsuiteConfig).includes(k))

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -412,10 +412,10 @@ export default class NetsuiteClient {
     const project = await this.initProject()
     const filePathsToImport = (await NetsuiteClient.listFilePaths(project.executor))
       .filter(path => filePathRegexSkipList.every(regex => !regex.test(path)))
-    const importFileResults = await NetsuiteClient.importFiles(filePathsToImport, project.executor)
+    const importFilesResults = await NetsuiteClient.importFiles(filePathsToImport, project.executor)
     // folder attributes file is returned multiple times
     const paths = _.uniq(
-      _.flatten(importFileResults.map(importResult => makeArray(importResult.data.results)))
+      _.flatten(importFilesResults.map(importResult => makeArray(importResult.data.results)))
         .filter(result => result.loaded)
         .map(result => result.path)
     )

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -47,3 +47,4 @@ export const WEB_SITE_HOSTING_FILES_FOLDER_NAME = 'Web Site Hosting Files'
 
 // NetsuiteConfig
 export const TYPES_TO_SKIP = 'typesToSkip'
+export const FILE_PATHS_REGEX_SKIP_LIST = 'filePathRegexSkipList'

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -77,7 +77,7 @@ describe('Adapter', () => {
         + '  <label>elementName</label>'
         + '</entitycustomfield>'
       const customTypeInfo = convertToCustomTypeInfo(xmlContent, 'custentity_my_script_id')
-      client.importFileCabinet = jest.fn()
+      client.importFileCabinetContent = jest.fn()
         .mockResolvedValue([folderCustomizationInfo, fileCustomizationInfo])
       client.listCustomObjects = jest.fn().mockResolvedValue([customTypeInfo])
       const { elements } = await netsuiteAdapter.fetch()
@@ -96,14 +96,14 @@ describe('Adapter', () => {
     })
 
     it('should handle exceptions during listCustomObjects', async () => {
-      client.importFileCabinet = jest.fn().mockResolvedValue([])
+      client.importFileCabinetContent = jest.fn().mockResolvedValue([])
       client.listCustomObjects = jest.fn().mockImplementation(async () => Promise.reject())
       const { elements } = await netsuiteAdapter.fetch()
       expect(elements).toHaveLength(getAllTypes().length)
     })
 
-    it('should handle exceptions during importFileCabinet', async () => {
-      client.importFileCabinet = jest.fn().mockImplementation(async () => Promise.reject())
+    it('should handle exceptions during importFileCabinetContent', async () => {
+      client.importFileCabinetContent = jest.fn().mockImplementation(async () => Promise.reject())
       client.listCustomObjects = jest.fn().mockResolvedValue([])
       const { elements } = await netsuiteAdapter.fetch()
       expect(elements).toHaveLength(getAllTypes().length)
@@ -114,7 +114,7 @@ describe('Adapter', () => {
         + '  <label>elementName</label>'
         + '</unknowntype>'
       const customTypeInfo = convertToCustomTypeInfo(xmlContent, 'unknown')
-      client.importFileCabinet = jest.fn().mockResolvedValue([])
+      client.importFileCabinetContent = jest.fn().mockResolvedValue([])
       client.listCustomObjects = jest.fn().mockResolvedValue([customTypeInfo])
       const { elements } = await netsuiteAdapter.fetch()
       expect(elements).toHaveLength(getAllTypes().length)

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -17,7 +17,7 @@ import { ElemID, InstanceElement, ObjectType, ServiceIds } from '@salto-io/adapt
 import { adapter } from '../src/adapter_creator'
 import NetsuiteClient from '../src/client/client'
 import NetsuiteAdapter from '../src/adapter'
-import { TYPES_TO_SKIP } from '../src/constants'
+import { TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST } from '../src/constants'
 
 jest.mock('../src/client/client')
 jest.mock('../src/adapter')
@@ -38,6 +38,7 @@ describe('NetsuiteAdapter creator', () => {
     adapter.configType as ObjectType,
     {
       [TYPES_TO_SKIP]: ['test1'],
+      [FILE_PATHS_REGEX_SKIP_LIST]: ['^/Templates.*'],
       notExist: ['not exist'],
     }
   )
@@ -78,6 +79,7 @@ describe('NetsuiteAdapter creator', () => {
         client: expect.any(Object),
         config: {
           [TYPES_TO_SKIP]: ['test1'],
+          [FILE_PATHS_REGEX_SKIP_LIST]: ['^/Templates.*'],
         },
         getElemIdFunc: mockGetElemIdFunc,
       })
@@ -89,6 +91,7 @@ describe('NetsuiteAdapter creator', () => {
         client: expect.any(Object),
         config: {
           [TYPES_TO_SKIP]: [],
+          [FILE_PATHS_REGEX_SKIP_LIST]: [],
         },
         getElemIdFunc: mockGetElemIdFunc,
       })

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -96,5 +96,22 @@ describe('NetsuiteAdapter creator', () => {
         getElemIdFunc: mockGetElemIdFunc,
       })
     })
+
+    it('should throw an error when creating the adapter with an invalid regex for FILE_PATHS_REGEX_SKIP_LIST', () => {
+      const invalidConfig = new InstanceElement(
+        ElemID.CONFIG_NAME,
+        adapter.configType as ObjectType,
+        {
+          [FILE_PATHS_REGEX_SKIP_LIST]: ['\\'],
+        }
+      )
+      expect(
+        () => adapter.operations({
+          credentials,
+          config: invalidConfig,
+          getElemIdFunc: mockGetElemIdFunc,
+        })
+      ).toThrow()
+    })
   })
 })

--- a/packages/salesforce-adapter/test/adapter.creator.test.ts
+++ b/packages/salesforce-adapter/test/adapter.creator.test.ts
@@ -57,11 +57,8 @@ describe('SalesforceAdapter creator', () => {
   })
 
   describe('when passed config elements', () => {
-    beforeAll(() => {
-      adapter.operations({ credentials, config })
-    })
-
     it('creates the client correctly', () => {
+      adapter.operations({ credentials, config })
       expect(SalesforceClient).toHaveBeenCalledWith({
         credentials: {
           username: 'myUser',
@@ -73,6 +70,7 @@ describe('SalesforceAdapter creator', () => {
     })
 
     it('creates the adapter correctly', () => {
+      adapter.operations({ credentials, config })
       expect(SalesforceAdapter).toHaveBeenCalledWith({
         config: {
           metadataTypesSkippedList: ['test1'],
@@ -81,6 +79,15 @@ describe('SalesforceAdapter creator', () => {
         client: expect.any(Object),
         getElemIdFunc: undefined,
       })
+    })
+
+    it('should throw an error when creating the adapter with an invalid regex for instancesRegexSkippedList', () => {
+      const invalidConfig = new InstanceElement(
+        ElemID.CONFIG_NAME,
+        adapter.configType as ObjectType,
+        { instancesRegexSkippedList: ['\\'] },
+      )
+      expect(() => adapter.operations({ credentials, config: invalidConfig })).toThrow()
     })
   })
 })


### PR DESCRIPTION
This PR  reduces the amount of path args to importFiles in case of failure. It might happen in the following scenarios:
- If having too many arguments, the command might fail due to OS memory issues.
- when having a single file that fails (e.g. due to locked file), the whole command fails. thus, splitting to smaller chunks will eventually return only the valid files.

In addition, filePathRegexSkipList mechanism to accelerate the fetch / reduce noise for users.