### PR TITLE
SALTO-811: Make restore behave more like deploy, add dry-run and plan printing options

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -300,8 +300,11 @@ Syncs this workspace with the current local state
 
 **Options:**
 * `--force, -f ` : Accept all incoming changes [boolean] [default: false]
-* `--interactive, -i` : Interactively approve every incoming change [boolean] [default: false]
+* `--interactive, -i` : Interactively approve incoming changes (use `a` on first prompt to approve all at once) [boolean] [default: true]
 * `--isolated, -t` : Restrict restore from modifying common configuration (might result in changes in other env folders) [boolean] [default: false]
+* `--dry-run, -d` : Preview the restore plan without making changes [boolean] [default: false]
+* `--detailed-plan, -p` : Print detailed changes including values [boolean] [default: false]
+* `--list-planned-changes, -l` : Print a summary of the expected changes [boolean] [default: false]
 * `--services, -s` : Specific services to perform this action for (default=all) [array]
 * `--env, -e` : The name of the environment to use [string]
 
@@ -311,10 +314,10 @@ Deploys the current NaCl files config to the target services
 
 **Options:**
 * `--force, -f` : Do not ask for approval before deploying the changes [boolean] [default: false]
-* `--services, -s` : Specific services to perform this action for (default=all) [array]
-* `--env, -e` : The name of the environment to use
 * `--dry-run, -d` : Preview the execution plan without deploying the changes [boolean] [default: false]
 * `--detailed-plan, -p` : Print detailed plan including value changes [boolean] [default: false]
+* `--services, -s` : Specific services to perform this action for (default=all) [array]
+* `--env, -e` : The name of the environment to use
 
 ### **salto services \<command> [name]**
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -300,7 +300,7 @@ Syncs this workspace with the current local state
 
 **Options:**
 * `--force, -f ` : Accept all incoming changes [boolean] [default: false]
-* `--interactive, -i` : Interactively approve incoming changes (use `a` on first prompt to approve all at once) [boolean] [default: true]
+* `--interactive, -i` : Interactively approve every incoming change [boolean] [default: false]
 * `--isolated, -t` : Restrict restore from modifying common configuration (might result in changes in other env folders) [boolean] [default: false]
 * `--dry-run, -d` : Preview the restore plan without making changes [boolean] [default: false]
 * `--detailed-plan, -p` : Print detailed changes including values [boolean] [default: false]

--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -114,12 +114,14 @@ export class RestoreCommand implements CliCommand {
 
     const changes = await restore(workspace, this.inputServices, filters)
 
-    const detailedChanges = changes.map(change => change.change)
     if (this.listPlannedChanges) {
       outputLine(EOL, this.output)
       outputLine(header(Prompts.RESTORE_CALC_DIFF_RESULT_HEADER), this.output)
-      if (detailedChanges.length > 0) {
-        outputLine(formatDetailedChanges([detailedChanges], this.detailedPlan), this.output)
+      if (changes.length > 0) {
+        outputLine(
+          formatDetailedChanges([changes.map(change => change.change)], this.detailedPlan),
+          this.output,
+        )
       } else {
         outputLine('No changes', this.output)
       }
@@ -235,9 +237,9 @@ const restoreBuilder = createCommandBuilder({
       },
       interactive: {
         alias: ['i'],
-        describe: 'Interactively approve incoming changes (use `a` on first prompt to approve all at once)',
+        describe: 'Interactively approve every incoming change',
         boolean: true,
-        default: true,
+        default: false,
         demandOption: false,
       },
       isolated: {

--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -13,22 +13,22 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Telemetry, restore, StepEmitter, RestoreProgressEvents } from '@salto-io/core'
+import { restore, RestoreChange, Tags } from '@salto-io/core'
 import { logger } from '@salto-io/logging'
+import { Workspace } from '@salto-io/workspace'
 import { EOL } from 'os'
-import { EventEmitter } from 'pietile-eventemitter'
 import _ from 'lodash'
 import { ServicesArgs, servicesFilter } from '../filters/services'
 import { EnvironmentArgs } from './env'
-import { ParsedCliInput, CliOutput, SpinnerCreator, CliExitCode, CliCommand } from '../types'
+import { ParsedCliInput, CliOutput, SpinnerCreator, CliExitCode, CliCommand, CliTelemetry } from '../types'
 import { createCommandBuilder } from '../command_builder'
 import { environmentFilter } from '../filters/env'
 import { getCliTelemetry } from '../telemetry'
-import { loadWorkspace, getWorkspaceTelemetryTags, applyChangesToWorkspace } from '../workspace/workspace'
+import { loadWorkspace, getWorkspaceTelemetryTags, updateWorkspace } from '../workspace/workspace'
 import { getApprovedChanges } from '../callbacks'
 import Prompts from '../prompts'
-import { formatChangesSummary, formatDetailedChanges, formatRestoreFinish, formatInvalidFilters } from '../formatter'
-import { progressOutputer, outputLine } from '../outputer'
+import { formatChangesSummary, formatDetailedChanges, formatRestoreFinish, formatInvalidFilters, formatStepStart, formatStepCompleted, formatStepFailed, header } from '../formatter'
+import { outputLine } from '../outputer'
 
 const log = logger(module)
 
@@ -36,7 +36,8 @@ type RestoreArgs = {
     force: boolean
     interactive: boolean
     dryRun: boolean
-    printDetails: boolean
+    detailedPlan: boolean
+    listPlannedChanges: boolean
     isolated: boolean
     filters: string[]
   } & ServicesArgs & EnvironmentArgs
@@ -60,89 +61,165 @@ const createRegexFilters = (
   return { filters, invalidFilters }
 }
 
+export class RestoreCommand implements CliCommand {
+  readonly output: CliOutput
+  private cliTelemetry: CliTelemetry
+  inputFilters: string[]
+  force: boolean
+  interactive: boolean
+  dryRun: boolean
+  detailedPlan: boolean
+  listPlannedChanges: boolean
 
-export const command = (
-  workspaceDir: string,
-  force: boolean,
-  interactive: boolean,
-  dryRun: boolean,
-  printDetails: boolean,
-  telemetry: Telemetry,
-  output: CliOutput,
-  spinnerCreator: SpinnerCreator,
-  inputIsolated: boolean,
-  shouldCalcTotalSize: boolean,
-  inputServices?: string[],
-  inputEnvironment?: string,
-  inputFilters: string[] = []
-): CliCommand => ({
-  async execute(): Promise<CliExitCode> {
-    log.debug(`running restore command on '${workspaceDir}' [force=${force}, interactive=${
-      interactive}, dryRun=${dryRun}, printDetails=${printDetails}, isolated=${inputIsolated}], environment=${inputEnvironment}, services=${inputServices}`)
-    const restoreProgress = new EventEmitter<RestoreProgressEvents>()
-    restoreProgress.on('diffWillBeCalculated', progressOutputer(
-      Prompts.RESTORE_CALC_DIFF_START,
-      Prompts.RESTORE_CALC_DIFF_FINISH,
-      Prompts.RESTORE_CALC_DIFF_FAIL,
-      output
-    ))
-    restoreProgress.on('diffWasCalculated', detailedChanges => {
-      outputLine(EOL, output)
+  constructor(
+    private readonly workspaceDir: string,
+    {
+      force,
+      interactive,
+      dryRun,
+      detailedPlan,
+      listPlannedChanges,
+    }: {
+      force: boolean
+      interactive: boolean
+      dryRun: boolean
+      detailedPlan: boolean
+      listPlannedChanges: boolean
+    },
+    cliTelemetry: CliTelemetry,
+    output: CliOutput,
+    private readonly spinnerCreator: SpinnerCreator,
+    readonly inputIsolated: boolean,
+    readonly shouldCalcTotalSize: boolean,
+    readonly inputServices?: string[],
+    readonly inputEnv?: string,
+    inputFilters: string[] = []
+  ) {
+    this.output = output
+    this.cliTelemetry = cliTelemetry
+    this.inputServices = inputServices
+    this.inputEnv = inputEnv
+    this.inputFilters = inputFilters
+    this.force = force
+    this.interactive = interactive
+    this.dryRun = dryRun
+    this.detailedPlan = detailedPlan
+    // dry-run always prints plan
+    this.listPlannedChanges = listPlannedChanges || dryRun
+  }
+
+  async computeRestorePlan(workspace: Workspace, filters: RegExp[]): Promise<RestoreChange[]> {
+    outputLine(EOL, this.output)
+    outputLine(formatStepStart(Prompts.RESTORE_CALC_DIFF_START), this.output)
+
+    const changes = await restore(workspace, this.inputServices, filters)
+
+    const detailedChanges = changes.map(change => change.change)
+    if (this.listPlannedChanges) {
+      outputLine(EOL, this.output)
+      outputLine(header(Prompts.RESTORE_CALC_DIFF_RESULT_HEADER), this.output)
       if (detailedChanges.length > 0) {
-        outputLine(formatDetailedChanges([detailedChanges], printDetails), output)
+        outputLine(formatDetailedChanges([detailedChanges], this.detailedPlan), this.output)
       } else {
-        outputLine('No changes', output)
+        outputLine('No changes', this.output)
       }
-      outputLine(EOL, output)
-    })
-    restoreProgress.on('workspaceWillBeUpdated', (progress: StepEmitter, changes: number, approved: number) =>
-      progressOutputer(
-        formatChangesSummary(changes, approved),
-        Prompts.RESTORE_UPDATE_WORKSPACE_SUCCESS,
-        Prompts.RESTORE_UPDATE_WORKSPACE_FAIL,
-        output
-      )(progress))
-    const { filters, invalidFilters } = createRegexFilters(inputFilters)
+      outputLine(EOL, this.output)
+    }
+    outputLine(formatStepStart(Prompts.RESTORE_CALC_DIFF_FINISH), this.output)
+    outputLine(EOL, this.output)
+
+    return changes
+  }
+
+  async applyRestoreChangesToWorkspace(
+    changes: RestoreChange[],
+    workspace: Workspace,
+    workspaceTags: Tags,
+  ): Promise<boolean> {
+    // If the workspace starts empty there is no point in showing a huge amount of changes
+    const changesToApply = this.force || (await workspace.isEmpty())
+      ? changes
+      : await getApprovedChanges(changes, this.interactive)
+
+    this.cliTelemetry.changesToApply(changesToApply.length, workspaceTags)
+    outputLine(EOL, this.output)
+    outputLine(
+      formatStepStart(formatChangesSummary(changes.length, changesToApply.length)),
+      this.output,
+    )
+
+    const success = await updateWorkspace(
+      workspace,
+      this.output,
+      changesToApply,
+      this.inputIsolated,
+    )
+    if (success) {
+      outputLine(formatStepCompleted(Prompts.RESTORE_UPDATE_WORKSPACE_SUCCESS), this.output)
+      if (this.shouldCalcTotalSize) {
+        const totalSize = await workspace.getTotalSize()
+        log.debug(`Total size of the workspace is ${totalSize} bytes`)
+        this.cliTelemetry.workspaceSize(totalSize, workspaceTags)
+      }
+      return true
+    }
+    outputLine(formatStepFailed(Prompts.RESTORE_UPDATE_WORKSPACE_FAIL), this.output)
+    outputLine(EOL, this.output)
+    return false
+  }
+
+  async execute(): Promise<CliExitCode> {
+    log.debug(`running restore command on '${this.workspaceDir}' [force=${this.force}, interactive=${
+      this.interactive}, dryRun=${this.dryRun}, detailedPlan=${this.detailedPlan}, listPlannedChanges=${
+      this.listPlannedChanges}, isolated=${this.inputIsolated}], environment=${this.inputEnv}, services=${this.inputServices}`)
+
+    const { filters, invalidFilters } = createRegexFilters(this.inputFilters)
     if (!_.isEmpty(invalidFilters)) {
-      output.stderr.write(formatInvalidFilters(invalidFilters))
+      this.output.stderr.write(formatInvalidFilters(invalidFilters))
       return CliExitCode.UserInputError
     }
-    const cliTelemetry = getCliTelemetry(telemetry, 'restore')
-    const { workspace, errored } = await loadWorkspace(workspaceDir, output,
-      { force, printStateRecency: true, spinnerCreator, sessionEnv: inputEnvironment })
+
+    const { workspace, errored } = await loadWorkspace(
+      this.workspaceDir,
+      this.output,
+      {
+        force: this.force,
+        printStateRecency: true,
+        spinnerCreator: this.spinnerCreator,
+        sessionEnv: this.inputEnv,
+      }
+    )
     if (errored) {
-      cliTelemetry.failure()
+      this.cliTelemetry.failure()
       return CliExitCode.AppError
     }
+
     const workspaceTags = await getWorkspaceTelemetryTags(workspace)
-    cliTelemetry.start(workspaceTags)
-    const changes = await restore(workspace, inputServices, filters, restoreProgress)
-    if (dryRun) {
-      cliTelemetry.success(workspaceTags)
+
+    this.cliTelemetry.start(workspaceTags)
+
+    const changes = await this.computeRestorePlan(workspace, filters)
+
+    if (this.dryRun) {
+      this.cliTelemetry.success(workspaceTags)
       return CliExitCode.Success
     }
-    const updatingWsSucceeded = await applyChangesToWorkspace({
+
+    const updatingWsSucceeded = await this.applyRestoreChangesToWorkspace(
       changes,
       workspace,
-      cliTelemetry,
       workspaceTags,
-      interactive,
-      force,
-      shouldCalcTotalSize,
-      applyProgress: restoreProgress,
-      output,
-      isIsolated: inputIsolated,
-      approveChangesCallback: getApprovedChanges,
-    })
+    )
+
     if (updatingWsSucceeded) {
-      outputLine(formatRestoreFinish(), output)
-      cliTelemetry.success(workspaceTags)
+      outputLine(formatRestoreFinish(), this.output)
+      this.cliTelemetry.success(workspaceTags)
       return CliExitCode.Success
     }
-    cliTelemetry.failure(workspaceTags)
+    this.cliTelemetry.failure(workspaceTags)
     return CliExitCode.AppError
-  },
-})
+  }
+}
 
 const restoreBuilder = createCommandBuilder({
   options: {
@@ -158,9 +235,9 @@ const restoreBuilder = createCommandBuilder({
       },
       interactive: {
         alias: ['i'],
-        describe: 'Interactively approve every incoming change',
+        describe: 'Interactively approve incoming changes (use `a` on first prompt to approve all at once)',
         boolean: true,
-        default: false,
+        default: true,
         demandOption: false,
       },
       isolated: {
@@ -171,7 +248,6 @@ const restoreBuilder = createCommandBuilder({
         default: false,
         demandOption: false,
       },
-      // will also be available as dryRun because of camel-case-expansion
       'dry-run': {
         alias: ['d'],
         describe: 'Preview the restore plan without making changes',
@@ -179,10 +255,16 @@ const restoreBuilder = createCommandBuilder({
         default: false,
         demandOption: false,
       },
-      // will also be available as printDetails because of camel-case-expansion
-      'print-details': {
+      'detailed-plan': {
         alias: ['p'],
         describe: 'Print detailed changes including values',
+        boolean: true,
+        default: false,
+        demandOption: false,
+      },
+      'list-planned-changes': {
+        alias: ['l'],
+        describe: 'Print a summary of the planned changes',
         boolean: true,
         default: false,
         demandOption: false,
@@ -192,14 +274,21 @@ const restoreBuilder = createCommandBuilder({
 
   filters: [servicesFilter, environmentFilter],
 
-  async build(input: RestoreParsedCliInput, output: CliOutput, spinnerCreator: SpinnerCreator) {
-    return command(
+  async build(
+    input: RestoreParsedCliInput,
+    output: CliOutput,
+    spinnerCreator: SpinnerCreator
+  ): Promise<CliCommand> {
+    return new RestoreCommand(
       '.',
-      input.args.force,
-      input.args.interactive,
-      input.args.dryRun,
-      input.args.printDetails,
-      input.telemetry,
+      {
+        force: input.args.force,
+        interactive: input.args.interactive,
+        dryRun: input.args.dryRun,
+        detailedPlan: input.args.detailedPlan,
+        listPlannedChanges: input.args.listPlannedChanges,
+      },
+      getCliTelemetry(input.telemetry, 'restore'),
       output,
       spinnerCreator,
       input.args.isolated,

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -192,6 +192,7 @@ ${Prompts.SERVICE_ADD_HELP}`
   ): string => `Failed to apply ${numOfChanges} changes to state.`
 
   public static readonly RESTORE_CALC_DIFF_START = 'Calculating the difference between state and NaCL files.'
+  public static readonly RESTORE_CALC_DIFF_RESULT_HEADER = 'The following changes can restore the local workspace to its last known state:'
   public static readonly RESTORE_CALC_DIFF_FINISH = 'Finished calculating the difference between state and NaCL files.'
   public static readonly RESTORE_CALC_DIFF_FAIL = 'Calculating diff failed!'
   public static readonly RESTORE_UPDATE_WORKSPACE_SUCCESS = 'Applied changes'

--- a/packages/cli/test/commands/restore.test.ts
+++ b/packages/cli/test/commands/restore.test.ts
@@ -16,7 +16,7 @@
 import { restore } from '@salto-io/core'
 import { Workspace } from '@salto-io/workspace'
 import { Spinner, SpinnerCreator, CliExitCode, CliTelemetry } from '../../src/types'
-import { RestoreCommand } from '../../src/commands/restore'
+import { command } from '../../src/commands/restore'
 
 import * as mocks from '../mocks'
 import * as mockCliWorkspace from '../../src/workspace/workspace'
@@ -38,7 +38,6 @@ jest.mock('@salto-io/core', () => ({
 }))
 jest.mock('../../src/workspace/workspace')
 describe('restore command', () => {
-  let command: RestoreCommand
   let spinners: Spinner[]
   let spinnerCreator: SpinnerCreator
   const services = ['salesforce']
@@ -78,7 +77,7 @@ describe('restore command', () => {
       } as unknown as Workspace
       mockLoadWorkspace.mockResolvedValueOnce({ workspace: erroredWorkspace, errored: true })
 
-      command = new RestoreCommand(
+      result = await command(
         '',
         {
           force: true,
@@ -93,8 +92,7 @@ describe('restore command', () => {
         false,
         true,
         services,
-      )
-      result = await command.execute()
+      ).execute()
     })
 
     it('should fail', async () => {
@@ -116,7 +114,7 @@ describe('restore command', () => {
         workspace: mocks.mockLoadWorkspace(workspaceName),
         errored: false,
       })
-      command = new RestoreCommand(
+      result = await command(
         workspaceName,
         {
           force: true,
@@ -131,8 +129,7 @@ describe('restore command', () => {
         false,
         true,
         services,
-      )
-      result = await command.execute()
+      ).execute()
     })
 
 
@@ -170,7 +167,7 @@ describe('restore command', () => {
       mockLoadWorkspace.mockClear()
     })
     it('should use current env when env is not provided', async () => {
-      command = new RestoreCommand(
+      result = await command(
         workspaceDir,
         {
           force: true,
@@ -185,15 +182,14 @@ describe('restore command', () => {
         false,
         true,
         services,
-      )
-      result = await command.execute()
+      ).execute()
       expect(mockLoadWorkspace).toHaveBeenCalledTimes(1)
       expect(mockLoadWorkspace.mock.results[0].value.workspace.currentEnv()).toEqual(
         mocks.withoutEnvironmentParam
       )
     })
     it('should use provided env', async () => {
-      command = new RestoreCommand(
+      result = await command(
         workspaceDir,
         {
           force: true,
@@ -209,8 +205,7 @@ describe('restore command', () => {
         true,
         services,
         mocks.withEnvironmentParam,
-      )
-      result = await command.execute()
+      ).execute()
       expect(mockLoadWorkspace).toHaveBeenCalledTimes(1)
       expect(mockLoadWorkspace.mock.results[0].value.workspace.currentEnv()).toEqual(
         mocks.withEnvironmentParam
@@ -229,7 +224,7 @@ describe('restore command', () => {
         workspace: mocks.mockLoadWorkspace(workspaceName),
         errored: false,
       })
-      command = new RestoreCommand(
+      result = await command(
         workspaceName,
         {
           force: true,
@@ -244,8 +239,7 @@ describe('restore command', () => {
         false,
         true,
         services,
-      )
-      result = await command.execute()
+      ).execute()
     })
 
     it('should return success code', () => {
@@ -282,7 +276,7 @@ describe('restore command', () => {
         workspace: mocks.mockLoadWorkspace('exist-on-error'),
         errored: false,
       })
-      command = new RestoreCommand(
+      result = await command(
         'exist-on-error',
         {
           force: true,
@@ -297,8 +291,7 @@ describe('restore command', () => {
         false,
         true,
         services,
-      )
-      result = await command.execute()
+      ).execute()
     })
 
     it('should return success code', () => {
@@ -316,7 +309,7 @@ describe('restore command', () => {
       })
     })
     it('should fail when invalid filters are provided', async () => {
-      command = new RestoreCommand(
+      result = await command(
         workspaceName,
         {
           force: true,
@@ -333,12 +326,11 @@ describe('restore command', () => {
         services,
         undefined,
         ['++']
-      )
-      result = await command.execute()
+      ).execute()
       expect(result).toBe(CliExitCode.UserInputError)
     })
     it('should succeed when invalid filters are provided', async () => {
-      command = new RestoreCommand(
+      result = await command(
         workspaceName,
         {
           force: true,
@@ -355,8 +347,7 @@ describe('restore command', () => {
         services,
         undefined,
         ['salto']
-      )
-      result = await command.execute()
+      ).execute()
       expect(result).toBe(CliExitCode.Success)
     })
   })

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -15,7 +15,6 @@
 */
 export { Plan, PlanItem } from './src/core/plan'
 export { FetchChange, FetchProgressEvents, StepEmitter } from './src/core/fetch'
-export { RestoreProgressEvents } from './src/core/restore'
 export * from './src/api'
 export { ItemStatus } from './src/core/deploy'
 export { getAdaptersCredentialsTypes } from './src/core/adapters/adapters'

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -50,7 +50,7 @@ import {
   toChangesWithPath,
 } from './core/fetch'
 import { defaultDependencyChangers } from './core/plan/plan'
-import { RestoreProgressEvents, createRestoreChanges } from './core/restore'
+import { createRestoreChanges } from './core/restore'
 import { getAdapterChangeGroupIdFunctions } from './core/adapters/custom_group_key'
 
 const { addHiddenValuesAndHiddenTypes, removeHiddenValuesAndHiddenTypes } = hiddenValues
@@ -243,13 +243,12 @@ export const fetch: FetchFunc = async (
   }
 }
 
-type RestoreChange = Omit<FetchChange, 'pendingChange'>
+export type RestoreChange = Omit<FetchChange, 'pendingChange'>
 
 export const restore = async (
   workspace: Workspace,
   servicesFilters?: string[],
   idFilters: RegExp[] = [],
-  progressEmitter?: EventEmitter<RestoreProgressEvents>
 ): Promise<RestoreChange[]> => {
   log.debug('restore starting..')
   const fetchServices = servicesFilters ?? workspace.services()
@@ -267,7 +266,6 @@ export const restore = async (
     stateElements,
     pathIndex,
     idFilters,
-    progressEmitter
   )
   return changes.map(change => ({ change, serviceChange: change }))
 }

--- a/packages/core/src/core/restore.ts
+++ b/packages/core/src/core/restore.ts
@@ -27,6 +27,7 @@ type PathIndex = pathIndex.PathIndex
 export type RestoreProgressEvents = {
   filtersWillBeCreated: (stepProgress: EventEmitter<StepEvents>) => void
   diffWillBeCalculated: (stepProgress: EventEmitter<StepEvents>) => void
+  diffWasCalculated: (detailedChanges: DetailedChange[]) => void
   workspaceWillBeUpdated: (
     stepProgress: EventEmitter<StepEvents>,
     changes: number,
@@ -117,6 +118,12 @@ export const createRestoreChanges = async (
     wu(await getDetailedChanges(workspaceElements, stateElements)).toArray(),
     idFilters
   )
+  const detailedChanges = _.flatten(await Promise.all(
+    changes.map(change => splitChangeByPath(change, index))
+  ))
+  if (progressEmitter) {
+    progressEmitter.emit('diffWasCalculated', detailedChanges)
+  }
   calculateDiffEmitter.emit('completed')
-  return _.flatten(await Promise.all(changes.map(change => splitChangeByPath(change, index))))
+  return detailedChanges
 }

--- a/packages/core/test/core/restore.test.ts
+++ b/packages/core/test/core/restore.test.ts
@@ -15,10 +15,8 @@
 */
 import { ObjectType, ElemID, BuiltinTypes, ListType, InstanceElement, DetailedChange } from '@salto-io/adapter-api'
 import { merger, pathIndex } from '@salto-io/workspace'
-import { EventEmitter } from 'pietile-eventemitter'
-import { createRestoreChanges, RestoreProgressEvents } from '../../src/core/restore'
+import { createRestoreChanges } from '../../src/core/restore'
 
-jest.mock('pietile-eventemitter')
 const { mergeElements } = merger
 const { createPathIndex } = pathIndex
 
@@ -127,15 +125,6 @@ describe('restore', () => {
 
   const index = createPathIndex(elementfragments)
 
-  it('should emit events', async () => {
-    const progressEmitter = new EventEmitter<RestoreProgressEvents>()
-    await createRestoreChanges([], [], index, [], progressEmitter)
-    expect(progressEmitter.emit).toHaveBeenCalledTimes(2)
-    const mockedEmit = progressEmitter.emit as jest.Mock
-    expect(mockedEmit.mock.calls[0][0]).toEqual('diffWillBeCalculated')
-    expect(mockedEmit.mock.calls[1][0]).toEqual('diffWasCalculated')
-    expect(mockedEmit.mock.calls[1][1]).toEqual([])
-  })
   describe('with no changes', () => {
     it('should not create changes ws and the state are the same', async () => {
       const changes = await createRestoreChanges(allElement, allElement, index)

--- a/packages/core/test/core/restore.test.ts
+++ b/packages/core/test/core/restore.test.ts
@@ -130,7 +130,11 @@ describe('restore', () => {
   it('should emit events', async () => {
     const progressEmitter = new EventEmitter<RestoreProgressEvents>()
     await createRestoreChanges([], [], index, [], progressEmitter)
-    expect(progressEmitter.emit).toHaveBeenCalled()
+    expect(progressEmitter.emit).toHaveBeenCalledTimes(2)
+    const mockedEmit = progressEmitter.emit as jest.Mock
+    expect(mockedEmit.mock.calls[0][0]).toEqual('diffWillBeCalculated')
+    expect(mockedEmit.mock.calls[1][0]).toEqual('diffWasCalculated')
+    expect(mockedEmit.mock.calls[1][1]).toEqual([])
   })
   describe('with no changes', () => {
     it('should not create changes ws and the state are the same', async () => {


### PR DESCRIPTION
* Refactored `restore` to work more like `deploy` than `fetch`, including:
  * ~Not making changes without user approval (default `interactive` to true - there's an "approve all" option on the first prompt)~ - reverted based on input from Tomer
  * Not relying on event emitters
* Added a `--dry-run` option that prints the change summary and exits
* Optionally print a summary of all the planned changes using `--list-planned-changes` (always included in dry-run mode)
* Optionally include value changes in the summary with `--detailed-plan`
