### PR TITLE
SALTO-843: Improve fetch plan calculation performance

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -73,7 +73,12 @@ export const getDetailedChanges = async (
   after: ReadonlyArray<Element>,
   additionalResolveContext?: ReadonlyArray<Element>,
 ): Promise<Iterable<DetailedChange>> =>
-  wu((await getPlan({ before, after, additionalResolveContext })).itemsByEvalOrder())
+  wu((await getPlan({
+    before,
+    after,
+    additionalResolveContext,
+    dependencyChangers: [],
+  })).itemsByEvalOrder())
     .map(item => item.detailedChanges())
     .flatten()
 

--- a/packages/core/src/core/plan/dependency/dependency.ts
+++ b/packages/core/src/core/plan/dependency/dependency.ts
@@ -50,6 +50,9 @@ const updateDeps = (
 export const addNodeDependencies = (
   changers: ReadonlyArray<DependencyChanger>
 ): PlanTransformer => graph => log.time(async () => {
+  if (changers.length === 0) {
+    return graph
+  }
   const changeData = new Map(wu(graph.keys()).map(id => [id, graph.getData(id)]))
   const outputDependencies = changers.reduce(
     async (deps, changer) => updateDeps(await deps, await changer(changeData, await deps)),

--- a/packages/core/src/core/plan/filter.ts
+++ b/packages/core/src/core/plan/filter.ts
@@ -135,6 +135,10 @@ export const filterInvalidChanges = async (
     return validDiffGraph
   }
 
+  if (Object.keys(changeValidators).length === 0) {
+    return { changeErrors: [], validDiffGraph: diffGraph }
+  }
+
   const changesByAdapter = collections.iterable.groupBy(
     wu(diffGraph.keys()).map(changeId => diffGraph.getData(changeId)),
     change => getChangeElement(change).elemID.adapter,


### PR DESCRIPTION
- Add shortcuts to dependency and plan filter to avoid the setup calculation
  when there are no dependencies / filters
- Skip dependencies on fetch plans where the dependencies do not matter