### PR TITLE
SALTO-843: Improve graph operations performance

### DIFF
--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -15,7 +15,7 @@
 */
 import wu from 'wu'
 import _ from 'lodash'
-import { GroupedNodeMap } from '@salto-io/dag'
+import { DataNodeMap, Group } from '@salto-io/dag'
 import {
   BuiltinTypes, Change, Element, ElemID, getChangeElement, InstanceElement,
   ObjectType, CORE_ANNOTATIONS, SaltoError, Values, ListType, DetailedChange,
@@ -347,7 +347,7 @@ const createChange = (action: 'add' | 'modify' | 'remove', ...path: string[]): C
 }
 
 export const configChangePlan = (): { plan: Plan; updatedConfig: InstanceElement } => {
-  const result = new GroupedNodeMap<Change>()
+  const result = new DataNodeMap<Group<Change>>()
   const configElemID = new ElemID('salesforce')
   const configType = new ObjectType({
     elemID: configElemID,
@@ -389,7 +389,7 @@ export const configChangePlan = (): { plan: Plan; updatedConfig: InstanceElement
 }
 
 export const preview = (): Plan => {
-  const result = new GroupedNodeMap<Change>()
+  const result = new DataNodeMap<Group<Change>>()
 
   const leadPlanItem = toPlanItem(
     createChange('modify', 'lead'),

--- a/packages/core/src/core/plan/dependency/dependency.ts
+++ b/packages/core/src/core/plan/dependency/dependency.ts
@@ -51,6 +51,7 @@ export const addNodeDependencies = (
   changers: ReadonlyArray<DependencyChanger>
 ): PlanTransformer => graph => log.time(async () => {
   if (changers.length === 0) {
+    // If there are no changers we return here to avoid creating changeData for no reason
     return graph
   }
   const changeData = new Map(wu(graph.keys()).map(id => [id, graph.getData(id)]))

--- a/packages/core/src/core/plan/filter.ts
+++ b/packages/core/src/core/plan/filter.ts
@@ -136,6 +136,7 @@ export const filterInvalidChanges = async (
   }
 
   if (Object.keys(changeValidators).length === 0) {
+    // Shortcut to avoid grouping all changes if there are no validators to run
     return { changeErrors: [], validDiffGraph: diffGraph }
   }
 

--- a/packages/core/test/common/plan.ts
+++ b/packages/core/test/common/plan.ts
@@ -17,7 +17,7 @@ import wu from 'wu'
 import {
   Change, ObjectType, isObjectType, ElemID, getChangeElement, ChangeDataType,
 } from '@salto-io/adapter-api'
-import { GroupedNodeMap, Group } from '@salto-io/dag'
+import { Group, DataNodeMap } from '@salto-io/dag'
 import { Plan, PlanItem, PlanItemId } from '../../src/core/plan'
 import { addPlanItemAccessors } from '../../src/core/plan/plan_item'
 import { getAllElements } from './elements'
@@ -27,7 +27,7 @@ export const createPlan = (changeGroups: Change[][]): Plan => {
     groupKey: getChangeElement(changes[0]).elemID.createTopLevelParentID().parent.getFullName(),
     items: new Map(changes.map((change, idx) => [`${idx}`, change])),
   })
-  const graph = new GroupedNodeMap<Change>(
+  const graph = new DataNodeMap<Group<Change>>(
     changeGroups.map((_changes, idx) => [`${idx}`, new Set()]),
     new Map(changeGroups.map((changes, idx) => [`${idx}`, toGroup(changes)])),
   )

--- a/packages/dag/src/group.ts
+++ b/packages/dag/src/group.ts
@@ -41,6 +41,7 @@ GroupedNodeMap<T> => log.time(() => {
       const mergeCandidate = mergeCandidates.get(key)
       if (mergeCandidate !== undefined) {
         const candidateDeps = new Set(
+          // Skip edges to mergeCandidate to avoid self reference cycle
           wu.chain(newDeps, graph.get(mergeCandidate)).filter(dep => dep !== mergeCandidate)
         )
         if (!graph.doesCreateCycle(new Map([[mergeCandidate, candidateDeps]]), mergeCandidate)) {

--- a/packages/dag/src/group.ts
+++ b/packages/dag/src/group.ts
@@ -16,6 +16,7 @@
 import wu from 'wu'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
+import { values } from '@salto-io/lowerdash'
 import { NodeId, DataNodeMap } from './nodemap'
 
 const log = logger(module)
@@ -25,71 +26,48 @@ export interface Group<T> {
   items: Map<NodeId, T>
 }
 
-export class GroupedNodeMap<T> extends DataNodeMap<Group<T>> {
-  getItems(groupId: NodeId): Map<NodeId, T> {
-    return _.get(this.getData(groupId) || {}, 'items')
-  }
-
-  getGroupIdFromItemId(nodeId: NodeId): NodeId | undefined {
-    return wu(this.nodes()).find(g => this.getItems(g).has(nodeId))
-  }
-
-  merge(from: NodeId, to: NodeId): void {
-    const toGroup = this.getData(to)
-    const fromGroup = this.getData(from)
-    if (!fromGroup || !toGroup || fromGroup.groupKey !== toGroup.groupKey) {
-      throw Error(`Cannot merge ${fromGroup} to ${toGroup}`)
-    }
-    // Clone toGroup so upon merge failures graph will not be "dirty"
-    const toGroupClone = { groupKey: toGroup.groupKey, items: _.clone(toGroup.items) }
-    wu(fromGroup.items.entries()).forEach(([id, item]) => toGroupClone.items.set(id, item))
-    this.setData(to, toGroupClone)
-    this.get(from).forEach(dep => {
-      if (dep !== to) {
-        this.get(to).add(dep)
-      }
-    })
-    this.deleteNode(from)
-  }
-}
+export type GroupedNodeMap<T> = DataNodeMap<Group<T>>
 
 export const buildGroupedGraph = <T>(source: DataNodeMap<T>, groupKey: (id: NodeId) => string):
 GroupedNodeMap<T> => log.time(() => {
     const mergeCandidates = new Map<string, NodeId>()
-    return (wu(source.evaluationOrder())
+    const itemToGroupId = new Map<NodeId, NodeId>()
 
-      .map((nodeId: NodeId): Group<T> | undefined => {
-        const node = source.getData(nodeId)
-        if (!node) return undefined
-        const groupNodes = {
-          groupKey: groupKey(nodeId),
-          items: new Map<NodeId, T>([[nodeId, node]]),
+    const getOrCreateGroupNode = (
+      graph: GroupedNodeMap<T>,
+      key: string,
+      newDeps: ReadonlySet<NodeId>,
+    ): NodeId => {
+      const mergeCandidate = mergeCandidates.get(key)
+      if (mergeCandidate !== undefined) {
+        const candidateDeps = new Set(
+          wu.chain(newDeps, graph.get(mergeCandidate)).filter(dep => dep !== mergeCandidate)
+        )
+        if (!graph.doesCreateCycle(new Map([[mergeCandidate, candidateDeps]]), mergeCandidate)) {
+          graph.set(mergeCandidate, candidateDeps)
+          return mergeCandidate
         }
-        return groupNodes
-      })
-      .reject(_.isUndefined) as wu.WuIterable<Group<T>>)
+      }
+      // Cannot merge to existing node, create a new one
+      const groupId = _.uniqueId(`${key}-`)
+      graph.addNode(groupId, newDeps, { groupKey: key, items: new Map() })
+      // mergeCandidates should point to the latest node of a given key
+      mergeCandidates.set(key, groupId)
+      return groupId
+    }
 
-      .reduce((result, group) =>
-        log.time(() => {
-          const deps = wu(group.items.keys())
-            .map(nodeId => source.get(nodeId)).flatten()
-            .map(dep => result.getGroupIdFromItemId(dep))
-            .reject(_.isUndefined) as Iterable<NodeId>
-          const groupId = _.uniqueId(`${group.groupKey}-`)
-          result.addNode(groupId, deps, group)
-
-          // Try to merge with existing node
-          const mergeCandidate = mergeCandidates.get(group.groupKey)
-          if (mergeCandidate) {
-            const [transformed, success] = result.tryTransform(groupGraph => {
-              groupGraph.merge(groupId, mergeCandidate)
-              return mergeCandidate
-            })
-            if (success) return transformed
-          }
-
-          // If merge failed, we need to update state of mergeCandidates
-          mergeCandidates.set(group.groupKey, groupId)
-          return result
-        }, 'merge nodes to group %o', group.groupKey), new GroupedNodeMap<T>())
+    return wu(source.evaluationOrder())
+      .reduce((result, nodeId) => {
+        const deps = new Set(
+          wu(source.get(nodeId))
+            .map(depId => itemToGroupId.get(depId))
+            .filter(values.isDefined)
+        )
+        const nodeGroupKey = groupKey(nodeId)
+        const groupId = getOrCreateGroupNode(result, nodeGroupKey, deps)
+        // Add item to the group node (the dependencies are handled by getOrCreateGroupNode)
+        result.getData(groupId).items.set(nodeId, source.getData(nodeId))
+        itemToGroupId.set(nodeId, groupId)
+        return result
+      }, new DataNodeMap<Group<T>>())
   }, 'build grouped graph for %o nodes', source.size)

--- a/packages/dag/test/diff.test.ts
+++ b/packages/dag/test/diff.test.ts
@@ -97,7 +97,8 @@ describe('DiffGraph functions', () => {
         graph.addNode('remove', [], diffNode(1, 'remove', 'data'))
         graph.addNode('add', [], diffNode(2, 'add', 'data'))
 
-        subject = await mergeNodesToModify(graph)
+        subject = graph.clone()
+        mergeNodesToModify(subject)
       })
       it('should not merge nodes', () => {
         expect(subject.size).toBe(2)
@@ -113,7 +114,8 @@ describe('DiffGraph functions', () => {
           graph.addNode(5, [1], diffNode(4, 'add', ''))
           graph.addNode(6, [2], diffNode(5, 'add', ''))
 
-          subject = await mergeNodesToModify(graph)
+          subject = graph.clone()
+          mergeNodesToModify(subject)
         })
         it('should merge the nodes', () => {
           expect(subject.size).toBe(graph.size - 1)
@@ -152,7 +154,8 @@ describe('DiffGraph functions', () => {
           graph.addNode(2, [1, 3], diffNode(1, 'remove', 'before'))
           graph.addNode(3, [1], diffNode(2, 'add', 'data'))
 
-          subject = await mergeNodesToModify(graph)
+          subject = graph.clone()
+          mergeNodesToModify(subject)
         })
         it('should not merge the nodes', () => {
           expect(subject).toEqual(graph)

--- a/packages/dag/test/nodemap.test.ts
+++ b/packages/dag/test/nodemap.test.ts
@@ -918,43 +918,41 @@ describe('NodeMap', () => {
     })
   })
 
-  describe('tryTransform', () => {
-    let transformResult: NodeMap
+  describe('doesCreateCycle', () => {
+    let modificationResult: boolean
+    let origGraph: NodeMap
 
-    describe('when the transformation does not create a cycle', () => {
+    beforeEach(() => {
+      subject.addNode(1, [2])
+      subject.addNode(2, [3, 4])
+      origGraph = subject.clone()
+    })
+
+    describe('when the modification does not create a cycle', () => {
       beforeEach(() => {
-        subject.addNode(1, [2])
-        subject.addNode(2, [3, 4])
-        const [result] = subject.tryTransform(nm => [...nm.deleteNode(1)][0])
-        transformResult = result
+        modificationResult = subject.doesCreateCycle(new Map([[1, new Set([3, 4])]]), 1)
       })
 
-      it('should return a new NodeMap', () => {
-        expect(transformResult).not.toBe(subject)
+      it('should return true', () => {
+        expect(modificationResult).toBeFalsy()
       })
 
-      it('should return the transformed NodeMap', () => {
-        expect(transformResult.nodes()).not.toContain(1)
+      it('should not modify the graph', () => {
+        expect(subject).toEqual(origGraph)
       })
     })
 
-    describe('when the transformation creates a cycle', () => {
+    describe('when the modification creates a cycle', () => {
       beforeEach(() => {
-        subject.addNode(1, [2])
-        const [result] = subject.tryTransform(nm => {
-          nm.addNode(2, [3])
-          nm.addNode(3, [1, 2])
-          return 2
-        })
-        transformResult = result
+        modificationResult = subject.doesCreateCycle(new Map([[3, new Set([1])]]), 3)
       })
 
-      it('should return the original NodeMap', () => {
-        expect(transformResult).toBe(subject)
+      it('should return false', () => {
+        expect(modificationResult).toBeTruthy()
       })
 
-      it('should return the untransformed NodeMap', () => {
-        expect(transformResult.nodes()).not.toContain(3)
+      it('should not modify the graph', () => {
+        expect(subject).toEqual(origGraph)
       })
     })
   })


### PR DESCRIPTION
General changes:
- Avoid cloning graphs for each node
- Remove multiple nodes to slightly improve deleteNode efficiency (still O(n))

mergeNodesToModify:
- check for cycles before creating the merged node

Group graph:
- Add index for node id -> group id to avoid O(n) searches for each node
- add items to existing node instead of creating a new one and merging
- removed log that wasn't very useful and took a non-trivial percentage of time

---

Based on top of #1225 - please review separately (only review second commit here)

profiling:

scenario - vanilla SFDC workspace, for each element add an annotation / value to create a modification diff, for each type create a copy new type to create an addition diff and rename all fields from the existing type to create remove and add changes that would be merged to the same group

before:
![image](https://user-images.githubusercontent.com/1883898/87668278-80d81500-c774-11ea-8546-2a32e7dbbc12.png)

after:
![image](https://user-images.githubusercontent.com/1883898/87668339-98af9900-c774-11ea-98b8-d5e17602fe17.png)

| function | before (ms) | after (ms) |
|---|---|---|
| updateDeps | 3220 | 0 |
| filterInvalidChanges | 1540 | 0 |
| mergeNodesToModify | 3540 | 351 |
| buildGroupedGraph... | 5160 | 2100 |

note that after the changes most (2000 out of 2100) of the time taken by buildGroupedGraph is due to the "walk" (which is mostly due to the time it takes to `deleteNode`), so the next PR will focus on that part