### PR TITLE
Add name-based ElemID logic to CustomObject instances

### DIFF
--- a/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
+++ b/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
@@ -44,6 +44,7 @@ describe('custom object instances e2e', () => {
       {
         name: 'testDataManagementConfig',
         enabled: true,
+        isNameBasedID: false,
         includeObjects: [productTwoMetadataName],
       },
     ],

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -34,6 +34,8 @@ const log = logger(module)
 
 const masterDetailNamesSeparator = '___'
 
+// This will be exctracted to a config once we have more knowledge
+// on naming "patterns"
 const objectsToAdditionalNameFields: Record<string, string[]> = {
   PricebookEntry: ['Pricebook2Id'],
   // eslint-disable-next-line @typescript-eslint/camelcase

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -106,14 +106,10 @@ const typesRecordsToInstances = (
       }
       const referenceToTypeNames = field.annotations[FIELD_ANNOTATIONS.REFERENCE_TO] as string[]
       return referenceToTypeNames.map(typeName => {
-        const typeRecords = recordByIdAndType[typeName]
-        if (typeRecords === undefined) {
-          log.warn(`failed to find object name ${typeName} when looking for master`)
-          return undefined
-        }
-        const rec = typeRecords[fieldValue]
+        const rec = recordByIdAndType[typeName] !== undefined
+          ? recordByIdAndType[typeName][fieldValue] : undefined
         if (rec === undefined) {
-          log.warn(`failed to find record with id ${fieldValue} in ${typeRecords} when looking for master`)
+          log.warn(`failed to find record with id ${fieldValue} of type ${typeName} when looking for parent`)
           return undefined
         }
         return getRecordSaltoName(rec, typeByName[typeName])

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -99,10 +99,12 @@ const objectsRecordToInstances = (
           const objectRecords = objectToIdsToRecords[objectName]
           if (objectRecords === undefined) {
             log.warn(`failed to find object name ${objectName} when looking for master`)
+            return undefined
           }
           const rec = objectRecords[masterId]
-          if (objectRecords === undefined) {
+          if (rec === undefined) {
             log.warn(`failed to find record with id ${masterId} in ${objectRecords} when looking for master`)
+            return undefined
           }
           return getRecordSaltoName(rec, objectNameToObject[objectName])
         }).find(isDefined)

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -41,6 +41,7 @@ export type FilterContext = {
 export type DataManagementConfig = {
   name: string
   enabled: boolean
+  isNameBasedID: boolean
   includeNamespaces?: string[]
   includeObjects?: string[]
   excludeObjects?: string[]
@@ -146,6 +147,7 @@ export const configType = new ObjectType({
           {
             name: 'CPQ',
             enabled: false,
+            isNameBasedID: true,
             includeNamespaces: ['SBQQ'],
             includeObjects: [
               'Product2',

--- a/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
@@ -13,7 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, ElemID, ObjectType, PrimitiveTypes, PrimitiveType, CORE_ANNOTATIONS, InstanceElement, ReferenceExpression, isInstanceElement } from '@salto-io/adapter-api'
+import { 
+  Element, ElemID, ObjectType, PrimitiveTypes, PrimitiveType, CORE_ANNOTATIONS, InstanceElement, ReferenceExpression, isInstanceElement,
+} from '@salto-io/adapter-api'
 import { FilterWith } from '../../src/filter'
 import SalesforceClient from '../../src/client/client'
 import filterCreator from '../../src/filters/custom_object_instances_references'

--- a/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
@@ -13,8 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { 
-  Element, ElemID, ObjectType, PrimitiveTypes, PrimitiveType, CORE_ANNOTATIONS, InstanceElement, ReferenceExpression, isInstanceElement,
+import {
+  Element, ElemID, ObjectType, PrimitiveTypes, PrimitiveType, CORE_ANNOTATIONS, InstanceElement,
+  ReferenceExpression, isInstanceElement,
 } from '@salto-io/adapter-api'
 import { FilterWith } from '../../src/filter'
 import SalesforceClient from '../../src/client/client'

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -115,6 +115,7 @@ describe('Custom Object Instances filter', () => {
   const testNamespace = 'TestNamespace'
   const disabledNamespace = 'DisabledNamespace'
   const anotherNamespace = 'AnotherNamespace'
+  const nameBasedNamespace = 'NameBasedNamespace'
   const includeObjectName = 'IncludeThisObject'
   const excludeObjectName = 'TestNamespace__ExcludeMe__c'
   const excludeOverrideObjectName = 'ExcludeOverrideObject'
@@ -132,24 +133,34 @@ describe('Custom Object Instances filter', () => {
             {
               name: 'enabledWithNamespace',
               enabled: true,
+              isNameBasedID: false,
               includeNamespaces: [testNamespace],
               excludeObjects: [excludeObjectName],
             },
             {
               name: 'disabledWithNamespace',
               enabled: false,
+              isNameBasedID: false,
               includeNamespaces: [disabledNamespace],
             },
             {
               name: 'enabledWithNamespaceAndObject',
               enabled: true,
+              isNameBasedID: false,
               includeNamespaces: [anotherNamespace],
               includeObjects: [includeObjectName, excludeOverrideObjectName],
             },
             {
               name: 'enabledWithExcludeObject',
               enabled: true,
+              isNameBasedID: false,
               excludeObjects: [excludeOverrideObjectName],
+            },
+            {
+              name: 'enabledWithNameID',
+              enabled: true,
+              isNameBasedID: true,
+              includeNamespaces: [nameBasedNamespace],
             },
           ],
         } }

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -52,8 +52,8 @@ describe('Custom Object Instances filter', () => {
       FirstName: 'First',
       LastName: 'Last',
       TestField: 'Test',
-      Father: 'hijklmn',
-      Grandfather: 'hijklmn',
+      Parent: 'hijklmn',
+      Grandparent: 'hijklmn',
       Pricebook2Id: 'hijklmn',
       SBQQ__Location__c: 'Quote',
       SBQQ__DisplayOrder__c: 2,
@@ -71,8 +71,8 @@ describe('Custom Object Instances filter', () => {
       FirstName: 'Firstizen',
       LastName: 'Lastizen',
       TestField: 'testizen',
-      Father: 'badId',
-      Grandfather: 'abcdefg',
+      Parent: 'badId',
+      Grandparent: 'abcdefg',
       Pricebook2Id: 'abcdefg',
       SBQQ__Location__c: 'Quote',
       SBQQ__DisplayOrder__c: 3,
@@ -436,19 +436,19 @@ describe('Custom Object Instances filter', () => {
   describe('When some CustomObjects are from the nameBasedID namespace', () => {
     let elements: Element[]
 
-    const grandfatherObjectName = `${nameBasedNamespace}__grandfather__c`
-    const grandfatherObject = createCustomObject(grandfatherObjectName)
+    const grandparentObjectName = `${nameBasedNamespace}__grandparent__c`
+    const grandparentObject = createCustomObject(grandparentObjectName)
 
-    const fatherObjectName = `${nameBasedNamespace}__father__c`
-    const fatherObject = createCustomObject(
-      fatherObjectName,
+    const parentObjectName = `${nameBasedNamespace}__parent__c`
+    const parentObject = createCustomObject(
+      parentObjectName,
       {
-        Grandfather: {
+        Grandparent: {
           type: Types.primitiveDataTypes.MasterDetail,
           annotations: {
             [LABEL]: 'master field',
             [API_NAME]: 'MasterField',
-            [FIELD_ANNOTATIONS.REFERENCE_TO]: [grandfatherObjectName],
+            [FIELD_ANNOTATIONS.REFERENCE_TO]: [grandparentObjectName],
           },
         },
       }
@@ -463,7 +463,7 @@ describe('Custom Object Instances filter', () => {
           annotations: {
             [LABEL]: 'Pricebook2Id field',
             [API_NAME]: 'Pricebook2Id',
-            [FIELD_ANNOTATIONS.REFERENCE_TO]: [grandfatherObjectName],
+            [FIELD_ANNOTATIONS.REFERENCE_TO]: [grandparentObjectName],
           },
         },
       }
@@ -501,12 +501,12 @@ describe('Custom Object Instances filter', () => {
     const grandsonObject = createCustomObject(
       grandsonObjectName,
       {
-        Father: {
+        Parent: {
           type: Types.primitiveDataTypes.MasterDetail,
           annotations: {
             [LABEL]: 'master field',
             [API_NAME]: 'MasterField',
-            [FIELD_ANNOTATIONS.REFERENCE_TO]: [fatherObjectName],
+            [FIELD_ANNOTATIONS.REFERENCE_TO]: [parentObjectName],
           },
         },
       }
@@ -516,7 +516,7 @@ describe('Custom Object Instances filter', () => {
     const orphanObject = createCustomObject(
       orphanObjectName,
       {
-        Father: {
+        Parent: {
           type: Types.primitiveDataTypes.MasterDetail,
           annotations: {
             [LABEL]: 'master field',
@@ -529,7 +529,7 @@ describe('Custom Object Instances filter', () => {
 
     beforeEach(async () => {
       elements = [
-        grandfatherObject, fatherObject, grandsonObject, orphanObject,
+        grandparentObject, parentObject, grandsonObject, orphanObject,
         pricebookEntryObject, SBQQCustomActionObject,
       ]
       await filter.onFetch(elements)
@@ -541,11 +541,11 @@ describe('Custom Object Instances filter', () => {
       expect(elements.filter(e => isInstanceElement(e)).length).toEqual(12)
     })
 
-    describe('grandfather object (no master)', () => {
+    describe('grandparent object (no master)', () => {
       let instances: InstanceElement[]
       beforeEach(() => {
         instances = elements.filter(
-          e => isInstanceElement(e) && e.type === grandfatherObject
+          e => isInstanceElement(e) && e.type === grandparentObject
         ) as InstanceElement[]
       })
 
@@ -554,22 +554,22 @@ describe('Custom Object Instances filter', () => {
       })
     })
 
-    describe('father object (master is grandfather)', () => {
+    describe('parent object (master is grandparent)', () => {
       let instances: InstanceElement[]
       beforeEach(() => {
         instances = elements.filter(
-          e => isInstanceElement(e) && e.type === fatherObject
+          e => isInstanceElement(e) && e.type === parentObject
         ) as InstanceElement[]
       })
 
-      it('should base elemID on grandfatherName + father', () => {
-        const grandfatherName = TestCustomRecords[1].Name
-        const fatherName = TestCustomRecords[0].Name
-        expect(instances[0].elemID.name).toEqual(`${NAME_FROM_GET_ELEM_ID}${grandfatherName}___${fatherName}`)
+      it('should base elemID on grandparentName + parent', () => {
+        const grandparentName = TestCustomRecords[1].Name
+        const parentName = TestCustomRecords[0].Name
+        expect(instances[0].elemID.name).toEqual(`${NAME_FROM_GET_ELEM_ID}${grandparentName}___${parentName}`)
       })
     })
 
-    describe('grandson object (master is father who has grandfather as master)', () => {
+    describe('grandson object (master is parent who has grandparent as master)', () => {
       let instances: InstanceElement[]
       beforeEach(() => {
         instances = elements.filter(
@@ -577,14 +577,14 @@ describe('Custom Object Instances filter', () => {
         ) as InstanceElement[]
       })
 
-      it('should base elemID on grandfatherName + father + grandson if all exist', () => {
-        const grandfatherName = TestCustomRecords[0].Name
-        const fatherName = TestCustomRecords[1].Name
+      it('should base elemID on grandparentName + parent + grandson if all exist', () => {
+        const grandparentName = TestCustomRecords[0].Name
+        const parentName = TestCustomRecords[1].Name
         const grandsonName = TestCustomRecords[0].Name
-        expect(instances[0].elemID.name).toEqual(`${NAME_FROM_GET_ELEM_ID}${grandfatherName}___${fatherName}___${grandsonName}`)
+        expect(instances[0].elemID.name).toEqual(`${NAME_FROM_GET_ELEM_ID}${grandparentName}___${parentName}___${grandsonName}`)
       })
 
-      it('should base elemID on grandon name only if no record with references father id', () => {
+      it('should base elemID on grandon name only if no record with references parent id', () => {
         expect(instances[1].elemID.name).toEqual(`${NAME_FROM_GET_ELEM_ID}${TestCustomRecords[1].Name}`)
       })
     })


### PR DESCRIPTION
**Name-based ElemID logic:**
* If has no masterDetail fields ElemID is based on  record "Name" value
* If has masterDetail feilds ElemID is based on master's "Name" joined with record's "Name"
* Special support for PricebookEntry & CustomAction because masterDetail logic is not enough for their cases. This needs to be in the same PR cause currently they get "Name" as ElemID and duplicates can occur
 