### PR TITLE
SALTO-804 Resolve more references using Salesforce DescribeValueType API

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -58,6 +58,7 @@ import topicsForObjectsFilter from './filters/topics_for_objects'
 import globalValueSetFilter from './filters/global_value_sets'
 import instanceReferences from './filters/instance_references'
 import customObjectInstanceReferencesFilter from './filters/custom_object_instances_references'
+import foreignKeyReferences from './filters/foreign_key_references'
 import valueSetFilter from './filters/value_set'
 import customObjectTranslationFilter from './filters/custom_object_translation'
 import recordTypeFilter from './filters/record_type'
@@ -108,6 +109,7 @@ export const DEFAULT_FILTERS = [
   convertListsFilter,
   convertTypeFilter,
   instanceReferences,
+  foreignKeyReferences,
   // hideTypesFilter should come before customObjectsSplitFilter
   hideTypesFilter,
   customObjectsSplitFilter,

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -114,6 +114,7 @@ export const TOPICS_FOR_OBJECTS_ANNOTATION = 'topicsForObjects'
 export const HAS_META_FILE = 'hasMetaFile'
 export const FOLDER_TYPE = 'folderType'
 export const IS_FOLDER = 'isFolder'
+export const FOREIGN_KEY_DOMAIN = 'foreignKeyDomain'
 
 // Salesforce annotations
 export const LABEL = 'label'

--- a/packages/salesforce-adapter/src/filters/foreign_key_references.ts
+++ b/packages/salesforce-adapter/src/filters/foreign_key_references.ts
@@ -1,0 +1,118 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ElemID, Element, isObjectType, InstanceElement, ReferenceExpression,
+  isInstanceElement, isReferenceExpression,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { transformValues, TransformFunc } from '@salto-io/adapter-utils'
+import { values, collections } from '@salto-io/lowerdash'
+import { FilterCreator } from '../filter'
+import { groupByAPIName, ApiNameMapping } from './instance_references'
+import { FOREIGN_KEY_DOMAIN } from '../constants'
+import { apiName } from '../transformers/transformer'
+
+const { makeArray } = collections.array
+
+/**
+ * Convert foreign-key-domain annotations to reference expressions using the known metadata types.
+ *
+ * @param elements      The fetched elements
+ * @param typeToElemID  Known element ids by metadata type
+ */
+const convertAnnotationsToReferences = (
+  elements: Element[],
+  typeToElemID: Record<string, ElemID>,
+): void => {
+  const resolveTypeReference = (ref: string | ReferenceExpression):
+    string | ReferenceExpression => {
+    if (_.isString(ref)) {
+      const referenceElemId = typeToElemID[ref]
+      if (referenceElemId !== undefined) {
+        return new ReferenceExpression(referenceElemId)
+      }
+    }
+    return ref
+  }
+
+  elements
+    .filter(isObjectType)
+    .flatMap(obj => Object.values(obj.fields))
+    .filter(field => field.annotations[FOREIGN_KEY_DOMAIN] !== undefined)
+    .forEach(field => {
+      field.annotations[FOREIGN_KEY_DOMAIN] = field.annotations[FOREIGN_KEY_DOMAIN]
+        .map(resolveTypeReference)
+    })
+}
+
+/**
+ * Resolve references using the mapping genrated from the Salesforce DescribeValueType API.
+ *
+ * @param instance                The current instance being modified
+ * @param apiNameToElemIDs        Known element ids, mapped by API name and metadata type
+ */
+const resolveReferences = (
+  instance: InstanceElement,
+  apiNameToElemIDs: ApiNameMapping,
+): void => {
+  const transformPrimitive: TransformFunc = ({ value, field }) => {
+    if (field === undefined || value === undefined || !_.isString(value)) {
+      return value
+    }
+
+    const refTarget = makeArray(field.annotations[FOREIGN_KEY_DOMAIN])
+      .filter(isReferenceExpression)
+      .map((ref: ReferenceExpression) => apiNameToElemIDs[value]?.[
+        ref.elemId.typeName
+      ])
+      .find(values.isDefined)
+    return refTarget !== undefined ? new ReferenceExpression(refTarget) : value
+  }
+
+  // not using transformElement because we're editing the instance in-place
+  instance.value = transformValues({
+    values: instance.value,
+    type: instance.type,
+    transformFunc: transformPrimitive,
+    strict: false,
+  }) ?? instance.value
+}
+
+export const apiNameToElemID = (elements: Element[]): Record<string, ElemID> => (
+  Object.fromEntries(
+    elements
+      .filter(isObjectType)
+      .map(e => [apiName(e), e.elemID])
+  )
+)
+
+/**
+ * Use annotations generated from the DescribeValueType API foreignKeyDomain data to resolve
+ * names into reference expressions.
+ */
+const filter: FilterCreator = () => ({
+  onFetch: async (elements: Element[]) => {
+    const typeToElemID = apiNameToElemID(elements)
+    convertAnnotationsToReferences(elements, typeToElemID)
+
+    const apiNameToElemIDs = groupByAPIName(elements)
+    elements.filter(isInstanceElement).forEach(instance => {
+      resolveReferences(instance, apiNameToElemIDs)
+    })
+  },
+})
+
+export default filter

--- a/packages/salesforce-adapter/src/filters/hide_types.ts
+++ b/packages/salesforce-adapter/src/filters/hide_types.ts
@@ -28,7 +28,7 @@ import {
 
 const filterCreator: FilterCreator = ({ config }) => ({
   onFetch: async (elements: Element[]): Promise<void> => {
-    //  Skipping on the filter it hide is not enabled
+    //  Skipping on the filter if hide is not enabled
     if (!config[ENABLE_HIDE_TYPES_IN_NACLS]) {
       return
     }

--- a/packages/salesforce-adapter/src/filters/instance_references.ts
+++ b/packages/salesforce-adapter/src/filters/instance_references.ts
@@ -29,7 +29,6 @@ import { apiName, isCustomObject, metadataType } from '../transformers/transform
 export type ApiNameMapping = Record<string, Record<string, ElemID>>
 
 const fieldToTypeMappingDefs: Array<[ElemID, string]> = [
-  [new ElemID(SALESFORCE, 'Role', 'field', 'parentRole'), 'Role'],
   [new ElemID(SALESFORCE, 'ProfileApplicationVisibility', 'field', 'application'), 'CustomApplication'],
   [new ElemID(SALESFORCE, 'ProfileLayoutAssignment', 'field', 'layout'), 'Layout'],
   [new ElemID(SALESFORCE, 'ProfileFlowAccess', 'field', 'flow'), 'Flow'],
@@ -41,7 +40,6 @@ const fieldToTypeMappingDefs: Array<[ElemID, string]> = [
   [new ElemID(SALESFORCE, 'ProfileFieldLevelSecurity', 'field', 'field'), CUSTOM_FIELD],
   [new ElemID(SALESFORCE, 'ProfileObjectPermissions', 'field', 'object'), CUSTOM_OBJECT],
   [new ElemID(SALESFORCE, 'FlowActionCall', 'field', 'actionName'), 'WorkflowAlert'],
-  [new ElemID(SALESFORCE, 'WorkflowAlert', 'field', 'template'), 'EmailTemplate'],
   [new ElemID(SALESFORCE, 'WorkflowEmailRecipient', 'field', 'recipient'), 'Role'],
   [new ElemID(SALESFORCE, 'FilterItem', 'field', 'field'), CUSTOM_FIELD],
   [new ElemID(SALESFORCE, 'DashboardComponent', 'field', 'report'), 'Report'],

--- a/packages/salesforce-adapter/src/filters/workflow_rule.ts
+++ b/packages/salesforce-adapter/src/filters/workflow_rule.ts
@@ -82,6 +82,7 @@ const isWorkflowRule = (value: Values): value is WorkflowRule => (
  * @param action            The action to update
  * @param parentObjName     The name of the containing workflow rule's parent object
  * @param apiNameToElemIDs  Known element ids, mapped by API name and metadata type
+ * @param workflowRuleName  The name of the rule being processed
  */
 const convertActionToReference = (
   action: WorkflowActionReference,

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -48,6 +48,7 @@ import {
   HAS_META_FILE,
   IS_FOLDER,
   CUSTOM_OBJECT_ID_FIELD,
+  FOREIGN_KEY_DOMAIN,
 } from '../constants'
 import SalesforceClient from '../client/client'
 import { allMissingTypes, allMissingSubTypes } from './salesforce_types'
@@ -917,6 +918,11 @@ export const getValueTypeFieldElement = (parent: ObjectType, field: ValueTypeFie
       annotations[CORE_ANNOTATIONS.DEFAULT] = defaults.pop()
     }
   }
+
+  if (field.isForeignKey) {
+    annotations[FOREIGN_KEY_DOMAIN] = makeArray(field.foreignKeyDomain)
+  }
+
   return new Field(parent, field.name, naclFieldType, annotations)
 }
 

--- a/packages/salesforce-adapter/test/connection.ts
+++ b/packages/salesforce-adapter/test/connection.ts
@@ -43,8 +43,8 @@ export type MockValueTypeFieldInput =
 export const mockValueTypeField = (
   props: MockValueTypeFieldInput,
 ): ValueTypeField => ({
-  foreignKeyDomain: '',
-  isForeignKey: false,
+  foreignKeyDomain: props.foreignKeyDomain ?? '',
+  isForeignKey: props.isForeignKey ?? false,
   isNameField: false,
   minOccurs: 0,
   picklistValues: [],

--- a/packages/salesforce-adapter/test/filters/foreign_key_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/foreign_key_references.test.ts
@@ -1,0 +1,181 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { InstanceElement, ObjectType, ElemID, BuiltinTypes, ReferenceExpression, ListType } from '@salto-io/adapter-api'
+import { FilterWith } from '../../src/filter'
+import { INSTANCE_FULL_NAME_FIELD, SALESFORCE, METADATA_TYPE, FOREIGN_KEY_DOMAIN } from '../../src/constants'
+import filterCreator from '../../src/filters/foreign_key_references'
+import mockClient from '../client'
+
+// Based on the instance_reference test scenarios
+describe('foregin_key_references filter', () => {
+  const { client } = mockClient()
+
+  const filter = filterCreator({ client, config: {} }) as FilterWith<'onFetch'>
+
+  const parentObjFullName = 'parentFullName'
+  const parentObjFieldName = 'parentObj'
+  const invalidRefFieldName = 'invalidRef'
+  const nestedId = new ElemID(SALESFORCE, 'nested')
+  const objTypeID = new ElemID(SALESFORCE, 'obj')
+
+  let objType: ObjectType
+  let nestedType: ObjectType
+  let parentInstance: InstanceElement
+  let referrerInstance: InstanceElement
+  let instanceWithoutReferences: InstanceElement
+  let objTypeElements: ObjectType[]
+  let instanceElements: InstanceElement[]
+
+  const generateElements = (): void => {
+    nestedType = new ObjectType({
+      elemID: nestedId,
+      fields: {
+        [parentObjFieldName]: {
+          annotations: {
+            [FOREIGN_KEY_DOMAIN]: [objTypeID.typeName],
+          },
+          type: BuiltinTypes.STRING,
+        },
+        [invalidRefFieldName]: {
+          annotations: {
+            [FOREIGN_KEY_DOMAIN]: ['nonExistingType'],
+          },
+          type: BuiltinTypes.STRING,
+        },
+      },
+    })
+    objType = new ObjectType({
+      annotations: { [METADATA_TYPE]: 'obj' },
+      elemID: objTypeID,
+      fields: {
+        reg: { type: BuiltinTypes.STRING },
+        [parentObjFieldName]: {
+          annotations: {
+            [FOREIGN_KEY_DOMAIN]: [objTypeID.typeName],
+          },
+          type: BuiltinTypes.STRING,
+        },
+        [invalidRefFieldName]: {
+          annotations: {
+            [FOREIGN_KEY_DOMAIN]: ['nonExistingType'],
+          },
+          type: BuiltinTypes.STRING,
+        },
+        parentObjNested: { type: nestedType },
+        parentObjArr: {
+          annotations: {
+            [FOREIGN_KEY_DOMAIN]: [objTypeID.typeName],
+          },
+          type: new ListType(BuiltinTypes.STRING),
+        },
+      },
+    })
+
+    // Instances
+    parentInstance = new InstanceElement('parentInstance', objType, {
+      [INSTANCE_FULL_NAME_FIELD]: parentObjFullName,
+      reg: 'orig',
+      parentObjNested: {
+        nestedInst: 'InstRef',
+      },
+      parentObjArr: ['arrValue'],
+    })
+    referrerInstance = new InstanceElement('referrerInstance', objType, {
+      [INSTANCE_FULL_NAME_FIELD]: 'referrerInstance',
+      [parentObjFieldName]: parentObjFullName,
+      [invalidRefFieldName]: parentObjFullName,
+      reg: 'someRegularValue',
+      parentObjNested: {
+        [parentObjFieldName]: parentObjFullName,
+      },
+      parentObjArr: [parentObjFullName],
+    })
+    instanceWithoutReferences = new InstanceElement('instanceWithoutReferences', objType, {
+      [INSTANCE_FULL_NAME_FIELD]: 'noChangesInstance',
+      reg: 'somevalue',
+      [parentObjFieldName]: 'someRef',
+    })
+  }
+
+  beforeAll(async () => {
+    generateElements()
+    objTypeElements = [nestedType, objType].map(elem => elem)
+    instanceElements = [
+      parentInstance,
+      referrerInstance,
+      instanceWithoutReferences,
+    ].map(elem => elem)
+
+    const elements = [
+      ...objTypeElements,
+      ...instanceElements,
+    ]
+
+    await filter.onFetch(elements)
+  })
+
+  // Test the results
+  describe('convert values to references', () => {
+    it('should convert regular values to references', () => {
+      expect(instanceElements[1].value.parentObj).toBeInstanceOf(ReferenceExpression)
+      expect(instanceElements[1].value.parentObj.elemId.typeName).toEqual(objTypeID.typeName)
+    })
+
+    it('should convert nested objects to references', () => {
+      expect(
+        instanceElements[1].value.parentObjNested.parentObj
+      ).toBeInstanceOf(ReferenceExpression)
+    })
+
+    it('should convert objects in arrays to references', () => {
+      expect(_.head(instanceElements[1].value.parentObjArr))
+        .toBeInstanceOf(ReferenceExpression)
+    })
+
+    it('should not change an instance without valid references', () => {
+      expect(instanceElements[0]).toStrictEqual(parentInstance)
+      expect(instanceElements[2]).toStrictEqual(instanceWithoutReferences)
+    })
+
+    it('should not replace regular values', () => {
+      expect(instanceElements[0].value.reg).toEqual(parentInstance.value.reg)
+      expect(instanceElements[1].value.reg).toEqual(referrerInstance.value.reg)
+    })
+
+    it('should not replace a ref that has a foreign key annotation for a non-existing type', () => {
+      expect(instanceElements[1].value[invalidRefFieldName]).toEqual(parentObjFullName)
+    })
+
+    it('should convert foreignKeyDomain annotations to references when valid', () => {
+      expect(
+        objTypeElements[0].fields[parentObjFieldName].annotations[FOREIGN_KEY_DOMAIN][0]
+      ).toBeInstanceOf(ReferenceExpression)
+      expect(
+        objTypeElements[1].fields[parentObjFieldName].annotations[FOREIGN_KEY_DOMAIN][0]
+      ).toBeInstanceOf(ReferenceExpression)
+    })
+
+    it('should not convert foreignKeyDomain annotations to references when not valid', () => {
+      expect(
+        objTypeElements[0].fields[invalidRefFieldName].annotations[FOREIGN_KEY_DOMAIN]
+      ).toEqual(['nonExistingType'])
+      expect(
+        objTypeElements[1].fields[invalidRefFieldName].annotations[FOREIGN_KEY_DOMAIN]
+      ).toEqual(['nonExistingType'])
+    })
+  })
+})


### PR DESCRIPTION
Use the `isForeignKey` and `foreignKeyDomain` fields of the `DescribeValueType` API to identify references.
This is done by introducing a new annotation type for Salesforce - `FOREIGN_KEY_DOMAIN` (starting with a SF-specific one until we see a need to generalize), and using it to look for instances of relevant types for each of the annotated fields.
