### PR TITLE
SALTO-843: Improve DAG deleteNode performance

### DIFF
--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -16,7 +16,7 @@
 import wu from 'wu'
 import _ from 'lodash'
 import { Element, isObjectType, isInstanceElement, ChangeDataType, isField, isPrimitiveType, ChangeValidator, Change, ChangeError, DependencyChanger, ChangeGroupIdFunction, getChangeElement, isAdditionOrRemovalDiff, isFieldChange } from '@salto-io/adapter-api'
-import { DataNodeMap, GroupedNodeMap, DiffNode, mergeNodesToModify, removeEqualNodes, DiffGraph, removeEdges, Group } from '@salto-io/dag'
+import { DataNodeMap, GroupedNodeMap, DiffNode, mergeNodesToModify, removeEqualNodes, DiffGraph, Group } from '@salto-io/dag'
 import { logger } from '@salto-io/logging'
 import { expressions } from '@salto-io/workspace'
 import { PlanItem, addPlanItemAccessors, PlanItemId } from './plan_item'
@@ -140,7 +140,8 @@ const addModifyNodes = (
       // Some of the nodes were merged, this may enable other nodes to be merged
       // Note that with each iteration that changes the size we merge at least one node pair
       // so if we have N node pairs this recursion will run at most N times
-      return runMergeStep(await removeEdges(mergedGraph))
+      mergedGraph.clearEdges()
+      return runMergeStep(mergedGraph)
     }
     return mergedGraph
   }

--- a/packages/dag/src/diff.ts
+++ b/packages/dag/src/diff.ts
@@ -90,7 +90,9 @@ const mergeNodes = <T>(
   target.addNode(newId, deps, newData)
 
   // update reverse deps to new node
-  target.deleteNode(...oldIds).forEach(affected => target.get(affected).add(newId))
+  oldIds.forEach(id => {
+    target.deleteNode(id).forEach(affected => target.addEdge(affected, newId))
+  })
 }
 
 const tryCreateModificationNode = <T>(
@@ -159,12 +161,3 @@ export const mergeNodesToModify = <T>(target: DiffGraph<T>): void => {
       target,
     )
 }
-
-export const removeEdges = async <T>(target: DiffGraph<T>): Promise<DiffGraph<T>> => (
-  new DataNodeMap<DiffNode<T>>(
-    wu(target.keys()).map(id => [id, new Set()]),
-    new Map<collections.set.SetId, DiffNode<T>>(
-      wu(target.keys()).map(id => [id, target.getData(id)]),
-    ),
-  )
-)

--- a/packages/dag/src/group.ts
+++ b/packages/dag/src/group.ts
@@ -41,13 +41,12 @@ GroupedNodeMap<T> => log.time(() => {
       const mergeCandidate = mergeCandidates.get(key)
       if (mergeCandidate !== undefined) {
         const currentDeps = graph.get(mergeCandidate)
-        const filteredNewDeps = new Set(
-          wu(newDeps)
-            // Skip edges to mergeCandidate to avoid self reference cycle
-            .filter(dep => dep !== mergeCandidate)
-            .filter(dep => !currentDeps.has(dep))
-        )
-        if (filteredNewDeps.size === 0) {
+        const filteredNewDeps = wu(newDeps)
+          .filter(dep => !currentDeps.has(dep))
+          // Skip edges to mergeCandidate to avoid self reference cycle
+          .filter(dep => dep !== mergeCandidate)
+          .toArray()
+        if (filteredNewDeps.length === 0) {
           // Merging will not add new edges and therefore cannot create a cycle
           return mergeCandidate
         }

--- a/packages/dag/test/diff.test.ts
+++ b/packages/dag/test/diff.test.ts
@@ -16,7 +16,7 @@
 import wu from 'wu'
 import { collections } from '@salto-io/lowerdash'
 import { DataNodeMap } from '../src/nodemap'
-import { removeEqualNodes, DiffNode, DiffGraph, mergeNodesToModify, ModificationDiff, removeEdges } from '../src/diff'
+import { removeEqualNodes, DiffNode, DiffGraph, mergeNodesToModify, ModificationDiff } from '../src/diff'
 
 describe('DiffGraph functions', () => {
   const diffNode = <T>(
@@ -161,23 +161,6 @@ describe('DiffGraph functions', () => {
           expect(subject).toEqual(graph)
         })
       })
-    })
-  })
-
-  describe('removeEdges', () => {
-    beforeEach(async () => {
-      graph.addNode(1, [2, 3], diffNode(1, 'add', 'data1'))
-      graph.addNode(2, [3], diffNode(2, 'add', 'data2'))
-      graph.addNode(3, [], diffNode(3, 'add', 'data3'))
-
-      subject = await removeEdges(graph)
-    })
-    it('should remove all edges', () => {
-      expect(subject.edges()).toHaveLength(0)
-    })
-    it('should keep all data', () => {
-      expect(subject.size).toEqual(graph.size)
-      wu(graph.keys()).forEach(key => expect(graph.getData(key)).toEqual(subject.getData(key)))
     })
   })
 })


### PR DESCRIPTION
- Add reverse neighbors mapping to data structure to allow for faster deleteNode
- Add "clearEdges" to avoid the need to clone the graph in order to remove all edges