### PR TITLE
remove redundant --inspect-brk from jest launch command

### DIFF
--- a/packages/adapter-api/.vscode/launch.json
+++ b/packages/adapter-api/.vscode/launch.json
@@ -10,7 +10,6 @@
           "name": "Debug Jest Tests",
           "cwd": "${workspaceFolder}",
           "args": [
-              "--inspect-brk",
               "${workspaceRoot}/node_modules/.bin/jest",
               "--runInBand",
               "--config",
@@ -18,7 +17,6 @@
           ],
           "windows": {
               "args": [
-                  "--inspect-brk",
                   "${workspaceRoot}/node_modules/jest/bin/jest.js",
                   "--runInBand",
                   "--config",

--- a/packages/adapter-utils/.vscode/launch.json
+++ b/packages/adapter-utils/.vscode/launch.json
@@ -10,7 +10,6 @@
       "name": "Debug Jest Tests",
       "cwd": "${workspaceFolder}",
       "args": [
-        "--inspect-brk",
         "${workspaceRoot}/node_modules/.bin/jest",
         "--runInBand",
         "--config",
@@ -18,7 +17,6 @@
       ],
       "windows": {
         "args": [
-          "--inspect-brk",
           "${workspaceRoot}/node_modules/jest/bin/jest.js",
           "--runInBand",
           "--config",

--- a/packages/cli/.vscode/launch.json
+++ b/packages/cli/.vscode/launch.json
@@ -10,7 +10,6 @@
             "name": "Debug Jest Tests",
             "cwd": "${workspaceFolder}",
             "args": [
-                "--inspect-brk",
                 "${workspaceRoot}/node_modules/.bin/jest",
                 "--runInBand",
                 "--config",
@@ -18,7 +17,6 @@
             ],
             "windows": {
                 "args": [
-                    "--inspect-brk",
                     "${workspaceRoot}/node_modules/jest/bin/jest.js",
                     "--runInBand",
                     "--config",
@@ -37,7 +35,6 @@
               "RUN_E2E_TESTS": "1"
             },
             "args": [
-              "--inspect-brk",
               "${workspaceRoot}/node_modules/.bin/jest",
               "--runInBand",
               "--config",
@@ -46,7 +43,6 @@
             "windows": {
                 "args": [
                   "RUN_E2E_TESTS=1",
-                  "--inspect-brk",
                   "${workspaceRoot}/node_modules/jest/bin/jest.js",
                   "--runInBand",
                   "--config",

--- a/packages/core/.vscode/launch.json
+++ b/packages/core/.vscode/launch.json
@@ -10,7 +10,6 @@
             "name": "Debug Jest Tests",
             "cwd": "${workspaceFolder}",
             "args": [
-                "--inspect-brk",
                 "${workspaceRoot}/node_modules/.bin/jest",
                 "--runInBand",
                 "--config",
@@ -18,7 +17,6 @@
             ],
             "windows": {
                 "args": [
-                    "--inspect-brk",
                     "${workspaceRoot}/node_modules/jest/bin/jest.js",
                     "--runInBand",
                     "--config",

--- a/packages/dag/.vscode/launch.json
+++ b/packages/dag/.vscode/launch.json
@@ -10,7 +10,6 @@
           "name": "Debug Jest Tests",
           "cwd": "${workspaceFolder}",
           "args": [
-              "--inspect-brk",
               "${workspaceRoot}/node_modules/.bin/jest",
               "--runInBand",
               "--config",
@@ -18,7 +17,6 @@
           ],
           "windows": {
               "args": [
-                  "--inspect-brk",
                   "${workspaceRoot}/node_modules/jest/bin/jest.js",
                   "--runInBand",
                   "--config",

--- a/packages/hubspot-adapter/.vscode/launch.json
+++ b/packages/hubspot-adapter/.vscode/launch.json
@@ -10,7 +10,6 @@
       "name": "Debug Jest Tests",
       "cwd": "${workspaceFolder}",
       "args": [
-        "--inspect-brk",
         "${workspaceRoot}/node_modules/.bin/jest",
         "--runInBand",
         "--config",
@@ -18,7 +17,6 @@
       ],
       "windows": {
         "args": [
-          "--inspect-brk",
           "${workspaceRoot}/node_modules/jest/bin/jest.js",
           "--runInBand",
           "--config",

--- a/packages/lang-server/.vscode/launch.json
+++ b/packages/lang-server/.vscode/launch.json
@@ -19,7 +19,6 @@
             "name": "Debug Jest Tests",
             "cwd": "${workspaceFolder}",
             "args": [
-                "--inspect-brk",
                 "${workspaceRoot}/node_modules/.bin/jest",
                 "--runInBand",
                 "--config",

--- a/packages/logging/.vscode/launch.json
+++ b/packages/logging/.vscode/launch.json
@@ -10,7 +10,6 @@
           "name": "Debug Jest Tests",
           "cwd": "${workspaceFolder}",
           "args": [
-              "--inspect-brk",
               "${workspaceRoot}/node_modules/.bin/jest",
               "--runInBand",
               "--config",
@@ -18,7 +17,6 @@
           ],
           "windows": {
               "args": [
-                  "--inspect-brk",
                   "${workspaceRoot}/node_modules/jest/bin/jest.js",
                   "--runInBand",
                   "--config",

--- a/packages/netsuite-adapter/.vscode/launch.json
+++ b/packages/netsuite-adapter/.vscode/launch.json
@@ -7,7 +7,6 @@
       "name": "Debug Jest Tests",
       "cwd": "${workspaceFolder}",
       "args": [
-        "--inspect-brk",
         "${workspaceRoot}/node_modules/.bin/jest",
         "--runInBand",
         "--config",
@@ -15,7 +14,6 @@
       ],
       "windows": {
         "args": [
-          "--inspect-brk",
           "${workspaceRoot}/node_modules/jest/bin/jest.js",
           "--runInBand",
           "--config",

--- a/packages/salesforce-adapter/.vscode/launch.json
+++ b/packages/salesforce-adapter/.vscode/launch.json
@@ -10,7 +10,6 @@
       "name": "Debug Jest Tests",
       "cwd": "${workspaceFolder}",
       "args": [
-        "--inspect-brk",
         "${workspaceRoot}/node_modules/.bin/jest",
         "--runInBand",
         "--config",
@@ -18,7 +17,6 @@
       ],
       "windows": {
         "args": [
-          "--inspect-brk",
           "${workspaceRoot}/node_modules/jest/bin/jest.js",
           "--runInBand",
           "--config",
@@ -37,7 +35,6 @@
           "RUN_E2E_TESTS": "1"
         },
         "args": [
-          "--inspect-brk",
           "${workspaceRoot}/node_modules/.bin/jest",
           "--runInBand",
           "--config",
@@ -46,7 +43,6 @@
         "windows": {
             "args": [
               "RUN_E2E_TESTS=1",
-              "--inspect-brk",
               "${workspaceRoot}/node_modules/jest/bin/jest.js",
               "--runInBand",
               "--config",

--- a/packages/vscode/.vscode/launch.json
+++ b/packages/vscode/.vscode/launch.json
@@ -19,7 +19,6 @@
             "name": "Debug Jest Tests",
             "cwd": "${workspaceFolder}",
             "args": [
-                "--inspect-brk",
                 "${workspaceRoot}/node_modules/.bin/jest",
                 "--runInBand",
                 "--config",

--- a/packages/workspace/.vscode/launch.json
+++ b/packages/workspace/.vscode/launch.json
@@ -10,7 +10,6 @@
             "name": "Debug Jest Tests",
             "cwd": "${workspaceFolder}",
             "args": [
-                "--inspect-brk",
                 "${workspaceRoot}/node_modules/.bin/jest",
                 "--runInBand",
                 "--config",
@@ -18,7 +17,6 @@
             ],
             "windows": {
                 "args": [
-                    "--inspect-brk",
                     "${workspaceRoot}/node_modules/jest/bin/jest.js",
                     "--runInBand",
                     "--config",


### PR DESCRIPTION
seems like newer versions of vscode don't handle this extra `--inspect-brk` well
old versions should handle the command without it (seems to work for other commands)