### PR TITLE
SALTO-858 - Convert referenceTo to reference expressions

### DIFF
--- a/packages/cli/e2e_test/NACL/salto.config/salesforce.nacl
+++ b/packages/cli/e2e_test/NACL/salto.config/salesforce.nacl
@@ -5,6 +5,7 @@ salesforce {
     "ReportFolder",
     "Dashboard",
     "DashboardFolder",
+    "Profile",
   ]
   instancesRegexSkippedList = [
     "^EmailTemplate.MarketoEmailTemplates",

--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import {
   ObjectType, ElemID, InstanceElement, Field, Value, Element, Values, BuiltinTypes,
-  isInstanceElement, ReferenceExpression, CORE_ANNOTATIONS,
+  isInstanceElement, isReferenceExpression, ReferenceExpression, CORE_ANNOTATIONS,
   TypeElement, isObjectType, getRestriction, StaticFile, isStaticFile, getChangeElement,
 } from '@salto-io/adapter-api'
 import {
@@ -24,7 +24,7 @@ import {
   findObjectType, naclCase,
 } from '@salto-io/adapter-utils'
 import { MetadataInfo, RetrieveResult } from 'jsforce'
-import { collections } from '@salto-io/lowerdash'
+import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
 import { CredsLease } from '@salto-io/e2e-credentials-store'
 import { testHelpers } from '../index'
 import * as constants from '../src/constants'
@@ -71,7 +71,17 @@ import {
 
 const { makeArray } = collections.array
 const { PROFILE_METADATA_TYPE } = constants
+const { isDefined } = lowerDashValues
 
+const extractReferenceTo = (annotations: Values): (string | undefined)[] => (
+  makeArray(annotations[constants.FIELD_ANNOTATIONS.REFERENCE_TO]).map(
+    (ref: ReferenceExpression | string): string | undefined => (
+      isReferenceExpression(ref)
+        ? ref.elemId.typeName
+        : ref
+    )
+  )
+)
 
 describe('Salesforce adapter E2E with real account', () => {
   let client: SalesforceClient
@@ -167,7 +177,7 @@ describe('Salesforce adapter E2E with real account', () => {
 
         // Test lookup reference_to annotation
         expect(
-          lead.fields.OwnerId.annotations[constants.FIELD_ANNOTATIONS.REFERENCE_TO]
+          extractReferenceTo(lead.fields.OwnerId.annotations)
         ).toEqual(['Group', 'User'])
 
         // Test lookup allow_lookup_record_deletion annotation
@@ -1253,7 +1263,7 @@ describe('Salesforce adapter E2E with real account', () => {
 
       const testLookup = (annotations: Values): void => {
         expect(annotations[constants.LABEL]).toBe('Lookup label')
-        expect(annotations[constants.FIELD_ANNOTATIONS.REFERENCE_TO]).toEqual(['Opportunity'])
+        expect(extractReferenceTo(annotations)).toEqual(['Opportunity'])
         expect(annotations[CORE_ANNOTATIONS.REQUIRED]).toBe(false)
         const lookupFilter = annotations[constants.FIELD_ANNOTATIONS.LOOKUP_FILTER]
         expect(lookupFilter).toBeDefined()
@@ -1280,7 +1290,7 @@ describe('Salesforce adapter E2E with real account', () => {
 
       const testMasterDetail = (annotations: Values): void => {
         expect(annotations[constants.LABEL]).toBe('MasterDetail label')
-        expect(annotations[constants.FIELD_ANNOTATIONS.REFERENCE_TO]).toEqual(['Case'])
+        expect(extractReferenceTo(annotations)).toEqual(['Case'])
         expect(annotations[constants.FIELD_ANNOTATIONS.REPARENTABLE_MASTER_DETAIL])
           .toBe(true)
         expect(annotations[constants.FIELD_ANNOTATIONS.WRITE_REQUIRES_MASTER_READ])
@@ -1563,19 +1573,33 @@ describe('Salesforce adapter E2E with real account', () => {
             },
           })
 
-          // Resolve GVS valueSetName reference expression
-          const normalizeGVSReference = (ref: ReferenceExpression): string | undefined => {
-            const elem = findElement(result, ref.elemId)
-            return elem ? apiName(elem) : undefined
+          // Resolve reference expression before deploy
+          const normalizeReference = (
+            ref: ReferenceExpression | string | undefined
+          ): string | undefined => {
+            if (isReferenceExpression(ref)) {
+              const elem = findElement(result, ref.elemId)
+              return elem
+                // adding fallback for partially-resolved elements
+                ? apiName(elem) || elem.elemID.typeName
+                : undefined
+            }
+            return ref
           }
-          Object.values(newCustomObject.fields)
-            .filter(f => f.annotations[constants.VALUE_SET_FIELDS.VALUE_SET_NAME]
-              instanceof ReferenceExpression)
-            .forEach(f => {
-              f.annotations[constants.VALUE_SET_FIELDS.VALUE_SET_NAME] = normalizeGVSReference(
-                f.annotations[constants.VALUE_SET_FIELDS.VALUE_SET_NAME]
-              )
-            })
+
+          const potentialReferenceAnnotations = [
+            constants.VALUE_SET_FIELDS.VALUE_SET_NAME,
+            constants.FIELD_ANNOTATIONS.REFERENCE_TO,
+          ]
+          potentialReferenceAnnotations.forEach(annotationName => {
+            Object.values(newCustomObject.fields)
+              .filter(f => makeArray(f.annotations[annotationName]).some(isReferenceExpression))
+              .forEach(f => {
+                f.annotations[annotationName] = Array.isArray(f.annotations[annotationName])
+                  ? f.annotations[annotationName].map(normalizeReference).filter(isDefined)
+                  : normalizeReference(f.annotations[annotationName])
+              })
+          })
 
           await removeElementIfAlreadyExists(client, customFieldsObject)
           post = await createElement(adapter, newCustomObject)
@@ -2383,7 +2407,9 @@ describe('Salesforce adapter E2E with real account', () => {
           annotations: {
             [constants.API_NAME]: lookupFieldApiFullName,
             [constants.LABEL]: fieldName,
-            [constants.FIELD_ANNOTATIONS.REFERENCE_TO]: ['Case'],
+            [constants.FIELD_ANNOTATIONS.REFERENCE_TO]: [
+              'Case',
+            ],
           },
         } },
         annotations: {

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -56,6 +56,7 @@ import settingsFilter from './filters/settings_type'
 import workflowFilter from './filters/workflow'
 import topicsForObjectsFilter from './filters/topics_for_objects'
 import globalValueSetFilter from './filters/global_value_sets'
+import referenceAnnotations from './filters/reference_annotations'
 import instanceReferences from './filters/instance_references'
 import customObjectInstanceReferencesFilter from './filters/custom_object_instances_references'
 import foreignKeyReferences from './filters/foreign_key_references'
@@ -111,6 +112,9 @@ export const DEFAULT_FILTERS = [
   convertListsFilter,
   convertTypeFilter,
   instanceReferences,
+  // should run after custom_object_instances for now
+  referenceAnnotations,
+  // foreignLeyReferences should come after referenceAnnotations
   foreignKeyReferences,
   // hideTypesFilter should come before customObjectsSplitFilter
   hideTypesFilter,

--- a/packages/salesforce-adapter/src/filters/reference_annotations.ts
+++ b/packages/salesforce-adapter/src/filters/reference_annotations.ts
@@ -1,0 +1,79 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ElemID, Element, Field, isObjectType, ReferenceExpression, ObjectType,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
+import { FilterCreator } from '../filter'
+import { FIELD_ANNOTATIONS, FOREIGN_KEY_DOMAIN } from '../constants'
+import { apiName } from '../transformers/transformer'
+
+const { makeArray } = collections.array
+const { REFERENCE_TO } = FIELD_ANNOTATIONS
+
+/**
+ * Convert annotations to reference expressions using the known metadata types.
+ *
+ * @param elements      The fetched elements
+ * @param typeToElemID  Known element ids by metadata type
+ */
+const convertAnnotationsToReferences = (
+  elements: Element[],
+  typeToElemID: Record<string, ElemID>,
+  annotationName: string,
+): void => {
+  const resolveTypeReference = (ref: string | ReferenceExpression):
+    string | ReferenceExpression => {
+    if (_.isString(ref)) {
+      const referenceElemId = typeToElemID[ref]
+      if (referenceElemId !== undefined) {
+        return new ReferenceExpression(referenceElemId)
+      }
+    }
+    return ref
+  }
+
+  elements
+    .filter(isObjectType)
+    .flatMap((obj: ObjectType) => Object.values(obj.fields))
+    .filter((field: Field) => field.annotations[annotationName] !== undefined)
+    .forEach((field: Field): void => {
+      field.annotations[annotationName] = makeArray(field.annotations[annotationName])
+        .map(resolveTypeReference)
+    })
+}
+
+export const apiNameToElemID = (elements: Element[]): Record<string, ElemID> => (
+  Object.fromEntries(
+    elements
+      .filter(isObjectType)
+      .map(e => [apiName(e), e.elemID])
+  )
+)
+
+/**
+ * Convert referenceTo and foreignKeyDomain annotations into reference expressions.
+ */
+const filter: FilterCreator = () => ({
+  onFetch: async (elements: Element[]) => {
+    const typeToElemID = apiNameToElemID(elements)
+    convertAnnotationsToReferences(elements, typeToElemID, REFERENCE_TO)
+    convertAnnotationsToReferences(elements, typeToElemID, FOREIGN_KEY_DOMAIN)
+  },
+})
+
+export default filter

--- a/packages/salesforce-adapter/src/filters/reference_annotations.ts
+++ b/packages/salesforce-adapter/src/filters/reference_annotations.ts
@@ -34,7 +34,7 @@ const { REFERENCE_TO } = FIELD_ANNOTATIONS
 const convertAnnotationsToReferences = (
   elements: Element[],
   typeToElemID: Record<string, ElemID>,
-  annotationName: string,
+  annotationNames: string[],
 ): void => {
   const resolveTypeReference = (ref: string | ReferenceExpression):
     string | ReferenceExpression => {
@@ -50,10 +50,11 @@ const convertAnnotationsToReferences = (
   elements
     .filter(isObjectType)
     .flatMap((obj: ObjectType) => Object.values(obj.fields))
-    .filter((field: Field) => field.annotations[annotationName] !== undefined)
+    .filter((field: Field) => annotationNames.some(name => field.annotations[name] !== undefined))
     .forEach((field: Field): void => {
-      field.annotations[annotationName] = makeArray(field.annotations[annotationName])
-        .map(resolveTypeReference)
+      annotationNames.filter(name => field.annotations[name] !== undefined).forEach(name => {
+        field.annotations[name] = makeArray(field.annotations[name]).map(resolveTypeReference)
+      })
     })
 }
 
@@ -71,8 +72,7 @@ export const apiNameToElemID = (elements: Element[]): Record<string, ElemID> => 
 const filter: FilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
     const typeToElemID = apiNameToElemID(elements)
-    convertAnnotationsToReferences(elements, typeToElemID, REFERENCE_TO)
-    convertAnnotationsToReferences(elements, typeToElemID, FOREIGN_KEY_DOMAIN)
+    convertAnnotationsToReferences(elements, typeToElemID, [REFERENCE_TO, FOREIGN_KEY_DOMAIN])
   },
 })
 

--- a/packages/salesforce-adapter/test/filters/foreign_key_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/foreign_key_references.test.ts
@@ -17,6 +17,7 @@ import _ from 'lodash'
 import { InstanceElement, ObjectType, ElemID, BuiltinTypes, ReferenceExpression, ListType } from '@salto-io/adapter-api'
 import { FilterWith } from '../../src/filter'
 import { INSTANCE_FULL_NAME_FIELD, SALESFORCE, METADATA_TYPE, FOREIGN_KEY_DOMAIN } from '../../src/constants'
+import referenceAnnotationfilterCreator from '../../src/filters/reference_annotations'
 import filterCreator from '../../src/filters/foreign_key_references'
 import mockClient from '../client'
 
@@ -24,6 +25,7 @@ import mockClient from '../client'
 describe('foregin_key_references filter', () => {
   const { client } = mockClient()
 
+  const refAnnotationFilter = referenceAnnotationfilterCreator({ client, config: {} }) as FilterWith<'onFetch'>
   const filter = filterCreator({ client, config: {} }) as FilterWith<'onFetch'>
 
   const parentObjFullName = 'parentFullName'
@@ -125,6 +127,8 @@ describe('foregin_key_references filter', () => {
       ...instanceElements,
     ]
 
+    // run the reference annotation filter to resolve the FOREIGN_KEY_DOMAIN references
+    await refAnnotationFilter.onFetch(elements)
     await filter.onFetch(elements)
   })
 

--- a/packages/salesforce-adapter/test/filters/reference_annotations.test.ts
+++ b/packages/salesforce-adapter/test/filters/reference_annotations.test.ts
@@ -1,0 +1,89 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, BuiltinTypes, ReferenceExpression } from '@salto-io/adapter-api'
+import { SALESFORCE, METADATA_TYPE, FIELD_ANNOTATIONS, FOREIGN_KEY_DOMAIN } from '../../src/constants'
+import { FilterWith } from '../../src/filter'
+import mockClient from '../client'
+import filterCreator from '../../src/filters/reference_annotations'
+
+describe('reference_annotations filter', () => {
+  // Definitions
+  const parentObjFieldName = 'parentObj'
+  const nestedId = new ElemID(SALESFORCE, 'nested')
+  const objTypeID = new ElemID(SALESFORCE, 'obj')
+
+  const { client } = mockClient()
+  const filter = filterCreator({ client, config: {} }) as FilterWith<'onFetch'>
+
+  let nestedType: ObjectType
+  let objType: ObjectType
+  beforeAll(async () => {
+    nestedType = new ObjectType({
+      elemID: nestedId,
+      fields: {
+        [parentObjFieldName]: {
+          annotations: {
+            [FIELD_ANNOTATIONS.REFERENCE_TO]: [
+              'obj',
+              'unknown',
+            ],
+            [FOREIGN_KEY_DOMAIN]: [
+              objTypeID.typeName,
+              'something',
+            ],
+          },
+          type: BuiltinTypes.STRING,
+        },
+      },
+    })
+    objType = new ObjectType({
+      annotations: { [METADATA_TYPE]: 'obj' },
+      elemID: objTypeID,
+      fields: {
+        reg: { type: BuiltinTypes.STRING },
+      },
+    })
+    const elements = [nestedType, objType]
+    await filter.onFetch(elements)
+  })
+
+  describe('replace values', () => {
+    it('should convert REFERENCE_TO to reference when found', () => {
+      expect(
+        nestedType.fields[parentObjFieldName].annotations[FIELD_ANNOTATIONS.REFERENCE_TO]
+      ).toHaveLength(2)
+      expect(
+        nestedType.fields[parentObjFieldName].annotations[FIELD_ANNOTATIONS.REFERENCE_TO][0]
+      ).toBeInstanceOf(ReferenceExpression)
+      expect(
+        nestedType.fields[parentObjFieldName].annotations[FIELD_ANNOTATIONS.REFERENCE_TO][0].elemId
+      ).toEqual(objTypeID)
+      expect(nestedType.fields[parentObjFieldName].annotations[FIELD_ANNOTATIONS.REFERENCE_TO][1]).toEqual('unknown')
+    })
+    it('should convert FOREIGN_KEY_DOMAIN to reference when found', () => {
+      expect(
+        nestedType.fields[parentObjFieldName].annotations[FOREIGN_KEY_DOMAIN]
+      ).toHaveLength(2)
+      expect(
+        nestedType.fields[parentObjFieldName].annotations[FOREIGN_KEY_DOMAIN][0]
+      ).toBeInstanceOf(ReferenceExpression)
+      expect(
+        nestedType.fields[parentObjFieldName].annotations[FOREIGN_KEY_DOMAIN][0].elemId
+      ).toEqual(objTypeID)
+      expect(nestedType.fields[parentObjFieldName].annotations[FOREIGN_KEY_DOMAIN][1]).toEqual('something')
+    })
+  })
+})


### PR DESCRIPTION
Note: This needs to be run on a clean environment in order for existing annotations to be converted to references.