### PR TITLE
Fix SFDC e2e setup failures

### DIFF
--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -111,9 +111,13 @@ describe('Salesforce adapter E2E with real account', () => {
   const lookupFieldName = `Quebec${randomString}__c`
   const masterDetailFieldName = `Romeo${randomString}__c`
   const formulaFieldName = 'Whiskey__c'
+  const summaryFieldName = 'Case.summary__c'
 
   const removeCustomObjectsWithVariousFields = async (): Promise<void> => {
     const deleteCustomObject = async (objectName: string): Promise<void> => {
+      if (await objectExists(client, constants.CUSTOM_FIELD, summaryFieldName)) {
+        await client.delete(constants.CUSTOM_FIELD, summaryFieldName)
+      }
       if (await objectExists(client, constants.CUSTOM_OBJECT, objectName)) {
         await client.delete(constants.CUSTOM_OBJECT, objectName)
       }
@@ -2545,8 +2549,7 @@ describe('Salesforce adapter E2E with real account', () => {
           })
 
           it('rollup summary', async () => {
-            const rollupSummaryFieldName = 'summary'
-            const rollupSummaryFieldApiName = `${rollupSummaryFieldName}__c`
+            const rollupSummaryFieldName = summaryFieldName.split('.')[1]
 
             const findCustomCase = (): ObjectType => {
               const caseObjects = findElements(result, 'Case') as ObjectType[]
@@ -2573,8 +2576,8 @@ describe('Salesforce adapter E2E with real account', () => {
               })
               return caseAfterFieldRemoval
             }
-            if (await objectExists(client, constants.CUSTOM_OBJECT, 'Case', [rollupSummaryFieldApiName])) {
-              origCase = await removeRollupSummaryFieldFromCase(origCase, rollupSummaryFieldApiName)
+            if (await objectExists(client, constants.CUSTOM_OBJECT, 'Case', [rollupSummaryFieldName])) {
+              origCase = await removeRollupSummaryFieldFromCase(origCase, rollupSummaryFieldName)
             }
 
             const addRollupSummaryField = async (): Promise<ObjectType> => {
@@ -2586,7 +2589,7 @@ describe('Salesforce adapter E2E with real account', () => {
                 {
                   [CORE_ANNOTATIONS.REQUIRED]: false,
                   [constants.LABEL]: 'Summary label',
-                  [constants.API_NAME]: apiNameAnno('Case', rollupSummaryFieldApiName),
+                  [constants.API_NAME]: apiNameAnno('Case', rollupSummaryFieldName),
                   [constants.FIELD_ANNOTATIONS.SUMMARIZED_FIELD]: `${customObjectAddFieldsName}.${currencyFieldName}`,
                   [constants.FIELD_ANNOTATIONS.SUMMARY_FOREIGN_KEY]: `${customObjectAddFieldsName}.${masterDetailApiName}`,
                   [constants.FIELD_ANNOTATIONS.SUMMARY_OPERATION]: 'max',
@@ -2610,7 +2613,7 @@ describe('Salesforce adapter E2E with real account', () => {
             }
             const verifyRollupSummaryField = async (): Promise<void> => {
               const fetchedRollupSummary = await getMetadata(client, constants.CUSTOM_FIELD,
-                `Case.${rollupSummaryFieldApiName}`) as CustomField
+                `Case.${rollupSummaryFieldName}`) as CustomField
               expect(_.get(fetchedRollupSummary, 'summarizedField'))
                 .toEqual(`${customObjectAddFieldsName}.${currencyFieldName}`)
               expect(_.get(fetchedRollupSummary, 'summaryForeignKey'))


### PR DESCRIPTION
During setup the test suite attempts to remove a custom object but it does not
remove a field that references that custom object first, so if that fields exists
the setup will fail and the whole suite will fail with it