### PR TITLE
minor refactor to dag after perf PR

### DIFF
--- a/packages/dag/src/group.ts
+++ b/packages/dag/src/group.ts
@@ -28,8 +28,9 @@ export interface Group<T> {
 
 export type GroupedNodeMap<T> = DataNodeMap<Group<T>>
 
-export const buildGroupedGraph = <T>(source: DataNodeMap<T>, groupKey: (id: NodeId) => string):
-GroupedNodeMap<T> => log.time(() => {
+export const buildGroupedGraph = <T>(
+  source: DataNodeMap<T>, groupKey: (id: NodeId) => string
+): GroupedNodeMap<T> => log.time(() => {
     const mergeCandidates = new Map<string, NodeId>()
     const itemToGroupId = new Map<NodeId, NodeId>()
 

--- a/packages/lowerdash/src/collections/map.ts
+++ b/packages/lowerdash/src/collections/map.ts
@@ -21,12 +21,16 @@ export class DefaultMap<K, V> extends Map<K, V> {
   }
 
   get(key: K): V {
-    if (this.has(key)) {
-      return super.get(key) as V
+    let result = super.get(key)
+    if (result === undefined) {
+      result = this.initDefault(key)
+      this.set(key, result)
     }
-    const res = this.initDefault(key)
-    this.set(key, res)
-    return res
+    return result
+  }
+
+  getOrUndefined(key: K): V | undefined {
+    return super.get(key)
   }
 }
 

--- a/packages/lowerdash/test/collections/map.test.ts
+++ b/packages/lowerdash/test/collections/map.test.ts
@@ -87,4 +87,51 @@ describe('DefaultMap', () => {
       })
     })
   })
+
+  describe('getOrUndefined', () => {
+    let subject: DefaultMap<string, {}>
+    let initDefault: jest.Mock<{}>
+    const initDefaultValue = {}
+    let result: {} | undefined
+
+    beforeEach(() => {
+      initDefault = jest.fn(() => initDefaultValue)
+      subject = new DefaultMap<string, {}>(initDefault)
+    })
+
+    describe('when the key exists', () => {
+      const v = {}
+
+      beforeEach(() => {
+        subject.set('x', v)
+        result = subject.getOrUndefined('x')
+      })
+
+      it('should return it', () => {
+        expect(result).toBe(v)
+      })
+
+      it('should not call the initDefault function', () => {
+        expect(initDefault).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the key does not exist', () => {
+      beforeEach(() => {
+        result = subject.getOrUndefined('x')
+      })
+
+      it('should not call the initDefault function', () => {
+        expect(initDefault).not.toHaveBeenCalled()
+      })
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined()
+      })
+
+      it('should not add the key to the map', () => {
+        expect(subject.has('x')).toBeFalsy()
+      })
+    })
+  })
 })


### PR DESCRIPTION
Make `AbstractNodeMap` abstract, and extract reverse map to `NodeMap`

The idea behind the split classes is that both the base and derived classes are consistent in terms of behavior - the base works on its own (assuming `getReverse` is implemented).

IMO adding the reverse map code inline, which is an optimization, makes the entire flow more complex and harder to understand.

In the split version, If you read the code by jumping between the base and derived version, it is admittedly even harder to understand. But if you read the base class first, understand how it works without optimizations, and only then add the optimization, it should be easier as a whole.