### PR TITLE
Resolve REFERENCE_TO annotations before custom-object-instance filters

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -85,6 +85,9 @@ export const DEFAULT_FILTERS = [
   workflowFilter,
   // customObjectsFilter depends on missingFieldsFilter and settingsFilter
   customObjectsFilter,
+  // referenceAnnotations should run before foreignLeyReferences, custom_object_instances,
+  // custom_object_instances_references
+  referenceAnnotations,
   // customObjectsInstancesFilter depends on customObjectsFilter
   customObjectsInstancesFilter,
   removeFieldsFilter,
@@ -112,9 +115,6 @@ export const DEFAULT_FILTERS = [
   convertListsFilter,
   convertTypeFilter,
   instanceReferences,
-  // should run after custom_object_instances for now
-  referenceAnnotations,
-  // foreignLeyReferences should come after referenceAnnotations
   foreignKeyReferences,
   // hideTypesFilter should come before customObjectsSplitFilter
   hideTypesFilter,

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -19,6 +19,7 @@ import { FilterWith } from '../../src/filter'
 import SalesforceClient from '../../src/client/client'
 import Connection from '../../src/client/jsforce'
 import filterCreator from '../../src/filters/custom_objects_instances'
+import referenceAnnotationfilterCreator from '../../src/filters/reference_annotations'
 import mockAdapter from '../adapter'
 import {
   LABEL, CUSTOM_OBJECT, API_NAME, METADATA_TYPE, SALESFORCE, INSTALLED_PACKAGES_PATH,
@@ -37,6 +38,7 @@ describe('Custom Object Instances filter', () => {
   let client: SalesforceClient
   type FilterType = FilterWith<'onFetch'>
   let filter: FilterType
+  let refAnnotationFilter: FilterType
 
   const NAME_FROM_GET_ELEM_ID = 'getElemIDPrefix'
   const mockGetElemIdFunc = (adapterName: string, _serviceIds: ServiceIds, name: string):
@@ -199,6 +201,7 @@ describe('Custom Object Instances filter', () => {
           ],
         } }
     ) as FilterType
+    refAnnotationFilter = referenceAnnotationfilterCreator({ client, config: {} }) as FilterType
     basicQueryImplementation = jest.fn().mockImplementation(async () => (
       {
         totalSize: 2,
@@ -227,6 +230,8 @@ describe('Custom Object Instances filter', () => {
         notConfiguredObj, includedNameSpaceObj, includedInAnotherNamespaceObj,
         includedObject, excludedObject, excludeOverrideObject,
       ]
+      // run the reference annotation filter to resolve the REFERENCE_TO references
+      await refAnnotationFilter.onFetch(elements)
       await filter.onFetch(elements)
     })
 
@@ -333,6 +338,8 @@ describe('Custom Object Instances filter', () => {
 
     beforeEach(async () => {
       elements = [simpleObject, objWithNameField, objWithAddressField, objNotInNamespace]
+      // run the reference annotation filter to resolve the REFERENCE_TO references
+      await refAnnotationFilter.onFetch(elements)
       await filter.onFetch(elements)
     })
 
@@ -512,6 +519,8 @@ describe('Custom Object Instances filter', () => {
         refToObject, refToFromNamespaceObject, refFromAndToObject,
         namespacedRefFromObject, emptyRefToObject,
       ]
+      // run the reference annotation filter to resolve the REFERENCE_TO references
+      await refAnnotationFilter.onFetch(elements)
       await filter.onFetch(elements)
     })
 
@@ -649,6 +658,8 @@ describe('Custom Object Instances filter', () => {
         grandparentObject, parentObject, grandsonObject, orphanObject,
         pricebookEntryObject, SBQQCustomActionObject, refFromObject, refToObject,
       ]
+      // run the reference annotation filter to resolve the REFERENCE_TO references
+      await refAnnotationFilter.onFetch(elements)
       await filter.onFetch(elements)
     })
 


### PR DESCRIPTION
Convert `REFERENCE_TO` strings to references earlier in the flow so that they can be used by other filters, as discussed in https://github.com/salto-io/salto/pull/1244#pullrequestreview-457227660.
Note: As it's written right now it doesn't simplify the flow (maybe even the opposite) - that will require more changes on the instance / instance-reference side.