### PR TITLE
SALTO-873 Multienv - suggest to isolate the existing env when adding a 2nd env

### DIFF
--- a/packages/cli/e2e_test/helpers/workspace.ts
+++ b/packages/cli/e2e_test/helpers/workspace.ts
@@ -125,12 +125,20 @@ export const runInit = async (
   }
 }
 
-export const runCreateEnv = async (workspaceDir: string, envName: string): Promise<void> => {
-  await envCommand(workspaceDir, 'create', mockCliOutput(), envName).execute()
+export const runCreateEnv = async (
+  workspaceDir: string,
+  envName: string,
+  force?: boolean,
+): Promise<void> => {
+  await envCommand(workspaceDir, 'create', mockCliOutput(), envName, undefined, force).execute()
 }
 
 export const runSetEnv = async (workspaceDir: string, envName: string): Promise<void> => {
   await envCommand(workspaceDir, 'set', mockCliOutput(), envName).execute()
+}
+
+export const runDeleteEnv = async (workspaceDir: string, envName: string): Promise<void> => {
+  await envCommand(workspaceDir, 'delete', mockCliOutput(), envName).execute()
 }
 
 export const getCurrentEnv = async (workspaceDir: string): Promise<string> => {

--- a/packages/cli/e2e_test/multi_env.test.ts
+++ b/packages/cli/e2e_test/multi_env.test.ts
@@ -536,7 +536,7 @@ describe('multi env tests', () => {
       })
 
 
-      it('should update the attributes added in the deploy in the proper file', async () => {
+      it('should update the attributes added in the deploy in the proper env file', async () => {
         await Promise.all([
           env1NaclFileName(),
           env2NaclFileName(),
@@ -551,6 +551,19 @@ describe('multi env tests', () => {
           expect(obj.annotationTypes.apiName).toBeDefined()
           expect(obj.annotationTypes.metadataType).toBeDefined()
         }))
+      })
+
+      it('should not update common with the attributes added in the deploy', async () => {
+        const filename = commonNaclFileName()
+        const element = (await getNaclFileElements(filename))[0]
+        expect(isObjectType(element)).toBeTruthy()
+        const obj = element as ObjectType
+        expect(obj.fields.alpha.annotations.apiName).toBeUndefined()
+        expect(obj.fields.alpha.annotations.apiName).toBeUndefined()
+        expect(obj.annotations.metadataType).toBeUndefined()
+        expect(obj.annotations.apiName).toBeUndefined()
+        expect(obj.annotationTypes.apiName).toBeUndefined()
+        expect(obj.annotationTypes.metadataType).toBeUndefined()
       })
     })
 

--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -165,3 +165,7 @@ export const getEnvName = async (currentName = 'env1'): Promise<string> => {
   }]
   return (await inquirer.prompt(questions))[currentName]
 }
+
+export const cliApproveIsolateBeforeMultiEnv = async (existingEnv: string): Promise<boolean> => (
+  getUserBooleanInput(Prompts.APPROVE_ISOLATE_BEFORE_MULTIENV_RECOMMENDATION(existingEnv))
+)

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -556,23 +556,13 @@ export const formatFinishedLoading = (envName?: string): string => (
     : Prompts.FINISHED_LOADING
 )
 
-export const formatApproveIsolatedModePrompt = (
-  newServices: string[],
-  oldServices: string[],
-  isolatedInput: boolean
-): string => {
-  if (_.isEmpty(oldServices)) {
-    return Prompts.ISOLATED_MODE_FOR_NEW_ENV_RECOMMENDATION
-  }
-  return isolatedInput
-    ? Prompts.NEW_SERVICES_ISOLATED_RECOMMENDATION(
-      formatWordsSeries(newServices),
-    )
-    : Prompts.ONLY_NEW_SERVICES_ISOLATED_RECOMMENDATION(
-      formatWordsSeries(newServices),
-      formatWordsSeries(oldServices)
-    )
-}
+export const formatApproveIsolateCurrentEnvPrompt = (envName: string): string => (
+  Prompts.ISOLATE_FIRST_ENV_RECOMMENDATION(envName)
+)
+
+export const formatDoneIsolatingCurrentEnv = (envName: string): string => (
+  Prompts.DONE_ISOLATING_FIRST_ENV(envName)
+)
 
 export const formatStateChanges = (
   numOfChanges: number

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -159,26 +159,19 @@ ${Prompts.SERVICE_ADD_HELP}`
   public static readonly RENAME_ENV = (currentEnvName: string, newEnvName: string): string =>
     `Renamed environment - ${currentEnvName} -> ${newEnvName}`
 
-  public static readonly ISOLATED_MODE_FOR_NEW_ENV_RECOMMENDATION = 'The current fetch command is running for the first time for this environment.'
-    + ' It is recommended to perform first fetch of an environment in isolated mode.'
+  public static readonly ISOLATE_FIRST_ENV_RECOMMENDATION = (
+    existingEnv: string
+  ): string => 'This action will add a second environment to the workspace.'
+    + ` It is recommended to move environment ${existingEnv} out of the common configuration before proceeding.`
 
-  public static readonly NEW_SERVICES_ISOLATED_RECOMMENDATION = (
-    servicesNames: string,
-  ): string => `The current fetch command is running for the first time for ${servicesNames}.`
-     + ' It is recommended to perform first fetch of a service in isolated mode, without fetching other services.'
+  public static readonly DONE_ISOLATING_FIRST_ENV = (
+    existingEnv: string
+  ): string => `Done moving environment ${existingEnv} out of the common configuration.`
 
-
-  public static readonly ONLY_NEW_SERVICES_ISOLATED_RECOMMENDATION = (
-    newServicesNames: string,
-    oldServicesNames: string
-  ): string => `The current fetch command is running for the first time for ${newServicesNames} in isolated mode.`
-    + ` This will also fetch ${oldServicesNames} in strict mode and may result in unwanted changes to `
-    + ' other environments.\n'
-    + `It is recommended to run this fetch as an isolated fetch only for ${newServicesNames}`
-
-  public static readonly APPROVE_ISOLATED_RECOMMENDATION = (
-    newServicesNames: string
-  ): string => `Would you like to switch to isolated mode and fetch ${newServicesNames}? (Answer No to continue without switching)`
+  public static readonly APPROVE_ISOLATE_BEFORE_MULTIENV_RECOMMENDATION = (
+    existingEnv: string
+  ): string => `Would you like to isolate the configuration for ${existingEnv} before adding the new environment?`
+    + ' (Answer No to continue without changes)'
 
   public static readonly STATE_ONLY_UPDATE_START = (
     numOfChanges: number

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -224,17 +224,17 @@ export const mockErrors = (errors: SaltoError[]): wsErrors.Errors => ({
   strings: () => errors.map(err => err.message),
 })
 
-export const mockLoadWorkspace = (name: string): Workspace =>
+export const mockLoadWorkspace = (name: string, envs = ['active', 'inactive'], isEmpty = false): Workspace =>
   ({
     uid: '123',
     name,
     currentEnv: () => 'active',
-    envs: () => ['active', 'inactive'],
+    envs: () => envs,
     services: () => ['salesforce', 'hubspot'],
     elements: jest.fn().mockResolvedValue([] as ReadonlyArray<Element>),
     hasErrors: () => jest.fn().mockResolvedValue(false),
     errors: () => jest.fn().mockResolvedValue(mockErrors([])),
-    isEmpty: jest.fn().mockResolvedValue(false),
+    isEmpty: jest.fn().mockResolvedValue(isEmpty),
     getTotalSize: jest.fn().mockResolvedValue(0),
     addEnvironment: jest.fn(),
     deleteEnvironment: jest.fn(),
@@ -251,6 +251,7 @@ export const mockLoadWorkspace = (name: string): Workspace =>
     fetchedServices: jest.fn().mockResolvedValue([]),
     promote: jest.fn().mockResolvedValue(undefined),
     demote: jest.fn().mockResolvedValue(undefined),
+    demoteAll: jest.fn().mockResolvedValue(undefined),
     flush: jest.fn().mockResolvedValue(undefined),
   } as unknown as Workspace)
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -20,7 +20,7 @@ export { ItemStatus } from './src/core/deploy'
 export { getAdaptersCredentialsTypes, getDefaultAdapterConfig } from './src/core/adapters/adapters'
 export {
   loadLocalWorkspace, initLocalWorkspace, loadLocalElementsSources, getNaclFilesSourceParams,
-  CACHE_DIR_NAME,
+  CACHE_DIR_NAME, envFolderExists,
 } from './src/local-workspace/workspace'
 export {
   workspaceConfigSource as localWorkspaceConfigSource,

--- a/packages/core/src/local-workspace/dir_store.ts
+++ b/packages/core/src/local-workspace/dir_store.ts
@@ -99,7 +99,7 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
 
   const removeDirIfEmpty = async (dirPath: string): Promise<void> => {
     if (await fileUtils.exists(dirPath)
-      && await fileUtils.isEmptyDir(dirPath)
+      && await fileUtils.isEmptyDir.notFoundAsUndefined(dirPath)
       && fileUtils.isSubDirectory(dirPath, currentBaseDir)) {
       await fileUtils.rm(dirPath)
       await removeDirIfEmpty(path.dirname(dirPath))

--- a/packages/core/src/local-workspace/static_files_cache.ts
+++ b/packages/core/src/local-workspace/static_files_cache.ts
@@ -44,7 +44,7 @@ export const buildLocalStaticFilesCache = (
       if (!await exists(cacheDir)) {
         await mkdirp(cacheDir)
       }
-      replaceContents(currentCacheFile, safeJsonStringify((await cache)))
+      await replaceContents(currentCacheFile, safeJsonStringify((await cache)))
     },
     clear: async () => {
       await rm(currentCacheFile)

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -104,6 +104,10 @@ const loadNaclFileSource = (
   return naclFilesSource(naclFilesStore, cache, staticFileSource)
 }
 
+const getEnvPath = (baseDir: string, env: string): string => (
+  path.resolve(baseDir, ENVS_PREFIX, env)
+)
+
 export const loadLocalElementsSources = (baseDir: string, localStorage: string,
   envs: ReadonlyArray<string>): EnvironmentsSources => ({
   commonSourceName: COMMON_ENV_PREFIX,
@@ -113,7 +117,7 @@ export const loadLocalElementsSources = (baseDir: string, localStorage: string,
         env,
         {
           naclFiles: loadNaclFileSource(
-            path.resolve(baseDir, ENVS_PREFIX, env),
+            getEnvPath(baseDir, env),
             path.resolve(localStorage, CACHE_DIR_NAME, ENVS_PREFIX, env)
           ),
           state: localState(path.join(getConfigDir(baseDir), STATES_DIR_NAME, env)),
@@ -135,6 +139,11 @@ const locateWorkspaceRoot = async (lookupDir: string): Promise<string|undefined>
   }
   const parentDir = lookupDir.substr(0, lookupDir.lastIndexOf(path.sep))
   return parentDir ? locateWorkspaceRoot(parentDir) : undefined
+}
+
+export const envFolderExists = async (workspaceDir: string, env: string): Promise<boolean> => {
+  const baseDir = await locateWorkspaceRoot(path.resolve(workspaceDir))
+  return (baseDir !== undefined) && exists(getEnvPath(baseDir, env))
 }
 
 const credentialsSource = (localStorage: string): cs.ConfigSource =>

--- a/packages/core/test/workspace/local/directory_store.test.ts
+++ b/packages/core/test/workspace/local/directory_store.test.ts
@@ -17,7 +17,7 @@ import * as path from 'path'
 import readdirp from 'readdirp'
 import {
   stat, exists, readFile, replaceContents, mkdirp, rm, isEmptyDir, isSubDirectory,
-  rename, existsSync, readFileSync, statSync,
+  rename, existsSync, readFileSync, statSync, notFoundAsUndefined,
 } from '@salto-io/file'
 import { localDirectoryStore } from '../../../src/local-workspace/dir_store'
 
@@ -38,6 +38,7 @@ jest.mock('@salto-io/file', () => ({
   isEmptyDir: jest.fn(),
   isSubDirectory: jest.fn(),
 }))
+isEmptyDir.notFoundAsUndefined = notFoundAsUndefined(isEmptyDir)
 jest.mock('readdirp')
 describe('localDirectoryStore', () => {
   const encoding = 'utf8'
@@ -56,7 +57,7 @@ describe('localDirectoryStore', () => {
   const mockMkdir = mkdirp as jest.Mock
   const mockRm = rm as jest.Mock
   const mockRename = rename as jest.Mock
-  const mockEmptyDir = isEmptyDir as jest.Mock
+  const mockEmptyDir = isEmptyDir as unknown as jest.Mock
   const mockIsSubFolder = isSubDirectory as jest.Mock
 
   describe('list', () => {

--- a/packages/file/src/file.ts
+++ b/packages/file/src/file.ts
@@ -61,6 +61,7 @@ export const isSubDirectory = (
 export const isEmptyDir = async (
   dirPath: string
 ): Promise<boolean> => (await readDir(dirPath)).length === 0
+isEmptyDir.notFoundAsUndefined = notFoundAsUndefined(isEmptyDir)
 
 export const exists = async (
   filename: string

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -108,6 +108,7 @@ export type Workspace = {
   getStateRecency(services: string): Promise<StateRecency>
   promote(ids: ElemID[]): Promise<void>
   demote(ids: ElemID[]): Promise<void>
+  demoteAll(): Promise<void>
 }
 
 // common source has no state
@@ -288,7 +289,7 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
       )
     )),
     isEmpty: async (naclFilesOnly = false): Promise<boolean> => {
-      const isNaclFilesSourceEmpty = _.isEmpty(await naclFilesSource.getAll())
+      const isNaclFilesSourceEmpty = !naclFilesSource || _.isEmpty(await naclFilesSource.getAll())
       return isNaclFilesSourceEmpty && (naclFilesOnly || _.isEmpty(await state().getAll()))
     },
     setNaclFiles: naclFilesSource.setNaclFiles,
@@ -302,6 +303,7 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
     getElements: naclFilesSource.getElements,
     promote: naclFilesSource.promote,
     demote: naclFilesSource.demote,
+    demoteAll: naclFilesSource.demoteAll,
     transformToWorkspaceError,
     transformError,
     getSourceFragment,


### PR DESCRIPTION
* Add a prompt when adding the 2nd env if some configuration exists and no configuration is isolated (if something is in the env folder we assume the user made a conscious decision about what should remain in the common folder)
* Add a `force` flag to the env command to avoid this interactive prompt
