### PR TITLE
SALTO-875 - add copy command for duplicating elements across environments

### DIFF
--- a/packages/cli/src/commands/copy.ts
+++ b/packages/cli/src/commands/copy.ts
@@ -1,0 +1,150 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { logger } from '@salto-io/logging'
+import _ from 'lodash'
+import { Workspace } from '@salto-io/workspace'
+import { convertToIDSelectors } from '../convertors'
+import { ParsedCliInput, CliOutput, SpinnerCreator, CliExitCode, CliCommand, CliTelemetry } from '../types'
+import { createCommandBuilder } from '../command_builder'
+import { getCliTelemetry } from '../telemetry'
+import { loadWorkspace, getWorkspaceTelemetryTags } from '../workspace/workspace'
+import Prompts from '../prompts'
+import { formatStepStart, formatStepFailed, formatInvalidID, formatStepCompleted, formatUnknownTargetEnv } from '../formatter'
+import { outputLine } from '../outputer'
+
+const log = logger(module)
+
+const validateEnvs = (
+  output: CliOutput,
+  workspace: Workspace,
+  targetEnvs: string[] = [],
+): boolean => {
+  if (targetEnvs.length === 0) {
+    return true
+  }
+  const missingEnvs = targetEnvs.filter(e => !workspace.envs().includes(e))
+  if (!_.isEmpty(missingEnvs)) {
+    outputLine(formatStepFailed(formatUnknownTargetEnv(missingEnvs)), output)
+    return false
+  }
+  if (targetEnvs.includes(workspace.currentEnv())) {
+    outputLine(formatStepFailed(Prompts.INVALID_ENV_TARGET_CURRENT), output)
+    return false
+  }
+  return true
+}
+
+export const command = (
+  workspaceDir: string,
+  cliTelemetry: CliTelemetry,
+  output: CliOutput,
+  spinnerCreator: SpinnerCreator,
+  force: boolean,
+  inputSelectors: string[],
+  targetEnvs?: string[],
+): CliCommand => ({
+  async execute(): Promise<CliExitCode> {
+    log.debug(`running copy command on '${workspaceDir}', targetEnvs=${
+      targetEnvs}, inputSelectors=${inputSelectors}`)
+    const { ids, invalidSelectors } = convertToIDSelectors(inputSelectors)
+    if (!_.isEmpty(invalidSelectors)) {
+      output.stdout.write(formatStepFailed(formatInvalidID(invalidSelectors)))
+      return CliExitCode.UserInputError
+    }
+
+    const { workspace, errored } = await loadWorkspace(
+      workspaceDir,
+      output,
+      {
+        force,
+        spinnerCreator,
+      }
+    )
+    if (errored) {
+      cliTelemetry.failure()
+      return CliExitCode.AppError
+    }
+    if (!validateEnvs(output, workspace, targetEnvs)) {
+      cliTelemetry.failure()
+      return CliExitCode.UserInputError
+    }
+
+    const workspaceTags = await getWorkspaceTelemetryTags(workspace)
+    cliTelemetry.start(workspaceTags)
+    try {
+      outputLine(formatStepStart(Prompts.COPY_TO_ENV_START(targetEnvs)), output)
+      await workspace.copyTo(ids, targetEnvs)
+      await workspace.flush()
+      outputLine(formatStepCompleted(Prompts.COPY_TO_ENV_FINISHED), output)
+      cliTelemetry.success(workspaceTags)
+      return CliExitCode.Success
+    } catch (e) {
+      cliTelemetry.failure()
+      outputLine(formatStepFailed(Prompts.COPY_TO_ENV_FAILED(e.message)), output)
+      return CliExitCode.AppError
+    }
+  },
+})
+
+type CopyArgs = {
+  force: boolean
+  env: string
+  targetEnv: string[]
+  selectors: string[]
+}
+
+type CopyParsedCliInput = ParsedCliInput<CopyArgs>
+
+const copyBuilder = createCommandBuilder({
+  options: {
+    command: 'copy [selectors..]',
+    description: 'Copy the selected elements to the target environment(s), overriding existing elements.',
+    keyed: {
+      force: {
+        alias: ['f'],
+        describe: 'Copy the elements even if the workspace is invalid.',
+        boolean: true,
+        default: false,
+        demandOption: false,
+      },
+      // will also be available as targetEnv because of camel-case-expansion
+      'target-env': {
+        alias: ['t'],
+        describe: 'Only copy the elements to the specified environment(s) (default=all)',
+        type: 'array',
+        string: true,
+      },
+    },
+  },
+
+  async build(
+    input: CopyParsedCliInput,
+    output: CliOutput,
+    spinnerCreator: SpinnerCreator
+  ): Promise<CliCommand> {
+    return command(
+      '.',
+      getCliTelemetry(input.telemetry, 'copy'),
+      output,
+      spinnerCreator,
+      input.args.force,
+      input.args.selectors,
+      input.args.targetEnv,
+    )
+  },
+})
+
+export default copyBuilder

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -23,7 +23,7 @@ import restoreBuilder from './restore'
 import diffBuilder from './diff'
 import promoteBuilder from './promote'
 import demoteBuilder from './demote'
-
+import copyBuilder from './copy'
 
 // The order of the builders determines order of appearance in help text
 export default [
@@ -36,4 +36,5 @@ export default [
   promoteBuilder,
   demoteBuilder,
   diffBuilder,
+  copyBuilder,
 ] as YargsCommandBuilder[]

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -590,3 +590,8 @@ export const formatInvalidID = (invalidIds: string[]): string => [
   formatSimpleError(Prompts.INVALID_IDS(formatWordsSeries(invalidIds))),
   emptyLine(),
 ].join('\n')
+
+export const formatUnknownTargetEnv = (unknownEnvs: string[]): string => [
+  formatSimpleError(Prompts.UNKNOWN_TARGET_ENVS(unknownEnvs)),
+  emptyLine(),
+].join('\n')

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -180,6 +180,13 @@ ${Prompts.SERVICE_ADD_HELP}`
   ): string => `Would you like to isolate the configuration for ${existingEnv} before adding the new environment?`
     + ' (Answer No to continue without changes)'
 
+    public static readonly ISOLATED_MODE_FOR_NEW_ENV_RECOMMENDATION = 'The current fetch command is running for the first time for this environment.'
+    + ' It is recommended to perform first fetch of an environment in isolated mode.'
+
+  public static readonly APPROVE_ISOLATED_RECOMMENDATION = (
+    newServicesNames: string
+  ): string => `Would you like to switch to isolated mode and fetch ${newServicesNames}? (Answer No to continue without switching)`
+
   public static readonly STATE_ONLY_UPDATE_START = (
     numOfChanges: number
   ): string => `Applying ${numOfChanges} changes to the state. Workspace will not be updated.`
@@ -227,9 +234,27 @@ ${Prompts.SERVICE_ADD_HELP}`
     invalidIds: string
   ): string => `Failed to created element ID filters for: ${invalidIds}. Invalid Element IDs provided.`
 
+  public static readonly INVALID_ENV_TARGET_CURRENT = 'The current environment cannot be a target environment'
+  public static readonly UNKNOWN_TARGET_ENVS = (
+    unknownEnvs: string[]
+  ): string => (unknownEnvs.length === 1
+    ? `Unknown target environment: ${unknownEnvs[0]}`
+    : `Unknown target environments: ${unknownEnvs?.join(' ')}`)
+
   public static readonly DEMOTE_START = 'Demoting the selected elements.'
   public static readonly DEMOTE_FINISHED = 'Done demoting elements.'
   public static readonly DEMOTE_FAILED = (
     error: string
   ): string => `Failed to move the selected elements out of the common folder: ${error}`
+
+  public static readonly COPY_TO_ENV_START = (
+    targetEnvs: string[] = []
+  ): string => `Copying the selected elements to ${
+    targetEnvs.length > 0 ? targetEnvs.join(', ') : 'all environments'
+  }.`
+
+  public static readonly COPY_TO_ENV_FINISHED = 'Done copying elements.'
+  public static readonly COPY_TO_ENV_FAILED = (
+    error: string
+  ): string => `Failed to copy the selected elements to the target environments: ${error}`
 }

--- a/packages/cli/test/commands/copy.test.ts
+++ b/packages/cli/test/commands/copy.test.ts
@@ -1,0 +1,328 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Workspace } from '@salto-io/workspace'
+import { ElemID } from '@salto-io/adapter-api'
+import { Spinner, SpinnerCreator, CliExitCode, CliTelemetry } from '../../src/types'
+import { command } from '../../src/commands/copy'
+
+import * as mocks from '../mocks'
+import * as mockCliWorkspace from '../../src/workspace/workspace'
+import { buildEventName, getCliTelemetry } from '../../src/telemetry'
+
+const commandName = 'copy'
+const eventsNames = {
+  success: buildEventName(commandName, 'success'),
+  start: buildEventName(commandName, 'start'),
+  failure: buildEventName(commandName, 'failure'),
+}
+
+jest.mock('../../src/workspace/workspace')
+describe('copy command', () => {
+  let spinners: Spinner[]
+  let spinnerCreator: SpinnerCreator
+  const services = ['salesforce']
+  let cliOutput: { stdout: mocks.MockWriteStream; stderr: mocks.MockWriteStream }
+  const mockLoadWorkspace = mockCliWorkspace.loadWorkspace as jest.Mock
+
+  beforeEach(() => {
+    spinners = []
+    spinnerCreator = mocks.mockSpinnerCreator(spinners)
+  })
+
+  let result: number
+  let mockTelemetry: mocks.MockTelemetry
+  let mockCliTelemetry: CliTelemetry
+  describe('with errored workspace', () => {
+    beforeEach(async () => {
+      cliOutput = { stdout: new mocks.MockWriteStream(), stderr: new mocks.MockWriteStream() }
+      mockTelemetry = mocks.getMockTelemetry()
+      mockCliTelemetry = getCliTelemetry(mockTelemetry, 'copy')
+      const erroredWorkspace = {
+        hasErrors: () => true,
+        errors: { strings: () => ['some error'] },
+        config: { services },
+      } as unknown as Workspace
+      mockLoadWorkspace.mockResolvedValueOnce({ workspace: erroredWorkspace, errored: true })
+
+      result = await command(
+        '',
+        mockCliTelemetry,
+        cliOutput,
+        spinnerCreator,
+        false,
+        []
+      ).execute()
+    })
+
+    it('should fail', async () => {
+      expect(result).toBe(CliExitCode.AppError)
+      expect(mockTelemetry.getEvents().length).toEqual(1)
+      expect(mockTelemetry.getEventsMap()[eventsNames.failure]).toHaveLength(1)
+      expect(mockTelemetry.getEventsMap()[eventsNames.failure][0].value).toEqual(1)
+    })
+  })
+
+
+  describe('with valid workspace', () => {
+    const workspaceName = 'valid-ws'
+    const workspace = mocks.mockLoadWorkspace(workspaceName)
+    const selector = new ElemID('salto', 'Account')
+    beforeAll(async () => {
+      cliOutput = { stdout: new mocks.MockWriteStream(), stderr: new mocks.MockWriteStream() }
+      mockTelemetry = mocks.getMockTelemetry()
+      mockCliTelemetry = getCliTelemetry(mockTelemetry, 'copy')
+      mockLoadWorkspace.mockResolvedValue({
+        workspace,
+        errored: false,
+      })
+      result = await command(
+        '',
+        mockCliTelemetry,
+        cliOutput,
+        spinnerCreator,
+        false,
+        [selector.getFullName()]
+      ).execute()
+    })
+
+
+    it('should return success code', () => {
+      expect(result).toBe(CliExitCode.Success)
+    })
+    it('should call workspace copyTo', () => {
+      expect(workspace.copyTo).toHaveBeenCalledWith([selector], undefined)
+    })
+
+    it('should flush workspace', () => {
+      expect(workspace.flush).toHaveBeenCalled()
+    })
+
+    it('should send telemetry events', () => {
+      expect(mockTelemetry.getEvents()).toHaveLength(2)
+      expect(mockTelemetry.getEventsMap()[eventsNames.start]).toHaveLength(1)
+      expect(mockTelemetry.getEventsMap()[eventsNames.success]).toHaveLength(1)
+    })
+
+    it('should print copy to console', () => {
+      expect(cliOutput.stdout.content).toContain('Copying the selected elements to all environments.')
+      expect(cliOutput.stdout.content).toContain('Done copying elements.')
+    })
+  })
+
+  describe('with valid workspace and specific env', () => {
+    const workspaceName = 'valid-ws'
+    const workspace = mocks.mockLoadWorkspace(workspaceName)
+    const selector = new ElemID('salto', 'Account')
+    beforeAll(async () => {
+      cliOutput = { stdout: new mocks.MockWriteStream(), stderr: new mocks.MockWriteStream() }
+      mockTelemetry = mocks.getMockTelemetry()
+      mockCliTelemetry = getCliTelemetry(mockTelemetry, 'copy')
+      mockLoadWorkspace.mockResolvedValue({
+        workspace,
+        errored: false,
+      })
+      result = await command(
+        '',
+        mockCliTelemetry,
+        cliOutput,
+        spinnerCreator,
+        false,
+        [selector.getFullName()],
+        ['inactive'],
+      ).execute()
+    })
+
+
+    it('should return success code', () => {
+      expect(result).toBe(CliExitCode.Success)
+    })
+    it('should call workspace copyTo', () => {
+      expect(workspace.copyTo).toHaveBeenCalledWith([selector], ['inactive'])
+    })
+
+    it('should flush workspace', () => {
+      expect(workspace.flush).toHaveBeenCalled()
+    })
+
+    it('should send telemetry events', () => {
+      expect(mockTelemetry.getEvents()).toHaveLength(2)
+      expect(mockTelemetry.getEventsMap()[eventsNames.start]).toHaveLength(1)
+      expect(mockTelemetry.getEventsMap()[eventsNames.success]).toHaveLength(1)
+    })
+
+    it('should print copy to console', () => {
+      expect(cliOutput.stdout.content).toContain('Copying the selected elements to inactive.')
+      expect(cliOutput.stdout.content).toContain('Done copying elements.')
+    })
+  })
+  describe('with invalid input', () => {
+    const workspaceName = 'invalid-input'
+    const workspace = mocks.mockLoadWorkspace(workspaceName)
+    beforeAll(async () => {
+      cliOutput = { stdout: new mocks.MockWriteStream(), stderr: new mocks.MockWriteStream() }
+      mockTelemetry = mocks.getMockTelemetry()
+      mockCliTelemetry = getCliTelemetry(mockTelemetry, 'copy')
+      mockLoadWorkspace.mockResolvedValue({
+        workspace,
+        errored: false,
+      })
+      result = await command(
+        '',
+        mockCliTelemetry,
+        cliOutput,
+        spinnerCreator,
+        false,
+        ['a.b.c.d']
+      ).execute()
+    })
+
+
+    it('should return failure code', () => {
+      expect(result).toBe(CliExitCode.UserInputError)
+    })
+    it('should not call workspace copyTo', () => {
+      expect(workspace.copyTo).not.toHaveBeenCalled()
+    })
+
+    it('should not flush workspace', () => {
+      expect(workspace.flush).not.toHaveBeenCalled()
+    })
+
+    it('should not send telemetry events', () => {
+      expect(mockTelemetry.getEvents()).toHaveLength(0)
+    })
+
+    it('should print copy to console', () => {
+      expect(cliOutput.stdout.content).toContain('Failed to created element ID filters')
+    })
+  })
+  describe('with invalid envs', () => {
+    const workspaceName = 'valid-ws'
+    const workspace = mocks.mockLoadWorkspace(workspaceName)
+    const selector = new ElemID('salto', 'Account')
+    beforeAll(async () => {
+      cliOutput = { stdout: new mocks.MockWriteStream(), stderr: new mocks.MockWriteStream() }
+      mockTelemetry = mocks.getMockTelemetry()
+      mockCliTelemetry = getCliTelemetry(mockTelemetry, 'copy')
+      mockLoadWorkspace.mockResolvedValue({
+        workspace,
+        errored: false,
+      })
+      result = await command(
+        '',
+        mockCliTelemetry,
+        cliOutput,
+        spinnerCreator,
+        false,
+        [selector.getFullName()],
+        ['inactive', 'unknown'],
+      ).execute()
+    })
+
+
+    it('should return failure code', () => {
+      expect(result).toBe(CliExitCode.UserInputError)
+    })
+    it('should send telemetry events', () => {
+      expect(mockTelemetry.getEvents()).toHaveLength(1)
+      expect(mockTelemetry.getEventsMap()[eventsNames.failure]).toHaveLength(1)
+    })
+
+    it('should print failure to console', () => {
+      expect(cliOutput.stdout.content)
+        .toContain('Unknown target environment')
+    })
+  })
+  describe('with current env as target env', () => {
+    const workspaceName = 'valid-ws'
+    const workspace = mocks.mockLoadWorkspace(workspaceName)
+    const selector = new ElemID('salto', 'Account')
+    beforeAll(async () => {
+      cliOutput = { stdout: new mocks.MockWriteStream(), stderr: new mocks.MockWriteStream() }
+      mockTelemetry = mocks.getMockTelemetry()
+      mockCliTelemetry = getCliTelemetry(mockTelemetry, 'copy')
+      mockLoadWorkspace.mockResolvedValue({
+        workspace,
+        errored: false,
+      })
+      result = await command(
+        '',
+        mockCliTelemetry,
+        cliOutput,
+        spinnerCreator,
+        false,
+        [selector.getFullName()],
+        ['active'],
+      ).execute()
+    })
+
+
+    it('should return failure code', () => {
+      expect(result).toBe(CliExitCode.UserInputError)
+    })
+    it('should send telemetry events', () => {
+      expect(mockTelemetry.getEvents()).toHaveLength(1)
+      expect(mockTelemetry.getEventsMap()[eventsNames.failure]).toHaveLength(1)
+    })
+
+    it('should print failure to console', () => {
+      expect(cliOutput.stdout.content)
+        .toContain('The current environment cannot be a target environment')
+    })
+  })
+  describe('when workspace throws an error', () => {
+    const workspaceName = 'unexpected-error'
+    const workspace = {
+      ...mocks.mockLoadWorkspace(workspaceName),
+      flush: async () => {
+        throw new Error('Oy Vey Zmir')
+      },
+    }
+    beforeAll(async () => {
+      cliOutput = { stdout: new mocks.MockWriteStream(), stderr: new mocks.MockWriteStream() }
+      mockTelemetry = mocks.getMockTelemetry()
+      mockCliTelemetry = getCliTelemetry(mockTelemetry, 'copy')
+      mockLoadWorkspace.mockResolvedValue({
+        workspace,
+        errored: false,
+      })
+      result = await command(
+        '',
+        mockCliTelemetry,
+        cliOutput,
+        spinnerCreator,
+        false,
+        ['salto.Account']
+      ).execute()
+    })
+
+
+    it('should return failure code', () => {
+      expect(result).toBe(CliExitCode.AppError)
+    })
+
+    it('should send telemetry events', () => {
+      expect(mockTelemetry.getEvents()).toHaveLength(2)
+      expect(mockTelemetry.getEventsMap()[eventsNames.start]).toHaveLength(1)
+      expect(mockTelemetry.getEventsMap()[eventsNames.failure]).toHaveLength(1)
+    })
+
+    it('should print failure to console', () => {
+      expect(cliOutput.stdout.content)
+        .toContain('Failed to copy the selected elements to the target environments')
+    })
+  })
+})

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -258,6 +258,7 @@ export const mockLoadWorkspace = (
     promote: jest.fn().mockResolvedValue(undefined),
     demote: jest.fn().mockResolvedValue(undefined),
     demoteAll: jest.fn().mockResolvedValue(undefined),
+    copyTo: jest.fn().mockResolvedValue(undefined),
     flush: jest.fn().mockResolvedValue(undefined),
   } as unknown as Workspace)
 

--- a/packages/workspace/src/workspace/nacl_files/mutil_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/mutil_env/routers.ts
@@ -391,14 +391,46 @@ export const routeChanges = async (
   }
 }
 
-const addToSource = async (
-  ids: ElemID[],
-  originSource: NaclFilesSource,
-  targetSource: NaclFilesSource,
-): Promise<DetailedChange[]> => {
+const overrideIdInSource = (
+  id: ElemID,
+  before: ChangeDataType,
+  topLevelElement: ChangeDataType,
+): DetailedChange[] => {
+  if (id.isTopLevel()) {
+    return detailedCompare(before, topLevelElement, true)
+  }
+
+  const afterValue = resolvePath(topLevelElement, id)
+  const beforeValue = resolvePath(before, id)
+  if (beforeValue === undefined) {
+    // Nothing to override, just need to add the new value
+    return [createAddChange(afterValue, id)]
+  }
+  // The value exists in the target - override only the relevant part
+  return detailedCompare(
+    wrapNestedValues([{ id, value: beforeValue }], before) as ChangeDataType,
+    wrapNestedValues([{ id, value: afterValue }], topLevelElement) as ChangeDataType,
+    true,
+  )
+}
+
+const addToSource = async ({
+  ids,
+  originSource,
+  targetSource,
+  overrideTargetElements = false,
+}: {
+  ids: ElemID[]
+  originSource: NaclFilesSource
+  targetSource: NaclFilesSource
+  overrideTargetElements?: boolean
+}): Promise<DetailedChange[]> => {
   const idsByParent = _.groupBy(ids, id => id.createTopLevelParentID().parent.getFullName())
   const fullChanges = _.flatten(await Promise.all(Object.values(idsByParent).map(async gids => {
     const topLevelElement = await originSource.get(gids[0].createTopLevelParentID().parent)
+    if (topLevelElement === undefined) {
+      throw new Error(`ElemID ${gids[0].getFullName()} does not exist in origin`)
+    }
     const topLevelIds = gids.filter(id => id.isTopLevel())
     const wrappedElement = !_.isEmpty(topLevelIds)
       ? topLevelElement
@@ -410,23 +442,34 @@ const addToSource = async (
     if (before === undefined) {
       return [createAddChange(wrappedElement, topLevelElement.elemID)]
     }
+
+    if (overrideTargetElements) {
+      // we want to override, not merge - so we need to wrap each gid individually
+      return gids.flatMap(id => overrideIdInSource(
+        id,
+        before as ChangeDataType,
+        topLevelElement as ChangeDataType,
+      ))
+    }
+
     const mergeResult = mergeElements([
       before,
       wrappedElement,
     ])
-    // We should't have errors since before and wrapped elements are from common/env
-    // so they should be mergeable
     if (mergeResult.errors.length > 0) {
+      // If either the origin or the target source is the common folder, all elements should be
+      // mergeable and we shouldn't see merge errors
       throw new Error(
-        `Failed to move ${gids.map(id => id.getFullName())} Can not move unmergable element fragments.`
+        `Failed to add ${gids.map(id => id.getFullName())} - unmergable element fragments.`
       )
     }
     const after = mergeResult.merged[0] as ChangeDataType
     return detailedCompare(before, after, true)
   })))
-  return _.flatten(
-    await Promise.all(fullChanges.map(change => seperateChangeByFiles(change, originSource)))
-  )
+  return (await Promise.all(fullChanges.map(change => seperateChangeByFiles(
+    change,
+    change.action === 'remove' ? targetSource : originSource
+  )))).flat()
 }
 
 const removeFromSource = async (
@@ -447,7 +490,7 @@ export const routePromote = async (
   secondarySources: Record<string, NaclFilesSource>,
 ): Promise<RoutedChanges> => ({
   primarySource: await removeFromSource(ids, primarySource),
-  commonSource: await addToSource(ids, primarySource, commonSource),
+  commonSource: await addToSource({ ids, originSource: primarySource, targetSource: commonSource }),
   secondarySources: await promises.object.mapValuesAsync(
     secondarySources,
     (source: NaclFilesSource) => removeFromSource(ids, source)
@@ -460,10 +503,36 @@ export const routeDemote = async (
   commonSource: NaclFilesSource,
   secondarySources: Record<string, NaclFilesSource>,
 ): Promise<RoutedChanges> => ({
-  primarySource: await addToSource(ids, commonSource, primarySource),
+  primarySource: await addToSource({
+    ids,
+    originSource: commonSource,
+    targetSource: primarySource,
+  }),
   commonSource: await removeFromSource(ids, commonSource),
   secondarySources: await promises.object.mapValuesAsync(
     secondarySources,
-    (source: NaclFilesSource) => addToSource(ids, commonSource, source)
+    (source: NaclFilesSource) => addToSource({
+      ids,
+      originSource: commonSource,
+      targetSource: source,
+    })
+  ),
+})
+
+export const routeCopyTo = async (
+  ids: ElemID[],
+  primarySource: NaclFilesSource,
+  targetSources: Record<string, NaclFilesSource>,
+): Promise<RoutedChanges> => ({
+  primarySource: [],
+  commonSource: [],
+  secondarySources: await promises.object.mapValuesAsync(
+    targetSources,
+    (source: NaclFilesSource) => addToSource({
+      ids,
+      originSource: primarySource,
+      targetSource: source,
+      overrideTargetElements: true,
+    })
   ),
 })

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -110,6 +110,7 @@ export type Workspace = {
   promote(ids: ElemID[]): Promise<void>
   demote(ids: ElemID[]): Promise<void>
   demoteAll(): Promise<void>
+  copyTo(ids: ElemID[], targetEnvs?: string[]): Promise<void>
 }
 
 // common source has no state
@@ -310,6 +311,7 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
     promote: naclFilesSource.promote,
     demote: naclFilesSource.demote,
     demoteAll: naclFilesSource.demoteAll,
+    copyTo: naclFilesSource.copyTo,
     transformToWorkspaceError,
     transformError,
     getSourceFragment,

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -19,6 +19,7 @@ import _ from 'lodash'
 import * as utils from '@salto-io/adapter-utils'
 import { createMockNaclFileSource } from '../../common/nacl_file_source'
 import { multiEnvSource, ENVS_PREFIX } from '../../../src/workspace/nacl_files/mutil_env/multi_env_source'
+import * as routers from '../../../src/workspace/nacl_files/mutil_env/routers'
 import { Errors } from '../../../src/workspace/errors'
 import { ValidationError } from '../../../src/validator'
 import { MergeError } from '../../../src/merger'
@@ -334,6 +335,24 @@ describe('multi env source', () => {
   describe('applyInstancesDefaults', () => {
     it('should call applyInstancesDefaults', () => {
       expect(utils.applyInstancesDefaults).toHaveBeenCalled()
+    })
+  })
+  describe('copyTo', () => {
+    it('should route a copy to the proper env sources when specified', async () => {
+      const ids = [new ElemID('salto', 'Account')]
+      jest.spyOn(routers, 'routeCopyTo').mockImplementationOnce(
+        () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
+      )
+      await source.copyTo(ids, ['inactive'])
+      expect(routers.routeCopyTo).toHaveBeenCalledWith(ids, envSource, { inactive: inactiveSource })
+    })
+    it('should route a copy to all env sources when not specified', async () => {
+      const ids = [new ElemID('salto', 'Account')]
+      jest.spyOn(routers, 'routeCopyTo').mockImplementationOnce(
+        () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
+      )
+      await source.copyTo(ids)
+      expect(routers.routeCopyTo).toHaveBeenCalledWith(ids, envSource, { inactive: inactiveSource })
     })
   })
 })


### PR DESCRIPTION
Add a cli command to copy elements between environments, without going through common - with temporary name `copy`.
The requirement is that if the element already exists in the target environment, it will be overwritten (rather than merged).

For completeness I think we'll want to add some more granular control (such as deciding between merge and override) - starting with the basic requirements and will discuss the rest separately (see the ticket for more details).