### PR TITLE
SALTO-793: store relevant information in type annotations on fetch

### DIFF
--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Value, ObjectType, ElemID, InstanceElement, Values, TypeElement, Element, isObjectType, ChangeGroup, getChangeElement, isInstanceElement } from '@salto-io/adapter-api'
+import { Value, ObjectType, ElemID, InstanceElement, TypeElement, Element, isObjectType, ChangeGroup, getChangeElement, isInstanceElement } from '@salto-io/adapter-api'
 import {
   findElement,
 } from '@salto-io/adapter-utils'
@@ -25,7 +25,7 @@ import { filtersRunner } from '../src/filter'
 import { SALESFORCE } from '../src/constants'
 import SalesforceAdapter, { DEFAULT_FILTERS } from '../src/adapter'
 import SalesforceClient from '../src/client/client'
-import { createInstanceElement, metadataType, apiName, createMetadataTypeElements, isCustomObject } from '../src/transformers/transformer'
+import { createInstanceElement, metadataType, apiName, createMetadataTypeElements, isCustomObject, MetadataValues } from '../src/transformers/transformer'
 import { ConfigChangeSuggestion, FilterContext } from '../src/types'
 
 const { makeArray } = collections.array
@@ -98,7 +98,7 @@ Promise<ObjectType[]> => {
     }))))
 }
 
-export const createInstance = async (client: SalesforceClient, value: Values,
+export const createInstance = async (client: SalesforceClient, value: MetadataValues,
   type: string | ObjectType): Promise<InstanceElement> => {
   const objectType = isObjectType(type)
     ? type

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -33,7 +33,7 @@ import * as constants from './constants'
 import {
   toCustomField, toCustomObject, apiName, Types, toMetadataInfo, createInstanceElement,
   metadataType, createMetadataTypeElements, instancesToUpdateRecords, instancesToDeleteRecords,
-  defaultApiName, getLookUpName, isCustomObject, instancesToCreateRecords,
+  defaultApiName, getLookUpName, isCustomObject, instancesToCreateRecords, isMetadataObjectType,
 } from './transformers/transformer'
 import { toMetadataPackageZip } from './transformers/xml_transformer'
 import layoutFilter from './filters/layouts'
@@ -73,7 +73,6 @@ import { createListMetadataObjectsConfigChange, createSkippedListConfigChange,
 import { FilterCreator, Filter, filtersRunner } from './filter'
 import { id, addApiName, addMetadataType, addLabel } from './filters/utils'
 import { retrieveMetadataInstances } from './fetch'
-import { FOLDER_CONTENT_TYPE } from './constants'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -887,10 +886,10 @@ export default class SalesforceAdapter implements AdapterOperations {
     const typeInfos = await typeInfoPromise
     const topLevelTypeNames = typeInfos.map(info => info.xmlName)
     const topLevelTypes = (await types)
-      .filter(isObjectType)
+      .filter(isMetadataObjectType)
       .filter(t => (
         topLevelTypeNames.includes(apiName(t))
-        || t.annotations[FOLDER_CONTENT_TYPE] !== undefined
+        || t.annotations.folderContentType !== undefined
       ))
 
     const [metadataTypesToRetrieve, metadataTypesToRead] = _.partition(

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -73,7 +73,7 @@ import { createListMetadataObjectsConfigChange, createSkippedListConfigChange,
 import { FilterCreator, Filter, filtersRunner } from './filter'
 import { id, addApiName, addMetadataType, addLabel } from './filters/utils'
 import { retrieveMetadataInstances } from './fetch'
-import { IS_FOLDER } from './constants'
+import { FOLDER_CONTENT_TYPE } from './constants'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -836,7 +836,12 @@ export default class SalesforceAdapter implements AdapterOperations {
       knownTypes,
       baseTypeNames,
       client: this.client,
-      annotations: { hasMetaFile: typeInfo.metaFile ? true : undefined, folderType },
+      annotations: {
+        hasMetaFile: typeInfo.metaFile ? true : undefined,
+        folderType,
+        suffix: typeInfo.suffix,
+        dirName: typeInfo.directoryName,
+      },
     })
     const folderTypes = folderType === undefined
       ? []
@@ -846,7 +851,11 @@ export default class SalesforceAdapter implements AdapterOperations {
         knownTypes,
         baseTypeNames,
         client: this.client,
-        annotations: { hasMetaFile: true, isFolder: true },
+        annotations: {
+          hasMetaFile: true,
+          folderContentType: typeInfo.xmlName,
+          dirName: typeInfo.directoryName,
+        },
       })
     return [...mainTypes, ...folderTypes]
   }
@@ -879,7 +888,10 @@ export default class SalesforceAdapter implements AdapterOperations {
     const topLevelTypeNames = typeInfos.map(info => info.xmlName)
     const topLevelTypes = (await types)
       .filter(isObjectType)
-      .filter(t => topLevelTypeNames.includes(apiName(t)) || t.annotations[IS_FOLDER] === true)
+      .filter(t => (
+        topLevelTypeNames.includes(apiName(t))
+        || t.annotations[FOLDER_CONTENT_TYPE] !== undefined
+      ))
 
     const [metadataTypesToRetrieve, metadataTypesToRead] = _.partition(
       topLevelTypes,

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -114,9 +114,6 @@ export enum ANNOTATION_TYPE_NAMES {
 export const API_NAME = 'apiName'
 export const METADATA_TYPE = 'metadataType'
 export const TOPICS_FOR_OBJECTS_ANNOTATION = 'topicsForObjects'
-export const HAS_META_FILE = 'hasMetaFile'
-export const FOLDER_TYPE = 'folderType'
-export const FOLDER_CONTENT_TYPE = 'folderContentType'
 export const FOREIGN_KEY_DOMAIN = 'foreignKeyDomain'
 export const IS_ATTRIBUTE = 'isAttribute'
 

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -116,7 +116,7 @@ export const METADATA_TYPE = 'metadataType'
 export const TOPICS_FOR_OBJECTS_ANNOTATION = 'topicsForObjects'
 export const HAS_META_FILE = 'hasMetaFile'
 export const FOLDER_TYPE = 'folderType'
-export const IS_FOLDER = 'isFolder'
+export const FOLDER_CONTENT_TYPE = 'folderContentType'
 export const FOREIGN_KEY_DOMAIN = 'foreignKeyDomain'
 export const IS_ATTRIBUTE = 'isAttribute'
 

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -18,10 +18,10 @@ import { FileProperties } from 'jsforce-types'
 import { InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { promises, values as lowerDashValues } from '@salto-io/lowerdash'
 import { FetchElements, ConfigChangeSuggestion } from './types'
-import { FOLDER_TYPE, METADATA_CONTENT_FIELD, HAS_META_FILE, FOLDER_CONTENT_TYPE } from './constants'
+import { METADATA_CONTENT_FIELD } from './constants'
 import SalesforceClient from './client/client'
 import { createListMetadataObjectsConfigChange, createRetrieveConfigChange } from './config_change'
-import { apiName, createInstanceElement } from './transformers/transformer'
+import { apiName, createInstanceElement, MetadataObjectType } from './transformers/transformer'
 import { fromRetrieveResult, toRetrieveRequest } from './transformers/xml_transformer'
 
 const { isDefined } = lowerDashValues
@@ -32,15 +32,15 @@ const getTypesWithContent = (types: ReadonlyArray<ObjectType>): Set<string> => n
     .map(t => apiName(t))
 )
 
-const getTypesWithMetaFile = (types: ReadonlyArray<ObjectType>): Set<string> => new Set(
+const getTypesWithMetaFile = (types: ReadonlyArray<MetadataObjectType>): Set<string> => new Set(
   types
-    .filter(t => t.annotations[HAS_META_FILE] === true)
+    .filter(t => t.annotations.hasMetaFile === true)
     .map(t => apiName(t))
 )
 
-type RetreiveMetadataInstancesArgs = {
+type RetrieveMetadataInstancesArgs = {
   client: SalesforceClient
-  types: ReadonlyArray<ObjectType>
+  types: ReadonlyArray<MetadataObjectType>
   maxItemsInRetrieveRequest: number
   maxConcurrentRetrieveRequests: number
   instancesRegexSkippedList: ReadonlyArray<RegExp>
@@ -52,15 +52,15 @@ export const retrieveMetadataInstances = async ({
   maxItemsInRetrieveRequest,
   maxConcurrentRetrieveRequests,
   instancesRegexSkippedList,
-}: RetreiveMetadataInstancesArgs): Promise<FetchElements<InstanceElement[]>> => {
+}: RetrieveMetadataInstancesArgs): Promise<FetchElements<InstanceElement[]>> => {
   const configChanges: ConfigChangeSuggestion[] = []
 
   const notInSkipList = (file: FileProperties): boolean => (
     !instancesRegexSkippedList.some(re => re.test(`${file.type}.${file.fullName}`))
   )
 
-  const getFolders = async (type: ObjectType): Promise<(FileProperties | undefined)[]> => {
-    const folderType = type.annotations[FOLDER_TYPE]
+  const getFolders = async (type: MetadataObjectType): Promise<(FileProperties | undefined)[]> => {
+    const { folderType } = type.annotations
     if (folderType === undefined) {
       return [undefined]
     }
@@ -72,8 +72,8 @@ export const retrieveMetadataInstances = async ({
       .value()
   }
 
-  const listFilesOfType = async (type: ObjectType): Promise<FileProperties[]> => {
-    if (type.annotations[FOLDER_CONTENT_TYPE] !== undefined) {
+  const listFilesOfType = async (type: MetadataObjectType): Promise<FileProperties[]> => {
+    if (type.annotations.folderContentType !== undefined) {
       // We get folders as part of getting the records inside them
       return []
     }
@@ -99,7 +99,7 @@ export const retrieveMetadataInstances = async ({
     // Because of a salesforce quirk, in order to get folder instances we actually need to use the
     // "child" type with the folder fullName
     const filesToRetrieve = fileProps.map(inst => (
-      { ...inst, type: typesByName[inst.type]?.annotations[FOLDER_CONTENT_TYPE] ?? inst.type }
+      { ...inst, type: typesByName[inst.type]?.annotations?.folderContentType ?? inst.type }
     ))
     const request = toRetrieveRequest(filesToRetrieve)
     const result = await client.retrieve(request)

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -43,8 +43,8 @@ import {
   VALUE_SET_DEFINITION_FIELDS, CUSTOM_FIELD, LAYOUT_TYPE_ID_METADATA_TYPE,
   LAYOUT_ITEM_METADATA_TYPE, WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
   WORKFLOW_RULE_METADATA_TYPE, WORKFLOW_ACTION_REFERENCE_METADATA_TYPE,
-  COMPOUND_FIELDS_SOAP_TYPE_NAMES, FOLDER_TYPE, HAS_META_FILE, IS_FOLDER, CUSTOM_OBJECT_ID_FIELD,
-  FOREIGN_KEY_DOMAIN, XML_ATTRIBUTE_PREFIX,
+  COMPOUND_FIELDS_SOAP_TYPE_NAMES, FOLDER_TYPE, HAS_META_FILE, FOLDER_CONTENT_TYPE,
+  CUSTOM_OBJECT_ID_FIELD, FOREIGN_KEY_DOMAIN, XML_ATTRIBUTE_PREFIX,
 } from '../constants'
 import SalesforceClient from '../client/client'
 import { allMissingTypes, allMissingSubTypes } from './salesforce_types'
@@ -1199,14 +1199,18 @@ type MetadataTypeAnnotations = {
   [METADATA_TYPE]: string
   [HAS_META_FILE]?: boolean
   [FOLDER_TYPE]?: string
-  [IS_FOLDER]?: boolean
+  [FOLDER_CONTENT_TYPE]?: string
+  suffix?: string
+  dirName?: string
 }
 
 const metadataAnnotationTypes = {
   [METADATA_TYPE]: BuiltinTypes.SERVICE_ID,
   [HAS_META_FILE]: BuiltinTypes.BOOLEAN,
   [FOLDER_TYPE]: BuiltinTypes.STRING,
-  [IS_FOLDER]: BuiltinTypes.BOOLEAN,
+  [FOLDER_CONTENT_TYPE]: BuiltinTypes.STRING,
+  suffix: BuiltinTypes.STRING,
+  dirName: BuiltinTypes.STRING,
 }
 
 type CreateMetadataTypeParams = {
@@ -1229,7 +1233,7 @@ export const createMetadataTypeElements = async ({
 
   const element = Types.get(name, false, isSettings) as ObjectType
   knownTypes.set(name, element)
-  const isTopLevelType = baseTypeNames.has(name) || annotations[IS_FOLDER]
+  const isTopLevelType = baseTypeNames.has(name) || annotations.folderContentType !== undefined
   element.annotationTypes = _.clone(metadataAnnotationTypes)
   element.annotate({
     ..._.pickBy(annotations, isDefined),

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import parser from 'fast-xml-parser'
-import { MetadataInfo, RetrieveResult, FileProperties, RetrieveRequest } from 'jsforce'
+import { RetrieveResult, FileProperties, RetrieveRequest } from 'jsforce'
 import JSZip from 'jszip'
 import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
 import { Values, StaticFile, InstanceElement } from '@salto-io/adapter-api'
@@ -28,7 +28,7 @@ import {
   INSTANCE_FULL_NAME_FIELD, IS_ATTRIBUTE, METADATA_CONTENT_FIELD, SALESFORCE, XML_ATTRIBUTE_PREFIX,
   NAMESPACE_SEPARATOR, INSTALLED_PACKAGES_PATH, RECORDS_PATH,
 } from '../constants'
-import { apiName, metadataType } from './transformer'
+import { apiName, metadataType, MetadataValues } from './transformer'
 
 const { isDefined } = lowerDashValues
 const { makeArray } = collections.array
@@ -196,8 +196,6 @@ export const toRetrieveRequest = (files: ReadonlyArray<FileProperties>): Retriev
       .value(),
   },
 })
-
-export type MetadataValues = MetadataInfo & Values
 
 const addContentFieldAsStaticFile = (values: Values, valuePath: string[], content: Buffer,
   fileName: string, type: string, namespacePrefix?: string): void => {

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -15,9 +15,7 @@
 */
 import {
   ElemID, ObjectType, BuiltinTypes, CORE_ANNOTATIONS, ListType, createRestriction,
-  StaticFile,
 } from '@salto-io/adapter-api'
-import { MetadataInfo } from 'jsforce'
 import * as constants from './constants'
 
 export const METADATA_TYPES_SKIPPED_LIST = 'metadataTypesSkippedList'
@@ -180,7 +178,3 @@ export const configType = new ObjectType({
     },
   },
 })
-
-export interface MetadataInfoWithStaticFile extends MetadataInfo {
- content: StaticFile
-}

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -27,6 +27,7 @@ import {
   getSObjectFieldElement, Types, toCustomField, toCustomObject, instancesToUpdateRecords,
   getValueTypeFieldElement, createMetadataTypeElements, getLookUpName,
   METADATA_TYPES_TO_RENAME, instancesToDeleteRecords, instancesToCreateRecords,
+  isMetadataObjectType, isMetadataInstanceElement,
 } from '../../src/transformers/transformer'
 import {
   FIELD_ANNOTATIONS, FIELD_TYPE_NAMES, LABEL, API_NAME, COMPOUND_FIELD_TYPE_NAMES,
@@ -1526,6 +1527,44 @@ describe('transformer', () => {
       METADATA_TYPES_TO_RENAME.forEach((_value, key) => {
         const elemId: ElemID = Types.getElemId(key, false, undefined)
         expect(elemId.name).toEqual(METADATA_TYPES_TO_RENAME.get(key))
+      })
+    })
+  })
+  describe('metadata type guards', () => {
+    const mdType = new ObjectType({
+      elemID: new ElemID(SALESFORCE, 'test'),
+      annotations: { [METADATA_TYPE]: 'test' },
+    })
+    const nonMdType = new ObjectType({ elemID: new ElemID(SALESFORCE, 'test2') })
+    describe('isMetadataObjectType', () => {
+      it('should return true for metadata object types', () => {
+        expect(isMetadataObjectType(mdType)).toBeTruthy()
+      })
+      it('should return false for other object types', () => {
+        expect(isMetadataObjectType(nonMdType)).toBeFalsy()
+      })
+    })
+    describe('isMetadataInstanceElement', () => {
+      it('should return true for metadata instances', () => {
+        expect(isMetadataInstanceElement(new InstanceElement(
+          'test',
+          mdType,
+          { [INSTANCE_FULL_NAME_FIELD]: 'test' },
+        ))).toBeTruthy()
+      })
+      it('should return false for instance of non metadata types', () => {
+        expect(isMetadataInstanceElement(new InstanceElement(
+          'test',
+          nonMdType,
+          { [INSTANCE_FULL_NAME_FIELD]: 'test' },
+        ))).toBeFalsy()
+      })
+      it('should return false for instances without a fullName', () => {
+        expect(isMetadataInstanceElement(new InstanceElement(
+          'test',
+          mdType,
+          {},
+        ))).toBeFalsy()
       })
     })
   })

--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -19,7 +19,7 @@ import {
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { RetrieveResult, FileProperties } from 'jsforce'
-import { fromRetrieveResult, toMetadataPackageZip, MetadataValues } from '../../src/transformers/xml_transformer'
+import { fromRetrieveResult, toMetadataPackageZip } from '../../src/transformers/xml_transformer'
 import {
   INSTANCE_FULL_NAME_FIELD, METADATA_TYPE, SALESFORCE, ASSIGNMENT_RULES_METADATA_TYPE,
 } from '../../src/constants'
@@ -27,6 +27,7 @@ import { API_VERSION } from '../../src/client/client'
 import { createEncodedZipContent } from '../utils'
 import { mockFileProperties } from '../connection'
 import { allMissingSubTypes } from '../../src/transformers/salesforce_types'
+import { MetadataValues } from '../../src/transformers/transformer'
 
 
 describe('XML Transformer', () => {


### PR DESCRIPTION
- Additional annotations on metadata types (dirName, suffix) to store information that will later be useful for deploy
- Change isFolder annotation to folderContentType annotation for simpler lookup and for deploy where we won’t have context
- Add typescript types for metadata instances and object types instead of relying on constants
- Removed unused type MetadataInfoWithStaticFile
- Remove duplicate constants for metadata content field name

---

As preparation for supporting the `deploy` api on all types, we need to store information that we get in `fetch` so we can use it later in `deploy` (otherwise we'd have to manually add all this information under the `ZipProps` map which is not a scalable solution.
This PR doesn't actually use this information yet, the next PR will contain the implementation of deploy that actually needs this info, but this is a self contained part so it can be reviewed separately (while I am writing the tests for the deploy code)