### PR TITLE
SALTO-873 Add accept-suggestions / y cmdline argument

### DIFF
--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -180,13 +180,6 @@ ${Prompts.SERVICE_ADD_HELP}`
   ): string => `Would you like to isolate the configuration for ${existingEnv} before adding the new environment?`
     + ' (Answer No to continue without changes)'
 
-    public static readonly ISOLATED_MODE_FOR_NEW_ENV_RECOMMENDATION = 'The current fetch command is running for the first time for this environment.'
-    + ' It is recommended to perform first fetch of an environment in isolated mode.'
-
-  public static readonly APPROVE_ISOLATED_RECOMMENDATION = (
-    newServicesNames: string
-  ): string => `Would you like to switch to isolated mode and fetch ${newServicesNames}? (Answer No to continue without switching)`
-
   public static readonly STATE_ONLY_UPDATE_START = (
     numOfChanges: number
   ): string => `Applying ${numOfChanges} changes to the state. Workspace will not be updated.`

--- a/packages/cli/test/commands/env.test.ts
+++ b/packages/cli/test/commands/env.test.ts
@@ -125,7 +125,27 @@ describe('env commands', () => {
       expect(lastWorkspace.demoteAll).toHaveBeenCalled()
     })
 
-    it('should not prompt on 2nd environment creation if  workspace is empty', async () => {
+    it('should not prompt if force=true and acceptSuggestions=false, and do nothing', async () => {
+      await command('.', 'create', cliOutput, 'me2', undefined, true).execute()
+      expect(cliOutput.stdout.content.search('me2')).toBeGreaterThan(0)
+      expect(callbacks.cliApproveIsolateBeforeMultiEnv).not.toHaveBeenCalled()
+      expect(lastWorkspace.demoteAll).not.toHaveBeenCalled()
+    })
+
+    it('should isolate without prompting if acceptSuggestions=true', async () => {
+      await command('.', 'create', cliOutput, 'me2', undefined, undefined, true).execute()
+      expect(cliOutput.stdout.content.search('me2')).toBeGreaterThan(0)
+      expect(callbacks.cliApproveIsolateBeforeMultiEnv).not.toHaveBeenCalled()
+      expect(lastWorkspace.demoteAll).toHaveBeenCalled()
+    })
+    it('should isolate without prompting if acceptSuggestions=true and force=true', async () => {
+      await command('.', 'create', cliOutput, 'me2', undefined, true, true).execute()
+      expect(cliOutput.stdout.content.search('me2')).toBeGreaterThan(0)
+      expect(callbacks.cliApproveIsolateBeforeMultiEnv).not.toHaveBeenCalled()
+      expect(lastWorkspace.demoteAll).toHaveBeenCalled()
+    })
+
+    it('should not prompt on 2nd environment creation if workspace is empty', async () => {
       jest.spyOn(core, 'loadLocalWorkspace').mockImplementationOnce(baseDir => {
         lastWorkspace = mocks.mockLoadWorkspace(baseDir, ['me1'], true)
         return Promise.resolve(lastWorkspace)


### PR DESCRIPTION
Add a flag for accepting all salto suggestions - currently only used for a `create env` recommendation.
