### PR TITLE
dataManagement config by regex and not full string match

### DIFF
--- a/packages/cli/e2e_test/NACL/salto.config/salesforce.nacl
+++ b/packages/cli/e2e_test/NACL/salto.config/salesforce.nacl
@@ -17,10 +17,8 @@ salesforce {
     {
       name = "CPQ"
       enabled = false
-      includeNamespaces = [
-        "SBQQ",
-      ]
       includeObjects = [
+        "^SBQQ__.*",
         "Product2",
       ]
       excludeObjects = [

--- a/packages/cli/src/convertors.ts
+++ b/packages/cli/src/convertors.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { ElemID } from '@salto-io/adapter-api'
+import { regex } from '@salto-io/lowerdash'
 import _ from 'lodash'
 
 export const convertToIDSelectors = (
@@ -33,13 +34,10 @@ export const convertToIDSelectors = (
 export const createRegexFilters = (
   inputFilters: string[]
 ): {filters: RegExp[]; invalidFilters: string[]} => {
-  const [validFilters, invalidFilters] = _.partition(inputFilters, filter => {
-    try {
-      return new RegExp(filter)
-    } catch (e) {
-      return false
-    }
-  })
+  const [validFilters, invalidFilters] = _.partition(
+    inputFilters,
+    filter => regex.isValidRegex(filter)
+  )
   const filters = validFilters.map(filter => new RegExp(filter))
   return { filters, invalidFilters }
 }

--- a/packages/cli/src/convertors.ts
+++ b/packages/cli/src/convertors.ts
@@ -34,10 +34,7 @@ export const convertToIDSelectors = (
 export const createRegexFilters = (
   inputFilters: string[]
 ): {filters: RegExp[]; invalidFilters: string[]} => {
-  const [validFilters, invalidFilters] = _.partition(
-    inputFilters,
-    filter => regex.isValidRegex(filter)
-  )
+  const [validFilters, invalidFilters] = _.partition(inputFilters, regex.isValidRegex)
   const filters = validFilters.map(filter => new RegExp(filter))
   return { filters, invalidFilters }
 }

--- a/packages/lowerdash/src/index.ts
+++ b/packages/lowerdash/src/index.ts
@@ -25,6 +25,7 @@ import * as validators from './validators'
 import * as stack from './stack'
 import * as hash from './hash'
 import * as values from './values'
+import * as regex from './regex'
 
 export {
   collections,
@@ -39,4 +40,5 @@ export {
   stack,
   hash,
   values,
+  regex,
 }

--- a/packages/lowerdash/src/regex.ts
+++ b/packages/lowerdash/src/regex.ts
@@ -1,0 +1,24 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+export const isValidRegex = (str: string): boolean => {
+  try {
+    RegExp(str)
+    return true
+  } catch (e) {
+    return false
+  }
+}

--- a/packages/lowerdash/test/regex.test.ts
+++ b/packages/lowerdash/test/regex.test.ts
@@ -1,0 +1,28 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { isValidRegex } from '../src/regex'
+
+describe('regex', () => {
+  describe('isValidRegex', () => {
+    it('should return false for an invalid regex string', () => {
+      expect(isValidRegex('\\')).toBeFalsy()
+    })
+
+    it('should return true for a valid regex', () => {
+      expect(isValidRegex('validRegex')).toBeTruthy()
+    })
+  })
+})

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -17,7 +17,7 @@ import {
   Adapter, BuiltinTypes, ElemID, InstanceElement, ObjectType, AdapterInstallResult,
   AdapterOperationsContext, AdapterOperations,
 } from '@salto-io/adapter-api'
-import { collections } from '@salto-io/lowerdash'
+import { collections, regex } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { SDKDownloadService } from '@salto-io/suitecloud-cli'
@@ -54,14 +54,7 @@ const netsuiteConfigFromConfig = (config: Readonly<InstanceElement> | undefined)
   NetsuiteConfig => {
   const validateRegularExpressions = (regularExpressions: string[]): void => {
     const invalidRegularExpressions = regularExpressions
-      .filter(regex => {
-        try {
-          RegExp(regex)
-          return false
-        } catch (e) {
-          return true
-        }
-      })
+      .filter(strRegex => !regex.isValidRegex(strRegex))
     if (!_.isEmpty(invalidRegularExpressions)) {
       const errMessage = `Failed to load config due to an invalid ${FILE_PATHS_REGEX_SKIP_LIST} value. The following regular expressions are invalid: ${invalidRegularExpressions}`
       log.error(errMessage)

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -49,15 +49,9 @@ SalesforceConfig => {
 
   const validateDataManagement = (dataManagementConfigs: DataManagementConfig[]): void => {
     dataManagementConfigs.forEach(dataManagementConfig => {
-      if (Array.isArray(dataManagementConfig.includeObjects)) {
-        validateRegularExpressions(`${DATA_MANAGEMENT}.includeObjects`, dataManagementConfig.includeObjects)
-      }
-      if (Array.isArray(dataManagementConfig.excludeObjects)) {
-        validateRegularExpressions(`${DATA_MANAGEMENT}.excludeObjects`, dataManagementConfig.excludeObjects)
-      }
-      if (Array.isArray(dataManagementConfig.allowReferenceTo)) {
-        validateRegularExpressions(`${DATA_MANAGEMENT}.allowReferenceTo`, dataManagementConfig.allowReferenceTo)
-      }
+      validateRegularExpressions(`${DATA_MANAGEMENT}.includeObjects`, makeArray(dataManagementConfig.includeObjects))
+      validateRegularExpressions(`${DATA_MANAGEMENT}.excludeObjects`, makeArray(dataManagementConfig.excludeObjects))
+      validateRegularExpressions(`${DATA_MANAGEMENT}.allowReferenceTo`, makeArray(dataManagementConfig.allowReferenceTo))
     })
   }
 

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -23,9 +23,7 @@ import SalesforceClient, { Credentials, validateCredentials } from './client/cli
 import changeValidator from './change_validator'
 import { getChangeGroupIds } from './group_changes'
 import SalesforceAdapter from './adapter'
-import {
-  configType, credentialsType, INSTANCES_REGEX_SKIPPED_LIST, SalesforceConfig,
-} from './types'
+import { configType, credentialsType, INSTANCES_REGEX_SKIPPED_LIST, SalesforceConfig, DataManagementConfig, DATA_MANAGEMENT } from './types'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -49,8 +47,24 @@ SalesforceConfig => {
     }
   }
 
+  const validateDataManagement = (dataManagementConfigs: DataManagementConfig[]): void => {
+    dataManagementConfigs.forEach(dataManagementConfig => {
+      if (Array.isArray(dataManagementConfig.includeObjects)) {
+        validateRegularExpressions(`${DATA_MANAGEMENT}.includeObjects`, dataManagementConfig.includeObjects)
+      }
+      if (Array.isArray(dataManagementConfig.excludeObjects)) {
+        validateRegularExpressions(`${DATA_MANAGEMENT}.excludeObjects`, dataManagementConfig.excludeObjects)
+      }
+      if (Array.isArray(dataManagementConfig.allowReferenceTo)) {
+        validateRegularExpressions(`${DATA_MANAGEMENT}.allowReferenceTo`, dataManagementConfig.allowReferenceTo)
+      }
+    })
+  }
+
   const instancesRegexSkippedList = makeArray(config?.value?.instancesRegexSkippedList)
   validateRegularExpressions(INSTANCES_REGEX_SKIPPED_LIST, instancesRegexSkippedList)
+  const dataManagementConfigs = makeArray(config?.value?.dataManagement)
+  validateDataManagement(dataManagementConfigs)
   const adapterConfig = {
     metadataTypesSkippedList: makeArray(config?.value?.metadataTypesSkippedList),
     instancesRegexSkippedList: makeArray(config?.value?.instancesRegexSkippedList),

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { collections } from '@salto-io/lowerdash'
+import { collections, regex } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import {
   InstanceElement, Adapter,
@@ -39,25 +39,18 @@ const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials =
 
 const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
 SalesforceConfig => {
-  const validateRegularExpressions = (regularExpressions: string[]): void => {
+  const validateRegularExpressions = (listName: string, regularExpressions: string[]): void => {
     const invalidRegularExpressions = regularExpressions
-      .filter(regex => {
-        try {
-          RegExp(regex)
-          return false
-        } catch (e) {
-          return true
-        }
-      })
+      .filter(strRegex => !regex.isValidRegex(strRegex))
     if (!_.isEmpty(invalidRegularExpressions)) {
-      const errMessage = `Failed to load config due to an invalid ${INSTANCES_REGEX_SKIPPED_LIST} value. The following regular expressions are invalid: ${invalidRegularExpressions}`
+      const errMessage = `Failed to load config due to an invalid ${listName} value. The following regular expressions are invalid: ${invalidRegularExpressions}`
       log.error(errMessage)
       throw Error(errMessage)
     }
   }
 
   const instancesRegexSkippedList = makeArray(config?.value?.instancesRegexSkippedList)
-  validateRegularExpressions(instancesRegexSkippedList)
+  validateRegularExpressions(INSTANCES_REGEX_SKIPPED_LIST, instancesRegexSkippedList)
   const adapterConfig = {
     metadataTypesSkippedList: makeArray(config?.value?.metadataTypesSkippedList),
     instancesRegexSkippedList: makeArray(config?.value?.instancesRegexSkippedList),

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -327,7 +327,9 @@ const getAllowReferencedTypesNames = (
   configs: DataManagementConfig[]
 ): string[] => {
   const allowReferencesToRegexes = configs
-    .flatMap(config => makeArray(config.allowReferenceTo)).filter(isDefined).map(e => new RegExp(e))
+    .flatMap(config => makeArray(config.allowReferenceTo))
+    .filter(isDefined)
+    .map(e => new RegExp(e))
   const baseObjectNames = getBaseTypesNames(customObjectNames, configs)
   return customObjectNames.filter(customObjectName =>
     allowReferencesToRegexes.some(objRegex => objRegex.test(customObjectName))

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -25,7 +25,7 @@ import {
 } from '../constants'
 import { FilterCreator } from '../filter'
 import { apiName, isCustomObject, Types, createInstanceServiceIds } from '../transformers/transformer'
-import { getNamespace, getNamespaceFromString } from './utils'
+import { getNamespace } from './utils'
 import { DataManagementConfig } from '../types'
 
 const { mapValuesAsync } = promises.object
@@ -310,15 +310,16 @@ const getBaseTypesNames = (
   customObjectNames: string[],
   configs: DataManagementConfig[]
 ): string[] => {
-  const groupedIncludeNamespaces = configs.flatMap(config => makeArray(config.includeNamespaces))
-  const groupedIncludeObjects = configs.flatMap(config => makeArray(config.includeObjects))
-  const groupedExcludeObjects = configs.flatMap(config => makeArray(config.excludeObjects))
-  return customObjectNames.filter(customObjectName => {
-    const namespace = getNamespaceFromString(customObjectName)
-    return ((namespace !== undefined && groupedIncludeNamespaces.includes(namespace))
-      || groupedIncludeObjects.includes(customObjectName))
-      && !groupedExcludeObjects.includes(customObjectName)
-  })
+  const groupedIncludeObjects = configs
+    .flatMap(config => makeArray(config.includeObjects))
+    .map(e => new RegExp(e))
+  const groupedExcludeObjects = configs
+    .flatMap(config => makeArray(config.excludeObjects))
+    .map(e => new RegExp(e))
+  return customObjectNames
+    .filter(customObjectName =>
+      (groupedIncludeObjects.some(objRegex => objRegex.test(customObjectName))
+      && !groupedExcludeObjects.some(objRejex => objRejex.test(customObjectName))))
 }
 
 const getAllowReferencedTypesNames = (

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -326,11 +326,11 @@ const getAllowReferencedTypesNames = (
   customObjectNames: string[],
   configs: DataManagementConfig[]
 ): string[] => {
-  const allowReferebcedTypeNames = configs
-    .flatMap(config => makeArray(config.allowReferenceTo)).filter(isDefined)
+  const allowReferencesToRegexes = configs
+    .flatMap(config => makeArray(config.allowReferenceTo)).filter(isDefined).map(e => new RegExp(e))
   const baseObjectNames = getBaseTypesNames(customObjectNames, configs)
   return customObjectNames.filter(customObjectName =>
-    allowReferebcedTypeNames.includes(customObjectName)
+    allowReferencesToRegexes.some(objRegex => objRegex.test(customObjectName))
     && !baseObjectNames.includes(customObjectName))
 }
 

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -147,7 +147,9 @@ export const configType = new ObjectType({
             name: 'CPQ',
             enabled: false,
             isNameBasedID: true,
-            includeNamespaces: ['SBQQ'],
+            includeObjects: [
+              '^SBQQ__.*',
+            ],
             excludeObjects: [
               'SBQQ__ContractedPrice__c',
               'SBQQ__Quote__c',

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -40,7 +40,6 @@ export type DataManagementConfig = {
   name: string
   enabled: boolean
   isNameBasedID: boolean
-  includeNamespaces?: string[]
   includeObjects?: string[]
   excludeObjects?: string[]
   allowReferenceTo?: string[]
@@ -94,7 +93,6 @@ const dataManagementType = new ObjectType({
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
     },
-    includeNamespaces: { type: new ListType(BuiltinTypes.STRING) },
     includeObjects: { type: new ListType(BuiltinTypes.STRING) },
     excludeObjects: { type: new ListType(BuiltinTypes.STRING) },
     allowReferenceTo: { type: new ListType(BuiltinTypes.STRING) },

--- a/packages/salesforce-adapter/test/adapter.creator.test.ts
+++ b/packages/salesforce-adapter/test/adapter.creator.test.ts
@@ -89,5 +89,47 @@ describe('SalesforceAdapter creator', () => {
       )
       expect(() => adapter.operations({ credentials, config: invalidConfig })).toThrow()
     })
+
+    it('should throw an error when creating adapter with invalid regex in dataManagement.includeObjects', () => {
+      const invalidConfig = new InstanceElement(
+        ElemID.CONFIG_NAME,
+        adapter.configType as ObjectType,
+        { dataManagement: [{
+          name: 'test',
+          enabled: true,
+          isNameBasedID: true,
+          includeObjects: ['\\'],
+        }] },
+      )
+      expect(() => adapter.operations({ credentials, config: invalidConfig })).toThrow()
+    })
+
+    it('should throw an error when creating adapter with invalid regex in dataManagement.excludeObjects', () => {
+      const invalidConfig = new InstanceElement(
+        ElemID.CONFIG_NAME,
+        adapter.configType as ObjectType,
+        { dataManagement: [{
+          name: 'test',
+          enabled: true,
+          isNameBasedID: true,
+          excludeObjects: ['\\'],
+        }] },
+      )
+      expect(() => adapter.operations({ credentials, config: invalidConfig })).toThrow()
+    })
+
+    it('should throw an error when creating adapter with invalid regex in dataManagement.allowReferenceTo', () => {
+      const invalidConfig = new InstanceElement(
+        ElemID.CONFIG_NAME,
+        adapter.configType as ObjectType,
+        { dataManagement: [{
+          name: 'test',
+          enabled: true,
+          isNameBasedID: true,
+          allowReferenceTo: ['\\'],
+        }] },
+      )
+      expect(() => adapter.operations({ credentials, config: invalidConfig })).toThrow()
+    })
   })
 })

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -161,7 +161,7 @@ describe('Custom Object Instances filter', () => {
               includeObjects: [
                 createNamespaceRegexFromString(testNamespace),
               ],
-              excludeObjects: [excludeObjectName],
+              excludeObjects: ['^TestNamespace__Exclude.*'],
             },
             {
               name: 'disabledWithNamespaceRegex',
@@ -207,7 +207,7 @@ describe('Custom Object Instances filter', () => {
                 refFromAndToObjectName,
               ],
               allowReferenceTo: [
-                refToObjectName, refToFromNamespaceObjectName,
+                refToObjectName, '^RefFromNamespace__RefTo.*',
                 refFromAndToObjectName, emptyRefToObjectName,
               ],
             },

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -38,6 +38,9 @@ describe('Custom Object Instances filter', () => {
   type FilterType = FilterWith<'onFetch'>
   let filter: FilterType
 
+  const createNamespaceRegexFromString = (namespace: string): string =>
+    `${namespace}__.*`
+
   const NAME_FROM_GET_ELEM_ID = 'getElemIDPrefix'
   const mockGetElemIdFunc = (adapterName: string, _serviceIds: ServiceIds, name: string):
     ElemID => new ElemID(adapterName, `${NAME_FROM_GET_ELEM_ID}${name}`)
@@ -152,24 +155,31 @@ describe('Custom Object Instances filter', () => {
         config: {
           dataManagement: [
             {
-              name: 'enabledWithNamespace',
+              name: 'enabledWithNamespaceRegex',
               enabled: true,
               isNameBasedID: false,
-              includeNamespaces: [testNamespace],
+              includeObjects: [
+                createNamespaceRegexFromString(testNamespace),
+              ],
               excludeObjects: [excludeObjectName],
             },
             {
-              name: 'disabledWithNamespace',
+              name: 'disabledWithNamespaceRegex',
               enabled: false,
               isNameBasedID: false,
-              includeNamespaces: [disabledNamespace],
+              includeObjects: [
+                createNamespaceRegexFromString(disabledNamespace),
+              ],
             },
             {
-              name: 'enabledWithNamespaceAndObject',
+              name: 'enabledWithNamespaceRegexAndObject',
               enabled: true,
               isNameBasedID: false,
-              includeNamespaces: [anotherNamespace],
-              includeObjects: [includeObjectName, excludeOverrideObjectName],
+              includeObjects: [
+                createNamespaceRegexFromString(anotherNamespace),
+                includeObjectName,
+                excludeOverrideObjectName,
+              ],
             },
             {
               name: 'enabledWithExcludeObject',
@@ -181,16 +191,21 @@ describe('Custom Object Instances filter', () => {
               name: 'enabledWithNameID',
               enabled: true,
               isNameBasedID: true,
-              includeNamespaces: [nameBasedNamespace],
-              includeObjects: ['PricebookEntry', 'SBQQ__CustomAction__c'],
+              includeObjects: [
+                createNamespaceRegexFromString(nameBasedNamespace),
+                'PricebookEntry',
+                'SBQQ__CustomAction__c',
+              ],
               allowReferenceTo: [refToObjectName],
             },
             {
               name: 'enabledWithReferenceTo',
               enabled: true,
               isNameBasedID: false,
-              includeNamespaces: [refFromNamespace],
-              includeObjects: [refFromAndToObjectName],
+              includeObjects: [
+                createNamespaceRegexFromString(refFromNamespace),
+                refFromAndToObjectName,
+              ],
               allowReferenceTo: [
                 refToObjectName, refToFromNamespaceObjectName,
                 refFromAndToObjectName, emptyRefToObjectName,
@@ -238,14 +253,14 @@ describe('Custom Object Instances filter', () => {
         expect(notConfiguredObjInstances.length).toEqual(0)
       })
 
-      it('should fetch for namespace configured objects', () => {
+      it('should fetch for regex configured objects', () => {
         const includedNameSpaceObjInstances = elements.filter(
           e => isInstanceElement(e) && e.type === includedNameSpaceObj
         ) as InstanceElement[]
         expect(includedNameSpaceObjInstances.length).toEqual(2)
       })
 
-      it('should fetch for namespace configured objects in another conf object', () => {
+      it('should fetch for regex configured objects in another conf object', () => {
         const includedInAnotherNamespaceObjInstances = elements.filter(
           e => isInstanceElement(e) && e.type === includedInAnotherNamespaceObj
         ) as InstanceElement[]
@@ -259,7 +274,7 @@ describe('Custom Object Instances filter', () => {
         expect(includedObjectInstances.length).toEqual(2)
       })
 
-      it('should not fetch for object from a configured namespace whose excluded specifically', () => {
+      it('should not fetch for object from a configured regex whose excluded specifically', () => {
         const excludedObjectInstances = elements.filter(
           e => isInstanceElement(e) && e.type === excludedObject
         ) as InstanceElement[]
@@ -307,7 +322,7 @@ describe('Custom Object Instances filter', () => {
     })
   })
 
-  describe('When some CustomObjects are from the namespace', () => {
+  describe('When some CustomObjects fit the configured regex (namespace)', () => {
     let elements: Element[]
     const simpleName = `${testNamespace}__simple__c`
     const simpleObject = createCustomObject(simpleName)
@@ -336,7 +351,7 @@ describe('Custom Object Instances filter', () => {
       await filter.onFetch(elements)
     })
 
-    it('should add instances per namespaced object', () => {
+    it('should add instances per catched by regex object', () => {
       // 2 new instances per namespaced object because of TestCustomRecords's length
       expect(elements.length).toEqual(10)
       expect(elements.filter(e => isInstanceElement(e)).length).toEqual(6)


### PR DESCRIPTION
Use regex for `includeObjects`, `excludeObjects` and `allowReferencesTo` in `dataManagement` config.

What's here?
* Extract `isValidRegex` to lowerdash and use it all around the code
* Use regex'es instead of complete matches in custom_object_instances filter
* Validate the regex'es in the configuration