### PR TITLE
SALTO-900 Add state-only and memory-only salesforce internal ids

### DIFF
--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -59,7 +59,6 @@ describe('Test utils.ts', () => {
       numArray: { type: new ListType(BuiltinTypes.NUMBER) },
       strArray: { type: new ListType(BuiltinTypes.STRING) },
       obj: {
-
         type: new ListType(new ObjectType({
           elemID: mockElem,
           fields: {

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -15,7 +15,11 @@
 */
 import wu from 'wu'
 import _ from 'lodash'
-import { Element, isObjectType, isInstanceElement, ChangeDataType, isField, isPrimitiveType, ChangeValidator, Change, ChangeError, DependencyChanger, ChangeGroupIdFunction, getChangeElement, isAdditionOrRemovalChange, isFieldChange } from '@salto-io/adapter-api'
+import {
+  Element, isObjectType, isInstanceElement, ChangeDataType, isField, isPrimitiveType,
+  ChangeValidator, Change, ChangeError, DependencyChanger, ChangeGroupIdFunction, getChangeElement,
+  isAdditionOrRemovalChange, isFieldChange,
+} from '@salto-io/adapter-api'
 import { DataNodeMap, GroupedNodeMap, DiffNode, mergeNodesToModify, removeEqualNodes, DiffGraph, Group } from '@salto-io/dag'
 import { logger } from '@salto-io/logging'
 import { expressions } from '@salto-io/workspace'

--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -91,6 +91,7 @@ export const fetchTypes = async (
   const typeInfos = await client.listMetadataTypes()
   const topLevelTypes = typeInfos.filter(info => types.includes(info.xmlName))
   const baseTypeNames = new Set(topLevelTypes.map(info => info.xmlName))
+  const childTypeNames = new Set(topLevelTypes.flatMap(info => info.childXmlNames))
   const additionalTypeInfos = types
     .filter(typeName => !baseTypeNames.has(typeName))
     .map(typeName => ({
@@ -105,7 +106,7 @@ export const fetchTypes = async (
   const res = await Promise.all(
     topLevelTypes
       .concat(additionalTypeInfos)
-      .map(info => fetchMetadataType(client, info, knownTypes, baseTypeNames))
+      .map(info => fetchMetadataType(client, info, knownTypes, baseTypeNames, childTypeNames))
   )
   return res.flat().filter(isObjectType)
 }

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -25,6 +25,7 @@ export const ADMIN_PROFILE = 'Admin'
 export const NAMESPACE_SEPARATOR = '__'
 export const API_NAME_SEPARATOR = '.'
 export const CUSTOM_OBJECT_ID_FIELD = 'Id'
+export const INTERNAL_ID_FIELD = 'internalId'
 export const XML_ATTRIBUTE_PREFIX = 'attr_'
 
 export enum FIELD_TYPE_NAMES {
@@ -116,6 +117,12 @@ export const METADATA_TYPE = 'metadataType'
 export const TOPICS_FOR_OBJECTS_ANNOTATION = 'topicsForObjects'
 export const FOREIGN_KEY_DOMAIN = 'foreignKeyDomain'
 export const IS_ATTRIBUTE = 'isAttribute'
+// must have the same name as INTERNAL_ID_FIELD
+// TODO should be state-only once that's supported for annotations (SALTO-910)
+export const INTERNAL_ID_ANNOTATION = INTERNAL_ID_FIELD
+
+// Temporary list of memory-only annotations, until we support state-only (SALTO-910)
+export const MEMORY_ONLY_ANNOTATIONS = [INTERNAL_ID_ANNOTATION]
 
 // Salesforce annotations
 export const LABEL = 'label'
@@ -162,6 +169,8 @@ export const FIELD_ANNOTATIONS = {
   UPDATEABLE: 'updateable',
   // indicates whether a field is queryable by SOQL (default true)
   QUERYABLE: 'queryable',
+  // when true, the field should not be deployed to the service
+  LOCAL_ONLY: 'localOnly',
 }
 
 export const VALUE_SET_FIELDS = {

--- a/packages/salesforce-adapter/src/filters/add_missing_ids.ts
+++ b/packages/salesforce-adapter/src/filters/add_missing_ids.ts
@@ -1,0 +1,86 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Element, isObjectType, isInstanceElement, isField,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../filter'
+import { apiName, metadataType } from '../transformers/transformer'
+import SalesforceClient from '../client/client'
+import { getFullName, getInternalId, setInternalId } from './utils'
+
+const log = logger(module)
+
+const getIdsForType = async (
+  client: SalesforceClient, type: string,
+): Promise<Record<string, string>> => {
+  const { result, errors } = await client.listMetadataObjects({ type })
+  if (errors && errors.length > 0) {
+    log.debug(`Encountered errors while listing ${type}: ${errors}`)
+  }
+  return Object.fromEntries(
+    result
+      .filter(info => info.id !== undefined && info.id !== '')
+      .map(info => [getFullName(info), info.id])
+  )
+}
+
+/**
+ * Try to add internal ids for the remaining types using listMetadataObjects.
+ *
+ * @param client          The salesforce client to use for the query
+ * @param elementsByType  Elements missing internal ids, grouped by type
+ */
+const addMissingIds = async (
+  client: SalesforceClient,
+  typeName: string,
+  elements: Element[],
+): Promise<void> => {
+  const allIds = await getIdsForType(client, typeName)
+  elements.forEach(element => {
+    const id = allIds[apiName(element)]
+    if (id !== undefined) {
+      setInternalId(element, id)
+    }
+  })
+}
+
+const elementsWithMissingIds = (elements: Element[]): Element[] => (
+  elements
+    .flatMap(e => (isObjectType(e) ? Object.values(e.fields) : [e]))
+    .filter(e => (isInstanceElement(e) && !e.type.isSettings) || isField(e))
+    .filter(e => apiName(e) !== undefined && getInternalId(e) === undefined)
+)
+
+/**
+ * Add missing env-specific ids using listMetadataObjects.
+ */
+const filter: FilterCreator = ({ client }) => ({
+  onFetch: async (elements: Element[]) => {
+    const groupedElements = _.groupBy(
+      elementsWithMissingIds(elements),
+      metadataType,
+    )
+    log.debug(`Getting missing ids for the following types: ${Object.keys(groupedElements)}`)
+    await Promise.all(
+      Object.entries(groupedElements)
+        .map(([typeName, typeElements]) => addMissingIds(client, typeName, typeElements))
+    )
+  },
+})
+
+export default filter

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -334,12 +334,17 @@ const createNestedMetadataInstances = (instance: InstanceElement,
       })
     }))
 
-const createObjectType = (
-  name: string,
-  label: string,
-  fields?: SObjField[],
+const createObjectType = ({
+  name,
+  label,
+  fields,
+  systemFields,
+}: {
+  name: string
+  label: string
+  fields?: SObjField[]
   systemFields?: string[]
-): ObjectType => {
+}): ObjectType => {
   const serviceIds = {
     [ADAPTER]: SALESFORCE,
     [API_NAME]: name,
@@ -369,7 +374,10 @@ const createObjectType = (
 const createFromInstance = (instance: InstanceElement,
   typesFromInstance: TypesFromInstance): Element[] => {
   const objectName = instance.value[INSTANCE_FULL_NAME_FIELD]
-  const object = createObjectType(objectName, instance.value[LABEL])
+  const object = createObjectType({
+    name: objectName,
+    label: instance.value[LABEL],
+  })
   transformObjectAnnotations(object, isCustom(objectName)
     ? typesFromInstance.customAnnotationTypes
     : typesFromInstance.standardAnnotationTypes, instance)
@@ -420,7 +428,7 @@ const createFromSObjectsAndInstances = (
   systemFields: string[],
 ): Element[] =>
   _.flatten(sObjects.map(({ name, label, custom, fields }) => {
-    const object = createObjectType(name, label, fields, systemFields)
+    const object = createObjectType({ name, label, fields, systemFields })
     const instance = instances[name]
     if (!instance) {
       return [object]

--- a/packages/salesforce-adapter/src/filters/remove_memory_only_annotations.ts
+++ b/packages/salesforce-adapter/src/filters/remove_memory_only_annotations.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Element, isObjectType,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import * as constants from '../constants'
+import { FilterCreator } from '../filter'
+
+const removeMemoryOnlyAnnotations = (elements: Element[]): void => {
+  elements
+    .filter(isObjectType)
+    .flatMap(e => ([e, ...Object.values(e.fields)]))
+    .filter(e => (Object.keys(e.annotations).concat(Object.keys(e.annotationTypes))).some(
+      t => constants.MEMORY_ONLY_ANNOTATIONS.includes(t)
+    ))
+    .forEach(e => {
+      e.annotations = _.omit(e.annotations, constants.MEMORY_ONLY_ANNOTATIONS)
+      e.annotationTypes = _.omit(e.annotationTypes, constants.MEMORY_ONLY_ANNOTATIONS)
+    })
+}
+
+/**
+ * Remove annotations that should not be persisted.
+ *
+ * Note: This is a temporary filter, it should be replaced by state-only hidden annotations
+ * once SALTO-910 is supported.
+ */
+const filter: FilterCreator = () => ({
+  onFetch: async (elements: Element[]) => {
+    removeMemoryOnlyAnnotations(elements)
+  },
+})
+
+export default filter

--- a/packages/salesforce-adapter/src/filters/settings_type.ts
+++ b/packages/salesforce-adapter/src/filters/settings_type.ts
@@ -43,6 +43,7 @@ const createSettingsType = async (
       fields: typeFields.valueTypeFields,
       knownTypes,
       baseTypeNames,
+      childTypeNames: new Set(),
       client,
       isSettings: true,
     })

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -23,8 +23,9 @@ import {
 import { collections } from '@salto-io/lowerdash'
 import wu from 'wu'
 import { findElements } from '@salto-io/adapter-utils'
+import { FileProperties } from 'jsforce-types'
 import { API_NAME, LABEL, CUSTOM_OBJECT,
-  METADATA_TYPE, NAMESPACE_SEPARATOR, API_NAME_SEPARATOR, INSTANCE_FULL_NAME_FIELD, SALESFORCE } from '../constants'
+  METADATA_TYPE, NAMESPACE_SEPARATOR, API_NAME_SEPARATOR, INSTANCE_FULL_NAME_FIELD, SALESFORCE, INTERNAL_ID_FIELD, INTERNAL_ID_ANNOTATION } from '../constants'
 import { JSONBool } from '../client/types'
 import { isCustomObject, metadataType, apiName, defaultApiName } from '../transformers/transformer'
 
@@ -158,3 +159,23 @@ export const parentApiNameToMetadataTypeInstances = (elements: Element[], type: 
 Dictionary<InstanceElement[]> => _(getInstancesOfMetadataType(elements, type))
   .groupBy(instance => instanceParent(instance)?.getFullName())
   .value() as Dictionary<InstanceElement[]>
+
+export const getFullName = (obj: FileProperties): string => {
+  const namePrefix = obj.namespacePrefix
+    ? `${obj.namespacePrefix}${NAMESPACE_SEPARATOR}` : ''
+  return obj.fullName.startsWith(namePrefix) ? obj.fullName : `${namePrefix}${obj.fullName}`
+}
+
+export const getInternalId = (elem: Element): string => (
+  (isInstanceElement(elem))
+    ? elem.value[INTERNAL_ID_FIELD]
+    : elem.annotations[INTERNAL_ID_ANNOTATION]
+)
+
+export const setInternalId = (elem: Element, val: string): void => {
+  if (isInstanceElement(elem)) {
+    elem.value[INTERNAL_ID_FIELD] = val
+  } else {
+    elem.annotations[INTERNAL_ID_ANNOTATION] = val
+  }
+}

--- a/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
@@ -1,0 +1,188 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Element, ElemID, ObjectType, InstanceElement, BuiltinTypes, Field,
+} from '@salto-io/adapter-api'
+import { FilterWith } from '../../src/filter'
+import SalesforceClient from '../../src/client/client'
+import filterCreator from '../../src/filters/add_missing_ids'
+import mockAdapter from '../adapter'
+import {
+  SALESFORCE, API_NAME, METADATA_TYPE, INSTANCE_FULL_NAME_FIELD, INTERNAL_ID_ANNOTATION,
+  INTERNAL_ID_FIELD,
+} from '../../src/constants'
+
+describe('Internal IDs filter', () => {
+  let client: SalesforceClient
+  type FilterType = FilterWith<'onFetch'>
+  let filter: FilterType
+  const objTypeID = new ElemID(SALESFORCE, 'Obj')
+
+  const generateElements = (): Element[] => {
+    const objType = new ObjectType({
+      annotations: { [METADATA_TYPE]: 'obj' },
+      elemID: objTypeID,
+      fields: {
+        standard: { type: BuiltinTypes.STRING },
+        custom: {
+          annotations: {
+            [API_NAME]: 'Obj.custom__c',
+          },
+          type: BuiltinTypes.STRING,
+        },
+        special: {
+          annotations: {
+            [API_NAME]: 'pre__Obj.special__c',
+          },
+          type: BuiltinTypes.STRING,
+        },
+      },
+    })
+    const instances = [
+      new InstanceElement(
+        'inst',
+        objType,
+        {
+          standard: 'aaa',
+          custom: 'bbb',
+          [INSTANCE_FULL_NAME_FIELD]: 'inst',
+        },
+      ),
+      new InstanceElement(
+        'unknownInst',
+        objType,
+        {
+          standard: 'aaa',
+          custom: 'bbb',
+          [INSTANCE_FULL_NAME_FIELD]: 'unknownInst',
+        },
+      ),
+      new InstanceElement(
+        'dontChange',
+        objType,
+        {
+          standard: 'aaa',
+          custom: 'bbb',
+          [INTERNAL_ID_FIELD]: 'already defined',
+          [INSTANCE_FULL_NAME_FIELD]: 'dontChange',
+        },
+      ),
+    ]
+    return [objType, ...instances]
+  }
+
+  beforeAll(() => {
+    ({ client } = mockAdapter({
+      adapterParams: {
+      },
+    }))
+    filter = filterCreator({ client, config: {} }) as FilterType
+  })
+
+  describe('resolve internal ids', () => {
+    let elements: Element[]
+    let numElements: number
+    let mockListMetadataObjects: jest.Mock
+
+    beforeAll(async () => {
+      mockListMetadataObjects = jest.fn()
+        .mockImplementationOnce(async () => ({ result: [
+          {
+            id: 'custom field id 456',
+            namespacePrefix: 'pre',
+            fullName: 'Obj.special__c',
+          },
+          {
+            id: 'custom field id 123',
+            fullName: 'Obj.custom__c',
+            namespacePrefix: undefined,
+          },
+          // should not be looked up
+          {
+            id: 'should not be used',
+            fullName: 'Obj.standard',
+            namespacePrefix: undefined,
+          },
+        ] }))
+        .mockImplementationOnce(async () => ({ result: [
+          {
+            id: 'instance id 431',
+            fullName: 'inst',
+          },
+          {
+            id: 'instance id 547',
+            fullName: 'dontChange',
+          },
+        ] }))
+      SalesforceClient.prototype.listMetadataObjects = mockListMetadataObjects
+
+      elements = generateElements()
+      numElements = elements.length
+      await filter.onFetch(elements)
+    })
+
+    it('should not change # of elements', () => {
+      expect(elements.length).toEqual(numElements)
+    })
+    it('should make the right requests from listMetadataObjects', () => {
+      expect(mockListMetadataObjects).toHaveBeenCalledTimes(2)
+      expect(mockListMetadataObjects.mock.calls[0][0].type).toEqual('CustomField')
+      expect(mockListMetadataObjects.mock.calls[1][0].type).toEqual('obj')
+    })
+
+    it('should add id annotation for custom fields', () => {
+      expect(elements[0]).toBeInstanceOf(ObjectType)
+      const objType = elements[0] as ObjectType
+      expect(objType.fields.custom).toBeInstanceOf(Field)
+      expect(objType.fields.custom.annotations?.[INTERNAL_ID_ANNOTATION]).toEqual('custom field id 123')
+      expect(objType.fields.special).toBeInstanceOf(Field)
+      expect(objType.fields.special.annotations?.[INTERNAL_ID_ANNOTATION]).toEqual('custom field id 456')
+    })
+
+    it('should not add id annotation for standard field', () => {
+      expect(elements[0]).toBeInstanceOf(ObjectType)
+      const objType = elements[0] as ObjectType
+      expect(objType.fields.standard?.annotations?.[INTERNAL_ID_ANNOTATION]).toBeUndefined()
+    })
+
+    it('should add id field for instance element', () => {
+      expect(elements[1]).toBeInstanceOf(InstanceElement)
+      const inst = elements[1] as InstanceElement
+      expect(inst.value[INTERNAL_ID_FIELD]).toEqual('instance id 431')
+    })
+
+    it('should not add id field if instance is not found', () => {
+      expect(elements[2]).toBeInstanceOf(InstanceElement)
+      const inst = elements[2] as InstanceElement
+      expect(inst.value[INTERNAL_ID_FIELD]).toBeUndefined()
+    })
+
+    it('should not add id field if id is already known', () => {
+      expect(elements[3]).toBeInstanceOf(InstanceElement)
+      const inst = elements[3] as InstanceElement
+      expect(inst.value[INTERNAL_ID_FIELD]).toEqual('already defined')
+    })
+
+    it('should add id annotation for instance elements', () => {
+      expect(elements[1]).toBeInstanceOf(InstanceElement)
+      expect(elements[2]).toBeInstanceOf(InstanceElement)
+      expect(elements[3]).toBeInstanceOf(InstanceElement)
+      expect(elements[1].annotations?.[INTERNAL_ID_ANNOTATION]).toBeUndefined()
+      expect(elements[2].annotations?.[INTERNAL_ID_ANNOTATION]).toBeUndefined()
+      expect(elements[3].annotations?.[INTERNAL_ID_ANNOTATION]).toBeUndefined()
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/filters/remove_memory_only_annotations.test.ts
+++ b/packages/salesforce-adapter/test/filters/remove_memory_only_annotations.test.ts
@@ -1,0 +1,119 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Element, ElemID, ObjectType, InstanceElement, BuiltinTypes, Field,
+} from '@salto-io/adapter-api'
+import { FilterWith } from '../../src/filter'
+import SalesforceClient from '../../src/client/client'
+import filterCreator from '../../src/filters/remove_memory_only_annotations'
+import mockAdapter from '../adapter'
+import { SALESFORCE, API_NAME, METADATA_TYPE, INTERNAL_ID_ANNOTATION, INSTANCE_FULL_NAME_FIELD } from '../../src/constants'
+
+describe('Remove memory-only annotations filter', () => {
+  let client: SalesforceClient
+  type FilterType = FilterWith<'onFetch'>
+  let filter: FilterType
+  const objTypeID = new ElemID(SALESFORCE, 'Obj')
+
+  const generateElements = (): Element[] => {
+    const objType = new ObjectType({
+      annotationTypes: {
+        [INTERNAL_ID_ANNOTATION]: BuiltinTypes.STRING,
+        [METADATA_TYPE]: BuiltinTypes.STRING,
+      },
+      annotations: {
+        [METADATA_TYPE]: 'obj',
+        // won't exist but this is the only example right now
+        [INTERNAL_ID_ANNOTATION]: 'some id',
+      },
+      elemID: objTypeID,
+      fields: {
+        standard: { type: BuiltinTypes.STRING },
+        custom: {
+          annotations: {
+            [API_NAME]: 'Obj.custom__c',
+          },
+          type: BuiltinTypes.STRING,
+        },
+        special: {
+          annotations: {
+            [API_NAME]: 'pre__Obj.special__c',
+            [INTERNAL_ID_ANNOTATION]: 'some id',
+          },
+          type: BuiltinTypes.STRING,
+        },
+      },
+    })
+    const instanceName = 'inst'
+    const instance = new InstanceElement(
+      instanceName,
+      objType,
+      {
+        standard: 'aaa',
+        custom: 'bbb',
+        [INSTANCE_FULL_NAME_FIELD]: 'inst',
+      },
+      undefined,
+      {
+        [INTERNAL_ID_ANNOTATION]: 'some id',
+      }
+    )
+    return [objType, instance]
+  }
+
+  beforeAll(() => {
+    ({ client } = mockAdapter({
+      adapterParams: {
+      },
+    }))
+    filter = filterCreator({ client, config: {} }) as FilterType
+  })
+
+  describe('resolve internal ids', () => {
+    let elements: Element[]
+    let numElements: number
+
+    beforeAll(async () => {
+      elements = generateElements()
+      numElements = elements.length
+      await filter.onFetch(elements)
+    })
+
+    it('should not change # of elements', () => {
+      expect(elements.length).toEqual(numElements)
+    })
+
+    it('should remove memory-only annotation from field if it exists', () => {
+      expect(elements[0]).toBeInstanceOf(ObjectType)
+      const objType = elements[0] as ObjectType
+      expect(objType.fields.custom).toBeInstanceOf(Field)
+      expect(Object.keys(objType.fields.custom.annotations)).not.toContain(INTERNAL_ID_ANNOTATION)
+      expect(Object.keys(objType.fields.custom.annotations)).toHaveLength(1)
+      expect(objType.fields.special).toBeInstanceOf(Field)
+      expect(Object.keys(objType.fields.special.annotations)).not.toContain(INTERNAL_ID_ANNOTATION)
+      expect(Object.keys(objType.fields.special.annotations)).toHaveLength(1)
+    })
+
+    it('should remove memory-only annotation and annotationType from object type', () => {
+      expect(elements[0]).toBeInstanceOf(ObjectType)
+      const objType = elements[0] as ObjectType
+      expect(Object.keys(objType.annotations)).not.toContain(INTERNAL_ID_ANNOTATION)
+      expect(Object.keys(objType.annotations)).toHaveLength(1)
+      expect(Object.keys(objType.annotationTypes)).not.toContain(INTERNAL_ID_ANNOTATION)
+      expect(Object.keys(objType.annotationTypes)).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
Step 1 for SALTO-900 - retrieving salesforce ids for use to translate results from the tooling API (SALTO-899).
For instance elements, we're using the existing state-only mechanism. 
For fields, we use a new memory-only annotation (`id`). Once SALTO-910 is implemented, it will be converted to state-only and the removal filter will be deleted.