### PR TITLE
SALTO-899 Add references from the tooling API

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -403,6 +403,7 @@ Salto supports various annotations whose semantic is enforced by the tool itself
     - **regex** A regular expression that the value should match (e.g. "^[a-z]*$" for lowercase values)
 - **\_depends\_on** Can be used to explicitly define dependencies between blocks. Its value is a list of references, each reference marks that this block depends on the reference target
 - **_parent** Can be used to explicitly define a relationship between blocks. Its value is a list of references, each reference marks that this block is a child of the reference target, unlike _depends_on, a parent relationship means the child block is assumed to be deleted automatically (by the service) when the parent is removed
+- **_generated_dependencies** System-generated list of additional references besides the ones already covered elsewhere. Should not be modified manually - use _depends_on instead
 
 ## Salto builtin types
 

--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -51,11 +51,13 @@ export const CORE_ANNOTATIONS = {
 export const INSTANCE_ANNOTATIONS = {
   DEPENDS_ON: '_depends_on',
   PARENT: '_parent',
+  GENERATED_DEPENDENCIES: '_generated_dependencies',
 }
 
 export const InstanceAnnotationTypes: TypeMap = {
   [INSTANCE_ANNOTATIONS.DEPENDS_ON]: new ListType(BuiltinTypes.STRING),
   [INSTANCE_ANNOTATIONS.PARENT]: new ListType(BuiltinTypes.STRING),
+  [INSTANCE_ANNOTATIONS.GENERATED_DEPENDENCIES]: new ListType(BuiltinTypes.STRING),
 }
 
 const restrictionType = new ObjectType({

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -708,3 +708,17 @@ export const createDefaultInstanceFromType = (name: string, objectType: ObjectTy
 }
 
 export const safeJsonStringify = (value: Value): string => safeStringify(value)
+
+export const getAllReferencedIds = (element: Element): Set<string> => {
+  const allReferencedIds = new Set<string>()
+  const transformFunc: TransformFunc = ({ value }) => {
+    if (isReferenceExpression(value)) {
+      allReferencedIds.add(value.elemId.getFullName())
+    }
+    return value
+  }
+
+  transformElement({ element, transformFunc, strict: false })
+
+  return allReferencedIds
+}

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -29,7 +29,7 @@ import {
   findElement, findElements, findObjectType, GetLookupNameFunc, safeJsonStringify, naclCase,
   findInstances, flattenElementStr, valuesDeepSome, filterByID, setPath, ResolveValuesFunc,
   flatValues, mapKeysRecursive, createDefaultInstanceFromType, applyInstancesDefaults,
-  restoreChangeElement, RestoreValuesFunc,
+  restoreChangeElement, RestoreValuesFunc, getAllReferencedIds,
 } from '../src/utils'
 import { mockFunction } from './common'
 
@@ -63,6 +63,9 @@ describe('Test utils.ts', () => {
           elemID: mockElem,
           fields: {
             field: { type: BuiltinTypes.STRING },
+            otherField: {
+              type: BuiltinTypes.STRING,
+            },
             value: { type: BuiltinTypes.STRING },
             innerObj: {
 
@@ -112,6 +115,7 @@ describe('Test utils.ts', () => {
       obj: [
         {
           field: 'firstField',
+          otherField: 'doesn\'t matter',
           value: {
             val: 'someString',
             anotherVal: { objTest: '123' },
@@ -127,6 +131,7 @@ describe('Test utils.ts', () => {
         },
         {
           field: 'true',
+          undeployable: valueRef,
           value: ['123', '456'],
           innerObj: {
             name: 'name1',
@@ -141,6 +146,7 @@ describe('Test utils.ts', () => {
           field: '123',
           innerObj: {
             name: 'name1',
+            undeployable: new ReferenceExpression(new ElemID('mockAdapter', 'test2', 'field', 'aaa')),
             listOfNames: ['str4', 'str1', 'str2'],
             magical: {
               deepNumber: '',
@@ -1441,6 +1447,13 @@ describe('Test utils.ts', () => {
       it('should serialize to the same result JSON.stringify', () => {
         expect(saltoJSON).toEqual(regJSON)
       })
+    })
+  })
+
+  describe('getAllReferencedIds', () => {
+    it('should find referenced ids', () => {
+      const res = getAllReferencedIds(mockInstance)
+      expect(res).toEqual(new Set(['mockAdapter.test', 'mockAdapter.test2.field.aaa']))
     })
   })
 })

--- a/packages/core/src/core/plan/dependency/reference_dependency.ts
+++ b/packages/core/src/core/plan/dependency/reference_dependency.ts
@@ -21,23 +21,8 @@ import {
   DependencyChanger,
 } from '@salto-io/adapter-api'
 import {
-  TransformFunc,
-  transformElement,
+  getAllReferencedIds,
 } from '@salto-io/adapter-utils'
-
-const getAllReferencedIds = (element: ChangeDataType): Set<string> => {
-  const allReferencedIds = new Set<string>()
-  const transformFunc: TransformFunc = ({ value }) => {
-    if (isReferenceExpression(value)) {
-      allReferencedIds.add(value.elemId.getFullName())
-    }
-    return value
-  }
-
-  transformElement({ element, transformFunc, strict: false })
-
-  return allReferencedIds
-}
 
 const isString = (val?: string): val is string => val !== undefined
 const getParentIds = (elem: ChangeDataType): Set<string> => new Set(

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -65,6 +65,7 @@ import customObjectTranslationFilter from './filters/custom_object_translation'
 import recordTypeFilter from './filters/record_type'
 import hideTypesFilter from './filters/hide_types'
 import customFeedFilterFilter, { CUSTOM_FEED_FILTER_METADATA_TYPE } from './filters/custom_feed_filter'
+import extraDependenciesFilter from './filters/extra_dependencies'
 import staticResourceFileExtFilter from './filters/static_resource_file_ext'
 import xmlAttributesFilter from './filters/xml_attributes'
 import { ConfigChangeSuggestion, FetchElements, SalesforceConfig } from './types'
@@ -120,6 +121,8 @@ export const DEFAULT_FILTERS = [
   referenceAnnotations,
   // foreignLeyReferences should come after referenceAnnotations
   foreignKeyReferences,
+  // extraDependenciesFilter should run after addMissingIdsFilter
+  extraDependenciesFilter,
   // hideTypesFilter should come before customObjectsSplitFilter
   hideTypesFilter,
   customObjectsSplitFilter,

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -473,17 +473,21 @@ export default class SalesforceClient {
    */
   @SalesforceClient.logDecorator()
   @SalesforceClient.requiresLogin
-  public async *queryAll(queryString: string): AsyncIterable<SalesforceRecord[]> {
+  public async *queryAll(
+    queryString: string,
+    useToolingApi = false,
+  ): AsyncIterable<SalesforceRecord[]> {
     const hadMore = (results: QueryResult<Value>): boolean =>
       !_.isUndefined(results.nextRecordsUrl)
 
-    let results = await this.conn.query(queryString)
+    const conn = useToolingApi ? this.conn.tooling : this.conn
+    let results = await conn.query(queryString)
     yield results.records as SalesforceRecord[]
 
     let hasMore = hadMore(results)
     while (hasMore) {
       // eslint-disable-next-line no-await-in-loop
-      results = await this.conn.queryMore(results.nextRecordsUrl as string)
+      results = await conn.queryMore(results.nextRecordsUrl as string)
       yield results.records as SalesforceRecord[]
       hasMore = hadMore(results)
     }

--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -67,11 +67,17 @@ export interface Bulk {
   load(type: string, operation: BulkLoadOperation, options?: BulkOptions, input?: SfRecord[]): Batch
 }
 
+export interface Tooling {
+  query(soql: string): Promise<QueryResult<Value>>
+  queryMore(locator: string): Promise<QueryResult<Value>>
+}
+
 export default interface Connection {
   login(user: string, password: string): Promise<UserInfo>
   metadata: Metadata
   soap: Soap
   bulk: Bulk
+  tooling: Tooling
   describeGlobal(): Promise<Global>
   query(soql: string): Promise<QueryResult<Value>>
   queryMore(locator: string): Promise<QueryResult<Value>>

--- a/packages/salesforce-adapter/src/filters/extra_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/extra_dependencies.ts
@@ -1,0 +1,189 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  Element, isObjectType, INSTANCE_ANNOTATIONS, ReferenceExpression, ElementMap, ElemID,
+} from '@salto-io/adapter-api'
+import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { getAllReferencedIds } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../filter'
+import { metadataType, apiName } from '../transformers/transformer'
+import SalesforceClient from '../client/client'
+import { getInternalId, getCustomObjects } from './utils'
+
+const { isDefined } = lowerDashValues
+const log = logger(module)
+
+type ElementMapByMetadataType = Record<string, ElementMap>
+
+const STANDARD_ENTITY_TYPES = ['StandardEntity', 'User']
+
+type DependencyDetails = {
+  type: string
+  id: string
+  name: string
+}
+
+type DependencyGroup = {
+  from: DependencyDetails
+  to: DependencyDetails[]
+}
+
+/**
+ * Get a list of known dependencies between metadata components.
+ *
+ * @param client  The client to use to run the query
+ */
+const getDependencies = async (client: SalesforceClient): Promise<DependencyGroup[]> => {
+  const allDepsIter = await client.queryAll(
+    `SELECT 
+      MetadataComponentId, MetadataComponentType, MetadataComponentName, 
+      RefMetadataComponentId, RefMetadataComponentType, RefMetadataComponentName 
+    FROM MetadataComponentDependency`,
+    true,
+  )
+
+  const allDepsResult = collections.asynciterable.mapAsync(
+    allDepsIter,
+    recs => recs.map(rec => ({
+      from: {
+        type: rec.MetadataComponentType,
+        id: rec.MetadataComponentId,
+        name: rec.MetadataComponentName,
+      },
+      to: {
+        type: rec.RefMetadataComponentType,
+        id: rec.RefMetadataComponentId,
+        name: rec.RefMetadataComponentName,
+      },
+    }))
+  )
+
+  const deps = (await collections.asynciterable.toArrayAsync(allDepsResult)).flat()
+  return _.values(
+    _.groupBy(deps, dep => Object.entries(dep.from))
+  ).map(depArr => ({
+    from: depArr[0].from,
+    to: depArr.map(dep => dep.to),
+  }))
+}
+
+/**
+ * Generate a lookup for elements by metadata type and id.
+ *
+ * @param elements  The fetched elements
+ */
+const generateElemLookup = (elements: Element[]): ElementMapByMetadataType => (
+  _(elements)
+    .flatMap(e => (isObjectType(e) ? [e, ...Object.values(e.fields)] : [e]))
+    .filter(e => getInternalId(e) !== undefined && getInternalId(e) !== '')
+    .groupBy(metadataType)
+    .mapValues(items => _.keyBy(items, item => getInternalId(item)))
+    .value()
+)
+
+/**
+ * Generate a lookup for custom objects by type.
+ *
+ * @param elements  The fetched elements
+ */
+const generateCustomObjectLookup = (elements: Element[]): ElementMap => (
+  _.keyBy(
+    getCustomObjects(elements),
+    elem => apiName(elem),
+  )
+)
+
+/**
+ * Add references to the generated-dependencies annotation,
+ * except for those already referenced elsewhere.
+ *
+ * @param elem        The element to modify
+ * @param refElemIDs  The reference ids to add
+ */
+const addGeneratedDependencies = (elem: Element, refElemIDs: ElemID[]): void => {
+  if (refElemIDs.length === 0) {
+    return
+  }
+
+  const existingReferences = getAllReferencedIds(elem)
+  const newDependencies = refElemIDs
+    .filter(elemId => !existingReferences.has(elemId.getFullName()))
+    .map(elemId => new ReferenceExpression(elemId))
+
+  if (newDependencies.length !== 0) {
+    elem.annotations[INSTANCE_ANNOTATIONS.GENERATED_DEPENDENCIES] = [
+      ...collections.array.makeArray(elem.annotations[INSTANCE_ANNOTATIONS.GENERATED_DEPENDENCIES]),
+      ...newDependencies,
+    ]
+  }
+}
+
+/**
+ * Add an annotation with the references that are not already represented more granularly
+ * in the element.
+ *
+ * @param groupedDeps         All dependencies, grouped by src
+ * @param elemLookup          Element lookup by type and internal salesforce id
+ * @param customObjectLookup  Element lookup for custom objects
+ */
+const addExtraReferences = async (
+  groupedDeps: DependencyGroup[],
+  elemLookup: ElementMapByMetadataType,
+  customObjectLookup: ElementMap,
+): Promise<void> => {
+  const getElem = ({ type, id }: DependencyDetails): Element | undefined => {
+    // Special case handling:
+    // - standard entities are returned with type=StandardEntity and id=<entity name>
+    // - User is returned with type=User and id=User
+    if (STANDARD_ENTITY_TYPES.includes(type)) {
+      return customObjectLookup[id]
+    }
+    return elemLookup[type]?.[id]
+  }
+
+  groupedDeps.forEach(edge => {
+    const elem = getElem(edge.from)
+    if (elem === undefined) {
+      log.debug(`Element ${edge.from.type}:${edge.from.id} (${edge.from.name}) not found, skipping ${
+        edge.to.length} dependencies`)
+      return
+    }
+    const dependencies = edge.to.map(dst => ({ dep: dst, elem: getElem(dst) }))
+    const missingDeps = dependencies.filter(item => item.elem === undefined).map(item => item.dep)
+    missingDeps.forEach(dep => {
+      log.debug(`Referenced element ${dep.type}:${dep.id} (${dep.name}) not found for ${
+        elem.elemID.getFullName()}`)
+    })
+
+    addGeneratedDependencies(elem, dependencies.map(item => item.elem?.elemID).filter(isDefined))
+  })
+}
+
+/**
+ * Add references using the tooling API.
+ */
+const creator: FilterCreator = ({ client }) => ({
+  onFetch: async (elements: Element[]) => {
+    const groupedDeps = await getDependencies(client)
+    const elemLookup = generateElemLookup(elements)
+    const customObjectLookup = generateCustomObjectLookup(elements)
+    await addExtraReferences(groupedDeps, elemLookup, customObjectLookup)
+  },
+})
+
+export default creator

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -24,8 +24,10 @@ import { collections } from '@salto-io/lowerdash'
 import wu from 'wu'
 import { findElements } from '@salto-io/adapter-utils'
 import { FileProperties } from 'jsforce-types'
-import { API_NAME, LABEL, CUSTOM_OBJECT,
-  METADATA_TYPE, NAMESPACE_SEPARATOR, API_NAME_SEPARATOR, INSTANCE_FULL_NAME_FIELD, SALESFORCE, INTERNAL_ID_FIELD, INTERNAL_ID_ANNOTATION } from '../constants'
+import {
+  API_NAME, LABEL, CUSTOM_OBJECT, METADATA_TYPE, NAMESPACE_SEPARATOR, API_NAME_SEPARATOR,
+  INSTANCE_FULL_NAME_FIELD, SALESFORCE, INTERNAL_ID_FIELD, INTERNAL_ID_ANNOTATION,
+} from '../constants'
 import { JSONBool } from '../client/types'
 import { isCustomObject, metadataType, apiName, defaultApiName } from '../transformers/transformer'
 

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -270,7 +270,30 @@ describe('salesforce client', () => {
       })
     })
 
-    describe('when results are returned in more tha one query', () => {
+    describe('when all results are in a single query from tooling api', () => {
+      beforeEach(async () => {
+        dodoScope = nock('http://dodo22/services/data/v47.0/tooling/query/')
+          .get(/.*tooling.*/)
+          .times(1)
+          .reply(200, {
+            totalSize: 2,
+            done: true,
+            records: [{ val: 1 }, { val: 2 }],
+          })
+        resultsIterable = await client.queryAll('queryString', true)
+      })
+
+      it('should have the query returned elements', async () => {
+        const counter = await asyncCounter(resultsIterable)
+        expect(counter).toEqual(2)
+      })
+
+      afterAll(() => {
+        expect(dodoScope.isDone()).toBeTruthy()
+      })
+    })
+
+    describe('when results are returned in more than one query', () => {
       beforeEach(async () => {
         dodoScope = nock('http://dodo22/services/data/v47.0/query')
           .persist()

--- a/packages/salesforce-adapter/test/connection.ts
+++ b/packages/salesforce-adapter/test/connection.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { Value } from '@salto-io/adapter-api'
 import { MetadataObject, DescribeMetadataResult, ValueTypeField, DescribeValueTypeResult, FileProperties, RetrieveResult, RetrieveResultLocator, DeployResultLocator, DeployResult, QueryResult } from 'jsforce-types'
-import Connection, { Metadata, Soap, Bulk } from '../src/client/jsforce'
+import Connection, { Metadata, Soap, Bulk, Tooling } from '../src/client/jsforce'
 import { createEncodedZipContent, MockInterface, mockFunction, ZipFile } from './utils'
 
 export type MockDescribeResultInput = Pick<MetadataObject, 'xmlName'> & Partial<MetadataObject>
@@ -166,4 +166,8 @@ export const mockJsforce: () => MockInterface<Connection> = () => ({
   limits: mockFunction<Connection['limits']>().mockResolvedValue({
     DailyApiRequests: { Remaining: 10000 },
   }),
+  tooling: {
+    query: mockFunction<Tooling['query']>().mockResolvedValue(mockQueryResult({})),
+    queryMore: mockFunction<Tooling['queryMore']>().mockResolvedValue(mockQueryResult({})),
+  },
 })

--- a/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
@@ -1,0 +1,200 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Element, ElemID, ObjectType, InstanceElement, BuiltinTypes, ReferenceExpression,
+  INSTANCE_ANNOTATIONS,
+} from '@salto-io/adapter-api'
+import { FilterWith } from '../../src/filter'
+import SalesforceClient from '../../src/client/client'
+import filterCreator from '../../src/filters/extra_dependencies'
+import mockAdapter from '../adapter'
+import {
+  SALESFORCE, API_NAME, METADATA_TYPE, INSTANCE_FULL_NAME_FIELD, FIELD_ANNOTATIONS,
+  CUSTOM_FIELD, INTERNAL_ID_FIELD, INTERNAL_ID_ANNOTATION,
+} from '../../src/constants'
+import { SalesforceRecord } from '../../src/client/types'
+
+describe('Internal IDs filter', () => {
+  let client: SalesforceClient
+  type FilterType = FilterWith<'onFetch'>
+  let filter: FilterType
+  const objTypeID = new ElemID(SALESFORCE, 'Obj')
+  const otherObjTypeID = new ElemID(SALESFORCE, 'OtherO')
+
+  const generateElements = (): Element[] => {
+    const objType = new ObjectType({
+      annotations: { [METADATA_TYPE]: 'obj' },
+      elemID: objTypeID,
+      fields: {
+        standard: { type: BuiltinTypes.STRING },
+        custom: {
+          annotations: {
+            [API_NAME]: 'Obj.custom__c',
+            [INTERNAL_ID_ANNOTATION]: 'custom id',
+          },
+          type: BuiltinTypes.STRING,
+        },
+        special: {
+          annotations: {
+            [API_NAME]: 'Obj.special__c',
+            [FIELD_ANNOTATIONS.REFERENCE_TO]: [
+              new ReferenceExpression(new ElemID(SALESFORCE, 'OtherO', 'field', 'moreSpecial')),
+            ],
+            [INTERNAL_ID_ANNOTATION]: 'special id',
+          },
+          type: BuiltinTypes.STRING,
+        },
+      },
+    })
+    const otherObjType = new ObjectType({
+      annotations: { [METADATA_TYPE]: 'OtherO' },
+      elemID: otherObjTypeID,
+      fields: {
+        moreSpecial: {
+          annotations: {
+            [API_NAME]: 'OtherO.moreSpecial__c',
+            [INTERNAL_ID_ANNOTATION]: 'more special id',
+          },
+          type: BuiltinTypes.STRING,
+        },
+      },
+    })
+    const instances = [
+      new InstanceElement(
+        'inst1',
+        objType,
+        {
+          standard: 'aaa',
+          custom: new ReferenceExpression(objType.fields.custom.elemID),
+          [INTERNAL_ID_FIELD]: 'inst1 id',
+          [INSTANCE_FULL_NAME_FIELD]: 'inst1',
+        },
+      ),
+      new InstanceElement(
+        'inst2',
+        objType,
+        {
+          standard: 'aaa',
+          custom: 'Obj.custom__c',
+          [INTERNAL_ID_FIELD]: 'inst2 id',
+          [INSTANCE_FULL_NAME_FIELD]: 'inst2',
+        },
+      ),
+    ]
+    return [objType, otherObjType, ...instances]
+  }
+
+  beforeAll(() => {
+    ({ client } = mockAdapter({
+      adapterParams: {
+      },
+    }))
+    filter = filterCreator({ client, config: {} }) as FilterType
+  })
+
+  describe('resolve internal ids', () => {
+    let elements: Element[]
+    let numElements: number
+    let mockQueryAll: jest.Mock
+
+    async function *mockQueryAllImpl(): AsyncIterable<SalesforceRecord[]> {
+      yield [
+        {
+          MetadataComponentType: 'obj',
+          MetadataComponentId: 'inst1 id',
+          MetadataComponentName: 'n1',
+          RefMetadataComponentType: CUSTOM_FIELD,
+          RefMetadataComponentId: 'custom id',
+          RefMetadataComponentName: 'n2',
+        },
+        {
+          MetadataComponentType: 'obj',
+          MetadataComponentId: 'inst1 id',
+          MetadataComponentName: 'n3',
+          RefMetadataComponentType: CUSTOM_FIELD,
+          RefMetadataComponentId: 'special id',
+          RefMetadataComponentName: 'n4',
+        },
+        {
+          MetadataComponentType: 'obj',
+          MetadataComponentId: 'inst2 id',
+          MetadataComponentName: 'n5',
+          RefMetadataComponentType: CUSTOM_FIELD,
+          RefMetadataComponentId: 'custom id',
+          RefMetadataComponentName: 'n6',
+        },
+      ] as unknown as SalesforceRecord[]
+      yield [
+        {
+          MetadataComponentType: 'obj',
+          MetadataComponentId: 'inst2 id',
+          MetadataComponentName: 'n7',
+          RefMetadataComponentType: CUSTOM_FIELD,
+          RefMetadataComponentId: 'more special id',
+          RefMetadataComponentName: 'n8',
+        },
+        {
+          MetadataComponentType: 'obj',
+          MetadataComponentId: 'inst2 id',
+          MetadataComponentName: 'n7',
+          RefMetadataComponentType: CUSTOM_FIELD,
+          RefMetadataComponentId: 'unknown field',
+          RefMetadataComponentName: 'n8',
+        },
+        {
+          MetadataComponentType: 'obj',
+          MetadataComponentId: 'unknown src id',
+          MetadataComponentName: 'n1',
+          RefMetadataComponentType: CUSTOM_FIELD,
+          RefMetadataComponentId: 'custom id',
+          RefMetadataComponentName: 'n2',
+        },
+      ] as unknown as SalesforceRecord[]
+    }
+
+    beforeAll(async () => {
+      mockQueryAll = jest.fn()
+        .mockImplementationOnce(mockQueryAllImpl)
+      SalesforceClient.prototype.queryAll = mockQueryAll
+
+      elements = generateElements()
+      numElements = elements.length
+      await filter.onFetch(elements)
+    })
+
+    it('should not change # of elements', () => {
+      expect(elements.length).toEqual(numElements)
+    })
+
+    it('should add _generated_dependencies when reference does not already exist', () => {
+      expect(elements[2]).toBeInstanceOf(InstanceElement)
+      const inst1Deps = elements[2].annotations[INSTANCE_ANNOTATIONS.GENERATED_DEPENDENCIES]
+      // "custom" is already referenced using a reference expression on a field
+      expect(inst1Deps).toHaveLength(1)
+      expect(inst1Deps[0]).toBeInstanceOf(ReferenceExpression)
+      expect(inst1Deps[0].elemId.getFullName()).toEqual('salesforce.Obj.field.special')
+
+      expect(elements[3]).toBeInstanceOf(InstanceElement)
+      const inst2Deps = elements[3].annotations[INSTANCE_ANNOTATIONS.GENERATED_DEPENDENCIES]
+      // "moreSpecial" is not referenced from an instance so it is included
+      // "unknown" is not a real field so it's not included
+      expect(inst2Deps).toHaveLength(2)
+      expect(inst2Deps[0]).toBeInstanceOf(ReferenceExpression)
+      expect(inst2Deps[0].elemId.getFullName()).toEqual('salesforce.Obj.field.custom')
+      expect(inst2Deps[1].elemId.getFullName()).toEqual('salesforce.OtherO.field.moreSpecial')
+    })
+  })
+})


### PR DESCRIPTION
Note: This also contains the changes from https://github.com/salto-io/salto/pull/1316 - please review only the 2nd commit (`extra_dependencies.ts` has almost all the new logic), and review the `internalId` changes on the other PR.

First step for populating references from the tooling API, continuing @ori-moisis 's initial work.
Using a new annotation for that, so that `_depends_on` can be kept for manually-configured dependencies.
Using salesforce ids retrieved from earlier calls to `listMetadataObjects` to avoid making additional API calls for this (so far, all references were resolved successfully).

We only include in in the new list references that are not already found on the element or (for instance elements) the object type. 

Next step: Reduce the number of references further by placing as many references as possible directly on the referring fields.
