### PR TITLE
SALTO-908: Do not create base types as embedded types

### DIFF
--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1306,15 +1306,16 @@ export const createMetadataTypeElements = async ({
     return field
   }))
 
-  const embeddedTypes = await Promise.all(_.flatten(enrichedFields
+  const embeddedTypes = await Promise.all(enrichedFields
+    .filter(field => !baseTypeNames.has(field.soapType))
     .filter(field => !_.isEmpty(field.fields))
-    .map(field => createMetadataTypeElements({
+    .flatMap(field => createMetadataTypeElements({
       name: field.soapType,
       fields: makeArray(field.fields),
       knownTypes,
       baseTypeNames,
       client,
-    }))))
+    })))
 
   // Enum fields sometimes show up with a type name that is not primitive but also does not
   // have fields (so we won't create an embedded type for it). it seems like these "empty" types

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -1146,10 +1146,9 @@ describe('transformer', () => {
         baseTypeNames: new Set(['BaseType', 'FieldType', 'NestedFieldType']),
         client,
       })
-      expect(elements).toHaveLength(2)
-      const [element, fieldType] = elements
+      expect(elements).toHaveLength(1)
+      const [element] = elements
       expect(element.path).not.toContain(SUBTYPES_PATH)
-      expect(fieldType.path).not.toContain(SUBTYPES_PATH)
       expect(connection.metadata.describeValueType).toHaveBeenCalledTimes(0)
     })
 
@@ -1179,13 +1178,13 @@ describe('transformer', () => {
       const elements = await createMetadataTypeElements({
         name: 'BaseType',
         fields: [field],
-        baseTypeNames: new Set(['BaseType', 'FieldType']),
+        baseTypeNames: new Set(['BaseType']),
         client,
       })
       expect(elements).toHaveLength(3)
       const [element, fieldType, nestedFieldType] = elements
       expect(element.path).not.toContain(SUBTYPES_PATH)
-      expect(fieldType.path).not.toContain(SUBTYPES_PATH)
+      expect(fieldType.path).toContain(SUBTYPES_PATH)
       expect(nestedFieldType.path).toContain(SUBTYPES_PATH)
       expect(connection.metadata.describeValueType).toHaveBeenCalledTimes(1)
     })
@@ -1194,13 +1193,13 @@ describe('transformer', () => {
       const elements = await createMetadataTypeElements({
         name: 'BaseType',
         fields: [field],
-        baseTypeNames: new Set(['BaseType', 'FieldType']),
+        baseTypeNames: new Set(['BaseType']),
         client,
       })
       expect(elements).toHaveLength(2)
       const [element, fieldType] = elements
       expect(element.path).not.toContain(SUBTYPES_PATH)
-      expect(fieldType.path).not.toContain(SUBTYPES_PATH)
+      expect(fieldType.path).toContain(SUBTYPES_PATH)
       expect(connection.metadata.describeValueType).toHaveBeenCalledTimes(1)
     })
 


### PR DESCRIPTION
Some "top level" types are also embedded in other types, we need to avoid the race
condition of creating them as embedded types if we happen to get to the embedded
definition before we get to the top level definition

---

While this doesn't resolve the issue that causes e2e to fail, it should take away the base scenario that caused it to happen so often