### PR TITLE
Service add login bundle

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -331,6 +331,7 @@ Manage your environments' services
 **Options:**
 
 * `--env, -e` : The name of the environment to use
+* `--nologin, -nl` : Do not login to service when adding it (should follow `service add <service-name>`) [boolean] [default: false]
 
 ### **salto env \<command> [\<name>] [\<new-name>]**
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -331,7 +331,7 @@ Manage your environments' services
 **Options:**
 
 * `--env, -e` : The name of the environment to use
-* `--nologin, -nl` : Do not login to service when adding it (should follow `service add <service-name>`) [boolean] [default: false]
+* `--nologin, -n` : Do not login to service when adding it. Example usage: `service add <service-name> --nologin`) [boolean] [default: false]
 
 ### **salto env \<command> [\<name>] [\<new-name>]**
 

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -21,6 +21,7 @@ import {
   LoginStatus,
   updateCredentials,
   loadLocalWorkspace,
+  getAdaptersCredentialsTypes,
 } from '@salto-io/core'
 import { Workspace } from '@salto-io/workspace'
 
@@ -72,11 +73,12 @@ const addService = async (
     return CliExitCode.UserInputError
   }
 
-  const adapterCredentialsType = await addAdapter(workspace, serviceName)
-  stdout.write(formatServiceAdded(serviceName))
-
   try {
+    const adapterCredentialsType = getAdaptersCredentialsTypes([serviceName])[serviceName]
     await getLoginInputFlow(workspace, adapterCredentialsType, getLoginInput, stdout)
+
+    await addAdapter(workspace, serviceName)
+    stdout.write(formatServiceAdded(serviceName))
   } catch (e) {
     stderr.write(formatLoginToServiceFailed(serviceName, e.message))
   }

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -175,8 +175,8 @@ const servicesBuilder = createCommandBuilder({
     description: 'Manage your environment services',
     keyed: {
       nologin: {
-        alias: ['nl'],
-        describe: 'Add the service without logging in to it (should follow \'service add <service-name>\').',
+        alias: ['n'],
+        describe: 'Do not login to service when adding it. Example usage: \'service add <service-name> --nologin\'.',
         boolean: true,
         default: false,
         demandOption: false,

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -66,6 +66,7 @@ const addService = async (
   getLoginInput: (configType: ObjectType) => Promise<InstanceElement>,
   serviceName: string,
   inputEnvironment?: string,
+  nologin?: boolean
 ): Promise<CliExitCode> => {
   const workspace = await loadWorkspace(workspaceDir, inputEnvironment)
   if (workspace.services().includes(serviceName)) {
@@ -74,8 +75,10 @@ const addService = async (
   }
 
   try {
-    const adapterCredentialsType = getAdaptersCredentialsTypes([serviceName])[serviceName]
-    await getLoginInputFlow(workspace, adapterCredentialsType, getLoginInput, stdout)
+    if (!nologin) {
+      const adapterCredentialsType = getAdaptersCredentialsTypes([serviceName])[serviceName]
+      await getLoginInputFlow(workspace, adapterCredentialsType, getLoginInput, stdout)
+    }
 
     await addAdapter(workspace, serviceName)
     stdout.write(formatServiceAdded(serviceName))
@@ -133,6 +136,7 @@ export const command = (
   getLoginInput: (configType: ObjectType) => Promise<InstanceElement>,
   serviceName = '',
   inputEnvironment?: string,
+  nologin?: boolean
 ): CliCommand => ({
   async execute(): Promise<CliExitCode> {
     switch (commandName) {
@@ -142,7 +146,8 @@ export const command = (
           { stdout, stderr },
           getLoginInput,
           serviceName,
-          inputEnvironment
+          inputEnvironment,
+          nologin,
         )
       case 'list':
         return listServices(workspaceDir, { stdout, stderr }, serviceName, inputEnvironment)
@@ -168,6 +173,15 @@ const servicesBuilder = createCommandBuilder({
   options: {
     command: 'service <command> [name]',
     description: 'Manage your environment services',
+    keyed: {
+      nologin: {
+        alias: ['nl'],
+        describe: 'Add the service without logging in to it (should follow \'service add <service-name>\').',
+        boolean: true,
+        default: false,
+        demandOption: false,
+      },
+    },
   },
 
   filters: [serviceCmdFilter, environmentFilter],
@@ -179,6 +193,7 @@ const servicesBuilder = createCommandBuilder({
       getCredentialsFromUser,
       input.args.name,
       input.args.env,
+      input.args.nologin,
     )
   },
 })

--- a/packages/cli/src/filters/service.ts
+++ b/packages/cli/src/filters/service.ts
@@ -23,6 +23,7 @@ import { EnvironmentArgs } from '../commands/env'
 export interface ServiceCmdArgs {
   command: string
   name?: string
+  nologin?: boolean
 }
 
 export type ServiceCmdParsedCliInput = ParsedCliInput<ServiceCmdArgs>
@@ -48,6 +49,7 @@ export const serviceCmdFilter: ServiceCmdFilter = {
         }).check((args: yargs.Arguments<{
           command?: string
           name?: string
+          nologin?: boolean
         }>): true => {
         if (args.command && nameRequiredCommands.includes(args.command)) {
           if (_.isEmpty(args.name)) {

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -149,7 +149,7 @@ The steps are: I. Fetching configs, II. Calculating difference and III. Applying
   public static readonly SERVICES_LOGIN_UPDATED = 'Login information successfully updated!'
   public static readonly SERVICES_LOGIN_OVERRIDE = '** This will override the current login information **'
   public static readonly SERVICE_LOGIN_FAILED = (serviceName: string, errorMessage: string): string => `Could not login to ${serviceName}: ${errorMessage}`
-  public static readonly SERVICE_LOGIN_FAILED_TRY_AGAIN = (serviceName: string): string => `To try again run: \`salto service login ${serviceName}\``
+  public static readonly SERVICE_LOGIN_FAILED_TRY_AGAIN = (serviceName: string): string => `To try again run: \`salto service add ${serviceName}\``
   public static readonly SERVICE_CONFIGURED = (serviceName: string): string => `${serviceName} is configured in this environment`
   public static readonly SERVICE_NOT_CONFIGURED = (serviceName: string): string => `${serviceName} is not configured in this environment`
   public static readonly CONFIGURED_SERVICES_TITLE = 'The configured services are:'

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -68,7 +68,7 @@ export default class Prompts {
     return `Could not initiate workspace: ${msg}\n`
   }
 
-  private static readonly SERVICE_ADD_HELP = 'Use `salto services add <service-name>` to add services to the environment'
+  private static readonly SERVICE_ADD_HELP = 'Use `salto service add <service-name>` to add services to the environment'
 
   public static initCompleted(name: string, baseDir: string): string {
     return `Initiated empty workspace ${name} at ${baseDir}
@@ -144,12 +144,12 @@ The steps are: I. Fetching configs, II. Calculating difference and III. Applying
 
   public static readonly CANCELED = 'Canceling...'
   public static readonly CREDENTIALS_HEADER = (serviceName: string): string => `Please enter your ${serviceName} credentials:`
-  public static readonly SERVICE_HOW_ADD = (serviceName: string): string => `Use \`salto services add ${serviceName}\` to add the service to the environment`
+  public static readonly SERVICE_HOW_ADD = (serviceName: string): string => `Use \`salto service add ${serviceName}\` to add the service to the environment`
   public static readonly SERVICE_ADDED = (serviceName: string): string => `${serviceName} was added to the environment`
   public static readonly SERVICES_LOGIN_UPDATED = 'Login information successfully updated!'
   public static readonly SERVICES_LOGIN_OVERRIDE = '** This will override the current login information **'
   public static readonly SERVICE_LOGIN_FAILED = (serviceName: string, errorMessage: string): string => `Could not login to ${serviceName}: ${errorMessage}`
-  public static readonly SERVICE_LOGIN_FAILED_TRY_AGAIN = (serviceName: string): string => `To try again run: \`salto services login ${serviceName}\``
+  public static readonly SERVICE_LOGIN_FAILED_TRY_AGAIN = (serviceName: string): string => `To try again run: \`salto service login ${serviceName}\``
   public static readonly SERVICE_CONFIGURED = (serviceName: string): string => `${serviceName} is configured in this environment`
   public static readonly SERVICE_NOT_CONFIGURED = (serviceName: string): string => `${serviceName} is not configured in this environment`
   public static readonly CONFIGURED_SERVICES_TITLE = 'The configured services are:'

--- a/packages/cli/test/commands/service.test.ts
+++ b/packages/cli/test/commands/service.test.ts
@@ -215,7 +215,7 @@ describe('service command', () => {
           })
 
           it('should print try again text', async () => {
-            expect(cliOutput.stderr.content).toContain('To try again run: `salto service login newAdapter`')
+            expect(cliOutput.stderr.content).toContain('To try again run: `salto service add newAdapter`')
           })
 
           it('should not print login information updated', async () => {

--- a/packages/cli/test/commands/service.test.ts
+++ b/packages/cli/test/commands/service.test.ts
@@ -21,6 +21,12 @@ import * as mocks from '../mocks'
 
 jest.mock('@salto-io/core', () => ({
   ...jest.requireActual('@salto-io/core'),
+  getAdaptersCredentialsTypes: jest.fn().mockImplementation(():
+   Record<string, ObjectType> => ({
+    newAdapter: mocks.mockCredentialsType('newAdapter'),
+    hubspot: mocks.mockCredentialsType('hubspot'),
+    '': mocks.mockCredentialsType(''),
+  })),
   addAdapter: jest.fn().mockImplementation((
     _workspace: Workspace,
     adapterName: string
@@ -174,10 +180,6 @@ describe('services command', () => {
           await command('', 'add', cliOutput, mockGetCredentialsFromUser, 'newAdapter').execute()
         })
 
-        it('should print added', async () => {
-          expect(cliOutput.stdout.content).toContain('added to the environment')
-        })
-
         it('should print please enter credentials', async () => {
           expect(cliOutput.stdout.content).toContain('Please enter your Newadapter credentials:')
         })
@@ -189,10 +191,18 @@ describe('services command', () => {
           it('should print login information updated', async () => {
             expect(cliOutput.stdout.content).toContain('Login information successfully updated!')
           })
+
+          it('should print added', async () => {
+            expect(cliOutput.stdout.content).toContain('added to the environment')
+          })
         })
 
         describe('when called with invalid credentials', () => {
           beforeEach(async () => {
+            cliOutput = {
+              stdout: new mocks.MockWriteStream(),
+              stderr: new mocks.MockWriteStream(),
+            };
             (updateCredentials as jest.Mock).mockRejectedValue('Rejected!')
             await command('', 'add', cliOutput, mockGetCredentialsFromUser, 'newAdapter').execute()
           })
@@ -207,7 +217,33 @@ describe('services command', () => {
           it('should print try again text', async () => {
             expect(cliOutput.stderr.content).toContain('To try again run: `salto services login newAdapter`')
           })
+
+          it('should not print login information updated', async () => {
+            expect(cliOutput.stdout.content).not.toContain('Login information successfully updated!')
+          })
+
+          it('should not print added', async () => {
+            expect(cliOutput.stdout.content).not.toContain('added to the environment')
+          })
         })
+
+        // describe('No-Login flag', () => {
+        //   it('should add without login', async () => {
+        //     await command(
+        //       '',
+        //       'add',
+        //       cliOutput,
+        //       mockGetCredentialsFromUser,
+        //       'newAdapter',
+        //       undefined,
+        //       true
+        //     ).execute()
+        //     expect(cliOutput.stdout.content).toContain('added to the environment')
+        //     expect(cliOutput.stdout.content).not.toContain(
+        //  'Please enter your Newadapter credentials:')
+        //   })
+        // })
+
         describe('Environment flag', () => {
           const mockAddAdapter = addAdapter as jest.Mock
           beforeEach(async () => {

--- a/packages/cli/test/commands/service.test.ts
+++ b/packages/cli/test/commands/service.test.ts
@@ -60,7 +60,7 @@ jest.mock('@salto-io/core', () => ({
   loadLocalWorkspace: jest.fn(),
 }))
 
-describe('services command', () => {
+describe('service command', () => {
   let cliOutput: { stdout: mocks.MockWriteStream; stderr: mocks.MockWriteStream }
   const mockGetCredentialsFromUser = mocks.createMockGetCredentialsFromUser({
     username: 'test@test',
@@ -215,7 +215,7 @@ describe('services command', () => {
           })
 
           it('should print try again text', async () => {
-            expect(cliOutput.stderr.content).toContain('To try again run: `salto services login newAdapter`')
+            expect(cliOutput.stderr.content).toContain('To try again run: `salto service login newAdapter`')
           })
 
           it('should not print login information updated', async () => {
@@ -227,22 +227,29 @@ describe('services command', () => {
           })
         })
 
-        // describe('No-Login flag', () => {
-        //   it('should add without login', async () => {
-        //     await command(
-        //       '',
-        //       'add',
-        //       cliOutput,
-        //       mockGetCredentialsFromUser,
-        //       'newAdapter',
-        //       undefined,
-        //       true
-        //     ).execute()
-        //     expect(cliOutput.stdout.content).toContain('added to the environment')
-        //     expect(cliOutput.stdout.content).not.toContain(
-        //  'Please enter your Newadapter credentials:')
-        //   })
-        // })
+        describe('nologin flag', () => {
+          beforeEach(async () => {
+            cliOutput = {
+              stdout: new mocks.MockWriteStream(),
+              stderr: new mocks.MockWriteStream(),
+            }
+            await command(
+              '',
+              'add',
+              cliOutput,
+              mockGetCredentialsFromUser,
+              'newAdapter',
+              undefined,
+              true
+            ).execute()
+          })
+          it('should add without login', async () => {
+            expect(cliOutput.stdout.content).toContain('added to the environment')
+            expect(cliOutput.stdout.content).not.toContain(
+              'Please enter your Newadapter credentials:'
+            )
+          })
+        })
 
         describe('Environment flag', () => {
           const mockAddAdapter = addAdapter as jest.Mock

--- a/packages/cli/test/filters/service.test.ts
+++ b/packages/cli/test/filters/service.test.ts
@@ -155,13 +155,6 @@ describe('service filter', () => {
           out = await runCli('service add sales force')
           expect(out.err).toMatch('')
         })
-
-        describe('nologin flag', () => {
-          it('succeed with add --nologin', async () => {
-            out = await runCli('service add salesforce --nologin')
-            expect(out.err).toMatch('')
-          })
-        })
       })
     })
   })

--- a/packages/cli/test/filters/service.test.ts
+++ b/packages/cli/test/filters/service.test.ts
@@ -23,12 +23,12 @@ jest.mock('@salto-io/core', () => ({
   ...jest.requireActual('@salto-io/core'),
   loadLocalWorkspace: jest.fn().mockImplementation(() => mockLoadWorkspace('name')),
 }))
-describe('services filter', () => {
+describe('service filter', () => {
   let out: MockCliOutput
   let buildFunc: jest.Mock
   let builder: YargsCommandBuilder
 
-  describe('verify services filter', () => {
+  describe('verify service filter', () => {
     beforeEach(async () => {
       buildFunc = jest.fn(() =>
         Promise.resolve({ execute: () => Promise.resolve(CliExitCode.Success) })) as jest.Mock
@@ -154,6 +154,13 @@ describe('services filter', () => {
         it('succeed with add', async () => {
           out = await runCli('service add sales force')
           expect(out.err).toMatch('')
+        })
+
+        describe('nologin flag', () => {
+          it('succeed with add --nologin', async () => {
+            out = await runCli('service add salesforce --nologin')
+            expect(out.err).toMatch('')
+          })
         })
       })
     })

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -298,6 +298,22 @@ export const mockLoadWorkspaceEnvironment = (
   }
 }
 
+export const mockCredentialsType = (adapterName: string): ObjectType => {
+  const configID = new ElemID(adapterName)
+  return new ObjectType({
+    elemID: configID,
+    fields: {
+      username: { type: BuiltinTypes.STRING },
+      password: { type: BuiltinTypes.STRING },
+      token: {
+        type: BuiltinTypes.STRING,
+        annotations: {},
+      },
+      sandbox: { type: BuiltinTypes.BOOLEAN },
+    },
+  })
+}
+
 export const mockConfigType = (adapterName: string): ObjectType => {
   const configID = new ElemID(adapterName)
   return new ObjectType({


### PR DESCRIPTION
changed 'service add' command so that it now requests credentials, and only if they are valid - adds an adapter.
also added a 'nologin' flag (to be used like: 'service add salesforce --nologin') that leads to adding the adapter without asking for credentials at the moment.
please note that it was impossible to name the flag 'no-login' because '--no-' is a Yargs prefix and causes Yargs to not recognise 'no-login' as one string.