### PR TITLE
Fix bug where deploy tried to add removed elements back to workspace

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -142,11 +142,12 @@ export const deploy = async (
   const postDeployAction = async (appliedChanges: ReadonlyArray<Change>): Promise<void> => {
     await promises.array.series(appliedChanges.map(change => async () => {
       const updatedElement = await getUpdatedElement(change)
-      const stateUpdate = (change.action === 'remove' && !isFieldChange(change))
-        ? workspace.state().remove(updatedElement.elemID)
-        : workspace.state().set(updatedElement)
-      await stateUpdate
-      changedElements.set(updatedElement.elemID.getFullName(), updatedElement)
+      if (change.action === 'remove' && !isFieldChange(change)) {
+        await workspace.state().remove(updatedElement.elemID)
+      } else {
+        await workspace.state().set(updatedElement)
+        changedElements.set(updatedElement.elemID.getFullName(), updatedElement)
+      }
     }))
   }
   const errors = await deployActions(actionPlan, adapters, reportProgress, postDeployAction)

--- a/packages/core/test/common/helpers.ts
+++ b/packages/core/test/common/helpers.ts
@@ -13,5 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export const mockFunction = <T extends (...args: never[]) => unknown | undefined >():
-jest.Mock<ReturnType<T>, Parameters<T>> => jest.fn()
+export type MockFunction<T extends (...args: never[]) => unknown> =
+  jest.Mock<ReturnType<T>, Parameters<T>>
+
+export const mockFunction = <T extends (...args: never[]) => unknown>(): MockFunction<T> => (
+  jest.fn()
+)

--- a/packages/core/test/common/plan.ts
+++ b/packages/core/test/common/plan.ts
@@ -24,7 +24,9 @@ import { getAllElements } from './elements'
 
 export const createPlan = (changeGroups: Change[][]): Plan => {
   const toGroup = (changes: Change[]): Group<Change> => ({
-    groupKey: getChangeElement(changes[0]).elemID.createTopLevelParentID().parent.getFullName(),
+    groupKey: changes.length > 0
+      ? getChangeElement(changes[0]).elemID.createTopLevelParentID().parent.getFullName()
+      : '',
     items: new Map(changes.map((change, idx) => [`${idx}`, change])),
   })
   const graph = new DataNodeMap<Group<Change>>(


### PR DESCRIPTION
In the second commit there are the tests for this feature which required changed to existing tests to remove redundant mocks