### PR TITLE
remove redundant element clone

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -152,10 +152,6 @@ export const deploy = async (
   }
   const errors = await deployActions(actionPlan, adapters, reportProgress, postDeployAction)
 
-  // Clone the elements because getDetailedChanges can change its input
-  const clonedElements = wu(changedElements.values()).map(e => e.clone())
-    .toArray()
-
   const workspaceElements = await workspace.elements()
   const relevantWorkspaceElements = workspaceElements
     .filter(e => changedElements.has(e.elemID.getFullName()))
@@ -165,7 +161,7 @@ export const deploy = async (
   // with the value of a reference.
   const changes = wu(await getDetailedChanges(
     relevantWorkspaceElements,
-    clonedElements,
+    [...changedElements.values()],
     workspaceElements
   )).map(change => ({ change, serviceChange: change }))
     .map(toChangesWithPath(name => collections.array.makeArray(changedElements.get(name))))


### PR DESCRIPTION
seems like the bug where `getDetailedChanges` changed its input was resolved and there is no need to clone the input anymore

Release notes: small performance improvement in deploy