### PR TITLE
Correctly hide fields added to existing elements

### DIFF
--- a/packages/adapter-api/src/utils.ts
+++ b/packages/adapter-api/src/utils.ts
@@ -80,7 +80,7 @@ export const getSubElement = (
   }
 }
 
-export const getField = (
+const getFieldAndPath = (
   baseType: TypeElement,
   pathParts: ReadonlyArray<string>
 ): SubElementSearchResult | undefined => {
@@ -91,11 +91,11 @@ export const getField = (
   return undefined
 }
 
-export const getFieldDef = (
+export const getField = (
   baseType: TypeElement,
   pathParts: ReadonlyArray<string>,
 ): Field | undefined => (
-  getField(baseType, pathParts)?.field
+  getFieldAndPath(baseType, pathParts)?.field
 )
 
 export const getFieldType = (baseType: TypeElement, path: ReadonlyArray<string>):
@@ -113,7 +113,7 @@ export const getFieldType = (baseType: TypeElement, path: ReadonlyArray<string>)
     }
     return undefined
   }
-  const fieldData = getField(baseType, path)
+  const fieldData = getFieldAndPath(baseType, path)
   return fieldData?.field && getFieldInternalType(fieldData.field.type, fieldData.path)
 }
 

--- a/packages/adapter-api/src/utils.ts
+++ b/packages/adapter-api/src/utils.ts
@@ -91,6 +91,13 @@ export const getField = (
   return undefined
 }
 
+export const getFieldDef = (
+  baseType: TypeElement,
+  pathParts: ReadonlyArray<string>,
+): Field | undefined => (
+  getField(baseType, pathParts)?.field
+)
+
 export const getFieldType = (baseType: TypeElement, path: ReadonlyArray<string>):
   TypeElement | undefined => {
   const getFieldInternalType = (

--- a/packages/adapter-api/test/utils.test.ts
+++ b/packages/adapter-api/test/utils.test.ts
@@ -16,6 +16,9 @@
 
 import {
   getDeepInnerType,
+  getField,
+  getFieldDef,
+  getFieldType,
 } from '../src/utils'
 import {
   ObjectType, ListType, isElement, isField, isListType,
@@ -94,6 +97,32 @@ describe('Test utils.ts & isXXX in elements.ts', () => {
     it('should recognize getDeepInnerType in list of lists', () => {
       expect(getDeepInnerType(mockObjectType.fields.listOfListFieldTest.type as ListType))
         .toEqual(BuiltinTypes.NUMBER)
+    })
+  })
+
+  describe('getField, getFieldDef, getFieldType funcs', () => {
+    it('should succeed on a standard field', () => {
+      expect(getFieldDef(mockObjectType, ['fieldTest'])).toEqual(mockObjectType.fields.fieldTest)
+      expect(getField(mockObjectType, ['fieldTest'])).toEqual({
+        field: mockObjectType.fields.fieldTest,
+        path: [],
+      })
+      expect(getFieldType(mockObjectType, ['fieldTest'])).toEqual(BuiltinTypes.NUMBER)
+    })
+
+    it('should succeed on a list field', () => {
+      expect(getFieldDef(mockObjectType, ['listFieldTest'])).toEqual(mockObjectType.fields.listFieldTest)
+      expect(getField(mockObjectType, ['listFieldTest'])).toEqual({
+        field: mockObjectType.fields.listFieldTest,
+        path: [],
+      })
+      expect(getFieldType(mockObjectType, ['listFieldTest'])).toEqual(new ListType(BuiltinTypes.NUMBER))
+    })
+
+    it('should return undefined on a nonexistent field', () => {
+      expect(getFieldDef(mockObjectType, ['nonExistentField'])).toBeUndefined()
+      expect(getField(mockObjectType, ['nonExistentField'])).toBeUndefined()
+      expect(getFieldType(mockObjectType, ['nonExistentField'])).toBeUndefined()
     })
   })
 })

--- a/packages/adapter-api/test/utils.test.ts
+++ b/packages/adapter-api/test/utils.test.ts
@@ -17,7 +17,6 @@
 import {
   getDeepInnerType,
   getField,
-  getFieldDef,
   getFieldType,
 } from '../src/utils'
 import {
@@ -100,27 +99,18 @@ describe('Test utils.ts & isXXX in elements.ts', () => {
     })
   })
 
-  describe('getField, getFieldDef, getFieldType funcs', () => {
+  describe('getField, getFieldType funcs', () => {
     it('should succeed on a standard field', () => {
-      expect(getFieldDef(mockObjectType, ['fieldTest'])).toEqual(mockObjectType.fields.fieldTest)
-      expect(getField(mockObjectType, ['fieldTest'])).toEqual({
-        field: mockObjectType.fields.fieldTest,
-        path: [],
-      })
+      expect(getField(mockObjectType, ['fieldTest'])).toEqual(mockObjectType.fields.fieldTest)
       expect(getFieldType(mockObjectType, ['fieldTest'])).toEqual(BuiltinTypes.NUMBER)
     })
 
     it('should succeed on a list field', () => {
-      expect(getFieldDef(mockObjectType, ['listFieldTest'])).toEqual(mockObjectType.fields.listFieldTest)
-      expect(getField(mockObjectType, ['listFieldTest'])).toEqual({
-        field: mockObjectType.fields.listFieldTest,
-        path: [],
-      })
+      expect(getField(mockObjectType, ['listFieldTest'])).toEqual(mockObjectType.fields.listFieldTest)
       expect(getFieldType(mockObjectType, ['listFieldTest'])).toEqual(new ListType(BuiltinTypes.NUMBER))
     })
 
     it('should return undefined on a nonexistent field', () => {
-      expect(getFieldDef(mockObjectType, ['nonExistentField'])).toBeUndefined()
       expect(getField(mockObjectType, ['nonExistentField'])).toBeUndefined()
       expect(getFieldType(mockObjectType, ['nonExistentField'])).toBeUndefined()
     })

--- a/packages/lang-server/src/completions/suggestions.ts
+++ b/packages/lang-server/src/completions/suggestions.ts
@@ -209,7 +209,7 @@ export const fieldValueSuggestions = (params: SuggestionsParams): Suggestions =>
   if (!(params.ref && isInstanceElement(params.ref.element))) return []
   const attrName = params.tokens[0]
   const refPathWithAttr = getRefPathWithAttr(attrName, params.ref)
-  const valueField = getField(params.ref.element.type, refPathWithAttr)?.field
+  const valueField = getField(params.ref.element.type, refPathWithAttr)
   const valueFieldType = getFieldType(params.ref.element.type, refPathWithAttr)
   const valueToken = _.last(params.tokens) || ''
   return (valueField && valueFieldType)
@@ -250,7 +250,7 @@ export const annoValueSuggestions = (params: SuggestionsParams): Suggestions => 
 
   const valueToken = _.last(params.tokens) || ''
   if (annoType && !_.isEmpty(refPath)) {
-    const attrField = getField(annoType, refPath)?.field
+    const attrField = getField(annoType, refPath)
     const attrFieldType = getFieldType(annoType, refPath)
     return (attrField && attrFieldType)
       ? [

--- a/packages/lang-server/src/definitions.ts
+++ b/packages/lang-server/src/definitions.ts
@@ -27,7 +27,7 @@ export const provideWorkspaceDefinition = async (
   if (context.ref && isInstanceElement(context.ref.element)) {
     const refPath = context.ref.path
     if (!_.isEmpty(refPath) && _.last(refPath) === token) {
-      const field = getField(context.ref.element.type, refPath)?.field
+      const field = getField(context.ref.element.type, refPath)
       return field ? getLocations(workspace, field.elemID.getFullName()) : []
     }
   }

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -18,7 +18,7 @@ import {
   CORE_ANNOTATIONS, Element, InstanceElement,
   isInstanceElement, isType, Values, isListType,
   TypeElement,
-  getFieldDef,
+  getField,
 } from '@salto-io/adapter-api'
 import {
   transformElement, TransformFunc, transformValues,
@@ -39,7 +39,7 @@ export const isHiddenType = (element: Element): boolean => (
 export const isHiddenField = (baseType: TypeElement, fieldPath: ReadonlyArray<string>): boolean => (
   fieldPath.length === 0
     ? false
-    : isHidden(getFieldDef(baseType, fieldPath))
+    : isHidden(getField(baseType, fieldPath))
       || isHiddenField(baseType, fieldPath.slice(0, -1))
 )
 

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -18,7 +18,7 @@ import {
   CORE_ANNOTATIONS, Element, InstanceElement,
   isInstanceElement, isType, Values, isListType,
   TypeElement,
-  getFieldType,
+  getFieldDef,
 } from '@salto-io/adapter-api'
 import {
   transformElement, TransformFunc, transformValues,
@@ -39,7 +39,8 @@ export const isHiddenType = (element: Element): boolean => (
 export const isHiddenField = (baseType: TypeElement, fieldPath: ReadonlyArray<string>): boolean => (
   fieldPath.length === 0
     ? false
-    : isHidden(getFieldType(baseType, fieldPath)) || isHiddenField(baseType, fieldPath.slice(0, -1))
+    : isHidden(getFieldDef(baseType, fieldPath))
+      || isHiddenField(baseType, fieldPath.slice(0, -1))
 )
 
 export const addHiddenValuesAndHiddenTypes = (

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import path from 'path'
 import {
   Element, SaltoError, SaltoElementError, ElemID, InstanceElement, DetailedChange, isRemovalChange,
-  CORE_ANNOTATIONS, isAdditionChange, isInstanceElement, getFieldDef, isObjectType,
+  CORE_ANNOTATIONS, isAdditionChange, isInstanceElement, getField, isObjectType,
 } from '@salto-io/adapter-api'
 import { transformValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -174,7 +174,7 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
             // The whole value is hidden, omit the change
             return undefined
           }
-          const fieldType = getFieldDef(parentInstance.type, fieldPath)
+          const fieldType = getField(parentInstance.type, fieldPath)
           if (fieldType !== undefined && isObjectType(fieldType)) {
             // The field itself is not hidden, but it might have hidden parts
             change.data.after = transformValues({

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import path from 'path'
 import {
   Element, SaltoError, SaltoElementError, ElemID, InstanceElement, DetailedChange, isRemovalChange,
-  CORE_ANNOTATIONS, isAdditionChange, isInstanceElement, getFieldType, isObjectType,
+  CORE_ANNOTATIONS, isAdditionChange, isInstanceElement, getFieldDef, isObjectType,
 } from '@salto-io/adapter-api'
 import { transformValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -170,11 +170,11 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
         const { parent, path: fieldPath } = change.id.createTopLevelParentID()
         const parentInstance = await state().get(parent)
         if (parentInstance !== undefined) {
-          if (isHiddenField(parentInstance, fieldPath)) {
+          if (isHiddenField(parentInstance.type, fieldPath)) {
             // The whole value is hidden, omit the change
             return undefined
           }
-          const fieldType = getFieldType(parentInstance, fieldPath)
+          const fieldType = getFieldDef(parentInstance.type, fieldPath)
           if (fieldType !== undefined && isObjectType(fieldType)) {
             // The field itself is not hidden, but it might have hidden parts
             change.data.after = transformValues({

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -25,6 +25,7 @@ import {
 import {
   addHiddenValuesAndHiddenTypes,
   removeHiddenValuesForInstance,
+  isHiddenField,
 } from '../../src/workspace/hidden_values'
 
 describe('hidden_values.ts', () => {
@@ -349,6 +350,21 @@ describe('hidden_values.ts', () => {
 
     it('should not change new instances', () => {
       expect(normalInstance).toEqual(newNormalInstance)
+    })
+  })
+
+  describe('isHiddenField func', () => {
+    it('should return true for hidden fields', () => {
+      expect(isHiddenField(hiddenType, ['hidden'])).toEqual(true)
+      expect(isHiddenField(hiddenType, ['numHidden'])).toEqual(true)
+      expect(isHiddenField(hiddenType, ['hiddenList'])).toEqual(true)
+      expect(isHiddenField(hiddenType, ['hiddenObj'])).toEqual(true)
+    })
+
+    it('should return false for non-hidden fields', () => {
+      expect(isHiddenField(hiddenType, ['reg'])).toEqual(false)
+      expect(isHiddenField(hiddenType, ['listOfObjects'])).toEqual(false)
+      expect(isHiddenField(hiddenType, ['objField'])).toEqual(false)
     })
   })
 })


### PR DESCRIPTION
This is an existing bug that's preventing the addition of a hidden `internalId` in SALTO-900, and also related to SALTO-907.
(@ori-moisis 's solution)

Scenario: Adding a hidden field to an existing instance element.

Additional e2e tests are added [here](https://github.com/salto-io/salto/pull/1316/files#diff-c90bec8f7ee92483f615e645ca8da141R287).