### PR TITLE
Salesforce oauth

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,6 +24,7 @@ Support for other services is in the works.
 
 Currently, service credentials are stored under your $SALTO_HOME directory (e.g. $HOME/.salto on MacOS), in the directory corresponding to the relevant workspace. We choose to store the credentials there by default in order to reduce the chances you'll check-in by mistake credentials in plaintext to your source control system.
 
+Credential types supported vary by service. Currently all services require username and password, except for Salesforce, in which we support OAuth credentials as well.
 In the future we're planning support for storing credentials in a secured shared location.
 
 ## What is Salto's License?

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -368,7 +368,7 @@ Manage your environment services
 
 * `--env, -e` : The name of the environment to use
 * `--nologin, -n` : Do not login to service when adding it. Example usage: `service add <service-name> --nologin`) [boolean] [default: false]
-
+* `--auth-type, -a` : The type of authorization you would like to use for the service. Options are 'basic' for username/password login, and 'oauth'.
 
 ### **salto env \<command> [\<name>] [\<new-name>]**
 

--- a/jest.base.config.js
+++ b/jest.base.config.js
@@ -32,7 +32,6 @@ module.exports = {
     '!coverage/**',
     '!dist/test/**',
     '!dist/e2e_test/**',
-    
   ],
 }
 

--- a/packages/adapter-api/index.ts
+++ b/packages/adapter-api/index.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+export * from './src/authentication_types'
 export * from './src/elements'
 export * from './src/element_id'
 export * from './src/values'

--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -16,6 +16,7 @@
 import {
   InstanceElement, ObjectType, Element,
 } from './elements'
+import { AdapterAuthentication } from './authentication_types'
 import { ElemID } from './element_id'
 import { Change } from './change'
 import { DependencyChanger } from './dependency_changer'
@@ -60,7 +61,7 @@ export const isAdapterSuccessInstallResult = (result: AdapterInstallResult):
 export type Adapter = {
   operations: (context: AdapterOperationsContext) => AdapterOperations
   validateCredentials: (config: Readonly<InstanceElement>) => Promise<AccountId>
-  credentialsType: ObjectType
+  authenticationMethods: AdapterAuthentication
   configType?: ObjectType
   deployModifiers?: {
     changeValidator?: ChangeValidator

--- a/packages/adapter-api/src/authentication_types.ts
+++ b/packages/adapter-api/src/authentication_types.ts
@@ -1,0 +1,44 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, InstanceElement } from './elements'
+import { Values } from './values'
+
+export type OAuthRequestParameters = {
+  url: string
+  accessTokenField: string
+}
+
+export type AuthMethod = {
+  credentialsType: ObjectType
+}
+
+export type OAuthMethod = AuthMethod & {
+  oauthRequestParameters: ObjectType
+  createOAuthRequest: (userInput: InstanceElement) => OAuthRequestParameters
+  createFromOauthResponse: (oldConfig: Values, response: OauthAccessTokenResponse) => Values
+}
+
+export type AdapterAuthentication = {
+  basic: AuthMethod
+  oauth?: OAuthMethod
+}
+
+export type OauthAccessTokenResponse = {
+  instanceUrl: string
+  accessToken: string
+}
+
+export type AdapterAuthMethod = keyof AdapterAuthentication

--- a/packages/cli/e2e_test/helpers/salesforce.ts
+++ b/packages/cli/e2e_test/helpers/salesforce.ts
@@ -18,10 +18,12 @@ import SalesforceAdapter, {
   testHelpers as salesforceTestHelpers,
   testTypes as salesforceTestTypes,
   adapter as salesforceAdapter,
-  Credentials,
+  UsernamePasswordCredentials,
+  OauthAccessTokenCredentials,
 } from '@salto-io/salesforce-adapter'
 import _ from 'lodash'
 import { InstanceElement, ElemID, ObjectType, ChangeGroup, getChangeElement } from '@salto-io/adapter-api'
+
 
 export const naclNameToSFName = (objName: string): string => `${objName}__c`
 export const objectExists = async (client: SalesforceClient, name: string, fields: string[] = [],
@@ -55,18 +57,35 @@ export const instanceExists = async (client: SalesforceClient, type: string, nam
   return true
 }
 
-export const getSalesforceCredsInstance = (creds: Credentials): InstanceElement => {
+export const getSalesforceCredsInstance = (creds: UsernamePasswordCredentials): InstanceElement => {
   const configValues = {
     username: creds.username,
     password: creds.password,
     token: creds.apiToken ?? '',
     sandbox: creds.isSandbox,
   }
-  const { credentialsType } = salesforceAdapter
+  const { authenticationMethods } = salesforceAdapter
 
   return new InstanceElement(
     ElemID.CONFIG_NAME,
-    credentialsType,
+    authenticationMethods.basic.credentialsType,
+    configValues,
+  )
+}
+
+export const getSalesforceOAuthCreds = (creds: OauthAccessTokenCredentials): InstanceElement => {
+  const configValues = {
+    accessToken: creds.accessToken,
+    instanceUrl: creds.instanceUrl,
+    isSandbox: creds.isSandbox,
+    authType: 'oauth',
+  }
+
+  const { authenticationMethods } = salesforceAdapter
+
+  return new InstanceElement(
+    ElemID.CONFIG_NAME,
+    authenticationMethods.oauth?.credentialsType as ObjectType,
     configValues,
   )
 }

--- a/packages/cli/e2e_test/helpers/workspace.ts
+++ b/packages/cli/e2e_test/helpers/workspace.ts
@@ -101,7 +101,22 @@ export const runAddSalesforceService = async (
     'add',
     mockCliOutput(),
     () => Promise.resolve(credentials),
-    'salesforce'
+    'basic',
+    'salesforce',
+  ).execute()
+}
+
+export const runSalesforceOauthLogin = async (
+  workspaceDir: string,
+  sfCredsInstance: InstanceElement
+): Promise<void> => {
+  await servicesCommand(
+    workspaceDir,
+    'login',
+    mockCliOutput(),
+    () => Promise.resolve(sfCredsInstance),
+    'oauth',
+    'salesforce',
   ).execute()
 }
 
@@ -114,7 +129,8 @@ export const runSalesforceLogin = async (
     'login',
     mockCliOutput(),
     () => Promise.resolve(sfCredsInstance),
-    'salesforce'
+    'basic',
+    'salesforce',
   ).execute()
 }
 

--- a/packages/cli/e2e_test/multi_env.test.ts
+++ b/packages/cli/e2e_test/multi_env.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { SalesforceClient, testHelpers as salesforceTestHelpers, Credentials } from '@salto-io/salesforce-adapter'
+import { SalesforceClient, testHelpers as salesforceTestHelpers, UsernamePasswordCredentials } from '@salto-io/salesforce-adapter'
 import path from 'path'
 import { Plan } from '@salto-io/core'
 import { parser } from '@salto-io/workspace'
@@ -173,10 +173,10 @@ describe('multi env tests', () => {
   const env2Elements = [commonObj, env2Obj, diffObjEnv2, commonInst, env2Inst, diffInstEnv2]
   let env1ElementAfterDeploy: typeof env1Elements
   let env2ElementAfterDeploy: typeof env2Elements
-  let env1CredsLease: CredsLease<Credentials>
-  let env2CredsLease: CredsLease<Credentials>
-  let env1Creds: Credentials
-  let env2Creds: Credentials
+  let env1CredsLease: CredsLease<UsernamePasswordCredentials>
+  let env2CredsLease: CredsLease<UsernamePasswordCredentials>
+  let env1Creds: UsernamePasswordCredentials
+  let env2Creds: UsernamePasswordCredentials
   let env1Client: SalesforceClient
   let env2Client: SalesforceClient
 
@@ -186,8 +186,8 @@ describe('multi env tests', () => {
     env2CredsLease = await salesforceTestHelpers().credentials('ENV_2')
     env1Creds = env1CredsLease.value
     env2Creds = env2CredsLease.value
-    env1Client = new SalesforceClient({ credentials: env1Creds })
-    env2Client = new SalesforceClient({ credentials: env2Creds })
+    env1Client = new SalesforceClient({ credentials: new UsernamePasswordCredentials(env1Creds) })
+    env2Client = new SalesforceClient({ credentials: new UsernamePasswordCredentials(env2Creds) })
 
     baseDir = (await tmp.dir()).path
     saltoHomeDir = (await tmp.dir()).path

--- a/packages/cli/e2e_test/salto.test.ts
+++ b/packages/cli/e2e_test/salto.test.ts
@@ -18,7 +18,7 @@ import wu from 'wu'
 import tmp from 'tmp-promise'
 import { strings } from '@salto-io/lowerdash'
 import { copyFile, rm, mkdirp, exists, readFile } from '@salto-io/file'
-import { testHelpers as salesforceTestHelpers, SalesforceClient, Credentials } from '@salto-io/salesforce-adapter'
+import { testHelpers as salesforceTestHelpers, SalesforceClient, UsernamePasswordCredentials } from '@salto-io/salesforce-adapter'
 import { Plan, SALTO_HOME_VAR } from '@salto-io/core'
 import { Workspace, parser } from '@salto-io/workspace'
 // eslint-disable-next-line no-restricted-imports
@@ -47,7 +47,7 @@ import { instanceExists, objectExists, getSalesforceCredsInstance } from './help
 
 
 let lastPlan: Plan
-let credsLease: CredsLease<Credentials>
+let credsLease: CredsLease<UsernamePasswordCredentials>
 
 const apiNameAnno = (
   obj: string,
@@ -128,7 +128,9 @@ describe('cli e2e', () => {
 
     process.env[SALTO_HOME_VAR] = homePath
     credsLease = await salesforceTestHelpers().credentials()
-    client = new SalesforceClient({ credentials: credsLease.value })
+    client = new SalesforceClient({
+      credentials: new UsernamePasswordCredentials(credsLease.value),
+    })
     await mkdirp(`${fetchOutputDir}/salto.config`)
     await mkdirp(`${fetchOutputDir}/salto.config/adapters`)
     await mkdirp(localStorageDir)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,7 @@
     "@salto-io/salesforce-adapter": "0.1.33",
     "@salto-io/workspace": "0.1.33",
     "chalk": "^2.4.2",
+    "express": "^4.17.1",
     "figlet": "^1.2.4",
     "glob": "^7.1.6",
     "inquirer": "^7.0.0",
@@ -54,6 +55,7 @@
     "mkdirp": "^0.5.1",
     "moment": "^2.24.0",
     "null-loader": "^4.0.0",
+    "open": "^7.2.0",
     "ora": "^4.0.3",
     "pietile-eventemitter": "^1.0.0",
     "raw-loader": "^4.0.1",
@@ -65,10 +67,12 @@
     "yargs": "^13.3.0"
   },
   "devDependencies": {
+    "@types/express": "^4.17.7",
     "@types/figlet": "^1.2.0",
     "@types/inquirer": "0.0.35",
     "@types/jest": "^24.0.0",
     "@types/mkdirp": "^0.5.2",
+    "@types/mock-req-res": "^1.1.2",
     "@types/rimraf": "^2.0.3",
     "@types/semver": "^7.3.3",
     "@types/source-map-support": "^0.5.0",
@@ -86,9 +90,12 @@
     "jest-junit": "^6.4.0",
     "memory-streams": "^0.1.3",
     "nexe": "4.0.0-beta.6",
+    "sinon": "^9.0.3",
     "source-map-loader": "^0.2.4",
+    "supertest": "^5.0.0",
     "tmp-promise": "^2.0.2",
     "typescript": "3.9.3",
+    "wait-for-expect": "^3.0.2",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10"
   }

--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -145,7 +145,7 @@ export const getApprovedChanges = async (
 
 // TODO: SALTO-770 CLI should mask secret credentials based on adapter definition
 const isPasswordInputType = (fieldName: string): boolean =>
-  ['token', 'password', 'tokenId', 'tokenSecret'].includes(fieldName)
+  ['token', 'password', 'tokenId', 'tokenSecret', 'consumerKey'].includes(fieldName)
 
 export const getFieldInputType = (fieldType: TypeElement, fieldName: string): string => {
   if (!isPrimitiveType(fieldType) || fieldType.primitive === PrimitiveTypes.UNKNOWN) {

--- a/packages/cli/src/cli_oauth_authenticator.ts
+++ b/packages/cli/src/cli_oauth_authenticator.ts
@@ -1,0 +1,68 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import open from 'open'
+import http from 'http'
+import express, { Request, Response } from 'express'
+import { OauthAccessTokenResponse } from '@salto-io/adapter-api'
+import { CliOutput } from './types'
+import { outputLine } from './outputer'
+import { formatGoToBrowser } from './formatter'
+
+export const createServer = (port: number, accessTokenField: string,
+  resolve: (value: OauthAccessTokenResponse | PromiseLike<OauthAccessTokenResponse>) => void,
+  reject: (reason?: Error) => void): http.Server => {
+  let server: http.Server
+  const app = express()
+  app.get('/', (_req: Request, res: Response) => {
+    res.send(`<script>url = window.location.href;window.location.replace("http://localhost:${port}/extract/?" + url.substring(url.search("#") + 1, url.length));</script>`)
+  })
+  app.get('/extract', (req: Request, res: Response) => {
+    res.send(`<script>window.location.replace("http://localhost:${port}/done")</script>`)
+    const accessToken = req.query[accessTokenField]
+    if (typeof req.query.instance_url === 'string' && typeof accessToken === 'string') {
+      resolve({
+        instanceUrl: req.query.instance_url,
+        accessToken,
+      })
+    } else {
+      reject(new Error('Unexpected oauth response structure'))
+    }
+  })
+  app.get('/done', (_req: Request, res: Response) => {
+    res.send('<h3>Done configuring Salto\'s Oauth access. You may close this tab.</h3>')
+    if (server) {
+      server.close()
+    }
+  })
+  server = app.listen(port)
+  return server
+}
+
+const createLocalOauthServer = async (port: number, accessTokenField: string):
+  Promise<OauthAccessTokenResponse> => new Promise<OauthAccessTokenResponse>((resolve,
+    reject) => createServer(port, accessTokenField, resolve, reject))
+
+export const processOauthCredentials = async (
+  port: number,
+  accessTokenField: string,
+  url: string,
+  output: CliOutput,
+): Promise<OauthAccessTokenResponse> => {
+  const accessTokenPromise = createLocalOauthServer(port, accessTokenField)
+  outputLine(formatGoToBrowser(url), output)
+  open(url)
+  return accessTokenPromise
+}

--- a/packages/cli/src/filters/service.ts
+++ b/packages/cli/src/filters/service.ts
@@ -16,6 +16,7 @@
 import _ from 'lodash'
 import yargs from 'yargs'
 import { loadLocalWorkspace } from '@salto-io/core'
+import { AdapterAuthMethod } from '@salto-io/adapter-api'
 import { ParsedCliInput } from '../types'
 import { ParserFilter, ParsedCliInputFilter } from '../filter'
 import { EnvironmentArgs } from '../commands/env'
@@ -24,6 +25,7 @@ export interface ServiceCmdArgs {
   command: string
   name?: string
   nologin?: boolean
+  authType?: AdapterAuthMethod
 }
 
 export type ServiceCmdParsedCliInput = ParsedCliInput<ServiceCmdArgs>
@@ -46,10 +48,19 @@ export const serviceCmdFilter: ServiceCmdFilter = {
         {
           type: 'string',
           desc: 'The name of the service [required for add & login]',
+        })
+      .option('auth-type',
+        {
+          alias: 'a',
+          type: 'string',
+          choices: ['basic', 'oauth'],
+          desc: 'The type of authorization you would like to use for the service',
+          default: 'basic',
         }).check((args: yargs.Arguments<{
           command?: string
           name?: string
           nologin?: boolean
+          authType?: AdapterAuthMethod
         }>): true => {
         if (args.command && nameRequiredCommands.includes(args.command)) {
           if (_.isEmpty(args.name)) {

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -425,15 +425,22 @@ export const formatCredentialsHeader = (adapterName: string): string => [
   emptyLine(),
 ].join('\n')
 
+export const formatGoToBrowser = (url: string): string => [
+  Prompts.GO_TO_BROWSER(url),
+  emptyLine(),
+].join('\n')
+
 export const formatFetchHeader = (): string => [
   emptyLine(),
   header(Prompts.FETCH_HEADER),
   subHeader(Prompts.FETCH_SUB_HEADER),
 ].join('\n')
+
 export const formatFetchFinish = (): string => [
   emptyLine(),
   Prompts.FETCH_SUCCESS_FINISHED,
 ].join('\n')
+
 export const formatStepStart = (text: string, indentLevel?: number): string => indent(`${chalk.yellow('>>>')} ${text}`, indentLevel ?? 1)
 export const formatStepCompleted = (text: string, indentLevel?: number): string => indent(`${chalk.green('vvv')} ${text}`, indentLevel ?? 1)
 export const formatStepFailed = (text: string, indentLevel?: number): string => indent(`${error('xxx')} ${text}`, indentLevel ?? 1)

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -144,6 +144,7 @@ The steps are: I. Fetching configs, II. Calculating difference and III. Applying
 
   public static readonly CANCELED = 'Canceling...'
   public static readonly CREDENTIALS_HEADER = (serviceName: string): string => `Please enter your ${serviceName} credentials:`
+  public static readonly GO_TO_BROWSER = (url: string): string => `Please follow the steps for authenticating in your browser. If a new tab has not opened automatically, please go to ${url}`
   public static readonly SERVICE_HOW_ADD = (serviceName: string): string => `Use \`salto service add ${serviceName}\` to add the service to the environment`
   public static readonly SERVICE_ADDED = (serviceName: string): string => `${serviceName} was added to the environment`
   public static readonly SERVICES_LOGIN_UPDATED = 'Login information successfully updated!'

--- a/packages/cli/test/cli_oauth_authenticator.test.ts
+++ b/packages/cli/test/cli_oauth_authenticator.test.ts
@@ -1,0 +1,83 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { OauthAccessTokenResponse } from '@salto-io/adapter-api'
+import supertest from 'supertest'
+import waitForExpect from 'wait-for-expect'
+import * as cliOauthAuthenticator from '../src/cli_oauth_authenticator'
+import { MockWriteStream } from './mocks'
+
+let mockWriteStream: MockWriteStream
+const createServer = jest.spyOn(cliOauthAuthenticator, 'createServer')
+
+describe('When using the cli oauth authenticates', () => {
+  let returnPromise: Promise<OauthAccessTokenResponse>
+  beforeEach(async () => {
+    mockWriteStream = new MockWriteStream()
+    returnPromise = cliOauthAuthenticator.processOauthCredentials(8080, 'access_token_field', 'testUrl', {
+      stdout: mockWriteStream,
+      stderr: new MockWriteStream(),
+    })
+  })
+
+  // The actual behavior of the server will be tested in e2e,
+  // because it's too specific to tailor a test to. Important thing is that oauth succeeds
+  it('should process the credentials through the server', async () => {
+    await waitForExpect(() => {
+      expect(createServer.mock.results[0].value.address().port).toBeDefined()
+    })
+    const newLocal = createServer.mock.results.filter(
+      result => (result ? result.value.address().port === 8080 : false)
+    )
+    const app = newLocal[0].value
+    await supertest(app).get('/#instance_url=testInstanceUrl&access_token_field=accessTokenThing').expect(response => {
+      const responseText = response.text
+      expect(responseText).toContain('window.location.replace')
+    })
+    await supertest(app).get('/extract?instance_url=testInstanceUrl2&access_token_field=accessTokenThing2').expect(response => {
+      expect(response.text).toContain('/done')
+    })
+    await supertest(app).get('/done').expect(response => {
+      expect(response.text).toContain('Done configuring Salto')
+    })
+    const retVal = await returnPromise
+    expect(retVal.accessToken).toEqual('accessTokenThing2')
+    expect(retVal.instanceUrl).toEqual('testInstanceUrl2')
+  })
+})
+
+describe('when oauth output is badly shapen', () => {
+  let returnPromise: Promise<OauthAccessTokenResponse>
+  beforeEach(async () => {
+    mockWriteStream = new MockWriteStream()
+    returnPromise = cliOauthAuthenticator.processOauthCredentials(8081, 'testAccessTokenField', 'testUrl',
+      {
+        stdout: mockWriteStream,
+        stderr: new MockWriteStream(),
+      })
+    returnPromise.catch(() => undefined)
+  })
+
+  it('Rejects the oauth promise', async () => {
+    await waitForExpect(() => {
+      expect(createServer.mock.results[0]).not.toBeNull()
+    })
+    const app = createServer.mock.results.filter(
+      result => (result.value.address() ? result.value.address().port === 8081 : false)
+    )[0].value
+    await supertest(app).get('/extract')
+    await expect(returnPromise).rejects.toThrow(new Error('Unexpected oauth response structure'))
+  })
+})

--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -14,7 +14,10 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ObjectType, AdapterOperations, ElemIdGetter, AdapterOperationsContext, ElemID, InstanceElement, Adapter } from '@salto-io/adapter-api'
+import {
+  AdapterOperations, ElemIdGetter, AdapterOperationsContext, ElemID, InstanceElement,
+  Adapter, AdapterAuthentication,
+} from '@salto-io/adapter-api'
 import { createDefaultInstanceFromType } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import adapterCreators from './creators'
@@ -23,7 +26,7 @@ const log = logger(module)
 
 export const getAdaptersCredentialsTypes = (
   names?: ReadonlyArray<string>
-): Record<string, ObjectType> => {
+): Record<string, AdapterAuthentication> => {
   let relevantAdapterCreators: Record<string, Adapter>
   if (names === undefined) {
     relevantAdapterCreators = adapterCreators
@@ -34,7 +37,7 @@ export const getAdaptersCredentialsTypes = (
     }
     relevantAdapterCreators = _.pick(adapterCreators, names)
   }
-  return _.mapValues(relevantAdapterCreators, creator => creator.credentialsType)
+  return _.mapValues(relevantAdapterCreators, creator => creator.authenticationMethods)
 }
 
 export const initAdapters = (

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -148,17 +148,19 @@ describe('api.ts', () => {
   }
   const mockAdapter = {
     operations: mockFunction<Adapter['operations']>().mockReturnValue(mockAdapterOps),
-    credentialsType: mockConfigType,
+    authenticationMethods: { basic: { credentialsType: mockConfigType } },
     validateCredentials: mockFunction<Adapter['validateCredentials']>().mockResolvedValue(''),
   }
 
   const mockEmptyAdapter = {
     operations: mockFunction<Adapter['operations']>().mockReturnValue(mockAdapterOps),
-    credentialsType: mockEmptyConfigType,
+    authenticationMethods: { basic: { credentialsType: mockEmptyConfigType } },
     validateCredentials: mockFunction<Adapter['validateCredentials']>().mockResolvedValue(''),
   }
   const mockAdapterWithInstall = {
-    credentialsType: new ObjectType({ elemID: new ElemID(mockServiceWithInstall) }),
+    authenticationMethods: { basic: {
+      credentialsType: new ObjectType({ elemID: new ElemID(mockServiceWithInstall) }),
+    } },
     operations: mockFunction<Adapter['operations']>().mockReturnValue(mockAdapterOps),
     validateCredentials: mockFunction<Adapter['validateCredentials']>().mockResolvedValue(''),
     install: jest.fn().mockResolvedValue({ success: true, installedVersion: '123' }),
@@ -192,6 +194,7 @@ describe('api.ts', () => {
       new InstanceElement('instance_2', objType, {}),
       new InstanceElement('instance_3_hidden', typeWithHiddenField, { hidden: 'Hidden', regField: 'regValue' }),
     ]
+
     beforeAll(() => {
       mockFetchChanges.mockResolvedValue({
         changes: [],
@@ -202,6 +205,7 @@ describe('api.ts', () => {
         adapterNameToConfigMessage: {},
       })
     })
+
     describe('Full fetch', () => {
       let ws: workspace.Workspace
       let stateOverride: jest.SpyInstance
@@ -413,7 +417,9 @@ describe('api.ts', () => {
       it('should set adapter config', async () => {
         const serviceName = 'test'
         adapterCreators[serviceName] = {
-          credentialsType: new ObjectType({ elemID: new ElemID(serviceName) }),
+          authenticationMethods: {
+            basic: { credentialsType: new ObjectType({ elemID: new ElemID(serviceName) }) },
+          },
           operations: mockFunction<Adapter['operations']>().mockReturnValue(mockAdapterOps),
           validateCredentials: mockFunction<Adapter['validateCredentials']>().mockResolvedValue(''),
         }

--- a/packages/core/test/core/adapters/adapters.test.ts
+++ b/packages/core/test/core/adapters/adapters.test.ts
@@ -13,11 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, ElemID, ObjectType } from '@salto-io/adapter-api'
+import { InstanceElement, ElemID, AdapterAuthentication } from '@salto-io/adapter-api'
 import * as utils from '@salto-io/adapter-utils'
 import { adapter } from '@salto-io/salesforce-adapter'
 import {
-  initAdapters, getAdaptersCredentialsTypes, getAdaptersCreatorConfigs, getDefaultAdapterConfig,
+  initAdapters, getAdaptersCredentialsTypes, getAdaptersCreatorConfigs,
+  getDefaultAdapterConfig,
 } from '../../../src/core/adapters'
 
 jest.mock('@salto-io/workspace', () => ({
@@ -30,11 +31,11 @@ jest.mock('@salto-io/adapter-utils', () => ({
 }))
 
 describe('adapters.ts', () => {
-  const { credentialsType } = adapter
+  const { authenticationMethods } = adapter
   const services = ['salesforce']
   const sfConfig = new InstanceElement(
     ElemID.CONFIG_NAME,
-    credentialsType,
+    authenticationMethods.basic.credentialsType,
     {
       username: 'nacluser',
       password: 'naclpass',
@@ -44,11 +45,11 @@ describe('adapters.ts', () => {
   )
 
   describe('run get adapters config statuses', () => {
-    let credentials: Record<string, ObjectType>
+    let credentials: Record<string, AdapterAuthentication>
 
     it('should return config for defined adapter', () => {
       credentials = getAdaptersCredentialsTypes(services)
-      expect(credentials.salesforce).toEqual(credentialsType)
+      expect(credentials.salesforce).toEqual(authenticationMethods)
     })
 
     it('should throw error for non defined adapter', () => {

--- a/packages/core/test/core/adapters/dependency_changers.test.ts
+++ b/packages/core/test/core/adapters/dependency_changers.test.ts
@@ -13,13 +13,16 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Adapter, ObjectType, ElemID, DependencyChanger, dependencyChange, DependencyChange, ChangeEntry, AdapterOperations, toChange } from '@salto-io/adapter-api'
+import { Adapter, ObjectType, ElemID, DependencyChanger, dependencyChange,
+  DependencyChange, ChangeEntry, AdapterOperations, toChange } from '@salto-io/adapter-api'
 import { getAdapterDependencyChangers } from '../../../src/core/adapters'
 import { mockFunction } from '../../common/helpers'
 
 describe('getAdapterDependencyChangers', () => {
   const mockAdapter = (dependencyChanger?: DependencyChanger): Adapter => ({
-    credentialsType: new ObjectType({ elemID: new ElemID('test') }),
+    authenticationMethods: { basic: {
+      credentialsType: new ObjectType({ elemID: new ElemID('test') }),
+    } },
     configType: new ObjectType({ elemID: new ElemID('test') }),
     operations: mockFunction<Adapter['operations']>().mockReturnValue({
       fetch: mockFunction<AdapterOperations['fetch']>(),

--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -33,6 +33,8 @@ export const configType = new ObjectType({
 export const adapter: Adapter = {
   operations: context => new DummyAdapter(context.config?.value as GeneratorParams),
   validateCredentials: async () => '',
-  credentialsType: new ObjectType({ elemID: new ElemID(DUMMY_ADAPTER) }),
+  authenticationMethods: ({ basic: {
+    credentialsType: new ObjectType({ elemID: new ElemID(DUMMY_ADAPTER) }),
+  } }),
   configType,
 }

--- a/packages/dummy-adapter/test/adapter_creator.test.ts
+++ b/packages/dummy-adapter/test/adapter_creator.test.ts
@@ -24,16 +24,18 @@ describe('adapter creator', () => {
     expect(Object.keys(config?.fields)).toEqual(Object.keys(defaultParams))
   })
   it('should return an empty creds type', () => {
-    expect(Object.keys(adapter.credentialsType.fields)).toHaveLength(0)
+    expect(Object.keys(adapter.authenticationMethods.basic.credentialsType.fields)).toHaveLength(0)
   })
   it('should have a credential validator that does nothing and return an empty id', async () => {
     expect(
-      await adapter.validateCredentials(new InstanceElement(DUMMY_ADAPTER, adapter.credentialsType))
+      await adapter.validateCredentials(new InstanceElement(DUMMY_ADAPTER,
+        adapter.authenticationMethods.basic.credentialsType))
     ).toBe('')
   })
   it('should return the dummy adapter', () => {
     expect(adapter.operations({
-      credentials: new InstanceElement(DUMMY_ADAPTER, adapter.credentialsType),
+      credentials: new InstanceElement(DUMMY_ADAPTER,
+        adapter.authenticationMethods.basic.credentialsType),
       config: new InstanceElement(
         DUMMY_ADAPTER,
                 adapter.configType as ObjectType,

--- a/packages/e2e-credentials-store/src/jest-environment/creds.ts
+++ b/packages/e2e-credentials-store/src/jest-environment/creds.ts
@@ -96,7 +96,6 @@ const creds = <TCreds extends {}>(
       runningTasksPrinter.unschedule(CREDS_INTERVAL_ID)
     }
   }
-
   const fromEnv = async (): Promise<CredsLease<TCreds>> => {
     const lease = {
       id: 'from environment variables',
@@ -107,7 +106,6 @@ const creds = <TCreds extends {}>(
   }
 
   const envUtils = createEnvUtils(env)
-
   return envUtils.bool('USE_CRED_POOL') || !spec.envHasCreds(env)
     ? fromPool()
     : Promise.resolve(fromEnv())

--- a/packages/hubspot-adapter/src/adapter_creator.ts
+++ b/packages/hubspot-adapter/src/adapter_creator.ts
@@ -22,7 +22,7 @@ import changeValidator from './change_validator'
 
 const configID = new ElemID('hubspot')
 
-const credentialsType = new ObjectType({
+export const defaultCredentialsType = new ObjectType({
   elemID: configID,
   fields: { apiKey: { type: BuiltinTypes.STRING } },
   annotationTypes: {},
@@ -43,7 +43,11 @@ export const adapter: Adapter = {
     client: clientFromCredentials(context.credentials),
   }),
   validateCredentials: config => HubspotClient.validateCredentials(credentialsFromConfig(config)),
-  credentialsType,
+  authenticationMethods: {
+    basic: {
+      credentialsType: defaultCredentialsType,
+    },
+  },
   deployModifiers: {
     changeValidator,
   },

--- a/packages/hubspot-adapter/test/adapter.creator.test.ts
+++ b/packages/hubspot-adapter/test/adapter.creator.test.ts
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { adapter } from '../src/adapter_creator'
 import HubspotClient from '../src/client/client'
+import { defaultCredentialsType, adapter } from '../src/adapter_creator'
 
 jest.mock('../src/client/client')
 
@@ -23,7 +23,7 @@ describe('HubspotAdapter creator', () => {
   describe('when validateCredentials is called', () => {
     const config = new InstanceElement(
       ElemID.CONFIG_NAME,
-      adapter.credentialsType,
+      defaultCredentialsType,
       {
         apiKey: 'myKey',
       }
@@ -44,7 +44,7 @@ describe('HubspotAdapter creator', () => {
   describe('when passed a config element', () => {
     const credentials = new InstanceElement(
       ElemID.CONFIG_NAME,
-      adapter.credentialsType,
+      defaultCredentialsType,
       {
         apiKey: 'myApiKey',
       }

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -36,7 +36,7 @@ const { makeArray } = collections.array
 
 const configID = new ElemID(NETSUITE)
 
-const credentialsType = new ObjectType({
+export const defaultCredentialsType = new ObjectType({
   elemID: configID,
   fields: {
     accountId: { type: BuiltinTypes.STRING },
@@ -98,7 +98,11 @@ export const adapter: Adapter = {
     const credentials = netsuiteCredentialsFromCredentials(config)
     return NetsuiteClient.validateCredentials(credentials)
   },
-  credentialsType,
+  authenticationMethods: {
+    basic: {
+      credentialsType: defaultCredentialsType,
+    },
+  },
   configType,
   deployModifiers: {
     changeValidator,

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -38,7 +38,7 @@ mockDownload.mockResolvedValue({ success: true, installedVersion: '123' })
 describe('NetsuiteAdapter creator', () => {
   const credentials = new InstanceElement(
     ElemID.CONFIG_NAME,
-    adapter.credentialsType,
+    adapter.authenticationMethods.basic.credentialsType,
     {
       accountId: 'foo',
       tokenId: 'bar',

--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -37,6 +37,7 @@ import {
   CustomField, CustomObject, FieldPermissions, FilterItem, ObjectPermissions, ProfileInfo,
   TopicsForObjectsInfo,
 } from '../src/client/types'
+import { UsernamePasswordCredentials } from '../src/types'
 import {
   Types, metadataType, apiName, formulaTypeName, MetadataInstanceElement, MetadataObjectType,
   createInstanceElement,
@@ -46,7 +47,7 @@ import {
   findElements, findStandardFieldsObject, findAnnotationsObject, findCustomFieldsObject,
   findFullCustomObject,
 } from '../test/utils'
-import SalesforceClient, { API_VERSION, Credentials } from '../src/client/client'
+import SalesforceClient, { API_VERSION } from '../src/client/client'
 import SalesforceAdapter from '../src/adapter'
 import { fromRetrieveResult, createDeployPackage } from '../src/transformers/xml_transformer'
 import { mockTypes, lwcJsResourceContent, lwcHtmlResourceContent, mockDefaultValues } from '../test/mock_elements'
@@ -77,10 +78,11 @@ const extractReferenceTo = (annotations: Values): (string | undefined)[] => (
 describe('Salesforce adapter E2E with real account', () => {
   let client: SalesforceClient
   let adapter: SalesforceAdapter
-  let credLease: CredsLease<Credentials>
+  let credLease: CredsLease<UsernamePasswordCredentials>
   beforeAll(async () => {
     credLease = await testHelpers().credentials()
-    const adapterAttr = realAdapter({ credentials: credLease.value })
+    const adapterAttr = realAdapter({ credentials:
+      new UsernamePasswordCredentials(credLease.value) })
     adapter = adapterAttr.adapter
     client = adapterAttr.client
   })

--- a/packages/salesforce-adapter/e2e_test/adapter.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.ts
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 import { ElemID, ServiceIds } from '@salto-io/adapter-api'
-import SalesforceClient, { Credentials } from '../src/client/client'
+import SalesforceClient from '../src/client/client'
 import SalesforceAdapter, { SalesforceAdapterParams } from '../src/adapter'
-import { SalesforceConfig } from '../src/types'
+import { SalesforceConfig, Credentials } from '../src/types'
 
 export type Reals = {
   client: SalesforceClient

--- a/packages/salesforce-adapter/e2e_test/credentials_store/adapter.ts
+++ b/packages/salesforce-adapter/e2e_test/credentials_store/adapter.ts
@@ -16,7 +16,7 @@
 import { Adapter } from '@salto-io/e2e-credentials-store'
 import { Connection, MetadataInfo } from 'jsforce'
 import { strings } from '@salto-io/lowerdash'
-import { Credentials, validateCredentials } from '../../src/client/client'
+import { validateCredentials } from '../../src/client/client'
 
 interface OauthConfig {
   consumerKey: string
@@ -60,6 +60,14 @@ type Args = {
   password: string
   'api-token'?: string
   sandbox: boolean
+}
+
+type Credentials = {
+  username: string
+  password: string
+  isSandbox: boolean
+  consumerKey?: string
+  apiToken?: string
 }
 
 const adapter: Adapter<Args, Credentials> = {

--- a/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
+++ b/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
@@ -21,7 +21,8 @@ import { CredsLease } from '@salto-io/e2e-credentials-store'
 import { SalesforceRecord } from '../src/client/types'
 import SalesforceAdapter, { testHelpers } from '../index'
 import realAdapter from './adapter'
-import SalesforceClient, { Credentials } from '../src/client/client'
+import SalesforceClient from '../src/client/client'
+import { UsernamePasswordCredentials } from '../src/types'
 import { runFiltersOnFetch, createElement, removeElementAndVerify, createInstance, getRecordOfInstance } from './utils'
 import { isCustomObject, apiName } from '../src/transformers/transformer'
 import customObjectsFilter from '../src/filters/custom_objects'
@@ -37,7 +38,7 @@ describe('custom object instances e2e', () => {
   let client: SalesforceClient
   let adapter: SalesforceAdapter
   let elements: Element[]
-  let credLease: CredsLease<Credentials>
+  let credLease: CredsLease<UsernamePasswordCredentials>
 
   const filtersContext = {
     dataManagement: {
@@ -49,7 +50,8 @@ describe('custom object instances e2e', () => {
   }
   beforeAll(async () => {
     credLease = await testHelpers().credentials()
-    const adapterParams = realAdapter({ credentials: credLease.value }, filtersContext)
+    const adapterParams = realAdapter({ credentials:
+      new UsernamePasswordCredentials(credLease.value) }, filtersContext)
     adapter = adapterParams.adapter
     client = adapterParams.client
 

--- a/packages/salesforce-adapter/e2e_test/globals.d.ts
+++ b/packages/salesforce-adapter/e2e_test/globals.d.ts
@@ -1,4 +1,4 @@
-import { Credentials } from '../src/client/client'
+import { Credentials } from '../src/types'
 
 declare global {
   module NodeJS {

--- a/packages/salesforce-adapter/e2e_test/jest_environment.ts
+++ b/packages/salesforce-adapter/e2e_test/jest_environment.ts
@@ -22,10 +22,10 @@ import {
 } from '@salto-io/e2e-credentials-store'
 import { logger } from '@salto-io/logging'
 import {
-  Credentials,
   ApiLimitsTooLowError,
   validateCredentials,
 } from '../src/client/client'
+import { UsernamePasswordCredentials } from '../src/types'
 
 
 const log = logger(module)
@@ -33,7 +33,7 @@ const log = logger(module)
 const MIN_API_REQUESTS_NEEDED = 2000
 const NOT_ENOUGH_API_REQUESTS_SUSPENSION_TIMEOUT = 1000 * 60 * 60
 
-export const credsSpec = (envName?: string): CredsSpec<Credentials> => {
+export const credsSpec = (envName?: string): CredsSpec<UsernamePasswordCredentials> => {
   const addEnvName = (varName: string): string => (envName === undefined
     ? varName
     : [varName, envName].join('_'))
@@ -52,9 +52,9 @@ export const credsSpec = (envName?: string): CredsSpec<Credentials> => {
         isSandbox: envUtils.bool(sandboxEnvVarName),
       }
     },
-    validate: async (creds: Credentials): Promise<void> => {
+    validate: async (creds: UsernamePasswordCredentials): Promise<void> => {
       try {
-        await validateCredentials(creds, MIN_API_REQUESTS_NEEDED)
+        await validateCredentials(new UsernamePasswordCredentials(creds), MIN_API_REQUESTS_NEEDED)
       } catch (e) {
         if (e instanceof ApiLimitsTooLowError) {
           throw new SuspendCredentialsError(e, NOT_ENOUGH_API_REQUESTS_SUSPENSION_TIMEOUT)

--- a/packages/salesforce-adapter/e2e_test/workflow.test.ts
+++ b/packages/salesforce-adapter/e2e_test/workflow.test.ts
@@ -25,7 +25,8 @@ import { MetadataInfo } from 'jsforce-types'
 import { CredsLease } from '@salto-io/e2e-credentials-store'
 import { testHelpers } from '../index'
 import realAdapter from './adapter'
-import SalesforceClient, { Credentials } from '../src/client/client'
+import SalesforceClient from '../src/client/client'
+import { UsernamePasswordCredentials } from '../src/types'
 import {
   WORKFLOW_ALERTS_FIELD, WORKFLOW_FIELD_UPDATES_FIELD, WORKFLOW_RULES_FIELD, WORKFLOW_TASKS_FIELD,
   WORKFLOW_FIELD_TO_TYPE,
@@ -50,10 +51,11 @@ describe('workflow filter', () => {
   let client: SalesforceClient
   let adapter: SalesforceAdapter
   let fetchResult: Element[]
-  let credLease: CredsLease<Credentials>
+  let credLease: CredsLease<UsernamePasswordCredentials>
   beforeAll(async () => {
     credLease = await testHelpers().credentials()
-    const adapterParams = realAdapter({ credentials: credLease.value })
+    const adapterParams = realAdapter({ credentials:
+      new UsernamePasswordCredentials(credLease.value) })
     adapter = adapterParams.adapter
     client = adapterParams.client
   })

--- a/packages/salesforce-adapter/index.ts
+++ b/packages/salesforce-adapter/index.ts
@@ -16,7 +16,7 @@
 import { creds, CredsLease } from '@salto-io/e2e-credentials-store'
 import { logger } from '@salto-io/logging'
 import { credsSpec } from './e2e_test/jest_environment'
-import { Credentials } from './src/client/client'
+import { UsernamePasswordCredentials } from './src/types'
 import { CUSTOM_OBJECT } from './src/constants'
 import { CustomObject as tCustomObject } from './src/client/types'
 
@@ -24,12 +24,12 @@ export { default } from './src/adapter'
 export { adapter } from './src/adapter_creator'
 export { default as changeValidator } from './src/change_validator'
 export { default as SalesforceClient } from './src/client/client'
-export { Credentials } from './src/client/client'
+export { UsernamePasswordCredentials, OauthAccessTokenCredentials } from './src/types'
 
 const log = logger(module)
 
 export type TestHelpers = {
-  credentials: (envName?: string) => Promise<CredsLease<Credentials>>
+  credentials: (envName?: string) => Promise<CredsLease<UsernamePasswordCredentials>>
   CUSTOM_OBJECT: string
 }
 

--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -19,7 +19,7 @@ import {
   ListMetadataQuery, FileProperties, DescribeSObjectResult, BulkOptions, BulkLoadOperation,
   DescribeGlobalSObjectResult, DeployOptions, DeployResultLocator, DeployResult,
   RetrieveRequest, RetrieveResult, Callback, RetrieveResultLocator, UserInfo, QueryResult, Batch,
-  Record as SfRecord,
+  IdentityInfo, Record as SfRecord,
 } from 'jsforce'
 import { Value } from '@salto-io/adapter-api'
 
@@ -82,4 +82,5 @@ export default interface Connection {
   query(soql: string): Promise<QueryResult<Value>>
   queryMore(locator: string): Promise<QueryResult<Value>>
   limits(): Promise<Limits>
+  identity(): Promise<IdentityInfo>
 }

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  ElemID, ObjectType, BuiltinTypes, CORE_ANNOTATIONS, ListType, createRestriction,
+  ElemID, ObjectType, InstanceElement, BuiltinTypes, CORE_ANNOTATIONS, ListType, createRestriction,
 } from '@salto-io/adapter-api'
 import * as constants from './constants'
 
@@ -74,7 +74,7 @@ export type FetchElements<T> = {
 
 const configID = new ElemID('salesforce')
 
-export const credentialsType = new ObjectType({
+export const usernamePasswordCredentialsType = new ObjectType({
   elemID: configID,
   fields: {
     username: { type: BuiltinTypes.STRING },
@@ -86,6 +86,69 @@ export const credentialsType = new ObjectType({
     sandbox: { type: BuiltinTypes.BOOLEAN },
   },
 })
+
+export const accessTokenCredentialsType = new ObjectType({
+  elemID: configID,
+  fields: {
+    accessToken: { type: BuiltinTypes.STRING },
+    instanceUrl: { type: BuiltinTypes.STRING },
+    isSandbox: { type: BuiltinTypes.BOOLEAN },
+  },
+})
+
+export const oauthRequestParameters = new ObjectType({
+  elemID: configID,
+  fields: {
+    consumerKey: {
+      type: BuiltinTypes.STRING,
+      annotations: { message: 'Consumer key for a connected app, whose redirect URI is http://localhost:port' },
+    },
+    port: {
+      type: BuiltinTypes.NUMBER,
+      annotations: { message: 'Port provided in the redirect URI' },
+    },
+    isSandbox: {
+      type: BuiltinTypes.BOOLEAN,
+      annotations: { message: 'Is connection to a sandbox?' },
+    },
+  },
+})
+
+export const isAccessTokenConfig = (config: Readonly<InstanceElement>): boolean =>
+  config.value.authType === 'oauth'
+
+export class UsernamePasswordCredentials {
+  constructor({ username, password, isSandbox, apiToken }:
+    { username: string; password: string; isSandbox: boolean; apiToken?: string }) {
+    this.username = username
+    this.password = password
+    this.isSandbox = isSandbox
+    this.apiToken = apiToken
+  }
+
+  username: string
+  password: string
+  apiToken?: string
+  isSandbox: boolean
+}
+
+export class OauthAccessTokenCredentials {
+  constructor({ instanceUrl, accessToken, isSandbox }: {
+    instanceUrl: string
+    accessToken: string
+    isSandbox: boolean
+  }) {
+    this.instanceUrl = instanceUrl
+    this.accessToken = accessToken
+    this.isSandbox = isSandbox
+  }
+
+  instanceUrl: string
+  accessToken: string
+  isSandbox: boolean
+}
+
+export type Credentials = UsernamePasswordCredentials | OauthAccessTokenCredentials
 
 const objectIdSettings = new ObjectType({
   elemID: new ElemID(constants.SALESFORCE, 'objectIdSettings'),

--- a/packages/salesforce-adapter/test/connection.ts
+++ b/packages/salesforce-adapter/test/connection.ts
@@ -15,6 +15,7 @@
 */
 import _ from 'lodash'
 import { Value } from '@salto-io/adapter-api'
+import { IdentityInfo } from 'jsforce'
 import { MetadataObject, DescribeMetadataResult, ValueTypeField, DescribeValueTypeResult, FileProperties, RetrieveResult, RetrieveResultLocator, DeployResultLocator, DeployResult, QueryResult } from 'jsforce-types'
 import Connection, { Metadata, Soap, Bulk, Tooling } from '../src/client/jsforce'
 import { createEncodedZipContent, MockInterface, mockFunction, ZipFile } from './utils'
@@ -136,10 +137,92 @@ const mockQueryResult = (
   ...props,
 })
 
+const mockIdentity = (organizationId: string): IdentityInfo => ({
+  id: '',
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  asserted_user: false,
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  user_id: '',
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  organization_id: organizationId,
+  username: '',
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  nick_name: '',
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  display_name: '',
+  email: '',
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  email_verified: false,
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  first_name: '',
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  last_name: '',
+  timezone: '',
+  photos: {
+    picture: '',
+    thumbnail: '',
+  },
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  addr_street: '',
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  addr_city: '',
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  addr_state: '',
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  addr_country: '',
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  addr_zip: '',
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  mobile_phone: '',
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  mobile_phone_verified: false,
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  is_lightning_login_user: false,
+  status: {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    created_date: null,
+    body: '',
+  },
+  urls: {
+    enterprise: '',
+    metadata: '',
+    partner: '',
+    rest: '',
+    sobjects: '',
+    search: '',
+    query: '',
+    recent: '',
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    tooling_soap: '',
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    tooling_rest: '',
+    profile: '',
+    feeds: '',
+    groups: '',
+    users: '',
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    feed_items: '',
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    feed_elements: '',
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    custom_domain: '',
+  },
+  active: false,
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  user_type: '',
+  language: '',
+  locale: '',
+  utcOffset: 0,
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  last_modified_date: new Date(),
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  is_app_installed: false,
+})
+
 export const mockJsforce: () => MockInterface<Connection> = () => ({
-  login: mockFunction<Connection['login']>().mockResolvedValue(
+  login: mockFunction<Connection['login']>().mockImplementation(async () => (
     { id: '', organizationId: '', url: '' }
-  ),
+  )),
   metadata: {
     describe: mockFunction<Metadata['describe']>().mockResolvedValue({ metadataObjects: [] }),
     describeValueType: mockFunction<Metadata['describeValueType']>().mockResolvedValue(
@@ -170,4 +253,5 @@ export const mockJsforce: () => MockInterface<Connection> = () => ({
     query: mockFunction<Tooling['query']>().mockResolvedValue(mockQueryResult({})),
     queryMore: mockFunction<Tooling['queryMore']>().mockResolvedValue(mockQueryResult({})),
   },
+  identity: mockFunction<Connection['identity']>().mockImplementation(async () => mockIdentity('')),
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,6 +1318,42 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.7.2":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
+  integrity sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
+  integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/formatio@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-5.0.1.tgz#f13e713cb3313b1ab965901b01b0828ea6b77089"
+  integrity sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^5.0.2"
+
+"@sinonjs/samsam@^5.0.2", "@sinonjs/samsam@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.1.0.tgz#3afe719232b541bb6cf3411a4c399a188de21ec0"
+  integrity sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 "@slack/logger@>=1.0.0 <3.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-2.0.0.tgz#6a4e1c755849bc0f66dac08a8be54ce790ec0e6b"
@@ -1397,6 +1433,14 @@
   resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.32.tgz#381e7b59e39f010d20bbf7e044e48f5caf1ab620"
   integrity sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g==
 
+"@types/body-parser@*":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
+  integrity sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
 "@types/caseless@*":
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
@@ -1406,6 +1450,13 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/connect@*":
+  version "3.4.33"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
+  integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
+  dependencies:
+    "@types/node" "*"
 
 "@types/cookiejar@*":
   version "2.1.1"
@@ -1436,6 +1487,25 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
+
+"@types/express-serve-static-core@*":
+  version "4.17.12"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.12.tgz#9a487da757425e4f267e7d1c5720226af7f89591"
+  integrity sha512-EaEdY+Dty1jEU7U6J4CUWwxL+hyEGMkO5jan5gplfegUgCUsIUWqXxqw47uGjimeT4Qgkz/XUfwoau08+fgvKA==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express@*", "@types/express@^4.17.7":
+  version "4.17.8"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.8.tgz#3df4293293317e61c60137d273a2e96cd8d5f27a"
+  integrity sha512-wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
 
 "@types/figlet@^1.2.0":
   version "1.2.0"
@@ -1547,6 +1617,11 @@
   resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.0.tgz#9ca52cda363f699c69466c2a6ccdaad913ea7a73"
   integrity sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=
 
+"@types/mime@*":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"
+  integrity sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
+
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1563,6 +1638,14 @@
   integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
   dependencies:
     "@types/node" "*"
+
+"@types/mock-req-res@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/mock-req-res/-/mock-req-res-1.1.2.tgz#624607cde786db4cfbeee21c8fb1a2ed035a62ca"
+  integrity sha512-EDnLJUzUmYD9vhHPxixkRz5lOF/30xwBmfSt65G4unIbs5r8Cb4kIif6bJ2+h760qrUpceev9dnPOPqZP8EMGQ==
+  dependencies:
+    "@types/express" "*"
+    "@types/sinon" "*"
 
 "@types/moo@^0.5.0":
   version "0.5.3"
@@ -1660,6 +1743,16 @@
     "@types/node" "*"
     "@types/pino-std-serializers" "*"
     "@types/sonic-boom" "*"
+
+"@types/qs@*":
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.4.tgz#a59e851c1ba16c0513ea123830dd639a0a15cb6a"
+  integrity sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ==
+
+"@types/range-parser@*":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
+  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
 "@types/request-promise@^4.1.45":
   version "4.1.46"
@@ -1811,6 +1904,14 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.3.tgz#3ad6ed949e7487e7bda6f886b4a2434a2c3d7b1a"
   integrity sha512-jQxClWFzv9IXdLdhSaTf16XI3NYe6zrEbckSpb5xhKfPbWgIyAY0AFyWWWfaiDcBuj3UHmMkCIwSRqpKMTZL2Q==
 
+"@types/serve-static@*":
+  version "1.13.5"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.5.tgz#3d25d941a18415d3ab092def846e135a08bbcf53"
+  integrity sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/mime" "*"
+
 "@types/shelljs@^0.7.8":
   version "0.7.9"
   resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.9.tgz#3abecb72d9cad9cd4b0e7cb86ed10a97d93ba602"
@@ -1818,6 +1919,18 @@
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
+
+"@types/sinon@*":
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.5.tgz#56b2a12662dd8c7d081cdc511af5f872cb37377f"
+  integrity sha512-4CnkGdM/5/FXDGqL32JQ1ttVrGvhOoesLLF7VnTh4KdjK5N5VQOtxaylFqqTjnHx55MnD9O02Nbk5c1ELC8wlQ==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
+
+"@types/sinonjs__fake-timers@*":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz#681df970358c82836b42f989188d133e218c458e"
+  integrity sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==
 
 "@types/sonic-boom@*":
   version "0.7.0"
@@ -3452,7 +3565,7 @@ compare-func@^1.3.1:
     array-ify "^1.0.0"
     dot-prop "^3.0.0"
 
-component-emitter@^1.2.1:
+component-emitter@^1.2.1, component-emitter@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -3641,6 +3754,11 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookiejar@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
+  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -4098,7 +4216,7 @@ diff2html@3.1.8:
   optionalDependencies:
     highlight.js "10.0.2"
 
-diff@4.0.2, diff@^4.0.1:
+diff@4.0.2, diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
@@ -4817,7 +4935,7 @@ expect@^24.9.0:
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
 
-express@4.17.1:
+express@4.17.1, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
@@ -5265,6 +5383,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formidable@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
+  integrity sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -6382,6 +6505,11 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
+is-docker@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
+  integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
+
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -6558,6 +6686,13 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+is-wsl@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -7245,6 +7380,11 @@ jszip@^3.2.2:
     readable-stream "~2.3.6"
     set-immediate-shim "~1.0.1"
 
+just-extend@^4.0.2:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.1.tgz#158f1fdb01f128c411dc8b286a7b4837b3545282"
+  integrity sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==
+
 kew@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"
@@ -7909,7 +8049,7 @@ meriyah@^1.9.15:
   resolved "https://registry.yarnpkg.com/meriyah/-/meriyah-1.9.15.tgz#85a8528c52d7a4bb95037fe5a44276a0f030d81e"
   integrity sha512-D4rT6XIYGqZab0EI/xbihUpwh0WbNRVQ35l2J/5QC2atxaI8h3KvA55DEJLBB/FRdaji7JwkNehfCRjCyjCjqw==
 
-methods@~1.1.2:
+methods@1.1.2, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -7965,6 +8105,11 @@ mime@1.6.0, mime@^1.3.4:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
+mime@^2.4.6:
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
+  integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -8252,6 +8397,17 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+nise@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
+  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/fake-timers" "^6.0.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
 
 nock@^12.0.1:
   version "12.0.3"
@@ -8695,6 +8851,14 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
+open@^7.2.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.2.1.tgz#07b0ade11a43f2a8ce718480bdf3d7563a095195"
+  integrity sha512-xbYCJib4spUdmcs0g/2mK1nKo/jO2T7INClWd/beL7PFkXRWgr8B23ssDHX/USPn2M2IjDR5UdpYs6I67SnTSA==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 opn@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
@@ -9112,6 +9276,13 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -9465,6 +9636,11 @@ qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
+qs@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
+  integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
 
 qs@~6.5.2:
   version "6.5.2"
@@ -10320,6 +10496,19 @@ simple-git@^2.6.0:
     "@kwsites/file-exists" "^1.1.1"
     debug "^4.1.1"
 
+sinon@^9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.0.3.tgz#bffc3ec28c936332cd2a41833547b9eed201ecff"
+  integrity sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==
+  dependencies:
+    "@sinonjs/commons" "^1.7.2"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@sinonjs/formatio" "^5.0.1"
+    "@sinonjs/samsam" "^5.1.0"
+    diff "^4.0.2"
+    nise "^4.0.4"
+    supports-color "^7.1.0"
+
 sisteransi@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -10874,6 +11063,31 @@ subleveldown@^4.1.4:
     levelup "^4.3.1"
     reachdown "^1.0.0"
 
+superagent@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-6.1.0.tgz#09f08807bc41108ef164cfb4be293cebd480f4a6"
+  integrity sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.2"
+    debug "^4.1.1"
+    fast-safe-stringify "^2.0.7"
+    form-data "^3.0.0"
+    formidable "^1.2.2"
+    methods "^1.1.2"
+    mime "^2.4.6"
+    qs "^6.9.4"
+    readable-stream "^3.6.0"
+    semver "^7.3.2"
+
+supertest@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-5.0.0.tgz#771aedfeb0a95466cc5d100d5d11288736fd25da"
+  integrity sha512-2JAWpPrUOZF4hHH5ZTCN2xjKXvJS3AEwPNXl0HUseHsfcXFvMy9kcsufIHCNAmQ5hlGCvgeAqaR5PBEouN3hlQ==
+  dependencies:
+    methods "1.1.2"
+    superagent "6.1.0"
+
 supports-color@6.1.0, supports-color@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
@@ -11312,6 +11526,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@4.0.8, type-detect@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
Temporary solution to:
[Salto-757]
https://salto-io.atlassian.net/browse/SALTO-757
See more discussion of solution methods here:
https://www.notion.so/saltoio/Possible-flows-for-oauth-4acf3d67f9d94f848cb6027bfec43c29 
This is a suggestion of how the salesforce oath can work.
It's not finished - haven't cleaned up some stuff, haven't done any fail-state handling, tests don't pass, and I haven't added tests.
However, the basic functionality - initializing and using salesforce using the oath - works.
I'm creating a pull request to give anyone who'd like a chance to review the code and see the in-code choices (which code goes where) before I cement them with more tests and stuff.
Will probably be interested:
@noamhammer  @ori-moisis @gilhoffer  