### PR TITLE
Add version field to deploy/retrieve packages

### DIFF
--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -2697,7 +2697,7 @@ describe('Salesforce adapter E2E with real account', () => {
           const retrieveRequest = {
             apiVersion: API_VERSION,
             singlePackage: false,
-            [packageName]: [{ types: { name: type, members: member } }],
+            [packageName]: { version: API_VERSION, types: [{ name: type, members: [member] }] },
           }
           return client.retrieve(retrieveRequest)
         }

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -55,6 +55,7 @@ export const toRetrieveRequest = (files: ReadonlyArray<FileProperties>): Retriev
   apiVersion: API_VERSION,
   singlePackage: false,
   [PACKAGE]: {
+    version: API_VERSION,
     types: _(files)
       .groupBy(file => file.type)
       .entries()


### PR DESCRIPTION
According to [the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_package.htm#meta_package) that field is required