### PR TITLE
Custom object instances upsert

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -480,6 +480,7 @@ export default class SalesforceAdapter implements AdapterOperations {
         resolvedChangeGroup,
         this.client,
         this.filtersRunner,
+        this.userConfig.dataManagement,
       )]
     } else {
       results = await Promise.all(

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -14,22 +14,28 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { values } from '@salto-io/lowerdash'
+import { values, collections } from '@salto-io/lowerdash'
 import {
-  ChangeGroup, getChangeElement, DeployResult, Change,
-  InstanceElement, isAdditionGroup, isRemovalGroup,
-  ChangeGroupId, ModificationChange, isModificationGroup,
+  ChangeGroup, getChangeElement, DeployResult, Change, isPrimitiveType,
+  InstanceElement, isAdditionGroup, isRemovalGroup, Value, PrimitiveTypes,
+  ChangeGroupId, ModificationChange, isModificationGroup, Field, ObjectType, isObjectType, Values,
 } from '@salto-io/adapter-api'
 import { BatchResultInfo } from 'jsforce-types'
-import {
-  isInstanceOfCustomObject, instancesToCreateRecords, apiName, instancesToDeleteRecords,
-  instancesToUpdateRecords,
-} from './transformers/transformer'
+import { isInstanceOfCustomObject, instancesToCreateRecords, apiName, instancesToDeleteRecords, instancesToUpdateRecords, Types } from './transformers/transformer'
 import SalesforceClient from './client/client'
-import * as constants from './constants'
+import { CUSTOM_OBJECT_ID_FIELD } from './constants'
 import { Filter } from './filter'
+import { DataManagementConfig } from './types'
+import { getIdFields, buildSelectStr, transformCompoundNameValues } from './filters/custom_objects_instances'
+import { SalesforceRecord } from './client/types'
 
 const { isDefined } = values
+const { toArrayAsync } = collections.asynciterable
+
+type ActionResult = {
+  successInstances: InstanceElement[]
+  errorMessages: string[]
+}
 
 const getErrorMessagesFromResults = (results: BatchResultInfo[]): string[] =>
   results
@@ -37,28 +43,195 @@ const getErrorMessagesFromResults = (results: BatchResultInfo[]): string[] =>
     .flatMap(erroredResult => erroredResult.errors)
     .filter(isDefined)
 
-const deployAddInstances = async (
+const getActionResult = (
+  results: BatchResultInfo[],
+  instances: InstanceElement[]
+): ActionResult => {
+  const successIds = results.filter(result => result.success).map(result => result.id)
+  const successInstances = instances.filter(instance => successIds.includes(apiName(instance)))
+  const errorMessages = getErrorMessagesFromResults(results)
+  return { successInstances, errorMessages }
+}
+
+const formatValueForWhere = (field: Field, value: Value): Value => {
+  if (value === undefined) {
+    return 'null'
+  }
+  if (isPrimitiveType(field.type)) {
+    if (field.type.primitive === PrimitiveTypes.STRING) {
+      return `'${value}'`
+    }
+    return JSON.stringify(value)
+  }
+  throw new Error(`Can not create upsert WHERE clause for non-primitve field ${field.name}`)
+}
+
+const capitalizeFirstLetter = (str: string): string =>
+  str.charAt(0).toUpperCase() + str.slice(1)
+
+const getRecordsBySaltoIds = async (
+  type: ObjectType,
+  instances: InstanceElement[],
+  saltoIdFields: Field[],
+  client: SalesforceClient,
+): Promise<SalesforceRecord[]> => {
+  // Should always query Id together with the SaltoIdFields to match it to instances
+  const saltoIdFieldsWithIdField = (saltoIdFields
+    .find(field => field.name === CUSTOM_OBJECT_ID_FIELD) === undefined)
+    ? [type.fields[CUSTOM_OBJECT_ID_FIELD], ...saltoIdFields] : saltoIdFields
+  const selectStr = buildSelectStr(saltoIdFieldsWithIdField)
+  // The use of IN can lead to querying uneeded records (cross values between instances)
+  // and can be optimized
+  const fieldsWheres = saltoIdFields.flatMap(field => {
+    const fieldType = field.type
+    if (isObjectType(fieldType)) {
+      const compoundFieldType = Object.values(Types.compoundDataTypes)
+        .find(compoundType => compoundType.isEqual(fieldType))
+      if (compoundFieldType !== undefined) {
+        return Object
+          .entries(compoundFieldType.fields).map(([compoundFieldName, compoundField]) => {
+            const compoundFieldValues = [
+              ...new Set(instances.map(instance =>
+                (formatValueForWhere(
+                  compoundField,
+                  instance.value[field.name]?.[compoundFieldName]
+                )))),
+            ]
+            return `${capitalizeFirstLetter(compoundFieldName)} IN (${compoundFieldValues.join(',')})`
+          })
+      }
+    }
+    const instancesFieldValues = [...new Set(instances
+      .map(instance =>
+        (formatValueForWhere(instance.type.fields[field.name], instance.value[field.name]))))]
+    return `${apiName(field, true)} IN (${instancesFieldValues.join(',')})`
+  })
+  const whereStr = fieldsWheres.join(' AND ')
+  const query = `SELECT ${selectStr} FROM ${apiName(type)} WHERE ${whereStr}`
+  const recordsIterable = await client.queryAll(query)
+  return (await toArrayAsync(recordsIterable)).flat()
+}
+
+const insertInstances = async (
+  typeName: string,
   instances: InstanceElement[],
   client: SalesforceClient,
-  filtersRunner: Required<Filter>,
-): Promise<DeployResult> => {
+): Promise<ActionResult> => {
+  if (instances.length === 0) {
+    return { successInstances: [], errorMessages: [] }
+  }
   const results = await client.bulkLoadOperation(
-    apiName(instances[0].type),
+    typeName,
     'insert',
     instancesToCreateRecords(instances)
   )
   const successInstances = instances
     .filter((_instance, index) => results[index]?.success)
   successInstances.forEach((instance, index) => {
-    instance.value[constants.CUSTOM_OBJECT_ID_FIELD] = results[index].id
+    instance.value[CUSTOM_OBJECT_ID_FIELD] = results[index].id
   })
-  const errors = getErrorMessagesFromResults(results)
+  const errorMessages = getErrorMessagesFromResults(results)
+  return { successInstances, errorMessages }
+}
+
+const updateInstances = async (
+  typeName: string,
+  instances: InstanceElement[],
+  client: SalesforceClient,
+): Promise<ActionResult> => {
+  if (instances.length === 0) {
+    return { successInstances: [], errorMessages: [] }
+  }
+  const results = await client.bulkLoadOperation(
+    typeName,
+    'update',
+    instancesToUpdateRecords(instances)
+  )
+  return getActionResult(results, instances)
+}
+
+const deleteInstances = async (
+  typeName: string,
+  instances: InstanceElement[],
+  client: SalesforceClient,
+): Promise<ActionResult> => {
+  const results = await client.bulkLoadOperation(
+    typeName,
+    'delete',
+    instancesToDeleteRecords(instances),
+  )
+  return getActionResult(results, instances)
+}
+
+const cloneWithoutNulls = (val: Values): Values =>
+  (Object.fromEntries(Object.entries(val).filter(([_k, v]) => (v !== null)).map(([k, v]) => {
+    if (_.isObject(v)) {
+      return [k, cloneWithoutNulls(v)]
+    }
+    return [k, v]
+  })))
+
+const isEqualRecordAndInstanceIdValues = (
+  record: SalesforceRecord,
+  instance: InstanceElement,
+  idFieldsNames: string[],
+): boolean => {
+  const recordValues = transformCompoundNameValues(instance.type, record)
+  // Remove null values from the record result to compare it to instance values
+  const recordValuesWithoutNulls = cloneWithoutNulls(recordValues)
+  return _.isEqual(
+    _.pick(instance.value, idFieldsNames),
+    _.pick(recordValuesWithoutNulls, idFieldsNames)
+  )
+}
+
+const deployAddInstances = async (
+  instances: InstanceElement[],
+  idFields: Field[],
+  client: SalesforceClient,
+  filtersRunner: Required<Filter>,
+): Promise<DeployResult> => {
+  const { type } = instances[0]
+  const typeName = apiName(type)
+  const idFieldsNames = idFields.map(field => field.name)
+  const existingRecords = await getRecordsBySaltoIds(type, instances, idFields, client)
+  const [existingInstances, newInstances] = _.partition(
+    instances,
+    instance => (existingRecords.find(record =>
+      isEqualRecordAndInstanceIdValues(record, instance, idFieldsNames)) !== undefined)
+  )
+  const {
+    successInstances: successInsertInstances,
+    errorMessages: insertErrorMessages,
+  } = await insertInstances(
+    typeName,
+    newInstances,
+    client,
+  )
+  existingInstances.forEach(instance => {
+    const existingRecord = existingRecords.find(
+      record =>
+        (isEqualRecordAndInstanceIdValues(record, instance, idFieldsNames))
+    )
+    if (existingRecord !== undefined) {
+      instance.value[CUSTOM_OBJECT_ID_FIELD] = existingRecord[CUSTOM_OBJECT_ID_FIELD]
+    }
+  })
+  const {
+    successInstances: successUpdateInstances,
+    errorMessages: updateErrorMessages,
+  } = await updateInstances(
+    apiName(type),
+    existingInstances,
+    client
+  )
+  const allSuccessInstances = [...successInsertInstances, ...successUpdateInstances]
   await Promise.all(
-    successInstances.map(postInstance => filtersRunner.onAdd(postInstance))
+    allSuccessInstances.map(postInstance => filtersRunner.onAdd(postInstance))
   )
   return {
-    appliedChanges: successInstances.map(instance => ({ action: 'add', data: { after: instance } })),
-    errors: errors.map(error => new Error(error)),
+    appliedChanges: allSuccessInstances.map(instance => ({ action: 'add', data: { after: instance } })),
+    errors: [...insertErrorMessages, ...updateErrorMessages].map(error => new Error(error)),
   }
 }
 
@@ -67,15 +240,11 @@ const deployRemoveInstances = async (
   client: SalesforceClient,
   filtersRunner: Required<Filter>,
 ): Promise<DeployResult> => {
-  const results = await client.bulkLoadOperation(
+  const { successInstances, errorMessages } = await deleteInstances(
     apiName(instances[0].type),
-    'delete',
-    instancesToDeleteRecords(instances),
+    instances,
+    client
   )
-  const successResultIds = results.filter(result => result.success).map(result => result.id)
-  const errorMessages = getErrorMessagesFromResults(results)
-  const successInstances = instances.filter(instance =>
-    successResultIds.includes(instance.value[constants.CUSTOM_OBJECT_ID_FIELD]))
   await Promise.all(successInstances.map(element => filtersRunner.onRemove(element)))
   return {
     appliedChanges: successInstances.map(instance => ({ action: 'remove', data: { before: instance } })),
@@ -96,16 +265,10 @@ const deployModifyChanges = async (
     changeData => apiName(changeData.before) === apiName(changeData.after)
   )
   const afters = validData.map(data => data.after)
-  const results = await client.bulkLoadOperation(
-    instancesType,
-    'update',
-    instancesToUpdateRecords(afters)
-  )
-  const successResultIds = results.filter(result => result.success).map(result => result.id)
-  const resultsErrorMessages = getErrorMessagesFromResults(results)
+  const { successInstances, errorMessages } = await updateInstances(instancesType, afters, client)
   const successData = validData
     .filter(changeData =>
-      successResultIds.includes(apiName(changeData.after)))
+      successInstances.find(instance => instance.isEqual(changeData.after)))
   await Promise.all(
     successData
       .map(changeData =>
@@ -114,7 +277,7 @@ const deployModifyChanges = async (
   const diffApiNameErrors = diffApiNameData.map(data => new Error(`Failed to update as api name prev=${apiName(
     data.before
   )} and new=${apiName(data.after)} are different`))
-  const errors = resultsErrorMessages.map(error => new Error(error)).concat(diffApiNameErrors)
+  const errors = errorMessages.map(error => new Error(error)).concat(diffApiNameErrors)
   return {
     appliedChanges: successData.map(data => ({ action: 'modify', data })),
     errors,
@@ -134,15 +297,23 @@ export const deployCustomObjectInstancesGroup = async (
     },
   client: SalesforceClient,
   filtersRunner: Required<Filter>,
+  dataManagementConfig?: DataManagementConfig,
 ): Promise<DeployResult> => {
   try {
+    if (dataManagementConfig === undefined) {
+      throw new Error('dataManagement must be defined in the salesforce.nacl config to deploy Custom Object instances')
+    }
     const instances = changeGroup.changes.map(change => getChangeElement(change))
     const instanceTypes = [...new Set(instances.map(inst => apiName(inst.type)))]
     if (instanceTypes.length > 1) {
       throw new Error(`Custom Object Instances change group should have a single type but got: ${instanceTypes}`)
     }
     if (isAdditionGroup(changeGroup)) {
-      return await deployAddInstances(instances, client, filtersRunner)
+      const { idFields, invalidFields } = getIdFields(instances[0].type, dataManagementConfig)
+      if (invalidFields !== undefined && invalidFields.length > 0) {
+        throw new Error(`Failed to add instances of type ${instanceTypes[0]} due to invalid SaltoIdFields - ${invalidFields}`)
+      }
+      return await deployAddInstances(instances, idFields, client, filtersRunner)
     }
     if (isRemovalGroup(changeGroup)) {
       return await deployRemoveInstances(instances, client, filtersRunner)
@@ -150,10 +321,7 @@ export const deployCustomObjectInstancesGroup = async (
     if (isModificationGroup(changeGroup)) {
       return await deployModifyChanges(changeGroup.changes, client, filtersRunner)
     }
-    return {
-      appliedChanges: [],
-      errors: [new Error('Custom Object Instances change group must have one action')],
-    }
+    throw new Error('Custom Object Instances change group must have one action')
   } catch (error) {
     return {
       appliedChanges: [],

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -1,0 +1,780 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, BuiltinTypes, DeployResult, ReferenceExpression, isRemovalChange, getChangeElement, isInstanceElement, ChangeGroup, isModificationChange, isAdditionChange } from '@salto-io/adapter-api'
+import { BulkLoadOperation, BulkOptions, Record as SfRecord, Batch } from 'jsforce'
+import { EventEmitter } from 'events'
+import { Types } from '../src/transformers/transformer'
+import SalesforceAdapter from '../src/adapter'
+import * as constants from '../src/constants'
+import Connection from '../src/client/jsforce'
+import mockAdapter from './adapter'
+
+describe('Custom Object Instances CRUD', () => {
+  let adapter: SalesforceAdapter
+  let result: DeployResult
+
+  const mockElemID = new ElemID(constants.SALESFORCE, 'Test')
+  const instanceName = 'Instance'
+  const anotherInstanceName = 'AnotherInstance'
+
+  const customObject = new ObjectType({
+    elemID: mockElemID,
+    fields: {
+      Id: {
+        type: BuiltinTypes.STRING,
+        annotations: {
+          [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+          [constants.FIELD_ANNOTATIONS.UPDATEABLE]: false,
+          [constants.API_NAME]: 'Id',
+        },
+      },
+      SaltoName: {
+        type: BuiltinTypes.STRING,
+        annotations: {
+          [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+          [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.API_NAME]: 'SaltoName',
+        },
+      },
+      NumField: {
+        type: BuiltinTypes.NUMBER,
+        annotations: {
+          [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+          [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.API_NAME]: 'NumField',
+        },
+      },
+      NotCreatable: {
+        type: BuiltinTypes.STRING,
+        annotations: {
+          [constants.FIELD_ANNOTATIONS.CREATABLE]: false,
+          [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.API_NAME]: 'NotCreatable',
+        },
+      },
+      AnotherField: {
+        type: BuiltinTypes.STRING,
+        annotations: {
+          [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+          [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.API_NAME]: 'AnotherField',
+        },
+      },
+      Address: {
+        type: Types.compoundDataTypes.Address,
+        annotations: {
+          [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+          [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.API_NAME]: 'Address',
+        },
+      },
+      Name: {
+        type: Types.compoundDataTypes.Name,
+        annotations: {
+          [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+          [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.API_NAME]: 'Name',
+        },
+      },
+    },
+    annotationTypes: {},
+    annotations: {
+      [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
+      [constants.API_NAME]: 'Type',
+    },
+  })
+  const existingInstance = new InstanceElement(
+    instanceName,
+    customObject,
+    {
+      SaltoName: 'existingInstance',
+      NotCreatable: 'DontSendMeOnCreate',
+      NumField: 1,
+      Address: {
+        city: 'Tel-Aviv',
+        country: 'Israel',
+      },
+      Name: {
+        FirstName: 'first',
+        LastName: 'last',
+        Salutation: 'mrs.',
+      },
+    }
+  )
+  const existingInstanceRecordValues = {
+    attributes: {
+      type: 'Type',
+    },
+    Id: 'queryId',
+    SaltoName: 'existingInstance',
+    NumField: 1,
+    Address: {
+      city: 'Tel-Aviv',
+      country: 'Israel',
+      postalCode: null,
+    },
+    FirstName: 'first',
+    LastName: 'last',
+    Salutation: 'mrs.',
+  }
+  const anotherExistingInstance = new InstanceElement(
+    anotherInstanceName,
+    customObject,
+    {
+      SaltoName: 'anotherExistingInstance',
+      NotCreatable: 'DontSendMeOnCreate',
+    }
+  )
+  const anotherExistingInstanceRecordValues = {
+    attributes: {
+      type: 'Type',
+    },
+    Id: 'anotherQueryId',
+    SaltoName: 'anotherExistingInstance',
+    NumField: null,
+  }
+  const newInstanceWithRefName = 'newInstanceWithRef'
+  const newInstanceWithRef = new InstanceElement(
+    newInstanceWithRefName,
+    customObject,
+    {
+      SaltoName: 'newInstanceWithRef',
+      AnotherField: new ReferenceExpression(mockElemID, 'Type'),
+      NumField: 2,
+    }
+  )
+  const anotherNewInstanceName = 'anotherNewInstance'
+  const anotherNewInstance = new InstanceElement(
+    anotherNewInstanceName,
+    customObject,
+    {
+      SaltoName: 'anotherNewInstance',
+      NumField: 3,
+      Address: {
+        city: 'Ashkelon',
+        country: 'Israel',
+      },
+    }
+  )
+
+  describe('When adapter defined with dataManagement config', () => {
+    let connection: Connection
+    let mockBulkLoad: jest.Mock
+    let partialBulkLoad: jest.Mock
+    const getBulkLoadMock = (mode: string): jest.Mock<Batch> =>
+      (jest.fn().mockImplementation(
+        (_type: string, _operation: BulkLoadOperation, _opt?: BulkOptions, input?: SfRecord[]) => {
+          const isError = (index: number): boolean => {
+            if (mode === 'fail') {
+              return true
+            }
+            // For partial mode return error every 2nd index
+            return mode === 'partial' && (index % 2) === 0
+          }
+
+          const loadEmitter = new EventEmitter()
+          loadEmitter.on('newListener', (_event, _listener) => {
+            // This is a workaround to call emit('close')
+            // that is really called as a side effect to load() inside
+            // jsforce *after* our code listens on.('close')
+            setTimeout(() => loadEmitter.emit('close'), 0)
+          })
+          return {
+            then: () => (Promise.resolve(input?.map((res, index) => ({
+              id: res.Id || 'newId',
+              success: !isError(index),
+              errors: isError(index) ? ['Error message'] : [],
+            })))),
+            job: loadEmitter,
+          }
+        }
+      ))
+    beforeEach(() => {
+      ({ connection, adapter } = mockAdapter({
+        adapterParams: {
+          filterCreators: [],
+          config: {
+            dataManagement: {
+              includeObjects: ['Test'],
+              saltoIDSettings: {
+                defaultIdFields: ['SaltoName', 'NumField', 'Address', 'Name'],
+              },
+            },
+          },
+        },
+      }))
+      mockBulkLoad = getBulkLoadMock('success')
+      partialBulkLoad = getBulkLoadMock('partial')
+      connection.bulk.load = mockBulkLoad
+    })
+
+    describe('When valid add group', () => {
+      let mockQuery: jest.Mock
+
+      describe('When loadBulk succeeds for all', () => {
+        describe('When called with both new and existing instances', () => {
+          beforeEach(async () => {
+            mockQuery = jest.fn().mockImplementation(async () => (
+              {
+                totalSize: 1,
+                done: true,
+                records: [existingInstanceRecordValues],
+              }))
+            connection.query = mockQuery
+            result = await adapter.deploy({
+              groupID: 'add_Test_instances',
+              changes: [
+                { action: 'add', data: { after: existingInstance } },
+                { action: 'add', data: { after: newInstanceWithRef } },
+              ],
+            })
+          })
+
+          it('Should query according to instance values', () => {
+            expect(mockQuery.mock.calls).toHaveLength(1)
+            expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,SaltoName,NumField,Address,FirstName,LastName,Salutation FROM Type WHERE SaltoName IN (\'existingInstance\',\'newInstanceWithRef\') AND NumField IN (1,2) AND City IN (\'Tel-Aviv\',null) AND Country IN (\'Israel\',null) AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (\'first\',null) AND LastName IN (\'last\',null) AND Salutation IN (\'mrs.\',null)')
+          })
+
+          it('Should call load operation twice - once with insert once with update', () => {
+            expect(mockBulkLoad.mock.calls).toHaveLength(2)
+            const insertCall = mockBulkLoad.mock.calls.find(call => call[1] === 'insert')
+            expect(insertCall).toBeDefined()
+            const updateCall = mockBulkLoad.mock.calls.find(call => call[1] === 'update')
+            expect(updateCall).toBeDefined()
+          })
+
+          it('Should call load operation with update for the "existing" record', () => {
+            const updateCall = mockBulkLoad.mock.calls.find(call => call[1] === 'update')
+            expect(updateCall).toHaveLength(4)
+            expect(updateCall[0]).toBe('Type')
+
+            // Record
+            expect(updateCall[3]).toHaveLength(1)
+            expect(updateCall[3][0].SaltoName).toBeDefined()
+            expect(updateCall[3][0].SaltoName).toEqual('existingInstance')
+            // Because it turns into an update it should send it
+            expect(updateCall[3][0].NotCreatable).toBeDefined()
+            expect(updateCall[3][0].NotCreatable).toEqual('DontSendMeOnCreate')
+          })
+
+          it('Should call load operation with insert for the "new" record', () => {
+            const insertCall = mockBulkLoad.mock.calls.find(call => call[1] === 'insert')
+            expect(insertCall.length).toBe(4)
+            expect(insertCall[0]).toBe('Type')
+
+            // Record
+            expect(insertCall[3]).toHaveLength(1)
+            expect(insertCall[3][0].SaltoName).toBeDefined()
+            expect(insertCall[3][0].SaltoName).toEqual('newInstanceWithRef')
+            expect(insertCall[3][0].NotCreatable).toBeUndefined()
+            expect(insertCall[3][0].AnotherField).toBeDefined()
+            expect(insertCall[3][0].AnotherField).toEqual('Type')
+          })
+
+          it('Should have result with 2 applied changes, add 2 instances with new Id', async () => {
+            expect(result.errors).toHaveLength(0)
+            expect(result.appliedChanges).toHaveLength(2)
+
+            // existingInstance appliedChange
+            const existingInstanceChangeElement = result.appliedChanges
+              .map(getChangeElement)
+              .find(element => element.elemID.isEqual(existingInstance.elemID)) as InstanceElement
+            expect(existingInstanceChangeElement).toBeDefined()
+            expect(existingInstanceChangeElement.value.SaltoName).toBeDefined()
+            expect(existingInstanceChangeElement.value.SaltoName).toBe('existingInstance')
+            // Should add result (query) Id
+            expect(existingInstanceChangeElement.value.Id).toBeDefined()
+            expect(existingInstanceChangeElement.value.Id).toEqual('queryId')
+
+            // newInstnace appliedChange
+            const newInstanceChangeElement = result.appliedChanges
+              .map(getChangeElement)
+              .find(element => element.elemID.isEqual(newInstanceWithRef.elemID)) as InstanceElement
+            expect(newInstanceChangeElement.elemID).toEqual(newInstanceWithRef.elemID)
+            expect(newInstanceChangeElement.value.SaltoName).toBeDefined()
+            expect(newInstanceChangeElement.value.SaltoName).toBe('newInstanceWithRef')
+            // Should add result Id
+            expect(newInstanceChangeElement.value.Id).toBeDefined()
+            expect(newInstanceChangeElement.value.Id).toEqual('newId')
+
+            // Reference should stay a referece
+            expect(newInstanceChangeElement.value.AnotherField)
+              .toEqual(new ReferenceExpression(mockElemID, 'Type'))
+          })
+        })
+        describe('When called with only new instances', () => {
+          beforeEach(async () => {
+            mockQuery = jest.fn().mockImplementation(async () => (
+              {
+                totalSize: 0,
+                done: true,
+                records: [],
+              }))
+            connection.query = mockQuery
+            result = await adapter.deploy({
+              groupID: 'add_Test_instances',
+              changes: [
+                { action: 'add', data: { after: newInstanceWithRef } },
+                { action: 'add', data: { after: anotherNewInstance } },
+              ],
+            })
+          })
+
+          it('Should query according to instance values', () => {
+            expect(mockQuery.mock.calls).toHaveLength(1)
+            expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,SaltoName,NumField,Address,FirstName,LastName,Salutation FROM Type WHERE SaltoName IN (\'newInstanceWithRef\',\'anotherNewInstance\') AND NumField IN (2,3) AND City IN (null,\'Ashkelon\') AND Country IN (null,\'Israel\') AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (null) AND LastName IN (null) AND Salutation IN (null)')
+          })
+
+          it('Should call load operation once with insert', () => {
+            expect(mockBulkLoad.mock.calls.length).toBe(1)
+            const insertCall = mockBulkLoad.mock.calls.find(call => call[1] === 'insert')
+            expect(insertCall).toBeDefined()
+          })
+
+          it('Should have result with 2 applied changes, add 2 instances with insert Id', async () => {
+            expect(result.errors).toHaveLength(0)
+            expect(result.appliedChanges).toHaveLength(2)
+            // newInstnace appliedChange
+            const newInstanceChangeElement = result.appliedChanges
+              .map(getChangeElement)
+              .find(element => element.elemID.isEqual(newInstanceWithRef.elemID)) as InstanceElement
+            expect(newInstanceChangeElement.elemID).toEqual(newInstanceWithRef.elemID)
+            expect(newInstanceChangeElement.value.SaltoName).toBeDefined()
+            expect(newInstanceChangeElement.value.SaltoName).toBe('newInstanceWithRef')
+            // Should add result Id
+            expect(newInstanceChangeElement.value.Id).toBeDefined()
+            expect(newInstanceChangeElement.value.Id).toEqual('newId')
+
+            // Reference should stay a referece
+            expect(newInstanceChangeElement.value.AnotherField)
+              .toEqual(new ReferenceExpression(mockElemID, 'Type'))
+
+            // anotherNewInstance appliedChange
+            const anotherNewInstanceChangeElement = result.appliedChanges
+              .map(getChangeElement)
+              .find(element => element.elemID.isEqual(anotherNewInstance.elemID)) as InstanceElement
+            expect(anotherNewInstanceChangeElement).toBeDefined()
+            expect(anotherNewInstanceChangeElement.value.SaltoName).toBeDefined()
+            expect(anotherNewInstanceChangeElement.value.SaltoName).toBe('anotherNewInstance')
+            // Should add result Id
+            expect(anotherNewInstanceChangeElement.value.Id).toBeDefined()
+            expect(anotherNewInstanceChangeElement.value.Id).toEqual('newId')
+          })
+        })
+        describe('When called with only existing instances', () => {
+          beforeEach(async () => {
+            mockQuery = jest.fn().mockImplementation(async () => (
+              {
+                totalSize: 2,
+                done: true,
+                records: [existingInstanceRecordValues, anotherExistingInstanceRecordValues],
+              }))
+            connection.query = mockQuery
+            result = await adapter.deploy({
+              groupID: 'add_Test_instances',
+              changes: [
+                { action: 'add', data: { after: existingInstance } },
+                { action: 'add', data: { after: anotherExistingInstance } },
+              ],
+            })
+          })
+
+          it('Should query according to instance values', () => {
+            expect(mockQuery.mock.calls).toHaveLength(1)
+            expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,SaltoName,NumField,Address,FirstName,LastName,Salutation FROM Type WHERE SaltoName IN (\'existingInstance\',\'anotherExistingInstance\') AND NumField IN (1,null) AND City IN (\'Tel-Aviv\',null) AND Country IN (\'Israel\',null) AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (\'first\',null) AND LastName IN (\'last\',null) AND Salutation IN (\'mrs.\',null)')
+          })
+
+          it('Should call load operation once with update', () => {
+            expect(mockBulkLoad.mock.calls.length).toBe(1)
+            const updateCall = mockBulkLoad.mock.calls.find(call => call[1] === 'update')
+            expect(updateCall).toBeDefined()
+          })
+
+          it('Should have result with 2 applied changes, add 2 instances with insert Id', async () => {
+            expect(result.errors).toHaveLength(0)
+            expect(result.appliedChanges).toHaveLength(2)
+
+            // existingInstance appliedChange
+            const existingInstanceChangeElement = result.appliedChanges
+              .map(getChangeElement)
+              .find(element => element.elemID.isEqual(existingInstance.elemID)) as InstanceElement
+            expect(existingInstanceChangeElement).toBeDefined()
+            expect(existingInstanceChangeElement.value.SaltoName).toBeDefined()
+            expect(existingInstanceChangeElement.value.SaltoName).toBe('existingInstance')
+            // Should add result Id
+            expect(existingInstanceChangeElement.value.Id).toBeDefined()
+            expect(existingInstanceChangeElement.value.Id).toEqual('queryId')
+
+            // anotherExistingInstance appliedChange
+            const anotherExistingInstanceChangeElement = result.appliedChanges
+              .map(getChangeElement)
+              .find(element =>
+                element.elemID.isEqual(anotherExistingInstance.elemID)) as InstanceElement
+            expect(anotherExistingInstanceChangeElement.elemID)
+              .toEqual(anotherExistingInstance.elemID)
+            expect(anotherExistingInstanceChangeElement.value.SaltoName).toBeDefined()
+            expect(anotherExistingInstanceChangeElement.value.SaltoName).toBe('anotherExistingInstance')
+            // Should add result Id
+            expect(anotherExistingInstanceChangeElement.value.Id).toBeDefined()
+            expect(anotherExistingInstanceChangeElement.value.Id).toEqual('anotherQueryId')
+          })
+        })
+      })
+
+      describe('When loadBulk partially succeeds', () => {
+        beforeEach(async () => {
+          mockQuery = jest.fn().mockImplementation(async () => (
+            {
+              totalSize: 2,
+              done: true,
+              records: [existingInstanceRecordValues, anotherExistingInstanceRecordValues],
+            }))
+          connection.query = mockQuery
+          connection.bulk.load = partialBulkLoad
+          result = await adapter.deploy({
+            groupID: 'add_Test_instances',
+            changes: [
+              { action: 'add', data: { after: existingInstance } },
+              { action: 'add', data: { after: newInstanceWithRef } },
+              { action: 'add', data: { after: anotherExistingInstance } },
+              { action: 'add', data: { after: anotherNewInstance } },
+            ],
+          })
+        })
+        it('Should query according to instance values', () => {
+          expect(mockQuery.mock.calls).toHaveLength(1)
+          expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,SaltoName,NumField,Address,FirstName,LastName,Salutation FROM Type WHERE SaltoName IN (\'existingInstance\',\'newInstanceWithRef\',\'anotherExistingInstance\',\'anotherNewInstance\') AND NumField IN (1,2,null,3) AND City IN (\'Tel-Aviv\',null,\'Ashkelon\') AND Country IN (\'Israel\',null) AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (\'first\',null) AND LastName IN (\'last\',null) AND Salutation IN (\'mrs.\',null)')
+        })
+
+        it('Should call load operation both with update and with insert', () => {
+          expect(partialBulkLoad.mock.calls.length).toBe(2)
+          const insertCall = partialBulkLoad.mock.calls.find(call => call[1] === 'insert')
+          expect(insertCall).toBeDefined()
+          const updateCall = partialBulkLoad.mock.calls.find(call => call[1] === 'update')
+          expect(updateCall).toBeDefined()
+        })
+
+        it('Should have two errors (one from each load call)', () => {
+          expect(result.errors).toHaveLength(2)
+          expect(result.errors[0]).toEqual(new Error('Error message'))
+          expect(result.errors[1]).toEqual(new Error('Error message'))
+        })
+
+        it('Should have two applied add change', () => {
+          expect(result.appliedChanges).toHaveLength(2)
+          expect(isAdditionChange(result.appliedChanges[0])).toBeTruthy()
+          const changeElement = getChangeElement(result.appliedChanges[0])
+          expect(changeElement).toBeDefined()
+          expect(isInstanceElement(changeElement)).toBeTruthy()
+          expect(isAdditionChange(result.appliedChanges[1])).toBeTruthy()
+          const anotherChangeElement = getChangeElement(result.appliedChanges[1])
+          expect(anotherChangeElement).toBeDefined()
+          expect(isInstanceElement(anotherChangeElement)).toBeTruthy()
+        })
+      })
+    })
+
+    describe('When valid modify group', () => {
+      const instanceToModify = existingInstance.clone()
+      instanceToModify.value.Id = 'modifyId'
+      const anotherInstanceToModify = anotherExistingInstance.clone()
+      anotherInstanceToModify.value.Id = 'anotherModifyId'
+      const modifyDeployGroup = {
+        groupID: 'modify__Test__c',
+        changes: [
+          { action: 'modify', data: { before: instanceToModify, after: instanceToModify } },
+          { action: 'modify', data: { before: anotherInstanceToModify, after: anotherInstanceToModify } },
+        ],
+      } as ChangeGroup
+      describe('when loadBulk succeeds for all', () => {
+        beforeEach(async () => {
+          result = await adapter.deploy(modifyDeployGroup)
+        })
+
+        it('should return no errors and 2 fitting applied changes', async () => {
+          expect(result.errors).toHaveLength(0)
+          expect(result.appliedChanges).toHaveLength(2)
+          expect(isModificationChange(result.appliedChanges[0])).toBeTruthy()
+          const changeElement = getChangeElement(result.appliedChanges[0])
+          expect(changeElement).toBeDefined()
+          expect(isInstanceElement(changeElement)).toBeTruthy()
+          expect(isModificationChange(result.appliedChanges[1])).toBeTruthy()
+          const secondChangeElement = getChangeElement(result.appliedChanges[1])
+          expect(secondChangeElement).toBeDefined()
+          expect(isInstanceElement(secondChangeElement)).toBeTruthy()
+        })
+      })
+
+      describe('when loadBulk partially succeeds', () => {
+        beforeEach(async () => {
+          connection.bulk.load = partialBulkLoad
+          result = await adapter.deploy(modifyDeployGroup)
+        })
+
+        it('should return one error and one applied change', async () => {
+          expect(result.errors).toHaveLength(1)
+          expect(result.errors[0]).toEqual(new Error('Error message'))
+          expect(result.appliedChanges).toHaveLength(1)
+          expect(isModificationChange(result.appliedChanges[0])).toBeTruthy()
+          const changeElement = getChangeElement(result.appliedChanges[0])
+          expect(changeElement).toBeDefined()
+          expect(isInstanceElement(changeElement)).toBeTruthy()
+        })
+      })
+
+      describe('when loadBulk fails for all', () => {
+        beforeEach(async () => {
+          connection.bulk.load = getBulkLoadMock('fail')
+          result = await adapter.deploy(modifyDeployGroup)
+        })
+
+        it('should return only an error', async () => {
+          expect(result.errors).toHaveLength(2)
+          expect(result.errors[0]).toEqual(new Error('Error message'))
+          expect(result.errors[1]).toEqual(new Error('Error message'))
+          expect(result.appliedChanges).toHaveLength(0)
+        })
+      })
+    })
+
+    describe('when valid remove group', () => {
+      const instanceToDelete = existingInstance.clone()
+      instanceToDelete.value.Id = 'deleteId'
+      const anotherInstanceToDelete = anotherExistingInstance.clone()
+      anotherInstanceToDelete.value.Id = 'anotherDeleteId'
+      const removeChangeGroup = {
+        groupID: 'delete__Test__c',
+        changes: [
+          { action: 'remove', data: { before: instanceToDelete } },
+          { action: 'remove', data: { before: anotherInstanceToDelete } },
+        ],
+      } as ChangeGroup
+      describe('when loadBulk succeeds for all', () => {
+        beforeEach(async () => {
+          result = await adapter.deploy(removeChangeGroup)
+        })
+
+        it('should return no errors and 2 fitting applied changes', () => {
+          expect(result.errors).toHaveLength(0)
+          expect(result.appliedChanges).toHaveLength(2)
+          expect(isRemovalChange(result.appliedChanges[0])).toBeTruthy()
+          const changeElement = getChangeElement(result.appliedChanges[0])
+          expect(changeElement).toBeDefined()
+          expect(isInstanceElement(changeElement)).toBeTruthy()
+          expect(isRemovalChange(result.appliedChanges[1])).toBeTruthy()
+          const secondChangeElement = getChangeElement(result.appliedChanges[1])
+          expect(secondChangeElement).toBeDefined()
+          expect(isInstanceElement(secondChangeElement)).toBeTruthy()
+        })
+      })
+
+      describe('when loadBulk partially succeeds', () => {
+        describe('when loadBulk succeeds for all', () => {
+          beforeEach(async () => {
+            connection.bulk.load = partialBulkLoad
+            result = await adapter.deploy(removeChangeGroup)
+          })
+
+          it('should return one error', () => {
+            expect(result.errors).toHaveLength(1)
+            expect(result.errors[0]).toEqual(new Error('Error message'))
+          })
+
+          it('should return one applied change', () => {
+            expect(result.appliedChanges).toHaveLength(1)
+            expect(isRemovalChange(result.appliedChanges[0])).toBeTruthy()
+            const changeElement = getChangeElement(result.appliedChanges[0])
+            expect(changeElement).toBeDefined()
+            expect(isInstanceElement(changeElement)).toBeTruthy()
+          })
+        })
+
+        describe('when loadBulk fails for all', () => {
+          beforeEach(async () => {
+            connection.bulk.load = getBulkLoadMock('fail')
+            result = await adapter.deploy(removeChangeGroup)
+          })
+
+          it('should return only an error', () => {
+            expect(result.errors).toHaveLength(2)
+            expect(result.errors[0]).toEqual(new Error('Error message'))
+            expect(result.errors[1]).toEqual(new Error('Error message'))
+            expect(result.appliedChanges).toHaveLength(0)
+          })
+        })
+      })
+
+      describe('When group has more than one type', () => {
+        const instanceOfAnotherType = new InstanceElement(
+          'diffTypeInstance',
+          new ObjectType({
+            elemID: new ElemID('anotherType'),
+            annotations: {
+              [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
+              [constants.API_NAME]: 'anotherType',
+            },
+          })
+        )
+        describe('Add group', () => {
+          it('should fail', async () => {
+            result = await adapter.deploy({
+              groupID: 'badGroup',
+              changes: [
+                { action: 'add', data: { after: existingInstance } },
+                { action: 'add', data: { after: instanceOfAnotherType } },
+              ],
+            })
+          })
+        })
+        describe('Modify group', () => {
+          it('should fail', async () => {
+            result = await adapter.deploy({
+              groupID: 'badGroup',
+              changes: [
+                { action: 'modify', data: { before: existingInstance, after: existingInstance } },
+                { action: 'modify', data: { before: instanceOfAnotherType, after: instanceOfAnotherType } },
+              ],
+            })
+          })
+        })
+        describe('Remove group', async () => {
+          it('should fail', async () => {
+            result = await adapter.deploy({
+              groupID: 'badGroup',
+              changes: [
+                { action: 'remove', data: { before: existingInstance } },
+                { action: 'remove', data: { before: instanceOfAnotherType } },
+              ],
+            })
+          })
+        })
+        afterEach(() => {
+          expect(result.errors).toHaveLength(1)
+          expect(result.errors[0]).toEqual(new Error('Custom Object Instances change group should have a single type but got: Type,anotherType'))
+        })
+      })
+
+      describe('When modify group tries to modify 2 diff instances', () => {
+        const instanceToModify = existingInstance.clone()
+        instanceToModify.value.Id = 'modifyId'
+        const anotherInstanceToModify = anotherExistingInstance.clone()
+        anotherInstanceToModify.value.Id = 'anotherModifyId'
+        it('Should return error', async () => {
+          result = await adapter.deploy({
+            groupID: 'invalidModifyGroup',
+            changes: [
+              { action: 'modify', data: { before: instanceToModify, after: anotherInstanceToModify } },
+            ],
+          })
+          expect(result.errors).toHaveLength(1)
+          expect(result.errors[0]).toEqual(new Error('Failed to update as api name prev=modifyId and new=anotherModifyId are different'))
+        })
+      })
+
+      describe('When group has more than one action', () => {
+        it('Should return with an error', async () => {
+          result = await adapter.deploy({
+            groupID: 'multipleActionsGroup',
+            changes: [
+              { action: 'add', data: { after: existingInstance } },
+              { action: 'remove', data: { before: newInstanceWithRef } },
+            ],
+          })
+          expect(result.errors).toHaveLength(1)
+          expect(result.errors[0]).toEqual(new Error('Custom Object Instances change group must have one action'))
+        })
+      })
+    })
+  })
+
+  describe('When adapter is defined with dataManagement config with invalid fields in SaltoIDSettings', () => {
+    beforeEach(() => {
+      ({ adapter } = mockAdapter({
+        adapterParams: {
+          filterCreators: [],
+          config: {
+            dataManagement: {
+              includeObjects: ['Test'],
+              saltoIDSettings: {
+                defaultIdFields: ['NonExistingFields'],
+              },
+            },
+          },
+        },
+      }))
+    })
+
+    it('Should fail with trying to run an add group', async () => {
+      result = await adapter.deploy({
+        groupID: 'add_Test_instances',
+        changes: [
+          { action: 'add', data: { after: existingInstance } },
+        ],
+      })
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0]).toEqual(new Error('Failed to add instances of type Type due to invalid SaltoIdFields - NonExistingFields'))
+    })
+  })
+
+  describe('When adapter is defined without dataManagement config', () => {
+    beforeEach(() => {
+      ({ adapter } = mockAdapter({
+        adapterParams: {
+          filterCreators: [],
+          config: {},
+        },
+      }))
+    })
+
+    describe('Add deploy group', () => {
+      it('should fail', async () => {
+        result = await adapter.deploy({
+          groupID: 'add_Test_instances',
+          changes: [
+            { action: 'add', data: { after: existingInstance } },
+          ],
+        })
+      })
+    })
+
+    describe('Modify deploy group', () => {
+      it('should fail', async () => {
+        result = await adapter.deploy({
+          groupID: 'modify_Test_instances',
+          changes: [
+            { action: 'modify', data: { before: existingInstance, after: existingInstance } },
+          ],
+        })
+      })
+    })
+
+    describe('Remove deploy group', () => {
+      it('should fail', async () => {
+        result = await adapter.deploy({
+          groupID: 'remove_Test_instances',
+          changes: [
+            { action: 'remove', data: { before: existingInstance } },
+          ],
+        })
+      })
+    })
+
+    afterEach(() => {
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0]).toEqual(new Error('dataManagement must be defined in the salesforce.nacl config to deploy Custom Object instances'))
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -134,7 +134,7 @@ describe('Custom Object Instances CRUD', () => {
     anotherInstanceName,
     customObject,
     {
-      SaltoName: 'anotherExistingInstance',
+      SaltoName: 'anotherExistingInstanceWithThing\'',
       NotCreatable: 'DontSendMeOnCreate',
     }
   )
@@ -143,7 +143,7 @@ describe('Custom Object Instances CRUD', () => {
       type: 'Type',
     },
     Id: 'anotherQueryId',
-    SaltoName: 'anotherExistingInstance',
+    SaltoName: 'anotherExistingInstanceWithThing\'',
     NumField: null,
   }
   const newInstanceWithRefName = 'newInstanceWithRef'
@@ -394,7 +394,7 @@ describe('Custom Object Instances CRUD', () => {
 
           it('Should query according to instance values', () => {
             expect(mockQuery.mock.calls).toHaveLength(1)
-            expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,SaltoName,NumField,Address,FirstName,LastName,Salutation FROM Type WHERE SaltoName IN (\'existingInstance\',\'anotherExistingInstance\') AND NumField IN (1,null) AND City IN (\'Tel-Aviv\',null) AND Country IN (\'Israel\',null) AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (\'first\',null) AND LastName IN (\'last\',null) AND Salutation IN (\'mrs.\',null)')
+            expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,SaltoName,NumField,Address,FirstName,LastName,Salutation FROM Type WHERE SaltoName IN (\'existingInstance\',\'anotherExistingInstanceWithThing\\\'\') AND NumField IN (1,null) AND City IN (\'Tel-Aviv\',null) AND Country IN (\'Israel\',null) AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (\'first\',null) AND LastName IN (\'last\',null) AND Salutation IN (\'mrs.\',null)')
           })
 
           it('Should call load operation once with update', () => {
@@ -426,7 +426,7 @@ describe('Custom Object Instances CRUD', () => {
             expect(anotherExistingInstanceChangeElement.elemID)
               .toEqual(anotherExistingInstance.elemID)
             expect(anotherExistingInstanceChangeElement.value.SaltoName).toBeDefined()
-            expect(anotherExistingInstanceChangeElement.value.SaltoName).toBe('anotherExistingInstance')
+            expect(anotherExistingInstanceChangeElement.value.SaltoName).toBe('anotherExistingInstanceWithThing\'')
             // Should add result Id
             expect(anotherExistingInstanceChangeElement.value.Id).toBeDefined()
             expect(anotherExistingInstanceChangeElement.value.Id).toEqual('anotherQueryId')
@@ -456,7 +456,7 @@ describe('Custom Object Instances CRUD', () => {
         })
         it('Should query according to instance values', () => {
           expect(mockQuery.mock.calls).toHaveLength(1)
-          expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,SaltoName,NumField,Address,FirstName,LastName,Salutation FROM Type WHERE SaltoName IN (\'existingInstance\',\'newInstanceWithRef\',\'anotherExistingInstance\',\'anotherNewInstance\') AND NumField IN (1,2,null,3) AND City IN (\'Tel-Aviv\',null,\'Ashkelon\') AND Country IN (\'Israel\',null) AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (\'first\',null) AND LastName IN (\'last\',null) AND Salutation IN (\'mrs.\',null)')
+          expect(mockQuery.mock.calls[0][0]).toEqual('SELECT Id,SaltoName,NumField,Address,FirstName,LastName,Salutation FROM Type WHERE SaltoName IN (\'existingInstance\',\'newInstanceWithRef\',\'anotherExistingInstanceWithThing\\\'\',\'anotherNewInstance\') AND NumField IN (1,2,null,3) AND City IN (\'Tel-Aviv\',null,\'Ashkelon\') AND Country IN (\'Israel\',null) AND GeocodeAccuracy IN (null) AND Latitude IN (null) AND Longitude IN (null) AND PostalCode IN (null) AND State IN (null) AND Street IN (null) AND FirstName IN (\'first\',null) AND LastName IN (\'last\',null) AND Salutation IN (\'mrs.\',null)')
         })
 
         it('Should call load operation both with update and with insert', () => {


### PR DESCRIPTION
Implemented `upsert` logic for Custom Object Instances on Add based on idFields from the configuration.

The general flow on Add is -
1. Query where WHERE based on idFields (to see if it already exists in the service)
2. If it exists, use update. If it didn't exist, use add.
3. Gather the results together

(A lot of the code is because I moved all the crud tests of Custom Object Instances out of the "adapter" file (well, the flow is separate so why not the tests as well!) and then added a lot of cases there. But a big chunk of is copy-paste.)

---
_Release Notes_
Added `upsert` logic for Custom Object Instances on Add based on `saltoIDSettings` in the `dataManagement` configuration.
Deploying Instances between environments is now "safer". It will not create logically duplicate Instances when they are already created as side effect of other Adds or already exist in the target environment.