### PR TITLE
Stop trying sending telemetry if error is unrecoverable

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,6 +71,7 @@
     "jest-junit": "^6.4.0",
     "nock": "^12.0.1",
     "tsc-watch": "^2.2.1",
-    "typescript": "3.9.3"
+    "typescript": "3.9.3",
+    "wait-for-expect": "^3.0.2"
   }
 }

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -26,7 +26,7 @@ const MAX_EVENTS_PER_REQUEST = 20
 const EVENTS_API_PATH = '/v1/events'
 const EVENTS_FLUSH_INTERVAL = 1000
 const EVENT_NAME_SEPARATOR = '.'
-const MAX_CONSECUTIVE_RETRIES = 5
+export const MAX_CONSECUTIVE_RETRIES = 5
 export const DEFAULT_EVENT_NAME_PREFIX = 'salto'
 
 export type TelemetryConfig = {
@@ -147,6 +147,7 @@ export const telemetrySender = (
           const { status } = e.response
           if (status >= 400 && status < 500) {
             stopped = true
+            return
           }
         }
         consecutiveRetryCount += 1
@@ -159,8 +160,8 @@ export const telemetrySender = (
   }
 
   const start = (): void => {
-    timer = setTimeout(() => {
-      flush()
+    timer = setTimeout(async () => {
+      await flush()
       if (!stopped) {
         start()
       }

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -146,6 +146,7 @@ export const telemetrySender = (
         if (e.response) {
           const { status } = e.response
           if (status >= 400 && status < 500) {
+            log.debug('telemetry http response status: %d, giving up on sending events', status)
             stopped = true
             return
           }

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -161,11 +161,12 @@ export const telemetrySender = (
   }
 
   const start = (): void => {
+    if (stopped) {
+      return
+    }
     timer = setTimeout(async () => {
       await flush()
-      if (!stopped) {
-        start()
-      }
+      start()
     }, flushInterval)
   }
 

--- a/packages/core/test/telemetry.test.ts
+++ b/packages/core/test/telemetry.test.ts
@@ -45,6 +45,9 @@ describe('telemetry', () => {
   let reqEvents = [] as Array<TelemetryEvent>
   let nockScope: nock.Scope
 
+  waitForExpect.defaults.timeout = 500
+  waitForExpect.defaults.interval = 100
+
   beforeEach(() => {
     nockScope = nock(url, { reqheaders: { authorization: token } }).persist()
     // eslint-disable-next-line prefer-arrow-callback
@@ -278,6 +281,7 @@ describe('telemetry', () => {
 
   it('should stop flushing events if HTTP response code is 4xx', async () => {
     let timesHTTPCalled = 0
+    let testDone = false
     nock.cleanAll()
     // eslint-disable-next-line prefer-arrow-callback
     nockScope.post('/v1/events').reply(403, function reply(_url, _body) {
@@ -287,20 +291,18 @@ describe('telemetry', () => {
     const telemetry = telemetrySender({ ...config, flushInterval: 1 }, requiredTags)
     telemetry.sendCountEvent('ev', 1)
     setTimeout(() => {
-      timesHTTPCalled += 1
+      testDone = true
     }, 100)
     await waitForExpect(() => {
       expect(telemetry.isStopped()).toBeTruthy()
-      // in order to validate that indeed we've stopped sending events,
-      // we're settings timeout above that will raise the total number of times
-      // the HTTP server was called by one and here we're expecting this number to be
-      // the number of times expected (1) + 1
-      expect(timesHTTPCalled).toEqual(2)
+      expect(timesHTTPCalled).toEqual(1)
+      expect(testDone).toBeTruthy()
     })
   })
 
   it('should stop flushing events after maximum amount of consecutive failed retries', async () => {
     let timesHTTPCalled = 0
+    let testDone = false
     nock.cleanAll()
     // eslint-disable-next-line prefer-arrow-callback
     nockScope.post('/v1/events').delayConnection(5000).reply(201, function reply(_url, _body) {
@@ -311,11 +313,12 @@ describe('telemetry', () => {
     const telemetry = telemetrySender({ ...config, flushInterval: 1 }, requiredTags)
     telemetry.sendCountEvent('ev', 1)
     setTimeout(() => {
-      timesHTTPCalled += 1
+      testDone = true
     }, 100)
     await waitForExpect(() => {
       expect(telemetry.isStopped()).toBeTruthy()
-      expect(timesHTTPCalled).toEqual(MAX_CONSECUTIVE_RETRIES + 1)
+      expect(timesHTTPCalled).toEqual(MAX_CONSECUTIVE_RETRIES)
+      expect(testDone).toBeTruthy()
     })
   })
 })

--- a/packages/core/test/telemetry.test.ts
+++ b/packages/core/test/telemetry.test.ts
@@ -173,9 +173,9 @@ describe('telemetry', () => {
     telemetry.sendCountEvent('ev', 1)
     await waitForExpect(async () => {
       expect(reqEvents.length).toEqual(1)
-      await telemetry.stop(1)
-      expect(telemetry.isStopped()).toBeTruthy()
     })
+    await telemetry.stop(1)
+    expect(telemetry.isStopped()).toBeTruthy()
   })
 
   it('should have os tags', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3830,28 +3830,7 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
-debug@3.1.0, debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
-debug@^3.1.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@2.6.9, debug@3.1.0, debug@=3.1.0, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9, debug@^3.1.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -8083,11 +8062,6 @@ move-concurrently@^1.0.1:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.3"
-
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 ms@2.1.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3830,7 +3830,28 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@2.6.9, debug@3.1.0, debug@=3.1.0, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9, debug@^3.1.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@3.1.0, debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
+debug@^3.1.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -8063,6 +8084,11 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
 ms@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
@@ -11582,6 +11608,11 @@ w3c-hr-time@^1.0.1:
   integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
   dependencies:
     browser-process-hrtime "^1.0.0"
+
+wait-for-expect@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
+  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
In case of unrecoverable error in sending telemetry, we'll give up on retrying, by this logic:

  1. If it's a user error (`4xx`), we will stop immediately without any further retries
  2. If it's another type of error (either `5xx` or any other network error) we will retry a few times and in case where we fail sending events consecutively we will give up

Also tested locally, once without any server running (so network error);
```
$ rg telemetry /tmp/fetch.log
1:2020-08-27T13:00:05.995Z info cli/cli CLI started. Version: version 0.1.23, branch salto-931/fix/telemetry_stop_retries, hash b536fe92
71:2020-08-27T13:00:07.079Z debug core/telemetry failed sending telemetry events: Error: connect ECONNREFUSED 127.0.0.1:8080
184:2020-08-27T13:00:08.084Z debug core/telemetry failed sending telemetry events: Error: connect ECONNREFUSED 127.0.0.1:8080
192:2020-08-27T13:00:09.087Z debug core/telemetry failed sending telemetry events: Error: connect ECONNREFUSED 127.0.0.1:8080
194:2020-08-27T13:00:10.322Z debug core/telemetry failed sending telemetry events: Error: connect ECONNREFUSED 127.0.0.1:8080
195:2020-08-27T13:00:11.328Z debug core/telemetry failed sending telemetry events: Error: connect ECONNREFUSED 127.0.0.1:8080
196:2020-08-27T13:00:11.329Z debug core/telemetry reached maximum retries: 5, giving up on sending events
```

And once with a server that returns always 403:
```
$ rg telemetry /tmp/fetch2.log
1:2020-08-27T13:03:10.493Z info cli/cli CLI started. Version: version 0.1.23, branch salto-931/fix/telemetry_stop_retries, hash b536fe92
81:2020-08-27T13:03:14.312Z debug core/telemetry failed sending telemetry events: Error: Request failed with status code 403
82:2020-08-27T13:03:14.312Z debug core/telemetry telemetry http response status: 403, giving up on sending events
```
