### PR TITLE
SALTO-934: Remove list type mismatch validation warnings on annotations

### DIFF
--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -396,7 +396,9 @@ const validateFieldValue = (elemID: ElemID, value: Value, field: Field, isAnnota
   ValidationError[] => {
   const fieldType = field.type
   if (isListType(fieldType)) {
-    if (!_.isArray(value)) {
+    // NOTE: the second part of the condition should be deleted as soon as
+    //  we complete the implementation of SALTO-228 (Support annotationTypes list)
+    if (!_.isArray(value) && !isAnnotations) {
       return [new InvalidValueValidationError({ elemID, value, fieldName: field.name, expectedValue: 'a list' })]
     }
     return _.flatten(


### PR DESCRIPTION
We currently omit validation warnings when annotation values are a list by the
type isn't and vice-versa.
This change also omits this type of warning for complex annotation values where
this mis-match occurs in a nested part of the annotation value