### PR TITLE
SALTO-930: debug log improvements

### DIFF
--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -111,6 +111,7 @@ const printWorkspaceErrors = async (
 ): Promise<void> => {
   if (status === 'Valid') return
   const stream = (status === 'Error' ? stderr : stdout)
+  log.debug('workspace status %s, errors:\n%s', status, errorsStr)
   stream.write(`\n${errorsStr}\n`)
 }
 


### PR DESCRIPTION
- Write workspace errors to the log (currently only printed to the console)
- Add more context for parsing errors that are caused by nacl update