### PR TITLE
Add function to apply transform on change data

### DIFF
--- a/packages/adapter-api/src/change.ts
+++ b/packages/adapter-api/src/change.ts
@@ -31,20 +31,25 @@ export type RemovalChange<T> = RemovalDiff<T>
 export type Change<T = ChangeDataType> =
   AdditionChange<T> | ModificationChange<T> | RemovalChange<T>
 
-export const isModificationChange = <T>(change: Change<T>): change is ModificationChange<T> =>
-  change.action === 'modify'
-export const isRemovalChange = <T>(change: Change<T>): change is RemovalChange<T> =>
-  change.action === 'remove'
-export const isAdditionChange = <T>(change: Change<T>): change is AdditionChange<T> =>
-  change.action === 'add'
-export const isAdditionOrModificationChange = <T>(
-  change: Change<T>
-): change is AdditionChange<T> | ModificationChange<T> => (
+export type ChangeData<T extends Change<unknown>> = T extends Change<infer U> ? U : never
+export const isModificationChange = <T extends Change<unknown>>(
+  change: T
+): change is T & ModificationChange<ChangeData<T>> => change.action === 'modify'
+export const isRemovalChange = <T extends Change<unknown>>(
+  change: T
+): change is T & RemovalChange<ChangeData<T>> => change.action === 'remove'
+export const isAdditionChange = <T extends Change<unknown>>(
+  change: T
+): change is T & AdditionChange<ChangeData<T>> => change.action === 'add'
+
+export const isAdditionOrModificationChange = <T extends Change<unknown>>(
+  change: T
+): change is T & (AdditionChange<ChangeData<T>> | ModificationChange<ChangeData<T>>) => (
     isAdditionChange(change) || isModificationChange(change)
   )
-export const isAdditionOrRemovalChange = <T>(
-  change: Change<T>
-): change is AdditionChange<T> | RemovalChange<T> => (
+export const isAdditionOrRemovalChange = <T extends Change<unknown>>(
+  change: T
+): change is T & (AdditionChange<ChangeData<T>> | RemovalChange<ChangeData<T>>) => (
     isAdditionChange(change) || isRemovalChange(change)
   )
 
@@ -66,7 +71,7 @@ export const isFieldChange = (change: Change): change is Change<Field> => (
 export type DetailedChange<T = ChangeDataType | Values | Value> =
   Change<T> & {
     id: ElemID
-    path?: string[]
+    path?: ReadonlyArray<string>
   }
 
 export type ChangeParams = { before?: ChangeDataType; after?: ChangeDataType }

--- a/packages/core/src/core/diff.ts
+++ b/packages/core/src/core/diff.ts
@@ -14,8 +14,9 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Element, ElemID, DetailedChange } from '@salto-io/adapter-api'
-import { filterByID } from '@salto-io/adapter-utils'
+import { values } from '@salto-io/lowerdash'
+import { Element, ElemID, DetailedChange, getChangeElement } from '@salto-io/adapter-api'
+import { filterByID, applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import wu from 'wu'
 import { getDetailedChanges } from './fetch'
 
@@ -23,29 +24,23 @@ const filterChangesByIDRegex = async (
   changes: DetailedChange[],
   filters: RegExp[]
 ): Promise<DetailedChange[]> => {
-  const filterIDByRegex = async (elemID: ElemID): Promise<boolean> => _.some(
+  const filterIDByRegex = (elemID: ElemID): boolean => _.some(
     filters, f => f.test(elemID.getFullName())
   )
 
-  const filterChangeByID = async (change: DetailedChange): Promise<DetailedChange | undefined> => {
-    if (change.action === 'add') {
-      const data = { after: await filterByID(change.id, change.data.after, filterIDByRegex) }
-      return _.isEmpty(data.after) ? undefined : { ...change, data }
-    }
-    if (change.action === 'remove') {
-      const data = { before: await filterByID(change.id, change.data.before, filterIDByRegex) }
-      return _.isEmpty(data.before) ? undefined : { ...change, data }
-    }
-    const data = {
-      before: await filterByID(change.id, change.data.before, filterIDByRegex),
-      after: await filterByID(change.id, change.data.after, filterIDByRegex),
-    }
-    return _.isEmpty(data.before) && _.isEmpty(data.after) ? undefined : { ...change, data }
+  const filterChangeByID = (change: DetailedChange): DetailedChange | undefined => {
+    const filteredChange = applyFunctionToChangeData(
+      change,
+      changeData => filterByID(change.id, changeData, filterIDByRegex),
+    )
+    return getChangeElement(filteredChange) === undefined
+      ? undefined
+      : filteredChange
   }
 
   return _.isEmpty(filters)
     ? changes
-    : _.compact(await Promise.all(changes.map(filterChangeByID)))
+    : changes.map(filterChangeByID).filter(values.isDefined)
 }
 
 export const createDiffChanges = async (

--- a/packages/core/src/core/plan/filter.ts
+++ b/packages/core/src/core/plan/filter.ts
@@ -112,7 +112,7 @@ export const filterInvalidChanges = async (
     }
     const replaceAfterElement = <T extends DiffNode<ChangeDataType>>(change: T): T => {
       if (isAdditionOrModificationChange(change)) {
-        const after = getValidAfter(getChangeElement(change)) ?? change.data.after
+        const after = getValidAfter(change.data.after) ?? change.data.after
         return { ...change, data: { ...change.data, after } }
       }
       return change

--- a/packages/workspace/src/workspace/nacl_files/multi_env/projections.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/projections.ts
@@ -109,7 +109,7 @@ export const projectElementOrValueToEnv = async (
 export const createAddChange = (
   value: Element | Value,
   id: ElemID,
-  path?: string[]
+  path?: ReadonlyArray<string>
 ): DetailedChange => ({
   data: { after: value },
   action: 'add',
@@ -120,7 +120,7 @@ export const createAddChange = (
 export const createRemoveChange = (
   value: Element | Value,
   id: ElemID,
-  path?: string[]
+  path?: ReadonlyArray<string>
 ): DetailedChange => ({
   data: { before: value },
   action: 'remove',
@@ -132,7 +132,7 @@ export const createModifyChange = (
   before: Element | Value,
   after: Element | Value,
   id: ElemID,
-  path?: string[]
+  path?: ReadonlyArray<string>
 ): DetailedChange => ({
   data: { before, after },
   action: 'modify',

--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -29,7 +29,7 @@ const FILE_EXTENSION = '.nacl'
 
 export type DetailedChangeWithSource = DetailedChange & { location: SourceRange }
 
-const createFileNameFromPath = (pathParts?: string[]): string =>
+const createFileNameFromPath = (pathParts?: ReadonlyArray<string>): string =>
   (pathParts
     ? `${path.join(...pathParts)}${FILE_EXTENSION}`
     : '')


### PR DESCRIPTION
- Replace a number of different places that duplicated the logic of applying a function on a change
- Change filterBy to be sync (needed in order to use the new function in some places)
- Improve type inference for is*Change functions (before this calling the type guard with a DetailedChange would have lost the data type information)

---
_Release Notes_
None (refactor)