### PR TITLE
Extend in memory state implementation to support the full State interface

### DIFF
--- a/packages/core/src/local-workspace/state.ts
+++ b/packages/core/src/local-workspace/state.ts
@@ -116,6 +116,7 @@ export const localState = (filePath: string): state.State => {
       return toMD5(stateText)
     },
     clear: async (): Promise<void> => {
+      await inMemState.clear()
       await rm(currentFilePath)
     },
   }

--- a/packages/core/test/common/state.ts
+++ b/packages/core/test/common/state.ts
@@ -13,57 +13,19 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { Element } from '@salto-io/adapter-api'
-import wu from 'wu'
-import { pathIndex, state as wsState } from '@salto-io/workspace'
-import { mockFunction } from './helpers'
+import { pathIndex, state } from '@salto-io/workspace'
 
 
 export const mockState = (
   services: string[] = [],
   elements: Element[] = [],
   index?: pathIndex.PathIndex
-): wsState.State => {
-  const state = new Map(elements.map(elem => [elem.elemID.getFullName(), elem]))
-  return {
-    list: mockFunction<wsState.State['list']>().mockImplementation(
-      () => Promise.resolve(wu(state.values()).toArray().map(elem => elem.elemID))
-    ),
-    get: mockFunction<wsState.State['get']>().mockImplementation(
-      id => Promise.resolve(state.get(id.getFullName()))
-    ),
-    getAll: mockFunction<wsState.State['getAll']>().mockImplementation(
-      () => Promise.resolve(wu(state.values()).toArray())
-    ),
-    set: mockFunction<wsState.State['set']>().mockImplementation(
-      async elem => { state.set(elem.elemID.getFullName(), elem) }
-    ),
-    remove: mockFunction<wsState.State['remove']>().mockImplementation(
-      async id => { state.delete(id.getFullName()) }
-    ),
-    clear: mockFunction<wsState.State['clear']>().mockImplementation(
-      async () => state.clear()
-    ),
-    rename: mockFunction<wsState.State['rename']>().mockResolvedValue(),
-    override: mockFunction<wsState.State['override']>().mockImplementation(
-      async overrideElements => {
-        state.clear()
-        const elemList = Array.isArray(overrideElements) ? overrideElements : [overrideElements]
-        elemList.forEach(elem => state.set(elem.elemID.getFullName(), elem))
-      }
-    ),
-    flush: mockFunction<wsState.State['flush']>().mockResolvedValue(),
-    getHash: mockFunction<wsState.State['getHash']>().mockResolvedValue('d5ebc45734aca2e8bed1d1ea433bad15'),
-    getServicesUpdateDates: mockFunction<wsState.State['getServicesUpdateDates']>()
-      .mockResolvedValue(
-        Object.assign({}, ...services.map(service => ({ [service]: Date.now() })))
-      ),
-    existingServices: mockFunction<wsState.State['existingServices']>()
-      .mockResolvedValue(services),
-    overridePathIndex: mockFunction<wsState.State['overridePathIndex']>(),
-    updatePathIndex: mockFunction<wsState.State['updatePathIndex']>(),
-    getPathIndex: mockFunction<wsState.State['getPathIndex']>().mockResolvedValue(
-      index || new pathIndex.PathIndex()
-    ),
-  }
-}
+): state.State => (
+  state.buildInMemState(async () => ({
+    elements: _.keyBy(elements, elem => elem.elemID.getFullName()),
+    pathIndex: index ?? new pathIndex.PathIndex(),
+    servicesUpdateDate: Object.fromEntries(services.map(serviceName => [serviceName, new Date()])),
+  }))
+)

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -21,8 +21,7 @@ import { State, StateData } from './state'
 
 const { makeArray } = collections.array
 
-export const buildInMemState = (loadData: () => Promise<StateData>):
-Omit<State, 'flush' | 'clear' | 'rename' | 'getHash'> => {
+export const buildInMemState = (loadData: () => Promise<StateData>): State => {
   let innerStateData: Promise<StateData>
   const stateData = (): Promise<StateData> => {
     if (innerStateData === undefined) {
@@ -72,5 +71,14 @@ Omit<State, 'flush' | 'clear' | 'rename' | 'getHash'> => {
       )
     },
     getPathIndex: async (): Promise<PathIndex> => (await stateData()).pathIndex,
+    clear: async () => {
+      const innerState = await stateData()
+      innerState.elements = {}
+      innerState.pathIndex = new PathIndex()
+      innerState.servicesUpdateDate = {}
+    },
+    flush: () => Promise.resolve(),
+    rename: () => Promise.resolve(),
+    getHash: () => Promise.reject(new Error('memory state not hashable')),
   }
 }

--- a/packages/workspace/test/workspace/state.test.ts
+++ b/packages/workspace/test/workspace/state.test.ts
@@ -89,5 +89,24 @@ describe('state', () => {
       await state.updatePathIndex(oneElement, ['salesforce'])
       expect(await state.getPathIndex()).toEqual(createPathIndex([elem, newElem]))
     })
+
+    it('clear should clear all data', async () => {
+      await state.clear()
+      expect(await state.getAll()).toHaveLength(0)
+      expect((await state.getPathIndex()).size).toEqual(0)
+      expect(await state.getServicesUpdateDates()).toEqual({})
+    })
+
+    it('flush should do nothing', async () => {
+      await expect(state.flush()).resolves.not.toThrow()
+    })
+
+    it('rename should do nothing', async () => {
+      await expect(state.rename('bla')).resolves.not.toThrow()
+    })
+
+    it('getHash should not work on in memory state', async () => {
+      await expect(state.getHash()).rejects.toThrow()
+    })
   })
 })


### PR DESCRIPTION
Use in memory state instead of partial mocked state in unit tests

---
_Release notes_
None (refactor)