### PR TITLE
Fix typo of an error string in salesforce adapter creator

### DIFF
--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -50,13 +50,13 @@ SalesforceConfig => {
   const validateDataManagement = (dataManagementConfig: DataManagementConfig | undefined): void => {
     if (dataManagementConfig !== undefined) {
       if (dataManagementConfig.includeObjects === undefined) {
-        throw Error('includeObjects is required when dataManagmenet is configured')
+        throw Error('includeObjects is required when dataManagement is configured')
       }
       if (dataManagementConfig.saltoIDSettings === undefined) {
-        throw Error('saltoIDSettings is required when dataManagmenet is configured')
+        throw Error('saltoIDSettings is required when dataManagement is configured')
       }
       if (dataManagementConfig.saltoIDSettings.defaultIdFields === undefined) {
-        throw Error('saltoIDSettings.defaultIdFields is required when dataManagmenet is configured')
+        throw Error('saltoIDSettings.defaultIdFields is required when dataManagement is configured')
       }
       validateRegularExpressions(`${DATA_MANAGEMENT}.includeObjects`, makeArray(dataManagementConfig.includeObjects))
       validateRegularExpressions(`${DATA_MANAGEMENT}.excludeObjects`, makeArray(dataManagementConfig.excludeObjects))

--- a/packages/salesforce-adapter/test/adapter.creator.test.ts
+++ b/packages/salesforce-adapter/test/adapter.creator.test.ts
@@ -165,7 +165,7 @@ describe('SalesforceAdapter creator', () => {
           },
         } },
       )
-      expect(() => adapter.operations({ credentials, config: invalidConfig })).toThrow('includeObjects is required when dataManagmenet is configured')
+      expect(() => adapter.operations({ credentials, config: invalidConfig })).toThrow('includeObjects is required when dataManagement is configured')
     })
 
     it('should throw error when dataManagement is created without saltoIDSettings', () => {
@@ -176,7 +176,7 @@ describe('SalesforceAdapter creator', () => {
           includeObjects: ['obj'],
         } },
       )
-      expect(() => adapter.operations({ credentials, config: invalidConfig })).toThrow('saltoIDSettings is required when dataManagmenet is configured')
+      expect(() => adapter.operations({ credentials, config: invalidConfig })).toThrow('saltoIDSettings is required when dataManagement is configured')
     })
 
     it('should throw error when dataManagement is created without saltoIDSettings.defaultIdFields', () => {
@@ -192,7 +192,7 @@ describe('SalesforceAdapter creator', () => {
           },
         } },
       )
-      expect(() => adapter.operations({ credentials, config: invalidConfig })).toThrow('saltoIDSettings.defaultIdFields is required when dataManagmenet is configured')
+      expect(() => adapter.operations({ credentials, config: invalidConfig })).toThrow('saltoIDSettings.defaultIdFields is required when dataManagement is configured')
     })
   })
 })


### PR DESCRIPTION
`dataManagmenet` => `dataManagement`