### PR TITLE
SALTO-945: Use dir-based workspace.isEmpty check

### DIFF
--- a/packages/core/src/local-workspace/dir_store.ts
+++ b/packages/core/src/local-workspace/dir_store.ts
@@ -148,6 +148,10 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
       .uniq()
       .value()
 
+  const isEmpty = async (): Promise<boolean> => (
+    (await list()).length === 0
+  )
+
   const flush = async (): Promise<void> => {
     await withLimitedConcurrency(
       Object.values(updated).map(f => () => writeFile(f)), WRITE_CONCURRENCY
@@ -164,6 +168,7 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
 
   return {
     list,
+    isEmpty,
     get,
     getSync,
     set: async (file: dirStore.File<T>): Promise<void> => {

--- a/packages/core/test/workspace/local/directory_store.test.ts
+++ b/packages/core/test/workspace/local/directory_store.test.ts
@@ -79,6 +79,30 @@ describe('localDirectoryStore', () => {
     })
   })
 
+  describe('isEmpty', () => {
+    it('returns true if dir does not exist', async () => {
+      mockFileExists.mockResolvedValue(false)
+      const result = await localDirectoryStore({ baseDir: 'not-found', encoding }).isEmpty()
+      expect(result).toEqual(true)
+    })
+    it('return true if dir is empty', async () => {
+      const fileFilter = '*.nacl'
+      const baseDir = 'base'
+      mockFileExists.mockResolvedValue(true)
+      mockReaddirp.mockResolvedValue([])
+      const result = await localDirectoryStore({ baseDir, encoding, fileFilter }).isEmpty()
+      expect(result).toEqual(true)
+    })
+    it('return false if dir has files', async () => {
+      const fileFilter = '*.nacl'
+      const baseDir = 'base'
+      mockFileExists.mockResolvedValue(true)
+      mockReaddirp.mockResolvedValue([{ fullPath: 'test1' }, { fullPath: 'test2' }])
+      const result = await localDirectoryStore({ baseDir, encoding, fileFilter }).isEmpty()
+      expect(result).toEqual(false)
+    })
+  })
+
   describe('get', () => {
     it('does not return the file if it does not exist', async () => {
       const baseDir = 'not-exists'

--- a/packages/workspace/src/workspace/dir_store.ts
+++ b/packages/workspace/src/workspace/dir_store.ts
@@ -34,6 +34,7 @@ export type DirectoryStore<T extends ContentType> = {
   getFiles(filenames: string[]): Promise<(File<T> | undefined) []>
   getTotalSize(): Promise<number>
   clone(): DirectoryStore<T>
+  isEmpty(): Promise<boolean>
 }
 
 export type SyncDirectoryStore<T extends ContentType> = DirectoryStore<T> & {

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -215,6 +215,12 @@ const buildMultiEnvSource = (
     ])
   }
 
+  const isEmpty = async (env?: string): Promise<boolean> => (
+    (await Promise.all(
+      _.values(getActiveSources(env)).filter(s => s !== undefined).map(s => s.isEmpty())
+    )).every(e => e)
+  )
+
   return {
     getNaclFile,
     updateNaclFiles,
@@ -224,6 +230,7 @@ const buildMultiEnvSource = (
     demoteAll,
     copyTo,
     list: async (): Promise<ElemID[]> => _.values((await getState()).elements).map(e => e.elemID),
+    isEmpty,
     get: async (id: ElemID): Promise<Element | Value> => (
       (await getState()).elements[id.getFullName()]
     ),

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -67,6 +67,7 @@ export type NaclFilesSource = ElementsSource & {
   getErrors: () => Promise<Errors>
   getElements: (filename: string) => Promise<Element[]>
   clone: () => NaclFilesSource
+  isEmpty: () => Promise<boolean>
 }
 
 export type ParsedNaclFile = {
@@ -402,6 +403,7 @@ const buildNaclFilesSource = (
     },
     getSourceMap,
     getElementNaclFiles,
+    isEmpty: () => naclFilesStore.isEmpty(),
   }
 }
 

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -319,7 +319,7 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
       )
     )),
     isEmpty: async (naclFilesOnly = false): Promise<boolean> => {
-      const isNaclFilesSourceEmpty = !naclFilesSource || _.isEmpty(await naclFilesSource.getAll())
+      const isNaclFilesSourceEmpty = !naclFilesSource || await naclFilesSource.isEmpty()
       return isNaclFilesSourceEmpty && (naclFilesOnly || _.isEmpty(await state().getAll()))
     },
     hasElementsInServices: async (serviceNames: string[]): Promise<boolean> => (

--- a/packages/workspace/test/common/nacl_file_source.ts
+++ b/packages/workspace/test/common/nacl_file_source.ts
@@ -28,6 +28,7 @@ export const createMockNaclFileSource = (
   sourceRanges?: SourceRange[]
 ): NaclFilesSource => ({
   list: async () => elements.map(e => e.elemID),
+  isEmpty: async () => elements.length === 0,
   get: async (id: ElemID) => {
     const { parent, path: idPath } = id.createTopLevelParentID()
     const element = elements.find(e => e.elemID.getFullName() === parent.getFullName())

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -84,6 +84,7 @@ export const mockDirStore = (exclude: string[] = ['error.nacl', 'dup.nacl'], emp
   return {
     list: jest.fn()
       .mockResolvedValue(Object.keys(naclFiles).filter(name => !exclude.includes(name))),
+    isEmpty: jest.fn().mockResolvedValue(Object.keys(naclFiles).length === 0),
     get: jest.fn().mockImplementation((filename: string) => Promise.resolve(naclFiles[filename])),
     set: jest.fn().mockImplementation(() => Promise.resolve()),
     delete: jest.fn().mockImplementation(() => Promise.resolve()),

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -119,6 +119,12 @@ const inactiveErrors = new Errors({
     context: inactiveSourceRange,
   }],
 })
+const emptySource = createMockNaclFileSource(
+  [],
+  {},
+  commonErrors,
+  []
+)
 const commonSource = createMockNaclFileSource(
   [commonObject, commonFragment],
   commonNaclFiles,
@@ -204,6 +210,30 @@ describe('multi env source', () => {
       expect(elements).toHaveLength(3)
       expectToContainAllItems(elements, [commonElemID, envElemID, objectElemID])
       expect(elements).not.toContain(inactiveElemID)
+    })
+  })
+  describe('isEmpty', () => {
+    it('should return true when there are no sources', async () => {
+      const srcs = {}
+      const src = multiEnvSource(srcs, activePrefix, commonPrefix)
+      expect(await src.isEmpty()).toBeTruthy()
+    })
+    it('should return true when some sources have files', async () => {
+      const srcs = {
+        [commonPrefix]: commonSource,
+        [activePrefix]: emptySource,
+        [inactivePrefix]: inactiveSource,
+      }
+      const src = multiEnvSource(srcs, activePrefix, commonPrefix)
+      expect(await src.isEmpty()).toBeFalsy()
+    })
+    it('should look at elements from all active sources and not inactive sources', async () => {
+      const srcs = {
+        [commonPrefix]: emptySource,
+        [inactivePrefix]: inactiveSource,
+      }
+      const src = multiEnvSource(srcs, activePrefix, commonPrefix)
+      expect(await src.isEmpty()).toBeTruthy()
     })
   })
   describe('get', () => {

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -41,6 +41,7 @@ describe('Nacl Files Source', () => {
     }
     mockDirStore = {
       list: () => Promise.resolve([]),
+      isEmpty: () => Promise.resolve(false),
       get: jest.fn().mockResolvedValue(undefined),
       getFiles: jest.fn().mockResolvedValue([undefined]),
       set: () => Promise.resolve(),
@@ -65,6 +66,14 @@ describe('Nacl Files Source', () => {
       expect(mockDirStore.clear as jest.Mock).toHaveBeenCalledTimes(1)
       expect(mockCache.clear).toHaveBeenCalledTimes(1)
       expect(mockedStaticFilesSource.clear).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('isEmpty', () => {
+    it('should use store\'s isEmpty', async () => {
+      mockDirStore.isEmpty = jest.fn().mockResolvedValue(Promise.resolve())
+      await naclFilesSource(mockDirStore, mockCache, mockedStaticFilesSource).isEmpty()
+      expect(mockDirStore.isEmpty as jest.Mock).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/packages/workspace/test/workspace/static_files/source.test.ts
+++ b/packages/workspace/test/workspace/static_files/source.test.ts
@@ -43,6 +43,7 @@ describe('Static Files Source', () => {
     } as StaticFilesCache
     mockDirStore = {
       list: () => Promise.resolve([]),
+      isEmpty: () => Promise.resolve(false),
       get: jest.fn().mockResolvedValue(undefined),
       getFiles: jest.fn().mockResolvedValue([undefined]),
       set: () => Promise.resolve(),


### PR DESCRIPTION
We shouldn't parse all the nacls in order to determine if a workspace is empty.