### PR TITLE
[WIP] SALTO-943 - New reference resolution config - reference expression serialization for deploy

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -30,7 +30,7 @@ import SalesforceClient from './client/client'
 import * as constants from './constants'
 import {
   toCustomField, toCustomObject, apiName, Types, toMetadataInfo,
-  metadataType, defaultApiName, getLookUpName, isMetadataObjectType,
+  metadataType, defaultApiName, isMetadataObjectType,
   isMetadataInstanceElement,
 } from './transformers/transformer'
 import { createDeployPackage } from './transformers/xml_transformer'
@@ -74,6 +74,7 @@ import { FilterCreator, Filter, filtersRunner } from './filter'
 import { id, addApiName, addMetadataType, addLabel } from './filters/utils'
 import { retrieveMetadataInstances, fetchMetadataType, fetchMetadataInstances, listMetadataObjects } from './fetch'
 import { isCustomObjectInstancesGroup, deployCustomObjectInstancesGroup } from './custom_object_instances_deploy'
+import { getLookUpName } from './transformers/reference_mapping'
 
 const { makeArray } = collections.array
 const log = logger(module)

--- a/packages/salesforce-adapter/src/change_validators/custom_object_instances.ts
+++ b/packages/salesforce-adapter/src/change_validators/custom_object_instances.ts
@@ -21,7 +21,8 @@ import {
 import { values } from '@salto-io/lowerdash'
 import { resolveValues } from '@salto-io/adapter-utils'
 import { FIELD_ANNOTATIONS } from '../constants'
-import { isCustomObject, getLookUpName } from '../transformers/transformer'
+import { isCustomObject } from '../transformers/transformer'
+import { getLookUpName } from '../transformers/reference_mapping'
 
 const getUpdateErrorsForNonUpdateableFields = (
   before: InstanceElement,

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -285,6 +285,7 @@ export const WORKFLOW_OUTBOUND_MESSAGE_METADATA_TYPE = 'WorkflowOutboundMessage'
 export const WORKFLOW_RULE_METADATA_TYPE = 'WorkflowRule'
 export const WORKFLOW_TASK_METADATA_TYPE = 'WorkflowTask'
 export const WEBLINK_METADATA_TYPE = 'WebLink'
+export const UNKNOWN_METADATA_TYPE = 'unknown'
 
 // Retrieve constants
 export const RETRIEVE_LOAD_OF_METADATA_ERROR_REGEX = /Load of metadata from db failed for metadata of type:(?<type>\w+) and file name:(?<instance>\w+).$/

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -1,0 +1,152 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Field, Element, isElement } from '@salto-io/adapter-api'
+import { GetLookupNameFunc, GetLookupNameFuncArgs } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { apiName, metadataType } from './transformer'
+import {
+  LAYOUT_ITEM_METADATA_TYPE, WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
+  WORKFLOW_ACTION_REFERENCE_METADATA_TYPE,
+} from '../constants'
+
+const log = logger(module)
+
+type ReferenceSerializationFunc = GetLookupNameFunc
+
+type ReferenceSerializationStrategyName = 'absoluteApiName' | 'relativeApiName'
+const ReferenceSerializationStrategyLookup: Record<
+  ReferenceSerializationStrategyName, ReferenceSerializationFunc
+> = {
+  absoluteApiName: (({ ref }) => apiName(ref.value)),
+  relativeApiName: ({ ref }) => apiName(ref.value, true),
+}
+
+type ReferenceResolutionStrategy = 'included' | 'instance_parent' | 'specific' | 'object'
+type TargetElemType = 'field' | 'instance' | 'object'
+
+export type ReferenceTargetDefinition = {
+  type: TargetElemType
+  strategy: ReferenceResolutionStrategy
+  name?: string
+}
+
+/**
+ * A rule defining how to convert values to reference expressions (on fetch),
+ * and reference expressions back to values (on deploy).
+ */
+export type FieldReferenceDefinition = {
+  src: {
+    field: string | RegExp
+    parentType?: string
+  }
+  serializationStrategy?: ReferenceSerializationStrategyName
+  // When target is missing, the definition will only be used for resolving
+  target?: ReferenceTargetDefinition
+}
+
+// Order matters - first successfully-resolved reference is used
+// TODO once this stabilizes, move to config file
+const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
+  // TODO will be populated as part of SALTO-942 and used instead of instance_references
+
+  // supporting all field names for backward compatibility with the old definitions.
+  // TODO: change to individual field names and add target
+  {
+    // TODO fields: field, customLink
+    src: { field: /.*/, parentType: LAYOUT_ITEM_METADATA_TYPE },
+    serializationStrategy: 'relativeApiName',
+  },
+  {
+    // TODO field: fieldUpdates
+    src: { field: /.*/, parentType: WORKFLOW_FIELD_UPDATE_METADATA_TYPE },
+    serializationStrategy: 'relativeApiName',
+  },
+  {
+    src: { field: 'name', parentType: WORKFLOW_ACTION_REFERENCE_METADATA_TYPE },
+    serializationStrategy: 'relativeApiName',
+    // target will be added as part of SALTO-942
+  },
+]
+
+const matchName = (fieldName: string, matcher: string | RegExp): boolean => (
+  _.isString(matcher)
+    ? matcher === fieldName
+    : matcher.test(fieldName)
+)
+
+const matchMetadataType = (elem: Element, type: string | undefined): boolean => (
+  // need typeName for backward compatibility - TODO remove after verifying
+  type === undefined ? true : (metadataType(elem) === type || elem.elemID.typeName === type)
+)
+
+export class FieldReferenceResolver {
+  refDef: FieldReferenceDefinition
+  constructor(refDef: FieldReferenceDefinition) {
+    this.refDef = refDef
+  }
+
+  static create(refDef: FieldReferenceDefinition): FieldReferenceResolver {
+    return new FieldReferenceResolver(refDef)
+  }
+
+  match(field: Field): boolean {
+    return (
+      matchName(field.name, this.refDef.src.field)
+      && matchMetadataType(field.parent, this.refDef.src.parentType)
+    )
+  }
+
+  serializationStrategy(): ReferenceSerializationFunc {
+    return ReferenceSerializationStrategyLookup[this.refDef.serializationStrategy ?? 'absoluteApiName']
+  }
+
+  refTarget(): ReferenceTargetDefinition | undefined {
+    return this.refDef.target
+  }
+}
+
+export const generateReferenceRules = (): FieldReferenceResolver[] => (
+  fieldNameToTypeMappingDefs.map(def => FieldReferenceResolver.create(def))
+)
+
+const getLookUpNameImpl = (): GetLookupNameFunc => {
+  const referenceRulesInner = generateReferenceRules()
+
+  const determineLookupFunc = (args: GetLookupNameFuncArgs): ReferenceSerializationFunc => {
+    const strategies = referenceRulesInner
+      .filter(def => args.field !== undefined && def.match(args.field))
+      .map(def => def.serializationStrategy())
+
+    if (strategies.length > 1) {
+      log.debug(`found ${strategies.length} matching strategies for field ${args.field?.elemID.getFullName()} - using the first one`)
+    }
+    if (strategies.length === 0) {
+      log.debug(`could not find matching strategy for field ${args.field?.elemID.getFullName()}`)
+    }
+    return strategies[0] ?? ReferenceSerializationStrategyLookup.absoluteApiName
+  }
+
+  return ({ ref, path, field }) => {
+    if (isElement(ref.value)) {
+      const lookupFunc = determineLookupFunc({ ref, path, field })
+      return lookupFunc({ ref })
+    }
+    return ref.value
+  }
+}
+
+export const getLookUpName = getLookUpNameImpl()

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -22,13 +22,11 @@ import {
   TypeElement, ObjectType, ElemID, PrimitiveTypes, PrimitiveType, Values,
   BuiltinTypes, Element, isInstanceElement, InstanceElement, isPrimitiveType, ElemIdGetter,
   ServiceIds, toServiceIdsString, OBJECT_SERVICE_ID, ADAPTER, CORE_ANNOTATIONS,
-  isElement, PrimitiveValue,
+  PrimitiveValue,
   Field, TypeMap, ListType, isField, createRestriction, isPrimitiveValue, Value, isObjectType,
 } from '@salto-io/adapter-api'
 import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
-import {
-  naclCase, GetLookupNameFunc, TransformFunc, transformElement,
-} from '@salto-io/adapter-utils'
+import { naclCase, TransformFunc, transformElement } from '@salto-io/adapter-utils'
 import { CustomObject, CustomField, SalesforceRecord } from '../client/types'
 import {
   API_NAME, CUSTOM_OBJECT, LABEL, SALESFORCE, FORMULA, FIELD_TYPE_NAMES,
@@ -40,11 +38,9 @@ import {
   CUSTOM_VALUE, API_NAME_SEPARATOR, MAX_METADATA_RESTRICTION_VALUES,
   VALUE_SET_FIELDS, COMPOUND_FIELD_TYPE_NAMES, ANNOTATION_TYPE_NAMES, FIELD_SOAP_TYPE_NAMES,
   RECORDS_PATH, SETTINGS_PATH, TYPES_PATH, SUBTYPES_PATH, INSTALLED_PACKAGES_PATH,
-  VALUE_SET_DEFINITION_FIELDS, CUSTOM_FIELD, LAYOUT_TYPE_ID_METADATA_TYPE,
-  LAYOUT_ITEM_METADATA_TYPE, WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
-  WORKFLOW_RULE_METADATA_TYPE, WORKFLOW_ACTION_REFERENCE_METADATA_TYPE,
+  VALUE_SET_DEFINITION_FIELDS, CUSTOM_FIELD,
   COMPOUND_FIELDS_SOAP_TYPE_NAMES, CUSTOM_OBJECT_ID_FIELD, FOREIGN_KEY_DOMAIN,
-  XML_ATTRIBUTE_PREFIX, INTERNAL_ID_FIELD,
+  XML_ATTRIBUTE_PREFIX, INTERNAL_ID_FIELD, UNKNOWN_METADATA_TYPE,
 } from '../constants'
 import SalesforceClient from '../client/client'
 import { allMissingSubTypes } from './salesforce_types'
@@ -60,7 +56,7 @@ export const metadataType = (element: Element): string => {
     // We expect to reach to this place only with field of CustomObject
     return CUSTOM_FIELD
   }
-  return element.annotations[METADATA_TYPE] || 'unknown'
+  return element.annotations[METADATA_TYPE] || UNKNOWN_METADATA_TYPE
 }
 
 export const isCustomObject = (element: Element): boolean =>
@@ -1387,23 +1383,4 @@ export const createMetadataTypeElements = async ({
     createIdField(element)
   }
   return _.flatten([element, ...embeddedTypes])
-}
-const lookUpRelative = (field?: Field, path?: ElemID): boolean => {
-  const lookUpRelativeTypes = new Map<string, string>(
-    [
-      [LAYOUT_TYPE_ID_METADATA_TYPE, LAYOUT_ITEM_METADATA_TYPE],
-      [WORKFLOW_FIELD_UPDATE_METADATA_TYPE, WORKFLOW_FIELD_UPDATE_METADATA_TYPE],
-      [WORKFLOW_RULE_METADATA_TYPE, WORKFLOW_ACTION_REFERENCE_METADATA_TYPE],
-    ]
-  )
-  return field !== undefined && path !== undefined
-    && lookUpRelativeTypes.get(path.typeName) === field.elemID.typeName
-}
-
-export const getLookUpName: GetLookupNameFunc = ({ ref, path, field }) => {
-  if (isElement(ref.value)) {
-    const isRelative = lookUpRelative(field, path)
-    return apiName(ref.value, isRelative)
-  }
-  return ref.value
 }

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -25,10 +25,11 @@ import {
 } from '@salto-io/adapter-utils'
 import {
   getSObjectFieldElement, Types, toCustomField, toCustomObject, instancesToUpdateRecords,
-  getValueTypeFieldElement, createMetadataTypeElements, getLookUpName,
+  getValueTypeFieldElement, createMetadataTypeElements,
   METADATA_TYPES_TO_RENAME, instancesToDeleteRecords, instancesToCreateRecords,
   isMetadataObjectType, isMetadataInstanceElement, toDeployableInstance,
 } from '../../src/transformers/transformer'
+import { getLookUpName } from '../../src/transformers/reference_mapping'
 import {
   FIELD_ANNOTATIONS, FIELD_TYPE_NAMES, LABEL, API_NAME, COMPOUND_FIELD_TYPE_NAMES,
   FIELD_DEPENDENCY_FIELDS, VALUE_SETTINGS_FIELDS, FILTER_ITEM_FIELDS, METADATA_TYPE,


### PR DESCRIPTION
Preparation for SALTO-942 (#1387 ) and for CPQ references - adding support for custom serialization functions when resolving reference expressions during deploy.

This is not the final implementation - eventually it is likely we will want to use annotations on the fields, in order to enable more complex reference resolution rules during fetch. 
However, since we already have today a hard-coded list of fields that need to resolve back to relative paths, we're starting with this approach to unblock the CPQ work, and may revisit it later.

This is not completely ready yet - but should demonstrate the configuration to make sure this will support the needs of the CPQ references (and I prepare it quickly for merging if it becomes a blocker).