### PR TITLE
Log adapter config values upon fetch & deploy

### DIFF
--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -16,7 +16,10 @@
 import _ from 'lodash'
 import { ObjectType, AdapterOperations, ElemIdGetter, AdapterOperationsContext, ElemID, InstanceElement, Adapter } from '@salto-io/adapter-api'
 import { createDefaultInstanceFromType } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 import adapterCreators from './creators'
+
+const log = logger(module)
 
 export const getAdaptersCredentialsTypes = (
   names?: ReadonlyArray<string>
@@ -46,6 +49,7 @@ export const initAdapters = (
       if (!creator) {
         throw new Error(`${adapter} adapter is not registered.`)
       }
+      log.debug('Using the following config for %s adapter: %o', adapter, config[adapter]?.config?.value)
       return creator.operations(context)
     }
   )

--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -49,7 +49,7 @@ export const initAdapters = (
       if (!creator) {
         throw new Error(`${adapter} adapter is not registered.`)
       }
-      log.debug('Using the following config for %s adapter: %o', adapter, config[adapter]?.config?.value)
+      log.debug('Using the following config for %s adapter: %o', adapter, context.config?.value)
       return creator.operations(context)
     }
   )


### PR DESCRIPTION
After @hadasb request to print the SDF concurrency that is used in Netsuite to the log I think that it worths to log all of the adapters config values for debugging purposes.