### PR TITLE
fix ChangeDataType definition to include ListType and add support to transformElement

### DIFF
--- a/packages/adapter-api/src/change.ts
+++ b/packages/adapter-api/src/change.ts
@@ -17,14 +17,14 @@ import {
   AdditionDiff, ModificationDiff, RemovalDiff, ActionName,
 } from '@salto-io/dag'
 import {
-  ObjectType, InstanceElement, Field, PrimitiveType, isInstanceElement, isObjectType, isField,
+  ObjectType, InstanceElement, Field, isInstanceElement, isObjectType, isField, TypeElement,
 } from './elements'
 import { ElemID } from './element_id'
 import { Values, Value } from './values'
 
 export { ActionName }
 
-export type ChangeDataType = ObjectType | InstanceElement | Field | PrimitiveType
+export type ChangeDataType = TypeElement | InstanceElement | Field
 export type AdditionChange<T> = AdditionDiff<T>
 export type ModificationChange<T> = ModificationDiff<T>
 export type RemovalChange<T> = RemovalDiff<T>

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -23,7 +23,7 @@ import {
   Element, isInstanceElement, InstanceElement, isPrimitiveType, TypeMap, isField, ChangeDataType,
   ReferenceExpression, Field, InstanceAnnotationTypes, isType, isObjectType, isAdditionChange,
   CORE_ANNOTATIONS, TypeElement, Change, isRemovalChange, isModificationChange, isListType,
-  ChangeData,
+  ChangeData, ListType,
 } from '@salto-io/adapter-api'
 
 const { isDefined } = lowerDashValues
@@ -259,6 +259,13 @@ export const transformElement = <T extends Element>(
       annotations: transformedAnnotations,
     })
 
+    return newElement as T
+  }
+
+  if (isListType(element)) {
+    newElement = new ListType(
+      transformElement({ element: element.innerType, transformFunc, strict })
+    )
     return newElement as T
   }
 


### PR DESCRIPTION
since list types are a part of element lists throughout the code base and we can have changes on list types (like for example when an adapter returns a new list type), the type definition of `ChangeDataType` needed to be fixed.
Also, `transformElement` with a list type would crash, so that had to be fixed as well
