### PR TITLE
Remove restrictions from percision and scale annotations in salesforce

### DIFF
--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -131,22 +131,25 @@ const addPicklistAnnotations = (
 const addressElemID = new ElemID(SALESFORCE, COMPOUND_FIELD_TYPE_NAMES.ADDRESS)
 const nameElemID = new ElemID(SALESFORCE, COMPOUND_FIELD_TYPE_NAMES.FIELD_NAME)
 const geoLocationElemID = new ElemID(SALESFORCE, COMPOUND_FIELD_TYPE_NAMES.LOCATION)
-type RestrictedNumberName = 'TextLength' | 'TextAreaLength' | 'EncryptedTextLength'
-  | 'Precision' | 'Scale' | 'LocationScale' | 'LongTextAreaVisibleLines'
-  | 'MultiPicklistVisibleLines' | 'RichTextAreaVisibleLines' | 'RelationshipOrder'
 
-const restrictedNumber = (
-  name: RestrictedNumberName, min: number, max: number, enforce_value = true,
-):
-  Record<string, PrimitiveType> => ({
-  [name]: new PrimitiveType({
+const restrictedNumberTypeDefinitions = {
+  TextLength: createRestriction({ min: 1, max: 255, enforce_value: false }),
+  TextAreaLength: createRestriction({ min: 1, max: 131072 }),
+  EncryptedTextLength: createRestriction({ min: 1, max: 175 }),
+  LongTextAreaVisibleLines: createRestriction({ min: 2, max: 50 }),
+  MultiPicklistVisibleLines: createRestriction({ min: 3, max: 10, enforce_value: false }),
+  RichTextAreaVisibleLines: createRestriction({ min: 10, max: 50 }),
+  RelationshipOrder: createRestriction({ min: 0, max: 1 }),
+}
+
+const restrictedNumberTypes = _.mapValues(
+  restrictedNumberTypeDefinitions,
+  (restriction, name) => new PrimitiveType({
     elemID: new ElemID(SALESFORCE, name),
     primitive: PrimitiveTypes.NUMBER,
-    annotations: {
-      [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ enforce_value, min, max }),
-    },
-  }),
-})
+    annotations: { [CORE_ANNOTATIONS.RESTRICTION]: restriction },
+  })
+)
 
 export const METADATA_TYPES_TO_RENAME: Map<string, string> = new Map([
   ['FlexiPage', 'LightningPage'],
@@ -331,19 +334,6 @@ export class Types {
     },
   })
 
-  private static restrictedNumberTypes: Record<RestrictedNumberName, PrimitiveType> = _.merge(
-    restrictedNumber('TextLength', 1, 255, false),
-    restrictedNumber('TextAreaLength', 1, 131072),
-    restrictedNumber('EncryptedTextLength', 1, 175),
-    restrictedNumber('Precision', 1, 18, false),
-    restrictedNumber('Scale', 0, 17),
-    restrictedNumber('LocationScale', 0, 15),
-    restrictedNumber('LongTextAreaVisibleLines', 2, 50),
-    restrictedNumber('MultiPicklistVisibleLines', 3, 10, false),
-    restrictedNumber('RichTextAreaVisibleLines', 10, 50),
-    restrictedNumber('RelationshipOrder', 0, 1),
-  )
-
   private static commonAnnotationTypes = {
     [API_NAME]: BuiltinTypes.SERVICE_ID,
     [DESCRIPTION]: BuiltinTypes.STRING,
@@ -369,7 +359,7 @@ export class Types {
         [FIELD_ANNOTATIONS.UNIQUE]: BuiltinTypes.BOOLEAN,
         [FIELD_ANNOTATIONS.EXTERNAL_ID]: BuiltinTypes.BOOLEAN,
         [FIELD_ANNOTATIONS.CASE_SENSITIVE]: BuiltinTypes.BOOLEAN,
-        [FIELD_ANNOTATIONS.LENGTH]: Types.restrictedNumberTypes.TextLength,
+        [FIELD_ANNOTATIONS.LENGTH]: restrictedNumberTypes.TextLength,
         [DEFAULT_VALUE_FORMULA]: BuiltinTypes.STRING,
       },
     }),
@@ -378,8 +368,8 @@ export class Types {
       primitive: PrimitiveTypes.NUMBER,
       annotationTypes: {
         ...Types.commonAnnotationTypes,
-        [FIELD_ANNOTATIONS.SCALE]: Types.restrictedNumberTypes.Scale,
-        [FIELD_ANNOTATIONS.PRECISION]: Types.restrictedNumberTypes.Precision,
+        [FIELD_ANNOTATIONS.SCALE]: BuiltinTypes.NUMBER,
+        [FIELD_ANNOTATIONS.PRECISION]: BuiltinTypes.NUMBER,
         [FIELD_ANNOTATIONS.UNIQUE]: BuiltinTypes.BOOLEAN,
         [FIELD_ANNOTATIONS.EXTERNAL_ID]: BuiltinTypes.BOOLEAN,
         [DEFAULT_VALUE_FORMULA]: BuiltinTypes.STRING,
@@ -431,8 +421,8 @@ export class Types {
       primitive: PrimitiveTypes.NUMBER,
       annotationTypes: {
         ...Types.commonAnnotationTypes,
-        [FIELD_ANNOTATIONS.SCALE]: Types.restrictedNumberTypes.Scale,
-        [FIELD_ANNOTATIONS.PRECISION]: Types.restrictedNumberTypes.Precision,
+        [FIELD_ANNOTATIONS.SCALE]: BuiltinTypes.NUMBER,
+        [FIELD_ANNOTATIONS.PRECISION]: BuiltinTypes.NUMBER,
         [DEFAULT_VALUE_FORMULA]: BuiltinTypes.STRING,
       },
     }),
@@ -454,7 +444,7 @@ export class Types {
       primitive: PrimitiveTypes.STRING,
       annotationTypes: {
         ...Types.commonAnnotationTypes,
-        [FIELD_ANNOTATIONS.VISIBLE_LINES]: Types.restrictedNumberTypes.MultiPicklistVisibleLines,
+        [FIELD_ANNOTATIONS.VISIBLE_LINES]: restrictedNumberTypes.MultiPicklistVisibleLines,
         [FIELD_ANNOTATIONS.FIELD_DEPENDENCY]: Types.fieldDependencyType,
         [FIELD_ANNOTATIONS.VALUE_SET]: Types.valueSetType,
         [FIELD_ANNOTATIONS.RESTRICTED]: BuiltinTypes.BOOLEAN,
@@ -478,8 +468,8 @@ export class Types {
       primitive: PrimitiveTypes.NUMBER,
       annotationTypes: {
         ...Types.commonAnnotationTypes,
-        [FIELD_ANNOTATIONS.SCALE]: Types.restrictedNumberTypes.Scale,
-        [FIELD_ANNOTATIONS.PRECISION]: Types.restrictedNumberTypes.Precision,
+        [FIELD_ANNOTATIONS.SCALE]: BuiltinTypes.NUMBER,
+        [FIELD_ANNOTATIONS.PRECISION]: BuiltinTypes.NUMBER,
         [DEFAULT_VALUE_FORMULA]: BuiltinTypes.STRING,
       },
     }),
@@ -496,8 +486,8 @@ export class Types {
       primitive: PrimitiveTypes.STRING,
       annotationTypes: {
         ...Types.commonAnnotationTypes,
-        [FIELD_ANNOTATIONS.VISIBLE_LINES]: Types.restrictedNumberTypes.LongTextAreaVisibleLines,
-        [FIELD_ANNOTATIONS.LENGTH]: Types.restrictedNumberTypes.TextAreaLength,
+        [FIELD_ANNOTATIONS.VISIBLE_LINES]: restrictedNumberTypes.LongTextAreaVisibleLines,
+        [FIELD_ANNOTATIONS.LENGTH]: restrictedNumberTypes.TextAreaLength,
         [DEFAULT_VALUE_FORMULA]: BuiltinTypes.STRING,
       },
     }),
@@ -506,8 +496,8 @@ export class Types {
       primitive: PrimitiveTypes.STRING,
       annotationTypes: {
         ...Types.commonAnnotationTypes,
-        [FIELD_ANNOTATIONS.VISIBLE_LINES]: Types.restrictedNumberTypes.RichTextAreaVisibleLines,
-        [FIELD_ANNOTATIONS.LENGTH]: Types.restrictedNumberTypes.TextAreaLength,
+        [FIELD_ANNOTATIONS.VISIBLE_LINES]: restrictedNumberTypes.RichTextAreaVisibleLines,
+        [FIELD_ANNOTATIONS.LENGTH]: restrictedNumberTypes.TextAreaLength,
       },
     }),
     TextArea: new PrimitiveType({
@@ -525,7 +515,7 @@ export class Types {
         ...Types.commonAnnotationTypes,
         [FIELD_ANNOTATIONS.MASK_CHAR]: Types.encryptedTextMaskCharType,
         [FIELD_ANNOTATIONS.MASK_TYPE]: Types.encryptedTextMaskTypeType,
-        [FIELD_ANNOTATIONS.LENGTH]: Types.restrictedNumberTypes.EncryptedTextLength,
+        [FIELD_ANNOTATIONS.LENGTH]: restrictedNumberTypes.EncryptedTextLength,
       },
     }),
     Url: new PrimitiveType({
@@ -555,7 +545,7 @@ export class Types {
         [FIELD_ANNOTATIONS.WRITE_REQUIRES_MASTER_READ]: BuiltinTypes.BOOLEAN,
         [FIELD_ANNOTATIONS.LOOKUP_FILTER]: Types.lookupFilterType,
         [FIELD_ANNOTATIONS.REFERENCE_TO]: BuiltinTypes.STRING,
-        [FIELD_ANNOTATIONS.RELATIONSHIP_ORDER]: Types.restrictedNumberTypes.RelationshipOrder,
+        [FIELD_ANNOTATIONS.RELATIONSHIP_ORDER]: restrictedNumberTypes.RelationshipOrder,
       },
     }),
     Summary: new PrimitiveType({
@@ -643,7 +633,7 @@ export class Types {
       },
       annotationTypes: {
         [FIELD_ANNOTATIONS.DISPLAY_LOCATION_IN_DECIMAL]: BuiltinTypes.BOOLEAN,
-        [FIELD_ANNOTATIONS.SCALE]: Types.restrictedNumberTypes.LocationScale,
+        [FIELD_ANNOTATIONS.SCALE]: BuiltinTypes.NUMBER,
         ...Types.commonAnnotationTypes,
       },
     }),
@@ -717,7 +707,7 @@ export class Types {
       Types.encryptedTextMaskCharType, Types.encryptedTextMaskTypeType,
       Types.BusinessStatusType, Types.SecurityClassificationType, Types.valueSetType,
       Types.TreatBlankAsType,
-      ...Object.values(Types.restrictedNumberTypes),
+      ...Object.values(restrictedNumberTypes),
     ]
       .map(type => {
         const fieldType = type.clone()

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -215,7 +215,7 @@ describe('SalesforceAdapter fetch', () => {
         + 1 /* treat blank as */
         + 1 /* value set */
         + 2 /* field dependency & value settings */
-        + 10 /* range restrictions */)
+        + 7 /* range restrictions */)
 
       const types = _.assign({}, ...result.map(t => ({ [id(t)]: t })))
       const nestingType = types['salesforce.NestingType']


### PR DESCRIPTION
The documentation does not seems to suggest the limits defined in the code exists
Removing after seeing numbers that exceed the supposed restrictions in a real account