### PR TITLE
Install adapter before calling validateCredentials

### DIFF
--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -16,12 +16,8 @@
 import _ from 'lodash'
 import { EOL } from 'os'
 import {
-  addAdapter,
-  getLoginStatuses,
-  LoginStatus,
-  updateCredentials,
-  loadLocalWorkspace,
-  getAdaptersCredentialsTypes,
+  addAdapter, getLoginStatuses, LoginStatus, updateCredentials, loadLocalWorkspace,
+  getAdaptersCredentialsTypes, installAdapter,
 } from '@salto-io/core'
 import { Workspace } from '@salto-io/workspace'
 
@@ -74,6 +70,7 @@ const addService = async (
     return CliExitCode.UserInputError
   }
 
+  await installAdapter(serviceName)
   if (!nologin) {
     const adapterCredentialsType = getAdaptersCredentialsTypes([serviceName])[serviceName]
     try {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -471,20 +471,6 @@ describe('api.ts', () => {
       await api.updateCredentials(ws, newConf)
       expect((ws.updateServiceConfig as jest.Mock).call).toHaveLength(1)
     })
-
-    describe('when the adapter implements the install method', () => {
-      it('should invoke the adapter install method', async () => {
-        const wsp = mockWorkspace({})
-        await api.addAdapter(wsp, mockServiceWithInstall)
-        expect(mockAdapterWithInstall.install).toHaveBeenCalled()
-      })
-      it('should throw an error if the adapter failed to install', async () => {
-        mockAdapterWithInstall.install.mockResolvedValueOnce({ success: false })
-        const wsp = mockWorkspace({})
-        return expect(api.addAdapter(wsp, mockServiceWithInstall)).rejects
-          .toThrow()
-      })
-    })
   })
 
   describe('installAdapter', () => {


### PR DESCRIPTION
Before that change, there was a bug which called `installAdapter` only after `validateCredentials` or upon service addition when the `--nologin` flag was supplied. It causes a failure when adding netsuite adapter because it requires the jar to be installed prior to validating the credentials