### PR TITLE
SALTO-958: Support type change for fields and annotations

### DIFF
--- a/packages/adapter-utils/src/compare.ts
+++ b/packages/adapter-utils/src/compare.ts
@@ -15,9 +15,8 @@
 */
 import _ from 'lodash'
 import {
-  ChangeDataType, DetailedChange, isField, isListType, isInstanceElement,
-  ElemID, Value, ObjectType, PrimitiveType, isObjectType, isPrimitiveType,
-  isEqualElements, isEqualValues, isRemovalChange,
+  ChangeDataType, DetailedChange, isField, isInstanceElement, ElemID, Value, ObjectType,
+  PrimitiveType, isObjectType, isPrimitiveType, isEqualElements, isEqualValues, isRemovalChange,
 } from '@salto-io/adapter-api'
 import { setPath } from './utils'
 
@@ -125,12 +124,8 @@ export const detailedCompare = (
     ]
   }
 
-  // A special case to handle isList changes in fields.
-  // should only happen if we misidentified the type
-  // in fetch. See SALTO-322
-  if (isField(before)
-      && isField(after)
-      && isListType(after.type) !== isListType(before.type)) {
+  // A special case to handle type changes in fields, we have to modify the whole field
+  if (isField(before) && isField(after) && !before.type.elemID.isEqual(after.type.elemID)) {
     return [{ action: 'modify', data: { before, after }, id: after.elemID }]
   }
 

--- a/packages/workspace/test/workspace/multi_env/projections.test.ts
+++ b/packages/workspace/test/workspace/multi_env/projections.test.ts
@@ -16,6 +16,7 @@
 import {
   ObjectType, ElemID, PrimitiveType, PrimitiveTypes, InstanceElement, Field, BuiltinTypes, ListType,
   DetailedChange,
+  getChangeElement,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { AdditionDiff, ModificationDiff, RemovalDiff } from '@salto-io/dag/dist'
@@ -224,15 +225,14 @@ describe('projections', () => {
     it('should project an add change for a non existing fragment for instances', async () => {
       const change: DetailedChange = {
         action: 'add',
-        data: { after: newPartialInstance },
-        id: newPartialInstance.elemID,
+        data: { after: newPartialInstance.value.nested2 },
+        id: newPartialInstance.elemID.createNestedID('nested2'),
       }
       const projected = await projectChange(change, source)
       expect(projected).toHaveLength(1)
       expect(projected[0].action).toBe('add')
-      const { data } = projected[0] as unknown as AdditionDiff<InstanceElement>
-      expect(data.after).toBeInstanceOf(InstanceElement)
-      expect(data.after).toEqual(newPartialInstance)
+      const changeData = getChangeElement(projected[0])
+      expect(changeData).toEqual(newPartialInstance.value.nested2)
     })
     it('should not project an add change for an existing fragment for instances', async () => {
       const change: DetailedChange = {
@@ -282,16 +282,6 @@ describe('projections', () => {
       annotations: _.clone(objectType.annotations),
     })
 
-    const newPartialObject = new ObjectType({
-      elemID: objectType.elemID,
-      fields: _.omit(objectType.fields, _.keys(partialObjectType.fields)),
-      annotations: _.omit(objectType.annotations, _.keys(partialObjectType.annotations)),
-      annotationTypes: _.omit(
-        objectType.annotationTypes,
-        _.keys(partialObjectType.annotationTypes)
-      ),
-    })
-
     const modifiedObject = new ObjectType({
       elemID: objectType.elemID,
       fields: objectType.fields,
@@ -319,15 +309,14 @@ describe('projections', () => {
     it('should project an add change for a non existing fragment for object types', async () => {
       const change: DetailedChange = {
         action: 'add',
-        data: { after: newPartialObject },
-        id: newPartialObject.elemID,
+        data: { after: objectType.annotations.nested2 },
+        id: objectType.elemID.createNestedID('attr', 'nested2'),
       }
       const projected = await projectChange(change, source)
       expect(projected).toHaveLength(1)
       expect(projected[0].action).toBe('add')
-      const { data } = projected[0] as unknown as AdditionDiff<ObjectType>
-      expect(data.after).toBeInstanceOf(ObjectType)
-      expect(data.after).toEqual(newPartialObject)
+      const changeData = getChangeElement(projected[0])
+      expect(changeData).toEqual(objectType.annotations.nested2)
     })
     it('should not project an add change for an existing fragment for object types', async () => {
       const change: DetailedChange = {
@@ -377,16 +366,6 @@ describe('projections', () => {
       primitive: primitiveType.primitive,
     })
 
-    const newPartialPrimitive = new PrimitiveType({
-      elemID: primitiveType.elemID,
-      annotations: _.omit(primitiveType.annotations, _.keys(partialPrimitiveType.annotations)),
-      annotationTypes: _.omit(
-        primitiveType.annotationTypes,
-        _.keys(partialPrimitiveType.annotationTypes)
-      ),
-      primitive: primitiveType.primitive,
-    })
-
     const modifiedPrimitive = new PrimitiveType({
       elemID: primitiveType.elemID,
       annotations: _.cloneDeepWith(primitiveType.annotations, v => (_.isString(v) ? 'MODIFIED' : undefined)),
@@ -411,15 +390,14 @@ describe('projections', () => {
     it('should project an add change for a non existing fragment for primitive types', async () => {
       const change: DetailedChange = {
         action: 'add',
-        data: { after: newPartialPrimitive },
-        id: newPartialPrimitive.elemID,
+        data: { after: primitiveType.annotations.nested2 },
+        id: primitiveType.elemID.createNestedID('attr', 'nested2'),
       }
       const projected = await projectChange(change, source)
       expect(projected).toHaveLength(1)
       expect(projected[0].action).toBe('add')
-      const { data } = projected[0] as unknown as AdditionDiff<PrimitiveType>
-      expect(data.after).toBeInstanceOf(PrimitiveType)
-      expect(data.after).toEqual(newPartialPrimitive)
+      const changeData = getChangeElement(projected[0])
+      expect(changeData).toEqual(primitiveType.annotations.nested2)
     })
     it('should not project an add change for an existing fragment for primitive types', async () => {
       const change: DetailedChange = {


### PR DESCRIPTION
Change projections and router code to not omit changes to annotation types

---

_Release notes_
- Fix issue where annotation type change was not written to Nacl