### PR TITLE
Netsuite: skip savedsearch type by default but allow the user to enable it

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -28,7 +28,7 @@ import {
   customTypes, getAllTypes, fileCabinetTypes,
 } from './types'
 import {
-  SAVED_SEARCH, TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST, FETCH_ALL_TYPES_AT_ONCE,
+  TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST, FETCH_ALL_TYPES_AT_ONCE,
 } from './constants'
 import replaceInstanceReferencesFilter from './filters/instance_references'
 import convertLists from './filters/convert_lists'
@@ -72,9 +72,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       convertLists,
       replaceInstanceReferencesFilter,
     ],
-    typesToSkip = [
-      SAVED_SEARCH, // Due to https://github.com/oracle/netsuite-suitecloud-sdk/issues/127 we receive changes each fetch
-    ],
+    typesToSkip = [],
     filePathRegexSkipList = [],
     fetchAllTypesAtOnce = DEFAULT_FETCH_ALL_TYPES_AT_ONCE,
     getElemIdFunc,

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -21,7 +21,7 @@ import {
 } from '@salto-io/adapter-api'
 import {
   FETCH_ALL_TYPES_AT_ONCE, TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST, NETSUITE,
-  SDF_CONCURRENCY_LIMIT,
+  SDF_CONCURRENCY_LIMIT, SAVED_SEARCH,
 } from './constants'
 
 const { makeArray } = collections.array
@@ -37,7 +37,11 @@ export const configType = new ObjectType({
     [TYPES_TO_SKIP]: {
       type: new ListType(BuiltinTypes.STRING),
       annotations: {
-        [CORE_ANNOTATIONS.DEFAULT]: [],
+        [CORE_ANNOTATIONS.DEFAULT]: [
+          SAVED_SEARCH, // Due to https://github.com/oracle/netsuite-suitecloud-sdk/issues/127 we receive changes each fetch.
+          // Although the SAVED_SEARCH is not editable since it's encrypted, there still might be
+          // a value for specific customers to use it for moving between envs, backup etc.
+        ],
       },
     },
     [FILE_PATHS_REGEX_SKIP_LIST]: {

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -53,7 +53,7 @@ describe('Adapter', () => {
   const filePathRegexStr = '^Some/File/Regex$'
   const client = createClient()
   const config = {
-    [TYPES_TO_SKIP]: [TRANSACTION_FORM],
+    [TYPES_TO_SKIP]: [SAVED_SEARCH, TRANSACTION_FORM],
     [FILE_PATHS_REGEX_SKIP_LIST]: [filePathRegexStr],
   }
   const netsuiteAdapter = new NetsuiteAdapter({


### PR DESCRIPTION
Until now we disabled the support for `savedsearch` type. We have a customer that said that although the value of the `savedsearch` is encrypted and regenerated every fetch, he has value in using it since this way he can back it up and move between envs. We still set it in skip list by default because it might be too noisy upon fetch but enable the user to control it using the config value.
@hadasb @netama @EllaSharakanski FYI