### PR TITLE
SALTO-961 Added a change validator for custom field types

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -19,13 +19,14 @@ import packageValidator from './change_validators/package'
 import picklistStandardFieldValidator from './change_validators/picklist_standard_field'
 import customObjectInstancesValidator from './change_validators/custom_object_instances'
 import unknownFieldValidator from './change_validators/unknown_field'
-
+import customFieldTypeValidator from './change_validators/custom_field_type'
 
 const changeValidators: ChangeValidator[] = [
   packageValidator,
   picklistStandardFieldValidator,
   customObjectInstancesValidator,
   unknownFieldValidator,
+  customFieldTypeValidator,
 ]
 
 export default createChangeValidator(changeValidators)

--- a/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
@@ -15,28 +15,38 @@
 */
 import {
   ChangeDataType, ChangeError, Field, getChangeElement, isAdditionOrModificationChange,
-  ChangeValidator, isField,
+  ChangeValidator, isField, Change, isModificationChange,
 } from '@salto-io/adapter-api'
 import { CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES, FIELD_TYPE_NAMES, COMPOUND_FIELD_TYPE_NAMES } from '../constants'
 import { isCustomObject } from '../transformers/transformer'
 
-export const isInvalidCustomFieldType = (changedElement: ChangeDataType):
-changedElement is Field => {
-  if (isField(changedElement) && isCustomObject(changedElement.parent)) {
-    const fieldType = changedElement.type.elemID.typeName as
+export const isInvalidCustomFieldType = (change: Change<ChangeDataType>): boolean => {
+  let isFieldTypeModification = true
+  const afterElement = getChangeElement(change)
+  if (isField(afterElement) && isCustomObject(afterElement.parent)) {
+    const afterFieldType = afterElement.type.elemID.typeName as
      FIELD_TYPE_NAMES | COMPOUND_FIELD_TYPE_NAMES
-    return !CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES.includes(fieldType)
+    if (isModificationChange(change)) {
+      const beforeFieldType = (change.data.before as Field).type.elemID.typeName as
+      FIELD_TYPE_NAMES | COMPOUND_FIELD_TYPE_NAMES
+      isFieldTypeModification = (afterFieldType !== beforeFieldType)
+    }
+    return isFieldTypeModification
+     && !CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES.includes(afterFieldType)
   }
   return false
 }
 
-const createChangeError = (field: Field): ChangeError =>
-  ({
+const createChangeError = (change: Change<ChangeDataType>): ChangeError => {
+  const field = getChangeElement(change) as Field
+  return {
     elemID: field.elemID,
     severity: 'Error',
     message: `You cannot create or modify a custom field type to ${field.type.elemID.typeName}. Field: ${field.name}`,
-    detailedMessage: `You cannot create or modify a custom field type to ${field.type.elemID.typeName}. Valid types can be found at: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_field_types.htm#meta_type_fieldtype`,
-  })
+    detailedMessage: `You cannot create or modify a custom field type to ${field.type.elemID.typeName}. Valid types can be found at:\nhttps://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_field_types.htm#meta_type_fieldtype`,
+  }
+}
+
 
 /**
    * It is forbidden to add or modify a field with unknown type.
@@ -44,9 +54,7 @@ const createChangeError = (field: Field): ChangeError =>
    */
 const changeValidator: ChangeValidator = async changes => changes
   .filter(isAdditionOrModificationChange)
-  .map(getChangeElement)
   .filter(isInvalidCustomFieldType)
   .map(createChangeError)
 
 export default changeValidator
-// TODO: write a test for this validator

--- a/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
@@ -14,53 +14,46 @@
 * limitations under the License.
 */
 import {
-  ChangeDataType, ChangeError, Field, getChangeElement, isAdditionOrModificationChange,
-  ChangeValidator, isField, Change, isAdditionChange,
+  ChangeError, Field, getChangeElement, isAdditionOrModificationChange,
+  ChangeValidator, Change, isAdditionChange, isFieldChange,
 } from '@salto-io/adapter-api'
 import { CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES, FIELD_TYPE_NAMES, COMPOUND_FIELD_TYPE_NAMES } from '../constants'
 import { isCustomObject } from '../transformers/transformer'
 
-const isCustomField = (changedElement: ChangeDataType): changedElement is Field =>
-  (isField(changedElement) && isCustomObject(changedElement.parent))
+const isCustomFieldChange = (change: Change<Field>): boolean =>
+  (isCustomObject(getChangeElement(change).parent))
 
-const isInvalidCustomFieldType = (change: Change<ChangeDataType>): boolean => {
-  const afterElement = getChangeElement(change)
-  if (isCustomField(afterElement)) {
-    const afterFieldType = afterElement.type.elemID.typeName as
-    FIELD_TYPE_NAMES | COMPOUND_FIELD_TYPE_NAMES
-    const isAfterTypeAllowed = CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES.includes(afterFieldType)
-    if (isAfterTypeAllowed) {
-      return false
-    } if (isAdditionChange(change)) {
-      return true
-    }
-
-    // modification change and the target type is invalid
-    const beforeElement = change.data.before
-    return isField(beforeElement)
-      && beforeElement.type.elemID.typeName !== afterFieldType
+const isInvalidTypeChange = (change: Change<Field>): boolean => {
+  const afterFieldType = getChangeElement(change).type.elemID.typeName as
+  FIELD_TYPE_NAMES | COMPOUND_FIELD_TYPE_NAMES
+  const isAfterTypeAllowed = CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES.includes(afterFieldType)
+  if (isAfterTypeAllowed) {
+    return false
+  } if (isAdditionChange(change)) {
+    return true
   }
-  return false
+
+  // it's a modification change and the target type is invalid
+  return change.data.before.type.elemID.typeName !== afterFieldType
 }
 
-const createChangeError = (change: Change<ChangeDataType>): ChangeError => {
-  const field = getChangeElement(change) as Field
-  return {
-    elemID: field.elemID,
-    severity: 'Error',
-    message: `You cannot create or modify a custom field type to ${field.type.elemID.typeName}. Field: ${field.name}`,
-    detailedMessage: `You cannot create or modify a custom field type to ${field.type.elemID.typeName}. Valid types can be found at:\nhttps://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_field_types.htm#meta_type_fieldtype`,
-  }
-}
-
+const createChangeError = (changedElement: Field): ChangeError => ({
+  elemID: changedElement.elemID,
+  severity: 'Error',
+  message: `You cannot create or modify a custom field type to ${changedElement.type.elemID.typeName}. Field: ${changedElement.name}`,
+  detailedMessage: `You cannot create or modify a custom field type to ${changedElement.type.elemID.typeName}. Valid types can be found at:\nhttps://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_field_types.htm#meta_type_fieldtype`,
+})
 
 /**
-   * It is forbidden to add or modify a field with unknown type.
-   * A missing type means this field is not accessible on Salesforce.
+   * Modification of a custom field type is restriced to certain types,
+   * as well as the type of new custom fields.
    */
 const changeValidator: ChangeValidator = async changes => changes
   .filter(isAdditionOrModificationChange)
-  .filter(isInvalidCustomFieldType)
+  .filter(isFieldChange)
+  .filter(isCustomFieldChange)
+  .filter(isInvalidTypeChange)
+  .map(getChangeElement)
   .map(createChangeError)
 
 export default changeValidator

--- a/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
@@ -1,0 +1,52 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeDataType, ChangeError, Field, getChangeElement, isAdditionOrModificationChange,
+  ChangeValidator, isField,
+} from '@salto-io/adapter-api'
+import { CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES, FIELD_TYPE_NAMES, COMPOUND_FIELD_TYPE_NAMES } from '../constants'
+import { isCustomObject } from '../transformers/transformer'
+
+export const isInvalidCustomFieldType = (changedElement: ChangeDataType):
+changedElement is Field => {
+  if (isField(changedElement) && isCustomObject(changedElement.parent)) {
+    const fieldType = changedElement.type.elemID.typeName as
+     FIELD_TYPE_NAMES | COMPOUND_FIELD_TYPE_NAMES
+    return !CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES.includes(fieldType)
+  }
+  return false
+}
+
+const createChangeError = (field: Field): ChangeError =>
+  ({
+    elemID: field.elemID,
+    severity: 'Error',
+    message: `You cannot create or modify a custom field type to ${field.type.elemID.typeName}. Field: ${field.name}`,
+    detailedMessage: `You cannot create or modify a custom field type to ${field.type.elemID.typeName}. Valid types can be found at: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_field_types.htm#meta_type_fieldtype`,
+  })
+
+/**
+   * It is forbidden to add or modify a field with unknown type.
+   * A missing type means this field is not accessible on Salesforce.
+   */
+const changeValidator: ChangeValidator = async changes => changes
+  .filter(isAdditionOrModificationChange)
+  .map(getChangeElement)
+  .filter(isInvalidCustomFieldType)
+  .map(createChangeError)
+
+export default changeValidator
+// TODO: write a test for this validator

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -76,6 +76,13 @@ export const COMPOUND_FIELDS_SOAP_TYPE_NAMES:
     // name is handled differently with nameField
   }
 
+// target types for creating / updating custom fields:
+export const CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES = [
+  // other valid field types that we do not currently support are:
+  // MetadataRelationship, ExternalLookup, IndirectLookup, Hierarchy, File
+  ...(FIELD_TYPE_NAME_VALUES.filter(type => type !== FIELD_TYPE_NAMES.UNKNOWN)),
+  COMPOUND_FIELD_TYPE_NAMES.LOCATION]
+
 export const FIELD_SOAP_TYPE_NAMES:
 Record<string, FIELD_TYPE_NAMES> = {
   anyType: FIELD_TYPE_NAMES.ANYTYPE,

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -62,6 +62,9 @@ export const metadataType = (element: Element): string => {
 export const isCustomObject = (element: Element): boolean =>
   metadataType(element) === CUSTOM_OBJECT
 
+export const isCustomField = (field: Field): boolean =>
+  isCustomObject(field.parent)
+
 export const isInstanceOfCustomObject = (element: Element): element is InstanceElement =>
   isInstanceElement(element) && isCustomObject(element.type)
 

--- a/packages/salesforce-adapter/test/change_validators/custom_field_type.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/custom_field_type.test.ts
@@ -1,0 +1,84 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeError, ElemID, Field, ObjectType, toChange, TypeElement,
+} from '@salto-io/adapter-api'
+import { Types } from '../../src/transformers/transformer'
+import customFieldTypeValidator from '../../src/change_validators/custom_field_type'
+import { API_NAME, CUSTOM_OBJECT } from '../../src/constants'
+
+describe('custom field type change validator', () => {
+  describe('onUpdate', () => {
+    let customObj: ObjectType
+    beforeEach(() => {
+      customObj = new ObjectType({
+        elemID: new ElemID('salesforce', 'obj'),
+        annotations: { metadataType: CUSTOM_OBJECT },
+      })
+    })
+
+    const createCustomField = (fieldType: TypeElement, fieldApiName: string): Field => {
+      const newField = new Field(customObj, 'field', fieldType, {
+        [API_NAME]: fieldApiName,
+      })
+      customObj.fields.field = newField
+      return newField
+    }
+
+    const runChangeValidator = (before: Field | undefined, after: Field):
+        Promise<ReadonlyArray<ChangeError>> =>
+      customFieldTypeValidator([toChange({ before, after })])
+
+    it('should have error for custom field type change to an invalid field type', async () => {
+      const beforeField = createCustomField(Types.primitiveDataTypes.Time, 'Something')
+      const afterField = createCustomField(Types.compoundDataTypes.Address, 'Something')
+      const changeErrors = await runChangeValidator(beforeField, afterField)
+      expect(changeErrors).toHaveLength(1)
+      const [changeError] = changeErrors
+      expect(changeError.elemID).toEqual(beforeField.elemID)
+      expect(changeError.severity).toEqual('Error')
+    })
+
+    it('should have error for field creation with invalid field type', async () => {
+      const field = createCustomField(Types.compoundDataTypes.Address, 'Something')
+      const changeErrors = await runChangeValidator(undefined, field)
+      expect(changeErrors).toHaveLength(1)
+      const [changeError] = changeErrors
+      expect(changeError.elemID).toEqual(field.elemID)
+      expect(changeError.severity).toEqual('Error')
+    })
+
+    it('should have no error when changing a field type to a valid type', async () => {
+      const beforeField = createCustomField(Types.primitiveDataTypes.Text, 'Something')
+      const afterField = createCustomField(Types.primitiveDataTypes.Time, 'Somthing')
+      const changeErrors = await runChangeValidator(beforeField, afterField)
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('should have no error when creating a field with a valid field type', async () => {
+      const field = createCustomField(Types.primitiveDataTypes.Checkbox, 'Something')
+      const changeErrors = await runChangeValidator(undefined, field)
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('should have no error for object', async () => {
+      const changeErrors = await customFieldTypeValidator([
+        toChange({ before: customObj, after: customObj.clone() }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/change_validators/picklist_standard_field.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/picklist_standard_field.test.ts
@@ -14,13 +14,12 @@
 * limitations under the License.
 */
 import {
-  ChangeError, ElemID, Field, ObjectType, PrimitiveType, ReferenceExpression, toChange,
+  ChangeError, ElemID, Field, ObjectType, ReferenceExpression, toChange,
 } from '@salto-io/adapter-api'
 import { Types } from '../../src/transformers/transformer'
 import picklistStandardFieldValidator from '../../src/change_validators/picklist_standard_field'
-import {
-  API_NAME, FIELD_ANNOTATIONS, SALESFORCE, VALUE_SET_FIELDS,
-} from '../../src/constants'
+import { FIELD_ANNOTATIONS, SALESFORCE, VALUE_SET_FIELDS } from '../../src/constants'
+import { createField } from '../utils'
 
 
 describe('picklist standard field change validator', () => {
@@ -31,15 +30,6 @@ describe('picklist standard field change validator', () => {
         elemID: new ElemID('salesforce', 'obj'),
       })
     })
-
-    const createField = (fieldType: PrimitiveType, fieldApiName: string): Field => {
-      const newField = new Field(obj, 'field', fieldType, {
-        [API_NAME]: fieldApiName,
-        modifyMe: 'modifyMe',
-      })
-      obj.fields.field = newField
-      return newField
-    }
 
     const createAfterField = (beforeField: Field): Field => {
       const afterField = beforeField.clone()
@@ -52,7 +42,7 @@ describe('picklist standard field change validator', () => {
       picklistStandardFieldValidator([toChange({ before, after })])
 
     it('should have error for picklist standard field without API_NAME_SEPARATOR', async () => {
-      const beforeField = createField(Types.primitiveDataTypes.Picklist, 'Standard')
+      const beforeField = createField(obj, Types.primitiveDataTypes.Picklist, 'Standard')
       const afterField = createAfterField(beforeField)
       const changeErrors = await runChangeValidatorOnUpdate(beforeField, afterField)
       expect(changeErrors).toHaveLength(1)
@@ -62,21 +52,21 @@ describe('picklist standard field change validator', () => {
     })
 
     it('should have error for picklist standard field with API_NAME_SEPARATOR', async () => {
-      const beforeField = createField(Types.primitiveDataTypes.Picklist, 'Obj.Standard')
+      const beforeField = createField(obj, Types.primitiveDataTypes.Picklist, 'Obj.Standard')
       const afterField = createAfterField(beforeField)
       const changeErrors = await runChangeValidatorOnUpdate(beforeField, afterField)
       expect(changeErrors).toHaveLength(1)
     })
 
     it('should have error for multi picklist standard field', async () => {
-      const beforeField = createField(Types.primitiveDataTypes.MultiselectPicklist, 'Standard')
+      const beforeField = createField(obj, Types.primitiveDataTypes.MultiselectPicklist, 'Standard')
       const afterField = createAfterField(beforeField)
       const changeErrors = await runChangeValidatorOnUpdate(beforeField, afterField)
       expect(changeErrors).toHaveLength(1)
     })
 
     it('should have error for GlobalValueSet picklist standard field', async () => {
-      const beforeField = createField(Types.primitiveDataTypes.Picklist, 'Standard')
+      const beforeField = createField(obj, Types.primitiveDataTypes.Picklist, 'Standard')
       beforeField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME] = 'valueSet'
       const afterField = createAfterField(beforeField)
       const changeErrors = await runChangeValidatorOnUpdate(beforeField, afterField)
@@ -84,7 +74,7 @@ describe('picklist standard field change validator', () => {
     })
 
     it('should have no error for StandardValueSet picklist standard field', async () => {
-      const beforeField = createField(Types.primitiveDataTypes.Picklist, 'Standard')
+      const beforeField = createField(obj, Types.primitiveDataTypes.Picklist, 'Standard')
       const dummyElemID = new ElemID(SALESFORCE, 'referenced')
       beforeField.annotations[FIELD_ANNOTATIONS.VALUE_SET] = new ReferenceExpression(dummyElemID)
       const afterField = createAfterField(beforeField)
@@ -93,14 +83,14 @@ describe('picklist standard field change validator', () => {
     })
 
     it('should not have error for picklist custom field', async () => {
-      const beforeField = createField(Types.primitiveDataTypes.Picklist, 'Custom__c')
+      const beforeField = createField(obj, Types.primitiveDataTypes.Picklist, 'Custom__c')
       const afterField = createAfterField(beforeField)
       const changeErrors = await runChangeValidatorOnUpdate(beforeField, afterField)
       expect(changeErrors).toHaveLength(0)
     })
 
     it('should have no error for non-picklist standard field', async () => {
-      const beforeField = createField(Types.primitiveDataTypes.Text, 'Standard')
+      const beforeField = createField(obj, Types.primitiveDataTypes.Text, 'Standard')
       const afterField = createAfterField(beforeField)
       const changeErrors = await runChangeValidatorOnUpdate(beforeField, afterField)
       expect(changeErrors).toHaveLength(0)

--- a/packages/salesforce-adapter/test/change_validators/unknown_field.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/unknown_field.test.ts
@@ -14,12 +14,11 @@
 * limitations under the License.
 */
 import {
-  ChangeError, ElemID, Field, ObjectType, PrimitiveType, toChange,
+  ChangeError, ElemID, Field, ObjectType, toChange,
 } from '@salto-io/adapter-api'
 import { Types } from '../../src/transformers/transformer'
 import unknownFieldValidator from '../../src/change_validators/unknown_field'
-import { API_NAME } from '../../src/constants'
-
+import { createField } from '../utils'
 
 describe('unknown field change validator', () => {
   describe('onUpdate', () => {
@@ -29,15 +28,6 @@ describe('unknown field change validator', () => {
         elemID: new ElemID('salesforce', 'obj'),
       })
     })
-
-    const createField = (fieldType: PrimitiveType, fieldApiName: string): Field => {
-      const newField = new Field(obj, 'field', fieldType, {
-        [API_NAME]: fieldApiName,
-        modifyMe: 'modifyMe',
-      })
-      obj.fields.field = newField
-      return newField
-    }
 
     const createAfterField = (beforeField: Field): Field => {
       const afterField = beforeField.clone()
@@ -50,7 +40,7 @@ describe('unknown field change validator', () => {
       unknownFieldValidator([toChange({ before, after })])
 
     it('should have error for unknown field modification', async () => {
-      const beforeField = createField(Types.primitiveDataTypes.Unknown, 'Something')
+      const beforeField = createField(obj, Types.primitiveDataTypes.Unknown, 'Something')
       const afterField = createAfterField(beforeField)
       const changeErrors = await runChangeValidator(beforeField, afterField)
       expect(changeErrors).toHaveLength(1)
@@ -60,7 +50,7 @@ describe('unknown field change validator', () => {
     })
 
     it('should have error for unknown field creation', async () => {
-      const field = createField(Types.primitiveDataTypes.Unknown, 'Something')
+      const field = createField(obj, Types.primitiveDataTypes.Unknown, 'Something')
       const changeErrors = await runChangeValidator(undefined, field)
       expect(changeErrors).toHaveLength(1)
       const [changeError] = changeErrors
@@ -69,14 +59,14 @@ describe('unknown field change validator', () => {
     })
 
     it('should have no error when changing a field with a valid type', async () => {
-      const beforeField = createField(Types.primitiveDataTypes.Text, 'Something')
+      const beforeField = createField(obj, Types.primitiveDataTypes.Text, 'Something')
       const afterField = createAfterField(beforeField)
       const changeErrors = await runChangeValidator(beforeField, afterField)
       expect(changeErrors).toHaveLength(0)
     })
 
     it('should have no error when creating a field with a valid type', async () => {
-      const field = createField(Types.primitiveDataTypes.Checkbox, 'Something')
+      const field = createField(obj, Types.primitiveDataTypes.Checkbox, 'Something')
       const changeErrors = await runChangeValidator(undefined, field)
       expect(changeErrors).toHaveLength(0)
     })

--- a/packages/salesforce-adapter/test/utils.ts
+++ b/packages/salesforce-adapter/test/utils.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  Element, ElemID, Values, ObjectType,
+  Element, ElemID, Values, ObjectType, Field, TypeElement,
 } from '@salto-io/adapter-api'
 import {
   findElements as findElementsByID,
@@ -34,6 +34,16 @@ export const findElements = (
     ? new ElemID(constants.SALESFORCE, name[0])
     : new ElemID(constants.SALESFORCE, name[0], 'instance', ...name.slice(1))
   return [...findElementsByID(elements, expectedElemId)]
+}
+
+export const createField = (parent: ObjectType, fieldType: TypeElement,
+  fieldApiName: string): Field => {
+  const newField = new Field(parent, 'field', fieldType, {
+    [constants.API_NAME]: fieldApiName,
+    modifyMe: 'modifyMe',
+  })
+  parent.fields.field = newField
+  return newField
 }
 
 export const createValueSetEntry = (


### PR DESCRIPTION
the change validator checks for creation of new custom fields with invalid type, or change of existing custom fields to an invalid type.