### PR TITLE
Refactor salesforce adapter filters to have onDeploy callback

### DIFF
--- a/packages/lowerdash/src/values.ts
+++ b/packages/lowerdash/src/values.ts
@@ -13,4 +13,4 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export const isDefined = <T>(val: T | undefined): val is T => val !== undefined
+export const isDefined = <T>(val: T | undefined | void): val is T => val !== undefined

--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -44,6 +44,7 @@ import {
 import realAdapter from './adapter'
 import {
   findElements, findStandardFieldsObject, findAnnotationsObject, findCustomFieldsObject,
+  findFullCustomObject,
 } from '../test/utils'
 import SalesforceClient, { API_VERSION, Credentials } from '../src/client/client'
 import SalesforceAdapter from '../src/adapter'
@@ -2161,7 +2162,7 @@ describe('Salesforce adapter E2E with real account', () => {
         }
 
         beforeAll(async () => {
-          const customFieldsObject = findCustomFieldsObject(result, customObjectWithFieldsName)
+          const customFieldsObject = findFullCustomObject(result, customObjectWithFieldsName)
           const newCustomObject = customFieldsObject.clone()
           updateAnnotations(newCustomObject, customFieldsObject, fieldNamesToAnnotations)
           await adapter.deploy({

--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -654,6 +654,7 @@ describe('Salesforce adapter E2E with real account', () => {
           [constants.DEFAULT_VALUE_FORMULA]: 'test2',
           [constants.LABEL]: 'test2 label',
           [constants.API_NAME]: customObjectName,
+          [constants.METADATA_TYPE]: constants.CUSTOM_OBJECT,
         },
       })
 

--- a/packages/salesforce-adapter/src/filters/value_set.ts
+++ b/packages/salesforce-adapter/src/filters/value_set.ts
@@ -14,13 +14,11 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import wu from 'wu'
-import { collections } from '@salto-io/lowerdash'
+import { collections, values } from '@salto-io/lowerdash'
 import {
-  Element, Field, isObjectType, Change, getChangeElement,
-  isField, isModificationChange, ChangeDataType, isInstanceElement, ReferenceExpression,
+  Field, getChangeElement, isField, isModificationChange, ChangeDataType, ReferenceExpression,
+  InstanceElement, isInstanceChange, ModificationChange, isObjectTypeChange,
 } from '@salto-io/adapter-api'
-import { SaveResult } from 'jsforce'
 import { FilterWith } from '../filter'
 import { FIELD_ANNOTATIONS, VALUE_SET_FIELDS } from '../constants'
 import { PicklistValue } from '../client/types'
@@ -47,80 +45,71 @@ const isGlobalValueSetPicklistField = (field: Field): boolean =>
  *  - Global value set
  *  - Restricted custom value set
  */
-const filterCreator = (): FilterWith<'onUpdate'> => ({
-  onUpdate: async (before: Element, after: Element, changes: ReadonlyArray<Change>):
-    Promise<SaveResult[]> => {
+const filterCreator = (): FilterWith<'onDeploy'> => ({
+  onDeploy: async changes => {
     const isRestrictedPicklistField = (
       changedElement: ChangeDataType
     ): changedElement is Field =>
       isPicklistField(changedElement)
       && Boolean(changedElement.annotations[FIELD_ANNOTATIONS.RESTRICTED])
 
-    const isInstanceGlobalSetValue = (changedElement: ChangeDataType): boolean =>
-      isInstanceElement(changedElement)
-      && metadataType(changedElement) === GLOBAL_VALUE_SET
+    const isGlobalValueSetInstanceChange = (
+      change: ModificationChange<ChangeDataType>
+    ): change is ModificationChange<InstanceElement> => (
+      isInstanceChange(change) && metadataType(getChangeElement(change)) === GLOBAL_VALUE_SET
+    )
 
-    const getRemovedCustomValues = (beforeValues: PicklistValue[], afterValues: PicklistValue[]):
+    const withRemovedCustomValues = (beforeValues: PicklistValue[], afterValues: PicklistValue[]):
     PicklistValue[] => {
       const afterCustomValuesFullNames = afterValues.map(v => v.fullName)
       const setCustomValueInactive = (value: PicklistValue): PicklistValue => {
         value.isActive = false
         return value
       }
-      return beforeValues
-        .filter(v => !afterCustomValuesFullNames.includes(v.fullName))
-        .map(v => setCustomValueInactive(v))
+      return [
+        ...afterValues,
+        ...beforeValues
+          .filter(v => !afterCustomValuesFullNames.includes(v.fullName))
+          .map(v => setCustomValueInactive(v)),
+      ]
     }
 
-    const addRemovedCustomValues = (
-      valuesAnnotations: PicklistValue[],
-      beforeValues: PicklistValue[],
-      afterValues: PicklistValue[]
-    ): PicklistValue[] | undefined => {
-      const valuesToAdd = getRemovedCustomValues(beforeValues, afterValues)
-      if (!_.isEmpty(valuesAnnotations)) {
-        valuesAnnotations.push(...valuesToAdd)
-        return valuesAnnotations
-      }
-      return valuesToAdd
-    }
-
-    wu(changes)
-      .forEach(c => {
-        if (isModificationChange(c)) {
-          const changedElement = getChangeElement(c)
-          if (isRestrictedPicklistField(changedElement)
-            && isObjectType(after)
-            && isObjectType(before)) {
-            const beforeCustomValues = makeArray(
-              c.data.before.annotations[FIELD_ANNOTATIONS.VALUE_SET]
-            )
-            const afterCustomValues = makeArray(
-              c.data.after.annotations[FIELD_ANNOTATIONS.VALUE_SET]
-            )
-            const field = after.fields[changedElement.name]
-            if (!isGlobalValueSetPicklistField(field)
-              && !(isStandardValueSetPicklistField(field))) {
-              field.annotations[FIELD_ANNOTATIONS.VALUE_SET] = addRemovedCustomValues(
-                field.annotations[FIELD_ANNOTATIONS.VALUE_SET],
-                beforeCustomValues,
-                afterCustomValues,
-              )
-            }
-          }
-
-          if (isInstanceGlobalSetValue(changedElement)
-            && isInstanceElement(after) && isInstanceElement(before)) {
-            const beforeCustomValues = makeArray(before.value[CUSTOM_VALUE])
-            const afterCustomValues = makeArray(after.value[CUSTOM_VALUE])
-            after.value[CUSTOM_VALUE] = addRemovedCustomValues(
-              after.value[CUSTOM_VALUE],
-              beforeCustomValues,
-              afterCustomValues
-            )
-          }
-        }
+    // Handle global value set instances
+    changes
+      .filter(isModificationChange)
+      .filter(isGlobalValueSetInstanceChange)
+      .forEach(change => {
+        const beforeCustomValues = makeArray(change.data.before.value[CUSTOM_VALUE])
+        const afterCustomValues = makeArray(change.data.after.value[CUSTOM_VALUE])
+        change.data.after.value[CUSTOM_VALUE] = withRemovedCustomValues(
+          beforeCustomValues, afterCustomValues
+        )
       })
+
+    // Handle restricted picklist fields
+    const changedRestrictedPicklistFields = changes
+      .filter(isObjectTypeChange)
+      .filter(isModificationChange)
+      .flatMap(
+        change => Object.entries(change.data.after.fields)
+          .filter(([_name, field]) => (
+            isRestrictedPicklistField(field)
+            && !isGlobalValueSetPicklistField(field)
+            && !isStandardValueSetPicklistField(field)
+          ))
+          .map(([name, field]) => {
+            const beforeField = change.data.before.fields[name]
+            return beforeField === undefined ? undefined : { beforeField, afterField: field }
+          })
+          .filter(values.isDefined)
+      )
+    changedRestrictedPicklistFields.forEach(({ beforeField, afterField }) => {
+      const beforeCustomValues = makeArray(beforeField.annotations[FIELD_ANNOTATIONS.VALUE_SET])
+      const afterCustomValues = makeArray(afterField.annotations[FIELD_ANNOTATIONS.VALUE_SET])
+      afterField.annotations[FIELD_ANNOTATIONS.VALUE_SET] = withRemovedCustomValues(
+        beforeCustomValues, afterCustomValues
+      )
+    })
 
     return []
   },

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -650,7 +650,7 @@ describe('Custom Object Instances CRUD', () => {
             })
           })
         })
-        describe('Remove group', async () => {
+        describe('Remove group', () => {
           it('should fail', async () => {
             result = await adapter.deploy({
               groupID: 'badGroup',

--- a/packages/salesforce-adapter/test/filters/value_set.test.ts
+++ b/packages/salesforce-adapter/test/filters/value_set.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  ElemID, InstanceElement, ObjectType, CORE_ANNOTATIONS,
+  ElemID, InstanceElement, ObjectType, CORE_ANNOTATIONS, toChange,
 } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/value_set'
 import { FilterWith } from '../../src/filter'
@@ -22,10 +22,10 @@ import * as constants from '../../src/constants'
 import { GLOBAL_VALUE_SET, MASTER_LABEL, CUSTOM_VALUE } from '../../src/filters/global_value_sets'
 import { Types } from '../../src/transformers/transformer'
 
-describe('lookup filters filter', () => {
-  const filter = filterCreator() as FilterWith<'onUpdate'>
+describe('value set filter', () => {
+  const filter = filterCreator() as FilterWith<'onDeploy'>
 
-  describe('on update', () => {
+  describe('on deploy', () => {
     describe('Global value set', () => {
       const globalValueSetName = 'GVSTest'
       const createGlobalValueSetInstanceElement = (values: string[]): InstanceElement =>
@@ -48,15 +48,11 @@ describe('lookup filters filter', () => {
             })),
         })
 
-      it('should add inactive values to global value set', () => {
+      it('should add inactive values to global value set', async () => {
         const beforeInstance = createGlobalValueSetInstanceElement(['val1'])
         const afterInstance = createGlobalValueSetInstanceElement(['val2'])
 
-        filter.onUpdate(
-          beforeInstance,
-          afterInstance,
-          [{ action: 'modify', data: { before: beforeInstance, after: afterInstance } }]
-        )
+        await filter.onDeploy([toChange({ before: beforeInstance, after: afterInstance })])
         expect(afterInstance.value[CUSTOM_VALUE]).toEqual([{
           [constants.CUSTOM_VALUE.FULL_NAME]: 'val2',
           [constants.CUSTOM_VALUE.DEFAULT]: false,
@@ -71,14 +67,10 @@ describe('lookup filters filter', () => {
         }])
       })
 
-      it('should not add inactive values when there were no deletions', () => {
+      it('should not add inactive values when there were no deletions', async () => {
         const beforeInstance = createGlobalValueSetInstanceElement(['val1'])
         const afterInstance = createGlobalValueSetInstanceElement(['val1', 'val2'])
-        filter.onUpdate(
-          beforeInstance,
-          afterInstance,
-          [{ action: 'modify', data: { before: beforeInstance, after: afterInstance } }]
-        )
+        await filter.onDeploy([toChange({ before: beforeInstance, after: afterInstance })])
         expect(afterInstance.value[CUSTOM_VALUE]).toEqual([{
           [constants.CUSTOM_VALUE.FULL_NAME]: 'val1',
           [constants.CUSTOM_VALUE.DEFAULT]: false,
@@ -124,19 +116,11 @@ describe('lookup filters filter', () => {
           },
         })
 
-      it('should add inactive values to custom picklist', () => {
+      it('should add inactive values to custom picklist', async () => {
         const beforeObject = createObjectWithPicklistField(['val1'])
         const afterObject = createObjectWithPicklistField(['val2'])
 
-        filter.onUpdate(
-          beforeObject,
-          afterObject,
-          [{ action: 'modify',
-            data: {
-              before: beforeObject.fields[fieldName],
-              after: afterObject.fields[fieldName],
-            } }]
-        )
+        await filter.onDeploy([toChange({ before: beforeObject, after: afterObject })])
         expect(afterObject.fields[fieldName].annotations[constants.FIELD_ANNOTATIONS.VALUE_SET])
           .toEqual([{
             [constants.CUSTOM_VALUE.FULL_NAME]: 'val2',
@@ -152,19 +136,11 @@ describe('lookup filters filter', () => {
           }])
       })
 
-      it('should not add inactive values to non restricted custom picklist', () => {
+      it('should not add inactive values to non restricted custom picklist', async () => {
         const beforeObject = createObjectWithPicklistField(['val1'], false)
         const afterObject = createObjectWithPicklistField(['val2'], false)
 
-        filter.onUpdate(
-          beforeObject,
-          afterObject,
-          [{ action: 'modify',
-            data: {
-              before: beforeObject.fields[fieldName],
-              after: afterObject.fields[fieldName],
-            } }]
-        )
+        await filter.onDeploy([toChange({ before: beforeObject, after: afterObject })])
         expect(afterObject.fields[fieldName].annotations[constants.FIELD_ANNOTATIONS.VALUE_SET])
           .toEqual([{
             [constants.CUSTOM_VALUE.FULL_NAME]: 'val2',
@@ -175,19 +151,11 @@ describe('lookup filters filter', () => {
           ])
       })
 
-      it('should not add inactive values to custom picklist when there were no deletions', () => {
+      it('should not add inactive values to custom picklist when there were no deletions', async () => {
         const beforeObject = createObjectWithPicklistField(['val1'])
         const afterObject = createObjectWithPicklistField(['val1', 'val2'])
 
-        filter.onUpdate(
-          beforeObject,
-          afterObject,
-          [{ action: 'modify',
-            data: {
-              before: beforeObject.fields[fieldName],
-              after: afterObject.fields[fieldName],
-            } }]
-        )
+        await filter.onDeploy([toChange({ before: beforeObject, after: afterObject })])
         expect(afterObject.fields[fieldName].annotations[constants.FIELD_ANNOTATIONS.VALUE_SET])
           .toEqual([{
             [constants.CUSTOM_VALUE.FULL_NAME]: 'val1',
@@ -204,19 +172,11 @@ describe('lookup filters filter', () => {
           ])
       })
 
-      it('should not add values to global picklist field in custom object', () => {
+      it('should not add values to global picklist field in custom object', async () => {
         const beforeObject = createObjectWithPicklistField(['val1'])
         const afterObject = createObjectWithPicklistField()
 
-        filter.onUpdate(
-          beforeObject,
-          afterObject,
-          [{ action: 'modify',
-            data: {
-              before: beforeObject.fields[fieldName],
-              after: afterObject.fields[fieldName],
-            } }]
-        )
+        await filter.onDeploy([toChange({ before: beforeObject, after: afterObject })])
         expect(afterObject.fields[fieldName].annotations[constants.FIELD_ANNOTATIONS.VALUE_SET])
           .toEqual([{
             [constants.CUSTOM_VALUE.FULL_NAME]: 'val1',

--- a/packages/salesforce-adapter/test/filters/workflow.test.ts
+++ b/packages/salesforce-adapter/test/filters/workflow.test.ts
@@ -36,8 +36,7 @@ const { makeArray } = collections.array
 
 describe('Workflow filter', () => {
   const { client } = mockClient()
-  const filter = filterCreator({ client, config: {} }) as FilterWith<'onFetch'> & FilterWith<'onAdd'>
-    & FilterWith<'onUpdate'> & FilterWith<'onRemove'>
+  const filter = filterCreator({ client, config: {} }) as FilterWith<'onFetch'>
 
   const workflowInstanceName = 'Account'
   const generateWorkFlowInstance = (beforeFetch = false): InstanceElement => {

--- a/packages/salesforce-adapter/test/utils.ts
+++ b/packages/salesforce-adapter/test/utils.ts
@@ -83,6 +83,23 @@ export const findAnnotationsObject = (elements: Element[], name: string): Object
     .find(obj => obj.path?.slice(-1)[0] === annotationsFileName(name)) as ObjectType
 }
 
+export const findFullCustomObject = (elements: Element[], name: string): ObjectType => {
+  const customObjects = findElements(elements, name) as ObjectType[]
+  return new ObjectType({
+    elemID: customObjects[0].elemID,
+    annotationTypes: Object.fromEntries(
+      customObjects.flatMap(obj => Object.entries(obj.annotationTypes))
+    ),
+    annotations: Object.fromEntries(
+      customObjects.flatMap(obj => Object.entries(obj.annotations))
+    ),
+    fields: Object.fromEntries(
+      customObjects.flatMap(obj => Object.entries(obj.fields))
+    ),
+    isSettings: customObjects[0].isSettings,
+  })
+}
+
 export type MockFunction<T extends (...args: never[]) => unknown> =
   jest.Mock<ReturnType<T>, Parameters<T>>
 


### PR DESCRIPTION
The new callback replaces onAdd/onUpdate/onRemove and can be called in a more general way
from the adapter.
This is part of changing the adapter interface to apply multiple changes in one transaction

---
_Release notes_
- None (refactor)