### PR TITLE
Netsuite: fetch objects type by type by default instead of as a bulk due to failures in real accounts

### DIFF
--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -28,7 +28,7 @@ const { makeArray } = collections.array
 
 // in small Netsuite accounts the concurrency limit per integration can be between 1-4
 export const DEFAULT_SDF_CONCURRENCY = 4
-export const DEFAULT_FETCH_ALL_TYPES_AT_ONCE = true
+export const DEFAULT_FETCH_ALL_TYPES_AT_ONCE = false
 
 const configID = new ElemID(NETSUITE)
 export const configType = new ObjectType({

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -25,7 +25,7 @@ import NetsuiteAdapter from '../src/adapter'
 import { customTypes, fileCabinetTypes, getAllTypes } from '../src/types'
 import {
   ENTITY_CUSTOM_FIELD, SCRIPT_ID, SAVED_SEARCH, FILE, FOLDER, PATH, TRANSACTION_FORM, TYPES_TO_SKIP,
-  FILE_PATHS_REGEX_SKIP_LIST,
+  FILE_PATHS_REGEX_SKIP_LIST, FETCH_ALL_TYPES_AT_ONCE,
 } from '../src/constants'
 import { createInstanceElement, getLookUpName, toCustomizationInfo } from '../src/transformer'
 import {
@@ -55,6 +55,7 @@ describe('Adapter', () => {
   const config = {
     [TYPES_TO_SKIP]: [SAVED_SEARCH, TRANSACTION_FORM],
     [FILE_PATHS_REGEX_SKIP_LIST]: [filePathRegexStr],
+    [FETCH_ALL_TYPES_AT_ONCE]: true,
   }
   const netsuiteAdapter = new NetsuiteAdapter({
     client,


### PR DESCRIPTION
Most of our tests on real NetSuite accounts has failed to import all objects in a single call. Instead of waisting 10 minutes until failing and then use the automatic fallback to type by type, it feels like it would be better to fetch type by type at first place.