### PR TITLE
SALTO-965, SALTO-969 - Check state path prefix correctly and properly upgrade from old state file

### DIFF
--- a/packages/core/src/local-workspace/state.ts
+++ b/packages/core/src/local-workspace/state.ts
@@ -90,7 +90,7 @@ export const localState = (filePrefix: string): state.State => {
     let currentFilePaths: string[] = []
     let versions: string[] = []
     await new Promise<void>(resolve => {
-      glob(`${currentFilePrefix}*${ZIPPED_STATE_EXTENSION}`, (_err: Error | null, files: string[]) => {
+      glob(`${currentFilePrefix}.*${ZIPPED_STATE_EXTENSION}`, (_err: Error | null, files: string[]) => {
         currentFilePaths = files
         resolve()
       })
@@ -157,7 +157,7 @@ export const localState = (filePrefix: string): state.State => {
       dirty = true
     },
     rename: async (newPrefix: string): Promise<void> => {
-      glob(`${currentFilePrefix}*${ZIPPED_STATE_EXTENSION}`, async (_err: Error | null, files: string[]) => {
+      glob(`${currentFilePrefix}.*${ZIPPED_STATE_EXTENSION}`, async (_err: Error | null, files: string[]) => {
         files.forEach(async filename => {
           const newFilePath = filename.replace(currentFilePrefix,
             path.join(path.dirname(currentFilePrefix), newPrefix))


### PR DESCRIPTION
- Change state file regexp to not include env prefix (unless they contain `.` 😞)
- In upgrade scenario, read the old state file and remove it on flush
- Fix missing `await` on state rename

---

Based on top of #1456 with a few more fixes
There can still be a bug if we have environment names with `.` but this quick fix should at least make things workable for now

_Release Notes_
- Fixed bug where old state files would not be upgraded properly
- Fixed bug loading state in multi-env workspace with similar environment names
- Fixed potential bug with rename on state file