### PR TITLE
SALTO-975 - Avoid validation error for array in non-list type and vice versa

### DIFF
--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -19,7 +19,7 @@ import {
   Element, isObjectType, isInstanceElement, TypeElement, InstanceElement, Field, PrimitiveTypes,
   isPrimitiveType, Value, ElemID, CORE_ANNOTATIONS, SaltoElementError, SaltoErrorSeverity,
   ReferenceExpression, Values, isElement, isListType, getRestriction, isVariable, Variable,
-  isReferenceExpression, StaticFile, isPrimitiveValue,
+  isReferenceExpression, StaticFile, isPrimitiveValue, ListType,
 } from '@salto-io/adapter-api'
 import { InvalidStaticFile } from './workspace/static_files/common'
 import { UnresolvedReference, resolve, CircularReference } from './expressions'
@@ -56,10 +56,10 @@ const primitiveValidators = {
 const validateAnnotations = (elemID: ElemID, value: Value, type: TypeElement):
 ValidationError[] => {
   if (isObjectType(type)) {
-    return _.flatten(Object.keys(type.fields).map(
+    return Object.keys(type.fields).flatMap(
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       k => validateFieldAnnotations(elemID.createNestedID(k), value[k], type.fields[k])
-    ))
+    )
   }
 
   return []
@@ -201,7 +201,7 @@ const validateAnnotationsValue = (
     ValidationError[] => {
     // When value is array we iterate (validate) each element
     if (_.isArray(val)) {
-      return _.flatten(val.map(v => validateRestrictionsValue(v)))
+      return val.flatMap(v => validateRestrictionsValue(v))
     }
 
     const validateValueInsideRange = (): ValidationError[] => {
@@ -247,7 +247,7 @@ const validateAnnotationsValue = (
       validateValueInList,
       validateRegexMatches,
     ]
-    return _.flatten(restrictionValidations.map(validation => validation()))
+    return restrictionValidations.flatMap(validation => validation())
   }
 
   const validateRequiredValue = (): ValidationError[] =>
@@ -270,6 +270,17 @@ const validateAnnotationsValue = (
   return undefined
 }
 
+type ItemWithNestedId<T> = {
+  value: T
+  nestedID: ElemID
+}
+const mapAsArrayWithIds = <T>(value: T | T[], elemID: ElemID): ItemWithNestedId<T>[] => {
+  if (Array.isArray(value)) {
+    return value.flatMap((val, i) => ({ value: val, nestedID: elemID.createNestedID(String(i)) }))
+  }
+  return [{ value, nestedID: elemID }]
+}
+
 /**
  * Validate that field values corresponding with core annotations (_required, _values, _restriction)
  * @param value- the field value
@@ -283,18 +294,11 @@ const validateFieldAnnotations = (
     return errors
   }
 
-  const fieldType = field.type
-  // Apply validateAnnotations for each element in our values list
-  if (isListType(fieldType)) {
-    return _.isArray(value)
-      ? _.flatten(value.map((v, i) => validateAnnotations(
-        elemID.createNestedID(String(i)),
-        v,
-        fieldType.innerType
-      ))) : []
-  }
-
-  return validateAnnotations(elemID, value, field.type)
+  return mapAsArrayWithIds(value, elemID).flatMap(item => validateAnnotations(
+    item.nestedID,
+    item.value,
+    isListType(field.type) ? field.type.innerType : field.type,
+  ))
 }
 
 export class InvalidValueTypeValidationError extends ValidationError {
@@ -326,8 +330,7 @@ const createReferenceValidationErrors = (elemID: ElemID, value: Value): Validati
   return []
 }
 
-const validateValue = (elemID: ElemID, value: Value,
-  type: TypeElement, isAnnotations = false): ValidationError[] => {
+const validateValue = (elemID: ElemID, value: Value, type: TypeElement): ValidationError[] => {
   if (isReferenceExpression(value)) {
     return isElement(value.value) ? [] : validateValue(elemID, value.value, type)
   }
@@ -345,15 +348,18 @@ const validateValue = (elemID: ElemID, value: Value,
     return []
   }
 
-  // NOTE: this area should be deleted as soon as
-  //  we complete the implementation of SALTO-228 (Support annotationTypes list)
-  if (isAnnotations && !isListType(type) && _.isArray(value)) {
-    return _.flatten(value.map((val: Value) => validateValue(elemID, val, type, isAnnotations)))
-  }
-
   if (isPrimitiveType(type)) {
-    if (!primitiveValidators[type.primitive](value)) {
-      return [new InvalidValueTypeValidationError({ elemID, value, type })]
+    const validatePrimitiveValue = (val: Value, eid: ElemID): InvalidValueTypeValidationError[] => (
+      !primitiveValidators[type.primitive](val)
+        ? [new InvalidValueTypeValidationError({ elemID: eid, value: val, type })]
+        : []
+    )
+
+    const primitiveValidationErrors = mapAsArrayWithIds(value, elemID).flatMap(
+      item => validatePrimitiveValue(item.value, item.nestedID)
+    )
+    if (primitiveValidationErrors.length > 0) {
+      return primitiveValidationErrors
     }
   }
 
@@ -368,71 +374,65 @@ const validateValue = (elemID: ElemID, value: Value,
 
   if (isObjectType(type)) {
     if (!_.isObjectLike(value)) {
-      // NOTE: this area should be deleted as soon as
-      //  we complete the implementation of SALTO-228 (Support annotationTypes list)
       return [new InvalidValueTypeValidationError({ elemID, value, type })]
     }
-    if (_.isArray(value)) {
-      return [new InvalidValueTypeValidationError({ elemID, value, type })]
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        // return an error if value is required
+        return validateAnnotationsValue(elemID, undefined, type.annotations, type) ?? []
+      }
+      return validateValue(elemID, value, new ListType(type))
     }
-    return _.flatten(Object.keys(value).filter(k => type.fields[k]).map(
+    return Object.keys(value).filter(k => type.fields[k]).flatMap(
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      k => validateFieldValue(elemID.createNestedID(k), value[k], type.fields[k], isAnnotations)
-    ))
+      k => validateFieldValue(elemID.createNestedID(k), value[k], type.fields[k])
+    )
   }
 
   if (isListType(type)) {
-    if (!_.isArray(value)) {
-      return [new InvalidValueTypeValidationError({ elemID, value, type })]
-    }
-    return _.flatten(
-      value.map((val: Value) => validateValue(elemID, val, type.innerType, isAnnotations))
-    )
+    return mapAsArrayWithIds(value, elemID).flatMap(item => validateValue(
+      item.nestedID,
+      item.value,
+      type.innerType,
+    ))
   }
 
   return validateAnnotationsValue(elemID, value, type.annotations, type) || []
 }
 
-const validateFieldValue = (elemID: ElemID, value: Value, field: Field, isAnnotations: boolean):
-  ValidationError[] => {
-  const fieldType = field.type
-  if (isListType(fieldType)) {
-    // NOTE: the second part of the condition should be deleted as soon as
-    //  we complete the implementation of SALTO-228 (Support annotationTypes list)
-    if (!_.isArray(value) && !isAnnotations) {
-      return [new InvalidValueValidationError({ elemID, value, fieldName: field.name, expectedValue: 'a list' })]
-    }
-    return _.flatten(
-      makeArray(value).map((v, i) =>
-        validateValue(elemID.createNestedID(String(i)), v, fieldType.innerType, isAnnotations))
-    )
+const validateFieldValue = (elemID: ElemID, value: Value, field: Field): ValidationError[] => {
+  if (!isListType(field.type) && Array.isArray(value) && value.length === 0) {
+    // return an error if value is required
+    return validateAnnotationsValue(elemID, undefined, field.annotations, field.type) ?? []
   }
-  return validateValue(elemID, value, field.type, isAnnotations)
+  return mapAsArrayWithIds(value, elemID).flatMap(item => validateValue(
+    item.nestedID,
+    item.value,
+    isListType(field.type) ? field.type.innerType : field.type,
+  ))
 }
 
 const validateField = (field: Field): ValidationError[] =>
-  _.flatten(Object.keys(field.annotations)
+  Object.keys(field.annotations)
     .filter(k => field.type.annotationTypes[k])
-    .map(k => validateValue(
+    .flatMap(k => validateValue(
       field.elemID.createNestedID(k),
       field.annotations[k],
       field.type.annotationTypes[k],
-      true
-    )))
+    ))
 
 const validateType = (element: TypeElement): ValidationError[] => {
-  const errors = _.flatten(Object.keys(element.annotations)
-    .filter(k => element.annotationTypes[k]).map(
+  const errors = Object.keys(element.annotations)
+    .filter(k => element.annotationTypes[k]).flatMap(
       k => validateValue(
         element.elemID.createNestedID('attr', k),
         element.annotations[k],
         element.annotationTypes[k],
-        true
       )
-    ))
+    )
 
   if (isObjectType(element)) {
-    return [...errors, ..._.flatten(Object.values(element.fields).map(validateField))]
+    return [...errors, ...Object.values(element.fields).flatMap(validateField)]
   }
   return errors
 }
@@ -443,7 +443,7 @@ const instanceElementValidators = [
 ]
 
 const validateInstanceElements = (element: InstanceElement): ValidationError[] =>
-  _.flatten(instanceElementValidators.map(v => v(element.elemID, element.value, element.type)))
+  instanceElementValidators.flatMap(v => v(element.elemID, element.value, element.type))
 
 const validateVariableValue = (elemID: ElemID, value: Value): ValidationError[] => {
   if (isReferenceExpression(value)) {

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -52,7 +52,6 @@ describe('Elements validation', () => {
       annostr: 'str',
     },
   })
-
   const restrictedType = new PrimitiveType({
     elemID: new ElemID('salto', 'simple', 'type', 'restrictedType'),
     primitive: PrimitiveTypes.STRING,
@@ -123,6 +122,7 @@ describe('Elements validation', () => {
       flatbool: { type: BuiltinTypes.BOOLEAN },
       list: { type: new ListType(BuiltinTypes.STRING) },
       listOfList: { type: new ListType(new ListType(BuiltinTypes.STRING)) },
+      listOfListOfList: { type: new ListType(new ListType(new ListType(BuiltinTypes.STRING))) },
       listOfObject: { type: new ListType(simpleType) },
       reqStr: { type: BuiltinTypes.STRING },
       restrictStr: {
@@ -753,11 +753,17 @@ describe('Elements validation', () => {
         expect(errors[0].message).toMatch(new RegExp('Invalid value type for string$'))
       })
 
-      it('should return error on bad str primitive type with list', () => {
+      it('should not return error on str primitive type with list', () => {
         extInst.value.flatstr = ['str1', 'str2']
         const errors = validateElements([extInst])
+        expect(errors).toHaveLength(0)
+      })
+
+      it('should return error on str primitive type with invalid list', () => {
+        extInst.value.flatstr = ['str1', 57]
+        const errors = validateElements([extInst])
         expect(errors).toHaveLength(1)
-        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('flatstr'))
+        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('flatstr', '1'))
         expect(errors[0].message).toMatch(new RegExp('Invalid value type for string$'))
       })
 
@@ -814,21 +820,60 @@ describe('Elements validation', () => {
         expect(errors[1].elemID).toEqual(extInst.elemID.createNestedID('nested', 'bool'))
       })
 
-      it('should return error list/primitive mismatch', () => {
+      it('should not return error on list/primitive mismatch if inner type is valid', () => {
         extInst.value.list = 'not a list'
+        const errors = validateElements([extInst])
+        expect(errors).toHaveLength(0)
+      })
+
+      it('should return error on list/primitive mismatch if inner type is invalid', () => {
+        extInst.value.list = 75
         const errors = validateElements([extInst])
         expect(errors).toHaveLength(1)
         expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('list'))
       })
 
-      it('should return error list/object mismatch', () => {
+      it('should not return error for list/object mismatch with empty array', () => {
         extInst.value = { nested: [] }
         const errors = validateElements([extInst])
-        expect(errors).toHaveLength(2)
-        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('nested'))
-        // TODO: The second error is a stange UX and we should not have it
-        expect(errors[1].elemID).toEqual(extInst.elemID.createNestedID('nested', 'bool'))
+        expect(errors).toHaveLength(0)
       })
+
+      it('should return error for list/object mismatch with empty array on required field', () => {
+        const nestedRequiredType = nestedType.clone()
+        nestedRequiredType.fields.nested.annotations[CORE_ANNOTATIONS.REQUIRED] = true
+        extInst.type = nestedRequiredType
+        extInst.value = { nested: [] }
+        const errors = validateElements([extInst])
+        expect(errors).toHaveLength(1)
+        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('nested'))
+        expect(errors[0].error).toMatch('is required but has no value')
+      })
+
+      it('should return error for list/object mismatch with empty array on required field-object', () => {
+        const requiredType = nestedType.clone()
+        requiredType.annotations[CORE_ANNOTATIONS.REQUIRED] = true
+        extInst.type = requiredType
+        extInst.value = []
+        const errors = validateElements([extInst])
+        expect(errors).toHaveLength(1)
+        expect(errors[0].elemID).toEqual(extInst.elemID)
+        expect(errors[0].toString()).toMatch('is required but has no value')
+      })
+
+      it('should return inner error for list/object mismatch with non-empty invalid array', () => {
+        extInst.value = { nested: [{ bool: true }, { str: 'str' }] }
+        const errors = validateElements([extInst])
+        expect(errors).toHaveLength(1)
+        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('nested', '1', 'bool'))
+      })
+
+      it('should not return error list/object mismatch with non-empty valid array', () => {
+        extInst.value = { nested: [{ bool: true }] }
+        const errors = validateElements([extInst])
+        expect(errors).toHaveLength(0)
+      })
+
 
       it('should not return an error when matching list item', () => {
         extInst.value.list.push('abc')
@@ -840,7 +885,7 @@ describe('Elements validation', () => {
         extInst.value.listOfList[0].push(1)
         const errors = validateElements([extInst])
         expect(errors).toHaveLength(1)
-        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('listOfList', '0'))
+        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('listOfList', '0', '2'))
       })
 
       it('should not return an error when matching list object item', () => {
@@ -853,22 +898,43 @@ describe('Elements validation', () => {
         expect(errors).toHaveLength(0)
       })
 
-      it('should return error when not a list in list of lists', () => {
-        extInst.value.listOfList = [1]
+      it('should not return error when inner is not a list in list of lists', () => {
+        extInst.value.listOfList = ['a']
         const errors = validateElements([extInst])
-        expect(errors).toHaveLength(1)
-        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('listOfList', '0'))
+        expect(errors).toHaveLength(0)
       })
 
-      it('should return error when item instead of list', () => {
+      it('should not return error when not a list in list of lists', () => {
+        extInst.value.listOfList = 'a'
+        const errors = validateElements([extInst])
+        expect(errors).toHaveLength(0)
+      })
+
+      it('should not return error when not a list in list-of-lists-of-lists', () => {
+        extInst.value.listOfListOfList = 'a'
+        const errors = validateElements([extInst])
+        expect(errors).toHaveLength(0)
+      })
+
+      it('should not return error when item instead of list if item is of inner type', () => {
         extInst.value.listOfObject = {
           str: 'str',
           num: 3,
           bool: false,
         }
         const errors = validateElements([extInst])
+        expect(errors).toHaveLength(0)
+      })
+
+      it('should return error when item instead of list if item is of incorrect type', () => {
+        extInst.value.listOfObject = {
+          str: 'str',
+          num: 'str',
+          bool: false,
+        }
+        const errors = validateElements([extInst])
         expect(errors).toHaveLength(1)
-        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('listOfObject'))
+        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('listOfObject', 'num'))
       })
 
       it('should return an error when not matching list object item (missing req)', () => {

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -874,6 +874,18 @@ describe('Elements validation', () => {
         expect(errors).toHaveLength(0)
       })
 
+      it('should not return error list/object mismatch with non-empty array with reference expressions', () => {
+        extInst.value = {
+          flatnum: 32,
+          nested: [{
+            bool: true,
+            num: new ReferenceExpression(extInst.elemID.createNestedID('flatnum')),
+          }],
+        }
+        const errors = validateElements([extInst])
+        expect(errors).toHaveLength(0)
+      })
+
 
       it('should not return an error when matching list item', () => {
         extInst.value.list.push('abc')


### PR DESCRIPTION
In multienv we can get validation errors if an element in one of the environments has an array value, and the type is not from the known list types (the full scenario is described in the ticket).
This is one solution with some limitations - other alternatives are listed on the ticket.