### PR TITLE
SALTO-977 Fix filename suffix truncate

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -42,7 +42,7 @@ const filterByFile = (
   id => !_.isEmpty((fileElements).filter(e => resolvePath(e, id) !== undefined))
 )
 
-const toPath = (filename: string): string[] => {
+const toPathHint = (filename: string): string[] => {
   const parsedPath = path.parse(filename)
   const dirPath = _.isEmpty(parsedPath.dir) ? [] : parsedPath.dir.split(path.sep)
   return [...dirPath, parsedPath.name]
@@ -60,7 +60,7 @@ const separateChangeByFiles = async (
         change,
         changeData => filterByFile(change.id, changeData, fileElements),
       )
-      return { ...filteredChange, path: toPath(filename) }
+      return { ...filteredChange, path: toPathHint(filename) }
     })
 )
 

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -42,6 +42,12 @@ const filterByFile = (
   id => !_.isEmpty((fileElements).filter(e => resolvePath(e, id) !== undefined))
 )
 
+const toPath = (filename: string): string[] => {
+  const parsedPath = path.parse(filename)
+  const dirPath = _.isEmpty(parsedPath.dir) ? [] : parsedPath.dir.split(path.sep)
+  return [...dirPath, parsedPath.name]
+}
+
 const separateChangeByFiles = async (
   change: DetailedChange,
   source: NaclFilesSource
@@ -49,16 +55,12 @@ const separateChangeByFiles = async (
   (await source.getSourceRanges(change.id))
     .map(range => range.filename)
     .map(async filename => {
-      const parsedPath = path.parse(filename)
-      const pathHint = (parsedPath.dir
-        ? [...parsedPath.dir.split(path.sep), parsedPath.name]
-        : [parsedPath.name])
       const fileElements = await source.getElements(filename)
       const filteredChange = applyFunctionToChangeData(
         change,
         changeData => filterByFile(change.id, changeData, fileElements),
       )
-      return { ...filteredChange, path: pathHint }
+      return { ...filteredChange, path: toPath(filename) }
     })
 )
 

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -49,7 +49,10 @@ const separateChangeByFiles = async (
   (await source.getSourceRanges(change.id))
     .map(range => range.filename)
     .map(async filename => {
-      const pathHint = _.trimEnd(filename, FILE_EXTENSION).split(path.sep)
+      const parsedPath = path.parse(filename)
+      const pathHint = (parsedPath.dir
+        ? [...parsedPath.dir.split(path.sep), parsedPath.name]
+        : [parsedPath.name])
       const fileElements = await source.getElements(filename)
       const filteredChange = applyFunctionToChangeData(
         change,


### PR DESCRIPTION
`_.trimEnd` truncates a list of characters, not a substring - so filenames ending with n/a/c/l would get their last characters truncated (`salesforce/Types/Skill.nacl` becomes `salesforce/Types/Ski.nacl`).