### PR TITLE
SALTO-984: Fix field type validator false positive on formula fields

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
@@ -17,12 +17,11 @@ import {
   ChangeError, Field, getChangeElement, isAdditionOrModificationChange,
   ChangeValidator, Change, isAdditionChange, isFieldChange,
 } from '@salto-io/adapter-api'
-import { CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES, FIELD_TYPE_NAMES, COMPOUND_FIELD_TYPE_NAMES } from '../constants'
-import { isFieldOfCustomObject } from '../transformers/transformer'
+import { CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES } from '../constants'
+import { isFieldOfCustomObject, toCustomField } from '../transformers/transformer'
 
 const isInvalidTypeChange = (change: Change<Field>): boolean => {
-  const afterFieldType = getChangeElement(change).type.elemID.typeName as
-  FIELD_TYPE_NAMES | COMPOUND_FIELD_TYPE_NAMES
+  const afterFieldType = toCustomField(getChangeElement(change)).type
   const isAfterTypeAllowed = CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES.includes(afterFieldType)
   if (isAfterTypeAllowed) {
     return false
@@ -36,7 +35,7 @@ const isInvalidTypeChange = (change: Change<Field>): boolean => {
 
 const createChangeError = (field: Field): ChangeError => ({
   elemID: field.elemID,
-  severity: 'Error',
+  severity: 'Warning',
   message: `You cannot create or modify a custom field type to ${field.type.elemID.typeName}. Field: ${field.name}`,
   detailedMessage: `You cannot create or modify a custom field type to ${field.type.elemID.typeName}. Valid types can be found at:\nhttps://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_field_types.htm#meta_type_fieldtype`,
 })

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -50,18 +50,14 @@ export enum FIELD_TYPE_NAMES {
   LOOKUP = 'Lookup',
   MASTER_DETAIL = 'MasterDetail',
   ROLLUP_SUMMARY = 'Summary',
-  // internal-only placeholder for fields whose type is unknown
-  UNKNOWN = 'Unknown',
-  ANYTYPE = 'AnyType'
 }
-export const FIELD_TYPE_NAME_VALUES = [FIELD_TYPE_NAMES.AUTONUMBER, FIELD_TYPE_NAMES.TEXT,
-  FIELD_TYPE_NAMES.NUMBER, FIELD_TYPE_NAMES.PERCENT, FIELD_TYPE_NAMES.CHECKBOX,
-  FIELD_TYPE_NAMES.DATE, FIELD_TYPE_NAMES.TIME, FIELD_TYPE_NAMES.DATETIME,
-  FIELD_TYPE_NAMES.CURRENCY, FIELD_TYPE_NAMES.PICKLIST, FIELD_TYPE_NAMES.MULTIPICKLIST,
-  FIELD_TYPE_NAMES.EMAIL, FIELD_TYPE_NAMES.PHONE, FIELD_TYPE_NAMES.LONGTEXTAREA,
-  FIELD_TYPE_NAMES.RICHTEXTAREA, FIELD_TYPE_NAMES.TEXTAREA, FIELD_TYPE_NAMES.ENCRYPTEDTEXT,
-  FIELD_TYPE_NAMES.URL, FIELD_TYPE_NAMES.LOOKUP, FIELD_TYPE_NAMES.MASTER_DETAIL,
-  FIELD_TYPE_NAMES.ROLLUP_SUMMARY, FIELD_TYPE_NAMES.UNKNOWN]
+
+export enum INTERNAL_FIELD_TYPE_NAMES {
+  UNKNOWN = 'Unknown', // internal-only placeholder for fields whose type is unknown
+  ANY = 'AnyType',
+}
+
+export type ALL_FIELD_TYPE_NAMES = FIELD_TYPE_NAMES | INTERNAL_FIELD_TYPE_NAMES
 
 export enum COMPOUND_FIELD_TYPE_NAMES {
   ADDRESS = 'Address',
@@ -78,14 +74,20 @@ export const COMPOUND_FIELDS_SOAP_TYPE_NAMES:
 
 // target types for creating / updating custom fields:
 export const CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES = [
-  // other valid field types that we do not currently support are:
-  // MetadataRelationship, ExternalLookup, IndirectLookup, Hierarchy, File
-  ...(FIELD_TYPE_NAME_VALUES.filter(type => type !== FIELD_TYPE_NAMES.UNKNOWN)),
-  COMPOUND_FIELD_TYPE_NAMES.LOCATION]
+  ...Object.values(FIELD_TYPE_NAMES),
+  COMPOUND_FIELD_TYPE_NAMES.LOCATION,
+  // The following types are valid according to the documentation
+  // TODO - support these field types
+  'MetadataRelationship',
+  'ExternalLookup',
+  'IndirectLookup',
+  'Hierarchy',
+  'File',
+]
 
 export const FIELD_SOAP_TYPE_NAMES:
-Record<string, FIELD_TYPE_NAMES> = {
-  anyType: FIELD_TYPE_NAMES.ANYTYPE,
+Record<string, ALL_FIELD_TYPE_NAMES> = {
+  anyType: INTERNAL_FIELD_TYPE_NAMES.ANY,
   base64: FIELD_TYPE_NAMES.TEXT, // TODO: define specific type
   boolean: FIELD_TYPE_NAMES.CHECKBOX,
   combobox: FIELD_TYPE_NAMES.PICKLIST,

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -37,7 +37,7 @@ import {
   WORKFLOW_METADATA_TYPE, QUICK_ACTION_METADATA_TYPE, CUSTOM_TAB_METADATA_TYPE,
   DUPLICATE_RULE_METADATA_TYPE, CUSTOM_OBJECT_TRANSLATION_METADATA_TYPE, SHARING_RULES_TYPE,
   VALIDATION_RULES_METADATA_TYPE, BUSINESS_PROCESS_METADATA_TYPE, RECORD_TYPE_METADATA_TYPE,
-  WEBLINK_METADATA_TYPE,
+  WEBLINK_METADATA_TYPE, INTERNAL_FIELD_TYPE_NAMES,
 } from '../constants'
 import { FilterCreator } from '../filter'
 import {
@@ -260,7 +260,7 @@ const createFieldFromMetadataInstance = (
 ): Field => {
   let fieldValues = field
   if (!fieldValues[INSTANCE_TYPE_FIELD]) {
-    fieldValues = { [INSTANCE_TYPE_FIELD]: FIELD_TYPE_NAMES.UNKNOWN, ...fieldValues }
+    fieldValues = { [INSTANCE_TYPE_FIELD]: INTERNAL_FIELD_TYPE_NAMES.UNKNOWN, ...fieldValues }
   }
   const annotations = transformFieldAnnotations(
     fieldValues,

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -29,7 +29,7 @@ import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
 import { naclCase, TransformFunc, transformElement } from '@salto-io/adapter-utils'
 import { CustomObject, CustomField, SalesforceRecord } from '../client/types'
 import {
-  API_NAME, CUSTOM_OBJECT, LABEL, SALESFORCE, FORMULA, FIELD_TYPE_NAMES,
+  API_NAME, CUSTOM_OBJECT, LABEL, SALESFORCE, FORMULA, FIELD_TYPE_NAMES, ALL_FIELD_TYPE_NAMES,
   METADATA_TYPE, FIELD_ANNOTATIONS, SALESFORCE_CUSTOM_SUFFIX, DEFAULT_VALUE_FORMULA,
   LOOKUP_FILTER_FIELDS, ADDRESS_FIELDS, NAME_FIELDS, GEOLOCATION_FIELDS, INSTANCE_FULL_NAME_FIELD,
   FIELD_DEPENDENCY_FIELDS, VALUE_SETTINGS_FIELDS, FILTER_ITEM_FIELDS, DESCRIPTION,
@@ -40,7 +40,7 @@ import {
   RECORDS_PATH, SETTINGS_PATH, TYPES_PATH, SUBTYPES_PATH, INSTALLED_PACKAGES_PATH,
   VALUE_SET_DEFINITION_FIELDS, CUSTOM_FIELD,
   COMPOUND_FIELDS_SOAP_TYPE_NAMES, CUSTOM_OBJECT_ID_FIELD, FOREIGN_KEY_DOMAIN,
-  XML_ATTRIBUTE_PREFIX, INTERNAL_ID_FIELD,
+  XML_ATTRIBUTE_PREFIX, INTERNAL_ID_FIELD, INTERNAL_FIELD_TYPE_NAMES,
 } from '../constants'
 import SalesforceClient from '../client/client'
 import { allMissingSubTypes } from './salesforce_types'
@@ -348,7 +348,7 @@ export class Types {
   }
 
   // Type mapping for custom objects
-  public static primitiveDataTypes: Record<FIELD_TYPE_NAMES, PrimitiveType> = {
+  public static primitiveDataTypes: Record<ALL_FIELD_TYPE_NAMES, PrimitiveType> = {
     Text: new PrimitiveType({
       elemID: new ElemID(SALESFORCE, FIELD_TYPE_NAMES.TEXT),
       primitive: PrimitiveTypes.STRING,
@@ -560,14 +560,14 @@ export class Types {
       },
     }),
     Unknown: new PrimitiveType({
-      elemID: new ElemID(SALESFORCE, FIELD_TYPE_NAMES.UNKNOWN),
+      elemID: new ElemID(SALESFORCE, INTERNAL_FIELD_TYPE_NAMES.UNKNOWN),
       primitive: PrimitiveTypes.STRING,
       annotationTypes: {
         ...Types.commonAnnotationTypes,
       },
     }),
     AnyType: new PrimitiveType({
-      elemID: new ElemID(SALESFORCE, FIELD_TYPE_NAMES.ANYTYPE),
+      elemID: new ElemID(SALESFORCE, INTERNAL_FIELD_TYPE_NAMES.ANY),
       primitive: PrimitiveTypes.UNKNOWN,
       annotationTypes: {
         ...Types.commonAnnotationTypes,

--- a/packages/salesforce-adapter/test/change_validators/custom_field_type.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/custom_field_type.test.ts
@@ -42,7 +42,7 @@ describe('custom field type change validator', () => {
       expect(changeErrors).toHaveLength(1)
       const [changeError] = changeErrors
       expect(changeError.elemID).toEqual(beforeField.elemID)
-      expect(changeError.severity).toEqual('Error')
+      expect(changeError.severity).toEqual('Warning')
     })
 
     it('should have error for field creation with invalid field type', async () => {
@@ -51,7 +51,7 @@ describe('custom field type change validator', () => {
       expect(changeErrors).toHaveLength(1)
       const [changeError] = changeErrors
       expect(changeError.elemID).toEqual(field.elemID)
-      expect(changeError.severity).toEqual('Error')
+      expect(changeError.severity).toEqual('Warning')
     })
 
     it('should have no error when changing a field but not its type', async () => {
@@ -64,7 +64,14 @@ describe('custom field type change validator', () => {
 
     it('should have no error when changing a field type to a valid type', async () => {
       const beforeField = createField(customObj, Types.primitiveDataTypes.Text, 'Something')
-      const afterField = createField(customObj, Types.primitiveDataTypes.Time, 'Somthing')
+      const afterField = createField(customObj, Types.primitiveDataTypes.Time, 'Something')
+      const changeErrors = await runChangeValidator(beforeField, afterField)
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('should have no error when changing a field type to a valid formula type', async () => {
+      const beforeField = createField(customObj, Types.primitiveDataTypes.Number, 'Something')
+      const afterField = createField(customObj, Types.formulaDataTypes.FormulaNumber, 'Something')
       const changeErrors = await runChangeValidator(beforeField, afterField)
       expect(changeErrors).toHaveLength(0)
     })


### PR DESCRIPTION
- fixed bug where field type change validator did not allow formula fields
- reduced validation severity to warning until we better understand the side effects of
  removing field changes from a plan