### PR TITLE
SALTO-983: Fix reference dependency of types to not include all references from fields

### DIFF
--- a/packages/salesforce-adapter/test/filters/profile_permissions.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_permissions.test.ts
@@ -172,7 +172,6 @@ describe('Object Permissions filter', () => {
     after.fields[descriptionFieldName].type = Types.primitiveDataTypes.MasterDetail
 
     await filter().onDeploy([toChange({ before, after })])
-    // TODO:ORI - make the same change in other filters / tests
     expect(mockUpdate).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
In the diff graph object types are separate from their fields and therefore
the dependencies of the object type node should not include the references from the fields
they should only include references from the type annotations

also, self references should not be added, no matter where they come from