### PR TITLE
SALTO-938 - [continued but still not complete] Extract SBQQ__Code__c in CustomScript to static file

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -321,3 +321,4 @@ export const CPQ_CONSUMPTION_SCHEDULE_FIELDS = 'SBQQ__ConsumptionScheduleFields_
 export const CPQ_GROUP_FIELDS = 'SBQQ__GroupFields__c'
 export const CPQ_QUOTE_FIELDS = 'SBQQ__QuoteFields__c'
 export const CPQ_QUOTE_LINE_FIELDS = 'SBQQ__QuoteLineFields__c'
+export const CPQ_CODE_FIELD = 'SBQQ__Code__c'


### PR DESCRIPTION
**What's here?**

Extract the value of `SBQQ__Code__c` to a `.js` file. Handle sending it to SF as string using the `preDeploy`/`onDeploy` filter until SALTO-881 is done and the general case of string valued files and encoding in static files is handled