### PR TITLE
Reverse preDeploy & resolve and onDeploy & restore order + Change current filters accordingly

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -477,23 +477,33 @@ export default class SalesforceAdapter implements AdapterOperations {
       }
       return { action: 'modify', data: getBeforeAndAfterElements() }
     }
-    await this.filtersRunner.preDeploy(changeGroup.changes)
-    const resolvedChanges = changeGroup.changes
-      .map(change => resolveChangeElement(change, getLookUpName))
-    const resolvedChangeGroup = { groupID: changeGroup.groupID, changes: resolvedChanges }
-    const resolvedByElem = groupChangesByTopLevelName(resolvedChanges)
+    const topLevelNameToChanges = groupChangesByTopLevelName(changeGroup.changes)
+    const topLevelNameToResolvedMainChange = _.mapValues(
+      topLevelNameToChanges,
+      changes => {
+        const mainElemChange = getMainElemChange(changes)
+        return resolveChangeElement(mainElemChange, getLookUpName)
+      },
+    )
+    const mainElemChanges = Object.values(topLevelNameToResolvedMainChange)
+    await this.filtersRunner.preDeploy(mainElemChanges)
+    const mainElemChangesGroup = { groupID: changeGroup.groupID, changes: mainElemChanges }
     let results: DeployResult[]
-    if (isCustomObjectInstancesGroup(resolvedChangeGroup)) {
+    if (isCustomObjectInstancesGroup(mainElemChangesGroup)) {
       results = [await deployCustomObjectInstancesGroup(
-        resolvedChangeGroup,
+        mainElemChangesGroup,
         this.client,
         this.userConfig.dataManagement,
       )]
     } else {
       results = await Promise.all(
-        Object.values(resolvedByElem)
-          .map(elemChanges =>
-            this.deployElementChanges(elemChanges, getMainElemChange(elemChanges)))
+        Object.keys(topLevelNameToResolvedMainChange).map(
+          topLevelName =>
+            this.deployElementChanges(
+              topLevelNameToChanges[topLevelName],
+              topLevelNameToResolvedMainChange[topLevelName],
+            )
+        )
       )
     }
     const changesByElem = groupChangesByTopLevelName(changeGroup.changes)

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -501,9 +501,10 @@ export default class SalesforceAdapter implements AdapterOperations {
       Object.values(changesByElem).map(change => getChangeElement(getMainElemChange(change))),
       changeElement => changeElement.elemID.getFullName(),
     )
-    const appliedChanges = _.flatten(results.map(res => res.appliedChanges))
+    const appliedChangesBeforeRestore = results.flatMap(res => res.appliedChanges)
+    await this.filtersRunner.onDeploy(appliedChangesBeforeRestore)
+    const appliedChanges = appliedChangesBeforeRestore
       .map(change => restoreChangeElement(change, sourceElements, getLookUpName))
-    await this.filtersRunner.onDeploy(appliedChanges)
     return {
       appliedChanges,
       errors: _.flatten(results.map(res => res.errors)),

--- a/packages/salesforce-adapter/test/filters/cpq/custom_script.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/custom_script.test.ts
@@ -80,7 +80,7 @@ describe('cpq custom script filter', () => {
     [CPQ_GROUP_FIELDS]: null,
     [CPQ_CODE_FIELD]: new StaticFile({
       content: Buffer.from('if (this === "code") return true'),
-      filepath: mockCustomScripInstancePath.join('/'),
+      filepath: `${mockCustomScripInstancePath.join('/')}.js`,
     }),
     randomField: 'stayLikeThis',
   }
@@ -156,7 +156,7 @@ describe('cpq custom script filter', () => {
           .toEqual(new ListType(Types.primitiveDataTypes.Text))
       })
 
-      it('Should only change values of multi-line string in fieldsRefList to array of strings and code to static file', () => {
+      it('Should only change values of multi-line string in fieldsRefList to array of strings', () => {
         const customScriptInstanceAdd = changes
           .find(change =>
             getChangeElement(change).elemID.isEqual(mockCustomScriptInstance.elemID)
@@ -167,8 +167,8 @@ describe('cpq custom script filter', () => {
         ) as InstanceElement
         expect(changeElement.value[CPQ_CONSUMPTION_RATE_FIELDS])
           .toEqual(afterOnFetchCustomScriptValues[CPQ_CONSUMPTION_RATE_FIELDS])
-        expect(changeElement.value[CPQ_CODE_FIELD])
-          .toEqual(afterOnFetchCustomScriptValues[CPQ_CODE_FIELD])
+        expect(fromServiceCustomScriptValues[CPQ_CODE_FIELD])
+          .toEqual(fromServiceCustomScriptValues[CPQ_CODE_FIELD])
         expect(changeElement.value[CPQ_GROUP_FIELDS])
           .toEqual(fromServiceCustomScriptValues[CPQ_GROUP_FIELDS])
         expect(changeElement.value.randomField)
@@ -211,7 +211,7 @@ describe('cpq custom script filter', () => {
           .toEqual(new ListType(Types.primitiveDataTypes.Text))
       })
 
-      it('Should only change values of multi-line string in fieldsRefList to array of strings and code to static file', () => {
+      it('Should only change values of multi-line string in fieldsRefList to array of strings', () => {
         const customScriptInstanceModify = changes
           .find(change =>
             getChangeElement(change).elemID.isEqual(mockCustomScriptInstance.elemID)
@@ -223,7 +223,7 @@ describe('cpq custom script filter', () => {
         expect(changeElement.value[CPQ_CONSUMPTION_RATE_FIELDS])
           .toEqual(afterOnFetchCustomScriptValues[CPQ_CONSUMPTION_RATE_FIELDS])
         expect(changeElement.value[CPQ_CODE_FIELD])
-          .toEqual(afterOnFetchCustomScriptValues[CPQ_CODE_FIELD])
+          .toEqual(fromServiceCustomScriptValues[CPQ_CODE_FIELD])
         expect(changeElement.value[CPQ_GROUP_FIELDS])
           .toEqual(fromServiceCustomScriptValues[CPQ_GROUP_FIELDS])
         expect(changeElement.value.randomField)
@@ -239,12 +239,16 @@ describe('cpq custom script filter', () => {
       .fields[CPQ_CONSUMPTION_RATE_FIELDS].type = new ListType(Types.primitiveDataTypes.Text)
     mockAfterOnFetchCustomScriptObject
       .fields[CPQ_GROUP_FIELDS].type = new ListType(Types.primitiveDataTypes.Text)
+    const mockAfterRestoreCustomScriptInstance = mockAfterOnFetchCustomScriptInstance
+      .clone()
+    mockAfterRestoreCustomScriptInstance
+      .value[CPQ_CODE_FIELD] = mockAfterRestoreCustomScriptInstance.value[CPQ_CODE_FIELD].content
     describe('Modification changes', () => {
       beforeAll(async () => {
         changes = [
           toChange({
-            before: mockAfterOnFetchCustomScriptInstance.clone(),
-            after: mockAfterOnFetchCustomScriptInstance.clone(),
+            before: mockAfterRestoreCustomScriptInstance.clone(),
+            after: mockAfterRestoreCustomScriptInstance.clone(),
           }),
           toChange({
             before: mockAfterOnFetchCustomScriptObject.clone(),
@@ -304,7 +308,7 @@ describe('cpq custom script filter', () => {
     describe('Addition changes', () => {
       beforeAll(async () => {
         changes = [
-          toChange({ after: mockAfterOnFetchCustomScriptInstance.clone() }),
+          toChange({ after: mockAfterRestoreCustomScriptInstance.clone() }),
           toChange({ after: mockAfterOnFetchCustomScriptObject.clone() }),
         ]
         await filter.preDeploy(changes)

--- a/packages/salesforce-adapter/test/filters/cpq/custom_script.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/custom_script.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ObjectType, ElemID, Element, InstanceElement, ListType, ChangeDataType, Change, toChange, getChangeElement, isModificationChange, isAdditionChange, isFieldChange, Field, ModificationChange, isObjectTypeChange, AdditionChange, StaticFile } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, Element, InstanceElement, ListType, ChangeDataType, Change, toChange, getChangeElement, isModificationChange, isAdditionChange, ModificationChange, isObjectTypeChange, AdditionChange, StaticFile } from '@salto-io/adapter-api'
 import { FilterWith } from '../../../src/filter'
 import { fullApiName } from '../../../src/filters/utils'
 import SalesforceClient from '../../../src/client/client'
@@ -247,26 +247,31 @@ describe('cpq custom script filter', () => {
             after: mockAfterOnFetchCustomScriptInstance.clone(),
           }),
           toChange({
-            before: mockAfterOnFetchCustomScriptObject.fields[CPQ_CONSUMPTION_RATE_FIELDS].clone(),
-            after: mockAfterOnFetchCustomScriptObject.fields[CPQ_CONSUMPTION_RATE_FIELDS].clone(),
+            before: mockAfterOnFetchCustomScriptObject.clone(),
+            after: mockAfterOnFetchCustomScriptObject.clone(),
           }),
         ]
         await filter.preDeploy(changes)
       })
 
       it('Should change fieldsRefList fields type to long text on modification change', () => {
-        const cosRateFieldModifChange = changes
+        const cpqCustomScriptObjModificationChange = changes
           .find(change =>
-            (isModificationChange(change) && isFieldChange(change)
-              && getChangeElement(change).elemID
-                .isEqual(mockCustomScriptObject.fields[CPQ_CONSUMPTION_RATE_FIELDS].elemID)))
-        expect(cosRateFieldModifChange).toBeDefined()
-        expect(
-          ((cosRateFieldModifChange as ModificationChange<Field>).data.after).type
-        ).toEqual(Types.primitiveDataTypes.LongTextArea)
-        expect(
-          ((cosRateFieldModifChange as ModificationChange<Field>).data.before).type
-        ).toEqual(Types.primitiveDataTypes.LongTextArea)
+            (isModificationChange(change) && isObjectTypeChange(change)
+              && getChangeElement(change).elemID.isEqual(mockCustomScriptObject.elemID)))
+        expect(cpqCustomScriptObjModificationChange).toBeDefined()
+        const afterData = (cpqCustomScriptObjModificationChange as ModificationChange<ObjectType>)
+          .data.after
+        expect(afterData.fields[CPQ_CONSUMPTION_RATE_FIELDS].type)
+          .toEqual(Types.primitiveDataTypes.LongTextArea)
+        expect(afterData.fields[CPQ_GROUP_FIELDS].type)
+          .toEqual(Types.primitiveDataTypes.LongTextArea)
+        const beforeData = (cpqCustomScriptObjModificationChange as ModificationChange<ObjectType>)
+          .data.before
+        expect(beforeData.fields[CPQ_CONSUMPTION_RATE_FIELDS].type)
+          .toEqual(Types.primitiveDataTypes.LongTextArea)
+        expect(beforeData.fields[CPQ_GROUP_FIELDS].type)
+          .toEqual(Types.primitiveDataTypes.LongTextArea)
       })
 
       it('Should only change values of multi-line string in fieldsRefList and code back to string', () => {
@@ -299,30 +304,22 @@ describe('cpq custom script filter', () => {
     describe('Addition changes', () => {
       beforeAll(async () => {
         changes = [
-          toChange({
-            before: mockAfterOnFetchCustomScriptInstance.clone(),
-            after: mockAfterOnFetchCustomScriptInstance.clone(),
-          }),
           toChange({ after: mockAfterOnFetchCustomScriptInstance.clone() }),
-          toChange({
-            before: mockAfterOnFetchCustomScriptObject.fields[CPQ_CONSUMPTION_RATE_FIELDS].clone(),
-            after: mockAfterOnFetchCustomScriptObject.fields[CPQ_CONSUMPTION_RATE_FIELDS].clone(),
-          }),
-          toChange({
-            after: mockAfterOnFetchCustomScriptObject.fields[CPQ_CONSUMPTION_RATE_FIELDS].clone(),
-          }),
+          toChange({ after: mockAfterOnFetchCustomScriptObject.clone() }),
         ]
         await filter.preDeploy(changes)
       })
 
       it('Should change fieldsRefList fields type to long text on addition change', () => {
-        const cpqConsumptionRateFieldAddChange = changes
+        const cpqCustomScriptObjAddChange = changes
           .find(change =>
-            (isAdditionChange(change) && isFieldChange(change)
-              && getChangeElement(change).elemID
-                .isEqual(mockCustomScriptObject.fields[CPQ_CONSUMPTION_RATE_FIELDS].elemID)))
-        expect(cpqConsumptionRateFieldAddChange).toBeDefined()
-        expect((getChangeElement(cpqConsumptionRateFieldAddChange as Change) as Field).type)
+            (isAdditionChange(change) && isObjectTypeChange(change)
+              && getChangeElement(change).elemID.isEqual(mockCustomScriptObject.elemID)))
+        expect(cpqCustomScriptObjAddChange).toBeDefined()
+        const object = getChangeElement(cpqCustomScriptObjAddChange as AdditionChange<ObjectType>)
+        expect(object.fields[CPQ_CONSUMPTION_RATE_FIELDS].type)
+          .toEqual(Types.primitiveDataTypes.LongTextArea)
+        expect(object.fields[CPQ_GROUP_FIELDS].type)
           .toEqual(Types.primitiveDataTypes.LongTextArea)
       })
 


### PR DESCRIPTION
### **What's here?**
**Structure**
- `Resolve` before `preDeploy`
- `onDeploy` before `Restore`
- Run `restore` and `preDeploy` only on `mainElement` because `transformElement` on `Field` detaches it from parent

**Features**
- CustomScript `preDeploy` on `ObjectType` instead of `Field` changes
- Static file `preDeploy` on Buffer instead of StaticFile because it runs after `resolve` & remove `onDeploy` handling cause it's handled in restore