### PR TITLE
Fix deploy plan ignoring generated dependencies on fields and objects

### DIFF
--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -82,6 +82,7 @@ export const CoreAnnotationTypes: TypeMap = {
   [CORE_ANNOTATIONS.DEFAULT]: BuiltinTypes.STRING,
   [CORE_ANNOTATIONS.REQUIRED]: BuiltinTypes.BOOLEAN,
   [CORE_ANNOTATIONS.RESTRICTION]: restrictionType,
+  [CORE_ANNOTATIONS.HIDDEN]: BuiltinTypes.BOOLEAN,
 }
 
 export const getRestriction = (

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -23,7 +23,7 @@ import {
   Element, isInstanceElement, InstanceElement, isPrimitiveType, TypeMap, isField, ChangeDataType,
   ReferenceExpression, Field, InstanceAnnotationTypes, isType, isObjectType, isAdditionChange,
   CORE_ANNOTATIONS, TypeElement, Change, isRemovalChange, isModificationChange, isListType,
-  ChangeData, ListType,
+  ChangeData, ListType, CoreAnnotationTypes,
 } from '@salto-io/adapter-api'
 
 const { isDefined } = lowerDashValues
@@ -180,11 +180,11 @@ export const transformElementAnnotations = <T extends Element>(
       return InstanceAnnotationTypes
     }
 
-    if (isField(element)) {
-      return element.type.annotationTypes
+    return {
+      ...InstanceAnnotationTypes,
+      ...CoreAnnotationTypes,
+      ...(isField(element) ? element.type.annotationTypes : element.annotationTypes),
     }
-
-    return element.annotationTypes
   }
 
   return transformValues({

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -516,7 +516,13 @@ describe('Test utils.ts', () => {
         elemID: new ElemID('test', 'test'),
         fields: {
           f1: { type: BuiltinTypes.STRING },
-          f2: { type: listType, annotations: { a1: 'foo' } },
+          f2: {
+            type: listType,
+            annotations: {
+              a1: 'foo',
+              [INSTANCE_ANNOTATIONS.DEPENDS_ON]: [new ReferenceExpression(primType.elemID)],
+            },
+          },
         },
         annotationTypes: { a2: BuiltinTypes.STRING },
         annotations: { a2: 1 },
@@ -576,6 +582,11 @@ describe('Test utils.ts', () => {
       it('should transform field annotations', () => {
         expect(transformFunc).toHaveBeenCalledWith({
           value: 'foo', field: expect.any(Field), path: objType.fields.f2.elemID.createNestedID('a1'),
+        })
+        expect(transformFunc).toHaveBeenCalledWith({
+          value: new ReferenceExpression(primType.elemID),
+          field: expect.objectContaining({ type: BuiltinTypes.STRING }),
+          path: objType.fields.f2.elemID.createNestedID(INSTANCE_ANNOTATIONS.DEPENDS_ON, '0'),
         })
       })
     })


### PR DESCRIPTION
The _parent, _depends_on and _generated_dependencies annotations were not affecting deploy plans
because their types were not set when handling annotations of objects and fields and they were
lists which meant that transformElement with strict=false only called the transform func once with
the list and not for each reference (and it called with with an undefined field)

This fixes the issue for the other core annotations as well and provides the types properly
even though that had a smaller effect because they are not lists, so the transform function
was called with their values

---

_Release Notes_:
- Fixed issue where manually added / generated dependencies where not considered in deploy plans