### PR TITLE
SALTO-988 more flow references

### DIFF
--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -68,10 +68,22 @@ const neighborContextFunc = (
     return getLookUpName({ ref: refWithValue, field: contextField, path })
   }
 
+  const getParentPath = (currentFieldPath: ElemID): ElemID => {
+    const isNum = (str: string | undefined): boolean => (
+      !_.isEmpty(str) && !Number.isNaN(_.toNumber(str))
+    )
+    let path = currentFieldPath
+    // ignore array indices
+    while (isNum(path.getFullNameParts().pop())) {
+      path = path.createParentID()
+    }
+    return path.createParentID()
+  }
+
   if (fieldPath === undefined || contextFieldName === undefined) {
     return undefined
   }
-  const contextPath = fieldPath.createParentID().createNestedID(contextFieldName)
+  const contextPath = getParentPath(fieldPath).createNestedID(contextFieldName)
   const context = resolvePath(instance, contextPath)
   const contextStr = isReferenceExpression(context)
     ? resolveReference(context, contextPath)

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -104,6 +104,8 @@ const ContextStrategyLookup: Record<
   neighborCPQLookup: neighborContextFunc(CPQ_LOOKUP_OBJECT_NAME),
   neighborCPQRuleLookup: neighborContextFunc(CPQ_RULE_LOOKUP_OBJECT_FIELD),
   neighborLookupValueTypeLookup: neighborContextFunc('lookupValueType'),
+  neighborObjectLookup: neighborContextFunc('object'),
+  neighborPicklistObjectLookup: neighborContextFunc('picklistObject'),
 }
 
 const replaceReferenceValues = (

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -54,7 +54,10 @@ const ReferenceSerializationStrategyLookup: Record<
   },
 }
 
-export type ReferenceContextStrategyName = 'none' | 'instanceParent' | 'neighborTypeWorkflow' | 'neighborCPQLookup' | 'neighborCPQRuleLookup' | 'neighborLookupValueTypeLookup'
+export type ReferenceContextStrategyName = (
+  'none' | 'instanceParent' | 'neighborTypeWorkflow' | 'neighborCPQLookup' | 'neighborCPQRuleLookup'
+  | 'neighborLookupValueTypeLookup' | 'neighborObjectLookup' | 'neighborPicklistObjectLookup'
+)
 
 type PickOne<T, K extends keyof T> = Pick<T, K> & { [P in keyof Omit<T, K>]?: never };
 type MetadataTypeArgs = {
@@ -145,6 +148,10 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: 'ApexPage' },
   },
   {
+    src: { field: 'apexClass', parentTypes: ['FlowApexPluginCall', 'FlowVariable'] },
+    target: { type: 'ApexClass' },
+  },
+  {
     src: { field: 'recipient', parentTypes: ['WorkflowEmailRecipient'] },
     target: { type: 'Role' },
   },
@@ -185,11 +192,19 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: CUSTOM_OBJECT },
   },
   {
-    src: { field: 'object', parentTypes: ['ProfileObjectPermissions'] },
+    src: { field: 'object', parentTypes: ['ProfileObjectPermissions', 'FlowDynamicChoiceSet', 'FlowRecordLookup', 'FlowRecordUpdate', 'FlowRecordCreate', 'FlowRecordDelete', 'FlowStart'] },
+    target: { type: CUSTOM_OBJECT },
+  },
+  {
+    src: { field: 'picklistObject', parentTypes: ['FlowDynamicChoiceSet'] },
     target: { type: CUSTOM_OBJECT },
   },
   {
     src: { field: 'targetObject', parentTypes: ['QuickAction', 'AnalyticSnapshot'] },
+    target: { type: CUSTOM_OBJECT },
+  },
+  {
+    src: { field: 'typeValue', parentTypes: ['FlowDataTypeMapping'] },
     target: { type: CUSTOM_OBJECT },
   },
   {
@@ -233,6 +248,25 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     // if lookupValueType exists
     src: { field: 'lookupValue', parentTypes: ['WorkflowFieldUpdate'] },
     target: { typeContext: 'neighborLookupValueTypeLookup' },
+  },
+  ...(['displayField', 'sortField', 'valueField'].map(
+    (fieldName): FieldReferenceDefinition => ({
+      src: { field: fieldName, parentTypes: ['FlowDynamicChoiceSet'] },
+      serializationStrategy: 'relativeApiName',
+      target: { parentContext: 'neighborObjectLookup', type: CUSTOM_FIELD },
+    })
+  )),
+  ...(['queriedFields', 'sortField'].map(
+    (fieldName): FieldReferenceDefinition => ({
+      src: { field: fieldName, parentTypes: ['FlowRecordLookup'] },
+      serializationStrategy: 'relativeApiName',
+      target: { parentContext: 'neighborObjectLookup', type: CUSTOM_FIELD },
+    })
+  )),
+  {
+    src: { field: 'picklistField', parentTypes: ['FlowDynamicChoiceSet'] },
+    serializationStrategy: 'relativeApiName',
+    target: { parentContext: 'neighborPicklistObjectLookup', type: CUSTOM_FIELD },
   },
   {
     src: { field: CPQ_LOOKUP_FIELD, parentTypes: [CPQ_LOOKUP_QUERY] },


### PR DESCRIPTION
Populate more external-facing references (not pointing within the same flow).
Does not include some references that depend on a field of a parent object rather than a direct neighbor (such as `FlowRecordFilter.field`) - will add support for these in a separate PR.

Includes a small extension to the existing `neighborStrategy` so it will be able to pick the neighbor of an array correctly (ignore the nested array index).