### PR TITLE
SALTO-991 - Suppress errors for entries with insufficient access on readMetadata

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -69,7 +69,14 @@ const isAlreadyDeletedError = (error: SfError): boolean => (
 
 export type ErrorFilter = (error: Error) => boolean
 
-const isSFDCUnhandledException = (error: Error): boolean => error.name !== 'sf:UNKNOWN_EXCEPTION'
+const SFDC_UNKNOWN_EXCEPTION = 'sf:UNKNOWN_EXCEPTION'
+const SFDC_INSUFFICIENT_ACCESS = 'sf:INSUFFICIENT_ACCESS'
+const generateUnhandledExceptionFilter = (errorNames: string[]) =>
+  (error: Error): boolean => !errorNames.includes(error.name)
+const unhandledExceptionFilter = generateUnhandledExceptionFilter([SFDC_UNKNOWN_EXCEPTION])
+const unhandledOrInsufficientAccessFilter = generateUnhandledExceptionFilter(
+  [SFDC_UNKNOWN_EXCEPTION, SFDC_INSUFFICIENT_ACCESS]
+)
 
 const validateCRUDResult = (isDelete: boolean): decorators.InstanceMethodDecorator =>
   decorators.wrapMethodWith(
@@ -205,7 +212,7 @@ const sendChunked = async <TIn, TOut>({
           operationInfo, chunkInput[0], error)
         throw error
       }
-      log.warn('chunked %s unknown error on %o: %o',
+      log.warn('chunked %s skipping item with error on %o: %o',
         operationInfo, chunkInput[0], error)
       return { result: [], errors: chunkInput }
     }
@@ -334,7 +341,7 @@ export default class SalesforceClient {
   @SalesforceClient.requiresLogin
   public async listMetadataObjects(
     listMetadataQuery: ListMetadataQuery | ListMetadataQuery[],
-    isUnhandledError: ErrorFilter = isSFDCUnhandledException,
+    isUnhandledError: ErrorFilter = unhandledExceptionFilter,
   ): Promise<SendChunkedResult<ListMetadataQuery, FileProperties>> {
     return sendChunked({
       operationInfo: 'listMetadataObjects',
@@ -353,7 +360,7 @@ export default class SalesforceClient {
   public async readMetadata(
     type: string,
     name: string | string[],
-    isUnhandledError: ErrorFilter = isSFDCUnhandledException,
+    isUnhandledError: ErrorFilter = unhandledOrInsufficientAccessFilter,
   ): Promise<SendChunkedResult<string, MetadataInfo>> {
     return sendChunked({
       operationInfo: `readMetadata (${type})`,

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -200,7 +200,7 @@ describe('salesforce client', () => {
       expect(dodoScope.isDone()).toBeTruthy()
     })
 
-    it('should return non error responses', async () => {
+    it('should return non error responses for QuickAction targetObject', async () => {
       const dodoScope = nock('http://dodo22/servies/Soap/m/47.0')
         .post(/.*/)
         .times(2) // Once for the chunk and once for SendEmail
@@ -210,6 +210,24 @@ describe('salesforce client', () => {
         .reply(200, workingReadReplay)
 
       const { result } = await client.readMetadata('QuickAction', ['SendEmail', 'LogACall'])
+      expect(result).toHaveLength(1)
+      expect(dodoScope.isDone()).toBeTruthy()
+    })
+
+    it('should return non error responses for insufficient access', async () => {
+      const dodoScope = nock('http://dodo22/servies/Soap/m/47.0')
+        .post(/.*/)
+        .times(2) // Once for the chunk and once for item
+        .reply(
+          500,
+          '<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sf="http://soap.sforce.com/2006/04/metadata"><soapenv:Body><soapenv:Fault><faultcode>sf:INSUFFICIENT_ACCESS</faultcode><faultstring>INSUFFICIENT_ACCESS: insufficient access rights on cross-reference id</faultstring></soapenv:Fault></soapenv:Body></soapenv:Envelope>',
+          { 'content-type': 'text/xml' },
+        )
+        .post(/.*/)
+        .times(1)
+        .reply(200, workingReadReplay)
+
+      const { result } = await client.readMetadata('Layout', ['aaa', 'bbb'])
       expect(result).toHaveLength(1)
       expect(dodoScope.isDone()).toBeTruthy()
     })


### PR DESCRIPTION
See the ticket for full details - the simplest example is layouts failing due to `insufficient access rights on cross-reference id`, for some features that prod admins don't have access to by default (or at all).