### PR TITLE
SALTO-992: Stop omitting empty strings from salesforce values

### DIFF
--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -937,10 +937,6 @@ const isNull = (value: Value): boolean =>
       || _.get(value, `${XML_ATTRIBUTE_PREFIX}xsi:nil`) === 'true'))
 
 export const transformPrimitive: TransformFunc = ({ value, path, field }) => {
-  // We sometimes get empty strings that we want to filter out
-  if (value === '') {
-    return undefined
-  }
   if (isNull(value)) {
     // We transform null to undefined as currently we don't support null in Salto language
     // and the undefined values are omitted later in the code
@@ -962,7 +958,7 @@ export const transformPrimitive: TransformFunc = ({ value, path, field }) => {
     case PrimitiveTypes.BOOLEAN:
       return value.toString().toLowerCase() === 'true'
     case PrimitiveTypes.STRING:
-      return value.toString().length === 0 ? undefined : value.toString()
+      return value.toString()
     default:
       return value
   }

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -409,10 +409,13 @@ describe('SalesforceAdapter fetch', () => {
             .innerType as ObjectType).fields.name.type.elemID.name
         ).toBe('string')
         expect(layout.value.processMetadataValues[1].name).toBe('leftHandSideReferenceTo')
+        // empty objects should be omitted
         expect(layout.value.processMetadataValues[1].value).toBeUndefined()
         expect(layout.value.processMetadataValues[2].name).toBe('leftHandSideReferenceTo2')
-        expect(layout.value.processMetadataValues[2].value).toBeUndefined()
+        // empty strings should be kept
+        expect(layout.value.processMetadataValues[2].value).toEqual({ stringValue: '' })
         expect(layout.value.processMetadataValues[3].name).toBe('leftHandSideReferenceTo3')
+        // nulls should be omitted
         expect(layout.value.processMetadataValues[3].value).toBeUndefined()
       })
     })


### PR DESCRIPTION
sometimes these empty strings have real meaning, one example is in sharing rules
where the empty string is used as a marker for "sharedTo" type that requires no parameter

---

_Release Notes_:
- Fix issue where salesforce adapter would not fetch empty string values which prevented deploying SharingRules in some scenarios

---
The effect of this change on my dev account:
![image](https://user-images.githubusercontent.com/1883898/94786220-58f26800-03d9-11eb-8d7e-29c363cfd9e7.png)
