### PR TITLE
SALTO-1008: Fix nacl update code to support dumping objects into lists

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -202,7 +202,15 @@ export const updateNaclFileData = async (
       } else if (isListElement) {
         newData = await dumpValues(elem, functions, indentationLevel)
       } else {
-        newData = await dumpValues({ [changeKey]: elem }, functions, indentationLevel)
+        // We create a "dummy object" as the scope in which we are going to write this value
+        // We do this because we need to dump the key as well as the value and this is the easiest
+        // way to ensure we remain consistent
+        const dumpedObj = await dumpValues({ [changeKey]: elem }, functions, indentationLevel - 1)
+        // once we have the "new scope", we want to take just the serialized values because the
+        // brackets already exist in the original scope.
+        // We remove the first line that has the opening bracket and the two last lines, the second
+        // to last has the closing bracket, and the last line is always an empty line
+        newData = dumpedObj.split('\n').slice(1, -2).join('\n').concat('\n')
       }
       newData = fixEdgeIndentation(
         newData,

--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -166,6 +166,12 @@ export const groupAnnotationTypeChanges = (fileChanges: DetailedChange[],
   return [...otherChanges, ...transformedAnnotationTypeChanges]
 }
 
+const removeBracketLines = (dumpedObject: string): string => (
+  // We remove the first line that has the opening bracket and the two last lines, the second
+  // to last has the closing bracket, and the last line is always an empty line
+  dumpedObject.split('\n').slice(1, -2).join('\n').concat('\n')
+)
+
 export const updateNaclFileData = async (
   currentData: string,
   changes: DetailedChangeWithSource[],
@@ -208,9 +214,7 @@ export const updateNaclFileData = async (
         const dumpedObj = await dumpValues({ [changeKey]: elem }, functions, indentationLevel - 1)
         // once we have the "new scope", we want to take just the serialized values because the
         // brackets already exist in the original scope.
-        // We remove the first line that has the opening bracket and the two last lines, the second
-        // to last has the closing bracket, and the last line is always an empty line
-        newData = dumpedObj.split('\n').slice(1, -2).join('\n').concat('\n')
+        newData = removeBracketLines(dumpedObj)
       }
       newData = fixEdgeIndentation(
         newData,

--- a/packages/workspace/test/parser/dump.test.ts
+++ b/packages/workspace/test/parser/dump.test.ts
@@ -332,9 +332,9 @@ describe('Salto Dump', () => {
 
   describe('dump function', () => {
     it('should dump custom function a single parameter', async () => {
-      const body = await dumpValues({ attrush: new TestFuncImpl(funcName, [false]) }, functions)
+      const body = await dumpValues(new TestFuncImpl(funcName, [false]), functions)
 
-      expect(body).toMatch(/attrush = ZOMG\(false\)/)
+      expect(body).toMatch(/ZOMG\(false\)/)
     })
     it('should dump custom function that is nested', async () => {
       const body = await dumpValues({ nestalicous: { nestFunc: new TestFuncImpl(funcName, ['yes']) } }, functions)
@@ -357,16 +357,18 @@ describe('Salto Dump', () => {
         },
       }, functions)
 
-      expect(body).toEqual(`nestalicous = {
-  ss = 321
-  nestFunc = ZOMG("yes")
-  cc = 321
-}
-bb = 123
-nestFunc2 = ZOMG("maybe")
-deep = {
-  very = {
-    nestFunc3 = ZOMG("definitely")
+      expect(body).toEqual(`{
+  nestalicous = {
+    ss = 321
+    nestFunc = ZOMG("yes")
+    cc = 321
+  }
+  bb = 123
+  nestFunc2 = ZOMG("maybe")
+  deep = {
+    very = {
+      nestFunc3 = ZOMG("definitely")
+    }
   }
 }
 `)
@@ -379,8 +381,8 @@ deep = {
       body = await dumpValues({ attr: 'value' }, functions)
     })
 
-    it('should contain only attribute', () => {
-      expect(body).toMatch(/^attr\s+=\s+"value"$/m)
+    it('should contain attribute', () => {
+      expect(body).toMatch(/\{\s+attr\s+=\s+"value"\s+\}/m)
     })
   })
   describe('dump annotations', () => {
@@ -409,13 +411,13 @@ deep = {
   })
   describe('dump primitive', () => {
     it('should serialize numbers', async () => {
-      expect(await dumpValues(123, functions)).toEqual('123')
+      expect(await dumpValues(123, functions)).toEqual('123\n')
     })
     it('should serialize strings', async () => {
-      expect(await dumpValues('aaa', functions)).toEqual('"aaa"')
+      expect(await dumpValues('aaa', functions)).toEqual('"aaa"\n')
     })
     it('should serialize booleans', async () => {
-      expect(await dumpValues(false, functions)).toEqual('false')
+      expect(await dumpValues(false, functions)).toEqual('false\n')
     })
     it('should dump list', async () => {
       expect(await dumpValues(

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -480,6 +480,11 @@ describe('workspace', () => {
         action: 'modify',
         data: { before: 4, after: 5 },
       },
+      { // Change from primitive to object in a list
+        id: new ElemID('salesforce', 'lead', 'field', 'list_field', CORE_ANNOTATIONS.DEFAULT, '4'),
+        action: 'modify',
+        data: { before: 5, after: { foo: 'bla' } },
+      },
       { // Modify field isListValue
         id: newField.elemID,
         action: 'modify',
@@ -750,7 +755,7 @@ describe('workspace', () => {
     })
     it('should update value in list', () => {
       expect(lead.fields.list_field
-        .annotations[CORE_ANNOTATIONS.DEFAULT]).toEqual([1, 2, 3, 5, 5])
+        .annotations[CORE_ANNOTATIONS.DEFAULT]).toEqual([1, 2, 3, 5, { foo: 'bla' }])
     })
     it('should change isList value in fields', () => {
       expect(isListType(lead.fields.not_a_list_yet_field.type)).toBeTruthy()


### PR DESCRIPTION
This changes the update nacl logic to work when writing a new object value into a list
This fixes a bug in the scenario where a value in a list was primitive and changed to be complex
With the old code that would not dump the brackets for the new value and it would create a parse
error

---

_Release notes_:
- Fixed bug in nacl serialization that caused some fetch scenarios to create invalid nacl files