### PR TITLE
SALTO-988 - Support more action types for FlowActionCall

### DIFF
--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -32,6 +32,7 @@ import {
   WORKFLOW_ACTION_ALERT_METADATA_TYPE, WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
   WORKFLOW_FLOW_ACTION_METADATA_TYPE, WORKFLOW_OUTBOUND_MESSAGE_METADATA_TYPE,
   WORKFLOW_TASK_METADATA_TYPE, CPQ_LOOKUP_OBJECT_NAME, CPQ_RULE_LOOKUP_OBJECT_FIELD,
+  QUICK_ACTION_METADATA_TYPE,
 } from '../constants'
 
 const log = logger(module)
@@ -92,14 +93,23 @@ const neighborContextFunc = (
 })
 
 const workflowActionMapper: ContextValueMapperFunc = (val: string) => {
-  const workflowActionTypeMapping: Record<string, string> = {
+  const typeMapping: Record<string, string> = {
     Alert: WORKFLOW_ACTION_ALERT_METADATA_TYPE,
     FieldUpdate: WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
     FlowAction: WORKFLOW_FLOW_ACTION_METADATA_TYPE,
     OutboundMessage: WORKFLOW_OUTBOUND_MESSAGE_METADATA_TYPE,
     Task: WORKFLOW_TASK_METADATA_TYPE,
   }
-  return workflowActionTypeMapping[val]
+  return typeMapping[val]
+}
+
+const flowActionCallMapper: ContextValueMapperFunc = (val: string) => {
+  const typeMapping: Record<string, string> = {
+    apex: 'ApexClass',
+    emailAlert: WORKFLOW_ACTION_ALERT_METADATA_TYPE,
+    quickAction: QUICK_ACTION_METADATA_TYPE,
+  }
+  return typeMapping[val]
 }
 
 const ContextStrategyLookup: Record<
@@ -113,6 +123,7 @@ const ContextStrategyLookup: Record<
       : undefined)
   },
   neighborTypeWorkflow: neighborContextFunc('type', workflowActionMapper),
+  neighborActionTypeLookup: neighborContextFunc('actionType', flowActionCallMapper),
   neighborCPQLookup: neighborContextFunc(CPQ_LOOKUP_OBJECT_NAME),
   neighborCPQRuleLookup: neighborContextFunc(CPQ_RULE_LOOKUP_OBJECT_FIELD),
   neighborLookupValueTypeLookup: neighborContextFunc('lookupValueType'),

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -59,6 +59,7 @@ const ReferenceSerializationStrategyLookup: Record<
 export type ReferenceContextStrategyName = (
   'none' | 'instanceParent' | 'neighborTypeWorkflow' | 'neighborCPQLookup' | 'neighborCPQRuleLookup'
   | 'neighborLookupValueTypeLookup' | 'neighborObjectLookup' | 'neighborPicklistObjectLookup'
+  | 'neighborActionTypeLookup'
 )
 
 type PickOne<T, K extends keyof T> = Pick<T, K> & { [P in keyof Omit<T, K>]?: never };
@@ -162,10 +163,6 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: 'Role' },
   },
   {
-    src: { field: 'actionName', parentTypes: ['FlowActionCall'] },
-    target: { type: 'WorkflowAlert' },
-  },
-  {
     src: { field: 'application', parentTypes: ['ProfileApplicationVisibility'] },
     target: { type: 'CustomApplication' },
   },
@@ -192,6 +189,10 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   {
     src: { field: 'tab', parentTypes: ['WorkspaceMapping'] },
     target: { type: 'CustomTab' },
+  },
+  {
+    src: { field: 'actionName', parentTypes: ['FlowActionCall'] },
+    target: { typeContext: 'neighborActionTypeLookup' },
   },
   {
     src: { field: 'objectType', parentTypes: ['FlowVariable'] },


### PR DESCRIPTION
Small extension - we had an old rule that only supported one type - switching it to the new format.
(doesn't cover all the choices - some don't use the `actionName` field, and some need some more work to set up for testing)