### PR TITLE
Make workflow the parent of its subtypes

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -468,8 +468,7 @@ const removeUnsupportedFields = (elements: Element[], unsupportedSystemFields: s
 }
 
 // Instances metadataTypes that should be under the customObject folder and have a PARENT reference
-const workflowDependentMetadataTypes = new Set([WORKFLOW_METADATA_TYPE,
-  ...Object.values(WORKFLOW_FIELD_TO_TYPE)])
+const workflowDependentMetadataTypes = new Set(Object.values(WORKFLOW_FIELD_TO_TYPE))
 const dependentMetadataTypes = new Set([CUSTOM_TAB_METADATA_TYPE, DUPLICATE_RULE_METADATA_TYPE,
   QUICK_ACTION_METADATA_TYPE, WORKFLOW_METADATA_TYPE, LEAD_CONVERT_SETTINGS_METADATA_TYPE,
   ASSIGNMENT_RULES_METADATA_TYPE, CUSTOM_OBJECT_TRANSLATION_METADATA_TYPE, SHARING_RULES_TYPE,
@@ -485,7 +484,8 @@ const fixDependentInstancesPathAndSetParent = (elements: Element[]): void => {
     if (customObject.path) {
       instance.path = [
         ...customObject.path.slice(0, -1),
-        ...(workflowDependentMetadataTypes.has(instance.elemID.typeName)
+        ...((workflowDependentMetadataTypes.has(instance.elemID.typeName)
+            || instance.elemID.typeName === WORKFLOW_METADATA_TYPE)
           ? [WORKFLOW_METADATA_TYPE, instance.elemID.typeName] : [instance.elemID.typeName]),
         ...(apiNameParts(instance).length > 1 ? [instance.elemID.name] : []),
       ]
@@ -512,7 +512,10 @@ const fixDependentInstancesPathAndSetParent = (elements: Element[]): void => {
         return
       }
       setDependingInstancePath(instance, customObj)
-      addObjectParentReference(instance, customObj)
+      // workflow-dependent types already have the parent set
+      if (!workflowDependentMetadataTypes.has(metadataType(instance))) {
+        addObjectParentReference(instance, customObj)
+      }
     })
 }
 

--- a/packages/salesforce-adapter/src/filters/workflow.ts
+++ b/packages/salesforce-adapter/src/filters/workflow.ts
@@ -15,7 +15,7 @@
 */
 import {
   Element, ElemID, InstanceElement, isInstanceElement, isObjectType, ReferenceExpression,
-  ObjectType, BuiltinTypes, ListType,
+  ObjectType, BuiltinTypes, ListType, INSTANCE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
@@ -78,7 +78,12 @@ const filterCreator: FilterCreator = () => ({
           .map(innerValue => {
             innerValue[INSTANCE_FULL_NAME_FIELD] = fullApiName(apiName(workflowInstance),
               innerValue[INSTANCE_FULL_NAME_FIELD])
-            return createInstanceElement(innerValue, objType)
+            return createInstanceElement(
+              innerValue,
+              objType,
+              undefined,
+              { [INSTANCE_ANNOTATIONS.PARENT]: [new ReferenceExpression(workflowInstance.elemID)] },
+            )
           })
         if (!_.isEmpty(innerInstances)) {
           workflowInstance.value[fieldName] = innerInstances

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -30,6 +30,7 @@ import {
   OBJECTS_PATH, INSTALLED_PACKAGES_PATH, TYPES_PATH, RECORDS_PATH, WORKFLOW_METADATA_TYPE,
   ASSIGNMENT_RULES_METADATA_TYPE, LEAD_CONVERT_SETTINGS_METADATA_TYPE, QUICK_ACTION_METADATA_TYPE,
   CUSTOM_TAB_METADATA_TYPE, CUSTOM_OBJECT_TRANSLATION_METADATA_TYPE, SHARING_RULES_TYPE,
+  WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
 } from '../../src/constants'
 import mockAdapter from '../adapter'
 import { findElements, createValueSetEntry } from '../utils'
@@ -1164,8 +1165,23 @@ describe('Custom Objects filter', () => {
       const workflowInstance = new InstanceElement('Lead',
         workflowType, { [INSTANCE_FULL_NAME_FIELD]: 'Lead' })
 
+      const workflowFieldUpdateType = new ObjectType({
+        elemID: new ElemID(SALESFORCE, WORKFLOW_FIELD_UPDATE_METADATA_TYPE),
+        annotations: { [METADATA_TYPE]: WORKFLOW_FIELD_UPDATE_METADATA_TYPE },
+      })
+      const workflowFieldUpdateInstance = new InstanceElement(
+        'something',
+        workflowFieldUpdateType,
+        { [INSTANCE_FULL_NAME_FIELD]: 'something' },
+        undefined,
+        { [INSTANCE_ANNOTATIONS.PARENT]: [new ReferenceExpression(workflowInstance.elemID)] },
+      )
+
       beforeEach(async () => {
-        await filter().onFetch([workflowInstance, workflowType, leadType])
+        await filter().onFetch([
+          workflowInstance, workflowType, leadType, workflowFieldUpdateType,
+          workflowFieldUpdateInstance,
+        ])
       })
 
       it('should set workflow instance path correctly', async () => {
@@ -1176,6 +1192,11 @@ describe('Custom Objects filter', () => {
       it('should add PARENT annotation to workflow instance', async () => {
         expect(workflowInstance.annotations[INSTANCE_ANNOTATIONS.PARENT])
           .toContainEqual(new ReferenceExpression(leadType.elemID))
+      })
+
+      it('should not modify PARENT annotation on workflow subtype instance', async () => {
+        expect(workflowFieldUpdateInstance.annotations[INSTANCE_ANNOTATIONS.PARENT])
+          .toEqual([new ReferenceExpression(workflowInstance.elemID)])
       })
     })
 

--- a/packages/salesforce-adapter/test/filters/workflow.test.ts
+++ b/packages/salesforce-adapter/test/filters/workflow.test.ts
@@ -16,7 +16,7 @@
 import { collections } from '@salto-io/lowerdash'
 import {
   ElemID, InstanceElement, ObjectType, Element, ReferenceExpression, Field,
-  BuiltinTypes, isListType, ListType,
+  BuiltinTypes, isListType, ListType, INSTANCE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import {
   findElement,
@@ -125,6 +125,20 @@ describe('Workflow filter', () => {
             expect(val).toBeInstanceOf(ReferenceExpression)
           })
         })
+      })
+
+      it('should have workflow as parent for inner types', async () => {
+        const verifyParent = (e: Element): void => {
+          const parent = (e as InstanceElement).annotations[INSTANCE_ANNOTATIONS.PARENT][0]
+          expect(parent).toBeInstanceOf(ReferenceExpression)
+          expect(parent.elemId).toEqual(workflowWithInnerTypes.elemID)
+        }
+
+        verifyParent(elements[9])
+        verifyParent(elements[10])
+        verifyParent(elements[11])
+        verifyParent(elements[12])
+        verifyParent(elements[13])
       })
 
       it('should have list reference from workflow instance', () => {


### PR DESCRIPTION
In order to support upcoming changes in `deploy`, we need workflow to be the parent of its subtypes.
This includes:
* Changing the parent
* Adjusting the reference resolution to find the "grandparent" when needed

Tried to keep the changes minimal - not changing the nested paths of the workflow or its subtypes, and still supporting having fields with the same object types nested under "regular" types (so - only looking at the grandparent if the parent is the workflow).

@ori-moisis if there's a relevant ticket to link this to please add it.