### PR TITLE
When uploading an object of type "Custom settings" - treat it appropriately, not as normal custom object

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -29,7 +29,7 @@ import { decorators, collections, values } from '@salto-io/lowerdash'
 import SalesforceClient from './client/client'
 import * as constants from './constants'
 import {
-  toCustomField, toCustomObject, apiName, Types, toMetadataInfo,
+  toCustomField, toCustomProperties, apiName, Types, toMetadataInfo,
   metadataType, defaultApiName, isMetadataObjectType,
   isMetadataInstanceElement,
 } from './transformers/transformer'
@@ -548,7 +548,7 @@ export default class SalesforceAdapter implements AdapterOperations {
     addDefaults(post)
 
     await this.client.upsert(
-      constants.CUSTOM_OBJECT, toCustomObject(post, true, this.systemFields),
+      constants.CUSTOM_OBJECT, toCustomProperties(post, true, this.systemFields),
     )
 
     return post
@@ -671,11 +671,11 @@ export default class SalesforceAdapter implements AdapterOperations {
   private async updateObjectAnnotations(before: ObjectType, clonedObject: ObjectType,
     changes: ReadonlyArray<Change<Field | ObjectType>>): Promise<SaveResult[]> {
     if (changes.some(c => isObjectType(getChangeElement(c)))
-      && !_.isEqual(toCustomObject(before, false), toCustomObject(clonedObject, false))) {
+      && !_.isEqual(toCustomProperties(before, false), toCustomProperties(clonedObject, false))) {
       // Update object without its fields
       return this.client.update(
         metadataType(clonedObject),
-        toCustomObject(clonedObject, false)
+        toCustomProperties(clonedObject, false)
       )
     }
     return []

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -354,6 +354,7 @@ export default class SalesforceAdapter implements AdapterOperations {
       'RecordTypeId',
       'SystemModstamp',
       'OwnerId',
+      'SetupOwnerId',
     ],
     unsupportedSystemFields = [
       'LastReferencedDate',

--- a/packages/salesforce-adapter/src/client/types.ts
+++ b/packages/salesforce-adapter/src/client/types.ts
@@ -250,10 +250,23 @@ export class CustomField implements MetadataInfo {
   }
 }
 
-export class CustomObject implements MetadataInfo {
-  readonly pluralLabel: string
+export class CustomProperties implements MetadataInfo {
+  customSettingsType?: string
   readonly fields?: CustomField[] | CustomField
 
+  constructor(
+    readonly fullName: string,
+    readonly label: string,
+    fields?: CustomField[]
+  ) {
+    if (fields) {
+      this.fields = fields
+    }
+  }
+}
+
+export class CustomObject extends CustomProperties {
+  readonly pluralLabel: string
   readonly deploymentStatus = 'Deployed'
   readonly sharingModel: string
   readonly nameField = {
@@ -266,10 +279,8 @@ export class CustomObject implements MetadataInfo {
     readonly label: string,
     fields?: CustomField[]
   ) {
+    super(fullName, label, fields)
     this.pluralLabel = `${this.label}s`
-    if (fields) {
-      this.fields = fields
-    }
 
     const hasMasterDetailField = (): boolean|undefined => fields
       && fields.some(field => field.type === FIELD_TYPE_NAMES.MASTER_DETAIL)

--- a/packages/salesforce-adapter/src/client/types.ts
+++ b/packages/salesforce-adapter/src/client/types.ts
@@ -251,7 +251,6 @@ export class CustomField implements MetadataInfo {
 }
 
 export class CustomProperties implements MetadataInfo {
-  customSettingsType?: string
   readonly fields?: CustomField[] | CustomField
 
   constructor(

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -126,6 +126,7 @@ export const API_NAME = 'apiName'
 export const METADATA_TYPE = 'metadataType'
 export const TOPICS_FOR_OBJECTS_ANNOTATION = 'topicsForObjects'
 export const FOREIGN_KEY_DOMAIN = 'foreignKeyDomain'
+export const CUSTOM_SETTINGS_TYPE = 'customSettingsType'
 export const IS_ATTRIBUTE = 'isAttribute'
 // must have the same name as INTERNAL_ID_FIELD
 // TODO should be state-only once that's supported for annotations (SALTO-910)

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -127,9 +127,9 @@ const getFieldType = (type: string): TypeElement =>
   (_.isUndefined(type) ? BuiltinTypes.STRING : Types.get(type))
 
 const annotationTypesForObject = (typesFromInstance: TypesFromInstance,
-  object: ObjectType, custom: boolean): Record<string, TypeElement> => {
+  instance: InstanceElement, custom: boolean): Record<string, TypeElement> => {
   let annotationTypes = typesFromInstance.standardAnnotationTypes
-  if (isCustomSettings(object)) {
+  if (isCustomSettings(instance)) {
     annotationTypes = typesFromInstance.customSettingsOnlyAnnotationTypes
   } else if (custom) {
     annotationTypes = typesFromInstance.customAnnotationTypes
@@ -397,7 +397,8 @@ const createFromInstance = (instance: InstanceElement,
     name: objectName,
     label: instance.value[LABEL],
   })
-  const annotationTypes = annotationTypesForObject(typesFromInstance, object, isCustom(objectName))
+  const annotationTypes = annotationTypesForObject(typesFromInstance, instance,
+    isCustom(objectName))
   transformObjectAnnotations(object, annotationTypes, instance)
   const instanceFields = makeArray(instance.value.fields)
   instanceFields
@@ -450,7 +451,7 @@ const createFromSObjectsAndInstances = (
     if (!instance) {
       return [object]
     }
-    const annotationTypes = annotationTypesForObject(typesFromInstance, object, custom)
+    const annotationTypes = annotationTypesForObject(typesFromInstance, instance, custom)
     mergeCustomObjectWithInstance(
       object, instance, annotationTypes
     )

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -98,7 +98,7 @@ export const NESTED_INSTANCE_VALUE_TO_TYPE_NAME = {
 type TypesFromInstance = {
   standardAnnotationTypes: TypeMap
   customAnnotationTypes: TypeMap
-  customSettingsOnlyAnnotationTypes: TypeMap
+  customSettingsAnnotationTypes: TypeMap
   nestedMetadataTypes: Record<string, ObjectType>
 }
 
@@ -130,7 +130,7 @@ const annotationTypesForObject = (typesFromInstance: TypesFromInstance,
   instance: InstanceElement, custom: boolean): Record<string, TypeElement> => {
   let annotationTypes = typesFromInstance.standardAnnotationTypes
   if (isCustomSettings(instance)) {
-    annotationTypes = typesFromInstance.customSettingsOnlyAnnotationTypes
+    annotationTypes = typesFromInstance.customSettingsAnnotationTypes
   } else if (custom) {
     annotationTypes = typesFromInstance.customAnnotationTypes
   }
@@ -592,7 +592,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
       return {
         standardAnnotationTypes,
         customAnnotationTypes: { ...standardAnnotationTypes, ...customOnlyAnnotationTypes },
-        customSettingsOnlyAnnotationTypes: { ...standardAnnotationTypes,
+        customSettingsAnnotationTypes: { ...standardAnnotationTypes,
           ...customSettingsOnlyAnnotationTypes },
         nestedMetadataTypes,
       }

--- a/packages/salesforce-adapter/src/filters/topics_for_objects.ts
+++ b/packages/salesforce-adapter/src/filters/topics_for_objects.ts
@@ -72,7 +72,13 @@ const filterCreator: FilterCreator = ({ client }): FilterWith<'onFetch' | 'onDep
     const customObjectChanges = changes
       .filter(isObjectTypeChange)
       .filter(isAdditionOrModificationChange)
-      .filter(change => isCustomObject(getChangeElement(change)))
+      .filter((change): boolean => {
+        const element = getChangeElement(change)
+        if ('customSettingsType' in element.annotationTypes) {
+          return false
+        }
+        return isCustomObject(element)
+      })
 
     const newObjects = customObjectChanges
       .filter(isAdditionChange)

--- a/packages/salesforce-adapter/src/filters/topics_for_objects.ts
+++ b/packages/salesforce-adapter/src/filters/topics_for_objects.ts
@@ -19,7 +19,7 @@ import {
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { TOPICS_FOR_OBJECTS_FIELDS, TOPICS_FOR_OBJECTS_ANNOTATION, API_NAME,
-  TOPICS_FOR_OBJECTS_METADATA_TYPE } from '../constants'
+  TOPICS_FOR_OBJECTS_METADATA_TYPE, CUSTOM_SETTINGS_TYPE } from '../constants'
 import { isCustomObject, apiName, metadataType } from '../transformers/transformer'
 import { FilterCreator, FilterWith } from '../filter'
 import { TopicsForObjectsInfo } from '../client/types'
@@ -74,7 +74,7 @@ const filterCreator: FilterCreator = ({ client }): FilterWith<'onFetch' | 'onDep
       .filter(isAdditionOrModificationChange)
       .filter((change): boolean => {
         const element = getChangeElement(change)
-        if ('customSettingsType' in element.annotationTypes) {
+        if (CUSTOM_SETTINGS_TYPE in element.annotationTypes) {
           return false
         }
         return isCustomObject(element)

--- a/packages/salesforce-adapter/src/filters/topics_for_objects.ts
+++ b/packages/salesforce-adapter/src/filters/topics_for_objects.ts
@@ -19,7 +19,7 @@ import {
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { TOPICS_FOR_OBJECTS_FIELDS, TOPICS_FOR_OBJECTS_ANNOTATION, API_NAME,
-  TOPICS_FOR_OBJECTS_METADATA_TYPE, CUSTOM_SETTINGS_TYPE } from '../constants'
+  TOPICS_FOR_OBJECTS_METADATA_TYPE } from '../constants'
 import { isCustomObject, apiName, metadataType } from '../transformers/transformer'
 import { FilterCreator, FilterWith } from '../filter'
 import { TopicsForObjectsInfo } from '../client/types'
@@ -72,14 +72,7 @@ const filterCreator: FilterCreator = ({ client }): FilterWith<'onFetch' | 'onDep
     const customObjectChanges = changes
       .filter(isObjectTypeChange)
       .filter(isAdditionOrModificationChange)
-      .filter((change): boolean => {
-        const element = getChangeElement(change)
-        if (CUSTOM_SETTINGS_TYPE in element.annotationTypes) {
-          return false
-        }
-        return isCustomObject(element)
-      })
-
+      .filter((change): boolean => isCustomObject(getChangeElement(change)))
     const newObjects = customObjectChanges
       .filter(isAdditionChange)
       .map(getChangeElement)

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -74,6 +74,9 @@ export const isCustom = (fullName: string): boolean =>
 export const isCustomSettings = (instance: InstanceElement): boolean =>
   instance.value[CUSTOM_SETTINGS_TYPE]
 
+export const isCustomSettingsObject = (obj: ObjectType): boolean =>
+  obj.annnotations[CUSTOM_SETTINGS_TYPE]
+
 export const defaultApiName = (element: Element): string => {
   const { name } = element.elemID
   return isCustom(name) || isInstanceElement(element)
@@ -865,7 +868,7 @@ export const toCustomProperties = (
   element: ObjectType, includeFields: boolean, skipFields: string[] = [],
 ): CustomProperties => {
   let newCustomObject: CustomProperties
-  if (element.annotations[CUSTOM_SETTINGS_TYPE]) {
+  if (isCustomSettingsObject(element)) {
     newCustomObject = new CustomProperties(
       apiName(element),
       element.annotations[LABEL],

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -71,8 +71,8 @@ export const isInstanceOfCustomObject = (element: Element): element is InstanceE
 export const isCustom = (fullName: string): boolean =>
   fullName.endsWith(SALESFORCE_CUSTOM_SUFFIX)
 
-export const isCustomSettings = (object: ObjectType): boolean =>
-  object.annotations[CUSTOM_SETTINGS_TYPE]
+export const isCustomSettings = (instance: InstanceElement): boolean =>
+  instance.value[CUSTOM_SETTINGS_TYPE]
 
 export const defaultApiName = (element: Element): string => {
   const { name } = element.elemID

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -860,19 +860,13 @@ export const toCustomObject = (
   element: ObjectType, includeFields: boolean, skipFields: string[] = [],
 ): CustomProperties => {
   let newCustomObject: CustomProperties
-  // eslint-disable-next-line no-console
-  console.log('creating custom object')
   if (element.annotations.customSettingsType) {
-    // eslint-disable-next-line no-console
-    console.log('custom settings object')
     newCustomObject = new CustomProperties(
       apiName(element),
       element.annotations[LABEL],
       getFieldsIfIncluded(includeFields, element, skipFields)
     )
   } else {
-    // eslint-disable-next-line no-console
-    console.log('true object')
     newCustomObject = new CustomObject(
       apiName(element),
       element.annotations[LABEL],

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -75,7 +75,7 @@ export const isCustomSettings = (instance: InstanceElement): boolean =>
   instance.value[CUSTOM_SETTINGS_TYPE]
 
 export const isCustomSettingsObject = (obj: ObjectType): boolean =>
-  obj.annnotations[CUSTOM_SETTINGS_TYPE]
+  obj.annotations[CUSTOM_SETTINGS_TYPE]
 
 export const defaultApiName = (element: Element): string => {
   const { name } = element.elemID

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -860,13 +860,19 @@ export const toCustomObject = (
   element: ObjectType, includeFields: boolean, skipFields: string[] = [],
 ): CustomProperties => {
   let newCustomObject: CustomProperties
+  // eslint-disable-next-line no-console
+  console.log('creating custom object')
   if (element.annotations.customSettingsType) {
+    // eslint-disable-next-line no-console
+    console.log('custom settings object')
     newCustomObject = new CustomProperties(
       apiName(element),
       element.annotations[LABEL],
       getFieldsIfIncluded(includeFields, element, skipFields)
     )
   } else {
+    // eslint-disable-next-line no-console
+    console.log('true object')
     newCustomObject = new CustomObject(
       apiName(element),
       element.annotations[LABEL],

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -40,7 +40,7 @@ import {
   RECORDS_PATH, SETTINGS_PATH, TYPES_PATH, SUBTYPES_PATH, INSTALLED_PACKAGES_PATH,
   VALUE_SET_DEFINITION_FIELDS, CUSTOM_FIELD,
   COMPOUND_FIELDS_SOAP_TYPE_NAMES, CUSTOM_OBJECT_ID_FIELD, FOREIGN_KEY_DOMAIN,
-  XML_ATTRIBUTE_PREFIX, INTERNAL_ID_FIELD, INTERNAL_FIELD_TYPE_NAMES,
+  XML_ATTRIBUTE_PREFIX, INTERNAL_ID_FIELD, INTERNAL_FIELD_TYPE_NAMES, CUSTOM_SETTINGS_TYPE,
 } from '../constants'
 import SalesforceClient from '../client/client'
 import { allMissingSubTypes } from './salesforce_types'
@@ -70,6 +70,9 @@ export const isInstanceOfCustomObject = (element: Element): element is InstanceE
 
 export const isCustom = (fullName: string): boolean =>
   fullName.endsWith(SALESFORCE_CUSTOM_SUFFIX)
+
+export const isCustomSettings = (object: ObjectType): boolean =>
+  object.annotations[CUSTOM_SETTINGS_TYPE]
 
 export const defaultApiName = (element: Element): string => {
   const { name } = element.elemID
@@ -849,18 +852,20 @@ const isLocalOnly = (field?: Field): boolean => (
   field !== undefined && field.annotations[FIELD_ANNOTATIONS.LOCAL_ONLY] === true
 )
 
-const getFieldsIfIncluded = (includeFields: boolean, element: ObjectType,
-  skipFields: string[]): CustomField[] | undefined => (includeFields ? Object.values(
-  element.fields
-).filter(field => !isLocalOnly(field)).map(field => toCustomField(field)).filter(
-  field => !skipFields.includes(field.fullName)
-) : undefined)
+const getFieldsIfIncluded = (
+  includeFields: boolean, element: ObjectType, skipFields: string[]
+): CustomField[] | undefined =>
+  (includeFields ? Object.values(element.fields)
+    .filter(field => !isLocalOnly(field))
+    .map(field => toCustomField(field))
+    .filter(field => !skipFields.includes(field.fullName))
+    : undefined)
 
-export const toCustomObject = (
+export const toCustomProperties = (
   element: ObjectType, includeFields: boolean, skipFields: string[] = [],
 ): CustomProperties => {
   let newCustomObject: CustomProperties
-  if (element.annotations.customSettingsType) {
+  if (element.annotations[CUSTOM_SETTINGS_TYPE]) {
     newCustomObject = new CustomProperties(
       apiName(element),
       element.annotations[LABEL],

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -103,6 +103,7 @@ describe('Custom Objects filter', () => {
         [INSTANCE_FULL_NAME_FIELD]: { type: BuiltinTypes.STRING },
         pluralLabel: { type: BuiltinTypes.STRING },
         enableFeeds: { type: BuiltinTypes.BOOLEAN },
+        [CUSTOM_SETTINGS_TYPE]: { type: BuiltinTypes.STRING },
       },
       annotations: {
         [METADATA_TYPE]: CUSTOM_OBJECT,
@@ -1030,14 +1031,15 @@ describe('Custom Objects filter', () => {
 
         it('should merge regular instance element annotations into the custom settings-custom object type', async () => {
           const customSettingsInstance = customObjectInstance.clone()
-          customSettingsInstance.annotationTypes = { [CUSTOM_SETTINGS_TYPE]: BuiltinTypes.STRING }
-          customSettingsInstance.annotations = { [CUSTOM_SETTINGS_TYPE]: 'Hierarchical' }
+          customSettingsInstance.value[CUSTOM_SETTINGS_TYPE] = 'Hierarchical'
           result.push(customSettingsInstance)
           await filter().onFetch(result)
           const lead = findElements(result, 'Lead').pop() as ObjectType
           expect(lead.annotationTypes.enableFeeds).toBeDefined()
           expect(lead.annotations.enableFeeds).toBeTruthy()
           expect(lead.annotationTypes.pluralLabel).toBeUndefined()
+          expect(lead.annotations.customSettingsType).toBeDefined()
+          expect(lead.annotations.customSettingsType).toEqual('Hierarchical')
         })
 
         it('should merge regular instance element annotations into the custom-custom object type', async () => {
@@ -1118,11 +1120,27 @@ describe('Custom Objects filter', () => {
 
         describe('when instance exist but no object returned from soap API', () => {
           it('should merge regular instance element annotations into the object type', async () => {
-            result.push(customObjectInstance)
+            const customSettingsObjectInstance = customObjectInstance.clone()
+            customSettingsObjectInstance.value.customSettingsType = 'Hierarchical'
+            result.push(customSettingsObjectInstance)
             await filter().onFetch(result)
             const lead = findElements(result, 'Lead').pop() as ObjectType
             expect(lead.annotationTypes.enableFeeds).toBeDefined()
             expect(lead.annotations.enableFeeds).toBeTruthy()
+            expect(lead.annotationTypes.apiName).toBeDefined()
+            expect(lead.annotationTypes.pluralLabel).toBeUndefined()
+            expect(lead.annotations.pluralLabel).toBeUndefined()
+          })
+
+          it('Should create proper custom settings object', async () => {
+            const customSettingsObjectInstance = customObjectInstance.clone()
+            customSettingsObjectInstance.value.customSettingsType = 'Hierarchical'
+            result.push(customSettingsObjectInstance)
+            await filter().onFetch(result)
+            const lead = findElements(result, 'Lead').pop() as ObjectType
+            expect(lead.annotationTypes.enableFeeds).toBeDefined()
+            expect(lead.annotations.enableFeeds).toBeTruthy()
+            expect(lead.annotationTypes.apiName).toBeDefined()
             expect(lead.annotationTypes.pluralLabel).toBeUndefined()
             expect(lead.annotations.pluralLabel).toBeUndefined()
           })

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -24,7 +24,7 @@ import Connection from '../../src/client/jsforce'
 import {
   FIELD_ANNOTATIONS, FILTER_ITEM_FIELDS, SALESFORCE, METADATA_TYPE,
   CUSTOM_OBJECT, INSTANCE_FULL_NAME_FIELD, LABEL, NAMESPACE_SEPARATOR,
-  API_NAME, FORMULA, LOOKUP_FILTER_FIELDS,
+  API_NAME, FORMULA, LOOKUP_FILTER_FIELDS, CUSTOM_SETTINGS_TYPE,
   FIELD_DEPENDENCY_FIELDS, VALUE_SETTINGS_FIELDS, VALUE_SET_FIELDS,
   CUSTOM_VALUE, VALUE_SET_DEFINITION_FIELDS,
   OBJECTS_PATH, INSTALLED_PACKAGES_PATH, TYPES_PATH, RECORDS_PATH, WORKFLOW_METADATA_TYPE,
@@ -1026,6 +1026,18 @@ describe('Custom Objects filter', () => {
           expect(lead.annotations.enableFeeds).toBeTruthy()
           expect(lead.annotationTypes.pluralLabel).toBeUndefined()
           expect(lead.annotations.pluralLabel).toBeUndefined()
+        })
+
+        it('should merge regular instance element annotations into the custom settings-custom object type', async () => {
+          const customSettingsInstance = customObjectInstance.clone()
+          customSettingsInstance.annotationTypes = { [CUSTOM_SETTINGS_TYPE]: BuiltinTypes.STRING }
+          customSettingsInstance.annotations = { [CUSTOM_SETTINGS_TYPE]: 'Hierarchical' }
+          result.push(customSettingsInstance)
+          await filter().onFetch(result)
+          const lead = findElements(result, 'Lead').pop() as ObjectType
+          expect(lead.annotationTypes.enableFeeds).toBeDefined()
+          expect(lead.annotations.enableFeeds).toBeTruthy()
+          expect(lead.annotationTypes.pluralLabel).toBeUndefined()
         })
 
         it('should merge regular instance element annotations into the custom-custom object type', async () => {

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -34,7 +34,7 @@ import {
   FIELD_ANNOTATIONS, FIELD_TYPE_NAMES, LABEL, API_NAME, COMPOUND_FIELD_TYPE_NAMES,
   FIELD_DEPENDENCY_FIELDS, VALUE_SETTINGS_FIELDS, FILTER_ITEM_FIELDS, METADATA_TYPE,
   CUSTOM_OBJECT, VALUE_SET_FIELDS, SUBTYPES_PATH, INSTANCE_FULL_NAME_FIELD, DESCRIPTION,
-  SALESFORCE, WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
+  SALESFORCE, WORKFLOW_FIELD_UPDATE_METADATA_TYPE, CUSTOM_SETTINGS_TYPE,
   WORKFLOW_RULE_METADATA_TYPE, WORKFLOW_ACTION_REFERENCE_METADATA_TYPE, INTERNAL_ID_FIELD,
   WORKFLOW_ACTION_ALERT_METADATA_TYPE,
   LAYOUT_TYPE_ID_METADATA_TYPE,
@@ -724,6 +724,32 @@ describe('transformer', () => {
         })
         it('should not contain fields', () => {
           expect(customObj.fields).toBeUndefined()
+        })
+      })
+
+      describe('create a custom settings object', () => {
+        let customObj: CustomProperties
+        beforeEach(() => {
+          const customSettingsObj = new ObjectType({
+            elemID,
+            annotationTypes: {
+              [API_NAME]: BuiltinTypes.SERVICE_ID,
+              [METADATA_TYPE]: BuiltinTypes.STRING,
+              [DESCRIPTION]: BuiltinTypes.STRING,
+              [CUSTOM_SETTINGS_TYPE]: BuiltinTypes.STRING,
+            },
+            annotations: {
+              [API_NAME]: 'Test__c',
+              [METADATA_TYPE]: CUSTOM_OBJECT,
+              [DESCRIPTION]: 'MyDescription',
+              [CUSTOM_SETTINGS_TYPE]: 'Hierarchical',
+            },
+          })
+          customObj = toCustomObject(customSettingsObj, false)
+        })
+        it('should not create fields that dont exist on custom settings objects', () => {
+          expect(customObj).not.toHaveProperty('pluralLabel')
+          expect(customObj).not.toHaveProperty('sharingModel')
         })
       })
     })

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -24,7 +24,7 @@ import {
   restoreValues, resolveValues,
 } from '@salto-io/adapter-utils'
 import {
-  getSObjectFieldElement, Types, toCustomField, toCustomObject, instancesToUpdateRecords,
+  getSObjectFieldElement, Types, toCustomField, toCustomProperties, instancesToUpdateRecords,
   getValueTypeFieldElement, createMetadataTypeElements,
   METADATA_TYPES_TO_RENAME, instancesToDeleteRecords, instancesToCreateRecords,
   isMetadataObjectType, isMetadataInstanceElement, toDeployableInstance, transformPrimitive,
@@ -634,7 +634,7 @@ describe('transformer', () => {
     })
   })
 
-  describe('toCustomObject', () => {
+  describe('toCustomProperties', () => {
     const elemID = new ElemID('salesforce', 'test')
 
     describe('annotations transformation', () => {
@@ -656,7 +656,7 @@ describe('transformer', () => {
 
       let customObj: CustomProperties
       beforeEach(() => {
-        customObj = toCustomObject(objType, false)
+        customObj = toCustomProperties(objType, false)
       })
 
       it('should transform annotations', () => {
@@ -697,7 +697,7 @@ describe('transformer', () => {
       describe('with fields', () => {
         let customObj: CustomProperties
         beforeEach(() => {
-          customObj = toCustomObject(
+          customObj = toCustomProperties(
             objType, true, [objType.fields[ignoredField].annotations[API_NAME]],
           )
         })
@@ -720,7 +720,7 @@ describe('transformer', () => {
       describe('without fields', () => {
         let customObj: CustomProperties
         beforeEach(() => {
-          customObj = toCustomObject(objType, false)
+          customObj = toCustomProperties(objType, false)
         })
         it('should not contain fields', () => {
           expect(customObj.fields).toBeUndefined()
@@ -745,7 +745,7 @@ describe('transformer', () => {
               [CUSTOM_SETTINGS_TYPE]: 'Hierarchical',
             },
           })
-          customObj = toCustomObject(customSettingsObj, false)
+          customObj = toCustomProperties(customSettingsObj, false)
         })
         it('should not create fields that dont exist on custom settings objects', () => {
           expect(customObj).not.toHaveProperty('pluralLabel')
@@ -812,19 +812,19 @@ describe('transformer', () => {
 
       it('should have ControlledByParent sharing model when having masterdetail field', async () => {
         objectType.fields[fieldName].type = Types.primitiveDataTypes.MasterDetail
-        const customObjectWithMasterDetailField = toCustomObject(objectType, true)
+        const customObjectWithMasterDetailField = toCustomProperties(objectType, true)
         expect(customObjectWithMasterDetailField).toHaveProperty('sharingModel')
         expect((customObjectWithMasterDetailField as CustomObject).sharingModel).toEqual('ControlledByParent')
       })
 
       it('should have ReadWrite sharing model when not having masterdetail field', async () => {
-        const customObjectWithMasterDetailField = toCustomObject(objectType, true)
+        const customObjectWithMasterDetailField = toCustomProperties(objectType, true)
         expect(customObjectWithMasterDetailField).toHaveProperty('sharingModel')
         expect((customObjectWithMasterDetailField as CustomObject).sharingModel).toEqual('ReadWrite')
       })
 
       it('should have ReadWrite sharing model when not including fields', async () => {
-        const customObjectWithMasterDetailField = toCustomObject(objectType, false)
+        const customObjectWithMasterDetailField = toCustomProperties(objectType, false)
         expect(customObjectWithMasterDetailField).toHaveProperty('sharingModel')
         expect((customObjectWithMasterDetailField as CustomObject).sharingModel).toEqual('ReadWrite')
       })

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -41,7 +41,8 @@ import {
   CPQ_PRODUCT_RULE,
   CPQ_LOOKUP_PRODUCT_FIELD,
 } from '../../src/constants'
-import { CustomField, FilterItem, CustomObject, CustomPicklistValue, SalesforceRecord } from '../../src/client/types'
+import { CustomField, FilterItem, CustomObject, CustomProperties, CustomPicklistValue,
+  SalesforceRecord } from '../../src/client/types'
 import SalesforceClient from '../../src/client/client'
 import Connection from '../../src/client/jsforce'
 import mockClient from '../client'
@@ -653,7 +654,7 @@ describe('transformer', () => {
         },
       })
 
-      let customObj: CustomObject
+      let customObj: CustomProperties
       beforeEach(() => {
         customObj = toCustomObject(objType, false)
       })
@@ -694,7 +695,7 @@ describe('transformer', () => {
       })
 
       describe('with fields', () => {
-        let customObj: CustomObject
+        let customObj: CustomProperties
         beforeEach(() => {
           customObj = toCustomObject(
             objType, true, [objType.fields[ignoredField].annotations[API_NAME]],
@@ -717,7 +718,7 @@ describe('transformer', () => {
       })
 
       describe('without fields', () => {
-        let customObj: CustomObject
+        let customObj: CustomProperties
         beforeEach(() => {
           customObj = toCustomObject(objType, false)
         })
@@ -786,17 +787,20 @@ describe('transformer', () => {
       it('should have ControlledByParent sharing model when having masterdetail field', async () => {
         objectType.fields[fieldName].type = Types.primitiveDataTypes.MasterDetail
         const customObjectWithMasterDetailField = toCustomObject(objectType, true)
-        expect(customObjectWithMasterDetailField.sharingModel).toEqual('ControlledByParent')
+        expect(customObjectWithMasterDetailField).toHaveProperty('sharingModel')
+        expect((customObjectWithMasterDetailField as CustomObject).sharingModel).toEqual('ControlledByParent')
       })
 
       it('should have ReadWrite sharing model when not having masterdetail field', async () => {
         const customObjectWithMasterDetailField = toCustomObject(objectType, true)
-        expect(customObjectWithMasterDetailField.sharingModel).toEqual('ReadWrite')
+        expect(customObjectWithMasterDetailField).toHaveProperty('sharingModel')
+        expect((customObjectWithMasterDetailField as CustomObject).sharingModel).toEqual('ReadWrite')
       })
 
       it('should have ReadWrite sharing model when not including fields', async () => {
         const customObjectWithMasterDetailField = toCustomObject(objectType, false)
-        expect(customObjectWithMasterDetailField.sharingModel).toEqual('ReadWrite')
+        expect(customObjectWithMasterDetailField).toHaveProperty('sharingModel')
+        expect((customObjectWithMasterDetailField as CustomObject).sharingModel).toEqual('ReadWrite')
       })
     })
 


### PR DESCRIPTION
First part of fixing [Salto-758]. Custom settings objects will be uploaded with correct fields, preventing them from causing migration errors.

@omrilit  - maybe you will be interested in reviewing this, as you wrote code in this area?