### PR TITLE
SALTO-881 - files encoding + resolve/restore using the encoding

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -38,17 +38,24 @@ type HashOrContent = {
   hash: string
 }
 
-
 export type StaticFileParameters = {
   filepath: string
+  encoding?: BufferEncoding
 } & HashOrContent
+
+export const defaultStaticFileEncoding: BufferEncoding = 'binary'
 
 export class StaticFile {
   public readonly filepath: string
   public readonly hash: string
+  public readonly encoding: BufferEncoding
   protected internalContent?: Buffer
   constructor(params: StaticFileParameters) {
     this.filepath = params.filepath
+    this.encoding = params.encoding ?? defaultStaticFileEncoding
+    if (!Buffer.isEncoding(this.encoding)) {
+      throw Error(`Can not create StaticFile at path - ${this.filepath} due to invalid encoding - ${this.encoding}`)
+    }
     if ('content' in params) {
       this.internalContent = params.content
       this.hash = calculateStaticFileHash(this.internalContent)
@@ -62,7 +69,7 @@ export class StaticFile {
   }
 
   public isEqual(other: StaticFile): boolean {
-    return this.hash === other.hash
+    return this.hash === other.hash && this.encoding === other.encoding
   }
 }
 

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -43,7 +43,7 @@ export type StaticFileParameters = {
   encoding?: BufferEncoding
 } & HashOrContent
 
-export const defaultStaticFileEncoding: BufferEncoding = 'binary'
+export const DEFAULT_STATIC_FILE_ENCODING: BufferEncoding = 'binary'
 
 export class StaticFile {
   public readonly filepath: string
@@ -52,9 +52,9 @@ export class StaticFile {
   protected internalContent?: Buffer
   constructor(params: StaticFileParameters) {
     this.filepath = params.filepath
-    this.encoding = params.encoding ?? defaultStaticFileEncoding
+    this.encoding = params.encoding ?? DEFAULT_STATIC_FILE_ENCODING
     if (!Buffer.isEncoding(this.encoding)) {
-      throw Error(`Can not create StaticFile at path - ${this.filepath} due to invalid encoding - ${this.encoding}`)
+      throw Error(`Cannot create StaticFile at path - ${this.filepath} due to invalid encoding - ${this.encoding}`)
     }
     if ('content' in params) {
       this.internalContent = params.content

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -23,7 +23,7 @@ import {
   Element, isInstanceElement, InstanceElement, isPrimitiveType, TypeMap, isField, ChangeDataType,
   ReferenceExpression, Field, InstanceAnnotationTypes, isType, isObjectType, isAdditionChange,
   CORE_ANNOTATIONS, TypeElement, Change, isRemovalChange, isModificationChange, isListType,
-  ChangeData, ListType, CoreAnnotationTypes, defaultStaticFileEncoding,
+  ChangeData, ListType, CoreAnnotationTypes,
 } from '@salto-io/adapter-api'
 
 const { isDefined } = lowerDashValues
@@ -308,7 +308,7 @@ export const resolveValues: ResolveValuesFunc = (element, getLookUpName) => {
       })
     }
     if (isStaticFile(value)) {
-      return value.encoding === defaultStaticFileEncoding
+      return value.encoding === 'binary'
         ? value.content : value.content?.toString(value.encoding)
     }
     return value
@@ -358,7 +358,7 @@ export const restoreValues: RestoreValuesFunc = (source, targetElement, getLookU
     }
     const file = allStaticFilesPaths.get(path.getFullName())
     if (!_.isUndefined(file)) {
-      const content = file.encoding === defaultStaticFileEncoding
+      const content = file.encoding === 'binary'
         ? value : Buffer.from(value, file.encoding)
       return new StaticFile({ filepath: file.filepath, content, encoding: file.encoding })
     }

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -23,7 +23,7 @@ import {
   Element, isInstanceElement, InstanceElement, isPrimitiveType, TypeMap, isField, ChangeDataType,
   ReferenceExpression, Field, InstanceAnnotationTypes, isType, isObjectType, isAdditionChange,
   CORE_ANNOTATIONS, TypeElement, Change, isRemovalChange, isModificationChange, isListType,
-  ChangeData, ListType, CoreAnnotationTypes,
+  ChangeData, ListType, CoreAnnotationTypes, defaultStaticFileEncoding,
 } from '@salto-io/adapter-api'
 
 const { isDefined } = lowerDashValues
@@ -308,7 +308,8 @@ export const resolveValues: ResolveValuesFunc = (element, getLookUpName) => {
       })
     }
     if (isStaticFile(value)) {
-      return value.content
+      return value.encoding === defaultStaticFileEncoding
+        ? value.content : value.content?.toString(value.encoding)
     }
     return value
   }
@@ -357,7 +358,9 @@ export const restoreValues: RestoreValuesFunc = (source, targetElement, getLookU
     }
     const file = allStaticFilesPaths.get(path.getFullName())
     if (!_.isUndefined(file)) {
-      return new StaticFile({ filepath: file.filepath, content: Buffer.from(value) })
+      const content = file.encoding === defaultStaticFileEncoding
+        ? value : Buffer.from(value, file.encoding)
+      return new StaticFile({ filepath: file.filepath, content, encoding: file.encoding })
     }
 
     return value

--- a/packages/salesforce-adapter/src/filters/cpq/custom_script.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/custom_script.ts
@@ -76,6 +76,7 @@ const codeValueToFile = (
     cpqCustomScriptInstance.value[CPQ_CODE_FIELD] = new StaticFile({
       filepath: `${(cpqCustomScriptInstance.path ?? []).join('/')}.js`,
       content: Buffer.from(cpqCustomScriptInstance.value[CPQ_CODE_FIELD]),
+      encoding: 'utf-8',
     })
   }
   return cpqCustomScriptInstance
@@ -90,11 +91,6 @@ const transformInstanceToSFValues = (
       cpqCustomScriptInstance.value[fieldName] = fieldValue.join('\n')
     }
   })
-  // TODO: Remove this when SALTO-881 is done
-  const codeValue = cpqCustomScriptInstance.value[CPQ_CODE_FIELD]
-  if (Buffer.isBuffer(codeValue)) {
-    cpqCustomScriptInstance.value[CPQ_CODE_FIELD] = codeValue.toString('utf8')
-  }
   return cpqCustomScriptInstance
 }
 

--- a/packages/salesforce-adapter/test/filters/cpq/custom_script.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/custom_script.test.ts
@@ -81,6 +81,7 @@ describe('cpq custom script filter', () => {
     [CPQ_CODE_FIELD]: new StaticFile({
       content: Buffer.from('if (this === "code") return true'),
       filepath: `${mockCustomScripInstancePath.join('/')}.js`,
+      encoding: 'utf-8',
     }),
     randomField: 'stayLikeThis',
   }
@@ -239,16 +240,17 @@ describe('cpq custom script filter', () => {
       .fields[CPQ_CONSUMPTION_RATE_FIELDS].type = new ListType(Types.primitiveDataTypes.Text)
     mockAfterOnFetchCustomScriptObject
       .fields[CPQ_GROUP_FIELDS].type = new ListType(Types.primitiveDataTypes.Text)
-    const mockAfterRestoreCustomScriptInstance = mockAfterOnFetchCustomScriptInstance
+    const mockAfterResolveCustomScriptInstance = mockAfterOnFetchCustomScriptInstance
       .clone()
-    mockAfterRestoreCustomScriptInstance
-      .value[CPQ_CODE_FIELD] = mockAfterRestoreCustomScriptInstance.value[CPQ_CODE_FIELD].content
+    // Simulating resolve on the static-file
+    mockAfterResolveCustomScriptInstance
+      .value[CPQ_CODE_FIELD] = mockAfterResolveCustomScriptInstance.value[CPQ_CODE_FIELD].content.toString('utf-8')
     describe('Modification changes', () => {
       beforeAll(async () => {
         changes = [
           toChange({
-            before: mockAfterRestoreCustomScriptInstance.clone(),
-            after: mockAfterRestoreCustomScriptInstance.clone(),
+            before: mockAfterResolveCustomScriptInstance.clone(),
+            after: mockAfterResolveCustomScriptInstance.clone(),
           }),
           toChange({
             before: mockAfterOnFetchCustomScriptObject.clone(),
@@ -278,7 +280,7 @@ describe('cpq custom script filter', () => {
           .toEqual(Types.primitiveDataTypes.LongTextArea)
       })
 
-      it('Should only change values of multi-line string in fieldsRefList and code back to string', () => {
+      it('Should only change values of multi-line string in fieldsRefList', () => {
         const customScriptInstanceModify = changes
           .find(change =>
             getChangeElement(change).elemID.isEqual(mockAfterOnFetchCustomScriptInstance.elemID)
@@ -308,7 +310,7 @@ describe('cpq custom script filter', () => {
     describe('Addition changes', () => {
       beforeAll(async () => {
         changes = [
-          toChange({ after: mockAfterRestoreCustomScriptInstance.clone() }),
+          toChange({ after: mockAfterResolveCustomScriptInstance.clone() }),
           toChange({ after: mockAfterOnFetchCustomScriptObject.clone() }),
         ]
         await filter.preDeploy(changes)
@@ -327,7 +329,7 @@ describe('cpq custom script filter', () => {
           .toEqual(Types.primitiveDataTypes.LongTextArea)
       })
 
-      it('Should only change values of multi-line string in fieldsRefList and code back to string', () => {
+      it('Should only change values of multi-line string in fieldsRefList', () => {
         const customScriptInstanceAdd = changes
           .find(change =>
             getChangeElement(change).elemID.isEqual(mockAfterOnFetchCustomScriptInstance.elemID)

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -197,7 +197,9 @@ export const deserialize = async (
       new VariableExpression(reviveElemID(v.elemId))
     ),
     StaticFile: v => {
-      const staticFile = new StaticFile({ filepath: v.filepath, hash: v.hash })
+      const staticFile = new StaticFile(
+        { filepath: v.filepath, hash: v.hash, encoding: v.encoding }
+      )
       staticFiles[staticFile.filepath] = staticFile
       return staticFile
     },

--- a/packages/workspace/src/workspace/cache.ts
+++ b/packages/workspace/src/workspace/cache.ts
@@ -58,13 +58,13 @@ export const parseResultCache = (
       const cacheFileName = resolveCacheFileName(key)
       const cacheTimeMs = await dirStore.mtimestamp(cacheFileName) || -1
       if ((cacheTimeMs > key.lastModified) || (cacheTimeMs === key.lastModified)) {
-        const fileContent = (await dirStore.get(cacheFileName))?.buffer
+        const file = await dirStore.get(cacheFileName)
         try {
-          return _.isUndefined(fileContent)
+          return file === undefined
             ? Promise.resolve(undefined)
             : await parseResultSerializer.deserialize(
-              fileContent,
-              val => staticFilesSource.getStaticFile(val.filepath)
+              file.buffer,
+              val => staticFilesSource.getStaticFile(val.filepath, val.encoding)
             )
         } catch (err) {
           log.debug('Failed to handle cache file "%o": %o', cacheFileName, err)

--- a/packages/workspace/src/workspace/cache.ts
+++ b/packages/workspace/src/workspace/cache.ts
@@ -61,7 +61,7 @@ export const parseResultCache = (
         const file = await dirStore.get(cacheFileName)
         try {
           return file === undefined
-            ? Promise.resolve(undefined)
+            ? undefined
             : await parseResultSerializer.deserialize(
               file.buffer,
               val => staticFilesSource.getStaticFile(val.filepath, val.encoding)
@@ -70,7 +70,7 @@ export const parseResultCache = (
           log.debug('Failed to handle cache file "%o": %o', cacheFileName, err)
         }
       }
-      return Promise.resolve(undefined)
+      return undefined
     },
     clear: dirStore.clear,
     rename: dirStore.rename,

--- a/packages/workspace/src/workspace/static_files/common.ts
+++ b/packages/workspace/src/workspace/static_files/common.ts
@@ -16,7 +16,7 @@
 import { StaticFile, Value } from '@salto-io/adapter-api'
 
 export type StaticFilesSource = {
-  getStaticFile: (filepath: string) =>
+  getStaticFile: (filepath: string, encoding: BufferEncoding) =>
     Promise<StaticFile | InvalidStaticFile>
   getContent: (filepath: string) => Promise<Buffer>
   persistStaticFile: (staticFile: StaticFile) => Promise<void>
@@ -27,7 +27,6 @@ export type StaticFilesSource = {
   clone: () => StaticFilesSource
   delete: (staticFile: StaticFile) => Promise<void>
 }
-
 
 export abstract class InvalidStaticFile {
   constructor(

--- a/packages/workspace/src/workspace/static_files/functions.ts
+++ b/packages/workspace/src/workspace/static_files/functions.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { StaticFile, Value, isStaticFile } from '@salto-io/adapter-api'
+import { StaticFile, Value, isStaticFile, defaultStaticFileEncoding } from '@salto-io/adapter-api'
 
 import { StaticFilesSource, InvalidStaticFile } from './common'
 import { Functions, FunctionExpression } from '../../parser/functions'
@@ -21,16 +21,18 @@ import { Functions, FunctionExpression } from '../../parser/functions'
 export const getStaticFilesFunctions = (staticFilesSource: StaticFilesSource): Functions => ({
   file: {
     parse: (parameters): Promise<StaticFile | InvalidStaticFile> => {
-      const [filepath] = parameters
-      return staticFilesSource.getStaticFile(filepath)
+      const [filepath, encoding] = parameters
+      return staticFilesSource.getStaticFile(filepath, encoding)
     },
     dump: async (val: Value): Promise<FunctionExpression> => {
       if (val.content !== undefined) {
         await staticFilesSource.persistStaticFile(val)
       }
+      const params = val.encoding === defaultStaticFileEncoding
+        ? [val.filepath] : [val.filepath, val.encoding]
       return new FunctionExpression(
         'file',
-        [val.filepath],
+        params,
       )
     },
     isSerializedAsFunction: (val: Value) => isStaticFile(val),

--- a/packages/workspace/src/workspace/static_files/functions.ts
+++ b/packages/workspace/src/workspace/static_files/functions.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { StaticFile, Value, isStaticFile, defaultStaticFileEncoding } from '@salto-io/adapter-api'
+import { StaticFile, Value, isStaticFile, DEFAULT_STATIC_FILE_ENCODING } from '@salto-io/adapter-api'
 
 import { StaticFilesSource, InvalidStaticFile } from './common'
 import { Functions, FunctionExpression } from '../../parser/functions'
@@ -28,7 +28,7 @@ export const getStaticFilesFunctions = (staticFilesSource: StaticFilesSource): F
       if (val.content !== undefined) {
         await staticFilesSource.persistStaticFile(val)
       }
-      const params = val.encoding === defaultStaticFileEncoding
+      const params = val.encoding === DEFAULT_STATIC_FILE_ENCODING
         ? [val.filepath] : [val.filepath, val.encoding]
       return new FunctionExpression(
         'file',

--- a/packages/workspace/src/workspace/static_files/source.ts
+++ b/packages/workspace/src/workspace/static_files/source.ts
@@ -25,8 +25,13 @@ import {
 export class LazyStaticFile extends StaticFile {
   private dirStore: SyncDirectoryStore<Buffer>
 
-  constructor(filepath: string, hash: string, dirStore: SyncDirectoryStore<Buffer>) {
-    super({ filepath, hash })
+  constructor(
+    filepath: string,
+    hash: string,
+    dirStore: SyncDirectoryStore<Buffer>,
+    encoding?: BufferEncoding
+  ) {
+    super({ filepath, hash, encoding })
     this.dirStore = dirStore
   }
 
@@ -45,6 +50,7 @@ export const buildStaticFilesSource = (
   const staticFilesSource: StaticFilesSource = {
     getStaticFile: async (
       filepath: string,
+      encoding: BufferEncoding,
     ): Promise<StaticFile | InvalidStaticFile> => {
       const cachedResult = await staticFilesCache.get(filepath)
       let modified: number | undefined
@@ -70,6 +76,7 @@ export const buildStaticFilesSource = (
         const staticFileWithHashAndContent = new StaticFile({
           filepath,
           content: staticFileBuffer,
+          encoding,
         })
         await staticFilesCache.put({
           hash: staticFileWithHashAndContent.hash,
@@ -81,7 +88,8 @@ export const buildStaticFilesSource = (
       return new LazyStaticFile(
         filepath,
         cachedResult.hash,
-        staticFilesDirStore
+        staticFilesDirStore,
+        encoding,
       )
     },
     getContent: async (

--- a/packages/workspace/test/serializer/serializer.test.ts
+++ b/packages/workspace/test/serializer/serializer.test.ts
@@ -131,6 +131,7 @@ describe('State/cache serialization', () => {
     model,
     {
       file: new StaticFile({ filepath: 'some/path.ext', hash: 'hash' }),
+      fileWithEncoding: new StaticFile({ filepath: 'some/pathWithEncoding.ext', hash: 'hash', encoding: 'utf-8' }),
       singleparam: new TestFuncImpl('funcadelic', ['aaa']),
       multipleparams: new TestFuncImpl('george', [false, 321]),
       withlist: new TestFuncImpl('washington', ['ZOMG', [3, 2, 1]]),
@@ -248,9 +249,13 @@ describe('State/cache serialization', () => {
         parameters: [1, [1, { aa: '312' }], false, 'aaa'],
       })
     })
-    it('file', () => {
-      expect(funcElement.value).toHaveProperty('file', { filepath: 'some/path.ext', hash: 'hash' })
+    it('file with default encoding', () => {
+      expect(funcElement.value).toHaveProperty('file', { filepath: 'some/path.ext', hash: 'hash', encoding: 'binary' })
       expect(funcElement.value.file).toBeInstanceOf(StaticFile)
+    })
+    it('file with encoding', () => {
+      expect(funcElement.value).toHaveProperty('fileWithEncoding', { filepath: 'some/pathWithEncoding.ext', hash: 'hash', encoding: 'utf-8' })
+      expect(funcElement.value.fileWithEncoding).toBeInstanceOf(StaticFile)
     })
     it('nested parameter', () => {
       expect(funcElement.value).toHaveProperty('nested', {
@@ -267,10 +272,10 @@ describe('State/cache serialization', () => {
       const serialized = serialize(elementsToSerialize)
       const funcElement = (await deserialize(
         serialized,
-        x => Promise.resolve(new StaticFile({ filepath: x.filepath, hash: 'ZOMGZOMGZOMG' }))
+        x => Promise.resolve(new StaticFile({ filepath: x.filepath, hash: 'ZOMGZOMGZOMG', encoding: 'utf-8' }))
       ))[0] as InstanceElement
 
-      expect(funcElement.value).toHaveProperty('file', { filepath: 'some/path.ext', hash: 'ZOMGZOMGZOMG' })
+      expect(funcElement.value).toHaveProperty('file', { filepath: 'some/path.ext', hash: 'ZOMGZOMGZOMG', encoding: 'utf-8' })
       expect(funcElement.value.file).toBeInstanceOf(StaticFile)
     })
   })

--- a/packages/workspace/test/workspace/static_files/functions.test.ts
+++ b/packages/workspace/test/workspace/static_files/functions.test.ts
@@ -30,13 +30,13 @@ describe('Functions', () => {
   it('should have a file function', () =>
     expect(functions).toHaveProperty('file'))
   it('should identify static file values', () =>
-    expect(functions.file.isSerializedAsFunction(new StaticFile({ filepath: 'aa', hash: 'hash' }))).toBeTruthy())
+    expect(functions.file.isSerializedAsFunction(new StaticFile({ filepath: 'aa', hash: 'hash', encoding: 'binary' }))).toBeTruthy())
   it('should not identify for other values', () =>
     expect(functions.file.isSerializedAsFunction('a' as Value)).toBeFalsy())
   it('should convert valid function expression to valid static metadata', async () => {
-    await functions.file.parse(['aa'])
+    await functions.file.parse(['aa', 'utf-8'])
     expect(mockedStaticFilesSource.getStaticFile).toHaveBeenCalledTimes(1)
-    expect(mockedStaticFilesSource.getStaticFile).toHaveBeenCalledWith('aa')
+    expect(mockedStaticFilesSource.getStaticFile).toHaveBeenCalledWith('aa', 'utf-8')
   })
   it('should not persist when dumping static file with no content', async () => {
     const dumped = await functions.file.dump(new StaticFile({

--- a/packages/workspace/test/workspace/static_files/source.test.ts
+++ b/packages/workspace/test/workspace/static_files/source.test.ts
@@ -65,13 +65,13 @@ describe('Static Files Source', () => {
   describe('Get By Value', () => {
     describe('file finding logic', () => {
       it('not find when no matching', async () => {
-        const result = await staticFilesSource.getStaticFile('aa')
+        const result = await staticFilesSource.getStaticFile('aa', 'binary')
         expect(result).toBeInstanceOf(InvalidStaticFile)
         expect(result).toBeInstanceOf(MissingStaticFile)
       })
       it('blow up if invalid file', async () => {
         mockDirStore.mtimestamp = jest.fn().mockRejectedValue('whatevz')
-        const result = await staticFilesSource.getStaticFile('/aa')
+        const result = await staticFilesSource.getStaticFile('/aa', 'binary')
         expect(result).toBeInstanceOf(InvalidStaticFile)
         expect(result).toBeInstanceOf(AccessDeniedStaticFile)
       })
@@ -91,7 +91,7 @@ describe('Static Files Source', () => {
           modified: 100,
           hash: 'aaa',
         })
-        const result = await staticFilesSource.getStaticFile(filepathFromCache)
+        const result = await staticFilesSource.getStaticFile(filepathFromCache, 'binary')
 
         expect(mockDirStore.mtimestamp).toHaveBeenCalledWith(filepathFromCache)
         return expect(result).toHaveProperty('hash', hashedContent)
@@ -115,7 +115,7 @@ describe('Static Files Source', () => {
           modified: 1000,
           hash: 'aaa',
         })
-        const result = await staticFilesSource.getStaticFile('bb')
+        const result = await staticFilesSource.getStaticFile('bb', 'binary')
         expect(mockDirStore.get).toHaveBeenCalledTimes(0)
         expect(result).toHaveProperty('hash', 'aaa')
         expect(mockDirStore.getSync).not.toHaveBeenCalled()
@@ -139,7 +139,7 @@ describe('Static Files Source', () => {
           modified: 100,
           hash: 'aaa',
         })
-        const result = await staticFilesSource.getStaticFile('bb')
+        const result = await staticFilesSource.getStaticFile('bb', 'binary')
         expect(mockDirStore.get).toHaveBeenCalledTimes(1)
         return expect(result).toHaveProperty('hash', hashedContent)
       })
@@ -154,7 +154,7 @@ describe('Static Files Source', () => {
             )
         )
         mockCacheStore.get = jest.fn().mockResolvedValue(undefined)
-        const result = await staticFilesSource.getStaticFile('bb')
+        const result = await staticFilesSource.getStaticFile('bb', 'binary')
         expect(mockDirStore.get).toHaveBeenCalledTimes(1)
         return expect(result).toHaveProperty('hash', hashedContent)
       })
@@ -164,7 +164,7 @@ describe('Static Files Source', () => {
           .mockResolvedValue(Promise.resolve(42))
         mockCacheStore.get = jest.fn().mockResolvedValue(undefined)
 
-        const result = await staticFilesSource.getStaticFile('bb')
+        const result = await staticFilesSource.getStaticFile('bb', 'binary')
         return expect(result).toBeInstanceOf(InvalidStaticFile)
       })
     })


### PR DESCRIPTION
**What's here?**
- Add encoding to StaticFile (with a default 'binary')
- Use the encoding in restore/restoreValues
- Use the new encoding feature for StaticFiles in CustomScript

*** I will do the HubSpot changes in a different PR