### PR TITLE
SALTO-1005: Handle XML encoding in salesforce values

### DIFF
--- a/packages/salesforce-adapter/package.json
+++ b/packages/salesforce-adapter/package.json
@@ -39,6 +39,7 @@
     "@salto-io/lowerdash": "0.1.33",
     "@types/requestretry": "^1.12.5",
     "fast-xml-parser": "^3.15.0",
+    "he": "^1.2.0",
     "jsforce": "https://github.com/salto-io/jsforce.git",
     "jszip": "^3.2.2",
     "lodash": "^4.17.19",

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import he from 'he'
 import parser from 'fast-xml-parser'
 import { RetrieveResult, FileProperties, RetrieveRequest } from 'jsforce'
 import JSZip from 'jszip'
@@ -209,7 +210,11 @@ const isComplexType = (typeName: string): typeName is keyof ComplexTypesMap =>
 
 const xmlToValues = (xmlAsString: string, type: string): Values => parser.parse(
   xmlAsString,
-  { ignoreAttributes: false, attributeNamePrefix: XML_ATTRIBUTE_PREFIX }
+  {
+    ignoreAttributes: false,
+    attributeNamePrefix: XML_ATTRIBUTE_PREFIX,
+    tagValueProcessor: val => he.decode(val),
+  }
 )[type]
 
 const extractFileNameToData = async (zip: JSZip, fileName: string, withMetadataSuffix: boolean,
@@ -290,6 +295,7 @@ const toMetadataXml = (name: string, values: Values): string =>
   new parser.j2xParser({
     attributeNamePrefix: XML_ATTRIBUTE_PREFIX,
     ignoreAttributes: false,
+    tagValueProcessor: val => he.encode(String(val), { useNamedReferences: true }),
   }).parse({ [name]: _.omit(values, INSTANCE_FULL_NAME_FIELD) })
 
 const cloneValuesWithAttributePrefixes = (instance: InstanceElement): Values => {


### PR DESCRIPTION
Some field values may contain xml encoded values like < and > which should be translated
from `&gt;` on fetch and to `&gt;` on deploy (otherwise we fail deploying due to malformed XML)

---

_Release Notes_ (salesforce):
- Fix XML encoded values like `&gt;` or `&qout;` appearing in some instances (EmailTemplates, Reports, etc.)