### PR TITLE
SALTO-998 Fix validation error on filterScope

### DIFF
--- a/packages/salesforce-adapter/src/filters/missing_fields.json
+++ b/packages/salesforce-adapter/src/filters/missing_fields.json
@@ -839,7 +839,8 @@
               "Delegated",
               "MyTerritory",
               "MyTeamTerritory",
-              "Team"
+              "Team",
+              "SalesTeam"
             ]
           }
         }


### PR DESCRIPTION
salesforce lately added another option ("SalesTeam") for that enum (supported by the API since version 49.0 and above).