### PR TITLE
allow transform function to return reference in object field

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -96,6 +96,10 @@ export const transformValues = (
       return undefined
     }
 
+    if (isReferenceExpression(newVal)) {
+      return newVal
+    }
+
     const fieldType = field.type
 
     if (isListType(fieldType)) {


### PR DESCRIPTION
---

Before this fix if we try to return a reference on an `ObjectType` field it would have changed it to be an object (the class would be removed)

---

_Release Notes_:
- None (this bug had no reproduction in current code flows as far as we know)