### PR TITLE
SALTO-977 Fix remaining filename suffix truncate

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -23,7 +23,7 @@ import {
   projectChange, projectElementOrValueToEnv, createAddChange, createRemoveChange,
 } from './projections'
 import { wrapAdditions, DetailedAddition, wrapNestedValues } from '../addition_wrapper'
-import { NaclFilesSource, FILE_EXTENSION, RoutingMode } from '../nacl_files_source'
+import { NaclFilesSource, RoutingMode } from '../nacl_files_source'
 import { mergeElements } from '../../../merger'
 
 export interface RoutedChanges {
@@ -308,7 +308,7 @@ const getChangePathHint = async (
     .map(sourceRange => sourceRange.filename)[0]
 
   return refFilename
-    ? _.trimEnd(refFilename, FILE_EXTENSION).split(path.sep)
+    ? toPathHint(refFilename)
     : undefined
 }
 


### PR DESCRIPTION
Same as https://github.com/salto-io/salto/pull/1463 (linked to the same ticket because it's similar enough) - ran into this randomly in the code, but there are no remaining `trimEnd`s so hopefully we won't see any more of these.