### PR TITLE
SALTO-1011 corrected types of fields of KnowledgeCaseSettings

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -331,6 +331,7 @@ export default class SalesforceAdapter implements AdapterOperations {
       'PermissionSetRecordTypeVisibility',
       'PermissionSetTabSetting',
       'PermissionSetUserPermission',
+      'KnowledgeSitesSettings',
     ],
     metadataTypesToSkipMutation = [
       'Workflow', // handled in workflow filter

--- a/packages/salesforce-adapter/src/filters/missing_fields.json
+++ b/packages/salesforce-adapter/src/filters/missing_fields.json
@@ -2208,6 +2208,32 @@
     ]
   },
   {
+    "id": "KnowledgeCaseSettings",
+    "fields": [
+      {
+        "name": "articlePublicSharingCommunities",
+        "type": "Unknown"
+      },
+      {
+        "name": "articlePublicSharingSites",
+        "type": "KnowledgeSitesSettings"
+      },
+      {
+        "name": "articlePublicSharingSitesChatterAnswers",
+        "type": "KnowledgeSitesSettings"
+      }
+    ]
+  },
+  {
+    "id": "KnowledgeSitesSettings",
+    "fields": [
+      {
+        "name": "site",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
     "id": "PermissionSet",
     "fields": [
       {


### PR DESCRIPTION
Changed type of articlePublicSharingCommunities to unknown since it causes validation errors and it's missing in SFDC documentation. The other types were corrected in accordance with the documentation.