### PR TITLE
SALTO-381 replace ForecastingSettings id fields with their names

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -67,6 +67,7 @@ import customFeedFilterFilter, { CUSTOM_FEED_FILTER_METADATA_TYPE } from './filt
 import extraDependenciesFilter from './filters/extra_dependencies'
 import staticResourceFileExtFilter from './filters/static_resource_file_ext'
 import xmlAttributesFilter from './filters/xml_attributes'
+import replaceFieldValuesFilter from './filters/replace_instance_field_values'
 import { ConfigChangeSuggestion, FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges, getConfigChangeMessage } from './config_change'
 import { FilterCreator, Filter, filtersRunner } from './filter'
@@ -114,6 +115,7 @@ export const DEFAULT_FILTERS = [
   // The following filters should remain last in order to make sure they fix all elements
   convertListsFilter,
   convertTypeFilter,
+  replaceFieldValuesFilter,
   fieldReferences,
   // should run after custom_object_instances for now
   referenceAnnotations,

--- a/packages/salesforce-adapter/src/filters/add_missing_ids.ts
+++ b/packages/salesforce-adapter/src/filters/add_missing_ids.ts
@@ -25,7 +25,7 @@ import { getFullName, getInternalId, setInternalId } from './utils'
 
 const log = logger(module)
 
-const getIdsForType = async (
+export const getIdsForType = async (
   client: SalesforceClient, type: string,
 ): Promise<Record<string, string>> => {
   const { result, errors } = await client.listMetadataObjects({ type })

--- a/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
+++ b/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
@@ -1,0 +1,121 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Element, isInstanceElement, InstanceElement, Values, getChangeElement, Change,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../filter'
+import { apiName, metadataType } from '../transformers/transformer'
+import SalesforceClient from '../client/client'
+import { getIdsForType } from './add_missing_ids'
+
+const log = logger(module)
+
+const metadataTypesToChange: string[] = ['ForecastingSettings']
+
+const pathsToValues: Record<string, string[][]> = {
+  Forecasting: [
+    ['forecastingTypeSettings', 'opportunityListFieldsSelectedSettings', 'field'],
+    ['forecastingTypeSettings', 'opportunityListFieldsUnselectedSettings', 'field'],
+    ['forecastingTypeSettings', 'opportunityListFieldsLabelMappings', 'field'],
+  ],
+}
+
+const getApiNameToIdLookup = async (client: SalesforceClient): Promise<Record<string, string>> => {
+  const apiNameToId = await getIdsForType(client, 'CustomField')
+  Object.keys(apiNameToId).forEach(k => {
+    // remove last 3 chars to get a 15-char id from an 18-char id
+    apiNameToId[k] = apiNameToId[k].slice(0, -3)
+  })
+  return apiNameToId
+}
+
+const swapKeyValue = (obj: Record<string, string>): Record<string, string> => {
+  const res: Record<string, string> = {}
+  Object.keys(obj).forEach(k => {
+    res[obj[k]] = k
+  })
+  return res
+}
+
+const replaceValuesInPath = (i: number, val: Values, nameLookUp: Record<string, string>,
+  path: string[]): void => {
+  if (path[i] === undefined || val === undefined) {
+    return
+  }
+  const key = path[i]
+  if (_.isString(val[key])) {
+    val[key] = nameLookUp[val[key]] ?? val[key]
+  } else if (_.isArray(val[key])) {
+    const [stringElements, objectElements] = _.partition(val[key], _.isString)
+
+    val[key] = objectElements
+    stringElements.map((s: string) => nameLookUp[s] ?? s).forEach(s => val[key].push(s))
+
+    objectElements.forEach((element: Values) => {
+      replaceValuesInPath(i + 1, element, nameLookUp, path)
+    })
+  } else {
+    replaceValuesInPath(i + 1, val[key], nameLookUp, path)
+  }
+}
+
+const replaceInstanceValues = (instance: InstanceElement,
+  nameLookUp: Record<string, string>): void => {
+  const name = apiName(instance)
+  const allPathsForInstance = pathsToValues[name]
+  allPathsForInstance.forEach(path => {
+    replaceValuesInPath(0, instance.value, nameLookUp, path)
+  })
+}
+
+const replaceElementsValues = (elements: Element[], nameLookUp: Record<string, string>): void => {
+  elements
+    .filter(isInstanceElement)
+    .filter(e => metadataTypesToChange.includes(metadataType(e)))
+    .forEach(e => {
+      replaceInstanceValues(e, nameLookUp)
+      log.debug(`replaced values of instance ${apiName(e)}`)
+    })
+}
+
+/**
+ * Replace specific field values that are fetched as ids, to their names.
+ */
+const filter: FilterCreator = ({ client }) => ({
+  onFetch: async (elements: Element[]) => {
+    const idToApiNameLookUp = swapKeyValue(await getApiNameToIdLookup(client))
+    replaceElementsValues(elements, idToApiNameLookUp)
+  },
+  preDeploy: async (changes: ReadonlyArray<Change>): Promise<void> => {
+    const apiNameToIdLookup = await getApiNameToIdLookup(client)
+    replaceElementsValues(
+      changes.map(getChangeElement),
+      apiNameToIdLookup
+    )
+  },
+  onDeploy: async changes => {
+    const idToApiNameLookUp = swapKeyValue(await getApiNameToIdLookup(client))
+    replaceElementsValues(
+      changes.map(getChangeElement),
+      idToApiNameLookUp
+    )
+    return []
+  },
+})
+
+export default filter

--- a/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
+++ b/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
@@ -47,17 +47,13 @@ const fieldSelectMapping = [
  */
 const toShortId = (longId: string): string => (longId.slice(0, -3))
 
-const getApiNameToIdLookup = async (client: SalesforceClient): Promise<Record<string, string>> => {
-  let apiNameToId = await getIdsForType(client, CUSTOM_FIELD)
-  apiNameToId = Object.fromEntries(
-    Object.entries(apiNameToId).map(([name, id]) => [name, toShortId(id)])
-  )
-  return apiNameToId
-}
+const getApiNameToIdLookup = async (client: SalesforceClient): Promise<Record<string, string>> => (
+  _.mapValues(await getIdsForType(client, CUSTOM_FIELD), toShortId)
+)
 
 const shouldReplace = (field: Field): boolean => {
   const resolverFinder = generateReferenceResolverFinder(fieldSelectMapping)
-  return !_.isEmpty(resolverFinder(field))
+  return resolverFinder(field).length > 0
 }
 
 const replaceInstanceValues = (instance: InstanceElement,
@@ -104,9 +100,9 @@ const getIdToNameLookupFromAllElements = (elements: Element[]): Record<string, s
 
   Object.assign(lookup, ...fields.map(field => {
     const id = getInternalId(field)
-    return ({
-      [id === undefined ? id : toShortId(id)]: apiName(field),
-    })
+    return id === undefined ? {} : {
+      [toShortId(id)]: apiName(field),
+    }
   }))
   return lookup
 }

--- a/packages/salesforce-adapter/test/filters/replace_instance_field_values.test.ts
+++ b/packages/salesforce-adapter/test/filters/replace_instance_field_values.test.ts
@@ -1,0 +1,378 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Element, ElemID, ObjectType, InstanceElement, isInstanceElement,
+  Change, ChangeDataType,
+} from '@salto-io/adapter-api'
+import { FilterWith } from '../../src/filter'
+import SalesforceClient from '../../src/client/client'
+import filterCreator from '../../src/filters/replace_instance_field_values'
+import mockAdapter from '../adapter'
+import {
+  SALESFORCE, METADATA_TYPE, INSTANCE_FULL_NAME_FIELD,
+  CUSTOM_OBJECT,
+} from '../../src/constants'
+import { metadataType } from '../../src/transformers/transformer'
+
+const FORECASTING_METADATA_TYPE = 'ForecastingSettings'
+const BEFORE_ID_1 = '00N4K000004woj7'
+const AFTER_ID_1 = 'Opportunity.CurrentGenerators__c'
+const BEFORE_ID_2 = '00N4K000004woj8'
+const AFTER_ID_2 = 'Opportunity.DeliveryInstallationStatus__c'
+
+const NON_ID_NAME_1 = 'OPPORTUNITY.LAST_UPDATE'
+const NON_ID_NAME_2 = 'OPPORTUNITY.CREATED_DATE'
+
+interface ForecastingTypeSettings {
+  opportunityListFieldsSelectedSettings: {
+    field: string[]
+  }
+  opportunityListFieldsUnselectedSettings: {
+    field: string[]
+  }
+  opportunityListFieldsLabelMappings: Array<{
+    field: string
+    label: string
+  }>
+}
+
+interface ForecastingSettingsValue {
+  forecastingTypeSettings: ForecastingTypeSettings[]
+}
+
+const types: Record<string, ObjectType> = {
+  [FORECASTING_METADATA_TYPE]: new ObjectType({
+    annotations: { [METADATA_TYPE]: FORECASTING_METADATA_TYPE },
+    elemID: new ElemID(SALESFORCE, FORECASTING_METADATA_TYPE),
+    fields: {
+    },
+  }),
+  [CUSTOM_OBJECT]: new ObjectType({
+    annotations: { [METADATA_TYPE]: CUSTOM_OBJECT },
+    elemID: new ElemID(SALESFORCE, CUSTOM_OBJECT),
+    fields: {
+    },
+  }),
+}
+
+describe('replace instance field values filter', () => {
+  let client: SalesforceClient
+  let elements: Element[]
+  let orjNumElements: number
+  let mockListMetadataObjects: jest.Mock
+  let nonForecastingInstance: Element
+  let forecastingElementWithIDs: InstanceElement
+  let forecastingElementWithNames: InstanceElement
+
+
+  const createForecastingElement = (withIDs: boolean): InstanceElement => (
+    new InstanceElement(
+      'Forecasting',
+      types[FORECASTING_METADATA_TYPE],
+      {
+        [INSTANCE_FULL_NAME_FIELD]: 'Forecasting',
+        forecastingTypeSettings: [
+          {
+            opportunityListFieldsSelectedSettings: {
+              field: [
+                NON_ID_NAME_1,
+              ],
+            },
+            opportunityListFieldsUnselectedSettings: {
+              field: [
+                NON_ID_NAME_2,
+              ],
+            },
+            opportunityListFieldsLabelMappings: [
+              {
+                field: NON_ID_NAME_1,
+                label: '',
+              },
+              {
+                field: NON_ID_NAME_2,
+                label: '',
+              },
+            ],
+          },
+          {
+            opportunityListFieldsSelectedSettings: {
+              field: [
+                withIDs ? BEFORE_ID_1 : AFTER_ID_1,
+              ],
+            },
+            opportunityListFieldsUnselectedSettings: {
+              field: [
+                withIDs ? BEFORE_ID_2 : AFTER_ID_2,
+              ],
+            },
+            opportunityListFieldsLabelMappings: [
+              {
+                field: withIDs ? BEFORE_ID_1 : AFTER_ID_1,
+                label: '',
+              },
+              {
+                field: withIDs ? BEFORE_ID_2 : AFTER_ID_2,
+                label: '',
+              },
+            ],
+          },
+        ],
+      },
+    )
+  )
+
+
+  const getAllNamesFromForecastingValue = (forecastValue: ForecastingSettingsValue): string[] => {
+    const res: string[] = []
+    forecastValue.forecastingTypeSettings
+      .forEach(t => {
+        const additionalNames = [...t.opportunityListFieldsSelectedSettings.field,
+          ...t.opportunityListFieldsUnselectedSettings.field]
+        additionalNames.forEach(name => res.push(name))
+        t.opportunityListFieldsLabelMappings.forEach(map => {
+          res.push(map.field)
+        })
+      })
+    return res
+  }
+
+  const generateElements = (): Element[] => {
+    const instances = [
+      forecastingElementWithIDs,
+      new InstanceElement(
+        'notForecasting',
+        types[CUSTOM_OBJECT],
+        {
+          standard: 'aaa',
+          custom: 'bbb',
+          [INSTANCE_FULL_NAME_FIELD]: 'unknownInst',
+        },
+      ),
+    ]
+    return [
+      types[FORECASTING_METADATA_TYPE],
+      types[CUSTOM_OBJECT],
+      ...instances]
+  }
+
+  beforeAll(() => {
+    ({ client } = mockAdapter({
+      adapterParams: {
+      },
+    }))
+
+    forecastingElementWithIDs = createForecastingElement(true)
+    forecastingElementWithNames = createForecastingElement(false)
+
+
+    mockListMetadataObjects = jest.fn()
+      .mockImplementation(async () => ({ result: [
+        {
+          id: `${BEFORE_ID_2}UAA`,
+          namespacePrefix: undefined,
+          fullName: 'Opportunity.DeliveryInstallationStatus__c',
+        },
+        {
+          id: `${BEFORE_ID_1}UAA`,
+          fullName: 'Opportunity.CurrentGenerators__c',
+          namespacePrefix: undefined,
+        },
+        // should not be looked up
+        {
+          id: 'should not be used',
+          fullName: 'Obj.standard',
+          namespacePrefix: undefined,
+        },
+      ] }))
+
+    SalesforceClient.prototype.listMetadataObjects = mockListMetadataObjects
+  })
+
+  describe('onFetch', () => {
+    type FilterType = FilterWith<'onFetch'>
+    let filter: FilterType
+    let beforeNonForecastingInstance: Element
+    let namesAfterFilter: string[]
+    beforeAll(async () => {
+      elements = generateElements()
+      nonForecastingInstance = elements[elements.length - 1]
+      orjNumElements = elements.length
+      beforeNonForecastingInstance = nonForecastingInstance.clone()
+      filter = filterCreator({ client, config: {} }) as FilterType
+      await filter.onFetch(elements)
+
+      namesAfterFilter = []
+      elements
+        .filter(isInstanceElement)
+        .filter(e => metadataType(e) === FORECASTING_METADATA_TYPE)
+        .map(e => e.value)
+        .forEach(val => {
+          const names = getAllNamesFromForecastingValue(val as ForecastingSettingsValue)
+          names.forEach(name => namesAfterFilter.push(name))
+        })
+    })
+
+    describe('replace ids of forecasting settings', () => {
+      it('should replace ids to names', () => {
+        expect(namesAfterFilter).not.toContain(BEFORE_ID_1)
+        expect(namesAfterFilter).not.toContain(BEFORE_ID_2)
+        expect(namesAfterFilter).toContain(AFTER_ID_1)
+        expect(namesAfterFilter).toContain(AFTER_ID_2)
+      })
+
+      it('should not replace non-id names', () => {
+        expect(namesAfterFilter).toContain(NON_ID_NAME_2)
+        expect(namesAfterFilter).toContain(NON_ID_NAME_1)
+      })
+
+      it('should not replace instances of other types', () => {
+        expect(nonForecastingInstance).toEqual(beforeNonForecastingInstance)
+      })
+      it('should not change num of elements', () => {
+        expect(elements.length).toEqual(orjNumElements)
+      })
+    })
+  })
+
+  describe('preDeploy', () => {
+    type FilterType = FilterWith<'preDeploy'>
+    let filter: FilterType
+
+    beforeAll(() => {
+      filter = filterCreator({ client, config: {} }) as FilterType
+    })
+
+    describe('replace names of forecasting settings to ids', () => {
+      let beforeElem: InstanceElement
+      let afterElem: InstanceElement
+      let change: Change<ChangeDataType>
+      let namesAfterFilter: string[]
+      beforeAll(() => {
+        beforeElem = forecastingElementWithNames
+        afterElem = beforeElem.clone()
+      })
+      describe('the change is in selected/unselected fields', () => {
+        beforeAll(async () => {
+          // modify afterElem:
+          afterElem.value
+            .forecastingTypeSettings[0]
+            .opportunityListFieldsSelectedSettings
+            .field = [
+              ...afterElem.value
+                .forecastingTypeSettings[0]
+                .opportunityListFieldsSelectedSettings
+                .field,
+              ...afterElem.value
+                .forecastingTypeSettings[0]
+                .opportunityListFieldsUnselectedSettings
+                .field,
+            ]
+          afterElem.value
+            .forecastingTypeSettings[0]
+            .opportunityListFieldsUnselectedSettings
+            .field = []
+
+          change = {
+            action: 'modify',
+            data: {
+              before: beforeElem,
+              after: afterElem,
+            },
+          }
+
+          await filter.preDeploy([change])
+          namesAfterFilter = getAllNamesFromForecastingValue(
+            afterElem.value as ForecastingSettingsValue
+          )
+        })
+        it('should replace names to ids', () => {
+          expect(namesAfterFilter).toContain(BEFORE_ID_1)
+          expect(namesAfterFilter).toContain(BEFORE_ID_2)
+          expect(namesAfterFilter).not.toContain(AFTER_ID_1)
+          expect(namesAfterFilter).not.toContain(AFTER_ID_2)
+        })
+        it('should not replace names', () => {
+          expect(namesAfterFilter).toContain(NON_ID_NAME_1)
+          expect(namesAfterFilter).toContain(NON_ID_NAME_2)
+        })
+      })
+
+      describe('the change is not in selected/unselected fields', () => {
+        beforeAll(async () => {
+          afterElem.annotate({ newAnnotation: 'newAnnotationValue' })
+          await filter.preDeploy([change])
+          namesAfterFilter = getAllNamesFromForecastingValue(
+            afterElem.value as ForecastingSettingsValue
+          )
+        })
+
+        it('should replace names to ids', () => {
+          expect(namesAfterFilter).toContain(BEFORE_ID_1)
+          expect(namesAfterFilter).toContain(BEFORE_ID_2)
+          expect(namesAfterFilter).not.toContain(AFTER_ID_1)
+          expect(namesAfterFilter).not.toContain(AFTER_ID_2)
+        })
+        it('should not replace names', () => {
+          expect(namesAfterFilter).toContain(NON_ID_NAME_1)
+          expect(namesAfterFilter).toContain(NON_ID_NAME_2)
+        })
+      })
+    })
+  })
+
+
+  describe('onDeploy', () => {
+      type FilterType = FilterWith<'onDeploy'>
+      let filter: FilterType
+
+      beforeAll(() => {
+        filter = filterCreator({ client, config: {} }) as FilterType
+      })
+
+      describe('replace ids of forecasting settings to names', () => {
+        let beforeElem: InstanceElement
+        let afterElem: InstanceElement
+        let change: Change<ChangeDataType>
+        let namesAfterFilter: string[]
+        beforeAll(async () => {
+          beforeElem = forecastingElementWithIDs
+          afterElem = beforeElem.clone()
+          afterElem.annotate({ newAnnotation: 'newAnnotationValue' })
+          change = {
+            action: 'modify',
+            data: {
+              before: beforeElem,
+              after: afterElem,
+            },
+          }
+          await filter.onDeploy([change])
+          namesAfterFilter = getAllNamesFromForecastingValue(
+            afterElem.value as ForecastingSettingsValue
+          )
+        })
+        it('should replace ids to names', () => {
+          expect(namesAfterFilter).not.toContain(BEFORE_ID_1)
+          expect(namesAfterFilter).not.toContain(BEFORE_ID_2)
+          expect(namesAfterFilter).toContain(AFTER_ID_1)
+          expect(namesAfterFilter).toContain(AFTER_ID_2)
+        })
+        it('should not replace names', () => {
+          expect(namesAfterFilter).toContain(NON_ID_NAME_2)
+          expect(namesAfterFilter).toContain(NON_ID_NAME_1)
+        })
+      })
+  })
+})


### PR DESCRIPTION
This PR will result in mixed-styled nacls: 
* the field names that did not need change will stay the same, e.g: `OPPORTUNITY.LAST_UPDATE`
* the field names the required replacing by this filter will look like their API names: `Opportunity.DeliveryInstallationStatus__c`

Because changing the first kind to their API names is rather complicated (in order to make them actual references) I left it this way, and it could be done in another PR if needed.