### PR TITLE
SALTO-1028 Rename location compound field to geolocation

### DIFF
--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -41,6 +41,7 @@ import { UsernamePasswordCredentials } from '../src/types'
 import {
   Types, metadataType, apiName, formulaTypeName, MetadataInstanceElement, MetadataObjectType,
   createInstanceElement,
+  fieldTypeName,
 } from '../src/transformers/transformer'
 import realAdapter from './adapter'
 import {
@@ -1402,7 +1403,7 @@ describe('Salesforce adapter E2E with real account', () => {
             verifyFieldFetch(
               fields[CUSTOM_FIELD_NAMES.LOCATION],
               testLocation,
-              Types.compoundDataTypes.Location
+              Types.compoundDataTypes.Geolocation,
             )
           })
 
@@ -1640,7 +1641,7 @@ describe('Salesforce adapter E2E with real account', () => {
             void => {
             expect(field).toBeDefined()
             verificationFunc(field)
-            expect(field[INSTANCE_TYPE_FIELD]).toEqual(expectedType)
+            expect(field[INSTANCE_TYPE_FIELD]).toEqual(fieldTypeName(expectedType))
           }
 
           it('currency', async () => {
@@ -1695,7 +1696,7 @@ describe('Salesforce adapter E2E with real account', () => {
             verifyFieldAddition(
               fields[CUSTOM_FIELD_NAMES.LOCATION],
               testLocation,
-              constants.COMPOUND_FIELD_TYPE_NAMES.LOCATION,
+              constants.COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION,
             )
           })
 
@@ -2016,7 +2017,7 @@ describe('Salesforce adapter E2E with real account', () => {
             [constants.FIELD_ANNOTATIONS.SCALE]: 10,
             [constants.BUSINESS_STATUS]: 'Active',
             [CORE_ANNOTATIONS.REQUIRED]: true,
-            [INSTANCE_TYPE_FIELD]: constants.COMPOUND_FIELD_TYPE_NAMES.LOCATION,
+            [INSTANCE_TYPE_FIELD]: fieldTypeName(constants.COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION),
           },
           [CUSTOM_FIELD_NAMES.PERCENT]: {
             [constants.LABEL]: 'Percent label Updated',
@@ -2202,7 +2203,7 @@ describe('Salesforce adapter E2E with real account', () => {
           ):
             void => {
             const field = fields[name]
-            expect(field[INSTANCE_TYPE_FIELD]).toEqual(expectedType)
+            expect(field[INSTANCE_TYPE_FIELD]).toEqual(fieldTypeName(expectedType))
             expect(field).toEqual(expectedAnnotations ?? fieldNamesToAnnotations[name])
           }
 
@@ -2276,7 +2277,7 @@ describe('Salesforce adapter E2E with real account', () => {
           it('location', async () => {
             verifyFieldUpdate(
               CUSTOM_FIELD_NAMES.LOCATION,
-              constants.COMPOUND_FIELD_TYPE_NAMES.LOCATION
+              constants.COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION,
             )
           })
 

--- a/packages/salesforce-adapter/e2e_test/setup.ts
+++ b/packages/salesforce-adapter/e2e_test/setup.ts
@@ -18,7 +18,7 @@ import { ObjectType } from '@salto-io/adapter-api'
 import * as constants from '../src/constants'
 import { CustomField, ProfileInfo } from '../src/client/types'
 import { createDeployPackage } from '../src/transformers/xml_transformer'
-import { MetadataValues, createInstanceElement } from '../src/transformers/transformer'
+import { MetadataValues, createInstanceElement, fieldTypeName } from '../src/transformers/transformer'
 import SalesforceClient from '../src/client/client'
 import { objectExists } from './utils'
 import { mockTypes, mockDefaultValues } from '../test/mock_elements'
@@ -193,7 +193,7 @@ export const verifyElementsExist = async (client: SalesforceClient): Promise<voi
           label: 'Location label',
           required: false,
           scale: 2,
-          type: constants.COMPOUND_FIELD_TYPE_NAMES.LOCATION,
+          type: fieldTypeName(constants.COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION),
         },
         {
           fullName: CUSTOM_FIELD_NAMES.PERCENT,

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -62,20 +62,21 @@ export type ALL_FIELD_TYPE_NAMES = FIELD_TYPE_NAMES | INTERNAL_FIELD_TYPE_NAMES
 export enum COMPOUND_FIELD_TYPE_NAMES {
   ADDRESS = 'Address',
   FIELD_NAME = 'Name',
-  LOCATION = 'Location',
+  GEOLOCATION = 'Geolocation',
 }
+export const GEOLOCATION_SOAP_TYPE_NAME = 'Location'
 
 export const COMPOUND_FIELDS_SOAP_TYPE_NAMES:
   Record<string, COMPOUND_FIELD_TYPE_NAMES> = {
     address: COMPOUND_FIELD_TYPE_NAMES.ADDRESS,
-    location: COMPOUND_FIELD_TYPE_NAMES.LOCATION,
+    location: COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION,
     // name is handled differently with nameField
   }
 
 // target types for creating / updating custom fields:
 export const CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES = [
   ...Object.values(FIELD_TYPE_NAMES),
-  COMPOUND_FIELD_TYPE_NAMES.LOCATION,
+  GEOLOCATION_SOAP_TYPE_NAME, // salesforce-facing value for COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION
   // The following types are valid according to the documentation
   // TODO - support these field types
   'MetadataRelationship',

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -37,7 +37,8 @@ import {
   WORKFLOW_METADATA_TYPE, QUICK_ACTION_METADATA_TYPE, CUSTOM_TAB_METADATA_TYPE,
   DUPLICATE_RULE_METADATA_TYPE, CUSTOM_OBJECT_TRANSLATION_METADATA_TYPE, SHARING_RULES_TYPE,
   VALIDATION_RULES_METADATA_TYPE, BUSINESS_PROCESS_METADATA_TYPE, RECORD_TYPE_METADATA_TYPE,
-  WEBLINK_METADATA_TYPE, INTERNAL_FIELD_TYPE_NAMES,
+  WEBLINK_METADATA_TYPE, INTERNAL_FIELD_TYPE_NAMES, COMPOUND_FIELD_TYPE_NAMES,
+  GEOLOCATION_SOAP_TYPE_NAME,
 } from '../constants'
 import { FilterCreator } from '../filter'
 import {
@@ -118,10 +119,18 @@ const ANNOTATIONS_TO_IGNORE_FROM_INSTANCE = ['eventType', 'publishBehavior', 'fi
 const nestedMetadatatypeToReplaceDirName: Record<string, string> = { // <type, new-dir-name>
   [WEBLINK_METADATA_TYPE]: 'ButtonsLinksAndActions',
 }
-const getFieldName = (annotations: Values): string =>
+
+const toInternalTypeName = (typeName: string): string => (
+  typeName === GEOLOCATION_SOAP_TYPE_NAME
+    ? COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION
+    : typeName
+)
+
+const getFieldName = (annotations: Values): string => (
   (annotations[FORMULA]
     ? formulaTypeName(annotations[INSTANCE_TYPE_FIELD] as FIELD_TYPE_NAMES)
-    : annotations[INSTANCE_TYPE_FIELD])
+    : toInternalTypeName(annotations[INSTANCE_TYPE_FIELD]))
+)
 
 const getFieldType = (type: string): TypeElement =>
   (_.isUndefined(type) ? BuiltinTypes.STRING : Types.get(type))

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -38,7 +38,7 @@ import {
   CUSTOM_VALUE, API_NAME_SEPARATOR, MAX_METADATA_RESTRICTION_VALUES,
   VALUE_SET_FIELDS, COMPOUND_FIELD_TYPE_NAMES, ANNOTATION_TYPE_NAMES, FIELD_SOAP_TYPE_NAMES,
   RECORDS_PATH, SETTINGS_PATH, TYPES_PATH, SUBTYPES_PATH, INSTALLED_PACKAGES_PATH,
-  VALUE_SET_DEFINITION_FIELDS, CUSTOM_FIELD,
+  VALUE_SET_DEFINITION_FIELDS, CUSTOM_FIELD, GEOLOCATION_SOAP_TYPE_NAME,
   COMPOUND_FIELDS_SOAP_TYPE_NAMES, CUSTOM_OBJECT_ID_FIELD, FOREIGN_KEY_DOMAIN,
   XML_ATTRIBUTE_PREFIX, INTERNAL_ID_FIELD, INTERNAL_FIELD_TYPE_NAMES, CUSTOM_SETTINGS_TYPE,
 } from '../constants'
@@ -104,9 +104,15 @@ export const apiName = (elem: Element, relative = false): string => {
 export const formulaTypeName = (baseTypeName: FIELD_TYPE_NAMES): string =>
   `${FORMULA_TYPE_NAME}${baseTypeName}`
 
-const fieldTypeName = (typeName: string): string => (
-  typeName.startsWith(FORMULA_TYPE_NAME) ? typeName.slice(FORMULA_TYPE_NAME.length) : typeName
-)
+export const fieldTypeName = (typeName: string): string => {
+  if (typeName.startsWith(FORMULA_TYPE_NAME)) {
+    return typeName.slice(FORMULA_TYPE_NAME.length)
+  }
+  if (typeName === COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION) {
+    return GEOLOCATION_SOAP_TYPE_NAME
+  }
+  return typeName
+}
 
 const createPicklistValuesAnnotations = (picklistValues: PicklistEntry[]): Values =>
   picklistValues.map(val => ({
@@ -134,7 +140,7 @@ const addPicklistAnnotations = (
 
 const addressElemID = new ElemID(SALESFORCE, COMPOUND_FIELD_TYPE_NAMES.ADDRESS)
 const nameElemID = new ElemID(SALESFORCE, COMPOUND_FIELD_TYPE_NAMES.FIELD_NAME)
-const geoLocationElemID = new ElemID(SALESFORCE, COMPOUND_FIELD_TYPE_NAMES.LOCATION)
+const geoLocationElemID = new ElemID(SALESFORCE, COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION)
 
 const restrictedNumberTypeDefinitions = {
   TextLength: createRestriction({ min: 1, max: 255, enforce_value: false }),
@@ -636,7 +642,7 @@ export class Types {
         ...Types.commonAnnotationTypes,
       },
     }),
-    Location: new ObjectType({
+    Geolocation: new ObjectType({
       elemID: geoLocationElemID,
       fields: {
         [GEOLOCATION_FIELDS.LATITUDE]: { type: BuiltinTypes.NUMBER },
@@ -751,8 +757,8 @@ const transformCompoundValues = (
       // Other compound fields are added a prefix according to the field name
       // ie. LocalAddrress -> LocalCity, LocalState etc.
       const typeName = compoundField.type.elemID.isEqual(Types.compoundDataTypes.Address.elemID)
-        ? COMPOUND_FIELD_TYPE_NAMES.ADDRESS : COMPOUND_FIELD_TYPE_NAMES.LOCATION
-      const fieldPrefix = compoundFieldKey.slice(0, -typeName.length)
+        ? COMPOUND_FIELD_TYPE_NAMES.ADDRESS : COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION
+      const fieldPrefix = compoundFieldKey.slice(0, -fieldTypeName(typeName).length)
       return _.mapKeys(record[compoundFieldKey], (_vv, key) => fieldPrefix.concat(key))
     }
   )

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -342,7 +342,7 @@ describe('SalesforceAdapter CRUD', () => {
             },
           },
           location: {
-            type: Types.compoundDataTypes.Location,
+            type: Types.compoundDataTypes.Geolocation,
             annotations: {
               [constants.LABEL]: 'Location description label',
               [constants.FIELD_ANNOTATIONS.SCALE]: 2,

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -327,6 +327,11 @@ describe('Custom Objects filter', () => {
             {
               [INSTANCE_FULL_NAME_FIELD]: 'WhoKnows',
             },
+            {
+              [INSTANCE_FULL_NAME_FIELD]: 'Pepper',
+              [INSTANCE_TYPE_FIELD]: 'Location',
+              [INSTANCE_REQUIRED_FIELD]: 'false',
+            },
           ],
         },
       )
@@ -336,6 +341,7 @@ describe('Custom Objects filter', () => {
       const lead = findElements(result, 'Lead').pop() as ObjectType
       expect(lead.fields.NumberField.type.elemID.name).toBe('Number')
       expect(lead.fields.ExtraSalt.type.elemID.name).toBe('Checkbox')
+      expect(lead.fields.Pepper.type.elemID.name).toBe('Geolocation')
       expect(lead.fields.WhoKnows.type.elemID.name).toBe('Unknown')
     })
 

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -634,6 +634,11 @@ describe('transformer', () => {
       const customField = toCustomField(field)
       expect(customField.label).toEqual('Labelo')
     })
+    it('should convert geolocation type to location', () => {
+      field.type = Types.compoundDataTypes.Geolocation
+      const customField = toCustomField(field)
+      expect(customField.type).toEqual('Location')
+    })
   })
 
   describe('toCustomProperties', () => {
@@ -1019,6 +1024,10 @@ describe('transformer', () => {
         City: 'Manchester',
         State: 'UK',
       },
+      LocalLocation: {
+        Latitude: 345,
+        Longitude: 222.2,
+      },
       Creatable: 'Create',
       NotCreatable: 'DontSendMeOnCreate',
       Updateable: 'Update',
@@ -1046,6 +1055,13 @@ describe('transformer', () => {
           },
           LocalAddress: {
             type: Types.compoundDataTypes.Address,
+            annotations: {
+              [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+              [FIELD_ANNOTATIONS.CREATABLE]: true,
+            },
+          },
+          LocalLocation: {
+            type: Types.compoundDataTypes.Geolocation,
             annotations: {
               [FIELD_ANNOTATIONS.UPDATEABLE]: true,
               [FIELD_ANNOTATIONS.CREATABLE]: true,
@@ -1102,6 +1118,7 @@ describe('transformer', () => {
         expect(recordResult[0].Id).toEqual(values.Id)
         expect(recordResult[0].Name).toBeUndefined()
         expect(recordResult[0].LocalAddress).toBeUndefined()
+        expect(recordResult[0].LocalLocation).toBeUndefined()
         expect(recordResult[0].Creatable).toBeUndefined()
         expect(recordResult[0].NotCreatable).toBeUndefined()
         expect(recordResult[0].Updateable).toBeUndefined()
@@ -1143,6 +1160,10 @@ describe('transformer', () => {
         expect(recordResult[0].LocalCity).toEqual(values.LocalAddress.City)
         expect(recordResult[0].LocalState).toBeDefined()
         expect(recordResult[0].LocalState).toEqual(values.LocalAddress.State)
+        expect(recordResult[0].LocalLongitude).toBeDefined()
+        expect(recordResult[0].LocalLongitude).toEqual(values.LocalLocation.Longitude)
+        expect(recordResult[0].LocalLatitude).toBeDefined()
+        expect(recordResult[0].LocalLatitude).toEqual(values.LocalLocation.Latitude)
       })
     })
 
@@ -1179,6 +1200,10 @@ describe('transformer', () => {
         expect(recordResult[0].LocalCity).toEqual(values.LocalAddress.City)
         expect(recordResult[0].LocalState).toBeDefined()
         expect(recordResult[0].LocalState).toEqual(values.LocalAddress.State)
+        expect(recordResult[0].LocalLongitude).toBeDefined()
+        expect(recordResult[0].LocalLongitude).toEqual(values.LocalLocation.Longitude)
+        expect(recordResult[0].LocalLatitude).toBeDefined()
+        expect(recordResult[0].LocalLatitude).toEqual(values.LocalLocation.Latitude)
       })
     })
   })


### PR DESCRIPTION
Needed in order to avoid conflicts with the location standard object.

Need to finalize the upgrade plan before merging.