### PR TITLE
Netsuite: fix xml encoding for special chars

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -94,7 +94,10 @@ describe('Netsuite adapter E2E with real account', () => {
 
   const entityCustomFieldToCreate = createInstanceElement(
     ENTITY_CUSTOM_FIELD,
-    { label: randomString }
+    {
+      label: randomString,
+      description: 'Some string with special chars !"&​’',
+    }
   )
 
   const customRecordTypeToCreate = createInstanceElement(
@@ -209,12 +212,14 @@ describe('Netsuite adapter E2E with real account', () => {
       validateConfigSuggestions(fetchResult.updatedConfig?.config)
     })
 
-    it('should fetch the created entityCustomField', async () => {
+    it('should fetch the created entityCustomField and its special chars', async () => {
       const fetchedEntityCustomField = findElement(
         fetchedInstances,
         entityCustomFieldToCreate.elemID
       ) as InstanceElement
       expect(fetchedEntityCustomField.value.label).toEqual(randomString)
+      expect(fetchedEntityCustomField.value.description)
+        .toEqual(entityCustomFieldToCreate.value.description)
     })
 
     it('should fetch the created customRecordType', async () => {

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -158,11 +158,6 @@ export const isFolderCustomizationInfo = (customizationInfo: CustomizationInfo):
   customizationInfo is FolderCustomizationInfo =>
   customizationInfo.typeName === FOLDER
 
-// Without removing the ZeroWidthSpace, the deploy fails on:
-// 'The entity "ZeroWidthSpace" was referenced, but not declared.'
-// https://stackoverflow.com/questions/11305797/remove-zero-width-space-characters-from-a-javascript-string
-const removeZeroWidthSpace = (val: string): string => val.replace(/[\u200B-\u200D\uFEFF]/g, '')
-
 export const convertToXmlContent = (customizationInfo: CustomizationInfo): string =>
   // eslint-disable-next-line new-cap
   new xmlParser.j2xParser({
@@ -171,8 +166,7 @@ export const convertToXmlContent = (customizationInfo: CustomizationInfo): strin
     format: false,
     ignoreAttributes: false,
     cdataTagName: CDATA_TAG_NAME,
-    tagValueProcessor: val =>
-      he.encode(removeZeroWidthSpace(val), { useNamedReferences: true }),
+    tagValueProcessor: val => he.encode(val),
   }).parse({ [customizationInfo.typeName]: customizationInfo.values })
 
 const writeFileInFolder = async (folderPath: string, filename: string, content: string | Buffer):

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -109,7 +109,7 @@ describe('Transformer', () => {
       + '  <unknownfield>unknownVal</unknownfield>\n'
       + '</entitycustomfield>\n',
     WITH_HTML_CHARS: '<entitycustomfield scriptid="custentity_my_script_id">\n'
-    + '  <label>Golf &amp; Co</label>\n'
+    + '  <label>Golf &#x26; Co&#x2019;Co element&#x200B;Name</label>\n'
     + '</entitycustomfield>\n',
   }
 
@@ -231,7 +231,8 @@ describe('Transformer', () => {
 
     it('should decode html chars', () => {
       const result = transformCustomFieldRecord(XML_TEMPLATES.WITH_HTML_CHARS)
-      expect(result.value.label).toEqual('Golf & Co')
+      // There is ZeroWidthSpace char between element and Name
+      expect(result.value.label).toEqual('Golf & Co’Co element​Name')
     })
 
     it('should add content value with fileContent as static file', () => {
@@ -508,18 +509,12 @@ describe('Transformer', () => {
     })
 
     it('should encode to html chars', () => {
-      instance.value.label = 'Golf & Co'
+      instance.value.label = 'Golf & Co’Co element​Name' // There is ZeroWidthSpace char between element and Name
       const customizationInfo = toCustomizationInfo(instance)
       const xmlContent = convertToXmlContent(customizationInfo)
-      expect(xmlContent).toEqual(removeLineBreaks(XML_TEMPLATES.WITH_HTML_CHARS))
-    })
-
-    it('should omit ZeroWidthSpace chars', () => {
-      instance.value.label = 'element​Name' // There is ZeroWidthSpace char between element and Name
-      expect(instance.value.label).toHaveLength('elementName'.length + 1)
-      const customizationInfo = toCustomizationInfo(instance)
-      const xmlContent = convertToXmlContent(customizationInfo)
-      expect(xmlContent).toEqual(removeLineBreaks(XML_TEMPLATES.WITH_STRING_FIELD))
+      // We use here === instead of expect.toEqual() since jest treats html encoding as equal to
+      // the decoded value
+      expect(xmlContent === removeLineBreaks(XML_TEMPLATES.WITH_HTML_CHARS)).toBeTruthy()
     })
 
     it('should transform ordered values for forms', () => {


### PR DESCRIPTION
I encountered an issue when deploying to Riskified a record that contains the `’` char. It was encoded to `&rsquo;` and the deployment failed. With the new code it's encoded to `&#x2019;` and the deploy passes.

---
_Release Notes_
Bug fixes:
Netsuite:
- Fix encoding issue which caused the deployment of records with special characters to fail