### PR TITLE
SALTO-1016: Remove elements from all environments when fetch removes elements

### DIFF
--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -178,9 +178,9 @@ describe('multi env source', () => {
         {
           action: 'remove',
           data: {
-            before: commonObject,
+            before: commonObject.fields.field,
           },
-          id: commonElemID,
+          id: commonObject.fields.field.elemID,
         },
         {
           action: 'remove',

--- a/packages/workspace/test/workspace/multi_env/routers.test.ts
+++ b/packages/workspace/test/workspace/multi_env/routers.test.ts
@@ -258,13 +258,13 @@ describe('default fetch routing', () => {
     expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
     expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
   })
-  it('should split shared remove changes to common and env', async () => {
+  it('should split shared remove changes to all environments', async () => {
     const change: DetailedChange = {
       action: 'remove',
       data: { before: sharedObject },
       id: commonObj.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'default')
+    const routedChanges = await routeChanges([change], envSource, commonSource, { sec: secEnv }, 'default')
     expect(routedChanges.primarySource).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(1)
     const commonChangeElement = routedChanges.commonSource
@@ -273,7 +273,8 @@ describe('default fetch routing', () => {
         && (routedChanges.primarySource[0] as RemovalDiff<ObjectType>).data.before
     expect(commonChangeElement).toEqual(commonObj)
     expect(envChangeElement).toEqual(envObj)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(routedChanges.secondarySources).toBeDefined()
+    expect(routedChanges.secondarySources?.sec).toHaveLength(1)
   })
   it('should route add changes of values of env specific elements to the '
     + 'env when there are multiple envs configured', async () => {
@@ -543,7 +544,7 @@ describe('override fetch routing', () => {
       data: { before: sharedObject },
       id: commonObj.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'override')
+    const routedChanges = await routeChanges([change], envSource, commonSource, { sec: secEnv }, 'override')
     expect(routedChanges.primarySource).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(1)
     const commonChangeElement = routedChanges.commonSource
@@ -552,7 +553,8 @@ describe('override fetch routing', () => {
         && (routedChanges.primarySource[0] as RemovalDiff<ObjectType>).data.before
     expect(commonChangeElement).toEqual(commonObj)
     expect(envChangeElement).toEqual(envObj)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(routedChanges.secondarySources).toBeDefined()
+    expect(routedChanges.secondarySources?.sec).toHaveLength(1)
   })
   it('should route add changes of values of env specific elements to the env', async () => {
     const newField = new Field(envOnlyObj, 'dreams', BuiltinTypes.STRING)


### PR DESCRIPTION
This changes the behavior of the `default` and `override` fetch modes such that if they fetch a delete of a top level element that is at least partially common, it will be deleted from all environments instead of leaving a partial (and usually invalid) element fragment in other environments.

---

_Release Notes_:
- Fix issue in multi-env workspaces where removing an element that was partially common could break other environments