### PR TITLE
SALTO-1028: Rename location compound field to geolocation

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -124,7 +124,7 @@ const getFieldName = (annotations: Values): string =>
     : annotations[INSTANCE_TYPE_FIELD])
 
 const getFieldType = (type: string): TypeElement =>
-  (_.isUndefined(type) ? BuiltinTypes.STRING : Types.get(type))
+  (_.isUndefined(type) ? BuiltinTypes.STRING : Types.getKnownType(type))
 
 const annotationTypesForObject = (typesFromInstance: TypesFromInstance,
   instance: InstanceElement, custom: boolean): Record<string, TypeElement> => {
@@ -369,7 +369,7 @@ const createObjectType = ({
     [API_NAME]: name,
     [METADATA_TYPE]: CUSTOM_OBJECT,
   }
-  const object = Types.get(name, true, false, serviceIds) as ObjectType
+  const object = Types.createObjectType(name, true, false, serviceIds)
   addApiName(object, name)
   addMetadataType(object)
   addLabel(object, label)

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -502,7 +502,7 @@ describe('SalesforceAdapter CRUD', () => {
         expect(object.fields[5].unique).toBe(true)
         // Location
         expect(object.fields[6].fullName).toBe('location__c')
-        expect(object.fields[6].type).toBe('Location')
+        expect(object.fields[6].type).toBe('Geolocation')
         expect(object.fields[6].label).toBe('Location description label')
         expect(object.fields[6].displayLocationInDecimal).toBe(true)
         expect(object.fields[6].scale).toBe(2)


### PR DESCRIPTION
Needed in order to avoid conflicts with the location standard object.

This also changes the type creation functions in `transfomer.ts` to be more explicit with their expectation (each call to `Types.get` actually knows whether it expects to create a new type or get a field type)