### PR TITLE
SALTO-1028 Improve geolocation handling

### DIFF
--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -41,7 +41,6 @@ import { UsernamePasswordCredentials } from '../src/types'
 import {
   Types, metadataType, apiName, formulaTypeName, MetadataInstanceElement, MetadataObjectType,
   createInstanceElement,
-  fieldTypeName,
 } from '../src/transformers/transformer'
 import realAdapter from './adapter'
 import {
@@ -1403,7 +1402,7 @@ describe('Salesforce adapter E2E with real account', () => {
             verifyFieldFetch(
               fields[CUSTOM_FIELD_NAMES.LOCATION],
               testLocation,
-              Types.compoundDataTypes.Geolocation,
+              Types.compoundDataTypes.Location,
             )
           })
 
@@ -1641,7 +1640,7 @@ describe('Salesforce adapter E2E with real account', () => {
             void => {
             expect(field).toBeDefined()
             verificationFunc(field)
-            expect(field[INSTANCE_TYPE_FIELD]).toEqual(fieldTypeName(expectedType))
+            expect(field[INSTANCE_TYPE_FIELD]).toEqual(expectedType)
           }
 
           it('currency', async () => {
@@ -1696,7 +1695,7 @@ describe('Salesforce adapter E2E with real account', () => {
             verifyFieldAddition(
               fields[CUSTOM_FIELD_NAMES.LOCATION],
               testLocation,
-              constants.COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION,
+              constants.COMPOUND_FIELD_TYPE_NAMES.LOCATION,
             )
           })
 
@@ -2017,7 +2016,7 @@ describe('Salesforce adapter E2E with real account', () => {
             [constants.FIELD_ANNOTATIONS.SCALE]: 10,
             [constants.BUSINESS_STATUS]: 'Active',
             [CORE_ANNOTATIONS.REQUIRED]: true,
-            [INSTANCE_TYPE_FIELD]: fieldTypeName(constants.COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION),
+            [INSTANCE_TYPE_FIELD]: constants.COMPOUND_FIELD_TYPE_NAMES.LOCATION,
           },
           [CUSTOM_FIELD_NAMES.PERCENT]: {
             [constants.LABEL]: 'Percent label Updated',
@@ -2203,7 +2202,7 @@ describe('Salesforce adapter E2E with real account', () => {
           ):
             void => {
             const field = fields[name]
-            expect(field[INSTANCE_TYPE_FIELD]).toEqual(fieldTypeName(expectedType))
+            expect(field[INSTANCE_TYPE_FIELD]).toEqual(expectedType)
             expect(field).toEqual(expectedAnnotations ?? fieldNamesToAnnotations[name])
           }
 
@@ -2277,7 +2276,7 @@ describe('Salesforce adapter E2E with real account', () => {
           it('location', async () => {
             verifyFieldUpdate(
               CUSTOM_FIELD_NAMES.LOCATION,
-              constants.COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION,
+              constants.COMPOUND_FIELD_TYPE_NAMES.LOCATION,
             )
           })
 

--- a/packages/salesforce-adapter/e2e_test/setup.ts
+++ b/packages/salesforce-adapter/e2e_test/setup.ts
@@ -18,7 +18,7 @@ import { ObjectType } from '@salto-io/adapter-api'
 import * as constants from '../src/constants'
 import { CustomField, ProfileInfo } from '../src/client/types'
 import { createDeployPackage } from '../src/transformers/xml_transformer'
-import { MetadataValues, createInstanceElement, fieldTypeName } from '../src/transformers/transformer'
+import { MetadataValues, createInstanceElement } from '../src/transformers/transformer'
 import SalesforceClient from '../src/client/client'
 import { objectExists } from './utils'
 import { mockTypes, mockDefaultValues } from '../test/mock_elements'
@@ -193,7 +193,7 @@ export const verifyElementsExist = async (client: SalesforceClient): Promise<voi
           label: 'Location label',
           required: false,
           scale: 2,
-          type: fieldTypeName(constants.COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION),
+          type: constants.COMPOUND_FIELD_TYPE_NAMES.LOCATION,
         },
         {
           fullName: CUSTOM_FIELD_NAMES.PERCENT,

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -62,21 +62,22 @@ export type ALL_FIELD_TYPE_NAMES = FIELD_TYPE_NAMES | INTERNAL_FIELD_TYPE_NAMES
 export enum COMPOUND_FIELD_TYPE_NAMES {
   ADDRESS = 'Address',
   FIELD_NAME = 'Name',
-  GEOLOCATION = 'Geolocation',
+  LOCATION = 'Location',
 }
-export const GEOLOCATION_SOAP_TYPE_NAME = 'Location'
+// We use Geolocation internally to avoid conflicts with the Location standard object
+export const LOCATION_INTERNAL_COMPOUND_FIELD_TYPE_NAME = 'Geolocation'
 
 export const COMPOUND_FIELDS_SOAP_TYPE_NAMES:
   Record<string, COMPOUND_FIELD_TYPE_NAMES> = {
     address: COMPOUND_FIELD_TYPE_NAMES.ADDRESS,
-    location: COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION,
+    location: COMPOUND_FIELD_TYPE_NAMES.LOCATION,
     // name is handled differently with nameField
   }
 
 // target types for creating / updating custom fields:
 export const CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES = [
   ...Object.values(FIELD_TYPE_NAMES),
-  GEOLOCATION_SOAP_TYPE_NAME, // salesforce-facing value for COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION
+  COMPOUND_FIELD_TYPE_NAMES.LOCATION,
   // The following types are valid according to the documentation
   // TODO - support these field types
   'MetadataRelationship',

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -37,8 +37,7 @@ import {
   WORKFLOW_METADATA_TYPE, QUICK_ACTION_METADATA_TYPE, CUSTOM_TAB_METADATA_TYPE,
   DUPLICATE_RULE_METADATA_TYPE, CUSTOM_OBJECT_TRANSLATION_METADATA_TYPE, SHARING_RULES_TYPE,
   VALIDATION_RULES_METADATA_TYPE, BUSINESS_PROCESS_METADATA_TYPE, RECORD_TYPE_METADATA_TYPE,
-  WEBLINK_METADATA_TYPE, INTERNAL_FIELD_TYPE_NAMES, COMPOUND_FIELD_TYPE_NAMES,
-  GEOLOCATION_SOAP_TYPE_NAME,
+  WEBLINK_METADATA_TYPE, INTERNAL_FIELD_TYPE_NAMES,
 } from '../constants'
 import { FilterCreator } from '../filter'
 import {
@@ -120,16 +119,10 @@ const nestedMetadatatypeToReplaceDirName: Record<string, string> = { // <type, n
   [WEBLINK_METADATA_TYPE]: 'ButtonsLinksAndActions',
 }
 
-const toInternalTypeName = (typeName: string): string => (
-  typeName === GEOLOCATION_SOAP_TYPE_NAME
-    ? COMPOUND_FIELD_TYPE_NAMES.GEOLOCATION
-    : typeName
-)
-
 const getFieldName = (annotations: Values): string => (
   (annotations[FORMULA]
     ? formulaTypeName(annotations[INSTANCE_TYPE_FIELD] as FIELD_TYPE_NAMES)
-    : toInternalTypeName(annotations[INSTANCE_TYPE_FIELD]))
+    : annotations[INSTANCE_TYPE_FIELD])
 )
 
 const getFieldType = (type: string): TypeElement =>
@@ -378,7 +371,7 @@ const createObjectType = ({
     [API_NAME]: name,
     [METADATA_TYPE]: CUSTOM_OBJECT,
   }
-  const object = Types.get(name, true, false, serviceIds) as ObjectType
+  const object = Types.createObjectType(name, true, false, serviceIds)
   addApiName(object, name)
   addMetadataType(object)
   addLabel(object, label)

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -342,7 +342,7 @@ describe('SalesforceAdapter CRUD', () => {
             },
           },
           location: {
-            type: Types.compoundDataTypes.Geolocation,
+            type: Types.compoundDataTypes.Location,
             annotations: {
               [constants.LABEL]: 'Location description label',
               [constants.FIELD_ANNOTATIONS.SCALE]: 2,

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -635,7 +635,7 @@ describe('transformer', () => {
       expect(customField.label).toEqual('Labelo')
     })
     it('should convert geolocation type to location', () => {
-      field.type = Types.compoundDataTypes.Geolocation
+      field.type = Types.compoundDataTypes.Location
       const customField = toCustomField(field)
       expect(customField.type).toEqual('Location')
     })
@@ -1061,7 +1061,7 @@ describe('transformer', () => {
             },
           },
           LocalLocation: {
-            type: Types.compoundDataTypes.Geolocation,
+            type: Types.compoundDataTypes.Location,
             annotations: {
               [FIELD_ANNOTATIONS.UPDATEABLE]: true,
               [FIELD_ANNOTATIONS.CREATABLE]: true,


### PR DESCRIPTION
Reduce the special handling of `Geolocation` (see https://github.com/salto-io/salto/pull/1548 and https://github.com/salto-io/salto/pull/1552).
It's easiest to review by checking out the branch and diffing including the last master commit, as this reverts some of the changes from #1548.