### PR TITLE
fix comment spec in vscode language definition

### DIFF
--- a/packages/vscode/language-configuration.json
+++ b/packages/vscode/language-configuration.json
@@ -1,12 +1,7 @@
 {
 	"comments": {
 		// symbol used for single line comment. Remove this entry if your language does not support line comments
-		"lineComment": "#",
-		// symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-		"blockComment": [
-			"/*",
-			"*/"
-		]
+		"lineComment": "//"
 	},
 	// symbols used as brackets
 	"brackets": [


### PR DESCRIPTION
Before this change, trying to comment out a line of nacl in vscode would create invalid syntax

---
_Release Notes_:
- VSCode extension - Fixed comment character definition so commenting out won't create invalid nacls 