### PR TITLE
parse file path differently

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -45,7 +45,7 @@ const filterByFile = (
 const toPathHint = (filename: string): string[] => {
   const dirName = path.dirname(filename)
   const dirPathSplitted = (dirName === '.') ? [] : dirName.split(path.sep)
-  return [...dirPathSplitted, path.basename(filename)]
+  return [...dirPathSplitted, path.basename(filename, path.extname(filename))]
 }
 
 const separateChangeByFiles = async (

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -27,9 +27,9 @@ import { NaclFilesSource, RoutingMode } from '../nacl_files_source'
 import { mergeElements } from '../../../merger'
 
 export interface RoutedChanges {
-    primarySource?: DetailedChange[]
-    commonSource?: DetailedChange[]
-    secondarySources?: Record<string, DetailedChange[]>
+  primarySource?: DetailedChange[]
+  commonSource?: DetailedChange[]
+  secondarySources?: Record<string, DetailedChange[]>
 }
 
 const filterByFile = (
@@ -43,9 +43,9 @@ const filterByFile = (
 )
 
 const toPathHint = (filename: string): string[] => {
-  const parsedPath = path.parse(filename)
-  const dirPath = _.isEmpty(parsedPath.dir) ? [] : parsedPath.dir.split(path.sep)
-  return [...dirPath, parsedPath.name]
+  const dirName = path.dirname(filename)
+  const dirPathSplitted = (dirName === '.') ? [] : dirName.split(path.sep)
+  return [...dirPathSplitted, path.basename(filename)]
 }
 
 const separateChangeByFiles = async (


### PR DESCRIPTION
We removed the use of `parse` in order to keep it compatible with webpack.
Webpack uses a builtin path module that does not includes the `parse` function.