### PR TITLE
Fixed maptype validation

### DIFF
--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -420,6 +420,7 @@ export function isMapType(element: any): element is MapType {
   return element instanceof MapType
 }
 
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export function isGenericType(element: any): element is GenericType {
   return isMapType(element) || isListType(element)
 }

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -386,8 +386,6 @@ export class Variable extends Element {
   }
 }
 
-export type GenericType = ListType | MapType
-
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export function isElement(value: any): value is Element {
   return value && value.elemID && value.elemID instanceof ElemID
@@ -418,11 +416,6 @@ export function isListType(element: any): element is ListType {
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export function isMapType(element: any): element is MapType {
   return element instanceof MapType
-}
-
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-export function isGenericType(element: any): element is GenericType {
-  return isMapType(element) || isListType(element)
 }
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -386,6 +386,8 @@ export class Variable extends Element {
   }
 }
 
+export type GenericType = ListType | MapType
+
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export function isElement(value: any): value is Element {
   return value && value.elemID && value.elemID instanceof ElemID
@@ -416,6 +418,10 @@ export function isListType(element: any): element is ListType {
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export function isMapType(element: any): element is MapType {
   return element instanceof MapType
+}
+
+export function isGenericType(element: any): element is GenericType {
+  return isMapType(element) || isListType(element)
 }
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/packages/workspace/src/merger/index.ts
+++ b/packages/workspace/src/merger/index.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import {
   ObjectType, isType, isObjectType, isInstanceElement, Element, ContainerType,
-  isPrimitiveType, BuiltinTypes, TypeMap, ListType, isListType, isVariable, isContainerType,
+  isPrimitiveType, BuiltinTypes, TypeMap, ListType, isVariable, isContainerType, isGenericType, GenericType,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { mergeObjectTypes } from './internal/object_types'
@@ -49,16 +49,16 @@ export const updateMergedTypes = (
       field => {
         field.type = mergedTypes[field.type.elemID.getFullName()] || field.type
         const fieldType = field.type
-        if (isListType(fieldType)) {
-          const resolveListType = (listType: ListType): void => {
-            if (isListType(listType.innerType)) {
-              resolveListType(listType.innerType)
+        if (isGenericType(fieldType)) {
+          const resolveGenericType = (genericType: GenericType): void => {
+            if (isGenericType(genericType.innerType)) {
+              resolveGenericType(genericType.innerType)
             } else {
-              listType.setInnerType(mergedTypes[listType.innerType.elemID.getFullName()]
-              || listType.innerType)
+              genericType.setInnerType(mergedTypes[genericType.innerType.elemID.getFullName()]
+              || genericType.innerType)
             }
           }
-          resolveListType(fieldType)
+          resolveGenericType(fieldType)
         }
         return field
       }

--- a/packages/workspace/src/merger/index.ts
+++ b/packages/workspace/src/merger/index.ts
@@ -16,7 +16,8 @@
 import _ from 'lodash'
 import {
   ObjectType, isType, isObjectType, isInstanceElement, Element, ContainerType,
-  isPrimitiveType, BuiltinTypes, TypeMap, ListType, isVariable, isContainerType, isGenericType, GenericType,
+  isPrimitiveType, BuiltinTypes, TypeMap, ListType, isVariable, isContainerType,
+  isGenericType, GenericType,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { mergeObjectTypes } from './internal/object_types'

--- a/packages/workspace/src/merger/index.ts
+++ b/packages/workspace/src/merger/index.ts
@@ -17,7 +17,6 @@ import _ from 'lodash'
 import {
   ObjectType, isType, isObjectType, isInstanceElement, Element, ContainerType,
   isPrimitiveType, BuiltinTypes, TypeMap, ListType, isVariable, isContainerType,
-  isGenericType, GenericType,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { mergeObjectTypes } from './internal/object_types'
@@ -50,13 +49,13 @@ export const updateMergedTypes = (
       field => {
         field.type = mergedTypes[field.type.elemID.getFullName()] || field.type
         const fieldType = field.type
-        if (isGenericType(fieldType)) {
-          const resolveGenericType = (genericType: GenericType): void => {
-            if (isGenericType(genericType.innerType)) {
-              resolveGenericType(genericType.innerType)
+        if (isContainerType(fieldType)) {
+          const resolveGenericType = (containerType: ContainerType): void => {
+            if (isContainerType(containerType.innerType)) {
+              resolveGenericType(containerType.innerType)
             } else {
-              genericType.setInnerType(mergedTypes[genericType.innerType.elemID.getFullName()]
-              || genericType.innerType)
+              containerType.setInnerType(mergedTypes[containerType.innerType.elemID.getFullName()]
+              || containerType.innerType)
             }
           }
           resolveGenericType(fieldType)

--- a/packages/workspace/test/merger.test.ts
+++ b/packages/workspace/test/merger.test.ts
@@ -15,7 +15,7 @@
 */
 import {
   ObjectType, ElemID, BuiltinTypes, InstanceElement, PrimitiveType,
-  PrimitiveTypes, TypeElement, Variable,
+  PrimitiveTypes, TypeElement, Variable, MapType,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { mergeElements, DuplicateAnnotationError } from '../src/merger'
@@ -246,9 +246,9 @@ describe('merger', () => {
         elemID: new ElemID('salto', 'obj'),
         fields: {
           prim: {
-            type: new ObjectType({
+            type: new MapType(new ObjectType({
               elemID: primElemID,
-            }),
+            })),
           },
         },
       })
@@ -258,7 +258,8 @@ describe('merger', () => {
       expect(merged).toHaveLength(2)
       const mergedPrim = merged[0] as PrimitiveType
       const mergedObj = merged[1] as ObjectType
-      expect(mergedObj.fields.prim.type).toEqual(mergedPrim)
+      const mapType = mergedObj.fields.prim.type as MapType
+      expect(mapType.innerType).toEqual(mergedPrim)
     })
   })
 

--- a/packages/workspace/test/merger.test.ts
+++ b/packages/workspace/test/merger.test.ts
@@ -235,6 +235,31 @@ describe('merger', () => {
       expect(errors).toHaveLength(0)
       expect(merged).toHaveLength(4)
     })
+
+    it('update placehoder for map types', () => {
+      const primElemID = new ElemID('salto', 'string')
+      const prim = new PrimitiveType({
+        elemID: primElemID,
+        primitive: PrimitiveTypes.STRING,
+      })
+      const objType = new ObjectType({
+        elemID: new ElemID('salto', 'obj'),
+        fields: {
+          prim: {
+            type: new ObjectType({
+              elemID: primElemID,
+            }),
+          },
+        },
+      })
+
+      const { merged, errors } = mergeElements([prim, objType])
+      expect(errors).toHaveLength(0)
+      expect(merged).toHaveLength(2)
+      const mergedPrim = merged[0] as PrimitiveType
+      const mergedObj = merged[1] as ObjectType
+      expect(mergedObj.fields.prim.type).toEqual(mergedPrim)
+    })
   })
 
   describe('merging instances', () => {


### PR DESCRIPTION
When after fetching element with map fields, when loading the workspace type validation errors are created.

The root cause:
1. Map inner types are saved in the state/cache or parse from the nacl as object types (the placeholder used for any type ref)
2. The function in merger that replaces the placeholder with a reference to the real type ignored map types.
3. As a result, the validator always attempted to validate the map values as objects. Anything else resulted in validation errors.