### PR TITLE
Netsuite: dont validate credentials when grabbing creds from credsPool

### DIFF
--- a/packages/netsuite-adapter/e2e_test/jest_environment.ts
+++ b/packages/netsuite-adapter/e2e_test/jest_environment.ts
@@ -17,7 +17,7 @@ import {
   createEnvUtils, CredsSpec, SaltoE2EJestEnvironment, JestEnvironmentConstructorArgs,
 } from '@salto-io/e2e-credentials-store'
 import { logger } from '@salto-io/logging'
-import NetsuiteClient, { Credentials } from '../src/client/client'
+import { Credentials } from '../src/client/client'
 
 
 const log = logger(module)
@@ -39,8 +39,11 @@ export const credsSpec = (envName?: string): CredsSpec<Credentials> => {
         tokenSecret: envUtils.required(tokenSecretEnvVarName),
       }
     },
-    validate: async (credentials: Credentials): Promise<void> => {
-      await NetsuiteClient.validateCredentials(credentials)
+    validate: async (_credentials: Credentials): Promise<void> => {
+      // When validating netsuite credentials it requires the test runner to have java and
+      // access to the SDF jar. In SaaS, which uses this class we can't use the tested env's SDF jar
+      // when running against staging and prod from the test runner, opposed to regular backend e2e
+      // tests. Thus we skip the credentials validation in e2e tests.
     },
     typeName: 'netsuite',
     globalProp: envName ? `netsuite_${envName}` : 'netsuite',


### PR DESCRIPTION
When validating netsuite credentials it requires the test runner to have java and access to the SDF jar.
In SaaS, we can't use the tested env's SDF jar when running against staging and prod from the test runner, opposed to regular backend e2e tests.
Thus we skip the credentials validation in e2e tests.
Since we don't validate the creds anymore, there will be no reason to have java in the SaaS deploy's job docker (that runs e2e against staging & production) anymore.
