### PR TITLE
SALTO-1018 - validate profile map keys

### DIFF
--- a/packages/core/src/core/plan/filter.ts
+++ b/packages/core/src/core/plan/filter.ts
@@ -20,6 +20,7 @@ import { DataNodeMap, DiffGraph, DiffNode, WalkError } from '@salto-io/dag'
 import {
   ChangeError, ElementMap, InstanceElement, TypeElement, ChangeValidator, getChangeElement,
   ElemID, ObjectType, ChangeDataType, Element, isAdditionOrModificationChange, isField,
+  isObjectType,
 } from '@salto-io/adapter-api'
 import { values, collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
@@ -53,9 +54,16 @@ export const filterInvalidChanges = async (
       // modification of a top level element that should be reverted as a whole
       return beforeTopLevelElem.clone()
     }
+    if (
+      (beforeTopLevelElem && !isObjectType(beforeTopLevelElem))
+      || (afterTopLevelElem && !isObjectType(afterTopLevelElem))
+    ) {
+      // use the real top-level element (for example, the top-level instance for field changes)
+      return afterTopLevelElem.clone()
+    }
     // ObjectType's fields changes
-    const beforeObj = beforeTopLevelElem as ObjectType
-    const afterObj = afterTopLevelElem as ObjectType
+    const beforeObj = beforeTopLevelElem
+    const afterObj = afterTopLevelElem
     const afterFieldNames = afterObj ? Object.keys(afterObj.fields) : []
     const beforeFieldNames = beforeObj ? Object.keys(beforeObj.fields) : []
     const allFieldNames = [...new Set([...beforeFieldNames, ...afterFieldNames])]

--- a/packages/core/test/common/elements.ts
+++ b/packages/core/test/common/elements.ts
@@ -96,7 +96,7 @@ export const getAllElements = (): AllElementsTypes => {
   const saltoEmployeeInstance = new InstanceElement(
     'instance',
     saltoEmployee,
-    { name: 'FirstEmployee', nicknames: ['you', 'hi'], office: { label: 'bla', name: 'foo' } }
+    { name: 'FirstEmployee', nicknames: ['you', 'hi'], office: { label: 'bla', name: 'foo', seats: { c1: 'n1', c2: 'n2' } } }
   )
 
   return [BuiltinTypes.STRING, saltoAddr, saltoOffice,

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -21,6 +21,7 @@ import customObjectInstancesValidator from './change_validators/custom_object_in
 import unknownFieldValidator from './change_validators/unknown_field'
 import customFieldTypeValidator from './change_validators/custom_field_type'
 import standardFieldLabelValidator from './change_validators/standard_field_label'
+import profileMapKeysValidator from './change_validators/profile_map_keys'
 
 const changeValidators: ChangeValidator[] = [
   packageValidator,
@@ -29,6 +30,7 @@ const changeValidators: ChangeValidator[] = [
   unknownFieldValidator,
   customFieldTypeValidator,
   standardFieldLabelValidator,
+  profileMapKeysValidator,
 ]
 
 export default createChangeValidator(changeValidators)

--- a/packages/salesforce-adapter/src/change_validators/profile_map_keys.ts
+++ b/packages/salesforce-adapter/src/change_validators/profile_map_keys.ts
@@ -1,0 +1,78 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  ChangeValidator, getChangeElement, InstanceElement, ChangeError, isMapType, MapType, isObjectType,
+} from '@salto-io/adapter-api'
+import { TransformFunc, transformValues, resolveValues } from '@salto-io/adapter-utils'
+import { getInstanceChanges as getProfileInstanceChanges, PROFILE_MAP_FIELD_DEF, defaultMapper } from '../filters/profile_maps'
+import { API_NAME_SEPARATOR } from '../constants'
+import { getLookUpName } from '../transformers/reference_mapping'
+
+const isNum = (str: string | undefined): boolean => (
+  !_.isEmpty(str) && !Number.isNaN(_.toNumber(str))
+)
+
+const getMapKeyErrors = (
+  after: InstanceElement
+): ChangeError[] => {
+  const errors: ChangeError[] = []
+  Object.entries(after.value).filter(
+    ([fieldName]) => isMapType(after.type.fields[fieldName]?.type)
+    && PROFILE_MAP_FIELD_DEF[fieldName] !== undefined
+  ).forEach(([fieldName, fieldValues]) => {
+    const fieldType = after.type.fields[fieldName].type as MapType
+    const mapDef = PROFILE_MAP_FIELD_DEF[fieldName]
+    const findInvalidPaths: TransformFunc = ({ value, path, field }) => {
+      if (isObjectType(field?.type) && path !== undefined) {
+        // we reached the map's inner value
+        const expectedPath = defaultMapper(value[mapDef.key]).slice(0, mapDef.nested ? 2 : 1)
+        const pathParts = path.getFullNameParts().filter(part => !isNum(part))
+        const actualPath = pathParts.slice(-expectedPath.length)
+        const previewPrefix = actualPath.slice(0, actualPath.findIndex(
+          (val, idx) => val !== expectedPath[idx]
+        ) + 1)
+        if (!_.isEqual(actualPath, expectedPath)) {
+          errors.push({
+            elemID: after.elemID.createNestedID(fieldName, ...previewPrefix),
+            severity: 'Error',
+            message: `Incorrect map key in profile ${after.value.fullName} field ${fieldName}: ${previewPrefix?.join(API_NAME_SEPARATOR)} should be ${expectedPath.slice(0, previewPrefix.length).join(API_NAME_SEPARATOR)}`,
+            detailedMessage: `Profile ${after.value.fullName} field ${fieldName}: Incorrect map key ${actualPath?.join(API_NAME_SEPARATOR)}, should be ${expectedPath.join(API_NAME_SEPARATOR)}`,
+          })
+        }
+        return undefined
+      }
+      return value
+    }
+
+    transformValues({
+      values: fieldValues,
+      type: fieldType,
+      transformFunc: findInvalidPaths,
+      strict: false,
+      pathID: after.elemID.createNestedID(fieldName),
+    })
+  })
+  return errors
+}
+
+const changeValidator: ChangeValidator = async changes => (
+  getProfileInstanceChanges(changes).flatMap(change => getMapKeyErrors(
+    resolveValues(getChangeElement(change), getLookUpName)
+  ))
+)
+
+export default changeValidator

--- a/packages/salesforce-adapter/test/change_validators/profile_map_keys.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/profile_map_keys.test.ts
@@ -1,0 +1,138 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeError, ObjectType, toChange, InstanceElement,
+} from '@salto-io/adapter-api'
+import profileMapKeysValidator from '../../src/change_validators/profile_map_keys'
+import { generateProfileType } from '../filters/profile_maps.test'
+import { INSTANCE_FULL_NAME_FIELD } from '../../src/constants'
+
+const generateInstance = (profileObj: ObjectType): InstanceElement => (
+  new InstanceElement(
+    'Admin',
+    profileObj,
+    {
+      [INSTANCE_FULL_NAME_FIELD]: 'Admin',
+      applicationVisibilities: {
+        app1: { application: 'app1', default: true, visible: false },
+        app2: { application: 'app2', default: true, visible: false },
+      },
+      fieldPermissions: {
+        Account: {
+          AccountNumber: {
+            field: 'Account.AccountNumber',
+            editable: true,
+            readable: true,
+          },
+        },
+        Contact: {
+          HasOptedOutOfEmail: {
+            field: 'Contact.HasOptedOutOfEmail',
+            editable: true,
+            readable: true,
+          },
+        },
+      },
+      layoutAssignments: {
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        Account_Account_Layout: [
+          { layout: 'Account-Account Layout' },
+        ],
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        Account_random_characters_aaa___bbb: [
+          { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'something' },
+        ],
+      },
+    },
+  )
+)
+
+const breakInstanceMaps = (profileInstance: InstanceElement): void => {
+  profileInstance.value.applicationVisibilities.otherApp = { application: 'other app', default: true, visible: false }
+  profileInstance.value.fieldPermissions.Account.wrongName = (
+    profileInstance.value.fieldPermissions.Account.AccountNumber
+  )
+  delete profileInstance.value.fieldPermissions.Account.AccountNumber
+  profileInstance.value.fieldPermissions.Something = {
+    wrong: {
+      field: 'Correct.Path',
+      editable: true,
+      readable: true,
+    },
+  }
+  profileInstance.value.layoutAssignments.Account_Account_Layout[0].layout = 'new account layout name'
+}
+
+describe('profile map keys change validator', () => {
+  let profileObj: ObjectType
+  let profileInstance: InstanceElement
+  beforeEach(() => {
+    profileObj = generateProfileType(true)
+    profileInstance = generateInstance(profileObj)
+  })
+
+  const runChangeValidator = (before?: InstanceElement, after?: InstanceElement):
+      Promise<ReadonlyArray<ChangeError>> =>
+    profileMapKeysValidator([toChange({ before, after })])
+
+  it('should have no errors if keys are valid', async () => {
+    const afterProfileObj = generateProfileType(true)
+    const afterProfileInstance = generateInstance(afterProfileObj)
+    const changeErrors = await runChangeValidator(profileInstance, afterProfileInstance)
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('should have error for invalid keys on update', async () => {
+    const afterProfileObj = generateProfileType(true)
+    const afterProfileInstance = generateInstance(afterProfileObj)
+    breakInstanceMaps(afterProfileInstance)
+
+    const changeErrors = await runChangeValidator(profileInstance, afterProfileInstance)
+    expect(changeErrors).toHaveLength(4)
+    expect(changeErrors.map(c => c.severity)).toEqual(['Error', 'Error', 'Error', 'Error'])
+    expect(changeErrors[0].elemID).toEqual(afterProfileInstance.elemID.createNestedID('applicationVisibilities', 'otherApp'))
+    expect(changeErrors[0].detailedMessage).toEqual('Profile Admin field applicationVisibilities: Incorrect map key otherApp, should be other_app')
+    expect(changeErrors[1].elemID).toEqual(afterProfileInstance.elemID.createNestedID('fieldPermissions', 'Account', 'wrongName'))
+    expect(changeErrors[1].detailedMessage).toEqual('Profile Admin field fieldPermissions: Incorrect map key Account.wrongName, should be Account.AccountNumber')
+    expect(changeErrors[2].elemID).toEqual(afterProfileInstance.elemID.createNestedID('fieldPermissions', 'Something'))
+    expect(changeErrors[2].detailedMessage).toEqual('Profile Admin field fieldPermissions: Incorrect map key Something.wrong, should be Correct.Path')
+    expect(changeErrors[3].elemID).toEqual(afterProfileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout'))
+    expect(changeErrors[3].detailedMessage).toEqual('Profile Admin field layoutAssignments: Incorrect map key Account_Account_Layout, should be new_account_layout_name')
+  })
+
+  it('should have error for invalid keys on add', async () => {
+    breakInstanceMaps(profileInstance)
+
+    const changeErrors = await runChangeValidator(undefined, profileInstance)
+    expect(changeErrors).toHaveLength(4)
+    expect(changeErrors.map(c => c.severity)).toEqual(['Error', 'Error', 'Error', 'Error'])
+    expect(changeErrors[0].elemID).toEqual(profileInstance.elemID.createNestedID('applicationVisibilities', 'otherApp'))
+    expect(changeErrors[0].detailedMessage).toEqual('Profile Admin field applicationVisibilities: Incorrect map key otherApp, should be other_app')
+    expect(changeErrors[1].elemID).toEqual(profileInstance.elemID.createNestedID('fieldPermissions', 'Account', 'wrongName'))
+    expect(changeErrors[1].detailedMessage).toEqual('Profile Admin field fieldPermissions: Incorrect map key Account.wrongName, should be Account.AccountNumber')
+    expect(changeErrors[2].elemID).toEqual(profileInstance.elemID.createNestedID('fieldPermissions', 'Something'))
+    expect(changeErrors[2].detailedMessage).toEqual('Profile Admin field fieldPermissions: Incorrect map key Something.wrong, should be Correct.Path')
+    expect(changeErrors[3].elemID).toEqual(profileInstance.elemID.createNestedID('layoutAssignments', 'Account_Account_Layout'))
+    expect(changeErrors[3].detailedMessage).toEqual('Profile Admin field layoutAssignments: Incorrect map key Account_Account_Layout, should be new_account_layout_name')
+  })
+
+  it('should not validate map keys on delete', async () => {
+    breakInstanceMaps(profileInstance)
+
+    const changeErrors = await runChangeValidator(profileInstance, undefined)
+    expect(changeErrors).toHaveLength(0)
+  })
+})

--- a/packages/salesforce-adapter/test/filters/profile_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_maps.test.ts
@@ -18,12 +18,12 @@ import { FilterWith } from '../../src/filter'
 import filterCreator from '../../src/filters/profile_maps'
 import mockClient from '../client'
 import {
-  SALESFORCE, METADATA_TYPE, PROFILE_METADATA_TYPE,
+  SALESFORCE, METADATA_TYPE, PROFILE_METADATA_TYPE, INSTANCE_FULL_NAME_FIELD,
 } from '../../src/constants'
 
 type layoutAssignmentType = { layout: string; recordType?: string }
 
-const generateProfileType = (useMaps = false, preDeploy = false): ObjectType => {
+export const generateProfileType = (useMaps = false, preDeploy = false): ObjectType => {
   const ProfileApplicationVisibility = new ObjectType({
     elemID: new ElemID(SALESFORCE, 'ProfileApplicationVisibility'),
     fields: {
@@ -66,6 +66,7 @@ const generateProfileType = (useMaps = false, preDeploy = false): ObjectType => 
   return new ObjectType({
     elemID: new ElemID(SALESFORCE, PROFILE_METADATA_TYPE),
     fields: {
+      [INSTANCE_FULL_NAME_FIELD]: { type: BuiltinTypes.STRING },
       applicationVisibilities: { type: useMaps
         ? new MapType(ProfileApplicationVisibility)
         : ProfileApplicationVisibility },


### PR DESCRIPTION
Verify the keys for all map fields in profiles to make sure they were not modified manually by the user. The error includes the correct path.