### PR TITLE
SALTO-925 (Partial) - CPQ mapping references

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -311,6 +311,11 @@ export const CPQ_LOOKUP_QUERY = 'SBQQ__LookupQuery__c'
 export const CPQ_PRICE_ACTION = 'SBQQ__PriceAction__c'
 export const CPQ_FIELD_METADATA = 'SBQQ__FieldMetadata__c'
 export const CPQ_CUSTOM_SCRIPT = 'SBQQ__CustomScript__c'
+export const CPQ_CONFIGURATION_ATTRIBUTE = 'SBQQ__ConfigurationAttribute__c'
+export const CPQ_QUOTE = 'SBQQ__Quote__c'
+export const CPQ_QUOTE_LINE_GROUP = 'SBQQ__QuoteLineGroup__c'
+export const CPQ_QUOTE_LINE = 'SBQQ__QuoteLine__c'
+export const CPQ_PRODUCT_OPTION = 'SBQQ__ProductOption__c'
 
 // CPQ Fields
 export const CPQ_LOOKUP_OBJECT_NAME = 'SBQQ__LookupObject__c'
@@ -328,3 +333,29 @@ export const CPQ_GROUP_FIELDS = 'SBQQ__GroupFields__c'
 export const CPQ_QUOTE_FIELDS = 'SBQQ__QuoteFields__c'
 export const CPQ_QUOTE_LINE_FIELDS = 'SBQQ__QuoteLineFields__c'
 export const CPQ_CODE_FIELD = 'SBQQ__Code__c'
+export const CPQ_DEFAULT_OBJECT_FIELD = 'SBQQ__DefaultObject__c'
+export const CPQ_TESTED_OBJECT = 'SBQQ__TestedObject__c'
+
+export const CPQ_QUOTE_NO_PRE = 'Quote__c'
+export const CPQ_QUOTE_LINE_GROUP_NO_PRE = 'QuoteLineGroup__c'
+export const CONF_ATTR_NAME_TO_API_NAME = {
+  [CPQ_QUOTE_NO_PRE]: CPQ_QUOTE,
+  [CPQ_QUOTE_LINE_GROUP_NO_PRE]: CPQ_QUOTE_LINE_GROUP,
+} as Record<string, string>
+
+export const CONF_ATTR_API_NAME_TO_NAME = Object.fromEntries(
+  Object.entries(CONF_ATTR_NAME_TO_API_NAME).map(([key, val]) => ([val, key]))
+)
+
+export const CPQ_QUOTE_NAME = 'Quote'
+export const CPQ_QUOTE_LINE_NAME = 'Quote Line'
+export const CPQ_PRODUCT_OPTION_NAME = 'Product Option'
+export const LOOKUP_QUERY_NAME_TO_API_NAME = {
+  [CPQ_QUOTE_NAME]: CPQ_QUOTE,
+  [CPQ_QUOTE_LINE_NAME]: CPQ_QUOTE_LINE,
+  [CPQ_PRODUCT_OPTION_NAME]: CPQ_PRODUCT_OPTION,
+} as Record<string, string>
+
+export const LOOKUP_QUERY_API_NAME_TO_NAME = Object.fromEntries(
+  Object.entries(LOOKUP_QUERY_NAME_TO_API_NAME).map(([key, val]) => ([val, key]))
+)

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -343,10 +343,6 @@ export const CONF_ATTR_NAME_TO_API_NAME = {
   [CPQ_QUOTE_LINE_GROUP_NO_PRE]: CPQ_QUOTE_LINE_GROUP,
 } as Record<string, string>
 
-export const CONF_ATTR_API_NAME_TO_NAME = Object.fromEntries(
-  Object.entries(CONF_ATTR_NAME_TO_API_NAME).map(([key, val]) => ([val, key]))
-)
-
 export const CPQ_QUOTE_NAME = 'Quote'
 export const CPQ_QUOTE_LINE_NAME = 'Quote Line'
 export const CPQ_PRODUCT_OPTION_NAME = 'Product Option'
@@ -355,7 +351,3 @@ export const LOOKUP_QUERY_NAME_TO_API_NAME = {
   [CPQ_QUOTE_LINE_NAME]: CPQ_QUOTE_LINE,
   [CPQ_PRODUCT_OPTION_NAME]: CPQ_PRODUCT_OPTION,
 } as Record<string, string>
-
-export const LOOKUP_QUERY_API_NAME_TO_NAME = Object.fromEntries(
-  Object.entries(LOOKUP_QUERY_NAME_TO_API_NAME).map(([key, val]) => ([val, key]))
-)

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -175,10 +175,11 @@ const replaceReferenceValues = (
     const elemType = target.type ?? typeContextFunc({
       instance, elemByElemID, field, fieldPath: path,
     })
-    return findElem(
+    const elementFound = findElem(
       target.lookup(val, elemParent),
       elemType,
     )
+    return elementFound
   }
 
   const replacePrimitive = (val: string, field: Field, path?: ElemID): Value => {

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -175,11 +175,10 @@ const replaceReferenceValues = (
     const elemType = target.type ?? typeContextFunc({
       instance, elemByElemID, field, fieldPath: path,
     })
-    const elementFound = findElem(
+    return findElem(
       target.lookup(val, elemParent),
       elemType,
     )
-    return elementFound
   }
 
   const replacePrimitive = (val: string, field: Field, path?: ElemID): Value => {

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -59,12 +59,12 @@ const ReferenceSerializationStrategyLookup: Record<
   configurationAttributeMapping: {
     serialize: ({ ref }) => (_.invert(CONF_ATTR_NAME_TO_API_NAME)[apiName(ref.value)]
       ?? apiName(ref.value)),
-    lookup: val => (_.isString(val) ? CONF_ATTR_NAME_TO_API_NAME[val] ?? val : val),
+    lookup: val => (_.isString(val) ? (CONF_ATTR_NAME_TO_API_NAME[val] ?? val) : val),
   },
   lookupQueryMapping: {
     serialize: ({ ref }) => (_.invert(LOOKUP_QUERY_NAME_TO_API_NAME)[apiName(ref.value)]
       ?? apiName(ref.value)),
-    lookup: val => (_.isString(val) ? LOOKUP_QUERY_NAME_TO_API_NAME[val] ?? val : val),
+    lookup: val => (_.isString(val) ? (LOOKUP_QUERY_NAME_TO_API_NAME[val] ?? val) : val),
   },
 }
 

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -27,7 +27,9 @@ import {
   VALIDATION_RULES_METADATA_TYPE, RECORD_TYPE_METADATA_TYPE, BUSINESS_PROCESS_METADATA_TYPE,
   WEBLINK_METADATA_TYPE, SUMMARY_LAYOUT_ITEM_METADATA_TYPE, CPQ_CUSTOM_SCRIPT, CPQ_QUOTE_FIELDS,
   CPQ_CONSUMPTION_RATE_FIELDS, CPQ_CONSUMPTION_SCHEDULE_FIELDS, CPQ_GROUP_FIELDS,
-  CPQ_QUOTE_LINE_FIELDS,
+  CPQ_QUOTE_LINE_FIELDS, CONF_ATTR_API_NAME_TO_NAME, CONF_ATTR_NAME_TO_API_NAME,
+  LOOKUP_QUERY_NAME_TO_API_NAME, LOOKUP_QUERY_API_NAME_TO_NAME, CPQ_TESTED_OBJECT,
+  CPQ_CONFIGURATION_ATTRIBUTE, CPQ_DEFAULT_OBJECT_FIELD,
 } from '../constants'
 
 const log = logger(module)
@@ -39,7 +41,7 @@ export type ReferenceSerializationStrategy = {
   lookup: LookupFunc
 }
 
-type ReferenceSerializationStrategyName = 'absoluteApiName' | 'relativeApiName'
+type ReferenceSerializationStrategyName = 'absoluteApiName' | 'relativeApiName' | 'configurationAttributeMapping' | 'lookupQueryMapping'
 const ReferenceSerializationStrategyLookup: Record<
   ReferenceSerializationStrategyName, ReferenceSerializationStrategy
 > = {
@@ -53,6 +55,14 @@ const ReferenceSerializationStrategyLookup: Record<
       ? [context, val].join(API_NAME_SEPARATOR)
       : val
     ),
+  },
+  configurationAttributeMapping: {
+    serialize: ({ ref }) => (CONF_ATTR_API_NAME_TO_NAME[apiName(ref.value)]),
+    lookup: val => (_.isString(val) ? CONF_ATTR_NAME_TO_API_NAME[val] ?? val : val),
+  },
+  lookupQueryMapping: {
+    serialize: ({ ref }) => (LOOKUP_QUERY_API_NAME_TO_NAME[apiName(ref.value)]),
+    lookup: val => (_.isString(val) ? LOOKUP_QUERY_NAME_TO_API_NAME[val] ?? val : val),
   },
 }
 
@@ -270,6 +280,16 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   },
   {
     src: { field: CPQ_RULE_LOOKUP_OBJECT_FIELD, parentTypes: [CPQ_LOOKUP_QUERY, CPQ_PRICE_ACTION] },
+    target: { type: CUSTOM_OBJECT },
+  },
+  {
+    src: { field: CPQ_DEFAULT_OBJECT_FIELD, parentTypes: [CPQ_CONFIGURATION_ATTRIBUTE] },
+    serializationStrategy: 'configurationAttributeMapping',
+    target: { type: CUSTOM_OBJECT },
+  },
+  {
+    src: { field: CPQ_TESTED_OBJECT, parentTypes: [CPQ_LOOKUP_QUERY] },
+    serializationStrategy: 'lookupQueryMapping',
     target: { type: CUSTOM_OBJECT },
   },
   {

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -27,8 +27,8 @@ import {
   VALIDATION_RULES_METADATA_TYPE, RECORD_TYPE_METADATA_TYPE, BUSINESS_PROCESS_METADATA_TYPE,
   WEBLINK_METADATA_TYPE, SUMMARY_LAYOUT_ITEM_METADATA_TYPE, CPQ_CUSTOM_SCRIPT, CPQ_QUOTE_FIELDS,
   CPQ_CONSUMPTION_RATE_FIELDS, CPQ_CONSUMPTION_SCHEDULE_FIELDS, CPQ_GROUP_FIELDS,
-  CPQ_QUOTE_LINE_FIELDS, CONF_ATTR_API_NAME_TO_NAME, CONF_ATTR_NAME_TO_API_NAME,
-  LOOKUP_QUERY_NAME_TO_API_NAME, LOOKUP_QUERY_API_NAME_TO_NAME, CPQ_TESTED_OBJECT,
+  CPQ_QUOTE_LINE_FIELDS, CONF_ATTR_NAME_TO_API_NAME,
+  LOOKUP_QUERY_NAME_TO_API_NAME, CPQ_TESTED_OBJECT,
   CPQ_CONFIGURATION_ATTRIBUTE, CPQ_DEFAULT_OBJECT_FIELD,
 } from '../constants'
 
@@ -57,11 +57,13 @@ const ReferenceSerializationStrategyLookup: Record<
     ),
   },
   configurationAttributeMapping: {
-    serialize: ({ ref }) => (CONF_ATTR_API_NAME_TO_NAME[apiName(ref.value)]),
+    serialize: ({ ref }) => (_.invert(CONF_ATTR_NAME_TO_API_NAME)[apiName(ref.value)]
+      ?? apiName(ref.value)),
     lookup: val => (_.isString(val) ? CONF_ATTR_NAME_TO_API_NAME[val] ?? val : val),
   },
   lookupQueryMapping: {
-    serialize: ({ ref }) => (LOOKUP_QUERY_API_NAME_TO_NAME[apiName(ref.value)]),
+    serialize: ({ ref }) => (_.invert(LOOKUP_QUERY_NAME_TO_API_NAME)[apiName(ref.value)]
+      ?? apiName(ref.value)),
     lookup: val => (_.isString(val) ? LOOKUP_QUERY_NAME_TO_API_NAME[val] ?? val : val),
   },
 }

--- a/packages/salesforce-adapter/test/filters/cpq/lookup_object.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/lookup_object.test.ts
@@ -13,17 +13,17 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ObjectType, ElemID, Element, ReferenceExpression, isObjectType } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, Element, ReferenceExpression, isObjectType, ChangeDataType, Change, toChange, AdditionChange, ModificationChange } from '@salto-io/adapter-api'
 import { FilterWith } from '../../../src/filter'
 import SalesforceClient from '../../../src/client/client'
 import mockAdapter from '../../adapter'
 import filterCreator from '../../../src/filters/cpq/lookup_object'
-import { SALESFORCE, CPQ_PRODUCT_RULE, CPQ_LOOKUP_OBJECT_NAME, API_NAME, METADATA_TYPE, CUSTOM_OBJECT, FIELD_ANNOTATIONS } from '../../../src/constants'
+import { SALESFORCE, CPQ_PRODUCT_RULE, CPQ_LOOKUP_OBJECT_NAME, API_NAME, METADATA_TYPE, CUSTOM_OBJECT, FIELD_ANNOTATIONS, CPQ_CONFIGURATION_ATTRIBUTE, CPQ_DEFAULT_OBJECT_FIELD, CPQ_QUOTE_NO_PRE, CPQ_QUOTE } from '../../../src/constants'
 import { Types } from '../../../src/transformers/transformer'
 
 describe('lookup_object filter', () => {
   let client: SalesforceClient
-  type FilterType = FilterWith<'onFetch'>
+  type FilterType = FilterWith<'onFetch' | 'onDeploy' | 'preDeploy'>
   let filter: FilterType
   let elements: Element[]
   const existingObjectName = 'existingObject'
@@ -32,6 +32,14 @@ describe('lookup_object filter', () => {
     elemID: mockObjectElemID,
     annotations: {
       [API_NAME]: existingObjectName,
+      [METADATA_TYPE]: CUSTOM_OBJECT,
+    },
+  })
+  const mockQuoteElemID = new ElemID(SALESFORCE, CPQ_QUOTE)
+  const mockQuote = new ObjectType({
+    elemID: mockQuoteElemID,
+    annotations: {
+      [API_NAME]: CPQ_QUOTE,
       [METADATA_TYPE]: CUSTOM_OBJECT,
     },
   })
@@ -57,37 +65,212 @@ describe('lookup_object filter', () => {
       [METADATA_TYPE]: CUSTOM_OBJECT,
     },
   })
-  beforeAll(async () => {
-    ({ client } = mockAdapter({
-      adapterParams: {
+  const mockConfigurationAttributeElemID = new ElemID(SALESFORCE, CPQ_CONFIGURATION_ATTRIBUTE)
+  const mockConfigurationAttribute = new ObjectType({
+    elemID: mockConfigurationAttributeElemID,
+    fields: {
+      [CPQ_DEFAULT_OBJECT_FIELD]: {
+        type: Types.primitiveDataTypes.Picklist,
+        annotations: {
+          [API_NAME]: CPQ_DEFAULT_OBJECT_FIELD,
+          valueSet: [{
+            fullName: CPQ_QUOTE_NO_PRE,
+          },
+          {
+            fullName: existingObjectName,
+          },
+          {
+            fullName: 'nonExistingObject',
+          },
+          ],
+        },
       },
-    }))
-    filter = filterCreator({ client, config: {} }) as FilterType
-    elements = [mockObject.clone(), mockProductRuleObject.clone()]
-    await filter.onFetch(elements)
+    },
+    annotations: {
+      [API_NAME]: CPQ_CONFIGURATION_ATTRIBUTE,
+      [METADATA_TYPE]: CUSTOM_OBJECT,
+    },
   })
 
-  it('Should not add or remove elements', () => {
-    expect(elements).toHaveLength(2)
-    expect(elements.find(e => e.elemID.isEqual(mockObjectElemID))).toBeDefined()
-    expect(elements.find(e => e.elemID.isEqual(mockProductRuleElemID))).toBeDefined()
+  describe('onFetch', () => {
+    beforeAll(async () => {
+      ({ client } = mockAdapter({
+        adapterParams: {
+        },
+      }))
+      filter = filterCreator({ client, config: {} }) as FilterType
+      elements = [
+        mockObject.clone(),
+        mockProductRuleObject.clone(),
+        mockConfigurationAttribute.clone(),
+        mockQuote.clone(),
+      ]
+      await filter.onFetch(elements)
+    })
+
+    it('Should not add or remove elements', () => {
+      expect(elements).toHaveLength(4)
+      expect(elements.find(e => e.elemID.isEqual(mockObjectElemID))).toBeDefined()
+      expect(elements.find(e => e.elemID.isEqual(mockProductRuleElemID))).toBeDefined()
+      expect(elements.find(e => e.elemID.isEqual(mockConfigurationAttributeElemID))).toBeDefined()
+      expect(elements.find(e => e.elemID.isEqual(mockQuoteElemID))).toBeDefined()
+    })
+
+    it('Should not change elements not defined as ones with lookup', () => {
+      expect(elements.find(e => e.elemID.isEqual(mockObjectElemID))).toStrictEqual(mockObject)
+      expect(elements.find(e => e.elemID.isEqual(mockQuoteElemID))).toStrictEqual(mockQuote)
+    })
+
+    describe('Object with no valuesMapping defined', () => {
+      it('Should change lookup field value set fullName value to a ref if custom object exists and keep string if not', () => {
+        const mockProductElm = elements.find(e => e.elemID.isEqual(mockProductRuleElemID))
+        expect(mockProductElm).toBeDefined()
+        expect(isObjectType(mockProductElm)).toBeTruthy()
+        const lookupObjetField = (mockProductElm as ObjectType).fields[CPQ_LOOKUP_OBJECT_NAME]
+        expect(lookupObjetField).toBeDefined()
+        expect(
+          lookupObjetField.annotations[FIELD_ANNOTATIONS.VALUE_SET][0].fullName
+        ).toEqual(new ReferenceExpression(mockObjectElemID))
+        expect(
+          lookupObjetField.annotations[FIELD_ANNOTATIONS.VALUE_SET][1].fullName
+        ).toEqual('nonExistingObject')
+      })
+    })
+
+    describe('Object with valuesMapping defined', () => {
+      it('Should change lookup field value set fullName value to a ref if custom object exists (mapped and not) and keep string if not', () => {
+        const mockConfigurationAttr = elements
+          .find(e => e.elemID.isEqual(mockConfigurationAttributeElemID))
+        expect(mockConfigurationAttr).toBeDefined()
+        expect(isObjectType(mockConfigurationAttr)).toBeTruthy()
+        const defaultObjectField = (mockConfigurationAttr as ObjectType)
+          .fields[CPQ_DEFAULT_OBJECT_FIELD]
+        expect(defaultObjectField).toBeDefined()
+        expect(
+          defaultObjectField.annotations[FIELD_ANNOTATIONS.VALUE_SET][0].fullName
+        ).toEqual(new ReferenceExpression(mockQuoteElemID))
+        expect(
+          defaultObjectField.annotations[FIELD_ANNOTATIONS.VALUE_SET][1].fullName
+        ).toEqual(new ReferenceExpression(mockObjectElemID))
+        expect(
+          defaultObjectField.annotations[FIELD_ANNOTATIONS.VALUE_SET][2].fullName
+        ).toEqual('nonExistingObject')
+      })
+    })
   })
 
-  it('Should not change elements not defined as ones with lookup', () => {
-    expect(elements.find(e => e.elemID.isEqual(mockObjectElemID))).toStrictEqual(mockObject)
+  describe('preDeploy', () => {
+    let changes: Change<ChangeDataType>[]
+    const mockAfterResolveConfigurationAttribute = new ObjectType({
+      elemID: mockConfigurationAttributeElemID,
+      fields: {
+        [CPQ_DEFAULT_OBJECT_FIELD]: {
+          type: Types.primitiveDataTypes.Picklist,
+          annotations: {
+            [API_NAME]: CPQ_DEFAULT_OBJECT_FIELD,
+            valueSet: [{
+              fullName: CPQ_QUOTE,
+            },
+            {
+              fullName: existingObjectName,
+            },
+            {
+              fullName: 'nonExistingObject',
+            },
+            ],
+          },
+        },
+      },
+      annotations: {
+        [API_NAME]: CPQ_CONFIGURATION_ATTRIBUTE,
+        [METADATA_TYPE]: CUSTOM_OBJECT,
+      },
+    })
+    describe('Modification changes', () => {
+      beforeAll(async () => {
+        changes = [
+          toChange({
+            before: mockAfterResolveConfigurationAttribute.clone(),
+            after: mockAfterResolveConfigurationAttribute.clone(),
+          }),
+        ]
+        await filter.preDeploy(changes)
+      })
+      it('Should map back to the service name instead of api if theres mapping and keep same if not', () => {
+        expect(changes[0]).toBeDefined()
+        const afterData = (changes[0] as ModificationChange<ObjectType>).data.after
+        expect(afterData.fields[CPQ_DEFAULT_OBJECT_FIELD].annotations.valueSet[0].fullName)
+          .toEqual(CPQ_QUOTE_NO_PRE)
+        expect(afterData.fields[CPQ_DEFAULT_OBJECT_FIELD].annotations.valueSet[1].fullName)
+          .toEqual(existingObjectName)
+        expect(afterData.fields[CPQ_DEFAULT_OBJECT_FIELD].annotations.valueSet[2].fullName)
+          .toEqual('nonExistingObject')
+      })
+    })
+    describe('Addition changes', () => {
+      beforeAll(async () => {
+        changes = [
+          toChange({
+            after: mockAfterResolveConfigurationAttribute.clone(),
+          }),
+        ]
+        await filter.preDeploy(changes)
+      })
+      it('Should map back to the service name instead of api if theres mapping and keep same if not', () => {
+        expect(changes[0]).toBeDefined()
+        const afterData = (changes[0] as AdditionChange<ObjectType>).data.after
+        expect(afterData.fields[CPQ_DEFAULT_OBJECT_FIELD].annotations.valueSet[0].fullName)
+          .toEqual(CPQ_QUOTE_NO_PRE)
+        expect(afterData.fields[CPQ_DEFAULT_OBJECT_FIELD].annotations.valueSet[1].fullName)
+          .toEqual(existingObjectName)
+        expect(afterData.fields[CPQ_DEFAULT_OBJECT_FIELD].annotations.valueSet[2].fullName)
+          .toEqual('nonExistingObject')
+      })
+    })
   })
 
-  it('Should change lookup field value set fullName value to a ref if custom object exists and keep string if not', () => {
-    const mockProductElm = elements.find(e => e.elemID.isEqual(mockProductRuleElemID))
-    expect(mockProductElm).toBeDefined()
-    expect(isObjectType(mockProductElm)).toBeTruthy()
-    const lookupObjetField = (mockProductElm as ObjectType).fields[CPQ_LOOKUP_OBJECT_NAME]
-    expect(lookupObjetField).toBeDefined()
-    expect(
-      lookupObjetField.annotations[FIELD_ANNOTATIONS.VALUE_SET][0].fullName
-    ).toEqual(new ReferenceExpression(mockObjectElemID))
-    expect(
-      lookupObjetField.annotations[FIELD_ANNOTATIONS.VALUE_SET][1].fullName
-    ).toEqual('nonExistingObject')
+  describe('onDeploy', () => {
+    let changes: Change<ChangeDataType>[]
+    describe('Modification changes', () => {
+      beforeAll(async () => {
+        changes = [
+          toChange({
+            before: mockConfigurationAttribute.clone(),
+            after: mockConfigurationAttribute.clone(),
+          }),
+        ]
+        await filter.onDeploy(changes)
+      })
+      it('Should map to api name if theres mapping and keep same if not', () => {
+        expect(changes[0]).toBeDefined()
+        const afterData = (changes[0] as ModificationChange<ObjectType>).data.after
+        expect(afterData.fields[CPQ_DEFAULT_OBJECT_FIELD].annotations.valueSet[0].fullName)
+          .toEqual(CPQ_QUOTE)
+        expect(afterData.fields[CPQ_DEFAULT_OBJECT_FIELD].annotations.valueSet[1].fullName)
+          .toEqual(existingObjectName)
+        expect(afterData.fields[CPQ_DEFAULT_OBJECT_FIELD].annotations.valueSet[2].fullName)
+          .toEqual('nonExistingObject')
+      })
+    })
+    describe('Addition changes', () => {
+      beforeAll(async () => {
+        changes = [
+          toChange({
+            after: mockConfigurationAttribute.clone(),
+          }),
+        ]
+        await filter.onDeploy(changes)
+      })
+      it('Should map to api name if theres mapping and keep same if not', () => {
+        expect(changes[0]).toBeDefined()
+        const afterData = (changes[0] as AdditionChange<ObjectType>).data.after
+        expect(afterData.fields[CPQ_DEFAULT_OBJECT_FIELD].annotations.valueSet[0].fullName)
+          .toEqual(CPQ_QUOTE)
+        expect(afterData.fields[CPQ_DEFAULT_OBJECT_FIELD].annotations.valueSet[1].fullName)
+          .toEqual(existingObjectName)
+        expect(afterData.fields[CPQ_DEFAULT_OBJECT_FIELD].annotations.valueSet[2].fullName)
+          .toEqual('nonExistingObject')
+      })
+    })
   })
 })

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -19,11 +19,7 @@ import { FilterWith } from '../../src/filter'
 import filterCreator, { addReferences } from '../../src/filters/field_references'
 import { fieldNameToTypeMappingDefs } from '../../src/transformers/reference_mapping'
 import mockClient from '../client'
-import {
-  OBJECTS_PATH, SALESFORCE, CUSTOM_OBJECT, METADATA_TYPE, INSTANCE_FULL_NAME_FIELD,
-  CUSTOM_OBJECT_ID_FIELD, API_NAME, API_NAME_SEPARATOR, WORKFLOW_ACTION_REFERENCE_METADATA_TYPE,
-  WORKFLOW_RULE_METADATA_TYPE, CPQ_QUOTE_LINE_FIELDS, CPQ_CUSTOM_SCRIPT,
-} from '../../src/constants'
+import { OBJECTS_PATH, SALESFORCE, CUSTOM_OBJECT, METADATA_TYPE, INSTANCE_FULL_NAME_FIELD, CUSTOM_OBJECT_ID_FIELD, API_NAME, API_NAME_SEPARATOR, WORKFLOW_ACTION_REFERENCE_METADATA_TYPE, WORKFLOW_RULE_METADATA_TYPE, CPQ_QUOTE_LINE_FIELDS, CPQ_CUSTOM_SCRIPT, CPQ_CONFIGURATION_ATTRIBUTE, CPQ_DEFAULT_OBJECT_FIELD, CPQ_LOOKUP_QUERY, CPQ_TESTED_OBJECT } from '../../src/constants'
 import { metadataType, apiName } from '../../src/transformers/transformer'
 import { CUSTOM_OBJECT_TYPE_ID } from '../../src/filters/custom_objects'
 
@@ -125,6 +121,10 @@ describe('FieldReferences filter', () => {
       type: 'SBQQ__QuoteLine__c',
       fieldName: 'name',
     }),
+    ...generateObjectAndInstance({
+      type: 'SBQQ__Quote__c',
+      fieldName: 'name',
+    }),
 
     // site1.authorizationRequiredPage should point to page1
     ...generateObjectAndInstance({
@@ -180,6 +180,20 @@ describe('FieldReferences filter', () => {
       instanceName: 'customScript1',
       fieldName: CPQ_QUOTE_LINE_FIELDS,
       fieldValue: ['name'],
+    }),
+    ...generateObjectAndInstance({
+      type: CPQ_CONFIGURATION_ATTRIBUTE,
+      objType: CPQ_CONFIGURATION_ATTRIBUTE,
+      instanceName: 'configAttr1',
+      fieldName: CPQ_DEFAULT_OBJECT_FIELD,
+      fieldValue: 'Quote__c',
+    }),
+    ...generateObjectAndInstance({
+      type: CPQ_LOOKUP_QUERY,
+      objType: CPQ_LOOKUP_QUERY,
+      instanceName: 'lookupQuery1',
+      fieldName: CPQ_TESTED_OBJECT,
+      fieldValue: 'Quote',
     }),
     // fieldUpdate54.field should point to Account.name (instanceParent)
     ...generateObjectAndInstance({
@@ -251,6 +265,24 @@ describe('FieldReferences filter', () => {
       expect(inst.value[CPQ_QUOTE_LINE_FIELDS]).toHaveLength(1)
       expect(inst.value[CPQ_QUOTE_LINE_FIELDS][0]).toBeInstanceOf(ReferenceExpression)
       expect(inst.value[CPQ_QUOTE_LINE_FIELDS][0]?.elemId.getFullName()).toEqual('salesforce.SBQQ__QuoteLine__c.field.name')
+    })
+
+    it('should resolve object with configurationAttributeMapping strategy', () => {
+      const inst = elements.find(
+        e => isInstanceElement(e) && apiName(e.type) === CPQ_CONFIGURATION_ATTRIBUTE
+      ) as InstanceElement
+      expect(inst.value[CPQ_DEFAULT_OBJECT_FIELD]).toBeDefined()
+      expect(inst.value[CPQ_DEFAULT_OBJECT_FIELD]).toBeInstanceOf(ReferenceExpression)
+      expect(inst.value[CPQ_DEFAULT_OBJECT_FIELD]?.elemId.getFullName()).toEqual('salesforce.SBQQ__Quote__c')
+    })
+
+    it('should resolve object with lookupQueryMapping strategy', () => {
+      const inst = elements.find(
+        e => isInstanceElement(e) && apiName(e.type) === CPQ_LOOKUP_QUERY
+      ) as InstanceElement
+      expect(inst.value[CPQ_TESTED_OBJECT]).toBeDefined()
+      expect(inst.value[CPQ_TESTED_OBJECT]).toBeInstanceOf(ReferenceExpression)
+      expect(inst.value[CPQ_TESTED_OBJECT]?.elemId.getFullName()).toEqual('salesforce.SBQQ__Quote__c')
     })
 
     it('should resolve field with neighbor context using flow action call mapping', () => {


### PR DESCRIPTION
Added 2 new "Lookup Objects" references that also include special CPQ mapping between "Label" and ApiName.

**This includes -** 
* Handling the references in the Field's annotations (value set)
* Handling the references in the CustomObject's instances

This does not include all Objects but is supposed to be easy enough to add more (Checking that Product wise that it's right to add them all first).

* I am going to extend this to Fields references (not only Objects) in future PR but this stands alone so putting it our first 