### PR TITLE
SALTO-1018 - Convert recordTypeVisibilities to nested map

### DIFF
--- a/packages/salesforce-adapter/src/filters/profile_maps.ts
+++ b/packages/salesforce-adapter/src/filters/profile_maps.ts
@@ -60,7 +60,6 @@ export const PROFILE_MAP_FIELD_DEF: Record<string, MapDef> = {
   flowAccesses: { key: 'flow' },
   objectPermissions: { key: 'object' },
   pageAccesses: { key: 'apexPage' },
-  recordTypeVisibilities: { key: 'recordType' },
   userPermissions: { key: 'name' },
 
   // Non-unique maps (multiple values can have the same key)
@@ -70,6 +69,7 @@ export const PROFILE_MAP_FIELD_DEF: Record<string, MapDef> = {
   // Two-level maps
   fieldPermissions: { key: 'field', nested: true },
   fieldLevelSecurities: { key: 'field', nested: true }, // only available in API version 22.0 and earlier
+  recordTypeVisibilities: { key: 'recordType', nested: true },
 }
 
 /**


### PR DESCRIPTION
Need two levels in the map because of the api name structure.
(not adding tests because we already have a similar case covered)