### PR TITLE
SALTO-1036 - check valueSetName instead of valueSet for svs references

### DIFF
--- a/packages/salesforce-adapter/src/filters/value_set.ts
+++ b/packages/salesforce-adapter/src/filters/value_set.ts
@@ -35,7 +35,7 @@ export const isPicklistField = (changedElement: ChangeDataType): changedElement 
     ]).includes(changedElement.type.elemID.getFullName())
 
 export const isStandardValueSetPicklistField = (field: Field): boolean =>
-  field.annotations[FIELD_ANNOTATIONS.VALUE_SET] instanceof ReferenceExpression
+  field.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME] instanceof ReferenceExpression
 
 const isGlobalValueSetPicklistField = (field: Field): boolean =>
   !_.isUndefined(field.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME])

--- a/packages/salesforce-adapter/test/change_validators/picklist_standard_field.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/picklist_standard_field.test.ts
@@ -18,7 +18,7 @@ import {
 } from '@salto-io/adapter-api'
 import { Types } from '../../src/transformers/transformer'
 import picklistStandardFieldValidator from '../../src/change_validators/picklist_standard_field'
-import { FIELD_ANNOTATIONS, SALESFORCE, VALUE_SET_FIELDS } from '../../src/constants'
+import { SALESFORCE, VALUE_SET_FIELDS } from '../../src/constants'
 import { createField } from '../utils'
 
 
@@ -76,7 +76,9 @@ describe('picklist standard field change validator', () => {
     it('should have no error for StandardValueSet picklist standard field', async () => {
       const beforeField = createField(obj, Types.primitiveDataTypes.Picklist, 'Standard')
       const dummyElemID = new ElemID(SALESFORCE, 'referenced')
-      beforeField.annotations[FIELD_ANNOTATIONS.VALUE_SET] = new ReferenceExpression(dummyElemID)
+      beforeField.annotations[
+        VALUE_SET_FIELDS.VALUE_SET_NAME
+      ] = new ReferenceExpression(dummyElemID)
       const afterField = createAfterField(beforeField)
       const changeErrors = await runChangeValidatorOnUpdate(beforeField, afterField)
       expect(changeErrors).toHaveLength(0)


### PR DESCRIPTION
Seems this was missed when moving references from `valueSet` to `valueSetName` (done [here](https://github.com/salto-io/salto/blob/c6eda1184a9b563c3629f3820873cec998ae61eb/packages/salesforce-adapter/src/filters/standard_value_sets.ts#L148-L149)).
