### PR TITLE
Remove xmlns xml attributes since they are not part of the type

### DIFF
--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -208,14 +208,24 @@ const complexTypesMap: ComplexTypesMap = {
 const isComplexType = (typeName: string): typeName is keyof ComplexTypesMap =>
   Object.keys(complexTypesMap).includes(typeName)
 
-const xmlToValues = (xmlAsString: string, type: string): Values => parser.parse(
-  xmlAsString,
-  {
-    ignoreAttributes: false,
-    attributeNamePrefix: XML_ATTRIBUTE_PREFIX,
-    tagValueProcessor: val => he.decode(val),
+const xmlToValues = (xmlAsString: string, type: string): Values => {
+  const deleteXmlnsAttributes = (values: Values): void => {
+    delete values[`${XML_ATTRIBUTE_PREFIX}xmlns`]
+    delete values[`${XML_ATTRIBUTE_PREFIX}xmlns:xsi`]
   }
-)[type]
+
+  const values = parser.parse(
+    xmlAsString,
+    {
+      ignoreAttributes: false,
+      attributeNamePrefix: XML_ATTRIBUTE_PREFIX,
+      tagValueProcessor: val => he.decode(val),
+    }
+  )[type]
+
+  deleteXmlnsAttributes(values)
+  return values
+}
 
 const extractFileNameToData = async (zip: JSZip, fileName: string, withMetadataSuffix: boolean,
   complexType: boolean, namespacePrefix?: string): Promise<Record<string, Buffer>> => {

--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -27,6 +27,7 @@ import { API_VERSION } from '../../src/client/client'
 import { createEncodedZipContent } from '../utils'
 import { mockFileProperties } from '../connection'
 import { mockTypes, mockDefaultValues } from '../mock_elements'
+import { XML_ATTRIBUTE_PREFIX } from '../../src/constants'
 
 
 describe('XML Transformer', () => {
@@ -248,7 +249,7 @@ describe('XML Transformer', () => {
             {
               path: 'unpackaged/classes/MyApexClass.cls-meta.xml',
               content: '<?xml version="1.0" encoding="UTF-8"?>\n'
-                + '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">\n'
+                + '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n'
                 + '    <apiVersion>47.0</apiVersion>\n'
                 + '    <status>Active</status>\n'
                 + '</ApexClass>\n',
@@ -282,6 +283,8 @@ describe('XML Transformer', () => {
           .toEqual(Buffer.from('public class MyApexClass {\n    public void printLog() {\n        System.debug(\'Created\');\n    }\n}'))
         expect(contentStaticFile.filepath)
           .toEqual('salesforce/Records/ApexClass/MyApexClass.cls')
+        expect(Object.keys(metadataInfo).every(key => !key.startsWith(XML_ATTRIBUTE_PREFIX)))
+          .toBeTruthy()
       })
     })
 


### PR DESCRIPTION
In the past we used to omit all of the instance's values that are not part of the type.
Since we don't do that anymore we should manually remove the `xmlns` & `xmlns:xsi` xml attributes that are not deployable.