### PR TITLE
SALTO-1033 - Split profile instances into multiple files

### DIFF
--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -457,18 +457,54 @@ export const generateElements = (params: GeneratorParams): Element[] => {
         const objectPermissions = generatePermissions(allObjectsIDs)
         const fieldPermissions = generatePermissions(allFieldsIDs)
         const layoutAssignments = generateLayoutAssignments(allObjectsIDs)
-        return new InstanceElement(
-          name,
-          useOldProfile ? oldProfileType : profileType,
-          {
-            ObjectLevelPermissions: useOldProfile ? objectPermissions : toFlatMap(objectPermissions, 'name'),
-            FieldLevelPermissions: useOldProfile ? fieldPermissions : toNestedMap(fieldPermissions, 'name'),
-            ...(useOldProfile ? {} : { LayoutAssignments: toListMap(layoutAssignments, 'layout') }),
-          },
-          [DUMMY_ADAPTER, 'Records', 'Profile', name]
-        )
+        if (useOldProfile) {
+          return [new InstanceElement(
+            name,
+            oldProfileType,
+            {
+              fullName: name,
+              ObjectLevelPermissions: objectPermissions,
+              FieldLevelPermissions: fieldPermissions,
+            },
+            [DUMMY_ADAPTER, 'Records', 'Profile', name],
+          )]
+        }
+        return [
+          new InstanceElement(
+            name,
+            profileType,
+            {
+              fullName: name,
+            },
+            [DUMMY_ADAPTER, 'Records', 'Profile', name, 'Attributes'],
+          ),
+          new InstanceElement(
+            name,
+            profileType,
+            {
+              ObjectLevelPermissions: toFlatMap(objectPermissions, 'name'),
+            },
+            [DUMMY_ADAPTER, 'Records', 'Profile', name, 'ObjectLevelPermissions'],
+          ),
+          new InstanceElement(
+            name,
+            profileType,
+            {
+              FieldLevelPermissions: toNestedMap(fieldPermissions, 'name'),
+            },
+            [DUMMY_ADAPTER, 'Records', 'Profile', name, 'FieldLevelPermissions'],
+          ),
+          new InstanceElement(
+            name,
+            profileType,
+            {
+              LayoutAssignments: toListMap(layoutAssignments, 'layout'),
+            },
+            [DUMMY_ADAPTER, 'Records', 'Profile', name, 'LayoutAssignments'],
+          ),
+        ]
       }
-    )
+    ).flat()
   }
 
   const defaultTypes = [defaultObj, permissionsType, profileType]

--- a/packages/dummy-adapter/test/generator.test.ts
+++ b/packages/dummy-adapter/test/generator.test.ts
@@ -50,7 +50,10 @@ describe('elements generator', () => {
       expect(
         _.uniq(objects.map(obj => obj.elemID.getFullName()))
       ).toHaveLength(testParams.numOfObjs + 3) // 3 default types
-      expect(profiles).toHaveLength(testParams.numOfProfiles)
+      expect(profiles).toHaveLength(testParams.numOfProfiles * 4)
+      expect(_.uniq(profiles.map(p => p.elemID.getFullName()))).toHaveLength(
+        testParams.numOfProfiles
+      )
       expect(records).toHaveLength(testParams.numOfRecords)
     })
     it('should create list and map types', () => {

--- a/packages/lowerdash/src/strings.ts
+++ b/packages/lowerdash/src/strings.ts
@@ -24,3 +24,6 @@ export const insecureRandomString = (
 ): string => Array(...Array(length))
   .map(() => alphabet.charAt(Math.floor(Math.random() * alphabet.length)))
   .join('')
+
+export const capitalizeFirstLetter = (str: string): string =>
+  str.charAt(0).toUpperCase() + str.slice(1)

--- a/packages/lowerdash/test/strings.test.ts
+++ b/packages/lowerdash/test/strings.test.ts
@@ -65,4 +65,26 @@ describe('strings', () => {
       })
     })
   })
+
+  describe('capitalizeFirstLetter', () => {
+    it('should capitalize first letter when lowercase', () => {
+      expect(strings.capitalizeFirstLetter('abcdef')).toEqual('Abcdef')
+      expect(strings.capitalizeFirstLetter('abcDef')).toEqual('AbcDef')
+      expect(strings.capitalizeFirstLetter('aBcDef')).toEqual('ABcDef')
+      expect(strings.capitalizeFirstLetter('abc def')).toEqual('Abc def')
+    })
+    it('should not modify string when already capitalized', () => {
+      expect(strings.capitalizeFirstLetter('Abcdef')).toEqual('Abcdef')
+      expect(strings.capitalizeFirstLetter('ABC')).toEqual('ABC')
+    })
+    it('should not modify characters that are not letters', () => {
+      expect(strings.capitalizeFirstLetter('123abc')).toEqual('123abc')
+      expect(strings.capitalizeFirstLetter('!?')).toEqual('!?')
+    })
+    it('should handle short and empty strings', () => {
+      expect(strings.capitalizeFirstLetter('a')).toEqual('A')
+      expect(strings.capitalizeFirstLetter('A')).toEqual('A')
+      expect(strings.capitalizeFirstLetter('')).toEqual('')
+    })
+  })
 })

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -38,6 +38,7 @@ import layoutFilter from './filters/layouts'
 import customObjectsFilter from './filters/custom_objects'
 import customSettingsFilter from './filters/custom_settings_filter'
 import customObjectsSplitFilter from './filters/custom_object_split'
+import profileInstanceSplitFilter from './filters/profile_instance_split'
 import customObjectsInstancesFilter from './filters/custom_objects_instances'
 import profilePermissionsFilter from './filters/profile_permissions'
 import convertListsFilter from './filters/convert_lists'
@@ -55,10 +56,10 @@ import settingsFilter, { SETTINGS_METADATA_TYPE } from './filters/settings_type'
 import workflowFilter from './filters/workflow'
 import topicsForObjectsFilter from './filters/topics_for_objects'
 import globalValueSetFilter from './filters/global_value_sets'
-import referenceAnnotations from './filters/reference_annotations'
-import fieldReferences from './filters/field_references'
+import referenceAnnotationsFilter from './filters/reference_annotations'
+import fieldReferencesFilter from './filters/field_references'
 import customObjectInstanceReferencesFilter from './filters/custom_object_instances_references'
-import foreignKeyReferences from './filters/foreign_key_references'
+import foreignKeyReferencesFilter from './filters/foreign_key_references'
 import valueSetFilter from './filters/value_set'
 import cpqLookupFieldsFilter from './filters/cpq/lookup_fields'
 import cpqCustomScriptFilter from './filters/cpq/custom_script'
@@ -69,7 +70,7 @@ import staticResourceFileExtFilter from './filters/static_resource_file_ext'
 import xmlAttributesFilter from './filters/xml_attributes'
 import elementsPathFilter from './filters/elements_path'
 import replaceFieldValuesFilter from './filters/replace_instance_field_values'
-import profileMaps from './filters/profile_maps'
+import profileMapsFilter from './filters/profile_maps'
 import { ConfigChangeSuggestion, FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges, getConfigChangeMessage } from './config_change'
 import { FilterCreator, Filter, filtersRunner } from './filter'
@@ -101,8 +102,8 @@ export const DEFAULT_FILTERS = [
   // profilePermissionsFilter depends on layoutFilter because layoutFilter
   // changes ElemIDs that the profile references
   profilePermissionsFilter,
-  // profileMaps should run before profile values are converted to references (fieldReferences)
-  profileMaps,
+  // profileMapsFilter should run before profile fieldReferencesFilter
+  profileMapsFilter,
   standardValueSetFilter,
   flowFilter,
   lookupFiltersFilter,
@@ -121,13 +122,14 @@ export const DEFAULT_FILTERS = [
   convertListsFilter,
   convertTypeFilter,
   replaceFieldValuesFilter,
-  fieldReferences,
-  // should run after custom_object_instances for now
-  referenceAnnotations,
-  // foreignLeyReferences should come after referenceAnnotations
-  foreignKeyReferences,
+  fieldReferencesFilter,
+  // should run after customObjectsInstancesFilter for now
+  referenceAnnotationsFilter,
+  // foreignLeyReferences should come after referenceAnnotationsFilter
+  foreignKeyReferencesFilter,
   // extraDependenciesFilter should run after addMissingIdsFilter
   extraDependenciesFilter,
+  profileInstanceSplitFilter,
   // hideTypesFilter should come before customObjectsSplitFilter
   hideTypesFilter,
   customObjectsSplitFilter,

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -129,10 +129,10 @@ export const DEFAULT_FILTERS = [
   foreignKeyReferencesFilter,
   // extraDependenciesFilter should run after addMissingIdsFilter
   extraDependenciesFilter,
-  profileInstanceSplitFilter,
-  // hideTypesFilter should come before customObjectsSplitFilter
+  // hideTypesFilter should come before customObjectsSplitFilter and profileInstanceSplitFilter
   hideTypesFilter,
   customObjectsSplitFilter,
+  profileInstanceSplitFilter,
   // removeMemoryOnlyAnnotationsFilter should run at the end
   removeMemoryOnlyAnnotationsFilter,
 ]

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { values, collections, hash } from '@salto-io/lowerdash'
+import { values, collections, hash, strings } from '@salto-io/lowerdash'
 import {
   ChangeGroup, getChangeElement, DeployResult, Change, isPrimitiveType,
   InstanceElement, isAdditionGroup, isRemovalGroup, Value, PrimitiveTypes,
@@ -71,9 +71,6 @@ const formatValueForWhere = (field: Field, value: Value): string => {
   throw new Error(`Can not create WHERE clause for non-primitve field ${field.name}`)
 }
 
-const capitalizeFirstLetter = (str: string): string =>
-  str.charAt(0).toUpperCase() + str.slice(1)
-
 const getRecordsBySaltoIds = async (
   type: ObjectType,
   instances: InstanceElement[],
@@ -97,7 +94,7 @@ const getRecordsBySaltoIds = async (
                   instance.value[field.name]?.[compoundFieldName]
                 )))),
             ]
-            return `${capitalizeFirstLetter(compoundFieldName)} IN (${compoundFieldValues.join(',')})`
+            return `${strings.capitalizeFirstLetter(compoundFieldName)} IN (${compoundFieldValues.join(',')})`
           })
       }
     }

--- a/packages/salesforce-adapter/src/filters/profile_instance_split.ts
+++ b/packages/salesforce-adapter/src/filters/profile_instance_split.ts
@@ -1,0 +1,75 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { strings } from '@salto-io/lowerdash'
+import { Element, ObjectType, isMapType, InstanceElement } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { findProfileInstances } from './profile_maps'
+
+const DEFAULT_NACL_FILENAME = 'Attributes'
+
+const toNaclFilename = (fieldName: string, objType: ObjectType): string => (
+  (fieldName !== undefined && isMapType(objType.fields[fieldName]?.type))
+    ? strings.capitalizeFirstLetter(fieldName)
+    : DEFAULT_NACL_FILENAME
+)
+
+const splitProfile = (profile: InstanceElement): InstanceElement[] => {
+  const toInstancePart = (naclFilename: string, fieldNames: string[]): InstanceElement => {
+    const inst = profile.clone()
+    inst.value = _.pick(inst.value, ...fieldNames)
+    if (inst.path) {
+      inst.path = [...inst.path, naclFilename]
+    }
+    return inst
+  }
+
+  const targetFieldsByFile = _.groupBy(
+    Object.keys(profile.value),
+    fieldName => toNaclFilename(fieldName, profile.type),
+  )
+
+  // keep the default filename first so that it comes up first when searching the path index
+  return _.sortBy(
+    Object.entries(targetFieldsByFile),
+    ([fileName]) => fileName !== DEFAULT_NACL_FILENAME,
+  ).map(
+    ([fileName, fields]) => toInstancePart(fileName, fields)
+  )
+}
+
+/**
+ * Split profile instances, each assigned to its own nacl path.
+ * Each map field is assigned to a separate file, and the other fields and annotations
+ * to Attributes.nacl.
+ */
+const filterCreator: FilterCreator = ({ config }) => ({
+  onFetch: async (elements: Element[]) => {
+    if (config.useOldProfiles) {
+      return
+    }
+
+    const profileInstances = findProfileInstances(elements)
+    if (profileInstances.length === 0) {
+      return
+    }
+    const newProfileInstances = profileInstances.flatMap(splitProfile)
+    _.pullAll(elements, profileInstances)
+    elements.push(...newProfileInstances)
+  },
+})
+
+export default filterCreator

--- a/packages/salesforce-adapter/src/filters/profile_maps.ts
+++ b/packages/salesforce-adapter/src/filters/profile_maps.ts
@@ -294,7 +294,7 @@ export const getInstanceChanges = (
     .filter(change => metadataType(getChangeElement(change)) === PROFILE_METADATA_TYPE)
 )
 
-const findProfileInstances = (
+export const findProfileInstances = (
   elements: Element[],
 ): InstanceElement[] => {
   const instances = elements.filter(isInstanceElement)

--- a/packages/salesforce-adapter/src/filters/profile_maps.ts
+++ b/packages/salesforce-adapter/src/filters/profile_maps.ts
@@ -294,7 +294,7 @@ export const getInstanceChanges = (
     .filter(change => metadataType(getChangeElement(change)) === PROFILE_METADATA_TYPE)
 )
 
-export const findProfileInstances = (
+const findProfileInstances = (
   elements: Element[],
 ): InstanceElement[] => {
   const instances = elements.filter(isInstanceElement)

--- a/packages/salesforce-adapter/test/filters/profile_instance_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_instance_split.test.ts
@@ -1,0 +1,176 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ObjectType, Element, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/profile_instance_split'
+import { FilterWith } from '../../src/filter'
+import { generateProfileType } from './profile_maps.test'
+import mockClient from '../client'
+
+
+describe('Profile Instance Split filter', () => {
+  const { client } = mockClient()
+
+  describe('Map profile instances', () => {
+    const filter = filterCreator({ client, config: {} }) as FilterWith<'onFetch'>
+
+    let profileObj: ObjectType
+    let profileInstances: InstanceElement[]
+    let elements: Element[]
+
+    beforeAll(async () => {
+      profileObj = generateProfileType(true)
+      profileInstances = [
+        new InstanceElement(
+          'profile1',
+          profileObj,
+          {
+            applicationVisibilities: {
+              app1: { application: 'app1', default: true, visible: false },
+              app2: { application: 'app2', default: true, visible: false },
+            },
+            fieldPermissions: {
+              Account: {
+                AccountNumber: {
+                  field: 'Account.AccountNumber',
+                  editable: true,
+                  readable: true,
+                },
+              },
+              Contact: {
+                HasOptedOutOfEmail: {
+                  field: 'Contact.HasOptedOutOfEmail',
+                  editable: true,
+                  readable: true,
+                },
+              },
+            },
+            layoutAssignments: {
+              // eslint-disable-next-line @typescript-eslint/camelcase
+              Account_Account_Layout: [
+                { layout: 'Account-Account Layout' },
+              ],
+              // eslint-disable-next-line @typescript-eslint/camelcase
+              Account_random_characters_aaa___bbb: [
+                { layout: 'Account-random characters %3B%2E%2B%3F%22aaa%27_%2B- bbb', recordType: 'something' },
+              ],
+            },
+            fullName: 'profile1',
+            userLicense: 'Salesforce Platform',
+          },
+          ['salesforce', 'Records', 'Profile', 'profile1'],
+        ),
+        new InstanceElement(
+          'profile2',
+          profileObj,
+          {
+            fieldPermissions: {
+              Account: {
+                AccountNumber: {
+                  field: 'Account.AccountNumber',
+                  editable: true,
+                  readable: true,
+                },
+              },
+              Contact: {
+                HasOptedOutOfEmail: {
+                  field: 'Contact.HasOptedOutOfEmail',
+                  editable: true,
+                  readable: true,
+                },
+              },
+            },
+            fullName: 'profile2',
+          },
+          ['salesforce', 'Records', 'Profile', 'profile2'],
+        ),
+      ]
+
+      elements = [profileObj, ...profileInstances.map(e => e.clone())]
+      await filter.onFetch(elements)
+    })
+    it('should split each map field to its own path', () => {
+      const profElems = elements.filter(isInstanceElement).filter(e => e.elemID.name === 'profile1')
+      expect(profElems).toHaveLength(4)
+
+      const fieldsByPath = _.sortBy(profElems.map(
+        e => [e.path?.join('/'), Object.keys(e.value).sort()]
+      ), item => item[0])
+      expect(fieldsByPath).toEqual([
+        ['salesforce/Records/Profile/profile1/ApplicationVisibilities', ['applicationVisibilities']],
+        ['salesforce/Records/Profile/profile1/Attributes', ['fullName', 'userLicense']],
+        ['salesforce/Records/Profile/profile1/FieldPermissions', ['fieldPermissions']],
+        ['salesforce/Records/Profile/profile1/LayoutAssignments', ['layoutAssignments']],
+      ])
+    })
+
+    it('should only create elements for defined fields', () => {
+      const profElems = elements.filter(isInstanceElement).filter(e => e.elemID.name === 'profile2')
+      expect(profElems).toHaveLength(2)
+
+      const fieldsByPath = _.sortBy(profElems.map(
+        e => [e.path?.join('/'), Object.keys(e.value).sort()]
+      ), item => item[0])
+      expect(fieldsByPath).toEqual([
+        ['salesforce/Records/Profile/profile2/Attributes', ['fullName']],
+        ['salesforce/Records/Profile/profile2/FieldPermissions', ['fieldPermissions']],
+      ])
+    })
+
+    it('should have the default Attributes element first', () => {
+      const profElems = elements.filter(isInstanceElement).filter(e => e.elemID.name === 'profile1')
+      expect(profElems[0].path?.slice(-1)[0]).toEqual('Attributes')
+    })
+  })
+
+  describe('Old (list) profile instances', () => {
+    const filter = filterCreator({ client, config: { useOldProfiles: true } }) as FilterWith<'onFetch'>
+
+    let profileObj: ObjectType
+    let profileInstances: InstanceElement[]
+    let elements: Element[]
+
+    beforeAll(async () => {
+      profileObj = generateProfileType(false)
+      profileInstances = [
+        new InstanceElement(
+          'profile1',
+          profileObj,
+          {
+            applicationVisibilities: [
+              { application: 'app1', default: true, visible: false },
+            ],
+            fieldPermissions: [
+              { field: 'Account.AccountNumber', editable: true, readable: true },
+              { field: 'Contact.HasOptedOutOfEmail', editable: true, readable: true },
+            ],
+            fullName: 'profile1',
+            userLicense: 'Salesforce Platform',
+          },
+          ['salesforce', 'Records', 'Profile', 'profile1'],
+        ),
+      ]
+
+      elements = [profileObj, ...profileInstances.map(e => e.clone())]
+      await filter.onFetch(elements)
+    })
+    it('should do nothing, and keep the profile as a single instance with the original path', () => {
+      const profElems = elements.filter(isInstanceElement).filter(e => e.elemID.name === 'profile1')
+      expect(profElems).toHaveLength(1)
+      expect(profElems[0].path).toEqual(['salesforce', 'Records', 'Profile', 'profile1'])
+    })
+  })
+})

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -125,12 +125,12 @@ const singlePathInstance = new InstanceElement('singlePathInst', singlePathObjec
   } },
 ['salto', 'inst', 'simple'],)
 // multiPathInstance
-const multiPathInstace1 = new InstanceElement('multiPathInst', singlePathObject, { simple: 'Simple',
+const multiPathInstance1 = new InstanceElement('multiPathInst', singlePathObject, { simple: 'Simple',
   nested: {
     list: [1, 2, 3],
   } },
 ['salto', 'inst', 'nested', '1'],)
-const multiPathInstace2 = new InstanceElement('multiPathInst', singlePathObject, { nested: {
+const multiPathInstance2 = new InstanceElement('multiPathInst', singlePathObject, { nested: {
   str: 'Str',
   num: 7,
 } },
@@ -142,8 +142,8 @@ describe('create path index', () => {
     singlePathInstance,
     multiPathAnnoObj,
     multiPathFieldsObj,
-    multiPathInstace1,
-    multiPathInstace2,
+    multiPathInstance1,
+    multiPathInstance2,
   ])
   describe('elements which are defined in a single fragment', () => {
     it('should return the proper path for top level elements', () => {
@@ -187,27 +187,27 @@ describe('create path index', () => {
     })
   })
   describe('elements which are defined in a multiple fragments', () => {
-    it('should return the all paths for top level elements', () => {
-      const instPath = pathIndex.get(multiPathInstace1.elemID.getFullName())
-      expect(instPath).toEqual([multiPathInstace1.path, multiPathInstace2.path])
+    it('should return all paths for top level elements', () => {
+      const instPath = pathIndex.get(multiPathInstance1.elemID.getFullName())
+      expect(instPath).toEqual([multiPathInstance1.path, multiPathInstance2.path])
 
       const objPath = pathIndex.get(multiPathAnnoObj.elemID.getFullName())
       expect(objPath).toEqual([multiPathAnnoObj.path, multiPathFieldsObj.path])
     })
     it('should return all paths for nested ids which are defined in multiple fragments', () => {
-      const sharedNestedID = multiPathInstace1.elemID.createNestedID('nested').getFullName()
+      const sharedNestedID = multiPathInstance1.elemID.createNestedID('nested').getFullName()
       expect(pathIndex.get(sharedNestedID))
-        .toEqual([multiPathInstace1.path, multiPathInstace2.path])
+        .toEqual([multiPathInstance1.path, multiPathInstance2.path])
     })
     it('should return the path given in the defining element fragment for nested id', () => {
       const nestedInst1Ids = [
-        multiPathInstace1.elemID.createNestedID('simple'),
-        multiPathInstace1.elemID.createNestedID('nested').createNestedID('list'),
+        multiPathInstance1.elemID.createNestedID('simple'),
+        multiPathInstance1.elemID.createNestedID('nested').createNestedID('list'),
       ].map(id => id.getFullName())
 
       const nestedInst2Ids = [
-        multiPathInstace2.elemID.createNestedID('nested').createNestedID('str'),
-        multiPathInstace2.elemID.createNestedID('nested').createNestedID('num'),
+        multiPathInstance2.elemID.createNestedID('nested').createNestedID('str'),
+        multiPathInstance2.elemID.createNestedID('nested').createNestedID('num'),
       ].map(id => id.getFullName())
 
       const nestedObjFieldsIds = [
@@ -225,8 +225,8 @@ describe('create path index', () => {
         multiPathAnnoObj.elemID.createNestedID('attr').createNestedID('nested').createNestedID('list'),
       ].map(id => id.getFullName())
 
-      nestedInst1Ids.forEach(id => expect(pathIndex.get(id)).toEqual([multiPathInstace1.path]))
-      nestedInst2Ids.forEach(id => expect(pathIndex.get(id)).toEqual([multiPathInstace2.path]))
+      nestedInst1Ids.forEach(id => expect(pathIndex.get(id)).toEqual([multiPathInstance1.path]))
+      nestedInst2Ids.forEach(id => expect(pathIndex.get(id)).toEqual([multiPathInstance2.path]))
 
       nestedObjAnnoIds.forEach(id => expect(pathIndex.get(id)).toEqual([multiPathAnnoObj.path]))
       nestedObjFieldsIds.forEach(id => expect(pathIndex.get(id)).toEqual([multiPathFieldsObj.path]))
@@ -246,8 +246,8 @@ describe('create path index', () => {
         singlePathInstance,
         multiPathAnnoObj,
         multiPathFieldsObj,
-        multiPathInstace1,
-        multiPathInstace2,
+        multiPathInstance1,
+        multiPathInstance2,
       ])
     })
     it('symmetric operation on multiple path indexes', () => {


### PR DESCRIPTION
Split profiles into multiple files - each map field in its own nacl, and everything else under `Attributes.nacl`.

---

_Release Notes_ (should be combined with https://github.com/salto-io/salto/pull/1546 if in the same release)

Split salesforce profiles into multiple files for easier navigation.

_Upgrade Instructions_

No action required. In order to get the new file structure, clear the workspace using `salto clean` and fetch again (note that `salto clean` is irreversible).