### PR TITLE
make salesforce client configurable

### DIFF
--- a/packages/salesforce-adapter/README.md
+++ b/packages/salesforce-adapter/README.md
@@ -19,7 +19,7 @@ E2E tests need real SFDC credentials to run - a free developer account is good e
 - Register and login to your account at <https://developer.salesforce.com/>
 - [Add a security token (aka API token)](https://help.salesforce.com/articleView?id=user_security_token.htm), or make sure your IP address is trusted.
 
-### Using a sepecific set of credentials
+### Using a specific set of credentials
 
 Add the following environment variables to bash_profile:
 ```bash

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -20,18 +20,40 @@ salesforce {
   maxItemsInRetrieveRequest = 2500
   enableHideTypesInNacls = false
   dataManagement = {
-    includeObjects: [
+    includeObjects = [
       "SBQQ__CustomAction__c",
       "PricebookEntry",
     ],
-    saltoIDSettings: {
-      defaultIdFields: ['##allMasterDetailFields##', 'Name'],
-      overrides: [
-        { objectsRegex: pricebookEntryName, idFields: ['Pricebook2Id', 'Name'] },
-        { objectsRegex: SBQQCustomActionName, idFields: ['SBQQ__Location__c', 'SBQQ__DisplayOrder__c', 'Name'] },
-      ],
-    },
-},
+    saltoIDSettings = {
+      defaultIdFields = [
+        "##allMasterDetailFields##",
+        "Name",
+      ]
+      overrides = [
+        {
+          objectsRegex = "pricebookEntryName"
+          idFields = ["Pricebook2Id", "Name"]
+        },
+        {
+          objectsRegex = "SBQQCustomActionName"
+          idFields = ["SBQQ__Location__c", "SBQQ__DisplayOrder__c", "Name"]
+        },
+      ]
+    }
+  }
+  client = {
+    polling = {
+      interval = 10000
+      timeout = 3600000
+    }
+    deploy = {
+      rollbackOnError = true
+      ignoreWarnings = true
+      purgeOnDelete = false
+      runAllTests = false
+      runTests = ["Test name", "Other test"]
+    }
+  }
 }
 ```
 
@@ -45,6 +67,7 @@ salesforce {
 | maxItemsInRetrieveRequest                                | 2500                          | Limits the max number of requested items a single retrieve request
 | enableHideTypesInNacls                                   | false                         | Control whether to generate NaCL files for salesforce types (will be placed under the Types folder)
 | [dataManagement](#data-management-configuration-options) | {} (do not manage data)       | Data management configuration 
+| [client](#client-configuration-options)                  | {} (no overrides)             | Configuration relating to the client used to interact with salesforce
 
 ### Data management configuration options
 
@@ -68,3 +91,30 @@ salesforce {
 | -------------| --------------------------------------------| -----------
 | objectsRegex | N/A (required when overrides is configured) | Cross environments ids of the matched object names will be defined by the specified id fields
 | idFields     | []                                          | Fields list for defining the data record's cross environment id
+
+### Client configuration options
+
+| Name                                | Default when undefined   | Description
+|-------------------------------------|--------------------------|------------
+| [polling](#client-polling-options)  | `{}` (no overrides)      | Configuration for polling asynchronous operations (deploy, retrieve, bulk data operations)
+| [deploy](#client-deploy-options)    | `{}` (no overrides)      | Deploy options
+
+#### Client polling options
+
+| Name      | Default when undefined | Description
+|-----------|------------------------|------------
+| interval  | `3000` (3 seconds)       | The interval (milliseconds) at which the client checks wether the operation completed
+| timeout   | `5400000` (1.5 hours)    | The timeout (milliseconds) for giving up on a long running operation
+
+#### Client deploy options
+
+| Name            | Default when undefined                                 | Description
+|-----------------|--------------------------------------------------------|------------
+| rollbackOnError | `true`                                                 | Indicates whether any failure causes a complete rollback or not. Must be set to `true` if deploying to a production org. 
+| ignoreWarnings  | `true`                                                 | Indicates whether deployments with warnings complete successfully or not.
+| purgeOnDelete   | `false`                                                | If `true`, deleted components aren't stored in the Recycle Bin. Instead, they become immediately eligible for deletion. This option only works in Developer Edition or sandbox orgs. It doesn’t work in production orgs.
+| testLevel       | `NoTestRun` (development) `RunLocalTests` (production) | Specifies which tests are run as part of a deployment. possible values are: `NoTestRun`, `RunSpecifiedTests`, `RunLocalTests` and `RunAllTestsInOrg`
+| runTests        | `[]` (no tests)                                        | A list of Apex tests to run during deployment, must configure `RunSpecifiedTests` in `testLevel` for this option to work
+
+
+For more details see the DeployOptions section in the [salesforce documentation of the deploy API](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_deploy.htm)

--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -27,6 +27,8 @@ import { Value } from '@salto-io/adapter-api'
 // It's here so we will be able to mock jsforce efficiently
 
 export interface Metadata {
+  pollInterval: number
+  pollTimeout: number
   describe(): Promise<{ metadataObjects: MetadataObject[] }>
   describeValueType(type: string): Promise<DescribeValueTypeResult>
   read(type: string, fullNames: string | string[]): Promise<MetadataInfo | MetadataInfo[]>
@@ -64,6 +66,8 @@ export type Limits = {
 }
 
 export interface Bulk {
+  pollInterval: number
+  pollTimeout: number
   load(type: string, operation: BulkLoadOperation, options?: BulkOptions, input?: SfRecord[]): Batch
 }
 

--- a/packages/salesforce-adapter/test/connection.ts
+++ b/packages/salesforce-adapter/test/connection.ts
@@ -224,6 +224,8 @@ export const mockJsforce: () => MockInterface<Connection> = () => ({
     { id: '', organizationId: '', url: '' }
   )),
   metadata: {
+    pollInterval: 1000,
+    pollTimeout: 10000,
     describe: mockFunction<Metadata['describe']>().mockResolvedValue({ metadataObjects: [] }),
     describeValueType: mockFunction<Metadata['describeValueType']>().mockResolvedValue(
       mockDescribeValueResult({ valueTypeFields: [] })
@@ -244,6 +246,8 @@ export const mockJsforce: () => MockInterface<Connection> = () => ({
   query: mockFunction<Connection['query']>().mockResolvedValue(mockQueryResult({})),
   queryMore: mockFunction<Connection['queryMore']>().mockResolvedValue(mockQueryResult({})),
   bulk: {
+    pollInterval: 1000,
+    pollTimeout: 10000,
     load: mockFunction<Bulk['load']>().mockResolvedValue([]),
   },
   limits: mockFunction<Connection['limits']>().mockResolvedValue({


### PR DESCRIPTION
- Moved the salesforce `config_doc.md` to fix a broken link from the main Salto documentation
- Also fixed the example data management configuration that was not in nacl format

---

_Release Notes_:
- Allow configuration of more salesforce client options