### PR TITLE
Remove outdated list mismatch log

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -157,11 +157,8 @@ export const transformValues = (
         .filter((val: Value) => !_.isUndefined(val))
       return transformed.length === 0 ? undefined : transformed
     }
-    // It shouldn't get here because only ListType should have array values
     if (_.isArray(newVal)) {
-      if (strict) {
-        log.debug(`Array value and isListType mis-match for field - ${field.name}. Only ListTypes should have array values.`)
-      }
+      // Even fields that are not defined as ListType can have array values
       const transformed = newVal
         .map((item, index) => transformValue(item, keyPathID?.createNestedID(String(index)), field))
         .filter(val => !_.isUndefined(val))


### PR DESCRIPTION
This line is no longer correct (since SALTO-975), and it's polluting the log when there are array values on fields that are not explicitly defined as lists.
Keeping the warning in the other direction for now (non-array value in list field), because I think it's a less likely scenario and may be worth noticing - I can remove it too if that's preferred.