### PR TITLE
[WIP] SALTO-1022 Add element list command

### DIFF
--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -635,6 +635,11 @@ export const formatInvalidMoveArg = (invalidTo: string): string => [
   emptyLine(),
 ].join('\n')
 
+export const formatElementListFailed = (errorMessage: string): string => [
+  formatSimpleError(Prompts.LIST_FAILED(errorMessage)),
+  emptyLine(),
+].join('\n')
+
 export const formatInvalidElementCommand = (command: string): string => [
   formatSimpleError(Prompts.INVALID_MOVE_ARG(command)),
   emptyLine(),

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -248,11 +248,17 @@ ${Prompts.SERVICE_ADD_HELP}`
     error: string
   ): string => `Failed to move the specified elements: ${error}`
 
+  public static readonly LIST_FAILED = (
+    error: string
+  ): string => `Failed to list dependencies: ${error}`
+
   public static readonly CLONE_TO_ENV_START = (
     targetEnvs: string[] = []
   ): string => `Cloning the specified elements to ${
     targetEnvs.length > 0 ? targetEnvs.join(', ') : 'all environments'
   }.`
+
+  public static readonly LIST_START = (env: string): string => `Listing dependencies in ${env} for the specified elements`
 
   public static readonly CLONE_TO_ENV_FAILED = (
     error: string

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -47,6 +47,7 @@ import { getAdapterChangeGroupIdFunctions } from './core/adapters/custom_group_k
 import { createDiffChanges } from './core/diff'
 
 export { cleanWorkspace } from './core/clean'
+export { listElementDependencies } from './core/list'
 
 const log = logger(module)
 

--- a/packages/core/src/core/list.ts
+++ b/packages/core/src/core/list.ts
@@ -1,0 +1,127 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  ElemID, isElement, isInstanceElement, Element, InstanceElement, ReferenceExpression,
+  isReferenceExpression,
+} from '@salto-io/adapter-api'
+import { Workspace } from '@salto-io/workspace'
+import { resolvePath, setPath, transformElement, TransformFunc } from '@salto-io/adapter-utils'
+
+/**
+ * Generate a list of elements referenced by one or more of the specified elements in the
+ * current environment.
+ *
+ * @param workspace     The workspace to run the query on
+ * @param ids           The list of elem ids to start from
+ * @param maxDepth      The max number of hops to take from the original elements in the traversal
+ */
+export const listElementDependencies = async (
+  workspace: Workspace,
+  ids: ElemID[],
+  maxDepth: number,
+): Promise<string[]> => {
+  const initialElemIDs = new Set(ids.map(id => id.getFullName()))
+  const referencedElemIDs = new Set<string>()
+  const rootElements = Object.fromEntries(
+    (await workspace.elements(true, workspace.currentEnv()))
+      .filter(e => e.elemID.isTopLevel())
+      .map(e => [e.elemID.getFullName(), e])
+  )
+
+  const getElem = (id: ElemID): Element | undefined => {
+    const rootElem = rootElements[id.createTopLevelParentID().parent.getFullName()]
+    if (!rootElem) {
+      return undefined
+    }
+    const val = resolvePath(rootElem, id)
+    if (isElement(val)) {
+      return val
+    }
+    if (isInstanceElement(rootElem) && !id.isTopLevel()) {
+      const newInstance = new InstanceElement(
+        rootElem.elemID.name,
+        rootElem.type,
+        {},
+        rootElem.path,
+      )
+      setPath(newInstance, id, val)
+      return newInstance
+    }
+    return undefined
+  }
+
+  const hasReferencedAncestor = (idStr: string): boolean => {
+    const alreadyReferenced = (elemID: ElemID): boolean => {
+      if (referencedElemIDs.has(elemID.getFullName())) {
+        return true
+      }
+      if (elemID.isTopLevel()) {
+        return false
+      }
+      return alreadyReferenced(elemID.createParentID())
+    }
+
+    const elemID = ElemID.fromFullName(idStr)
+    if (elemID.isTopLevel()) {
+      return false
+    }
+    return alreadyReferenced(elemID.createParentID())
+  }
+
+  const uniq = (deps: ReferenceExpression[]): ReferenceExpression[] => (
+    _.uniqBy(deps, dep => dep.elemId.getFullName())
+  )
+
+  let elemRefs = uniq((ids.map(
+    id => new ReferenceExpression(id, getElem(id))
+  ).filter(ref => ref.value !== undefined)))
+
+  for (let level = 0; level <= maxDepth; level += 1) {
+    if (elemRefs.length === 0) {
+      break
+    }
+    const nextLevel: ReferenceExpression[] = []
+    elemRefs.forEach(ref => {
+      if (referencedElemIDs.has(ref.elemId.getFullName())
+        || hasReferencedAncestor(ref.elemId.getFullName())) {
+        return
+      }
+      referencedElemIDs.add(ref.elemId.getFullName())
+
+      const deps: ReferenceExpression[] = []
+      const findReferences: TransformFunc = ({ value }) => {
+        if (isReferenceExpression(value)) {
+          deps.push(new ReferenceExpression(value.elemId, value.value ?? getElem(value.elemId)))
+          return undefined
+        }
+        return value
+      }
+
+      transformElement({
+        element: ref.value,
+        transformFunc: findReferences,
+      })
+      nextLevel.push(...deps)
+    })
+    elemRefs = uniq(nextLevel).filter(dep => !referencedElemIDs.has(dep.elemId.getFullName()))
+  }
+
+  return [...referencedElemIDs]
+    .filter(idStr => !hasReferencedAncestor(idStr))
+    .filter(elemID => !initialElemIDs.has(elemID))
+    .sort()
+}

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -104,7 +104,7 @@ export const mockWorkspace = ({
     elements: jest.fn().mockImplementation(async () => elements),
     name,
     envs: () => ['default'],
-    currentEnv: 'default',
+    currentEnv: () => 'default',
     services: () => services,
     state: jest.fn().mockReturnValue(state),
     updateNaclFiles: jest.fn(),

--- a/packages/core/test/core/list.test.ts
+++ b/packages/core/test/core/list.test.ts
@@ -1,0 +1,136 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Workspace } from '@salto-io/workspace'
+import { ObjectType, InstanceElement, ElemID, BuiltinTypes, ReferenceExpression } from '@salto-io/adapter-api'
+import { mockWorkspace } from '../api.test'
+import { listElementDependencies } from '../../src/api'
+
+describe('listElementDependencies', () => {
+  let workspace: Workspace
+  let type1: ObjectType
+  let type2: ObjectType
+  let inst1: InstanceElement
+  let inst2: InstanceElement
+
+  beforeAll(async () => {
+    type1 = new ObjectType({
+      elemID: new ElemID('salesforce', 'someType'),
+      fields: {
+        f1: { type: BuiltinTypes.STRING },
+        f2: { type: BuiltinTypes.STRING },
+        f3: { type: BuiltinTypes.STRING },
+      },
+    })
+    type2 = new ObjectType({
+      elemID: new ElemID('salesforce', 'anotherType'),
+      annotations: { _parent: new ReferenceExpression(type1.elemID) },
+      fields: {
+        f1: { type: type1 },
+        f2: { type: BuiltinTypes.STRING },
+        f3: { type: type1 },
+      },
+    })
+    inst1 = new InstanceElement(
+      'inst1',
+      type1,
+      {
+        f1: 'aaa',
+        f2: new ReferenceExpression(new ElemID('salesforce', 'someType', 'field', 'f3')),
+        f3: 'ccc',
+      },
+    )
+    inst2 = new InstanceElement(
+      'inst2',
+      type2,
+      {
+        f1: {
+          f1: 'aaa',
+          f2: 'bbb',
+          f3: new ReferenceExpression(new ElemID('salesforce', 'someType', 'instance', 'inst1', 'f1')),
+        },
+        f3: new ReferenceExpression(new ElemID('salesforce', 'someType', 'instance', 'inst1')),
+      },
+    )
+    const elements = [type1, type2, inst1, inst2]
+    workspace = mockWorkspace({ elements, services: ['salesforce', 'netsuite'] })
+  })
+
+  afterAll(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should get elements for the active env', async () => {
+    await listElementDependencies(workspace, [type1.elemID], 1)
+    expect(workspace.elements).toHaveBeenCalledWith(true, 'default')
+  })
+
+  it('should return nothing when there are no reference expressions', async () => {
+    expect(await listElementDependencies(workspace, [type1.elemID], 1)).toHaveLength(0)
+    expect(await listElementDependencies(workspace, [type1.elemID], 2)).toHaveLength(0)
+    expect(await listElementDependencies(workspace, [type1.elemID], 3)).toHaveLength(0)
+  })
+  it('should return direct dependencies for types with depth 1', async () => {
+    expect(await listElementDependencies(workspace, [type2.elemID], 1)).toEqual([
+      type1.elemID.getFullName(),
+    ])
+  })
+
+  it('should return direct dependencies for instances with depth 1', async () => {
+    expect(await listElementDependencies(workspace, [inst1.elemID], 1)).toEqual(['salesforce.someType.field.f3'])
+  })
+
+  it('should resolve references for element parts', async () => {
+    const deps = await listElementDependencies(workspace, [inst2.elemID.createNestedID('f1')], 1)
+    expect(deps).toEqual(['salesforce.someType.instance.inst1.f1'])
+  })
+
+  it('should only include highest ancestor in list', async () => {
+    const deps = await listElementDependencies(workspace, [inst2.elemID], 1)
+    expect(deps).toEqual(['salesforce.someType.instance.inst1'])
+    expect(deps).not.toContain('salesforce.someType.instance.inst1.f1')
+  })
+
+  it('should also include indirect dependencies when depth >1', async () => {
+    const deps = await listElementDependencies(workspace, [inst2.elemID], 2)
+    expect(deps).toEqual([
+      'salesforce.someType.field.f3',
+      'salesforce.someType.instance.inst1',
+    ])
+  })
+
+  it('should support multiple ids, without repetitions and without source ids', async () => {
+    const deps = await listElementDependencies(workspace, [
+      inst2.elemID,
+      inst2.elemID.createNestedID('f1'),
+      inst1.elemID,
+    ], 2)
+    expect(deps).toEqual([
+      'salesforce.someType.field.f3',
+    ])
+    expect(await listElementDependencies(workspace, [
+      inst2.elemID, inst2.elemID, inst2.elemID,
+    ], 2)).toEqual([
+      'salesforce.someType.field.f3',
+      'salesforce.someType.instance.inst1',
+    ])
+    expect(await listElementDependencies(workspace, [
+      inst2.elemID, type2.elemID,
+    ], 2)).toEqual([
+      'salesforce.someType',
+      'salesforce.someType.instance.inst1',
+    ])
+  })
+})

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -17,9 +17,7 @@ import _ from 'lodash'
 import path from 'path'
 import {
   Element, SaltoError, SaltoElementError, ElemID, InstanceElement, DetailedChange,
-  isReferenceExpression, ReferenceExpression, isElement, isInstanceElement,
 } from '@salto-io/adapter-api'
-import { resolvePath, transformElement, TransformFunc, setPath } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, promises } from '@salto-io/lowerdash'
 import { validateElements } from '../validator'
@@ -68,8 +66,6 @@ export type WorkspaceComponents = {
   serviceConfig: boolean
 }
 
-export type ElemDependencyGraph = Map<string, ReferenceExpression[]>
-
 export type Workspace = {
   uid: string
   name: string
@@ -106,9 +102,6 @@ export type Workspace = {
   flush: () => Promise<void>
   clone: () => Promise<Workspace>
   clear: (args: Omit<WorkspaceComponents, 'serviceConfig'>) => Promise<void>
-  listElementDependencies: (
-    elemSelectors: ElemID[], maxDepth: number,
-  ) => Promise<ElemDependencyGraph>
 
   addService: (service: string) => Promise<void>
   addEnvironment: (env: string) => Promise<void>
@@ -184,86 +177,6 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
       subRange,
     }
   }
-
-  const listElementDependencies = async (
-    ids: ElemID[], maxDepth: number,
-  ): Promise<ElemDependencyGraph> => {
-    const rootElements = Object.fromEntries((await naclFilesSource.getAll(currentEnv())).filter(
-      e => e.elemID.isTopLevel()
-    ).map(e => [e.elemID.getFullName(), e]))
-
-    const getElem = (id: ElemID): Element | undefined => {
-      const rootElem = rootElements[id.createTopLevelParentID().parent.getFullName()]
-      if (!rootElem) {
-        return undefined
-      }
-      const val = resolvePath(rootElem, id)
-      if (isElement(val)) {
-        return val
-      }
-      if (isInstanceElement(rootElem) && !id.isTopLevel()) {
-        const newInstance = new InstanceElement(
-          rootElem.elemID.name,
-          rootElem.type,
-          {},
-          rootElem.path,
-        )
-        setPath(newInstance, id, val)
-        return newInstance
-      }
-      return undefined
-    }
-
-    const uniq = (deps: ReferenceExpression[]): ReferenceExpression[] => (
-      _.uniqBy(deps, dep => dep.elemId.getFullName())
-    )
-
-    const graph = new Map<string, ReferenceExpression[]>()
-
-    let elemRefs = uniq((ids.map(
-      id => new ReferenceExpression(id, getElem(id))
-    ).filter(ref => ref.value !== undefined)))
-
-    for (let level = 0; level < maxDepth; level += 1) {
-      if (elemRefs.length === 0) {
-        break
-      }
-      const nextLevel: ReferenceExpression[] = []
-      elemRefs.forEach(ref => {
-        if (graph.has(ref.elemId.getFullName())) {
-          return
-        }
-        const deps: ReferenceExpression[] = []
-        const findReferences: TransformFunc = ({ value }) => {
-          if (isReferenceExpression(value)) {
-            deps.push(new ReferenceExpression(
-              value.elemId,
-              value.value ?? getElem(value.elemId),
-            ))
-            return undefined
-          }
-          return value
-        }
-
-        transformElement({
-          element: ref.value,
-          transformFunc: findReferences,
-        })
-
-        // avoid self-loops and parent-child references
-        const refDeps = (uniq(deps)
-          .filter(dep => dep.elemId.getFullName() !== ref.elemId.getFullName())
-          .filter(dep => !ref.elemId.isParentOf(dep.elemId)))
-
-        graph.set(ref.elemId.getFullName(), refDeps)
-        nextLevel.push(...deps)
-      })
-      elemRefs = uniq(nextLevel)
-    }
-
-    return graph
-  }
-
   const transformParseError = async (error: ParseError): Promise<WorkspaceError<SaltoError>> => ({
     ...error,
     sourceFragments: [await getSourceFragment(error.context, error.subject)],
@@ -385,7 +298,6 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
         await promises.array.series(envs().map(e => (() => credentials.delete(e))))
       }
     },
-    listElementDependencies,
     addService: async (service: string): Promise<void> => {
       const currentServices = services() || []
       if (currentServices.includes(service)) {


### PR DESCRIPTION
WIP - NOT READY FOR REVIEW.

Adding the `element list` exploration command for identifying cross-element dependencies based on reference expressions. 
The first part is a list of referenced elements that can be easily edited and transferred to other commands (for example using `xargs`). For now this is based only on the selected environment.

Still missing:
* Support for Netsuite references (will add before merging)
* Integration with the new elem id selectors (either before or after merging depending on when the selectors are ready)

Sample output (not final):

Option 1 (graph traversal):
Duplicates between different branches are intentional in this presentation (see ticket for more details).
```
$ salto element list salesforce.Account salesforce.Profile.instance.Admin.layoutAssignments.Asset_Asset_Layout --max-depth 2
✔ Finished loading workspace for environment env1
salesforce.Account
   salesforce.Contract
      salesforce.Contact
      salesforce.Pricebook2
      salesforce.StandardValueSet.instance.ContractStatus
      salesforce.User
   salesforce.DandBCompany
      salesforce.User
   salesforce.OperatingHours
      salesforce.User
   salesforce.StandardValueSet.instance.AccountOwnership
   salesforce.StandardValueSet.instance.AccountRating
   salesforce.StandardValueSet.instance.AccountType
   salesforce.StandardValueSet.instance.Industry
   salesforce.StandardValueSet.instance.LeadSource
   salesforce.User
      salesforce.CallCenter
      salesforce.Contact
      salesforce.Group
      salesforce.Individual
      salesforce.Profile

salesforce.Profile.instance.Admin.layoutAssignments.Asset_Asset_Layout
   salesforce.Layout.instance.Asset_Layout
      salesforce.Asset
      salesforce.Asset.field.AccountId
      salesforce.Asset.field.ContactId
      salesforce.Asset.field.CreatedById
      salesforce.Asset.field.Description
      salesforce.Asset.field.InstallDate
      salesforce.Asset.field.IsCompetitorProduct
      salesforce.Asset.field.LastModifiedById
      salesforce.Asset.field.Name
      salesforce.Asset.field.Price
      salesforce.Asset.field.Product2Id
      salesforce.Asset.field.ProductCode
      salesforce.Asset.field.PurchaseDate
      salesforce.Asset.field.Quantity
      salesforce.Asset.field.SerialNumber
      salesforce.Asset.field.Status
      salesforce.Asset.field.UsageEndDate
```

Option 2 (flat list):
```
$ salto element list salesforce.Account salesforce.Profile.instance.Admin.layoutAssignments.Asset_Asset_Layout --max-depth 2
✔ Finished loading workspace for environment env1
Listing dependencies in env1 for the specified elements
  salesforce.Asset
  salesforce.CallCenter
  salesforce.Contact
  salesforce.Contract
  salesforce.DandBCompany
  salesforce.Group
  salesforce.Individual
  salesforce.Layout.instance.Asset_Layout
  salesforce.OperatingHours
  salesforce.Pricebook2
  salesforce.Profile
  salesforce.StandardValueSet.instance.AccountOwnership
  salesforce.StandardValueSet.instance.AccountRating
  salesforce.StandardValueSet.instance.AccountType
  salesforce.StandardValueSet.instance.ContractStatus
  salesforce.StandardValueSet.instance.Industry
  salesforce.StandardValueSet.instance.LeadSource
  salesforce.User
```