### PR TITLE
handle errors from apex tests in deploy

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -50,7 +50,7 @@ salesforce {
       rollbackOnError = true
       ignoreWarnings = true
       purgeOnDelete = false
-      runAllTests = false
+      testLevel = "NoTestRun"
       runTests = ["Test name", "Other test"]
     }
   }

--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -88,3 +88,29 @@ export default interface Connection {
   limits(): Promise<Limits>
   identity(): Promise<IdentityInfo>
 }
+
+type ArrayOrSingle<T> = T|T[]
+
+export interface RunTestFailure {
+  id: string
+  message: string
+  methodName: string
+  name: string
+  namespace?: string
+  seeAllData?: boolean
+  stackTrace: string
+  time: number
+}
+
+export interface RunTestsResult {
+  apexLogId?: string
+  codeCoverage?: ArrayOrSingle<object> // CodeCoverageResult[]
+  codeCoverageWarnings?: ArrayOrSingle<object> // CodeCoverageWarning[]
+  failures?: ArrayOrSingle<RunTestFailure>
+  flowCoverage?: ArrayOrSingle<object> // FlowCoverageResult[]
+  flowCoverageWarnings?: ArrayOrSingle<object> // FlowCoverageWarning[]
+  numFailures: number
+  numTestsRun: number
+  successes?: ArrayOrSingle<object> // RunTestSuccess[]
+  totalTime: number
+}

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -23,6 +23,7 @@ import { createDeployPackage, DeployPackage } from './transformers/xml_transform
 import { isMetadataInstanceElement, apiName, metadataType, isMetadataObjectType, MetadataInstanceElement } from './transformers/transformer'
 import { fullApiName } from './filters/utils'
 import { INSTANCE_FULL_NAME_FIELD } from './constants'
+import { RunTestsResult } from './client/jsforce'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -116,6 +117,11 @@ const processDeployResponse = (
   const allFailureMessages = collections.array.makeArray(result.details)
     .flatMap(detail => collections.array.makeArray(detail.componentFailures))
 
+  const testFailures = collections.array.makeArray(result.details)
+    .flatMap(detail => (
+      collections.array.makeArray((detail.runTestResult as RunTestsResult)?.failures)
+    ))
+
   // We want to treat deletes for things we haven't found as success
   // Note that if we deploy with ignoreWarnings, these might show up in the success list
   // so we have to look for these messages in both lists
@@ -123,18 +129,27 @@ const processDeployResponse = (
     .map(getUnFoundDeleteName)
     .filter(values.isDefined)
 
-  const successfulFullNames = result.success
+  const successfulFullNames = (result.rollbackOnError === false || result.success)
     ? allSuccessMessages
       .map(success => ({ type: success.componentType, fullName: success.fullName }))
       .concat(unFoundDeleteNames)
     : []
 
-  const errors = allFailureMessages
+  const testErrors = testFailures
+    .map(failure => new Error(
+      `Test failed for class ${failure.name} method ${failure.methodName} with error:\n${failure.message}\n${failure.stackTrace}`
+    ))
+
+  const componentErrors = allFailureMessages
     .filter(failure => !isUnFoundDelete(failure))
     .map(failure => new Error(
       `Failed to deploy ${failure.fullName} with error: ${failure.problem} (${failure.problemType})`
     ))
-  return { successfulFullNames, errors }
+
+  return {
+    successfulFullNames,
+    errors: [...testErrors, ...componentErrors],
+  }
 }
 
 export type NestedMetadataTypeInfo = {
@@ -205,7 +220,7 @@ export const deployMetadata = async (
 
   const deployRes = await client.deploy(pkgData)
 
-  log.debug('deploy result: %o', deployRes)
+  log.debug('deploy result: %s', JSON.stringify(deployRes, undefined, 2))
 
   const { errors, successfulFullNames } = processDeployResponse(deployRes)
 

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -111,16 +111,14 @@ const isUnFoundDelete = (message: DeployMessage): boolean => (
 const processDeployResponse = (
   result: SFDeployResult
 ): { successfulFullNames: ReadonlyArray<MetadataId>; errors: ReadonlyArray<Error> } => {
-  const allSuccessMessages = collections.array.makeArray(result.details)
-    .flatMap(detail => collections.array.makeArray(detail.componentSuccesses))
+  const allSuccessMessages = makeArray(result.details)
+    .flatMap(detail => makeArray(detail.componentSuccesses))
 
-  const allFailureMessages = collections.array.makeArray(result.details)
-    .flatMap(detail => collections.array.makeArray(detail.componentFailures))
+  const allFailureMessages = makeArray(result.details)
+    .flatMap(detail => makeArray(detail.componentFailures))
 
-  const testFailures = collections.array.makeArray(result.details)
-    .flatMap(detail => (
-      collections.array.makeArray((detail.runTestResult as RunTestsResult)?.failures)
-    ))
+  const testFailures = makeArray(result.details)
+    .flatMap(detail => makeArray((detail.runTestResult as RunTestsResult)?.failures))
 
   // We want to treat deletes for things we haven't found as success
   // Note that if we deploy with ignoreWarnings, these might show up in the success list


### PR DESCRIPTION
- Improve handling for failing tests in deploy result - include test failures in deploy result
- Unrelated fix to the adapter config example in the documentation

---
_Release notes_
- Fixed issue where deployments that failed due to failing apex tests would be considered successful