### PR TITLE
changed symbol search to use fullnames

### DIFF
--- a/packages/lang-server/src/symbols.ts
+++ b/packages/lang-server/src/symbols.ts
@@ -33,8 +33,11 @@ export interface SaltoSymbol {
   range: EditorRange
 }
 
-const getSaltoSymbolName = (context: PositionContext): string => {
+const getSaltoSymbolName = (context: PositionContext, useRealFullname = false): string => {
   if (context.ref) {
+    if (useRealFullname) {
+      return context.ref.element.elemID.getFullName()
+    }
     const fullName = _.last(context.ref.path) || context.ref.element.elemID.name
     return isIndexPathPart(fullName) ? `[${fullName}]` : fullName
   }
@@ -63,8 +66,9 @@ const getSaltoSymbolKind = (context: PositionContext): SaltoSymbolKind => {
 
 export const createSaltoSymbol = (
   context: PositionContext,
+  fullname = false
 ): SaltoSymbol => {
-  const name = getSaltoSymbolName(context)
+  const name = getSaltoSymbolName(context, fullname)
   const type = getSaltoSymbolKind(context)
   return { name, type, range: context.range }
 }

--- a/packages/lang-server/test/symbols.test.ts
+++ b/packages/lang-server/test/symbols.test.ts
@@ -99,4 +99,23 @@ describe('Cursor context resolver', () => {
     expect(symbol.name).toBe('global')
     expect(symbol.type).toBe(SaltoSymbolKind.File)
   })
+
+  it('should use the fullname as name if the fullname flag is set', async () => {
+    const pos = { line: 87, col: 10 }
+    const ctx = await getPositionContext(workspace, naclFilename, pos)
+    const symbol = createSaltoSymbol(ctx, true)
+    expect(symbol.name).toBe('vs.loan.instance.weekend_car')
+    expect(symbol.type).toBe(SaltoSymbolKind.Instance)
+  })
+
+  it(
+    'should return global as the name when the fullname flag is set and context is global',
+    async () => {
+      const pos = { line: 135, col: 0 }
+      const ctx = await getPositionContext(workspace, naclFilename, pos)
+      const symbol = createSaltoSymbol(ctx)
+      expect(symbol.name).toBe('global')
+      expect(symbol.type).toBe(SaltoSymbolKind.File)
+    }
+  )
 })

--- a/packages/vscode/src/adapters.ts
+++ b/packages/vscode/src/adapters.ts
@@ -45,9 +45,10 @@ const kindMap: {[key in symbols.SaltoSymbolKind]: vscode.SymbolKind} = {
 
 export const buildVSSymbol = (
   context: ctx.PositionContext,
-  filename: string
+  filename: string,
+  fullname = false
 ): vscode.SymbolInformation => {
-  const saltoSymbol = symbols.createSaltoSymbol(context)
+  const saltoSymbol = symbols.createSaltoSymbol(context, fullname)
   return {
     kind: kindMap[saltoSymbol.type],
     location: {

--- a/packages/vscode/src/adapters.ts
+++ b/packages/vscode/src/adapters.ts
@@ -46,9 +46,8 @@ const kindMap: {[key in symbols.SaltoSymbolKind]: vscode.SymbolKind} = {
 export const buildVSSymbol = (
   context: ctx.PositionContext,
   filename: string,
-  fullname = false
 ): vscode.SymbolInformation => {
-  const saltoSymbol = symbols.createSaltoSymbol(context, fullname)
+  const saltoSymbol = symbols.createSaltoSymbol(context, true)
   return {
     kind: kindMap[saltoSymbol.type],
     location: {
@@ -60,7 +59,7 @@ export const buildVSSymbol = (
     },
     name: saltoSymbol.name,
     containerName: context.parent
-      ? symbols.createSaltoSymbol(context.parent).name
+      ? symbols.createSaltoSymbol(context.parent, true).name
       : '',
   }
 }

--- a/packages/vscode/src/providers.ts
+++ b/packages/vscode/src/providers.ts
@@ -121,7 +121,6 @@ export const createWorkspaceSymbolProvider = (
       .map(async l => buildVSSymbol(
         await locToContext(l),
         toVSFileName(workspace.baseDir, l.filename),
-        true
       )))
   },
 })

--- a/packages/vscode/src/providers.ts
+++ b/packages/vscode/src/providers.ts
@@ -120,7 +120,8 @@ export const createWorkspaceSymbolProvider = (
     return Promise.all((await location.getQueryLocations(workspace, query))
       .map(async l => buildVSSymbol(
         await locToContext(l),
-        toVSFileName(workspace.baseDir, l.filename)
+        toVSFileName(workspace.baseDir, l.filename),
+        true
       )))
   },
 })


### PR DESCRIPTION
vscode does not display search result for which the query string is not a substring.
Since the new MO for search usage assumes query strings which are full or partial elemIDs we need to display the fullname in the search results. 