### PR TITLE
Support validation deploy

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -50,6 +50,7 @@ salesforce {
       rollbackOnError = true
       ignoreWarnings = true
       purgeOnDelete = false
+      checkOnly = false
       testLevel = "NoTestRun"
       runTests = ["Test name", "Other test"]
     }
@@ -113,6 +114,7 @@ salesforce {
 | rollbackOnError | `true`                                                 | Indicates whether any failure causes a complete rollback or not. Must be set to `true` if deploying to a production org. 
 | ignoreWarnings  | `true`                                                 | Indicates whether deployments with warnings complete successfully or not.
 | purgeOnDelete   | `false`                                                | If `true`, deleted components aren't stored in the Recycle Bin. Instead, they become immediately eligible for deletion. This option only works in Developer Edition or sandbox orgs. It doesn’t work in production orgs.
+| checkOnly       | `false`                                                | If `true`, deploy will run a "validation deploy", changes will not be immediately applied to the service
 | testLevel       | `NoTestRun` (development) `RunLocalTests` (production) | Specifies which tests are run as part of a deployment. possible values are: `NoTestRun`, `RunSpecifiedTests`, `RunLocalTests` and `RunAllTestsInOrg`
 | runTests        | `[]` (no tests)                                        | A list of Apex tests to run during deployment, must configure `RunSpecifiedTests` in `testLevel` for this option to work
 

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -145,7 +145,8 @@ const processDeployResponse = (
     ))
 
   return {
-    successfulFullNames,
+    // When running as "checkOnly" non of the changes are actually applied
+    successfulFullNames: result.checkOnly ? [] : successfulFullNames,
     errors: [...testErrors, ...componentErrors],
   }
 }

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -66,6 +66,7 @@ type ClientDeployConfig = Partial<{
   rollbackOnError: boolean
   ignoreWarnings: boolean
   purgeOnDelete: boolean
+  checkOnly: boolean
   testLevel: 'NoTestRun' | 'RunSpecifiedTests' | 'RunLocalTests' | 'RunAllTestsInOrg'
   runTests: string[]
 }>
@@ -235,6 +236,7 @@ const clientDeployConfigType = new ObjectType({
     rollbackOnError: { type: BuiltinTypes.BOOLEAN },
     ignoreWarnings: { type: BuiltinTypes.BOOLEAN },
     purgeOnDelete: { type: BuiltinTypes.BOOLEAN },
+    checkOnly: { type: BuiltinTypes.BOOLEAN },
     testLevel: {
       type: BuiltinTypes.STRING,
       annotations: {

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -174,6 +174,24 @@ describe('SalesforceAdapter CRUD', () => {
           expect(result.errors[0].message).toContain('Some error')
         })
       })
+
+      describe('when performing validation deploy with checkOnly', () => {
+        let result: DeployResult
+        beforeEach(async () => {
+          mockDeploy.mockReturnValueOnce(mockDeployResult({
+            success: true,
+            componentSuccess: [{ fullName: instanceName, componentType: 'Flow' }],
+            checkOnly: true,
+          }))
+          result = await adapter.deploy({
+            groupID: instance.elemID.getFullName(),
+            changes: [{ action: 'add', data: { after: instance } }],
+          })
+        })
+        it('should not return any changes as applied', () => {
+          expect(result.appliedChanges).toHaveLength(0)
+        })
+      })
     })
 
     describe('for a type element', () => {

--- a/packages/salesforce-adapter/test/connection.ts
+++ b/packages/salesforce-adapter/test/connection.ts
@@ -154,18 +154,20 @@ type GetDeployResultParams = {
   runTestResult?: PartialRunTestResult
   rollbackOnError?: boolean
   ignoreWarnings?: boolean
+  checkOnly?: boolean
 }
 export const mockDeployResult = ({
   success = true,
   componentSuccess = [],
   componentFailure = [],
+  runTestResult = undefined,
   ignoreWarnings = true,
   rollbackOnError = true,
-  runTestResult = undefined,
+  checkOnly = false,
 }: GetDeployResultParams): DeployResultLocator<DeployResult> => ({
   complete: jest.fn().mockResolvedValue({
     id: _.uniqueId(),
-    checkOnly: false,
+    checkOnly,
     completedDate: '2020-05-01T14:31:36.000Z',
     createdDate: '2020-05-01T14:21:36.000Z',
     done: true,


### PR DESCRIPTION
- Added checkOnly flag to salesforce adapter config
- When running a checkOnly deploy, do not update state file with any changes

---

_Release Notes_
- Add initial support for salesforce validation deploy using the `checkOnly` flag