### PR TITLE
SALTO-1044 - Fix nacl update when adding and removing elements form the same file

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -238,11 +238,12 @@ const logNaclFileUpdateErrorContext = (
   log.debug('Parse errors in file %s after updating with changes:', filename)
   fileChanges.forEach(change => {
     log.debug(
-      '%s of %s at location: (start=%o end=%o)',
+      '%s of %s at location: (start=%o end=%o eof=%s)',
       change.action,
       change.id.getFullName(),
       change.location.start,
       change.location.end,
+      change.location.eof,
     )
   })
   log.debug('data before:\n%s', naclDataBefore)

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -113,6 +113,7 @@ type salesforce.lead {
 }`,
 
   'willbempty.nacl': 'type nonempty { a = 2 }',
+  'hasexistingelement.nacl': 'type salesforce.oldType {}',
 }
 
 export const mockDirStore = (

--- a/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 import { InstanceElement, StaticFile, ElemID, BuiltinTypes, ObjectType, ListType } from '@salto-io/adapter-api'
-import { getNestedStaticFiles } from '../../../src/workspace/nacl_files/nacl_file_update'
+import { getNestedStaticFiles, getChangeLocations } from '../../../src/workspace/nacl_files/nacl_file_update'
+import { SourceRange } from '../../../src/parser'
 
 const mockType = new ObjectType({
   elemID: new ElemID('salto', 'mock'),
@@ -78,5 +79,24 @@ describe('getNestedStaticFiles', () => {
       .toEqual([
         'plain',
       ])
+  })
+})
+
+describe('getChangeLocations', () => {
+  it('should use eof when adding new elements that are not found in the source map', () => {
+    expect(getChangeLocations(
+      {
+        action: 'add',
+        data: { after: { new: 'data' } },
+        id: new ElemID('salesforce', 'type', 'instance', 'name'),
+      },
+      new Map<string, SourceRange[]>(),
+    )[0].location).toEqual({
+      filename: '',
+      start: { col: 1, line: 1, byte: 0 },
+      end: { col: 1, line: 1, byte: 0 },
+      // if there are existing elements in the file, don't override them
+      eof: true,
+    })
   })
 })


### PR DESCRIPTION
When an element is removed from an existing file and another one is added, the changes may overlap and cause the updated data to be invalid (see the ticket for the full scenario - it is not expected to happen in standard flows).
This happens because the new element's addition is aimed at the beginning of the file, overlapping with the removal.

Solving this by adding an optional `eof` directive on source ranges, that can mark additions as "append" operations (since when the ranges are computed we do not have direct access to the full contents of the existing file, and we don't really need it in order to support this).