### PR TITLE
SALTO-1043: add new elements at the end of the file

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -79,11 +79,12 @@ export const getChangeLocations = (
       }
     }
     // Fallback to using the path from the element itself
-    const naclFilePath = change.path || getChangeElement(change).path
+    const naclFilePath = change.path ?? getChangeElement(change).path
+    const endOfFileLocation = { col: 1, line: Infinity, byte: Infinity }
     return [{
       filename: createFileNameFromPath(naclFilePath),
-      start: { col: 1, line: 1, byte: 0 },
-      end: { col: 1, line: 1, byte: 0 },
+      start: endOfFileLocation,
+      end: endOfFileLocation,
     }]
   }
 

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -113,6 +113,8 @@ type salesforce.lead {
 }`,
 
   'willbempty.nacl': 'type nonempty { a = 2 }',
+  'renamed_type.nacl': `type salesforce.RenamedType1 {
+  }`,
 }
 
 export const mockDirStore = (

--- a/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, StaticFile, ElemID, BuiltinTypes, ObjectType, ListType } from '@salto-io/adapter-api'
-import { getNestedStaticFiles } from '../../../src/workspace/nacl_files/nacl_file_update'
+import { InstanceElement, StaticFile, ElemID, BuiltinTypes, ObjectType, ListType, toChange, DetailedChange } from '@salto-io/adapter-api'
+import { getNestedStaticFiles, getChangeLocations, DetailedChangeWithSource } from '../../../src/workspace/nacl_files/nacl_file_update'
 
 const mockType = new ObjectType({
   elemID: new ElemID('salto', 'mock'),
@@ -78,5 +78,20 @@ describe('getNestedStaticFiles', () => {
       .toEqual([
         'plain',
       ])
+  })
+})
+
+describe('getChangeLocations', () => {
+  let result: DetailedChangeWithSource[]
+  describe('with addition of top level element', () => {
+    beforeEach(() => {
+      const change: DetailedChange = { ...toChange({ after: mockType }), id: mockType.elemID }
+      result = getChangeLocations(change, new Map())
+    })
+    it('should add the element at the end of the file', () => {
+      expect(result).toHaveLength(1)
+      expect(result[0].location.start).toEqual({ col: 1, line: Infinity, byte: Infinity })
+      expect(result[0].location.end).toEqual({ col: 1, line: Infinity, byte: Infinity })
+    })
   })
 })


### PR DESCRIPTION
- Fix the logic that assigns locations to changes so that new top level elements are added to the end of the file instead of the beginning

---
_Release notes_:
- Fix issue where invalid nacls would be created in fetch when elements are renamed 