### PR TITLE
Fix vscode debug config for new versions of vscode

### DIFF
--- a/packages/adapter-api/.vscode/launch.json
+++ b/packages/adapter-api/.vscode/launch.json
@@ -7,7 +7,7 @@
         {
           "type": "node",
           "request": "launch",
-          "name": "Debug Jest Tests",
+          "name": "adapter-api Debug Jest Tests",
           "cwd": "${workspaceFolder}",
           "args": [
               "${workspaceRoot}/node_modules/.bin/jest",
@@ -15,14 +15,7 @@
               "--config",
               "${workspaceRoot}/jest.config.js"
           ],
-          "windows": {
-              "args": [
-                  "${workspaceRoot}/node_modules/jest/bin/jest.js",
-                  "--runInBand",
-                  "--config",
-                  "${workspaceRoot}/jest.config.js"
-              ],
-          },
+          "outFiles": [],
           "console": "integratedTerminal",
           "internalConsoleOptions": "neverOpen"
       },

--- a/packages/adapter-utils/.vscode/launch.json
+++ b/packages/adapter-utils/.vscode/launch.json
@@ -7,7 +7,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Debug Jest Tests",
+      "name": "adapter-utils Debug Jest Tests",
       "cwd": "${workspaceFolder}",
       "args": [
         "${workspaceRoot}/node_modules/.bin/jest",
@@ -15,14 +15,7 @@
         "--config",
         "${workspaceRoot}/jest.config.js"
       ],
-      "windows": {
-        "args": [
-          "${workspaceRoot}/node_modules/jest/bin/jest.js",
-          "--runInBand",
-          "--config",
-          "${workspaceRoot}/jest.config.js"
-        ],
-      },
+      "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     },

--- a/packages/cli/.vscode/launch.json
+++ b/packages/cli/.vscode/launch.json
@@ -7,7 +7,7 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Debug Jest Tests",
+            "name": "cli Debug Jest Tests",
             "cwd": "${workspaceFolder}",
             "args": [
                 "${workspaceRoot}/node_modules/.bin/jest",
@@ -15,21 +15,14 @@
                 "--config",
                 "${workspaceRoot}/jest.config.js"
             ],
-            "windows": {
-                "args": [
-                    "${workspaceRoot}/node_modules/jest/bin/jest.js",
-                    "--runInBand",
-                    "--config",
-                    "${workspaceRoot}/jest.config.js"
-                ],
-            },
+            "outFiles": [],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
         },
         {
             "type": "node",
             "request": "launch",
-            "name": "Debug Jest E2E Tests",
+            "name": "cli Debug Jest E2E Tests",
             "cwd": "${workspaceFolder}",
             "env": {
               "RUN_E2E_TESTS": "1"
@@ -40,15 +33,7 @@
               "--config",
               "${workspaceRoot}/jest.config.js"
             ],
-            "windows": {
-                "args": [
-                  "RUN_E2E_TESTS=1",
-                  "${workspaceRoot}/node_modules/jest/bin/jest.js",
-                  "--runInBand",
-                  "--config",
-                  "${workspaceRoot}/jest.config.js"
-                ]
-            },
+            "outFiles": [],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
         }

--- a/packages/core/.vscode/extensions.json
+++ b/packages/core/.vscode/extensions.json
@@ -1,6 +1,0 @@
-{
-    "recommendations": [
-        "dbaeumer.vscode-eslint",
-        "orta.vscode-jest"
-    ]
-}

--- a/packages/core/.vscode/launch.json
+++ b/packages/core/.vscode/launch.json
@@ -7,7 +7,7 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Debug Jest Tests",
+            "name": "core Debug Jest Tests",
             "cwd": "${workspaceFolder}",
             "args": [
                 "${workspaceRoot}/node_modules/.bin/jest",
@@ -15,14 +15,7 @@
                 "--config",
                 "${workspaceRoot}/jest.config.js"
             ],
-            "windows": {
-                "args": [
-                    "${workspaceRoot}/node_modules/jest/bin/jest.js",
-                    "--runInBand",
-                    "--config",
-                    "${workspaceRoot}/jest.config.js"
-                ],
-            },
+            "outFiles": [],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
         },

--- a/packages/dag/.vscode/launch.json
+++ b/packages/dag/.vscode/launch.json
@@ -5,26 +5,19 @@
     "version": "0.2.0",
     "configurations": [
         {
-          "type": "node",
-          "request": "launch",
-          "name": "Debug Jest Tests",
-          "cwd": "${workspaceFolder}",
-          "args": [
-              "${workspaceRoot}/node_modules/.bin/jest",
-              "--runInBand",
-              "--config",
-              "${workspaceRoot}/jest.config.js"
-          ],
-          "windows": {
-              "args": [
-                  "${workspaceRoot}/node_modules/jest/bin/jest.js",
-                  "--runInBand",
-                  "--config",
-                  "${workspaceRoot}/jest.config.js"
-              ],
-          },
-          "console": "integratedTerminal",
-          "internalConsoleOptions": "neverOpen"
-      },
+            "type": "node",
+            "request": "launch",
+            "name": "dag Debug Jest Tests",
+            "cwd": "${workspaceFolder}",
+            "args": [
+                "${workspaceRoot}/node_modules/.bin/jest",
+                "--runInBand",
+                "--config",
+                "${workspaceRoot}/jest.config.js"
+            ],
+            "outFiles": [],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+        },
     ]
 }

--- a/packages/dummy-adapter/.vscode/launch.json
+++ b/packages/dummy-adapter/.vscode/launch.json
@@ -4,7 +4,7 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Debug Jest Tests",
+            "name": "dummy-adapter Debug Jest Tests",
             "cwd": "${workspaceFolder}",
             "args": [
                 "${workspaceRoot}/node_modules/.bin/jest",
@@ -12,6 +12,7 @@
                 "--config",
                 "${workspaceRoot}/jest.config.js"
             ],
+            "outFiles": [],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
         }

--- a/packages/hubspot-adapter/.vscode/launch.json
+++ b/packages/hubspot-adapter/.vscode/launch.json
@@ -7,7 +7,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Debug Jest Tests",
+      "name": "hubspot-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
       "args": [
         "${workspaceRoot}/node_modules/.bin/jest",
@@ -15,14 +15,7 @@
         "--config",
         "${workspaceRoot}/jest.config.js"
       ],
-      "windows": {
-        "args": [
-          "${workspaceRoot}/node_modules/jest/bin/jest.js",
-          "--runInBand",
-          "--config",
-          "${workspaceRoot}/jest.config.js"
-        ],
-      },
+      "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     },

--- a/packages/lang-server/.vscode/launch.json
+++ b/packages/lang-server/.vscode/launch.json
@@ -1,22 +1,10 @@
 {
     "version": "0.2.0",
-    "configurations": [{
-            "name": "Run Extension",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}"
-            ],
-            "outFiles": [
-                "${workspaceFolder}/out/**/*.js"
-            ],
-            "preLaunchTask": "npm: build-ts"
-        },
+    "configurations": [
         {
             "type": "node",
             "request": "launch",
-            "name": "Debug Jest Tests",
+            "name": "lang-server Debug Jest Tests",
             "cwd": "${workspaceFolder}",
             "args": [
                 "${workspaceRoot}/node_modules/.bin/jest",
@@ -24,6 +12,7 @@
                 "--config",
                 "${workspaceRoot}/jest.config.js"
             ],
+            "outFiles": [],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
         }

--- a/packages/logging/.vscode/launch.json
+++ b/packages/logging/.vscode/launch.json
@@ -5,26 +5,19 @@
     "version": "0.2.0",
     "configurations": [
         {
-          "type": "node",
-          "request": "launch",
-          "name": "Debug Jest Tests",
-          "cwd": "${workspaceFolder}",
-          "args": [
-              "${workspaceRoot}/node_modules/.bin/jest",
-              "--runInBand",
-              "--config",
-              "${workspaceRoot}/jest.config.js"
-          ],
-          "windows": {
-              "args": [
-                  "${workspaceRoot}/node_modules/jest/bin/jest.js",
-                  "--runInBand",
-                  "--config",
-                  "${workspaceRoot}/jest.config.js"
-              ],
-          },
-          "console": "integratedTerminal",
-          "internalConsoleOptions": "neverOpen"
-      },
+            "type": "node",
+            "request": "launch",
+            "name": "logging Debug Jest Tests",
+            "cwd": "${workspaceFolder}",
+            "args": [
+                "${workspaceRoot}/node_modules/.bin/jest",
+                "--runInBand",
+                "--config",
+                "${workspaceRoot}/jest.config.js"
+            ],
+            "outFiles": [],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+        },
     ]
 }

--- a/packages/netsuite-adapter/.vscode/launch.json
+++ b/packages/netsuite-adapter/.vscode/launch.json
@@ -4,7 +4,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Debug Jest Tests",
+      "name": "netsuite-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
       "args": [
         "${workspaceRoot}/node_modules/.bin/jest",
@@ -12,14 +12,7 @@
         "--config",
         "${workspaceRoot}/jest.config.js"
       ],
-      "windows": {
-        "args": [
-          "${workspaceRoot}/node_modules/jest/bin/jest.js",
-          "--runInBand",
-          "--config",
-          "${workspaceRoot}/jest.config.js"
-        ],
-      },
+      "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     },

--- a/packages/salesforce-adapter/.vscode/extensions.json
+++ b/packages/salesforce-adapter/.vscode/extensions.json
@@ -1,6 +1,0 @@
-{
-    "recommendations": [
-        "dbaeumer.vscode-eslint",
-        "orta.vscode-jest"
-    ]
-}

--- a/packages/salesforce-adapter/.vscode/launch.json
+++ b/packages/salesforce-adapter/.vscode/launch.json
@@ -7,7 +7,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Debug Jest Tests",
+      "name": "salesforce-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
       "args": [
         "${workspaceRoot}/node_modules/.bin/jest",
@@ -15,21 +15,14 @@
         "--config",
         "${workspaceRoot}/jest.config.js"
       ],
-      "windows": {
-        "args": [
-          "${workspaceRoot}/node_modules/jest/bin/jest.js",
-          "--runInBand",
-          "--config",
-          "${workspaceRoot}/jest.config.js"
-        ]
-      },
+      "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     },
     {
         "type": "node",
         "request": "launch",
-        "name": "Debug Jest E2E Tests",
+        "name": "salesforce-adapter Debug Jest E2E Tests",
         "cwd": "${workspaceFolder}",
         "env": {
           "RUN_E2E_TESTS": "1"
@@ -40,15 +33,7 @@
           "--config",
           "${workspaceRoot}/jest.config.js"
         ],
-        "windows": {
-            "args": [
-              "RUN_E2E_TESTS=1",
-              "${workspaceRoot}/node_modules/jest/bin/jest.js",
-              "--runInBand",
-              "--config",
-              "${workspaceRoot}/jest.config.js"
-            ],
-        },
+        "outFiles": [],
         "console": "integratedTerminal",
         "internalConsoleOptions": "neverOpen"
     },

--- a/packages/workspace/.vscode/launch.json
+++ b/packages/workspace/.vscode/launch.json
@@ -7,7 +7,7 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Debug Jest Tests",
+            "name": "workspace Debug Jest Tests",
             "cwd": "${workspaceFolder}",
             "args": [
                 "${workspaceRoot}/node_modules/.bin/jest",
@@ -15,14 +15,7 @@
                 "--config",
                 "${workspaceRoot}/jest.config.js"
             ],
-            "windows": {
-                "args": [
-                    "${workspaceRoot}/node_modules/jest/bin/jest.js",
-                    "--runInBand",
-                    "--config",
-                    "${workspaceRoot}/jest.config.js"
-                ],
-            },
+            "outFiles": [],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
         },


### PR DESCRIPTION
It seems like the default configuration for outFiles finds the output .js files in our project
Not really clear why, but the new vscode debugger sets additional breakpoints in these .js files
and that causes it to move the correct breakpoints to other places (again, not clear why)

While I have no idea why making outFiles an empty list instead of the default fixes this,
It seems to work with the new debugger and it seems like the old vscode debugger is not broken

Also in this commit:
- added the package name to the debug jest task name so it will be easier to pick the tests of the
  relevant package
- Removed the separate "windows" section from all the configs since it was not used