### PR TITLE
SALTO-1022 - Add element list-unresolved command

### DIFF
--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -16,6 +16,7 @@
 import _ from 'lodash'
 import { Workspace, createElementSelectors, ElementSelector } from '@salto-io/workspace'
 import { logger } from '@salto-io/logging'
+import { listUnresolvedReferences } from '@salto-io/core'
 import { getCliTelemetry } from '../telemetry'
 import { EnvironmentArgs } from './env'
 import { outputLine, errorOutputLine } from '../outputer'
@@ -27,7 +28,7 @@ import Prompts from '../prompts'
 import {
   formatTargetEnvRequired, formatInvalidFilters, formatUnknownTargetEnv, formatCloneToEnvFailed,
   formatMissingCloneArg, formatInvalidEnvTargetCurrent, formatMoveFailed,
-  formatInvalidMoveArg, formatInvalidElementCommand,
+  formatInvalidMoveArg, formatInvalidElementCommand, formatElementListUnresolvedFailed,
 } from '../formatter'
 
 const log = logger(module)
@@ -76,7 +77,7 @@ const cloneElement = async (
     cliTelemetry.success(workspaceTags)
     return CliExitCode.Success
   } catch (e) {
-    cliTelemetry.failure()
+    cliTelemetry.failure(workspaceTags)
     errorOutputLine(formatCloneToEnvFailed(e.message), output)
     return CliExitCode.AppError
   }
@@ -103,15 +104,55 @@ const moveElement = async (
         break
       default:
         errorOutputLine(formatInvalidMoveArg(to), output)
-        cliTelemetry.failure()
+        cliTelemetry.failure(workspaceTags)
         return CliExitCode.UserInputError
     }
     await workspace.flush()
     cliTelemetry.success(workspaceTags)
     return CliExitCode.Success
   } catch (e) {
-    cliTelemetry.failure()
+    cliTelemetry.failure(workspaceTags)
     errorOutputLine(formatMoveFailed(e.message), output)
+    return CliExitCode.AppError
+  }
+}
+
+const listUnresolved = async (
+  workspace: Workspace,
+  output: CliOutput,
+  cliTelemetry: CliTelemetry,
+  completeFrom?: string,
+): Promise<CliExitCode> => {
+  if (completeFrom !== undefined && !validateEnvs(output, workspace, [completeFrom])) {
+    cliTelemetry.failure()
+    return CliExitCode.UserInputError
+  }
+
+  const workspaceTags = await getWorkspaceTelemetryTags(workspace)
+  cliTelemetry.start(workspaceTags)
+  outputLine(Prompts.LIST_UNRESOLVED_START(workspace.currentEnv()), output)
+
+  try {
+    const { found, missing } = await listUnresolvedReferences(workspace, completeFrom)
+
+    if (found.length > 0) {
+      outputLine(Prompts.LIST_UNRESOLVED_FOUND(completeFrom || '-'), output)
+      found.forEach(elemID => output.stdout.write(`  ${elemID.getFullName()}\n`))
+    }
+    if (missing.length > 0) {
+      outputLine(Prompts.LIST_UNRESOLVED_MISSING(), output)
+      missing.forEach(elemID => output.stdout.write(`  ${elemID.getFullName()}\n`))
+    }
+    if (missing.length === 0 && found.length === 0) {
+      outputLine(Prompts.LIST_UNRESOLVED_NONE(workspace.currentEnv()), output)
+    }
+
+    cliTelemetry.success(workspaceTags)
+    return CliExitCode.Success
+  } catch (e) {
+    log.error(`Error listing elements: ${e}`)
+    errorOutputLine(formatElementListUnresolvedFailed(e.message), output)
+    cliTelemetry.failure(workspaceTags)
     return CliExitCode.AppError
   }
 }
@@ -127,12 +168,17 @@ export const command = (
   inputFromEnv?: string,
   inputToEnvs?: string[],
   env?: string,
+  completeFrom?: string,
 ): CliCommand => ({
   async execute(): Promise<CliExitCode> {
     log.debug(
       `running element ${commandName} command on '${workspaceDir}' env=${env}, fromEnv=${inputFromEnv}, toEnvs=${inputToEnvs}
-      , force=${force}, elmSelectors=${inputElmSelectors}`
+      completeFrom=${completeFrom}, force=${force}, elmSelectors=${inputElmSelectors}`
     )
+
+    if (inputElmSelectors.length === 0 && commandName !== 'list-unresolved') {
+      throw new Error('No element selector specified')
+    }
 
     if ((commandName === 'clone')
     && ((inputFromEnv === undefined) || (inputToEnvs === undefined))) {
@@ -155,6 +201,7 @@ export const command = (
         force,
         spinnerCreator,
         sessionEnv,
+        ignoreUnresolvedRefs: (commandName === 'list-unresolved'),
       }
     )
     if (errored) {
@@ -175,6 +222,8 @@ export const command = (
         return moveElement(workspace, output, cliTelemetry, COMMON, validSelectors)
       case 'move-to-envs':
         return moveElement(workspace, output, cliTelemetry, ENVS, validSelectors)
+      case 'list-unresolved':
+        return listUnresolved(workspace, output, cliTelemetry, completeFrom)
       default:
         errorOutputLine(formatInvalidElementCommand(commandName), output)
         return CliExitCode.UserInputError
@@ -191,23 +240,27 @@ type MoveArgs = {
   to: string
 } & EnvironmentArgs
 
+type ListUnresolvedArgs = {
+  completeFrom: string
+} & EnvironmentArgs
+
 export type ElementArgs = {
   command: string
   force: boolean
   elementSelector: string[]
-} & CloneArgs & MoveArgs
+} & CloneArgs & MoveArgs & ListUnresolvedArgs
 
 type ElementParsedCliInput = ParsedCliInput<ElementArgs>
 
 const elementBuilder = createCommandBuilder({
   filters: [environmentFilter],
   options: {
-    command: 'element <command> <element-selector..>',
+    command: 'element <command> [element-selector..]',
     description: 'Manage configuration elements',
     positional: {
       command: {
         type: 'string',
-        choices: ['clone', 'move-to-common', 'move-to-envs'],
+        choices: ['clone', 'move-to-common', 'move-to-envs', 'list-unresolved'],
         description: 'The element management command',
       },
       'element-selector': {
@@ -232,6 +285,11 @@ const elementBuilder = createCommandBuilder({
         default: false,
         demandOption: false,
       },
+      // will also be available as completeFrom because of camel-case-expansion
+      'complete-from': {
+        type: 'string',
+        desc: 'The environment to use for finding unresolved references in list-unresolved',
+      },
     },
   },
   async build(input: ElementParsedCliInput, output: CliOutput, spinnerCreator: SpinnerCreator) {
@@ -246,6 +304,7 @@ const elementBuilder = createCommandBuilder({
       input.args.fromEnv,
       input.args.toEnvs,
       input.args.env,
+      input.args.completeFrom,
     )
   },
 })

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -64,12 +64,13 @@ const cloneElement = async (
   toEnvs: string[],
   selectors: ElementSelector[],
 ): Promise<CliExitCode> => {
+  const workspaceTags = await getWorkspaceTelemetryTags(workspace)
+
   if (!validateEnvs(output, workspace, toEnvs)) {
-    cliTelemetry.failure()
+    cliTelemetry.failure(workspaceTags)
     return CliExitCode.UserInputError
   }
 
-  const workspaceTags = await getWorkspaceTelemetryTags(workspace)
   cliTelemetry.start(workspaceTags)
   try {
     outputLine(Prompts.CLONE_TO_ENV_START(toEnvs), output)
@@ -124,12 +125,13 @@ const listUnresolved = async (
   cliTelemetry: CliTelemetry,
   completeFrom?: string,
 ): Promise<CliExitCode> => {
+  const workspaceTags = await getWorkspaceTelemetryTags(workspace)
+
   if (completeFrom !== undefined && !validateEnvs(output, workspace, [completeFrom])) {
-    cliTelemetry.failure()
+    cliTelemetry.failure(workspaceTags)
     return CliExitCode.UserInputError
   }
 
-  const workspaceTags = await getWorkspaceTelemetryTags(workspace)
   cliTelemetry.start(workspaceTags)
   outputLine(Prompts.LIST_UNRESOLVED_START(workspace.currentEnv()), output)
   outputLine(emptyLine(), output)
@@ -207,7 +209,8 @@ export const command = (
       }
     )
     if (errored) {
-      cliTelemetry.failure()
+      const workspaceTags = await getWorkspaceTelemetryTags(workspace)
+      cliTelemetry.failure(workspaceTags)
       return CliExitCode.AppError
     }
 

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -595,6 +595,11 @@ export const formatInvalidFilters = (invalidFilters: string[]): string => [
   emptyLine(),
 ].join('\n')
 
+export const formatMissingElementSelectors = (): string => [
+  formatSimpleError(Prompts.MISSING_ELEMENT_SELECTORS),
+  emptyLine(),
+].join('\n')
+
 export const formatUnknownTargetEnv = (unknownEnvs: string[]): string => [
   formatSimpleError(Prompts.UNKNOWN_TARGET_ENVS(unknownEnvs)),
   emptyLine(),
@@ -646,3 +651,15 @@ export const formatCleanWorkspace = (cleanArgs: WorkspaceComponents): string => 
     .map(([comp]) => _.startCase(comp).toLowerCase())
   return Prompts.CLEAN_WORKSPACE_SUMMARY(componentsToClean)
 }
+
+export const formatListUnresolvedFound = (env: string, elemIDs: ElemID[]): string => [
+  Prompts.LIST_UNRESOLVED_FOUND(env),
+  ...elemIDs.map(id => `  ${id.getFullName()}`),
+  emptyLine(),
+].join('\n')
+
+export const formatListUnresolvedMissing = (elemIDs: ElemID[]): string => [
+  Prompts.LIST_UNRESOLVED_MISSING(),
+  ...elemIDs.map(id => `  ${id.getFullName()}`),
+  emptyLine(),
+].join('\n')

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -630,6 +630,11 @@ export const formatInvalidMoveArg = (invalidTo: string): string => [
   emptyLine(),
 ].join('\n')
 
+export const formatElementListUnresolvedFailed = (errorMessage: string): string => [
+  formatSimpleError(Prompts.LIST_UNRESOLVED_FAILED(errorMessage)),
+  emptyLine(),
+].join('\n')
+
 export const formatInvalidElementCommand = (command: string): string => [
   formatSimpleError(Prompts.INVALID_MOVE_ARG(command)),
   emptyLine(),

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -202,6 +202,8 @@ ${Prompts.SERVICE_ADD_HELP}`
     invalidFilters: string
   ): string => `Failed to created element ID filters for: ${invalidFilters}. Invalid Regex provided.`
 
+  public static readonly MISSING_ELEMENT_SELECTORS = 'No element selectors specified'
+
   public static readonly DIFF_CALC_DIFF_START = (
     toEnv: string,
     fromEnv: string

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -244,11 +244,21 @@ ${Prompts.SERVICE_ADD_HELP}`
     error: string
   ): string => `Failed to move the specified elements: ${error}`
 
+  public static readonly LIST_UNRESOLVED_FAILED = (
+    error: string
+  ): string => `Failed to list unresolved references: ${error}`
+
   public static readonly CLONE_TO_ENV_START = (
     targetEnvs: string[] = []
   ): string => `Cloning the specified elements to ${
     targetEnvs.length > 0 ? targetEnvs.join(', ') : 'all environments'
   }.`
+
+  public static readonly LIST_UNRESOLVED_START = (env: string): string => `Looking for unresolved references in ${env}`
+  public static readonly LIST_UNRESOLVED_NONE = (env: string): string => `All references in ${env} were resolved successfully!`
+
+  public static readonly LIST_UNRESOLVED_FOUND = (env: string): string => `The following unresolved references can be copied from ${env}:`
+  public static readonly LIST_UNRESOLVED_MISSING = (): string => 'The following unresolved references could not be found:'
 
   public static readonly CLONE_TO_ENV_FAILED = (
     error: string

--- a/packages/cli/src/workspace/errors.ts
+++ b/packages/cli/src/workspace/errors.ts
@@ -14,9 +14,10 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { errors as wsErrors } from '@salto-io/workspace'
+import { errors as wsErrors, validator as wsValidator } from '@salto-io/workspace'
 import { ElemID, SaltoError, SaltoElementError, SaltoErrorSeverity } from '@salto-io/adapter-api'
 
+const { isUnresolvedRefError } = wsValidator
 
 export class UnresolvedReferenceGroupError implements SaltoElementError {
   readonly elemID: ElemID
@@ -32,12 +33,6 @@ export class UnresolvedReferenceGroupError implements SaltoElementError {
     this.severity = 'Warning'
   }
 }
-
-const isUnresolvedRefError = (
-  err: SaltoError
-): err is wsErrors.UnresolvedReferenceValidationError => (
-  err instanceof wsErrors.UnresolvedReferenceValidationError
-)
 
 const groupUnresolvedRefsByTarget = (
   origErrors: ReadonlyArray<SaltoError>,

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -704,7 +704,8 @@ describe('element command', () => {
   })
 
   describe('list-unresolved', () => {
-    const mockListUnresolved = core.listUnresolvedReferences as jest.Mock
+    const mockListUnresolved = core.listUnresolvedReferences as jest.MockedFunction<
+      typeof core.listUnresolvedReferences>
 
     describe('success - all unresolved references are found in complete-from', () => {
       const workspaceName = 'valid-ws'

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -697,6 +697,10 @@ describe('element command', () => {
       it('should return success', () => {
         expect(result).toBe(CliExitCode.Success)
       })
+
+      it('should ignore unresolved references when loading the workspace', () => {
+        expect(mockLoadWorkspace.mock.calls.slice(-1)[0][2].ignoreUnresolvedRefs).toBeTruthy()
+      })
       it('should call listUnresolvedReferences', () => {
         expect(core.listUnresolvedReferences).toHaveBeenCalledWith(workspace, 'inactive')
       })

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -47,6 +47,7 @@ import { getAdapterChangeGroupIdFunctions } from './core/adapters/custom_group_k
 import { createDiffChanges } from './core/diff'
 
 export { cleanWorkspace } from './core/clean'
+export { listUnresolvedReferences } from './core/list'
 
 const log = logger(module)
 

--- a/packages/core/src/core/list.ts
+++ b/packages/core/src/core/list.ts
@@ -37,7 +37,8 @@ export type UnresolvedElemIDs = {
 const compact = (sortedIds: ElemID[]): ElemID[] => {
   const ret = sortedIds.slice(0, 1)
   sortedIds.slice(1).forEach(id => {
-    if (!ret.slice(-1)[0].isParentOf(id)) {
+    const lastItem = _.last(ret) as ElemID // if we're in the loop then ret is not empty
+    if (!lastItem.isParentOf(id)) {
       ret.push(id)
     }
   })
@@ -74,10 +75,9 @@ export const listUnresolvedReferences = async (
     }
   }
 
-  const elemCompletionLookup: Record<string, Element> = Object.fromEntries(
-    (await workspace.elements(true, completeFromEnv))
-      .filter(e => e.elemID.isTopLevel())
-      .map(e => [e.elemID.getFullName(), e])
+  const elemCompletionLookup: Record<string, Element> = _.keyBy(
+    await workspace.elements(true, completeFromEnv),
+    e => e.elemID.getFullName(),
   )
 
   const completed = new Set<string>()

--- a/packages/core/src/core/list.ts
+++ b/packages/core/src/core/list.ts
@@ -1,0 +1,124 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  ElemID, Element,
+} from '@salto-io/adapter-api'
+import { Workspace, validator } from '@salto-io/workspace'
+
+const { validateElements, isUnresolvedRefError } = validator
+
+export type UnresolvedElemIDs = {
+  found: ElemID[]
+  missing: ElemID[]
+}
+
+/**
+ * Filter out descendants from the list of sorted elem ids.
+ *
+ * @param sortedIds   The list of elem id full names, sorted alphabetically
+ */
+const compact = (sortedIds: string[]): string[] => {
+  const ret = sortedIds.slice(0, 1)
+  sortedIds.slice(1).forEach(id => {
+    if (!id.startsWith(`${ret.slice(-1)[0]}.`)) {
+      ret.push(id)
+    }
+  })
+  return ret
+}
+
+/**
+ * Compute the unresolved references in the current environment.
+ * If completeFromEnv is specified, use it to resolve the missing references recursively.
+ *
+ * @param workspace     The workspace to run the query on
+ * @completeFromEnv     The env to use to populate the references from and look for additional
+ *                      downstream missing references
+ */
+export const listUnresolvedReferences = async (
+  workspace: Workspace,
+  completeFromEnv?: string,
+): Promise<UnresolvedElemIDs> => {
+  const getUnresolvedElemIDs = (
+    elements: ReadonlyArray<Element>,
+    additionalContext?: ReadonlyArray<Element>,
+  ): ElemID[] => _.uniqBy(
+    validateElements(elements, additionalContext).filter(isUnresolvedRefError).map(e => e.target),
+    elemID => elemID.getFullName(),
+  )
+
+  const workspaceElements = await workspace.elements(true, workspace.currentEnv())
+  const unresolvedElemIDs = getUnresolvedElemIDs(workspaceElements)
+
+  if (completeFromEnv === undefined) {
+    return {
+      found: [],
+      missing: _.sortBy(unresolvedElemIDs, id => id.getFullName()),
+    }
+  }
+
+  const idsToMove = new Set<string>()
+  const missing = new Set<string>()
+
+  const addAndValidate = async (ids: ElemID[]): Promise<void> => {
+    if (ids.length === 0) {
+      return
+    }
+
+    const copy = async (idsToCopy: ElemID[]): Promise<ElemID[]> => {
+      const env = workspace.currentEnv()
+
+      const copyWithRetry = async (elemIDs: ElemID[]): Promise<ElemID[]> => {
+        try {
+          await workspace.copyTo(elemIDs, [env])
+          return []
+        } catch (e) {
+          if (elemIDs.length <= 1) {
+            return elemIDs
+          }
+          return (await Promise.all(elemIDs.map(id => copyWithRetry([id])))).flat()
+        }
+      }
+
+      await workspace.setCurrentEnv(completeFromEnv, false)
+      const failed = await copyWithRetry(idsToCopy)
+      await workspace.setCurrentEnv(env, false)
+      return failed
+    }
+
+    ids.forEach(id => idsToMove.add(id.getFullName()))
+    const failed = await copy(ids)
+    failed.forEach(id => missing.add(id.getFullName()))
+    const idLookup = new Set(ids.map(id => id.getFullName()))
+    const [moved, existing] = _.partition(
+      await workspace.elements(true, workspace.currentEnv()),
+      e => (
+        idLookup.has(e.elemID.getFullName())
+        || idLookup.has(e.elemID.createTopLevelParentID().parent.getFullName())
+      ),
+    )
+    const unresolvedIDs = getUnresolvedElemIDs(moved, existing)
+    await addAndValidate(unresolvedIDs.filter(id => !idsToMove.has(id.getFullName())))
+  }
+
+  await addAndValidate(unresolvedElemIDs)
+
+  return {
+    found: compact([...idsToMove].filter(id => !missing.has(id)).sort()).map(ElemID.fromFullName),
+    missing: [...missing].sort().map(ElemID.fromFullName),
+  }
+}

--- a/packages/core/test/core/list.test.ts
+++ b/packages/core/test/core/list.test.ts
@@ -1,0 +1,240 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Workspace } from '@salto-io/workspace'
+import { ObjectType, InstanceElement, Element, ElemID, BuiltinTypes, ReferenceExpression } from '@salto-io/adapter-api'
+import { listUnresolvedReferences } from '../../src/api'
+import { UnresolvedElemIDs } from '../../src/core/list'
+
+const mockWorkspace = ({
+  name,
+  envElements,
+}: {
+  name: string
+  envElements: Record<string, Element[]>
+}): Workspace => {
+  let curEnv = name
+  return {
+    elements: jest.fn().mockImplementation(async (_, env: string) => envElements[env]),
+    name,
+    envs: () => Object.keys(envElements),
+    currentEnv: () => curEnv,
+    setCurrentEnv: jest.fn().mockImplementation((env: string) => { curEnv = env }),
+    copyTo: jest.fn().mockImplementation((ids: ElemID[], targetEnvs: string[]) => {
+      if (ids.some(id => id.typeName === 'unresolved')) {
+        throw new Error('unresolved')
+      }
+      targetEnvs.forEach(target => envElements[target].push(
+        ...envElements[curEnv].filter(e => ids.some(
+          id => id.createTopLevelParentID().parent.isEqual(e.elemID)
+        ))
+      ))
+    }),
+  } as unknown as Workspace
+}
+
+describe('listUnresolvedReferences', () => {
+  let workspace: Workspace
+  let res: UnresolvedElemIDs
+
+  const createEnvElements = (): Element[] => {
+    const type1 = new ObjectType({
+      elemID: new ElemID('salesforce', 'someType'),
+      fields: {
+        f1: { type: BuiltinTypes.STRING },
+        f2: { type: BuiltinTypes.STRING },
+        f3: { type: BuiltinTypes.STRING },
+      },
+    })
+    const type2 = new ObjectType({
+      elemID: new ElemID('salesforce', 'anotherType'),
+      annotations: { _parent: new ReferenceExpression(type1.elemID) },
+      fields: {
+        f1: { type: type1 },
+        f2: { type: BuiltinTypes.STRING },
+        f3: { type: type1 },
+      },
+    })
+    const inst1 = new InstanceElement(
+      'inst1',
+      type1,
+      {
+        f1: 'aaa',
+        f2: new ReferenceExpression(new ElemID('salesforce', 'someType', 'field', 'f3')),
+        f3: 'ccc',
+      },
+    )
+    const inst2 = new InstanceElement(
+      'inst2',
+      type2,
+      {
+        f1: {
+          f1: 'aaa',
+          f2: 'bbb',
+          f3: new ReferenceExpression(new ElemID('salesforce', 'someType', 'instance', 'inst1', 'f1')),
+        },
+        f3: new ReferenceExpression(new ElemID('salesforce', 'someType', 'instance', 'inst1')),
+      },
+    )
+    return [type1, type2, inst1, inst2]
+  }
+
+  describe('workspace with no references', () => {
+    beforeAll(async () => {
+      const elements = createEnvElements().slice(0, 1)
+      workspace = mockWorkspace({
+        name: 'default',
+        envElements: {
+          default: elements,
+          other: elements,
+        },
+      })
+      res = await listUnresolvedReferences(workspace)
+    })
+
+    it('should not find any unresolved references', async () => {
+      expect(res.found).toHaveLength(0)
+      expect(res.missing).toHaveLength(0)
+    })
+  })
+
+  describe('workspace with resolved references', () => {
+    beforeAll(async () => {
+      jest.resetAllMocks()
+      const elements = createEnvElements()
+      workspace = mockWorkspace({
+        name: 'default',
+        envElements: {
+          default: elements,
+          other: elements,
+        },
+      })
+      res = await listUnresolvedReferences(workspace, 'other')
+    })
+
+    it('should not find any unresolved references', () => {
+      expect(res.found).toHaveLength(0)
+      expect(res.missing).toHaveLength(0)
+    })
+
+    it('should not call copyTo', () => {
+      expect(workspace.copyTo).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('workspace with unresolved references and no complete-from env', () => {
+    beforeAll(async () => {
+      jest.resetAllMocks()
+      const defaultElements = createEnvElements().slice(3)
+      const otherElements = createEnvElements()
+      workspace = mockWorkspace({
+        name: 'default',
+        envElements: {
+          default: defaultElements,
+          other: otherElements,
+        },
+      })
+      res = await listUnresolvedReferences(workspace)
+    })
+
+    it('should not resolve any references', () => {
+      expect(res.found).toHaveLength(0)
+      expect(res.missing).toEqual([
+        new ElemID('salesforce', 'someType', 'instance', 'inst1'),
+        new ElemID('salesforce', 'someType', 'instance', 'inst1', 'f1'),
+      ])
+    })
+
+    it('should not call copyTo', () => {
+      expect(workspace.copyTo).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('workspace with unresolved references that exist in other env', () => {
+    beforeAll(async () => {
+      jest.resetAllMocks()
+      const defaultElements = createEnvElements().slice(3)
+      const otherElements = createEnvElements()
+      workspace = mockWorkspace({
+        name: 'default',
+        envElements: {
+          default: defaultElements,
+          other: otherElements,
+        },
+      })
+      res = await listUnresolvedReferences(workspace, 'other')
+    })
+
+    it('should successfully resolve all references', () => {
+      expect(res.found).toEqual([
+        new ElemID('salesforce', 'someType', 'field', 'f3'),
+        new ElemID('salesforce', 'someType', 'instance', 'inst1'),
+      ])
+      expect(res.missing).toHaveLength(0)
+    })
+
+    it('should call copyTo with the relevant elem ids', () => {
+      expect(workspace.copyTo).toHaveBeenCalledWith([
+        new ElemID('salesforce', 'someType', 'field', 'f3'),
+      ], ['default'])
+      expect(workspace.copyTo).toHaveBeenCalledWith([
+        new ElemID('salesforce', 'someType', 'instance', 'inst1', 'f1'),
+        new ElemID('salesforce', 'someType', 'instance', 'inst1'),
+      ], ['default'])
+    })
+  })
+
+  describe('workspace with unresolved references that do not exist in other env', () => {
+    beforeAll(async () => {
+      jest.resetAllMocks()
+      const defaultElements = createEnvElements().slice(3) as InstanceElement[]
+      defaultElements[0].value = {
+        ...(defaultElements[0] as InstanceElement).value,
+        f3: new ReferenceExpression(new ElemID('salesforce', 'unresolved')),
+      }
+      const otherElements = createEnvElements().slice(1)
+      workspace = mockWorkspace({
+        name: 'default',
+        envElements: {
+          default: defaultElements,
+          other: otherElements,
+        },
+      })
+      res = await listUnresolvedReferences(workspace, 'other')
+    })
+
+    it('should resolve some of the references', () => {
+      expect(res.found).toEqual([
+        new ElemID('salesforce', 'someType', 'instance', 'inst1', 'f1'),
+      ])
+      expect(res.missing).toEqual([
+        new ElemID('salesforce', 'unresolved'),
+      ])
+    })
+
+    it('should retry with individual calls to copyTo', () => {
+      expect(workspace.copyTo).toHaveBeenCalledWith([
+        new ElemID('salesforce', 'someType', 'instance', 'inst1', 'f1'),
+        new ElemID('salesforce', 'unresolved'),
+      ], ['default'])
+      expect(workspace.copyTo).toHaveBeenCalledWith([
+        new ElemID('salesforce', 'someType', 'instance', 'inst1', 'f1'),
+      ], ['default'])
+      expect(workspace.copyTo).toHaveBeenCalledWith([
+        new ElemID('salesforce', 'unresolved'),
+      ], ['default'])
+    })
+  })
+})

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -33,6 +33,7 @@ import * as pathIndex from './src/workspace/path_index'
 import { createElementSelector, ElementSelector, validateSelectorsMatches,
   selectElementsBySelectors, createElementSelectors, ElementIDToValue,
   getElementIdsFromSelectorsRecursively } from './src/workspace/element_selector'
+import * as validator from './src/validator'
 
 export {
   errors,
@@ -59,6 +60,7 @@ export {
   state,
   workspaceConfigSource,
   WorkspaceComponents,
+  validator,
   createElementSelector,
   ElementSelector,
   validateSelectorsMatches,

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -20,7 +20,7 @@ import {
   isPrimitiveType, Value, ElemID, CORE_ANNOTATIONS, SaltoElementError, SaltoErrorSeverity,
   Values, isElement, isListType, getRestriction, isVariable, Variable, isPrimitiveValue, ListType,
   isReferenceExpression, StaticFile, isContainerType, isMapType, ObjectType,
-  InstanceAnnotationTypes, GLOBAL_ADAPTER,
+  InstanceAnnotationTypes, GLOBAL_ADAPTER, SaltoError,
 } from '@salto-io/adapter-api'
 import { toObjectType } from '@salto-io/adapter-utils'
 import { InvalidStaticFile } from './workspace/static_files/common'
@@ -162,6 +162,13 @@ export class UnresolvedReferenceValidationError extends ValidationError {
     this.target = target
   }
 }
+
+export const isUnresolvedRefError = (
+  err: SaltoError
+): err is UnresolvedReferenceValidationError => (
+  err instanceof UnresolvedReferenceValidationError
+)
+
 
 export class IllegalReferenceValidationError extends ValidationError {
   constructor(
@@ -472,8 +479,10 @@ const validateVariable = (element: Variable): ValidationError[] => validateVaria
   element.elemID, element.value
 )
 
-export const validateElements = (elements: ReadonlyArray<Element>): ValidationError[] => (
-  _(resolve(elements))
+export const validateElements = (
+  elements: ReadonlyArray<Element>, additionalContext?: ReadonlyArray<Element>,
+): ValidationError[] => (
+  _(resolve(elements, additionalContext))
     .map(e => {
       if (isInstanceElement(e)) {
         return validateInstanceElements(e)


### PR DESCRIPTION
Adding `salto element list-unresolved` with an optional `--complete-from <env>` argument, for helping users identify and fix unresolved references after a partial `move-to-common` / `clone`. This is checked recursively - if moving a referenced element would result in new unresolved references, those references are listed too.

The output is divided into two parts:
1. `found` - references that were found in the `complete-from` env
2. `missing` - references that could not be found in the `complete-from` env

Sample output: If `env1` has references to `salesforce.Custom__c` and `salesforce.Layout.instance.Custom__c_Custom_Layout@uubs` which exist in `env2`, and also a reference to `salesforce.INVALID` that does not exist anywhere:
```
$ salto element list-unresolved --complete-from env2
✔ Finished loading workspace for environment env1
Looking for unresolved references in env1

The following unresolved references can be copied from env2:
  salesforce.Layout.instance.Custom__c_Custom_Layout@uubs
  salesforce.Custom__c

The following unresolved references could not be found:
  salesforce.INVALID

```

---

_Release Notes_

Added `salto element list-unresolved`, a helper command for finding unresolved references. Use this after `move-to-common` or `clone` to find dependencies that should also be moved/cloned.