### PR TITLE
Support passing ElemIDs instead of ElementSelectors

### DIFF
--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -222,3 +222,8 @@ export class ElemID {
       )
   }
 }
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+export function isElemID(value: any): value is ElemID {
+  return value instanceof ElemID
+}

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -169,7 +169,7 @@ const buildMultiEnvSource = (
   const getElementsFromSource = async (source: NaclFilesSource): Promise<ElementIDToValue[]> =>
     (await source.getAll()).map(elem => ({ elemID: elem.elemID, element: elem }))
 
-  const toElemIDs = async (
+  const getElemIDs = async (
     selectors: ElementSelector[] | ElemID[],
     source: NaclFilesSource,
   ): Promise<ElemID[]> => (
@@ -182,7 +182,7 @@ const buildMultiEnvSource = (
   )
 
   const promote = async (selectors: ElementSelector[] | ElemID[]): Promise<void> => {
-    const ids = await toElemIDs(selectors, primarySource())
+    const ids = await getElemIDs(selectors, primarySource())
     const routedChanges = await routePromote(
       ids,
       primarySource(),
@@ -193,7 +193,7 @@ const buildMultiEnvSource = (
   }
 
   const demote = async (selectors: ElementSelector[] | ElemID[]): Promise<void> => {
-    const ids = await toElemIDs(selectors, commonSource())
+    const ids = await getElemIDs(selectors, commonSource())
     const routedChanges = await routeDemote(
       ids,
       primarySource(),
@@ -208,7 +208,7 @@ const buildMultiEnvSource = (
     const targetSources = _.isEmpty(targetEnvs)
       ? secondarySources()
       : _.pick(secondarySources(), targetEnvs)
-    const ids = await toElemIDs(selectors, primarySource())
+    const ids = await getElemIDs(selectors, primarySource())
     const routedChanges = await routeCopyTo(
       ids,
       primarySource(),

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -113,10 +113,10 @@ export type Workspace = {
   updateServiceConfig: (service: string, newConfig: Readonly<InstanceElement>) => Promise<void>
 
   getStateRecency(services: string): Promise<StateRecency>
-  promote(selectors: ElementSelector[]): Promise<void>
-  demote(selectors: ElementSelector[]): Promise<void>
+  promote(selectors: ElementSelector[] | ElemID[]): Promise<void>
+  demote(selectors: ElementSelector[] | ElemID[]): Promise<void>
   demoteAll(): Promise<void>
-  copyTo(selectors: ElementSelector[], targetEnvs?: string[]): Promise<void>
+  copyTo(selectors: ElementSelector[] | ElemID[], targetEnvs?: string[]): Promise<void>
 }
 
 // common source has no state
@@ -268,10 +268,10 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
     getTotalSize: () => naclFilesSource.getTotalSize(),
     getNaclFile: (filename: string) => naclFilesSource.getNaclFile(filename),
     getParsedNaclFile: (filename: string) => naclFilesSource.getParsedNaclFile(filename),
-    promote: (selectors: ElementSelector[]) => naclFilesSource.promote(selectors),
-    demote: (selectors: ElementSelector[]) => naclFilesSource.demote(selectors),
+    promote: (selectors: ElementSelector[] | ElemID[]) => naclFilesSource.promote(selectors),
+    demote: (selectors: ElementSelector[] | ElemID[]) => naclFilesSource.demote(selectors),
     demoteAll: () => naclFilesSource.demoteAll(),
-    copyTo: (selectors: ElementSelector[],
+    copyTo: (selectors: ElementSelector[] | ElemID[],
       targetEnvs: string[]) => naclFilesSource.copyTo(selectors, targetEnvs),
     transformToWorkspaceError,
     transformError,

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -369,49 +369,99 @@ describe('multi env source', () => {
     })
   })
   describe('copyTo', () => {
-    it('should route a copy to the proper env sources when specified', async () => {
+    describe('with selectors', () => {
       const ids = createElementSelectors(['salto.*']).validSelectors
-      jest.spyOn(routers, 'routeCopyTo').mockImplementationOnce(
-        () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
-      )
-      await source.copyTo(ids, ['inactive'])
-      expect(routers.routeCopyTo).toHaveBeenCalledWith(
-        [envElemID, objectElemID], envSource, { inactive: inactiveSource }
-      )
+      it('should route a copy to the proper env sources when specified', async () => {
+        jest.spyOn(routers, 'routeCopyTo').mockImplementationOnce(
+          () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
+        )
+        await source.copyTo(ids, ['inactive'])
+        expect(routers.routeCopyTo).toHaveBeenCalledWith(
+          [envElemID, objectElemID], envSource, { inactive: inactiveSource }
+        )
+      })
+      it('should route a copy to all env sources when not specified', async () => {
+        jest.spyOn(routers, 'routeCopyTo').mockImplementationOnce(
+          () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
+        )
+        await source.copyTo(ids)
+        expect(routers.routeCopyTo).toHaveBeenCalledWith(
+          [envElemID, objectElemID], envSource, { inactive: inactiveSource }
+        )
+      })
     })
-    it('should route a copy to all env sources when not specified', async () => {
-      const ids = createElementSelectors(['salto.*']).validSelectors
-      jest.spyOn(routers, 'routeCopyTo').mockImplementationOnce(
-        () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
-      )
-      await source.copyTo(ids)
-      expect(routers.routeCopyTo).toHaveBeenCalledWith(
-        [envElemID, objectElemID], envSource, { inactive: inactiveSource }
-      )
+    describe('with ids', () => {
+      const ids = [new ElemID('salto', 'Account')]
+      it('should route a copy to the proper env sources when specified', async () => {
+        jest.spyOn(routers, 'routeCopyTo').mockImplementationOnce(
+          () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
+        )
+        await source.copyTo(ids, ['inactive'])
+        expect(routers.routeCopyTo).toHaveBeenCalledWith(
+          ids, envSource, { inactive: inactiveSource }
+        )
+      })
+      it('should route a copy to all env sources when not specified', async () => {
+        jest.spyOn(routers, 'routeCopyTo').mockImplementationOnce(
+          () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
+        )
+        await source.copyTo(ids)
+        expect(routers.routeCopyTo).toHaveBeenCalledWith(
+          ids, envSource, { inactive: inactiveSource }
+        )
+      })
     })
   })
   describe('promote', () => {
-    it('should route promote the proper ids', async () => {
-      const ids = createElementSelectors(['salto.*']).validSelectors
-      jest.spyOn(routers, 'routePromote').mockImplementationOnce(
-        () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
-      )
-      await source.promote(ids)
-      expect(routers.routePromote).toHaveBeenCalledWith(
-        [envElemID, objectElemID], envSource, commonSource, { inactive: inactiveSource }
-      )
+    describe('with selectors', () => {
+      it('should route promote the proper ids', async () => {
+        const ids = createElementSelectors(['salto.*']).validSelectors
+        jest.spyOn(routers, 'routePromote').mockImplementationOnce(
+          () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
+        )
+        await source.promote(ids)
+        expect(routers.routePromote).toHaveBeenCalledWith(
+          [envElemID, objectElemID], envSource, commonSource, { inactive: inactiveSource }
+        )
+      })
+    })
+    describe('with ids', () => {
+      it('should route promote the proper ids', async () => {
+        const ids = [new ElemID('salto', 'Account')]
+        jest.spyOn(routers, 'routePromote').mockImplementationOnce(
+          () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
+        )
+        await source.promote(ids)
+        expect(routers.routePromote).toHaveBeenCalledWith(
+          ids, envSource, commonSource, { inactive: inactiveSource }
+        )
+      })
     })
   })
   describe('demote', () => {
-    it('should route demote the proper ids', async () => {
-      const ids = createElementSelectors(['salto.*']).validSelectors
-      jest.spyOn(routers, 'routeDemote').mockImplementationOnce(
-        () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
-      )
-      await source.demote(ids)
-      expect(routers.routeDemote).toHaveBeenCalledWith(
-        [commonObject.elemID, objectElemID], envSource, commonSource, { inactive: inactiveSource }
-      )
+    describe('with selectors', () => {
+      it('should route demote the proper ids', async () => {
+        const ids = createElementSelectors(['salto.*']).validSelectors
+        jest.spyOn(routers, 'routeDemote').mockImplementationOnce(
+          () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
+        )
+        await source.demote(ids)
+        expect(routers.routeDemote).toHaveBeenCalledWith(
+          [commonObject.elemID, objectElemID], envSource, commonSource, { inactive: inactiveSource }
+        )
+      })
+    })
+    describe('with ids', () => {
+      it('should route demote the proper ids', async () => {
+        const ids = [new ElemID('salto', 'Account')]
+        jest.spyOn(routers, 'routeDemote').mockImplementationOnce(
+          () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
+        )
+        await source.demote(ids)
+        expect(routers.routeDemote).toHaveBeenCalledWith(
+          ids, envSource, commonSource, { inactive: inactiveSource }
+        )
+      })
     })
   })
   describe('demoteAll', () => {


### PR DESCRIPTION
Leaving this open for now, but it may be closed next week.

---

Small addition to https://github.com/salto-io/salto/pull/1558 - allow passing explicit ElemIDs to the workspace functions and skipping the selector resolution logic, for use in calls made from core (like https://github.com/salto-io/salto/pull/1609).

It may eventually be worth moving this support into the selectors themselves, which can give better support for mixed lists instead of either/or - not doing that for now as this is mostly intended to unblock the other PR.
If there are objections, the alternative is to translate the elem ids into selectors. That would require going through the selector flow which would be slightly less efficient.