### PR TITLE
SALTO-839: added validation for env name

### DIFF
--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -187,7 +187,7 @@ export const getConfigWithHeader = async (output: WriteStream, credentialsType: 
 }
 
 export const getEnvName = async (currentName = 'env1'): Promise<string> => {
-  const questions: Array<inquirer.Question> = [{
+  const questions: inquirer.Questions = [{
     type: 'input',
     mask: '*',
     message: 'Enter a name for the first environment in the workspace',

--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -187,18 +187,13 @@ export const getConfigWithHeader = async (output: WriteStream, credentialsType: 
 }
 
 export const getEnvName = async (currentName = 'env1'): Promise<string> => {
-  const questions = [{
+  const questions: Array<inquirer.Question> = [{
     type: 'input',
     mask: '*',
     message: 'Enter a name for the first environment in the workspace',
     name: currentName,
     default: currentName,
-    validate: (input: string): boolean | string => {
-      if (input === '') {
-        return 'Environment name cannot be empty'
-      }
-      return true
-    },
+    validate: input => (input === '' ? 'Environment name cannot be empty' : true),
   }]
   return (await inquirer.prompt(questions))[currentName]
 }

--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -193,6 +193,12 @@ export const getEnvName = async (currentName = 'env1'): Promise<string> => {
     message: 'Enter a name for the first environment in the workspace',
     name: currentName,
     default: currentName,
+    validate: (input: string): boolean | string => {
+      if (input === '') {
+        return 'Environment name cannot be empty'
+      }
+      return true
+    },
   }]
   return (await inquirer.prompt(questions))[currentName]
 }


### PR DESCRIPTION
---

_Release Notes_:
Now returns an error message when trying to name the first environment as an empty string.

