### PR TITLE
SALTO-971: Added check for file's hash in the cache mechanism

### DIFF
--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -191,7 +191,7 @@ describe('Nacl Files Source', () => {
       const elemID = new ElemID('dummy', 'elem')
       const elem = new ObjectType({ elemID, path: ['test', 'new'] })
       const elements = [elem]
-      const parsedFiles = [{ filename, elements, errors: [], timestamp: 0, referenced: [] }]
+      const parsedFiles = [{ filename, elements, errors: [], timestamp: 0, referenced: [], buffer: '' }]
       const naclSource = naclFilesSource(
         mockDirStore, mockCache, mockedStaticFilesSource, parsedFiles
       )


### PR DESCRIPTION
Added check for files' hash in the cache mechanism in addition to the modification time check for cases where a NaCl file is modified, but its content was not changed (common scenario when working with git).

Also moved ParseResults and ParseError to a different file (types.ts) since they were declared multiple times.

---
Added check in the cache for md5 change. For that, I had to add the file's content to the ParseResultsKey so the cache will have access to it and be able to calculate its md5. Also, in order to save the last known md5 in the filesystem, I added it to the ParseResults and modified the serializer to serialize it as well.
Some types were declared multiple times, so I moved them to a common file.

_Release Notes:_
Fixed NaCls cache to use the cache in cases where a NaCl file was modified, but its content was not changed.