### PR TITLE
WIP: SALTO-1051 - hidden fields in innerTypes of lists validation

### DIFF
--- a/packages/hubspot-adapter/src/transformers/transformer.ts
+++ b/packages/hubspot-adapter/src/transformers/transformer.ts
@@ -16,7 +16,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import _ from 'lodash'
 import { ElemID, ObjectType, PrimitiveType, PrimitiveTypes, Field, isObjectType, getDeepInnerType, BuiltinTypes, InstanceElement, TypeElement, CORE_ANNOTATIONS, isListType, TypeMap, Values, isPrimitiveType, Value, ListType, createRestriction, StaticFile, isContainerType, isMapType } from '@salto-io/adapter-api'
-import { TransformFunc, transformValues, GetLookupNameFunc, toObjectType, naclCase } from '@salto-io/adapter-utils'
+import { TransformFunc, transformValues, GetLookupNameFunc, toObjectType, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { isFormInstance } from '../filters/form_field'
 import {
   FIELD_TYPES, FORM_FIELDS, HUBSPOT, OBJECTS_NAMES, FORM_PROPERTY_FIELDS,
@@ -248,26 +248,11 @@ export class Types {
         elemID: actionElemID,
         fields: {
           [ACTION_FIELDS.TYPE]: { type: BuiltinTypes.STRING },
-          [ACTION_FIELDS.ACTIONID]: {
-            type: BuiltinTypes.NUMBER,
-            annotations: {
-              [CORE_ANNOTATIONS.HIDDEN]: true,
-            },
-          },
+          [ACTION_FIELDS.ACTIONID]: { type: BuiltinTypes.NUMBER },
           [ACTION_FIELDS.DELAYMILLS]: { type: BuiltinTypes.NUMBER },
-          [ACTION_FIELDS.STEPID]: {
-            type: BuiltinTypes.NUMBER,
-            annotations: {
-              [CORE_ANNOTATIONS.HIDDEN]: true,
-            },
-          },
+          [ACTION_FIELDS.STEPID]: { type: BuiltinTypes.NUMBER },
           [ACTION_FIELDS.ANCHORSETTING]: { type: Types.anchorSettingType },
-          [ACTION_FIELDS.FILTERSLISTID]: {
-            type: BuiltinTypes.NUMBER,
-            annotations: {
-              [CORE_ANNOTATIONS.HIDDEN]: true,
-            },
-          },
+          [ACTION_FIELDS.FILTERSLISTID]: { type: BuiltinTypes.NUMBER },
           [ACTION_FIELDS.FILTERS]: { type: new ListType(new ListType(Types.criteriaType)) },
           [ACTION_FIELDS.PROPERTYNAME]: { type: BuiltinTypes.STRING },
           [ACTION_FIELDS.BODY]: { type: BuiltinTypes.STRING },
@@ -1046,7 +1031,7 @@ export const createHubspotInstanceElement = (
     new ElemID(HUBSPOT, instanceName).name,
     type,
     hubspotMetadata as Values,
-    [HUBSPOT, RECORDS_PATH, typeName, instanceName],
+    [HUBSPOT, RECORDS_PATH, typeName, pathNaclCase(instanceName)],
   )
 }
 

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -16,7 +16,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import {
   ObjectType, ElemID, BuiltinTypes, InstanceElement, CORE_ANNOTATIONS,
-  ReferenceExpression, PrimitiveType, PrimitiveTypes, MapType,
+  ReferenceExpression, PrimitiveType, PrimitiveTypes, MapType, Field,
   ListType, getRestriction, createRestriction, VariableExpression, Variable, StaticFile,
   INSTANCE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
@@ -370,6 +370,24 @@ describe('Elements validation', () => {
         [typeWithHidden, objWithListWithHidden]
       )
       expect(errors).toHaveLength(1)
+    })
+
+    it('should not get stuck or return errors if there is a cyclic type', () => {
+      const objWithCyclicElemID = new ElemID('salto', 'objWithCyclic')
+      const objWithCyclic = new ObjectType({
+        elemID: objWithCyclicElemID,
+        fields: {
+        },
+      })
+      objWithCyclic.fields.cyclic = new Field(
+        objWithCyclic,
+        'cyclic',
+        new ListType(objWithCyclic),
+      )
+      const errors = validateElements(
+        [objWithCyclic]
+      )
+      expect(errors).toHaveLength(0)
     })
 
     it('should return error if innerType of list has an hidden field in object inner to map', () => {

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -317,6 +317,97 @@ describe('Elements validation', () => {
       const errors = validateElements([objWithListAnnotation])
       expect(errors).toHaveLength(2)
     })
+
+    it('should return error if innerType of list has an hidden field', () => {
+      const typeWithHiddenElemID = new ElemID('salto', 'typeWithHidden')
+      const typeWithHidden = new ObjectType({
+        elemID: typeWithHiddenElemID,
+        fields: {
+          hiddenField: {
+            type: BuiltinTypes.STRING,
+            annotations: {
+              [CORE_ANNOTATIONS.HIDDEN]: true,
+            },
+          },
+        },
+      })
+      const objWithListWithHiddenElemID = new ElemID('salto', 'objWithListWithHidden')
+      const objWithListWithHidden = new ObjectType({
+        elemID: objWithListWithHiddenElemID,
+        fields: {
+          listField: {
+            type: new ListType(typeWithHidden),
+          },
+        },
+      })
+      const errors = validateElements([typeWithHidden, objWithListWithHidden])
+      expect(errors).toHaveLength(1)
+    })
+
+    it('should return error if innerType of list is map of object with hidden field', () => {
+      const typeWithHiddenElemID = new ElemID('salto', 'typeWithHidden')
+      const typeWithHidden = new ObjectType({
+        elemID: typeWithHiddenElemID,
+        fields: {
+          hiddenField: {
+            type: BuiltinTypes.STRING,
+            annotations: {
+              [CORE_ANNOTATIONS.HIDDEN]: true,
+            },
+          },
+        },
+      })
+      const objWithListWithHiddenElemID = new ElemID('salto', 'objWithListWithHidden')
+      const objWithListWithHidden = new ObjectType({
+        elemID: objWithListWithHiddenElemID,
+        fields: {
+          listField: {
+            type: new ListType(new MapType(typeWithHidden)),
+          },
+        },
+      })
+      const errors = validateElements(
+        [typeWithHidden, objWithListWithHidden]
+      )
+      expect(errors).toHaveLength(1)
+    })
+
+    it('should return error if innerType of list has an hidden field in object inner to map', () => {
+      const typeWithHiddenElemID = new ElemID('salto', 'typeWithHidden')
+      const typeWithHidden = new ObjectType({
+        elemID: typeWithHiddenElemID,
+        fields: {
+          hiddenField: {
+            type: BuiltinTypes.STRING,
+            annotations: {
+              [CORE_ANNOTATIONS.HIDDEN]: true,
+            },
+          },
+        },
+      })
+      const typeWithMapWithHiddenElemID = new ElemID('salto', 'typeWithMapWithHidden')
+      const typeWithMapWithHidden = new ObjectType({
+        elemID: typeWithMapWithHiddenElemID,
+        fields: {
+          mapField: {
+            type: new MapType(typeWithHidden),
+          },
+        },
+      })
+      const objWithListWithHiddenElemID = new ElemID('salto', 'objWithListWithHidden')
+      const objWithListWithHidden = new ObjectType({
+        elemID: objWithListWithHiddenElemID,
+        fields: {
+          listField: {
+            type: new ListType(typeWithMapWithHidden),
+          },
+        },
+      })
+      const errors = validateElements(
+        [typeWithHidden, typeWithMapWithHidden, objWithListWithHidden]
+      )
+      expect(errors).toHaveLength(1)
+    })
   })
 
   describe('validate instances', () => {


### PR DESCRIPTION
**What's here?**
* Add validation that there are no hidden fields in innerTypes of Lists (because we can not handle this case properly)
* Remove current cases in HubSpot