### PR TITLE
SALTO-1030: added support for relationshipName annotation

### DIFF
--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -1431,6 +1431,10 @@ describe('Salesforce adapter E2E with real account', () => {
                 const annotations = _.cloneDeep(field.annotations)
                 annotations[constants.API_NAME] = `${customObjectAddFieldsName}.${name}`
 
+                if (constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME in field.annotations) {
+                  annotations[constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME] = `${testAddFieldPrefix}${annotations[constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME]}`
+                }
+
                 if (name === CUSTOM_FIELD_NAMES.MULTI_PICKLIST) {
                   annotations[constants.VALUE_SET_DEFINITION_FIELDS.SORTED] = true
                 }
@@ -1965,6 +1969,8 @@ describe('Salesforce adapter E2E with real account', () => {
             [CORE_ANNOTATIONS.REQUIRED]: false,
             [constants.FIELD_ANNOTATIONS.ALLOW_LOOKUP_RECORD_DELETION]: true,
             [constants.FIELD_ANNOTATIONS.REFERENCE_TO]: ['Opportunity'],
+            [constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME]: CUSTOM_FIELD_NAMES.LOOKUP
+              .split(constants.SALESFORCE_CUSTOM_SUFFIX)[0],
             [constants.FIELD_ANNOTATIONS.LOOKUP_FILTER]: {
               [constants.LOOKUP_FILTER_FIELDS.ACTIVE]: false,
               [constants.LOOKUP_FILTER_FIELDS.BOOLEAN_FILTER]: '1',
@@ -2204,8 +2210,7 @@ describe('Salesforce adapter E2E with real account', () => {
             const annotations = fieldNamesToAnnotations[CUSTOM_FIELD_NAMES.MASTER_DETAIL]
             verifyFieldUpdate(
               CUSTOM_FIELD_NAMES.MASTER_DETAIL,
-              constants.FIELD_TYPE_NAMES.MASTER_DETAIL,
-              _.omit(annotations, constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME)
+              constants.FIELD_TYPE_NAMES.MASTER_DETAIL, annotations
             )
           })
 
@@ -2267,6 +2272,7 @@ describe('Salesforce adapter E2E with real account', () => {
             [constants.FIELD_ANNOTATIONS.REFERENCE_TO]: [
               'Case',
             ],
+            [constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME]: 'TestAddLookupFilterRelationshipName',
           },
         } },
         annotations: {
@@ -2302,6 +2308,7 @@ describe('Salesforce adapter E2E with real account', () => {
                   [constants.FILTER_ITEM_FIELDS.VALUE_FIELD]: '$User.Id' },
               ],
             },
+            [constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME]: 'TestAddLookupFilterRelationshipName',
           },
         } },
         annotations: {

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -558,6 +558,7 @@ export class Types {
         [FIELD_ANNOTATIONS.ALLOW_LOOKUP_RECORD_DELETION]: BuiltinTypes.BOOLEAN,
         [FIELD_ANNOTATIONS.REFERENCE_TO]: BuiltinTypes.STRING,
         [FIELD_ANNOTATIONS.LOOKUP_FILTER]: Types.lookupFilterType,
+        [FIELD_ANNOTATIONS.RELATIONSHIP_NAME]: BuiltinTypes.STRING,
       },
     }),
     MasterDetail: new PrimitiveType({
@@ -570,6 +571,7 @@ export class Types {
         [FIELD_ANNOTATIONS.LOOKUP_FILTER]: Types.lookupFilterType,
         [FIELD_ANNOTATIONS.REFERENCE_TO]: BuiltinTypes.STRING,
         [FIELD_ANNOTATIONS.RELATIONSHIP_ORDER]: restrictedNumberTypes.RelationshipOrder,
+        [FIELD_ANNOTATIONS.RELATIONSHIP_NAME]: BuiltinTypes.STRING,
       },
     }),
     Summary: new PrimitiveType({
@@ -839,7 +841,7 @@ export const toCustomField = (field: Field): CustomField => {
     field.annotations[FORMULA],
     field.annotations[FIELD_ANNOTATIONS.SUMMARY_FILTER_ITEMS],
     field.annotations[FIELD_ANNOTATIONS.REFERENCE_TO],
-    field.name.split(SALESFORCE_CUSTOM_SUFFIX)[0],
+    field.annotations[FIELD_ANNOTATIONS.RELATIONSHIP_NAME],
     field.annotations[FIELD_ANNOTATIONS.ALLOW_LOOKUP_RECORD_DELETION],
     field.annotations[FIELD_ANNOTATIONS.LENGTH],
   )

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -774,11 +774,13 @@ describe('transformer', () => {
 
     describe('reference field transformation', () => {
       const relatedTo = ['User', 'Property__c']
+      const relationshipName = 'relationship_name'
       const annotations: Values = {
         [API_NAME]: COMPOUND_FIELD_TYPE_NAMES.FIELD_NAME,
         [LABEL]: 'field_label',
         [CORE_ANNOTATIONS.REQUIRED]: false,
         [FIELD_ANNOTATIONS.REFERENCE_TO]: relatedTo,
+        [FIELD_ANNOTATIONS.RELATIONSHIP_NAME]: relationshipName,
       }
       const fieldName = COMPOUND_FIELD_TYPE_NAMES.FIELD_NAME
       const origObjectType = new ObjectType({
@@ -805,7 +807,7 @@ describe('transformer', () => {
         objectType.fields[fieldName].annotations[FIELD_ANNOTATIONS.ALLOW_LOOKUP_RECORD_DELETION] = false
         const customLookupField = toCustomField(objectType.fields[fieldName])
         assertCustomFieldTransformation(customLookupField,
-          FIELD_TYPE_NAMES.LOOKUP, 'Name', 'Restrict', relatedTo)
+          FIELD_TYPE_NAMES.LOOKUP, relationshipName, 'Restrict', relatedTo)
       })
 
       it('should transform lookup field with no deletion constraint', async () => {
@@ -813,7 +815,7 @@ describe('transformer', () => {
         objectType.fields[fieldName].annotations[FIELD_ANNOTATIONS.ALLOW_LOOKUP_RECORD_DELETION] = true
         const customLookupField = toCustomField(objectType.fields[fieldName])
         assertCustomFieldTransformation(customLookupField,
-          FIELD_TYPE_NAMES.LOOKUP, 'Name', 'SetNull', relatedTo)
+          FIELD_TYPE_NAMES.LOOKUP, relationshipName, 'SetNull', relatedTo)
       })
 
       it('should transform masterdetail field', async () => {
@@ -823,7 +825,7 @@ describe('transformer', () => {
         masterDetailField.annotations[FIELD_ANNOTATIONS.REPARENTABLE_MASTER_DETAIL] = true
         const customMasterDetailField = toCustomField(masterDetailField)
         assertCustomFieldTransformation(customMasterDetailField,
-          FIELD_TYPE_NAMES.MASTER_DETAIL, 'Name', undefined, relatedTo)
+          FIELD_TYPE_NAMES.MASTER_DETAIL, relationshipName, undefined, relatedTo)
         expect(customMasterDetailField.reparentableMasterDetail).toBe(true)
         expect(customMasterDetailField.writeRequiresMasterRead).toBe(true)
       })


### PR DESCRIPTION
---

_Release Notes:_
Added support for relationshipName annotation in lookup and master-detail fields.