### PR TITLE
SALTO-1053: Make elements with the same name in a different case go to the same file

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -369,9 +369,12 @@ const buildNaclFilesSource = (
       _(changesToUpdate)
         .map(change => getChangeLocations(change, mergedSourceMap))
         .flatten()
-        .groupBy(change => change.location.filename)
+        // Group changes file, we use lower case in order to support case insensitive file systems
+        .groupBy(change => change.location.filename.toLowerCase())
         .entries()
-        .map(([filename, fileChanges]) => async () => {
+        .map(([_lowerCaseFilename, fileChanges]) => async () => {
+          // Changes might have a different cased filename, we just take the first variation
+          const [filename] = fileChanges.map(change => change.location.filename).sort()
           try {
             const naclFileData = await getNaclFileData(filename)
             const buffer = await updateNaclFileData(naclFileData, fileChanges, functions)

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -347,7 +347,7 @@ describe('workspace', () => {
     )
 
     const queueSobjectHiddenSubType = new ObjectType({
-      elemID: new ElemID('salesforce', 'QueueSobject', 'type', ''),
+      elemID: new ElemID('salesforce', 'QueueSobject'),
       annotations: {
         [CORE_ANNOTATIONS.HIDDEN]: true,
         [METADATA_TYPE]: 'QueueSobject',
@@ -363,7 +363,7 @@ describe('workspace', () => {
 
 
     const accountInsightsSettingsType = new ObjectType({
-      elemID: new ElemID('salesforce', 'AccountInsightsSettings', 'type'),
+      elemID: new ElemID('salesforce', 'AccountInsightsSettings'),
       annotations: {
         [METADATA_TYPE]: 'AccountInsightsSettings',
       },
@@ -371,7 +371,7 @@ describe('workspace', () => {
     })
 
     const queueHiddenType = new ObjectType({
-      elemID: new ElemID('salesforce', 'Queue', 'type', ''),
+      elemID: new ElemID('salesforce', 'Queue'),
       annotations: {
         [CORE_ANNOTATIONS.HIDDEN]: true,
         [METADATA_TYPE]: 'Queue',
@@ -423,6 +423,13 @@ describe('workspace', () => {
         boolNotHidden: false,
       },
       ['Records', 'Queue', 'queueInstance'],
+    )
+
+    const differentCaseQueue = new InstanceElement(
+      'QueueInstance',
+      queueHiddenType,
+      queueInstance.value,
+      ['Records', 'Queue', 'QueueInstance'],
     )
 
     const renamedTypes = {
@@ -593,6 +600,13 @@ describe('workspace', () => {
         action: 'add',
         data: {
           after: queueInstance,
+        },
+      },
+      { // new instance with a similar name
+        id: differentCaseQueue.elemID,
+        action: 'add',
+        data: {
+          after: differentCaseQueue,
         },
       },
       { // Hidden field change to visible
@@ -814,6 +828,13 @@ describe('workspace', () => {
       // Not hidden fields values should be defined
       expect(newInstance.value.queueSobjectNotHidden).toBeDefined()
       expect(newInstance.value.boolNotHidden).toEqual(false)
+    })
+
+    it('should add different cased elements to the same file', () => {
+      expect(dirStore.set).toHaveBeenCalledWith(expect.objectContaining({
+        filename: 'Records/Queue/QueueInstance.nacl',
+        buffer: expect.stringMatching(/.*salesforce.Queue QueueInstance.*salesforce.Queue queueInstance.*/s),
+      }))
     })
 
     it('should not add changes in hidden values', () => {


### PR DESCRIPTION
This change makes elements that have the same name in a different case -
e.g. "salesforce.A" and "salesforce.a" - go to the same file even if they come in the same fetch

Before this change this was broken when working over case insensitive filesystems because
our code would think these are different files and we would override one element with the other

---
_Release Notes_:
- Fix issue where instances with similar names would override each other when working in Windows / Mac