### PR TITLE
Workspace selector interface

### DIFF
--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -54,12 +54,6 @@ export class ElemID {
     return ElemID.fromFullName(nameParts.join(ElemID.NAMESPACE_SEPARATOR))
   }
 
-  static isTopLevelType(idType: string, nameParts?: readonly string[]): boolean {
-    return ElemID.TOP_LEVEL_ID_TYPES.includes(idType)
-    || (ElemID.TOP_LEVEL_ID_TYPES_WITH_NAME.includes(idType)
-    && nameParts !== undefined && nameParts.length === 1)
-  }
-
   readonly adapter: string
   readonly typeName: string
   readonly idType: ElemIDType
@@ -142,7 +136,9 @@ export class ElemID {
   }
 
   isTopLevel(): boolean {
-    return ElemID.isTopLevelType(this.idType, this.nameParts)
+    return ElemID.TOP_LEVEL_ID_TYPES.includes(this.idType)
+    || (ElemID.TOP_LEVEL_ID_TYPES_WITH_NAME.includes(this.idType)
+    && this.nameParts !== undefined && this.nameParts.length === 1)
   }
 
   isEqual(other: ElemID): boolean {

--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -138,7 +138,7 @@ export class ElemID {
   isTopLevel(): boolean {
     return ElemID.TOP_LEVEL_ID_TYPES.includes(this.idType)
     || (ElemID.TOP_LEVEL_ID_TYPES_WITH_NAME.includes(this.idType)
-    && this.nameParts !== undefined && this.nameParts.length === 1)
+    && this.nameParts.length === 1)
   }
 
   isEqual(other: ElemID): boolean {

--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -18,7 +18,6 @@ import _ from 'lodash'
 export type ElemIDType = 'type' | 'field' | 'instance' | 'attr' | 'annotation' | 'var'
 export const ElemIDTypes = ['type', 'field', 'instance', 'attr', 'annotation', 'var'] as ReadonlyArray<string>
 export const isElemIDType = (v: string): v is ElemIDType => ElemIDTypes.includes(v)
-export const ElemIDTopLevelTypes = ['instance']
 
 export const INSTANCE_ANNOTATIONS = {
   DEPENDS_ON: '_depends_on',
@@ -31,7 +30,8 @@ export class ElemID {
   static readonly NUM_ELEM_ID_NON_NAME_PARTS = 3
   static readonly CONFIG_NAME = '_config'
   static readonly VARIABLES_NAMESPACE = 'var'
-  private static readonly TOP_LEVEL_ID_TYPES = ['type', 'var']
+  static readonly TOP_LEVEL_ID_TYPES_WITH_NAME = ['instance']
+  static readonly TOP_LEVEL_ID_TYPES = ['type', 'var']
 
   static getDefaultIdType = (adapter: string): ElemIDType => (adapter === ElemID.VARIABLES_NAMESPACE ? 'var' : 'type')
 
@@ -137,7 +137,7 @@ export class ElemID {
 
   isTopLevel(): boolean {
     return ElemID.TOP_LEVEL_ID_TYPES.includes(this.idType)
-      || (this.idType === 'instance' && this.nameParts.length === 1)
+      || (ElemID.TOP_LEVEL_ID_TYPES_WITH_NAME.includes(this.idType) && this.nameParts.length === 1)
   }
 
   isEqual(other: ElemID): boolean {
@@ -191,7 +191,7 @@ export class ElemID {
       // This is already the top level ID
       return { parent: this, path: [] }
     }
-    if (ElemIDTopLevelTypes.includes(this.idType)) {
+    if (ElemID.TOP_LEVEL_ID_TYPES_WITH_NAME.includes(this.idType)) {
       // Instance is a top level ID, the name of the instance is always the first name part
       return {
         parent: new ElemID(this.adapter, this.typeName, this.idType, this.nameParts[0]),

--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -54,6 +54,12 @@ export class ElemID {
     return ElemID.fromFullName(nameParts.join(ElemID.NAMESPACE_SEPARATOR))
   }
 
+  static isTopLevelType(idType: string, nameParts?: readonly string[]): boolean {
+    return ElemID.TOP_LEVEL_ID_TYPES.includes(idType)
+    || (ElemID.TOP_LEVEL_ID_TYPES_WITH_NAME.includes(idType)
+    && nameParts !== undefined && nameParts.length === 1)
+  }
+
   readonly adapter: string
   readonly typeName: string
   readonly idType: ElemIDType
@@ -136,8 +142,7 @@ export class ElemID {
   }
 
   isTopLevel(): boolean {
-    return ElemID.TOP_LEVEL_ID_TYPES.includes(this.idType)
-      || (ElemID.TOP_LEVEL_ID_TYPES_WITH_NAME.includes(this.idType) && this.nameParts.length === 1)
+    return ElemID.isTopLevelType(this.idType, this.nameParts)
   }
 
   isEqual(other: ElemID): boolean {

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -74,7 +74,7 @@ const cloneElement = async (
   cliTelemetry.start(workspaceTags)
   try {
     outputLine(Prompts.CLONE_TO_ENV_START(toEnvs), output)
-    await workspace.copyTo(selectors, toEnvs)
+    await workspace.copyTo(await workspace.getElementIdsBySelectors(selectors), toEnvs)
     await workspace.flush()
     cliTelemetry.success(workspaceTags)
     return CliExitCode.Success
@@ -98,11 +98,11 @@ const moveElement = async (
     switch (to) {
       case COMMON:
         outputLine(Prompts.MOVE_START('common'), output)
-        await workspace.promote(elmSelectors)
+        await workspace.promote(await workspace.getElementIdsBySelectors(elmSelectors))
         break
       case ENVS:
         outputLine(Prompts.MOVE_START('environment-specific folders'), output)
-        await workspace.demote(elmSelectors)
+        await workspace.demote(await workspace.getElementIdsBySelectors(elmSelectors, true))
         break
       default:
         errorOutputLine(formatInvalidMoveArg(to), output)

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -20,7 +20,6 @@ import { Spinner, SpinnerCreator, CliExitCode, CliTelemetry } from '../../src/ty
 import { command } from '../../src/commands/element'
 
 import * as mocks from '../mocks'
-import { expectElementSelector } from '../utils'
 import * as mockCliWorkspace from '../../src/workspace/workspace'
 import { buildEventName, getCliTelemetry } from '../../src/telemetry'
 import Prompts from '../../src/prompts'
@@ -450,6 +449,7 @@ describe('element command', () => {
         workspace,
         errored: false,
       })
+      workspace.getElementIdsBySelectors = jest.fn().mockResolvedValue([selector])
       result = await command(
         '',
         cliOutput,
@@ -469,7 +469,7 @@ describe('element command', () => {
       expect(result).toBe(CliExitCode.Success)
     })
     it('should call workspace copyTo', () => {
-      expect(workspace.copyTo).toHaveBeenCalledWith(expectElementSelector(selector.getFullName()), ['inactive'])
+      expect(workspace.copyTo).toHaveBeenCalledWith([selector], ['inactive'])
     })
 
     it('should flush workspace', () => {
@@ -617,6 +617,7 @@ describe('element command', () => {
         workspace,
         errored: false,
       })
+      workspace.getElementIdsBySelectors = jest.fn().mockResolvedValue([selector])
       result = await command(
         '',
         cliOutput,
@@ -636,7 +637,7 @@ describe('element command', () => {
       expect(result).toBe(CliExitCode.Success)
     })
     it('should call workspace promote', () => {
-      expect(workspace.promote).toHaveBeenCalledWith(expectElementSelector(selector.getFullName()))
+      expect(workspace.promote).toHaveBeenCalledWith([selector])
     })
 
     it('should flush workspace', () => {
@@ -666,6 +667,7 @@ describe('element command', () => {
         workspace,
         errored: false,
       })
+      workspace.getElementIdsBySelectors = jest.fn().mockResolvedValue([selector])
       result = await command(
         '',
         cliOutput,
@@ -685,7 +687,7 @@ describe('element command', () => {
       expect(result).toBe(CliExitCode.Success)
     })
     it('should call workspace demote', () => {
-      expect(workspace.demote).toHaveBeenCalledWith(expectElementSelector(selector.getFullName()))
+      expect(workspace.demote).toHaveBeenCalledWith([selector])
     })
 
     it('should flush workspace', () => {

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -252,6 +252,7 @@ export const mockLoadWorkspace = (
     errors: () => jest.fn().mockResolvedValue(mockErrors([])),
     isEmpty: jest.fn().mockResolvedValue(isEmpty),
     hasElementsInServices: jest.fn().mockResolvedValue(hasElementsInServices),
+    getElementIdsBySelectors: jest.fn(),
     getTotalSize: jest.fn().mockResolvedValue(0),
     addEnvironment: jest.fn(),
     deleteEnvironment: jest.fn(),

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -32,7 +32,7 @@ import * as serialization from './src/serializer/elements'
 import * as pathIndex from './src/workspace/path_index'
 import { createElementSelector, ElementSelector, validateSelectorsMatches,
   selectElementsBySelectors, createElementSelectors, ElementIDToValue,
-  getElementIdsFromSelectorsRecursively } from './src/workspace/element_selector'
+  selectElementIdsByTraversal } from './src/workspace/element_selector'
 import * as validator from './src/validator'
 
 export {
@@ -67,5 +67,5 @@ export {
   selectElementsBySelectors,
   createElementSelectors,
   ElementIDToValue,
-  getElementIdsFromSelectorsRecursively,
+  selectElementIdsByTraversal,
 }

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -31,8 +31,7 @@ import * as expressions from './src/expressions'
 import * as serialization from './src/serializer/elements'
 import * as pathIndex from './src/workspace/path_index'
 import { createElementSelector, ElementSelector, validateSelectorsMatches,
-  selectElementsBySelectors, createElementSelectors, ElementIDToValue,
-  selectElementIdsByTraversal } from './src/workspace/element_selector'
+  selectElementsBySelectors, createElementSelectors, ElementIDToValue } from './src/workspace/element_selector'
 import * as validator from './src/validator'
 
 export {
@@ -67,5 +66,4 @@ export {
   selectElementsBySelectors,
   createElementSelectors,
   ElementIDToValue,
-  selectElementIdsByTraversal,
 }

--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -215,9 +215,8 @@ export const selectElementIdsByTraversal = (
     }
     return undefined
   }
-
   stillRelevantElements.forEach(elemContainer => transformElement({
-    element: elemContainer.element, transformFunc: selectFromSubElements,
+    element: elemContainer.element, transformFunc: selectFromSubElements, runOnFields: true,
   }))
   return [...ids].map(id => ElemID.fromFullName(id))
 }

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -21,7 +21,7 @@ import { Element, ElemID, getChangeElement, isInstanceElement, Value,
   DetailedChange } from '@salto-io/adapter-api'
 import { applyInstancesDefaults } from '@salto-io/adapter-utils'
 import { promises } from '@salto-io/lowerdash'
-import { ElementSelector, getElementIdsFromSelectorsRecursively, ElementIDToValue } from '../../element_selector'
+import { ElementSelector, selectElementIdsByTraversal, ElementIDToValue } from '../../element_selector'
 import { ValidationError } from '../../../validator'
 import { ParseError, SourceRange, SourceMap } from '../../../parser'
 
@@ -173,8 +173,8 @@ const buildMultiEnvSource = (
 
   const getElementIdsBySelectors = async (selectors: ElementSelector[],
     commonOnly = false): Promise<ElemID[]> =>
-    (getElementIdsFromSelectorsRecursively(selectors,
-      await getElementsFromSource(commonOnly ? commonSource() : primarySource())))
+    (selectElementIdsByTraversal(selectors, await getElementsFromSource(commonOnly
+      ? commonSource() : primarySource())))
 
   const promote = async (ids: ElemID[]): Promise<void> => {
     const routedChanges = await routePromote(

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -173,8 +173,8 @@ const buildMultiEnvSource = (
 
   const getElementIdsBySelectors = async (selectors: ElementSelector[],
     commonOnly = false): Promise<ElemID[]> =>
-    (selectElementIdsByTraversal(selectors, await getElementsFromSource(commonOnly
-      ? commonSource() : primarySource())))
+    selectElementIdsByTraversal(selectors, await getElementsFromSource(commonOnly
+      ? commonSource() : primarySource()))
 
   const promote = async (ids: ElemID[]): Promise<void> => {
     const routedChanges = await routePromote(

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -56,10 +56,12 @@ type MultiEnvState = {
 
 type MultiEnvSource = Omit<NaclFilesSource, 'getAll'> & {
   getAll: (env?: string) => Promise<Element[]>
-  promote: (selectors: ElementSelector[]) => Promise<void>
-  demote: (selectors: ElementSelector[]) => Promise<void>
+  promote: (ids: ElemID[]) => Promise<void>
+  getElementIdsBySelectors: (selectors: ElementSelector[],
+    commonOnly?: boolean) => Promise<ElemID[]>
+  demote: (ids: ElemID[]) => Promise<void>
   demoteAll: () => Promise<void>
-  copyTo: (selectors: ElementSelector[], targetEnvs?: string[]) => Promise<void>
+  copyTo: (ids: ElemID[], targetEnvs?: string[]) => Promise<void>
 }
 
 const buildMultiEnvSource = (
@@ -169,9 +171,12 @@ const buildMultiEnvSource = (
   const getElementsFromSource = async (source: NaclFilesSource): Promise<ElementIDToValue[]> =>
     (await source.getAll()).map(elem => ({ elemID: elem.elemID, element: elem }))
 
-  const promote = async (selectors: ElementSelector[]): Promise<void> => {
-    const ids = (await getElementIdsFromSelectorsRecursively(selectors,
-      await getElementsFromSource(primarySource()))).map(elem => elem.elemID)
+  const getElementIdsBySelectors = async (selectors: ElementSelector[],
+    commonOnly = false): Promise<ElemID[]> =>
+    (getElementIdsFromSelectorsRecursively(selectors,
+      await getElementsFromSource(commonOnly ? commonSource() : primarySource())))
+
+  const promote = async (ids: ElemID[]): Promise<void> => {
     const routedChanges = await routePromote(
       ids,
       primarySource(),
@@ -181,9 +186,7 @@ const buildMultiEnvSource = (
     return applyRoutedChanges(routedChanges)
   }
 
-  const demote = async (selectors: ElementSelector[]): Promise<void> => {
-    const ids = (await getElementIdsFromSelectorsRecursively(selectors,
-      await getElementsFromSource(commonSource()))).map(elem => elem.elemID)
+  const demote = async (ids: ElemID[]): Promise<void> => {
     const routedChanges = await routeDemote(
       ids,
       primarySource(),
@@ -193,12 +196,10 @@ const buildMultiEnvSource = (
     return applyRoutedChanges(routedChanges)
   }
 
-  const copyTo = async (selectors: ElementSelector[], targetEnvs: string[] = []): Promise<void> => {
+  const copyTo = async (ids: ElemID[], targetEnvs: string[] = []): Promise<void> => {
     const targetSources = _.isEmpty(targetEnvs)
       ? secondarySources()
       : _.pick(secondarySources(), targetEnvs)
-    const ids = (await getElementIdsFromSelectorsRecursively(selectors,
-      await getElementsFromSource(primarySource()))).map(elem => elem.elemID)
     const routedChanges = await routeCopyTo(
       ids,
       primarySource(),
@@ -236,6 +237,7 @@ const buildMultiEnvSource = (
     getNaclFile,
     updateNaclFiles,
     flush,
+    getElementIdsBySelectors,
     promote,
     demote,
     demoteAll,

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -235,7 +235,6 @@ describe('select elements recursively', () => {
     const selectors = createElementSelectors(['mockAdapter.*', 'mockAdapter.*.instance.*',
       'mockAdapter.*.field.*',
       'mockAdapter.*.field.*.*',
-      'mockAdapter.*.attr',
       'mockAdapter.*.attr.testAnno']).validSelectors
     const elementIds = (await selectElementIdsByTraversal(selectors,
       [mockInstance, mockType].map(element => ({
@@ -250,7 +249,6 @@ describe('select elements recursively', () => {
       ElemID.fromFullName('mockAdapter.test.field.obj'),
       ElemID.fromFullName('mockAdapter.test.field.num'),
       ElemID.fromFullName('mockAdapter.test.field.strArray'),
-      ElemID.fromFullName('mockAdapter.test.attr'),
       ElemID.fromFullName('mockAdapter.test.attr.testAnno')].sort((e1,
       e2) => e1.getFullName().localeCompare(e2.getFullName()))
     expect(elementIds).toEqual(expectedElements)

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -241,7 +241,8 @@ describe('select elements recursively', () => {
       [mockInstance, mockType].map(element => ({
         elemID: element.elemID,
         element,
-      })))).sort((el1, el2) => (el1.getFullName() > el2.getFullName() ? 1 : -1))
+      })))).sort((e1,
+      e2) => e1.getFullName().localeCompare(e2.getFullName()))
     const expectedElements = [mockInstance.elemID, mockType.elemID,
       ElemID.fromFullName('mockAdapter.test.field.bool'),
       ElemID.fromFullName('mockAdapter.test.field.strMap'),
@@ -250,8 +251,8 @@ describe('select elements recursively', () => {
       ElemID.fromFullName('mockAdapter.test.field.num'),
       ElemID.fromFullName('mockAdapter.test.field.strArray'),
       ElemID.fromFullName('mockAdapter.test.attr'),
-      ElemID.fromFullName('mockAdapter.test.attr.testAnno')].sort((el1, el2) =>
-      (el1.getFullName() > el2.getFullName() ? 1 : -1))
+      ElemID.fromFullName('mockAdapter.test.attr.testAnno')].sort((e1,
+      e2) => e1.getFullName().localeCompare(e2.getFullName()))
     expect(elementIds).toEqual(expectedElements)
   })
   it('returns nothing with non-matching subelements', async () => {
@@ -260,7 +261,7 @@ describe('select elements recursively', () => {
       [mockInstance, mockType].map(element => ({
         elemID: element.elemID,
         element,
-      })))).sort((el1, el2) => (el1.getFullName() > el2.getFullName() ? 1 : -1))
+      }))))
     expect(elementIds).toEqual([])
   })
   it('removes fields of type from list when compact', async () => {
@@ -275,6 +276,18 @@ describe('select elements recursively', () => {
   })
 
   it('removes child elements of field from list', async () => {
+    const selectors = createElementSelectors([
+      'mockAdapter.test.field.strMap.*',
+      'mockAdapter.test.field.strMap']).validSelectors
+    const elementIds = (await selectElementIdsByTraversal(selectors,
+      [mockInstance, mockType].map(element => ({
+        elemID: element.elemID,
+        element,
+      })), true))
+    expect(elementIds).toEqual([ElemID.fromFullName('mockAdapter.test.field.strMap')])
+  })
+
+  it('ignores multiple instances of the same', async () => {
     const selectors = createElementSelectors([
       'mockAdapter.test.field.strMap.*',
       'mockAdapter.test.field.strMap']).validSelectors
@@ -307,8 +320,6 @@ describe('select elements recursively', () => {
         elemID: element.elemID,
         element,
       }))))
-    expect(elementIds).toEqual([
-      ElemID.fromFullName('mockAdapter.test.instance.mockInstance.bool'),
-    ])
+    expect(elementIds).toEqual([ElemID.fromFullName('mockAdapter.test.instance.mockInstance.bool')])
   })
 })

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -16,7 +16,7 @@
 import { ElemID, PrimitiveTypes, ObjectType, PrimitiveType, BuiltinTypes,
   ListType, MapType, InstanceElement } from '@salto-io/adapter-api'
 import { selectElementsBySelectors, createElementSelectors, createElementSelector,
-  getElementIdsFromSelectorsRecursively } from '../src/workspace/element_selector'
+  selectElementIdsByTraversal } from '../src/workspace/element_selector'
 
 const mockStrType = new PrimitiveType({
   elemID: new ElemID('mockAdapter', 'str'),
@@ -231,29 +231,24 @@ describe('select elements recursively', () => {
   it('finds subElements one and two layers deep', async () => {
     const selectors = createElementSelectors(['mockAdapter.*', 'mockAdapter.*.instance.*',
       'mockAdapter.*.field.*',
-      'mockAdapter.test.instance.mockInstance.bool',
-      'mockAdapter.test.instance.mockInstance.strMap.*',
-      'mockAdapter.test.annotation.*']).validSelectors
-    const elementIds = (await getElementIdsFromSelectorsRecursively(selectors,
+      '*.*.annotation.*.*']).validSelectors
+    const elementIds = (await selectElementIdsByTraversal(selectors,
       [mockInstance, mockType].map(element => ({
         elemID: element.elemID,
         element,
       })))).sort((el1, el2) => (el1.getFullName() > el2.getFullName() ? 1 : -1))
-    expect(elementIds).toEqual([mockInstance.elemID, mockType.elemID,
-      ElemID.fromFullName('mockAdapter.test.instance.mockInstance.bool'),
-      ElemID.fromFullName('mockAdapter.test.instance.mockInstance.strMap.bla'),
-      ElemID.fromFullName('mockAdapter.test.instance.mockInstance.strMap.a'),
+    const expectedElements = [mockInstance.elemID, mockType.elemID,
       ElemID.fromFullName('mockAdapter.test.field.bool'),
       ElemID.fromFullName('mockAdapter.test.field.strMap'),
       ElemID.fromFullName('mockAdapter.test.field.obj'),
       ElemID.fromFullName('mockAdapter.test.field.num'),
-      ElemID.fromFullName('mockAdapter.test.field.strArray'),
-      ElemID.fromFullName('mockAdapter.test.annotation.testAnno')].sort((el1, el2) =>
-      (el1.getFullName() > el2.getFullName() ? 1 : -1)))
+      ElemID.fromFullName('mockAdapter.test.field.strArray')].sort((el1, el2) =>
+      (el1.getFullName() > el2.getFullName() ? 1 : -1))
+    expect(elementIds).toEqual(expectedElements)
   })
   it('returns nothing with non-matching subelements', async () => {
     const selectors = createElementSelectors(['mockAdapter.test.instance.mockInstance.obj.NoSuchThingExists*']).validSelectors
-    const elementIds = (await getElementIdsFromSelectorsRecursively(selectors,
+    const elementIds = (await selectElementIdsByTraversal(selectors,
       [mockInstance, mockType].map(element => ({
         elemID: element.elemID,
         element,
@@ -263,7 +258,7 @@ describe('select elements recursively', () => {
   it('removes fields of type from list when compact', async () => {
     const selectors = createElementSelectors(['mockAdapter.*', 'mockAdapter.*.field.*',
       'mockAdapter.test.field.obj.*']).validSelectors
-    const elementIds = (await getElementIdsFromSelectorsRecursively(selectors,
+    const elementIds = (await selectElementIdsByTraversal(selectors,
       [mockInstance, mockType].map(element => ({
         elemID: element.elemID,
         element,
@@ -275,7 +270,7 @@ describe('select elements recursively', () => {
     const selectors = createElementSelectors(['mockAdapter.*.instance.*',
       'mockAdapter.test.instance.mockInstance.*',
       'mockAdapter.test.instance.mockInstance.strMap.*']).validSelectors
-    const elementIds = (await getElementIdsFromSelectorsRecursively(selectors,
+    const elementIds = (await selectElementIdsByTraversal(selectors,
       [mockInstance, mockType].map(element => ({
         elemID: element.elemID,
         element,
@@ -287,7 +282,7 @@ describe('select elements recursively', () => {
     const selectors = createElementSelectors([
       'mockAdapter.test.instance.mockInstance.bool',
     ]).validSelectors
-    const elementIds = (await getElementIdsFromSelectorsRecursively(selectors,
+    const elementIds = (await selectElementIdsByTraversal(selectors,
       [mockInstance, mockType].map(element => ({
         elemID: element.elemID,
         element,

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -370,21 +370,21 @@ describe('multi env source', () => {
   })
   describe('copyTo', () => {
     it('should route a copy to the proper env sources when specified', async () => {
-      const ids = createElementSelectors(['salto.*']).validSelectors
+      const selectors = createElementSelectors(['salto.*']).validSelectors
       jest.spyOn(routers, 'routeCopyTo').mockImplementationOnce(
         () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
       )
-      await source.copyTo(ids, ['inactive'])
+      await source.copyTo(await source.getElementIdsBySelectors(selectors), ['inactive'])
       expect(routers.routeCopyTo).toHaveBeenCalledWith(
         [envElemID, objectElemID], envSource, { inactive: inactiveSource }
       )
     })
     it('should route a copy to all env sources when not specified', async () => {
-      const ids = createElementSelectors(['salto.*']).validSelectors
+      const selectors = createElementSelectors(['salto.*']).validSelectors
       jest.spyOn(routers, 'routeCopyTo').mockImplementationOnce(
         () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
       )
-      await source.copyTo(ids)
+      await source.copyTo(await source.getElementIdsBySelectors(selectors))
       expect(routers.routeCopyTo).toHaveBeenCalledWith(
         [envElemID, objectElemID], envSource, { inactive: inactiveSource }
       )
@@ -392,11 +392,11 @@ describe('multi env source', () => {
   })
   describe('promote', () => {
     it('should route promote the proper ids', async () => {
-      const ids = createElementSelectors(['salto.*']).validSelectors
+      const selectors = createElementSelectors(['salto.*']).validSelectors
       jest.spyOn(routers, 'routePromote').mockImplementationOnce(
         () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
       )
-      await source.promote(ids)
+      await source.promote(await source.getElementIdsBySelectors(selectors))
       expect(routers.routePromote).toHaveBeenCalledWith(
         [envElemID, objectElemID], envSource, commonSource, { inactive: inactiveSource }
       )
@@ -404,11 +404,11 @@ describe('multi env source', () => {
   })
   describe('demote', () => {
     it('should route demote the proper ids', async () => {
-      const ids = createElementSelectors(['salto.*']).validSelectors
+      const selectors = createElementSelectors(['salto.*']).validSelectors
       jest.spyOn(routers, 'routeDemote').mockImplementationOnce(
         () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
       )
-      await source.demote(ids)
+      await source.demote(await source.getElementIdsBySelectors(selectors, true))
       expect(routers.routeDemote).toHaveBeenCalledWith(
         [commonObject.elemID, objectElemID], envSource, commonSource, { inactive: inactiveSource }
       )


### PR DESCRIPTION
Extract usage of selectors from outside workspace (mostly), so that its methods can be used with element ids.