### PR TITLE
fetch SControl content to static file

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -213,6 +213,7 @@ const metadataToRetrieveAndDeploy = [
   'Report', // contains encoded zip content, is under a folder
   'ReportFolder',
   'ReportType',
+  'Scontrol', // contains encoded zip content
   'SiteDotCom', // contains encoded zip content
   'StaticResource', // contains encoded zip content
   // Other types that need retrieve / deploy to work


### PR DESCRIPTION
Scontrol is a deprecated metadata type in salesforce that has a base64 encoded content field.
It slipped under the radar because it is not possible to create it in new organizations, but in a recent demo we did encounter an instance of it.
moving it to be fetched with `retrieve` like the rest of the metadata with content seemed to work well.

---
_Release Notes_
- Extract content of SControl metadata to static files