### PR TITLE
fixed e2e test

### DIFF
--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -2272,7 +2272,7 @@ describe('Salesforce adapter E2E with real account', () => {
             [constants.FIELD_ANNOTATIONS.REFERENCE_TO]: [
               'Case',
             ],
-            [constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME]: `TestAddLookupFilterRelationshipName${String(Date.now()).substring(6)}`,
+            [constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME]: fieldName,
           },
         } },
         annotations: {
@@ -2308,7 +2308,7 @@ describe('Salesforce adapter E2E with real account', () => {
                   [constants.FILTER_ITEM_FIELDS.VALUE_FIELD]: '$User.Id' },
               ],
             },
-            [constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME]: `TestAddLookupFilterRelationshipName${String(Date.now()).substring(6)}`,
+            [constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME]: fieldName,
           },
         } },
         annotations: {

--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -2272,7 +2272,7 @@ describe('Salesforce adapter E2E with real account', () => {
             [constants.FIELD_ANNOTATIONS.REFERENCE_TO]: [
               'Case',
             ],
-            [constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME]: 'TestAddLookupFilterRelationshipName',
+            [constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME]: `TestAddLookupFilterRelationshipName${String(Date.now()).substring(6)}`,
           },
         } },
         annotations: {
@@ -2308,7 +2308,7 @@ describe('Salesforce adapter E2E with real account', () => {
                   [constants.FILTER_ITEM_FIELDS.VALUE_FIELD]: '$User.Id' },
               ],
             },
-            [constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME]: 'TestAddLookupFilterRelationshipName',
+            [constants.FIELD_ANNOTATIONS.RELATIONSHIP_NAME]: `TestAddLookupFilterRelationshipName${String(Date.now()).substring(6)}`,
           },
         } },
         annotations: {


### PR DESCRIPTION
Fixed a bug where an e2e test failed because the value of relationshipName was already existed (even though we delete the element at the beginning of the test, it is not deleted immediately but moved to the recycle bin and deleted 15 days later)
The solution was to include a random string (based on the current date time) in the relationshipName.

---
_Release Notes:_ None