### PR TITLE
SALTO-910 - Add hidden annotation support with hidden_string type

### DIFF
--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -18,7 +18,7 @@ import { Element, TypeMap, ObjectType, PrimitiveType, PrimitiveTypes, ListType }
 
 export const GLOBAL_ADAPTER = ''
 
-export const BuiltinTypes = {
+const StandardBuiltinTypes = {
   STRING: new PrimitiveType({
     elemID: new ElemID(GLOBAL_ADAPTER, 'string'),
     primitive: PrimitiveTypes.STRING,
@@ -50,23 +50,24 @@ export const CORE_ANNOTATIONS = {
   REQUIRED: '_required',
   RESTRICTION: '_restriction',
   HIDDEN: '_hidden',
+  HIDDEN_VALUE: '_hidden_value',
 }
 
 export const InstanceAnnotationTypes: TypeMap = {
-  [INSTANCE_ANNOTATIONS.DEPENDS_ON]: new ListType(BuiltinTypes.STRING),
-  [INSTANCE_ANNOTATIONS.PARENT]: new ListType(BuiltinTypes.STRING),
-  [INSTANCE_ANNOTATIONS.GENERATED_DEPENDENCIES]: new ListType(BuiltinTypes.STRING),
+  [INSTANCE_ANNOTATIONS.DEPENDS_ON]: new ListType(StandardBuiltinTypes.STRING),
+  [INSTANCE_ANNOTATIONS.PARENT]: new ListType(StandardBuiltinTypes.STRING),
+  [INSTANCE_ANNOTATIONS.GENERATED_DEPENDENCIES]: new ListType(StandardBuiltinTypes.STRING),
 }
 
 const restrictionType = new ObjectType({
   elemID: new ElemID('', 'restriction'),
   fields: {
     // eslint-disable-next-line @typescript-eslint/camelcase
-    enforce_value: { type: BuiltinTypes.BOOLEAN },
-    values: { type: BuiltinTypes.STRING },
-    min: { type: BuiltinTypes.NUMBER },
-    max: { type: BuiltinTypes.NUMBER },
-    regex: { type: BuiltinTypes.STRING },
+    enforce_value: { type: StandardBuiltinTypes.BOOLEAN },
+    values: { type: StandardBuiltinTypes.STRING },
+    min: { type: StandardBuiltinTypes.NUMBER },
+    max: { type: StandardBuiltinTypes.NUMBER },
+    regex: { type: StandardBuiltinTypes.STRING },
   },
 })
 
@@ -79,10 +80,23 @@ type RestrictionAnnotationType = Partial<{
 }>
 
 export const CoreAnnotationTypes: TypeMap = {
-  [CORE_ANNOTATIONS.DEFAULT]: BuiltinTypes.STRING,
-  [CORE_ANNOTATIONS.REQUIRED]: BuiltinTypes.BOOLEAN,
+  [CORE_ANNOTATIONS.DEFAULT]: StandardBuiltinTypes.STRING,
+  [CORE_ANNOTATIONS.REQUIRED]: StandardBuiltinTypes.BOOLEAN,
   [CORE_ANNOTATIONS.RESTRICTION]: restrictionType,
-  [CORE_ANNOTATIONS.HIDDEN]: BuiltinTypes.BOOLEAN,
+  [CORE_ANNOTATIONS.HIDDEN]: StandardBuiltinTypes.BOOLEAN,
+  [CORE_ANNOTATIONS.HIDDEN_VALUE]: StandardBuiltinTypes.BOOLEAN,
+}
+
+export const BuiltinTypes = {
+  ...StandardBuiltinTypes,
+  HIDDEN_STRING: new PrimitiveType({
+    elemID: new ElemID(GLOBAL_ADAPTER, 'hidden_string'),
+    primitive: PrimitiveTypes.STRING,
+    annotationTypes: CoreAnnotationTypes,
+    annotations: {
+      [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+    },
+  }),
 }
 
 export const getRestriction = (

--- a/packages/cli/e2e_test/salto.test.ts
+++ b/packages/cli/e2e_test/salto.test.ts
@@ -332,7 +332,7 @@ describe('cli e2e', () => {
     })
 
 
-    it('should not hide Types folder', async () => {
+    it('should hide Types folder', async () => {
       expect(await exists(`${fetchOutputDir}/salesforce/Types`))
         .toBe(false)
     })

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -62,6 +62,10 @@ describe('fetch', () => {
         type: BuiltinTypes.STRING,
         annotations: { [CORE_ANNOTATIONS.HIDDEN]: true },
       },
+      hiddenValue: {
+        type: BuiltinTypes.STRING,
+        annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+      },
     },
     path: ['records', 'hidden'],
   })
@@ -70,6 +74,7 @@ describe('fetch', () => {
     reg: 'reg',
     notHidden: 'notHidden',
     hidden: 'Hidden',
+    hiddenValue: 'hidden val',
   })
 
   // // Workspace elements should not contains hidden values
@@ -259,11 +264,13 @@ describe('fetch', () => {
 
     describe('when the change is only in the service', () => {
       const hiddenChangedVal = 'hiddenChanged'
+      const hiddenValueChangedVal = 'hiddenChanged2'
 
       beforeEach(async () => {
         // the (changed) service instance
         const hiddenInstanceFromService = hiddenInstance.clone()
         hiddenInstanceFromService.value.hidden = hiddenChangedVal
+        hiddenInstanceFromService.value.hiddenValue = hiddenValueChangedVal
         hiddenInstanceFromService.value.notHidden = 'notHiddenChanged'
 
         mockAdapters.dummy.fetch.mockResolvedValueOnce(
@@ -280,13 +287,15 @@ describe('fetch', () => {
       })
 
       it('should return the change with no conflict', () => {
-        expect(changes).toHaveLength(3)
+        expect(changes).toHaveLength(4)
         changes.forEach(c => expect(c.pendingChange).toBeUndefined())
       })
 
       it('shouldn not remove hidden values from changes', () => {
         // changes.forEach(c => expect(isModificationChange(c.change)).toEqual(true))
         expect(changes.some(c => (getChangeElement(c.change)) === hiddenChangedVal))
+          .toBeTruthy()
+        expect(changes.some(c => (getChangeElement(c.change)) === hiddenValueChangedVal))
           .toBeTruthy()
       })
     })

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1321,6 +1321,7 @@ const createIdField = (parent: ObjectType): void => {
     BuiltinTypes.STRING,
     {
       [CORE_ANNOTATIONS.REQUIRED]: false,
+      // TODO change to HIDDEN_VALUE (need to handle upgrade remove+add)
       [CORE_ANNOTATIONS.HIDDEN]: true,
       [FIELD_ANNOTATIONS.LOCAL_ONLY]: true,
     }

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -17,19 +17,9 @@ import _ from 'lodash'
 import { values } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import {
-  CORE_ANNOTATIONS, Element,
-  isInstanceElement, isType,
-  TypeElement,
-  getField,
-  DetailedChange,
-  isRemovalChange,
-  ElemID,
-  isObjectType,
-  ObjectType,
-  Values,
-  isRemovalOrModificationChange,
-  isAdditionOrModificationChange,
-  isElement,
+  CORE_ANNOTATIONS, Element, isInstanceElement, isType, TypeElement, getField, DetailedChange,
+  isRemovalChange, ElemID, isObjectType, ObjectType, Values, isRemovalOrModificationChange,
+  isAdditionOrModificationChange, isElement, isField,
 } from '@salto-io/adapter-api'
 import { transformElement, TransformFunc, transformValues, applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { mergeElements, MergeResult } from '../merger'
@@ -38,8 +28,13 @@ import { createAddChange, createRemoveChange } from './nacl_files/multi_env/proj
 
 const log = logger(module)
 
+const isHiddenValue = (element?: Element): boolean => (
+  element?.annotations?.[CORE_ANNOTATIONS.HIDDEN_VALUE] === true
+)
+
 const isHidden = (element?: Element): boolean => (
   element?.annotations?.[CORE_ANNOTATIONS.HIDDEN] === true
+  || ((isInstanceElement(element) || isField(element)) && isHiddenValue(element.type))
 )
 
 const splitElementHiddenParts = <T extends Element>(
@@ -78,9 +73,12 @@ const splitElementHiddenParts = <T extends Element>(
     // because then we'd never reach A.B.C
     // We also do not omit A.B.C.D because A.B.C was hidden, so by association everything inside
     // it is also hidden
-    path !== undefined && hiddenPaths.some(hiddenPath => (
-      path.isEqual(hiddenPath) || hiddenPath.isParentOf(path) || path.isParentOf(hiddenPath)
-    ))
+    path !== undefined && (
+      hiddenPaths.some(hiddenPath =>
+        (path.isEqual(hiddenPath) || hiddenPath.isParentOf(path) || path.isParentOf(hiddenPath)))
+      // workaround to enable reaching annotation values
+      || path.isEqual(path.createTopLevelParentID().parent.createNestedID('attr'))
+    )
   )
 
   const hidden = transformElement({
@@ -88,6 +86,8 @@ const splitElementHiddenParts = <T extends Element>(
     transformFunc: ({ value, path }) => (isPartOfHiddenPath(path) ? value : undefined),
     strict: true,
   })
+  // remove all annotation types from the hidden element so they don't cause merge conflicts
+  hidden.annotationTypes = {}
   return { hidden, visible }
 }
 
@@ -128,26 +128,25 @@ const removeHiddenFromValues = (
   })
 )
 
-const isChangeToHidden = (change: DetailedChange): boolean => (
-  change.id.name === CORE_ANNOTATIONS.HIDDEN
+const isChangeToHidden = (change: DetailedChange, hiddenValue: boolean): boolean => (
+  change.id.name === (hiddenValue ? CORE_ANNOTATIONS.HIDDEN_VALUE : CORE_ANNOTATIONS.HIDDEN)
   && isAdditionOrModificationChange(change) && change.data.after === true
 )
 
-const isChangeToNotHidden = (change: DetailedChange): boolean => (
-  change.id.name === CORE_ANNOTATIONS.HIDDEN
+const isChangeToNotHidden = (change: DetailedChange, hiddenValue: boolean): boolean => (
+  change.id.name === (hiddenValue ? CORE_ANNOTATIONS.HIDDEN_VALUE : CORE_ANNOTATIONS.HIDDEN)
   && isRemovalOrModificationChange(change) && change.data.before === true
 )
-
-const isHiddenChangeOnElement = (change: DetailedChange): boolean => (
+const isHiddenChangeOnElement = (change: DetailedChange, hiddenValue: boolean): boolean => (
   change.id.idType === 'attr'
   && change.id.nestingLevel === 1
-  && (isChangeToHidden(change) || isChangeToNotHidden(change))
+  && (isChangeToHidden(change, hiddenValue) || isChangeToNotHidden(change, hiddenValue))
 )
 
-const isHiddenChangeOnField = (change: DetailedChange): boolean => (
+const isHiddenChangeOnField = (change: DetailedChange, hiddenValue: boolean): boolean => (
   change.id.idType === 'field'
   && change.id.nestingLevel === 2
-  && (isChangeToHidden(change) || isChangeToNotHidden(change))
+  && (isChangeToHidden(change, hiddenValue) || isChangeToNotHidden(change, hiddenValue))
 )
 
 /**
@@ -160,7 +159,7 @@ const getHiddenTypeChanges = async (
 ): Promise<DetailedChange[]> => (
   (await Promise.all(
     changes
-      .filter(isHiddenChangeOnElement)
+      .filter(c => isHiddenChangeOnElement(c, false))
       .map(async change => {
         const elemId = change.id.createTopLevelParentID().parent
         const elem = await state.get(elemId)
@@ -168,11 +167,11 @@ const getHiddenTypeChanges = async (
           // Should never happen
           log.warn(
             'Element %s was changed to hidden %s but was not found in state',
-            elemId.getFullName(), isChangeToHidden(change),
+            elemId.getFullName(), isChangeToHidden(change, false),
           )
           return change
         }
-        return isChangeToHidden(change)
+        return isChangeToHidden(change, false)
           ? createRemoveChange(elem, elemId)
           : createAddChange(elem, elemId)
       })
@@ -180,21 +179,33 @@ const getHiddenTypeChanges = async (
 )
 
 /**
- * When a field changes from/to hidden, we need to create changes that add/remove the values
- * of that field in all relevant instances / annotation values
+ * When a field or annotation changes from/to hidden, we need to create changes that add/remove
+ * the values of that field in all relevant instances / annotation values
  */
-const getHiddenFieldValueChanges = async (
+const getHiddenFieldAndAnnotationValueChanges = async (
   changes: DetailedChange[],
   state: State,
   getWorkspaceElements: () => Promise<Element[]>,
 ): Promise<DetailedChange[]> => {
-  const hiddenFieldChanges = changes.filter(isHiddenChangeOnField)
+  // TODO checking both _hidden and _hidden_value for backward compatibility in calls to
+  // isHiddenChangeOnField and isChangeToHidden - should change to
+  //  1. only hide values when _hidden_value=true
+  //  2. hide fields marked with _hidden=true
+  // once all existing usages of _hidden for hiding values are eliminated
+  // (all current scenarios of 2 are intended only to hide the value).
+  const hiddenFieldChanges = changes.filter(c =>
+    isHiddenChangeOnField(c, true) || isHiddenChangeOnField(c, false)
+    || isHiddenChangeOnElement(c, true))
   if (hiddenFieldChanges.length === 0) {
     // This should be the common case where there are no changes to the hidden annotation
     return []
   }
 
-  const [hideFieldChanges, unHideFieldChanges] = _.partition(hiddenFieldChanges, isChangeToHidden)
+  const [hideFieldChanges, unHideFieldChanges] = _.partition(
+    hiddenFieldChanges,
+    // TODO should only check _hidden_value (true)
+    c => isChangeToHidden(c, true) || isChangeToHidden(c, false),
+  )
   const hideFieldIds = new Set(
     hideFieldChanges.map(change => change.id.createParentID().getFullName())
   )
@@ -219,7 +230,7 @@ const getHiddenFieldValueChanges = async (
     return value
   }
 
-  // In order to support making a field visible we must traverse all state elements
+  // In order to support making a field/annotation visible we must traverse all state elements
   // to find all the hidden values we need to add.
   // Theoretically in order to hide values we would need to iterate the workspace elements
   // but since we assume a redundant remove change is handled gracefully, we optimize this
@@ -276,7 +287,7 @@ const mergeWithHiddenChangeSideEffects = async (
 ): Promise<DetailedChange[]> => {
   const additionalChanges = [
     ...await getHiddenTypeChanges(changes, state),
-    ...await getHiddenFieldValueChanges(changes, state, getWorkspaceElements),
+    ...await getHiddenFieldAndAnnotationValueChanges(changes, state, getWorkspaceElements),
   ]
   // Additional changes may override / be overridden by original changes, so if we add new changes
   // we have to make sure we remove duplicates
@@ -285,12 +296,17 @@ const mergeWithHiddenChangeSideEffects = async (
     : removeDuplicateChanges(changes, additionalChanges)
 }
 
-const isHiddenField = (baseType: TypeElement, fieldPath: ReadonlyArray<string>): boolean => (
-  fieldPath.length === 0
+const isHiddenField = (
+  baseType: TypeElement,
+  fieldPath: ReadonlyArray<string>,
+  hiddenValue: boolean,
+): boolean => {
+  const hiddenFunc = hiddenValue ? isHiddenValue : isHidden
+  return fieldPath.length === 0
     ? false
-    : isHidden(getField(baseType, fieldPath))
-      || isHiddenField(baseType, fieldPath.slice(0, -1))
-)
+    : hiddenFunc(getField(baseType, fieldPath))
+      || isHiddenField(baseType, fieldPath.slice(0, -1), hiddenValue)
+}
 
 const filterOutHiddenChanges = async (
   changes: DetailedChange[],
@@ -316,26 +332,55 @@ const filterOutHiddenChanges = async (
       return undefined
     }
 
-    if (isInstanceElement(baseElem) || (isObjectType(baseElem) && change.id.idType === 'attr')) {
-      // Instance values and annotation values can be hidden
-      const [changeType, valuePath] = isInstanceElement(baseElem)
-        ? [baseElem.type, path]
-        : [baseElem.annotationTypes[path[0]], path.slice(1)]
+    if (isElement(change.data.after)) {
+      // Remove nested hidden parts of instances, object types and fields
+      return applyFunctionToChangeData(change, removeHiddenFromElement)
+    }
 
+    if (isInstanceElement(baseElem)
+      || (isObjectType(baseElem) && ['field', 'attr'].includes(change.id.idType))) {
+      // Instance values and annotation values in fields and objects can be hidden
+      const getChangeTypeAndPath = (): {
+        changeType: TypeElement
+        changePath: ReadonlyArray<string>
+      } => {
+        if (isInstanceElement(baseElem)) {
+          return {
+            changeType: baseElem.type,
+            changePath: path,
+          }
+        }
+        if (change.id.idType === 'attr') {
+          return {
+            changeType: baseElem.annotationTypes[path[0]],
+            changePath: path.slice(1),
+          }
+        }
+        // idType === 'field'
+        return {
+          // changeType will be undefined if the path is too short
+          changeType: baseElem.fields[path[0]].type.annotationTypes[path[1]],
+          changePath: path.slice(2),
+        }
+      }
+
+      const { changeType, changePath } = getChangeTypeAndPath()
       if (changeType === undefined) {
         // a value without a type cannot be hidden
         return change
       }
 
-      if (isHiddenField(changeType, valuePath)) {
+      if (isHiddenValue(changeType)) {
+        // The change is in a hidden annotation, omit it
+        return undefined
+      }
+
+      if (isHiddenField(changeType, changePath, isInstanceElement(baseElem))) {
         // The change is inside a hidden field value, omit the change
         return undefined
       }
-      // The change subject is not hidden, but it might contain hidden parts
-      if (isInstanceElement(change.data.after)) {
-        return applyFunctionToChangeData(change, removeHiddenFromElement)
-      }
-      const fieldType = changeType && getField(changeType, valuePath)?.type
+
+      const fieldType = changeType && getField(changeType, changePath)?.type
       if (isObjectType(fieldType)) {
         return applyFunctionToChangeData(
           change,

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -296,17 +296,12 @@ const mergeWithHiddenChangeSideEffects = async (
     : removeDuplicateChanges(changes, additionalChanges)
 }
 
-const isHiddenField = (
-  baseType: TypeElement,
-  fieldPath: ReadonlyArray<string>,
-  hiddenValue: boolean,
-): boolean => {
-  const hiddenFunc = hiddenValue ? isHiddenValue : isHidden
-  return fieldPath.length === 0
+const isHiddenField = (baseType: TypeElement, fieldPath: ReadonlyArray<string>): boolean => (
+  fieldPath.length === 0
     ? false
-    : hiddenFunc(getField(baseType, fieldPath))
-      || isHiddenField(baseType, fieldPath.slice(0, -1), hiddenValue)
-}
+    : isHidden(getField(baseType, fieldPath))
+      || isHiddenField(baseType, fieldPath.slice(0, -1))
+)
 
 const filterOutHiddenChanges = async (
   changes: DetailedChange[],
@@ -375,7 +370,7 @@ const filterOutHiddenChanges = async (
         return undefined
       }
 
-      if (isHiddenField(changeType, changePath, isInstanceElement(baseElem))) {
+      if (isHiddenField(changeType, changePath)) {
         // The change is inside a hidden field value, omit the change
         return undefined
       }

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -51,19 +51,41 @@ type salesforce.WithAnnotationsBlock {
   annotations {
     string firstAnnotation {
     }
+    hidden_string internalId {
+    }
   }
 }
 
 type salesforce.WithoutAnnotationsBlock {
 }
 
+
 type salesforce.ObjWithHidden {
+  annotations {
+    hidden_string internalId {
+    }
+  }
   number visible {
   }
   string hide {
     ${CORE_ANNOTATIONS.HIDDEN} = true
   }
+  string hide_val {
+    ${CORE_ANNOTATIONS.HIDDEN_VALUE} = true
+  }
   number other {
+  }
+}
+
+type salesforce.VisibleObjWithHidden {
+  annotations {
+    hidden_string internalId {
+    }
+  }
+  number visible {
+  }
+  string hide {
+    ${CORE_ANNOTATIONS.HIDDEN_VALUE} = true
   }
 }
 
@@ -75,12 +97,17 @@ salesforce.ObjWithHidden instWithHidden {
 type salesforce.ObjWithNestedHidden {
   salesforce.ObjWithHidden nested {
   }
+  salesforce.VisibleObjWithHidden nested_visible {
+  }
   number other {
   }
 }
 
 salesforce.ObjWithNestedHidden instWithNestedHidden {
   other = 1
+  nested_visible = {
+    visible = 111
+  }
 }
 
 type salesforce.ObjWithComplexHidden {
@@ -93,6 +120,59 @@ type salesforce.ObjWithComplexHidden {
 
 salesforce.ObjWithComplexHidden instWithComplexHidden {
   other = 1
+}
+
+type salesforce.ObjWithDoublyNestedHidden {
+  salesforce.ObjWithNestedHidden doubleNest {
+  }
+  salesforce.ObjWithHidden singleNest {
+  }
+  number noNest {
+  }
+  salesforce.ObjWithNestedHidden doubleHiddenVal {
+    ${CORE_ANNOTATIONS.HIDDEN_VALUE} = true
+  }
+}
+
+salesforce.ObjWithDoublyNestedHidden instWithDoublyNestedHidden {
+  noNest = 44
+  singleNest = {
+    other = 2
+    visible = 333
+  }
+  doubleNest = {
+    nested = {
+      other = -3
+      visible = 0
+    }
+  }
+}
+
+type salesforce.HiddenVal {
+  ${CORE_ANNOTATIONS.HIDDEN_VALUE} = true
+  string something {
+  }
+  number somethingElse {
+  }
+}
+
+type salesforce.HiddenToVisibleVal {
+  ${CORE_ANNOTATIONS.HIDDEN_VALUE} = true
+  string something {
+  }
+  number somethingElse {
+  }
+}
+
+type salesforce.NestedHiddenVal {
+  annotations {
+    salesforce.HiddenVal hidden_val_anno {
+    }
+    salesforce.HiddenToVisibleVal hidden_to_visible_anno {
+    }
+  }
+  string visible_val {
+  }
 }
 
 type multi.loc { a = 1 }

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -85,7 +85,7 @@ type salesforce.VisibleObjWithHidden {
   number visible {
   }
   string hide {
-    ${CORE_ANNOTATIONS.HIDDEN_VALUE} = true
+    ${CORE_ANNOTATIONS.HIDDEN} = true
   }
 }
 

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -498,7 +498,7 @@ describe('workspace', () => {
           new ObjectType({ elemID: new ElemID('salesforce', 'ObjWithNestedHidden') }),
           'new_field',
           BuiltinTypes.NUMBER,
-          { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+          { [CORE_ANNOTATIONS.HIDDEN]: true },
         ) },
       },
       { // add complex value (nested in parent scope)

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -24,7 +24,7 @@ import {
 } from '@salto-io/adapter-utils'
 // eslint-disable-next-line no-restricted-imports
 import {
-  METADATA_TYPE,
+  METADATA_TYPE, INTERNAL_ID_ANNOTATION,
 } from '@salto-io/salesforce-adapter/dist/src/constants'
 import { WorkspaceConfigSource } from '../../src/workspace/workspace_config_source'
 import { ConfigSource } from '../../src/workspace/config_source'
@@ -355,6 +355,19 @@ describe('workspace', () => {
       path: ['salesforce', 'Types', 'Subtypes', 'QueueSobject'],
     })
 
+    const objFieldWithHiddenAnnotationType = new ObjectType({
+      elemID: new ElemID('salesforce', 'SomeObj'),
+      fields: { aaa: { type: BuiltinTypes.NUMBER } },
+      annotations: {
+        hiddenStrAnno: 'some value',
+      },
+      annotationTypes: {
+        hiddenStrAnno: BuiltinTypes.HIDDEN_STRING,
+        visibleStrAnno: BuiltinTypes.STRING,
+      },
+      path: ['salesforce', 'Types', 'Subtypes', 'SomeObj'],
+    })
+
     queueSobjectHiddenSubType.fields.str = new Field(
       queueSobjectHiddenSubType,
       'str',
@@ -366,6 +379,10 @@ describe('workspace', () => {
       elemID: new ElemID('salesforce', 'AccountInsightsSettings'),
       annotations: {
         [METADATA_TYPE]: 'AccountInsightsSettings',
+        [INTERNAL_ID_ANNOTATION]: 'aaa',
+      },
+      annotationTypes: {
+        [INTERNAL_ID_ANNOTATION]: BuiltinTypes.HIDDEN_STRING,
       },
       path: ['salesforce', 'Types', 'AccountInsightsSettings'],
     })
@@ -385,9 +402,9 @@ describe('workspace', () => {
             [CORE_ANNOTATIONS.HIDDEN]: true,
           },
         ),
-        queueSobjectNotHidden: new Field(
+        queueSobjectWithHiddenType: new Field(
           queueSobjectHiddenSubType,
-          'queueSobjectNotHidden',
+          'queueSobjectWithHiddenType',
           queueSobjectHiddenSubType,
           {},
         ),
@@ -404,6 +421,14 @@ describe('workspace', () => {
           'boolNotHidden',
           BuiltinTypes.BOOLEAN,
         ),
+        objWithHiddenAnno: new Field(
+          queueSobjectHiddenSubType,
+          'objWithHiddenAnno',
+          objFieldWithHiddenAnnotationType,
+          {
+            hiddenStrAnno: 'bbb',
+          }
+        ),
       },
       path: ['salesforce', 'Types', 'Queue'],
       isSettings: false,
@@ -416,11 +441,12 @@ describe('workspace', () => {
         queueSobjectHidden: {
           str: 'text',
         },
-        queueSobjectNotHidden: {
+        queueSobjectWithHiddenType: {
           str: 'text2',
         },
         numHidden: 123,
         boolNotHidden: false,
+        objWithHiddenAnno: { aaa: 23 },
       },
       ['Records', 'Queue', 'queueInstance'],
     )
@@ -455,6 +481,25 @@ describe('workspace', () => {
         id: newElemID,
         action: 'add',
         data: { after: newElem },
+      },
+      { // add field
+        id: new ElemID('salesforce', 'lead', 'field', 'new_field'),
+        action: 'add',
+        data: { after: new Field(
+          fieldsParent,
+          'new_field',
+          BuiltinTypes.NUMBER,
+        ) },
+      },
+      { // add hidden field
+        id: new ElemID('salesforce', 'ObjWithNestedHidden', 'field', 'new_field'),
+        action: 'add',
+        data: { after: new Field(
+          new ObjectType({ elemID: new ElemID('salesforce', 'ObjWithNestedHidden') }),
+          'new_field',
+          BuiltinTypes.NUMBER,
+          { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+        ) },
       },
       { // add complex value (nested in parent scope)
         id: new ElemID('salesforce', 'lead', 'field', 'base_field', 'complex'),
@@ -546,6 +591,12 @@ describe('workspace', () => {
         action: 'add',
         data: { after: BuiltinTypes.NUMBER },
       },
+      { // new hidden annotation type
+        path: ['file'],
+        id: new ElemID('salesforce', 'lead', 'annotation', 'newHiddenAnno'),
+        action: 'add',
+        data: { after: BuiltinTypes.HIDDEN_STRING },
+      },
       { // new annotation type to a type with annotation types block
         path: ['file'],
         id: new ElemID('salesforce', 'WithAnnotationsBlock', 'annotation', 'secondAnnotation'),
@@ -561,6 +612,16 @@ describe('workspace', () => {
         id: new ElemID('salesforce', 'WithoutAnnotationsBlock', 'annotation', 'newAnnoType2'),
         action: 'add',
         data: { after: BuiltinTypes.NUMBER },
+      },
+      { // new annotation value with new hidden annotation type
+        id: new ElemID('salesforce', 'lead', 'attr', 'newHiddenAnno'),
+        action: 'add',
+        data: { after: 'foo' },
+      },
+      { // new annotation value to existing non-hidden annotation type
+        id: new ElemID('salesforce', 'lead', 'attr', 'visibleAnno'),
+        action: 'add',
+        data: { after: 'foo' },
       },
       { // new Hidden type (should be removed)
         id: new ElemID('salesforce', 'Queue'),
@@ -595,6 +656,11 @@ describe('workspace', () => {
         action: 'add',
         data: { after: true },
       },
+      { // change in a hidden annotation
+        id: new ElemID('salesforce', 'ObjWithHidden', 'attr', 'internalId'),
+        action: 'add',
+        data: { after: 'internal ID' },
+      },
       { // new instance
         id: new ElemID('salesforce', 'Queue', 'instance', 'queueInstance'),
         action: 'add',
@@ -614,6 +680,16 @@ describe('workspace', () => {
         action: 'modify',
         data: { before: true, after: false },
       },
+      { // Hidden value field change to visible
+        id: new ElemID('salesforce', 'ObjWithHidden', 'field', 'hide_val', CORE_ANNOTATIONS.HIDDEN_VALUE),
+        action: 'modify',
+        data: { before: true, after: false },
+      },
+      { // Hidden value annotation change to visible
+        id: new ElemID('salesforce', 'HiddenToVisibleVal', 'attr', CORE_ANNOTATIONS.HIDDEN_VALUE),
+        action: 'modify',
+        data: { before: true, after: false },
+      },
       { // Visible field change to hidden
         id: new ElemID('salesforce', 'ObjWithHidden', 'field', 'visible', CORE_ANNOTATIONS.HIDDEN),
         action: 'add',
@@ -623,6 +699,16 @@ describe('workspace', () => {
         id: new ElemID('salesforce', 'ObjWithHidden', 'instance', 'instWithHidden', 'hide'),
         action: 'add',
         data: { after: 'changed' },
+      },
+      { // Change to field value as it becomes visible
+        id: new ElemID('salesforce', 'ObjWithHidden', 'instance', 'instWithHidden', 'hide_val'),
+        action: 'add',
+        data: { after: 'changed2' },
+      },
+      { // Change to nested field value as it becomes visible
+        id: new ElemID('salesforce', 'ObjWithDoublyNestedHidden', 'instance', 'instWithDoublyNestedHidden', 'doubleNest', 'nested', 'hide'),
+        action: 'add',
+        data: { after: 'changed d' },
       },
       { // Change to field value as it becomes hidden
         id: new ElemID('salesforce', 'ObjWithHidden', 'instance', 'instWithHidden', 'visible'),
@@ -634,10 +720,41 @@ describe('workspace', () => {
         action: 'add',
         data: { after: { visible: 1, hide: 'a', other: 2 } },
       },
+      { // Change where only part of the value is visible
+        id: new ElemID('salesforce', 'ObjWithNestedHidden', 'instance', 'instWithNestedHidden', 'new_field'),
+        action: 'add',
+        data: { after: 424 },
+      },
       { // Change inside a hidden complex field
         id: new ElemID('salesforce', 'ObjWithComplexHidden', 'instance', 'instWithComplexHidden', 'nested', 'other'),
         action: 'modify',
         data: { before: 3, after: 4 },
+      },
+      { // Change inside a complex field (visible)
+        id: new ElemID('salesforce', 'ObjWithNestedHidden', 'instance', 'instWithNestedHidden', 'nested_visible', 'visible'),
+        action: 'modify',
+        data: { before: 111, after: 43 },
+      },
+      { // Change inside a complex field (hidden)
+        id: new ElemID('salesforce', 'ObjWithNestedHidden', 'instance', 'instWithNestedHidden', 'nested_visible', 'hide'),
+        action: 'add',
+        data: { after: 'abc' },
+      },
+      { // Change inside an annotation with hidden value
+        id: new ElemID('salesforce', 'NestedHiddenVal', 'attr', 'hidden_val_anno'),
+        action: 'add',
+        data: { after: {
+          something: 's',
+          somethingElse: 34,
+        } },
+      },
+      { // Change inside an annotation that became visible
+        id: new ElemID('salesforce', 'NestedHiddenVal', 'attr', 'hidden_to_visible_anno'),
+        action: 'add',
+        data: { after: {
+          something: 't',
+          somethingElse: 35,
+        } },
       },
       { // Add and remove a top level element in the same file
         id: renamedTypes.before.elemID,
@@ -665,9 +782,11 @@ describe('workspace', () => {
     let instWithHidden: InstanceElement
     let instWithComplexHidden: InstanceElement
     let instWithNestedHidden: InstanceElement
+    let instWithDoublyNestedHidden: InstanceElement
 
     let lead: ObjectType
     let elemMap: Record<string, Element>
+    let elemMapWithHidden: Record<string, Element>
     let workspace: Workspace
     const dirStore = mockDirStore()
 
@@ -692,14 +811,15 @@ describe('workspace', () => {
           applyDetailedChanges(elem, elemChanges)
         }
       })
-      state.override(
-        [...stateElements, accountInsightsSettingsType, queueHiddenType]
-      )
+      state.override([
+        ...stateElements, accountInsightsSettingsType, queueHiddenType,
+      ])
 
       clonedChanges = _.cloneDeep(changes)
       await workspace.updateNaclFiles(clonedChanges)
 
       elemMap = getElemMap(await workspace.elements(false))
+      elemMapWithHidden = getElemMap(await workspace.elements())
       lead = elemMap['salesforce.lead'] as ObjectType
 
       // New types (first time returned from service)
@@ -721,6 +841,9 @@ describe('workspace', () => {
       instWithNestedHidden = elemMap[
         'salesforce.ObjWithNestedHidden.instance.instWithNestedHidden'
       ] as InstanceElement
+      instWithDoublyNestedHidden = elemMap[
+        'salesforce.ObjWithDoublyNestedHidden.instance.instWithDoublyNestedHidden'
+      ] as InstanceElement
     })
 
     it('should not cause parse errors', async () => {
@@ -730,6 +853,7 @@ describe('workspace', () => {
     it('should modify existing element', () => {
       expect(lead).toBeDefined()
       expect(lead.fields.base_field.annotations[CORE_ANNOTATIONS.DEFAULT]).toEqual('foo')
+      expect(lead.fields.new_field).toBeDefined()
     })
 
     it('should not modify the changes object', () => {
@@ -758,6 +882,32 @@ describe('workspace', () => {
       expect(lead.annotationTypes.newAnnoType1).toEqual(BuiltinTypes.STRING)
       expect(lead.annotationTypes).toHaveProperty('newAnnoType2')
       expect(lead.annotationTypes.newAnnoType2).toEqual(BuiltinTypes.NUMBER)
+      expect(lead.annotationTypes).toHaveProperty('newHiddenAnno')
+      expect(lead.annotationTypes.newHiddenAnno).toEqual(BuiltinTypes.HIDDEN_STRING)
+    })
+    it('should add visible values', () => {
+      expect(lead.annotations).toHaveProperty('visibleAnno')
+      expect(instWithNestedHidden.value.nested_visible.visible).toEqual(43)
+      const nestedHiddenVal = elemMap['salesforce.NestedHiddenVal'] as ObjectType
+      expect(nestedHiddenVal.annotations.hidden_to_visible_anno.something).toEqual('t')
+    })
+    it('should not add hidden annotation value on new annotation type', () => {
+      expect(lead.annotations).not.toHaveProperty('newHiddenAnno')
+    })
+    it('should not add hidden annotation value on existing annotation type', () => {
+      const objWithHidden = elemMap['salesforce.ObjWithHidden'] as ObjectType
+      expect(objWithHidden.annotations).not.toHaveProperty('internalId')
+      const nestedHiddenVal = elemMap['salesforce.NestedHiddenVal'] as ObjectType
+      expect(nestedHiddenVal.annotationTypes).toHaveProperty('hidden_val_anno')
+      expect(nestedHiddenVal.annotations).not.toHaveProperty('hidden_val_anno')
+    })
+    it('should include hidden annotation value when fetching with hidden', () => {
+      const leadWithHidden = elemMapWithHidden['salesforce.lead'] as ObjectType
+      expect(leadWithHidden.annotations).toHaveProperty('newHiddenAnno')
+      const objWithHidden = elemMapWithHidden['salesforce.ObjWithHidden'] as ObjectType
+      expect(objWithHidden.annotations).toHaveProperty('internalId')
+      const nestedHiddenVal = elemMapWithHidden['salesforce.NestedHiddenVal'] as ObjectType
+      expect(nestedHiddenVal.annotations).toHaveProperty('hidden_val_anno')
     })
     it('should add annotation type to the existing annotations block with path hint', () => {
       const objWithAnnotationsBlock = elemMap['salesforce.WithAnnotationsBlock'] as ObjectType
@@ -808,13 +958,19 @@ describe('workspace', () => {
       expect(newNotHiddenType).toBeDefined()
     })
 
-    it('should add the type that change from hidden to not hidden ', () => {
+    it('should add the type that change from hidden to not hidden, excluding hidden annotations', () => {
       expect(typeBecameNotHidden).toBeDefined()
-      expect(typeBecameNotHidden).toEqual(accountInsightsSettingsType)
+      expect(typeBecameNotHidden).toEqual(_.omit(
+        accountInsightsSettingsType, 'annotations.internalId',
+      ))
     })
 
     it('should remove the type that became to be hidden', () => {
       expect(typeBecameHidden).toBeUndefined()
+    })
+
+    it('should keep the hidden annotation hidden', () => {
+      expect(typeBecameNotHidden.annotations[INTERNAL_ID_ANNOTATION]).toBeUndefined()
     })
 
     it('should add new instance without hidden fields values', () => {
@@ -826,8 +982,9 @@ describe('workspace', () => {
       expect(newInstance.value.numHidden).toBeUndefined()
 
       // Not hidden fields values should be defined
-      expect(newInstance.value.queueSobjectNotHidden).toBeDefined()
+      expect(newInstance.value.queueSobjectWithHiddenType).toBeDefined()
       expect(newInstance.value.boolNotHidden).toEqual(false)
+      expect(newInstance.value.objWithHiddenAnno).toEqual({ aaa: 23 })
     })
 
     it('should add different cased elements to the same file', () => {
@@ -839,16 +996,22 @@ describe('workspace', () => {
 
     it('should not add changes in hidden values', () => {
       expect(instWithComplexHidden.value).not.toHaveProperty('nested')
+      expect(instWithNestedHidden.value.nested_visible).not.toHaveProperty('hide')
+      expect(instWithNestedHidden.value).not.toHaveProperty('new_field')
     })
 
     it('should remove values of fields that became hidden', () => {
       expect(instWithHidden.value).not.toHaveProperty('visible')
       expect(instWithNestedHidden.value.nested).not.toHaveProperty('visible')
+      expect(instWithDoublyNestedHidden.value.singleNest).not.toHaveProperty('visible')
+      expect(instWithDoublyNestedHidden.value.doubleNest.nested).not.toHaveProperty('visible')
     })
 
     it('should add values that became visible', () => {
       expect(instWithHidden.value.hide).toEqual('changed')
+      expect(instWithHidden.value.hide_val).toEqual('changed2')
       expect(instWithNestedHidden.value.nested.hide).toEqual('a')
+      expect(instWithDoublyNestedHidden.value.doubleNest.nested.hide).toEqual('changed d')
     })
 
     it('should update file correctly when elements are removed and added in the same file', () => {


### PR DESCRIPTION
1. Add `hidden_string` builtin type to support hidden annotations.
2. Add a supporting `_hidden_value` annotation (that is used by `hidden_string`), in order to allow separating between marking elements as hidden (with the old `_hidden` annotation), and using type elements to mark their _values_ as hidden without hiding the types (like in this case). This was needed in order to avoid conflicts with hidden types (like when `enableHideTypesInNacls` is set to true)

Ideally we would allow adding annotations directly on the annotation type definitions, but this would introduce some conflicts with the annotations on the underlying types and require bigger changes that we decided not to do at this point.

---
No release notes (internal changes)