### PR TITLE
SALTO-910 - Switch internal salesforce fields from _hidden to _hidden_value

### DIFF
--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1178,7 +1178,7 @@ export const getSObjectFieldElement = (
   // Because they differ between envs and should not be edited through salto
   // Name is an exception because it can be editable and visible to the user
   if (!field.nameField && systemFields.includes(field.name)) {
-    annotations[CORE_ANNOTATIONS.HIDDEN] = true
+    annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
     annotations[FIELD_ANNOTATIONS.UPDATEABLE] = false
     annotations[FIELD_ANNOTATIONS.CREATABLE] = false
     annotations[CORE_ANNOTATIONS.REQUIRED] = false
@@ -1187,7 +1187,7 @@ export const getSObjectFieldElement = (
   // An autoNumber field should be hidden because it will differ between enviorments
   // and not required to be able to add without it (ie. when moving envs)
   if (field.autoNumber) {
-    annotations[CORE_ANNOTATIONS.HIDDEN] = true
+    annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
     annotations[CORE_ANNOTATIONS.REQUIRED] = false
   }
 
@@ -1324,8 +1324,7 @@ const createIdField = (parent: ObjectType): void => {
     BuiltinTypes.STRING,
     {
       [CORE_ANNOTATIONS.REQUIRED]: false,
-      // TODO change to HIDDEN_VALUE (need to handle upgrade remove+add)
-      [CORE_ANNOTATIONS.HIDDEN]: true,
+      [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
       [FIELD_ANNOTATIONS.LOCAL_ONLY]: true,
     }
   )

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -600,7 +600,7 @@ describe('Custom Objects filter', () => {
         expect(lead.fields.SystemField.annotations[CORE_ANNOTATIONS.REQUIRED]).toBeFalsy()
         expect(lead.fields.SystemField.annotations[FIELD_ANNOTATIONS.CREATABLE]).toBeFalsy()
         expect(lead.fields.SystemField.annotations[FIELD_ANNOTATIONS.UPDATEABLE]).toBeFalsy()
-        expect(lead.fields.SystemField.annotations[CORE_ANNOTATIONS.HIDDEN]).toBeTruthy()
+        expect(lead.fields.SystemField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toBeTruthy()
       })
 
       it('should fetch sobject with nameField system fields with original required/createable/updateable values', async () => {

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -549,7 +549,7 @@ describe('transformer', () => {
             {}
           )
           expect(fieldElement.type).toEqual(Types.primitiveDataTypes.AutoNumber)
-          expect(fieldElement.annotations[CORE_ANNOTATIONS.HIDDEN]).toBeTruthy()
+          expect(fieldElement.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toBeTruthy()
           expect(fieldElement.annotations[CORE_ANNOTATIONS.REQUIRED]).toBeFalsy()
         })
       })
@@ -564,7 +564,7 @@ describe('transformer', () => {
             {}
           )
           expect(fieldElement.type).toEqual(Types.primitiveDataTypes.AutoNumber)
-          expect(fieldElement.annotations[CORE_ANNOTATIONS.HIDDEN]).toBeTruthy()
+          expect(fieldElement.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toBeTruthy()
           expect(fieldElement.annotations[CORE_ANNOTATIONS.REQUIRED]).toBeFalsy()
         })
       })
@@ -652,7 +652,7 @@ describe('transformer', () => {
     it('should remove internalId', () => {
       field.annotations[INTERNAL_ID_ANNOTATION] = 'internal id'
       const customField = toCustomField(field)
-      expect(_.get(customField, INTERNAL_ID_ANNOTATION)).toBeUndefined()
+      expect(customField).not.toHaveProperty(INTERNAL_ID_ANNOTATION)
     })
   })
 

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -85,7 +85,7 @@ type salesforce.VisibleObjWithHidden {
   number visible {
   }
   string hide {
-    ${CORE_ANNOTATIONS.HIDDEN} = true
+    ${CORE_ANNOTATIONS.HIDDEN_VALUE} = true
   }
 }
 
@@ -112,7 +112,7 @@ salesforce.ObjWithNestedHidden instWithNestedHidden {
 
 type salesforce.ObjWithComplexHidden {
   salesforce.ObjWithHidden nested {
-    ${CORE_ANNOTATIONS.HIDDEN} = true
+    ${CORE_ANNOTATIONS.HIDDEN_VALUE} = true
   }
   number other {
   }

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -236,7 +236,7 @@ describe('workspace', () => {
         mockDirStore([], false, {
           'x.nacl': `type salto.t {
             number field {
-              ${CORE_ANNOTATIONS.HIDDEN} = true
+              ${CORE_ANNOTATIONS.HIDDEN_VALUE} = true
             }
           }
           salto.t inst {
@@ -413,7 +413,7 @@ describe('workspace', () => {
           'numHidden',
           BuiltinTypes.NUMBER,
           {
-            [CORE_ANNOTATIONS.HIDDEN]: true,
+            [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
           },
         ),
         boolNotHidden: new Field(
@@ -498,7 +498,7 @@ describe('workspace', () => {
           new ObjectType({ elemID: new ElemID('salesforce', 'ObjWithNestedHidden') }),
           'new_field',
           BuiltinTypes.NUMBER,
-          { [CORE_ANNOTATIONS.HIDDEN]: true },
+          { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
         ) },
       },
       { // add complex value (nested in parent scope)
@@ -691,7 +691,7 @@ describe('workspace', () => {
         data: { before: true, after: false },
       },
       { // Visible field change to hidden
-        id: new ElemID('salesforce', 'ObjWithHidden', 'field', 'visible', CORE_ANNOTATIONS.HIDDEN),
+        id: new ElemID('salesforce', 'ObjWithHidden', 'field', 'visible', CORE_ANNOTATIONS.HIDDEN_VALUE),
         action: 'add',
         data: { after: true },
       },
@@ -978,10 +978,10 @@ describe('workspace', () => {
       expect(newInstance).not.toEqual(queueInstance)
 
       // Hidden fields values should be undefined
-      expect(newInstance.value.queueSobjectHidden).toBeUndefined()
       expect(newInstance.value.numHidden).toBeUndefined()
 
       // Not hidden fields values should be defined
+      expect(newInstance.value.queueSobjectHidden).toBeDefined() // field is hidden but value isn't
       expect(newInstance.value.queueSobjectWithHiddenType).toBeDefined()
       expect(newInstance.value.boolNotHidden).toEqual(false)
       expect(newInstance.value.objWithHiddenAnno).toEqual({ aaa: 23 })
@@ -1000,7 +1000,7 @@ describe('workspace', () => {
       expect(instWithNestedHidden.value).not.toHaveProperty('new_field')
     })
 
-    it('should remove values of fields that became hidden', () => {
+    it('should remove values of fields that became hidden_value', () => {
       expect(instWithHidden.value).not.toHaveProperty('visible')
       expect(instWithNestedHidden.value.nested).not.toHaveProperty('visible')
       expect(instWithDoublyNestedHidden.value.singleNest).not.toHaveProperty('visible')


### PR DESCRIPTION
This also includes the changes from https://github.com/salto-io/salto/pull/1641 and https://github.com/salto-io/salto/pull/1642 , please only review the last commit here.

We now have two separate annotations for hiding elements and values - `_hidden` for hiding elements directly (for exmaple, for completely hiding a type so that it does not appear in the nacls), and `_hidden_value` for hiding values referencing the type that has the annotation (for example, for storing internalId values - we still want the _definition_ of the relevant field / annotation to be visible, but the value itself should only appear in the state).
This PR relies on https://github.com/salto-io/salto/pull/1641 and converts all salesforce fields that used the `_hidden` annotation to use the new `_hidden_value`.

Not included: Repurposing the old `_hidden` annotation on fields to hide the field itself rather than the value (there is no use case for it yet - so this will be done separately).

---
No release notes (internal changes)