### PR TITLE
SALTO-1076: Fix deployment of custom object with master-detail field

### DIFF
--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -352,7 +352,8 @@ const toPackageXml = (manifest: Map<string, string[]>): string => (
 )
 
 export type DeployPackage = {
-  add(instance: MetadataInstanceElement): void
+  add(instance: MetadataInstanceElement, withManifest?: boolean): void
+  addToManifest(type: MetadataObjectType, name: string): void
   delete(type: MetadataObjectType, name: string): void
   getZip(): Promise<Buffer>
 }
@@ -361,11 +362,16 @@ export const createDeployPackage = (): DeployPackage => {
   const zip = new JSZip()
   const addManifest = new collections.map.DefaultMap<string, string[]>(() => [])
   const deleteManifest = new collections.map.DefaultMap<string, string[]>(() => [])
+  const addToManifest: DeployPackage['addToManifest'] = (type, name) => {
+    const typeName = getManifestTypeName(type)
+    addManifest.get(typeName).push(name)
+  }
   return {
-    add: instance => {
+    add: (instance, withManifest = true) => {
       const instanceName = apiName(instance)
-      const manifestTypeName = getManifestTypeName(instance.type)
-      addManifest.get(manifestTypeName).push(instanceName)
+      if (withManifest) {
+        addToManifest(instance.type, instanceName)
+      }
       // Add instance file(s) to zip
       const typeName = metadataType(instance)
       const values = getValuesToDeploy(toDeployableInstance(instance))
@@ -408,6 +414,7 @@ export const createDeployPackage = (): DeployPackage => {
         }
       }
     },
+    addToManifest,
     delete: (type, name) => {
       const typeName = getManifestTypeName(type)
       deleteManifest.get(typeName).push(name)

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { collections, promises } from '@salto-io/lowerdash'
-import { ObjectType, ElemID, InstanceElement, BuiltinTypes, CORE_ANNOTATIONS, createRestriction, DeployResult, getChangeElement, Values, Change, toChange, ChangeGroup } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, InstanceElement, BuiltinTypes, CORE_ANNOTATIONS, createRestriction, DeployResult, getChangeElement, Values, Change, toChange, ChangeGroup, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { MetadataInfo, SaveResult, Package } from 'jsforce'
 import JSZip from 'jszip'
 import xmlParser from 'fast-xml-parser'
@@ -958,6 +958,7 @@ describe('SalesforceAdapter CRUD', () => {
                 [constants.API_NAME]: 'Test__c.address__c',
               },
             },
+            other: { type: stringType, annotations: { [constants.API_NAME]: 'Test__c.other__c' } },
           },
           annotations: {
             label: 'test2 label',
@@ -999,7 +1000,9 @@ describe('SalesforceAdapter CRUD', () => {
           expect(deployedValues).toBeDefined()
           const updatedObj = deployedValues.CustomObject
           expect(updatedObj.label).toEqual('test2 label')
-          const newField = updatedObj.fields
+          // It should deploy all fields when there is an annotation change
+          expect(updatedObj.fields).toHaveLength(2)
+          const [newField] = updatedObj.fields
           expect(newField.fullName).toEqual('address__c')
           expect(newField.type).toEqual('Text')
           expect(newField.label).toEqual('test2 label')
@@ -1094,27 +1097,55 @@ describe('SalesforceAdapter CRUD', () => {
           expect(result.appliedChanges).toEqual(changes)
         })
 
-        it('should call the connection methods correctly', async () => {
-          expect(mockDeploy).toHaveBeenCalledTimes(1)
-          const deployedPackage = await getDeployedPackage(mockDeploy.mock.calls[0][0])
-          expect(deployedPackage.manifest?.types).toContainEqual(
-            { name: constants.CUSTOM_OBJECT, members: 'Test__c' }
-          )
-          const deployedValues = await deployedPackage.getData('objects/Test__c.object')
-          expect(deployedValues).toBeDefined()
-          const changedObject = deployedValues.CustomObject
-          expect(changedObject.fields).toHaveLength(2)
-          const [bananaField, descField] = changedObject.fields
-          expect(descField.fullName).toBe('Description__c')
-          expect(descField.type).toBe('Text')
-          expect(descField.length).toBe(80)
-          expect(descField.required).toBe(false)
-          // Verify the custom field label change
-          expect(bananaField.label).toBe('Banana Split')
-          // Verify the custom fields deletion
-          expect(deployedPackage.deleteManifest?.types).toEqual(
-            { name: constants.CUSTOM_FIELD, members: 'Test__c.Address__c' }
-          )
+        describe('deploy request', () => {
+          let deployedPackage: DeployedPackage
+          beforeAll(async () => {
+            expect(mockDeploy).toHaveBeenCalledTimes(1)
+            deployedPackage = await getDeployedPackage(mockDeploy.mock.calls[0][0])
+          })
+          describe('package manifest', () => {
+            it('should contain the new and modified fields', () => {
+              expect(deployedPackage.manifest?.types).toContainEqual({
+                name: constants.CUSTOM_FIELD,
+                members: changes
+                  .filter(isAdditionOrModificationChange)
+                  .map(getChangeElement)
+                  .map(field => apiName(field)),
+              })
+            })
+            it('should contain the deleted field in the delete manifest', () => {
+              expect(deployedPackage.deleteManifest?.types).toEqual(
+                { name: constants.CUSTOM_FIELD, members: 'Test__c.Address__c' }
+              )
+            })
+            it('should not contain the custom object', () => {
+              expect(deployedPackage.manifest?.types).not.toContainEqual({
+                name: constants.CUSTOM_OBJECT,
+                members: 'Test__c',
+              })
+            })
+          })
+          describe('custom object values', () => {
+            let deployedObject: Values
+            beforeAll(async () => {
+              const deployedValues = await deployedPackage.getData('objects/Test__c.object')
+              deployedObject = deployedValues?.CustomObject
+              expect(deployedObject).toBeDefined()
+            })
+            it('should contain added and modified fields', () => {
+              expect(deployedObject.fields).toHaveLength(2)
+              const [bananaField, descField] = deployedObject.fields
+              expect(descField.fullName).toBe('Description__c')
+              expect(descField.type).toBe('Text')
+              expect(descField.length).toBe(80)
+              expect(descField.required).toBe(false)
+              // Verify the custom field label change
+              expect(bananaField.label).toBe('Banana Split')
+            })
+            it('should not contain object annotations', () => {
+              expect(deployedObject).not.toHaveProperty('label')
+            })
+          })
         })
       })
 

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -41,6 +41,7 @@ import filterCreator, {
 } from '../../src/filters/custom_objects'
 import { FilterWith } from '../../src/filter'
 import { isCustom, Types, createInstanceElement, MetadataTypeAnnotations, metadataType } from '../../src/transformers/transformer'
+import { DEPLOY_WRAPPER_INSTANCE_MARKER } from '../../src/metadata_deploy'
 
 describe('Custom Objects filter', () => {
   let connection: Connection
@@ -1519,7 +1520,6 @@ describe('Custom Objects filter', () => {
   })
 
   describe('preDeploy and onDeploy', () => {
-    let changes: Change[]
     let testObject: ObjectType
     let parentAnnotation: Record<string, Element[]>
     beforeAll(() => {
@@ -1543,11 +1543,13 @@ describe('Custom Objects filter', () => {
         annotations: {
           [METADATA_TYPE]: CUSTOM_OBJECT,
           [API_NAME]: 'Test__c',
+          [LABEL]: 'TestObject',
         },
       })
       parentAnnotation = { [INSTANCE_ANNOTATIONS.PARENT]: [testObject] }
     })
     describe('with inner instance addition', () => {
+      let changes: Change[]
       let testFieldSet: InstanceElement
       beforeAll(async () => {
         filter = filterCreator({ client, config: {} }) as typeof filter
@@ -1575,6 +1577,11 @@ describe('Custom Objects filter', () => {
             [{ ...testFieldSet.value, fullName: 'MyFieldSet' }]
           )
         })
+        it('should mark the created custom object as a wrapper and not populate annotation values', () => {
+          const inst = getChangeElement(changes[0]) as InstanceElement
+          expect(inst.value).not.toHaveProperty(LABEL)
+          expect(inst.value).toHaveProperty(DEPLOY_WRAPPER_INSTANCE_MARKER, true)
+        })
       })
       describe('onDeploy', () => {
         beforeAll(async () => {
@@ -1587,6 +1594,7 @@ describe('Custom Objects filter', () => {
       })
     })
     describe('with removal side effects', () => {
+      let changes: Change[]
       let sideEffectInst: InstanceElement
       beforeAll(() => {
         sideEffectInst = createInstanceElement(
@@ -1621,6 +1629,38 @@ describe('Custom Objects filter', () => {
           expect(changes).toHaveLength(2)
           expect(changes).toContainEqual(toChange({ before: testObject }))
           expect(changes).toContainEqual(toChange({ before: sideEffectInst }))
+        })
+      })
+    })
+    describe('with annotation value change', () => {
+      let changes: Change[]
+      let afterObj: ObjectType
+      beforeAll(() => {
+        filter = filterCreator({ client, config: {} }) as typeof filter
+        afterObj = testObject.clone()
+        afterObj.annotations[LABEL] = 'New Label'
+        changes = [
+          toChange({ before: testObject, after: afterObj }),
+        ]
+      })
+      describe('preDeploy', () => {
+        beforeAll(async () => {
+          await filter.preDeploy(changes)
+        })
+        it('should create a custom object instance change with all fields and annotations', () => {
+          expect(changes).toHaveLength(1)
+          const { before, after } = changes[0].data as ModificationChange<InstanceElement>['data']
+          expect(after.value.fields).toHaveLength(Object.keys(testObject.fields).length)
+          expect(after.value[LABEL]).toEqual('New Label')
+          expect(before.value[LABEL]).toEqual('TestObject')
+        })
+      })
+      describe('onDeploy', () => {
+        beforeAll(async () => {
+          await filter.onDeploy(changes)
+        })
+        it('should restore the custom object change', () => {
+          expect(changes).toEqual([toChange({ before: testObject, after: afterObj })])
         })
       })
     })


### PR DESCRIPTION
Custom object sharing model of "ControlledByParent" cannot be set without a master detail field
Turns out that salesforce enforces that on the deployed values so even if there is a mastet detail
field on the object it must be included in the deploy request if we try to deploy the custom object.

There are two related fixes here:
- When we don't have to deploy the whole custom object, we will only deploy the nested instances / fields
  this is done by specifying them specifically in the package.xml
- When we do have to deploy the whole custom object (annotation change) - we will always include all fields

---
_Release Notes_:
- Fixed issue in deploying changes to custom objects that have a master-detail field