### PR TITLE
Add debug logs to suspecious filters to have better visibility onFetc…

### DIFF
--- a/packages/salesforce-adapter/src/filters/cpq/custom_script.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/custom_script.ts
@@ -16,11 +16,13 @@
 import _ from 'lodash'
 import { Element, ObjectType, ListType, InstanceElement, isAdditionOrModificationChange, getChangeElement, Change, ChangeDataType, isListType, Field, isPrimitiveType, isObjectTypeChange, StaticFile, isFieldChange, isAdditionChange } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../../filter'
 import { isInstanceOfTypeChange } from '../utils'
 import { CPQ_CUSTOM_SCRIPT, CPQ_CONSUMPTION_SCHEDULE_FIELDS, CPQ_GROUP_FIELDS, CPQ_QUOTE_FIELDS, CPQ_QUOTE_LINE_FIELDS, CPQ_CONSUMPTION_RATE_FIELDS, CPQ_CODE_FIELD } from '../../constants'
 import { Types, apiName, isInstanceOfCustomObject, isCustomObject } from '../../transformers/transformer'
 
+const log = logger(module)
 
 const refListFieldNames = [
   CPQ_CONSUMPTION_RATE_FIELDS, CPQ_CONSUMPTION_SCHEDULE_FIELDS, CPQ_GROUP_FIELDS,
@@ -148,9 +150,13 @@ const filter: FilterCreator = () => ({
     }
     refListFieldsToTextLists(cpqCustomScriptObject)
     const cpqCustomScriptInstances = elements.filter(isInstanceOfCustomScript)
-    cpqCustomScriptInstances.forEach(instance => {
+    log.debug(`Transforming ${cpqCustomScriptInstances.length} instances of SBQQ__CustomScript`)
+    cpqCustomScriptInstances.forEach((instance, index) => {
       refListValuesToArray(instance)
       codeValueToFile(instance)
+      if (index % 100 === 0) {
+        log.debug(`Transformed ${index} instances of SBQQ__CustomScript`)
+      }
     })
   },
   preDeploy: async changes => {

--- a/packages/salesforce-adapter/src/filters/cpq/lookup_fields.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/lookup_fields.ts
@@ -16,10 +16,12 @@
 import _ from 'lodash'
 import { Element, ObjectType, ReferenceExpression, Value, Change, ChangeDataType, isAdditionOrModificationChange, getChangeElement, isObjectTypeChange, Field, isAdditionChange, isFieldChange } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../../filter'
 import { apiName, isCustomObject, relativeApiName } from '../../transformers/transformer'
 import { FIELD_ANNOTATIONS, CPQ_PRODUCT_RULE, CPQ_PRICE_RULE, CPQ_LOOKUP_OBJECT_NAME, DEFAULT_OBJECT_TO_API_MAPPING, CPQ_CONFIGURATION_ATTRIBUTE, CPQ_DEFAULT_OBJECT_FIELD, CPQ_LOOKUP_QUERY, CPQ_TESTED_OBJECT, TEST_OBJECT_TO_API_MAPPING, CUSTOM_OBJECT, CUSTOM_FIELD, CPQ_PRICE_SCHEDULE, SCHEDULE_CONTRAINT_FIELD_TO_API_MAPPING, CPQ_QUOTE, CPQ_CONSTRAINT_FIELD, CPQ_DISCOUNT_SCHEDULE, API_NAME_SEPARATOR } from '../../constants'
 
+const log = logger(module)
 
 type CustomObjectLookupDef = {
   type: 'CustomObject'
@@ -241,9 +243,11 @@ const applyFuncOnCustomObjectWithMappingLookupChange = (
 
 const filter: FilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
+    log.debug('Started replacing lookupObject values with references')
     replaceLookupObjectValueSetValuesWithReferences(
       elements.filter(isCustomObject)
     )
+    log.debug('Finished replacing lookupObject values with references')
   },
   preDeploy: async changes => {
     const addOrModifyChanges = changes.filter(isAdditionOrModificationChange)

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -16,6 +16,7 @@
 import _ from 'lodash'
 import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
 import { transformValues, TransformFunc } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 import {
   Element, Values, ObjectType, Field, InstanceElement,
   ReferenceExpression,
@@ -26,6 +27,8 @@ import { FIELD_ANNOTATIONS, CUSTOM_OBJECT_ID_FIELD } from '../constants'
 import { isLookupField, isMasterDetailField } from './utils'
 
 const { makeArray } = collections.array
+
+const log = logger(module)
 
 const replaceReferenceValues = (
   values: Values,
@@ -72,12 +75,15 @@ const replaceReferenceValues = (
 
 const replaceLookupsWithReferences = (elements: Element[]): void => {
   const customObjectInstances = elements.filter(isInstanceOfCustomObject)
-  customObjectInstances.forEach(instance => {
+  customObjectInstances.forEach((instance, index) => {
     instance.value = replaceReferenceValues(
       instance.value,
       instance.type,
       customObjectInstances,
     )
+    if (index % 500 === 0) {
+      log.debug(`Replaced lookup with references for ${index} instances`)
+    }
   })
 }
 

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -421,6 +421,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
       validChangesFetchSettings,
     )
     elements.push(...instances)
+    log.debug(`Fetched ${instances.length} instances of Custom Objects`)
     const invalidFieldSuggestions = invalidFetchSettings
       .map(setting =>
         createInvlidIdFieldConfigChange(


### PR DESCRIPTION
…h failures

This is specifically to help with Coupa's failure. We might want to add logs to filters systematically to check each one started and finished.