### PR TITLE
Avoid traversing invalid ids in transformElement

### DIFF
--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -80,12 +80,8 @@ const splitElementHiddenParts = <T extends Element>(
     // because then we'd never reach A.B.C
     // We also do not omit A.B.C.D because A.B.C was hidden, so by association everything inside
     // it is also hidden
-    path !== undefined && (
-      hiddenPaths.some(hiddenPath =>
-        (path.isEqual(hiddenPath) || hiddenPath.isParentOf(path) || path.isParentOf(hiddenPath)))
-      // workaround to enable reaching annotation values
-      || path.isEqual(path.createTopLevelParentID().parent.createNestedID('attr'))
-    )
+    path !== undefined && (hiddenPaths.some(hiddenPath =>
+      path.isEqual(hiddenPath) || hiddenPath.isParentOf(path) || path.isParentOf(hiddenPath)))
   )
 
   const hidden = transformElement({

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -81,7 +81,7 @@ const getElementPathHints = (element: Element): Iterable<[string, Path[]]> => {
     }
     return _.isArrayLikeObject(value) ? undefined : value
   }
-  transformElement({ element, transformFunc, strict: false })
+  transformElement({ element, transformFunc, strict: false, runOnFields: true })
   return wu(_.entries(pathHints))
 }
 


### PR DESCRIPTION
Based on a discussion on another PR, avoiding the synthetic traversal over `element.elemID.createNestedID('attr')`, which is not a valid elem id (for example, calling `isParentOf` comparing to this id will never be true, as can be seen in the workaround in `hidden_values`). The options discussed were either making this a valid id, or removing the usages - and there was a preference to do the latter.
It turns out that when fields do not have annotations, `transformElement` does not enter them at all - and one place in the code relied on accessing something in each field (and in general this seems like useful functionality given how we use `transform` in the code), so there is now an optional `runOnFields` argument that allows running the transform func directly on the field. We can decide to make this the default behavior, but that will require making more changes to avoid duplicates in some other places in the code that use `transformElement` to aggregate paths satisfying some criteria.

---
No release notes (internal change)