### PR TITLE
SALTO-1085: omit hidden annotation values in deleted fields

### DIFF
--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -92,10 +92,14 @@ const getElementHiddenParts = <T extends Element>(
   })
   // remove all annotation types from the hidden element so they don't cause merge conflicts
   hidden.annotationTypes = {}
-  // Workaround for transformElement not being able to omit fields from an ObjectType
+
   if (isObjectType(hidden) && isObjectType(workspaceElement)) {
-    // filter out fields that were deleted in the workspace
-    hidden.fields = _.pick(hidden.fields, Object.keys(workspaceElement.fields))
+    // filter out fields that were deleted in the workspace (unless the field itself is hidden)
+    const workspaceFields = new Set(Object.keys(workspaceElement.fields))
+    hidden.fields = _.pickBy(
+      hidden.fields,
+      (field, key) => workspaceFields.has(key) || isHidden(field)
+    )
   }
   return hidden
 }

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -1,0 +1,44 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, BuiltinTypes, PrimitiveType, PrimitiveTypes } from '@salto-io/adapter-api'
+import { mergeWithHidden } from '../../src/workspace/hidden_values'
+import { MergeResult } from '../../src/merger'
+
+describe('mergeWithHidden', () => {
+  describe('when parent value is deleted in the workspace', () => {
+    let result: MergeResult
+    beforeEach(() => {
+      const fieldType = new PrimitiveType({
+        elemID: new ElemID('test', 'prim'),
+        primitive: PrimitiveTypes.STRING,
+        annotationTypes: { hiddenAnno: BuiltinTypes.HIDDEN_STRING },
+      })
+      const mockObjType = new ObjectType({
+        elemID: new ElemID('test', 'type'),
+        fields: {
+          f1: { type: fieldType, annotations: { hiddenAnno: 'asd' } },
+        },
+      })
+      const workspaceObjType = mockObjType.clone()
+      delete workspaceObjType.fields.f1
+      result = mergeWithHidden([fieldType, workspaceObjType], [fieldType, mockObjType])
+    })
+    it('should omit the hidden value', () => {
+      const mergedWorkspaceObj = result.merged[1] as ObjectType
+      expect(mergedWorkspaceObj.fields).not.toHaveProperty('f1')
+    })
+  })
+})


### PR DESCRIPTION
Generally mergeWithHidden is supposed to add hidden values to workspace elements but it should not do so if the parent of the hidden value was deleted in the workspace.
However this did not work with hidden annotation values in fields because we only filtered out top level elements that were deleted

---
_Release Notes_
- Fixed issue that caused restoring deleted fields from state to fail