### PR TITLE
SALTO-1061: added deleteBeforeUpdate option to configuration

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -52,6 +52,7 @@ salesforce {
       checkOnly = false
       testLevel = "NoTestRun"
       runTests = ["Test name", "Other test"]
+      deleteBeforeUpdate = false
     }
     retry = {
       maxAttempts = 5
@@ -127,6 +128,7 @@ salesforce {
 | checkOnly       | `false`                                                | If `true`, deploy will run a "validation deploy", changes will not be immediately applied to the service
 | testLevel       | `NoTestRun` (development) `RunLocalTests` (production) | Specifies which tests are run as part of a deployment. possible values are: `NoTestRun`, `RunSpecifiedTests`, `RunLocalTests` and `RunAllTestsInOrg`
 | runTests        | `[]` (no tests)                                        | A list of Apex tests to run during deployment, must configure `RunSpecifiedTests` in `testLevel` for this option to work
+| deleteBeforeUpdate      | `false`                                        | If `true`, deploy will make deletions before any other deployed change
 
 For more details see the DeployOptions section in the [salesforce documentation of the deploy API](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_deploy.htm)
 

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -427,7 +427,8 @@ export default class SalesforceAdapter implements AdapterOperations {
       ? await deployCustomObjectInstancesGroup(
         resolvedChanges, this.client, this.userConfig.dataManagement,
       )
-      : await deployMetadata(resolvedChanges, this.client, this.nestedMetadataTypes)
+      : await deployMetadata(resolvedChanges, this.client,
+        this.nestedMetadataTypes, this.userConfig.client?.deploy?.deleteBeforeUpdate)
 
     // onDeploy can change the change list in place, so we need to give it a list it can modify
     const appliedChangesBeforeRestore = [...result.appliedChanges]

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -534,10 +534,12 @@ export default class SalesforceClient {
   @SalesforceClient.requiresLogin
   public async deploy(zip: Buffer): Promise<DeployResult> {
     const defaultDeployOptions = { rollbackOnError: true, ignoreWarnings: true }
+    const optionsToSend = ['rollbackOnError', 'ignoreWarnings', 'purgeOnDelete',
+      'checkOnly', 'testLevel', 'runTests']
     return flatValues(
       await this.conn.metadata.deploy(
         zip,
-        _.merge(defaultDeployOptions, this.config?.deploy),
+        _.merge(defaultDeployOptions, _.pick(this.config?.deploy, optionsToSend)),
       ).complete(true)
     )
   }

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -73,6 +73,7 @@ type ClientDeployConfig = Partial<{
   checkOnly: boolean
   testLevel: 'NoTestRun' | 'RunSpecifiedTests' | 'RunLocalTests' | 'RunAllTestsInOrg'
   runTests: string[]
+  deleteBeforeUpdate: boolean
 }>
 
 export enum RetryStrategyName {
@@ -261,6 +262,7 @@ const clientDeployConfigType = new ObjectType({
       },
     },
     runTests: { type: new ListType(BuiltinTypes.STRING) },
+    deleteBeforeUpdate: { type: BuiltinTypes.BOOLEAN },
   } as Record<keyof ClientDeployConfig, FieldDefinition>,
 })
 

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -54,7 +54,7 @@ describe('SalesforceAdapter CRUD', () => {
     const zip = await JSZip.loadAsync(zipData)
     const files = {
       manifest: zip.files['unpackaged/package.xml'],
-      deleteManifest: zip.files['unpackaged/destructiveChanges.xml'],
+      deleteManifest: zip.files['unpackaged/destructiveChangesPost.xml'],
     }
     return {
       ...(await promises.object.mapValuesAsync(
@@ -665,7 +665,7 @@ describe('SalesforceAdapter CRUD', () => {
               // componentSuccess list
               componentSuccess: [{
                 componentType: 'Flow',
-                fullName: 'destructiveChanges.xml',
+                fullName: 'destructiveChangesPost.xml',
                 problemType: 'Warning',
                 problem: `No Flow named: ${instanceName} found`,
               }],
@@ -688,7 +688,7 @@ describe('SalesforceAdapter CRUD', () => {
               success: false,
               componentFailure: [{
                 componentType: 'Flow',
-                fullName: 'destructiveChanges.xml',
+                fullName: 'destructiveChangesPost.xml',
                 problemType: 'Warning',
                 problem: `No Flow named: ${instanceName} found`,
               }],

--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -41,9 +41,26 @@ describe('XML Transformer', () => {
 
     const packageName = 'unpackaged'
     const addManifestPath = `${packageName}/package.xml`
-    const deleteManifestPath = `${packageName}/destructiveChanges.xml`
+    const deleteManifestPath = `${packageName}/destructiveChangesPost.xml`
     let pkg: DeployPackage
     let zipFiles: Record<string, string>
+
+    describe('getDeletionsPackageName', () => {
+      it('get the right package name when deleteBeforeUpdate is true', () => {
+        expect(createDeployPackage(true).getDeletionsPackageName())
+          .toBe('destructiveChanges.xml')
+      })
+
+      it('get the right package name when deleteBeforeUpdate is false', () => {
+        expect(createDeployPackage(false).getDeletionsPackageName())
+          .toBe('destructiveChangesPost.xml')
+      })
+
+      it('get the right package name when deleteBeforeUpdate is undefined', () => {
+        expect(createDeployPackage(undefined).getDeletionsPackageName())
+          .toBe('destructiveChangesPost.xml')
+      })
+    })
 
     beforeEach(() => {
       pkg = createDeployPackage()


### PR DESCRIPTION
Fixed bug where deletion of a referenced field (with the necessary changes where it was referenced) would fail because the deployment would attempt to make the deletion first.
This is solved by adding a deleteBeforeUpdate configuration option to the salesforce adapter to configure whether deletion changes will be deployed before or after any other changes (false by default).

---
_Relase Notes:_ 
Added "deleteBeforeUpdate" configuration option to salesforce adapter to configure whether deletions changes will be deployed before or after any other changes (false by default).