### PR TITLE
Avoid using hidden_string as a field type in dummy adapter

### DIFF
--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -181,7 +181,8 @@ export const generateElements = (params: GeneratorParams): Element[] => {
 
   const getFieldType = (allowContainers = false): TypeElement => {
     const fieldTypeOptions = [
-      Object.values(BuiltinTypes).filter(type => type !== BuiltinTypes.UNKNOWN),
+      Object.values(BuiltinTypes).filter(type =>
+        ![BuiltinTypes.UNKNOWN, BuiltinTypes.HIDDEN_STRING].includes(type)),
       weightedRandomSelect(primitiveByRank.slice(0, -1)) || [],
       weightedRandomSelect(objByRank.slice(0, -1)) || [],
     ]


### PR DESCRIPTION
`hidden_string` was added to `BuiltinTypes` as a way to hide annotations, but it is only in use by a specific annotation type in salesforce. It should not be used as a field type (at least not randomly when it can conflict with other hidden annotation values).