### PR TITLE
Support hidden_string in dummy adapter

### DIFF
--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -181,8 +181,7 @@ export const generateElements = (params: GeneratorParams): Element[] => {
 
   const getFieldType = (allowContainers = false): TypeElement => {
     const fieldTypeOptions = [
-      Object.values(BuiltinTypes).filter(type =>
-        ![BuiltinTypes.UNKNOWN, BuiltinTypes.HIDDEN_STRING].includes(type)),
+      Object.values(BuiltinTypes).filter(type => type !== BuiltinTypes.UNKNOWN),
       weightedRandomSelect(primitiveByRank.slice(0, -1)) || [],
       weightedRandomSelect(objByRank.slice(0, -1)) || [],
     ]
@@ -311,9 +310,14 @@ export const generateElements = (params: GeneratorParams): Element[] => {
       () => {
         const name = getName()
         const fieldType = getFieldType(true)
-        return [name, { type: fieldType,
-          annotations:
-          generateAnnotations(fieldType.annotationTypes) }]
+        return [name, {
+          type: fieldType,
+          annotations: generateAnnotations(
+            // don't generate random annotations for builtin types, even if they
+            // support additional annotation types
+            fieldType === BuiltinTypes.HIDDEN_STRING ? {} : fieldType.annotationTypes
+          ),
+        }]
       }
     )
   )


### PR DESCRIPTION
Instead of #1662. 
After digging a bit more - the random generator was attempting to add random annotations (surprise) on fields with the `hidden_string` type based on its annotation types, which caused some errors and warnings when the randomly-generated values were inconsistent (unlike all other builtins, `hidden_string` "supports" [all core annotation types](https://github.com/salto-io/salto/blob/master/packages/adapter-api/src/builtins.ts#L95) - but they should still be defined consistently). 
Note that additional annotations _can_ be defined on the field, it just needs to be done a little more carefully and this specific part of the generator was not intended for that (for example, a `regex` restriction can be added on string fields, but if it's added here it can generate a warning since the randomly-generated values on instances might not match).
