### PR TITLE
SALTO-1042: Saved salesforce url in state each fetch

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -240,7 +240,7 @@ export const allSystemFields = [
 ]
 
 // The random suffix is to avoid collisions with salesforce elements
-export const INTERNAL_SETTINGS = 'SaltoSettings5a2ca8777a7743c3814ec83e3c4f0147'
+export const INTERNAL_ACCOUNT_INFO = 'AccountInfo5a2ca8777a7743c3814ec83e3c4f0147'
 
 export default class SalesforceAdapter implements AdapterOperations {
   private metadataTypesSkippedList: string[]
@@ -397,7 +397,7 @@ export default class SalesforceAdapter implements AdapterOperations {
         metadataTypes]) as Element[][]
     )
 
-    elements.push(...await this.createInternalSettingsElements())
+    elements.push(...await this.createInternalAccountInfoElements())
 
     const {
       elements: metadataInstancesElements,
@@ -422,7 +422,7 @@ export default class SalesforceAdapter implements AdapterOperations {
     }
   }
 
-  private async createInternalSettingsElements(): Promise<Element[]> {
+  private async createInternalAccountInfoElements(): Promise<Element[]> {
     const instanceUrl = await this.client.getUrl()
 
     if (_.isUndefined(instanceUrl)) {
@@ -430,7 +430,7 @@ export default class SalesforceAdapter implements AdapterOperations {
     }
 
     const type = new ObjectType({
-      elemID: new ElemID(constants.SALESFORCE, INTERNAL_SETTINGS),
+      elemID: new ElemID(constants.SALESFORCE, INTERNAL_ACCOUNT_INFO),
       isSettings: true,
       fields: {
         instanceUrl: { type: BuiltinTypes.STRING },
@@ -438,14 +438,15 @@ export default class SalesforceAdapter implements AdapterOperations {
       annotations: {
         [CORE_ANNOTATIONS.HIDDEN]: true,
       },
-      path: [constants.SALESFORCE, constants.TYPES_PATH, INTERNAL_SETTINGS],
+      path: [constants.SALESFORCE, constants.TYPES_PATH, INTERNAL_ACCOUNT_INFO],
     })
 
     const instance = new InstanceElement(
       ElemID.CONFIG_NAME,
       type,
       { instanceUrl: instanceUrl.href },
-      [constants.SALESFORCE, constants.RECORDS_PATH, constants.SETTINGS_PATH, INTERNAL_SETTINGS],
+      [constants.SALESFORCE, constants.RECORDS_PATH, constants.SETTINGS_PATH,
+        INTERNAL_ACCOUNT_INFO],
       { [CORE_ANNOTATIONS.HIDDEN]: true },
     )
 

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -433,6 +433,16 @@ export default class SalesforceClient {
     })
   }
 
+  @SalesforceClient.requiresLogin
+  public getUrl(): URL | undefined {
+    try {
+      return new URL(this.conn.instanceUrl)
+    } catch (e) {
+      log.error(`Caught exception when tried to parse salesforce url: ${e.stack}`)
+      return undefined
+    }
+  }
+
   /**
    * Read metadata for salesforce object of specific type and name
    */

--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -87,6 +87,7 @@ export default interface Connection {
   queryMore(locator: string): Promise<QueryResult<Value>>
   limits(): Promise<Limits>
   identity(): Promise<IdentityInfo>
+  instanceUrl: string
 }
 
 type ArrayOrSingle<T> = T|T[]

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -20,7 +20,7 @@ import {
 } from '@salto-io/adapter-api'
 import { MetadataInfo } from 'jsforce'
 import { values, collections } from '@salto-io/lowerdash'
-import SalesforceAdapter from '../src/adapter'
+import SalesforceAdapter, { INTERNAL_SETTINGS } from '../src/adapter'
 import Connection from '../src/client/jsforce'
 import { Types } from '../src/transformers/transformer'
 import { findElements, ZipFile, MockInterface } from './utils'
@@ -31,7 +31,7 @@ import {
   INSTANCES_REGEX_SKIPPED_LIST, METADATA_TYPES_SKIPPED_LIST, MAX_ITEMS_IN_RETRIEVE_REQUEST,
 } from '../src/types'
 import { LAYOUT_TYPE_ID } from '../src/filters/layouts'
-import { MockFilePropertiesInput, MockDescribeResultInput, MockDescribeValueResultInput, mockDescribeResult, mockDescribeValueResult, mockFileProperties, mockRetrieveResult } from './connection'
+import { MockFilePropertiesInput, MockDescribeResultInput, MockDescribeValueResultInput, mockDescribeResult, mockDescribeValueResult, mockFileProperties, mockRetrieveResult, MOCK_INSTANCE_URL } from './connection'
 
 describe('SalesforceAdapter fetch', () => {
   let connection: MockInterface<Connection>
@@ -236,12 +236,13 @@ describe('SalesforceAdapter fetch', () => {
         + 1 /* treat blank as */
         + 1 /* value set */
         + 2 /* field dependency & value settings */
-        + 7 /* range restrictions */)
+        + 7 /* range restrictions */
+        + 2 /* internal salto settings */)
 
-      const types = _.assign({}, ...result.map(t => ({ [id(t)]: t })))
-      const nestingType = types['salesforce.NestingType']
-      const nestedType = types['salesforce.NestedType']
-      const singleField = types['salesforce.SingleFieldType']
+      const elementsMap = _.assign({}, ...result.map(t => ({ [id(t)]: t })))
+      const nestingType = elementsMap['salesforce.NestingType']
+      const nestedType = elementsMap['salesforce.NestedType']
+      const singleField = elementsMap['salesforce.SingleFieldType']
       expect(nestingType).toBeDefined()
       expect(nestingType.fields.field.type.elemID).toEqual(nestedType.elemID)
       expect(nestingType.fields.otherField.type.elemID).toEqual(singleField.elemID)
@@ -251,6 +252,17 @@ describe('SalesforceAdapter fetch', () => {
       expect(nestedType.fields.doubleNested.type.elemID).toEqual(singleField.elemID)
       expect(singleField).toBeDefined()
       expect(singleField.fields.str.type.elemID).toEqual(BuiltinTypes.STRING.elemID)
+      expect(elementsMap[`salesforce.${INTERNAL_SETTINGS}`]).toBeDefined()
+      expect(elementsMap[`salesforce.${INTERNAL_SETTINGS}.instance`]?.value?.instanceUrl).toBe(MOCK_INSTANCE_URL)
+    })
+
+    it('should not fetch internal settings when url is invalid', async () => {
+      connection.instanceUrl = 'invalidurl'
+      const { elements: result } = await adapter.fetch()
+
+      const elementsMap = _.assign({}, ...result.map(t => ({ [id(t)]: t })))
+      expect(elementsMap[`salesforce.${INTERNAL_SETTINGS}`]).toBeUndefined()
+      expect(elementsMap[`salesforce.${INTERNAL_SETTINGS}.instance`]).toBeUndefined()
     })
 
     describe('with metadata instance', () => {

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -20,7 +20,7 @@ import {
 } from '@salto-io/adapter-api'
 import { MetadataInfo } from 'jsforce'
 import { values, collections } from '@salto-io/lowerdash'
-import SalesforceAdapter, { INTERNAL_SETTINGS } from '../src/adapter'
+import SalesforceAdapter, { INTERNAL_ACCOUNT_INFO } from '../src/adapter'
 import Connection from '../src/client/jsforce'
 import { Types } from '../src/transformers/transformer'
 import { findElements, ZipFile, MockInterface } from './utils'
@@ -237,7 +237,7 @@ describe('SalesforceAdapter fetch', () => {
         + 1 /* value set */
         + 2 /* field dependency & value settings */
         + 7 /* range restrictions */
-        + 2 /* internal salto settings */)
+        + 2 /* internal account information */)
 
       const elementsMap = _.assign({}, ...result.map(t => ({ [id(t)]: t })))
       const nestingType = elementsMap['salesforce.NestingType']
@@ -252,17 +252,17 @@ describe('SalesforceAdapter fetch', () => {
       expect(nestedType.fields.doubleNested.type.elemID).toEqual(singleField.elemID)
       expect(singleField).toBeDefined()
       expect(singleField.fields.str.type.elemID).toEqual(BuiltinTypes.STRING.elemID)
-      expect(elementsMap[`salesforce.${INTERNAL_SETTINGS}`]).toBeDefined()
-      expect(elementsMap[`salesforce.${INTERNAL_SETTINGS}.instance`]?.value?.instanceUrl).toBe(MOCK_INSTANCE_URL)
+      expect(elementsMap[`salesforce.${INTERNAL_ACCOUNT_INFO}`]).toBeDefined()
+      expect(elementsMap[`salesforce.${INTERNAL_ACCOUNT_INFO}.instance`]?.value?.instanceUrl).toBe(MOCK_INSTANCE_URL)
     })
 
-    it('should not fetch internal settings when url is invalid', async () => {
+    it('should not fetch internal account info when url is invalid', async () => {
       connection.instanceUrl = 'invalidurl'
       const { elements: result } = await adapter.fetch()
 
-      const elementsMap = _.assign({}, ...result.map(t => ({ [id(t)]: t })))
-      expect(elementsMap[`salesforce.${INTERNAL_SETTINGS}`]).toBeUndefined()
-      expect(elementsMap[`salesforce.${INTERNAL_SETTINGS}.instance`]).toBeUndefined()
+      const elementsMap = _.keyBy(result, id)
+      expect(elementsMap[`salesforce.${INTERNAL_ACCOUNT_INFO}`]).toBeUndefined()
+      expect(elementsMap[`salesforce.${INTERNAL_ACCOUNT_INFO}.instance`]).toBeUndefined()
     })
 
     describe('with metadata instance', () => {

--- a/packages/salesforce-adapter/test/connection.ts
+++ b/packages/salesforce-adapter/test/connection.ts
@@ -21,6 +21,8 @@ import { MetadataObject, DescribeMetadataResult, ValueTypeField, DescribeValueTy
 import Connection, { Metadata, Soap, Bulk, Tooling, RunTestsResult, RunTestFailure } from '../src/client/jsforce'
 import { createEncodedZipContent, MockInterface, mockFunction, ZipFile } from './utils'
 
+export const MOCK_INSTANCE_URL = 'https://url.com/'
+
 export type MockDescribeResultInput = Pick<MetadataObject, 'xmlName'> & Partial<MetadataObject>
 export const mockDescribeResult = (
   ...objects: MockDescribeResultInput[]
@@ -321,4 +323,5 @@ export const mockJsforce: () => MockInterface<Connection> = () => ({
     queryMore: mockFunction<Tooling['queryMore']>().mockResolvedValue(mockQueryResult({})),
   },
   identity: mockFunction<Connection['identity']>().mockImplementation(async () => mockIdentity('')),
+  instanceUrl: MOCK_INSTANCE_URL,
 })


### PR DESCRIPTION
Saved the instance URL of salesforce as a hidden element, which will be retrieved at each fetch.

This is done for task SALTO-1042, so I won't need to login to salesforce to retrieve the URL each time I convert an element into a URL.

---
_Release Notes:_ None