### PR TITLE
SALTO-1092: Avoid adding topics for standard objects that do not support them

### DIFF
--- a/packages/salesforce-adapter/src/filters/topics_for_objects.ts
+++ b/packages/salesforce-adapter/src/filters/topics_for_objects.ts
@@ -103,7 +103,7 @@ const filterCreator: FilterCreator = (): FilterWith<'onFetch' | 'onDeploy'> => (
     const changedObjectTopics = customObjectChanges
       .filter(isModificationChange)
       .filter(change => (
-        getTopicsForObjects(change.data.before) !== getTopicsForObjects(change.data.after)
+        !_.isEqual(getTopicsForObjects(change.data.before), getTopicsForObjects(change.data.after))
       ))
       .map(getChangeElement)
 

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -1176,7 +1176,7 @@ describe('SalesforceAdapter CRUD', () => {
         it('should deploy changes to the object and fields', async () => {
           expect(mockDeploy).toHaveBeenCalledTimes(1)
           const deployedPackage = await getDeployedPackage(mockDeploy.mock.calls[0][0])
-          expect(deployedPackage.manifest?.types).toContainEqual(
+          expect(deployedPackage.manifest?.types).toEqual(
             { name: constants.CUSTOM_OBJECT, members: 'Test__c' }
           )
           const deployedValues = await deployedPackage.getData('objects/Test__c.object')

--- a/packages/salesforce-adapter/test/filters/topics_for_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/topics_for_objects.test.ts
@@ -94,18 +94,24 @@ describe('Topics for objects filter', () => {
           toChange({ after: mockObject('Test1__c') }),
           toChange({ after: mockObject('Test2__c', true) }),
           toChange({ before: mockObject('Test3__c', true), after: mockObject('Test3__c', false) }),
+          toChange({ before: mockObject('Test4__c'), after: mockObject('Test4__c') }),
         ]
         await filter.preDeploy(changes)
       })
-      it('should add topics annotation to types that do not have it', () => {
+      it('should add topics annotation to new types that do not have it', () => {
         expect(getChangeElement(changes[0]).annotations).toHaveProperty(
           TOPICS_FOR_OBJECTS_ANNOTATION,
           { [ENABLE_TOPICS]: false },
         )
       })
+      it('should not add topics to existing types that do not have it', () => {
+        expect(getChangeElement(changes[3]).annotations).not.toHaveProperty(
+          TOPICS_FOR_OBJECTS_ANNOTATION
+        )
+      })
       it('should add instance change to types that have changed topics enabled value', () => {
-        expect(changes).toHaveLength(5)
-        const topicsInstanceChanges = changes.slice(3)
+        expect(changes).toHaveLength(6)
+        const topicsInstanceChanges = changes.slice(4)
         expect(topicsInstanceChanges.map(change => change.action)).toEqual(['add', 'add'])
         const instances = topicsInstanceChanges.map(getChangeElement) as InstanceElement[]
         expect(instances.map(inst => apiName(inst))).toEqual(['Test2__c', 'Test3__c'])
@@ -125,7 +131,7 @@ describe('Topics for objects filter', () => {
         await filter.onDeploy(changes)
       })
       it('should remove topics instance changes', () => {
-        expect(changes).toHaveLength(3)
+        expect(changes).toHaveLength(4)
         expect(changes.filter(isInstanceChange)).toHaveLength(0)
       })
     })


### PR DESCRIPTION
This fixes a bug in the way the topics for objects filter would compare whether
topics for objects changed for an object type that would cause it to add topics
for existing objects that should not have them

---

_Release Notes_:
- Fixed issue with deploying standard objects that do not support topics