### PR TITLE
Support adapter progress reporting in fetch

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -33,10 +33,21 @@ export type DeployResult = {
   errors: ReadonlyArray<Error>
 }
 
+export type Progress = {
+  details: string
+  percents: number
+}
+
+export type ProgressReporter = {
+  reportProgress: (progress: Progress) => void
+}
+
 export type AdapterOperations = {
-  fetch: () => Promise<FetchResult>
+  fetch: (progressReporter?: ProgressReporter) => Promise<FetchResult>
   deploy: (changeGroup: ChangeGroup) => Promise<DeployResult>
 }
+
+export type AdapterOperationName = keyof AdapterOperations
 
 export type AdapterOperationsContext = {
   credentials: InstanceElement

--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -35,7 +35,7 @@ export type DeployResult = {
 
 export type Progress = {
   details: string
-  percents: number
+  completedPercents: number
 }
 
 export type ProgressReporter = {

--- a/packages/core/src/core/adapters/progress.ts
+++ b/packages/core/src/core/adapters/progress.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { EventEmitter } from 'pietile-eventemitter'
+
+import {
+  Progress as AdapterProgress,
+  ProgressReporter as AdapterProgressReporter,
+  AdapterOperationName,
+} from '@salto-io/adapter-api'
+
+
+export type AdapterEvents = {
+  adapterProgress: (
+    adapterName: string,
+    operationName: AdapterOperationName,
+    progress: AdapterProgress
+  ) => void
+}
+
+export const createAdapterProgressReporter = (
+  adapterName: string,
+  operationName: AdapterOperationName,
+  progressEmitter?: EventEmitter<AdapterEvents>
+): AdapterProgressReporter => ({
+  reportProgress: (progress: AdapterProgress) => {
+    if (progressEmitter) {
+      progressEmitter.emit(
+        'adapterProgress',
+        adapterName,
+        operationName,
+        progress
+      )
+    }
+  },
+})

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -17,7 +17,7 @@ import { EventEmitter } from 'pietile-eventemitter'
 import {
   ElemID, Field, BuiltinTypes, ObjectType, getChangeElement, AdapterOperations, Element,
   PrimitiveType, PrimitiveTypes, ADAPTER, OBJECT_SERVICE_ID, InstanceElement, CORE_ANNOTATIONS,
-  ListType, FieldDefinition, FIELD_NAME, INSTANCE_NAME, OBJECT_NAME,
+  ListType, FieldDefinition, FIELD_NAME, INSTANCE_NAME, OBJECT_NAME, ProgressReporter,
 } from '@salto-io/adapter-api'
 import * as utils from '@salto-io/adapter-utils'
 import {
@@ -301,27 +301,54 @@ describe('fetch', () => {
     })
     describe('when a progressEmitter is provided', () => {
       let progressEmitter: EventEmitter<FetchProgressEvents>
-      beforeEach(async () => {
-        mockAdapters.dummy.fetch.mockResolvedValueOnce(
-          Promise.resolve({ elements: [newTypeBase, newTypeExt] })
-        )
+      beforeEach(() => {
         progressEmitter = new EventEmitter<FetchProgressEvents>()
-        const result = await fetchChanges(
-          mockAdapters,
-          [],
-          [],
-          [],
-          progressEmitter
-        )
-        changes = [...result.changes]
       })
 
-      it('should call emit on changesWillBeFetched & diffWillBeCalculcated', () => {
-        expect(progressEmitter.emit).toHaveBeenCalledTimes(2)
-        expect(progressEmitter.emit).toHaveBeenCalledWith('changesWillBeFetched', expect.anything(), expect.anything())
-        expect(progressEmitter.emit).toHaveBeenCalledWith('diffWillBeCalculated', expect.anything())
+      describe('when adapter progress is not reported', () => {
+        beforeEach(async () => {
+          mockAdapters.dummy.fetch.mockResolvedValueOnce(
+            Promise.resolve({ elements: [newTypeBase, newTypeExt] })
+          )
+          const result = await fetchChanges(
+            mockAdapters,
+            [],
+            [],
+            [],
+            progressEmitter
+          )
+          changes = [...result.changes]
+        })
+        it('should call emit on changesWillBeFetched & diffWillBeCalculcated', () => {
+          expect(progressEmitter.emit).toHaveBeenCalledTimes(2)
+          expect(progressEmitter.emit).toHaveBeenCalledWith('changesWillBeFetched', expect.anything(), expect.anything())
+          expect(progressEmitter.emit).toHaveBeenCalledWith('diffWillBeCalculated', expect.anything())
+        })
+      })
+      describe('when adapter progress is reported ', () => {
+        beforeEach(async () => {
+          mockAdapters.dummy.fetch.mockImplementationOnce((progressReporter?: ProgressReporter) => {
+            if (progressReporter) progressReporter.reportProgress({ details: 'done', percents: 100 })
+            return Promise.resolve({ elements: [newTypeBase, newTypeExt] })
+          })
+          const result = await fetchChanges(
+            mockAdapters,
+            [],
+            [],
+            [],
+            progressEmitter
+          )
+          changes = [...result.changes]
+        })
+        it('should call emit on changesWillBeFetched & diffWillBeCalculcated and adapter events', () => {
+          expect(progressEmitter.emit).toHaveBeenCalledTimes(3)
+          expect(progressEmitter.emit).toHaveBeenCalledWith('changesWillBeFetched', expect.anything(), expect.anything())
+          expect(progressEmitter.emit).toHaveBeenCalledWith('diffWillBeCalculated', expect.anything())
+          expect(progressEmitter.emit).toHaveBeenCalledWith('adapterProgress', 'dummy', 'fetch', { details: 'done', percents: 100 })
+        })
       })
     })
+
     describe('when the adapter returns elements that should be split', () => {
       beforeEach(async () => {
         mockAdapters.dummy.fetch.mockResolvedValueOnce(

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -328,7 +328,7 @@ describe('fetch', () => {
       describe('when adapter progress is reported ', () => {
         beforeEach(async () => {
           mockAdapters.dummy.fetch.mockImplementationOnce((progressReporter?: ProgressReporter) => {
-            if (progressReporter) progressReporter.reportProgress({ details: 'done', percents: 100 })
+            if (progressReporter) progressReporter.reportProgress({ details: 'done', completedPercents: 100 })
             return Promise.resolve({ elements: [newTypeBase, newTypeExt] })
           })
           const result = await fetchChanges(
@@ -344,7 +344,7 @@ describe('fetch', () => {
           expect(progressEmitter.emit).toHaveBeenCalledTimes(3)
           expect(progressEmitter.emit).toHaveBeenCalledWith('changesWillBeFetched', expect.anything(), expect.anything())
           expect(progressEmitter.emit).toHaveBeenCalledWith('diffWillBeCalculated', expect.anything())
-          expect(progressEmitter.emit).toHaveBeenCalledWith('adapterProgress', 'dummy', 'fetch', { details: 'done', percents: 100 })
+          expect(progressEmitter.emit).toHaveBeenCalledWith('adapterProgress', 'dummy', 'fetch', { details: 'done', completedPercents: 100 })
         })
       })
     })

--- a/packages/dummy-adapter/src/adapter.ts
+++ b/packages/dummy-adapter/src/adapter.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  FetchResult, AdapterOperations, ChangeGroup, DeployResult,
+  FetchResult, AdapterOperations, ChangeGroup, DeployResult, ProgressReporter,
 } from '@salto-io/adapter-api'
 import { generateElements, GeneratorParams } from './generator'
 
@@ -27,9 +27,9 @@ export default class DummyAdapter implements AdapterOperations {
    * Fetch configuration elements: objects, types and instances for the given HubSpot account.
    * Account credentials were given in the constructor.
    */
-  public async fetch(): Promise<FetchResult> {
+  public async fetch(progressReporter?: ProgressReporter): Promise<FetchResult> {
     return {
-      elements: generateElements(this.genParams),
+      elements: generateElements(this.genParams, progressReporter),
     }
   }
 

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -520,8 +520,8 @@ export const generateElements = (
       }
     ).flat()
   }
-  const reportProgress = (details: string, percents: number): void => {
-    if (progressReporter) progressReporter.reportProgress({ details, percents })
+  const reportProgress = (details: string, completedPercents: number): void => {
+    if (progressReporter) progressReporter.reportProgress({ details, completedPercents })
   }
   const defaultTypes = [defaultObj, permissionsType, profileType]
   reportProgress('Generating primitive types', 10)

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -13,7 +13,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { PrimitiveType, ElemID, PrimitiveTypes, Element, ObjectType, FieldDefinition, BuiltinTypes, ListType, TypeElement, InstanceElement, Value, isPrimitiveType, isObjectType, isListType, TypeMap, Values, CORE_ANNOTATIONS, StaticFile, calculateStaticFileHash, ReferenceExpression, getDeepInnerType, isContainerType, MapType, isMapType } from '@salto-io/adapter-api'
+import {
+  PrimitiveType, ElemID, PrimitiveTypes, Element, ObjectType,
+  FieldDefinition, BuiltinTypes, ListType, TypeElement, InstanceElement,
+  Value, isPrimitiveType, isObjectType, isListType, TypeMap, Values,
+  CORE_ANNOTATIONS, StaticFile, calculateStaticFileHash, ReferenceExpression,
+  getDeepInnerType, isContainerType, MapType, isMapType, ProgressReporter,
+} from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { uniqueNamesGenerator, adjectives, colors, names } from 'unique-names-generator'
 import { collections } from '@salto-io/lowerdash'
@@ -138,7 +144,10 @@ const profileType = new ObjectType({
   path: [DUMMY_ADAPTER, 'Default', 'Profile'],
 })
 
-export const generateElements = (params: GeneratorParams): Element[] => {
+export const generateElements = (
+  params: GeneratorParams,
+  progressReporter?: ProgressReporter
+): Element[] => {
   seedrandom(params.seed.toString(), { global: true })
   const elementRanks: Record<string, number> = {}
   const primitiveByRank: PrimitiveType[][] = arrayOf(defaultParams.maxRank + 1, () => [])
@@ -511,13 +520,21 @@ export const generateElements = (params: GeneratorParams): Element[] => {
       }
     ).flat()
   }
-
+  const reportProgress = (details: string, percents: number): void => {
+    if (progressReporter) progressReporter.reportProgress({ details, percents })
+  }
   const defaultTypes = [defaultObj, permissionsType, profileType]
+  reportProgress('Generating primitive types', 10)
   const primtiveTypes = generatePrimitiveTypes()
+  reportProgress('Generating types', 30)
   const types = generateTypes()
+  reportProgress('Generating objects', 50)
   const objects = generateObjects()
+  reportProgress('Generating records', 70)
   const records = generateRecords()
+  reportProgress('Generating profile likes', 90)
   const profiles = generateProfileLike(params.useOldProfiles)
+  reportProgress('Generation done', 100)
   return [
     ...defaultTypes,
     ...primtiveTypes,

--- a/packages/dummy-adapter/test/adapter.test.ts
+++ b/packages/dummy-adapter/test/adapter.test.ts
@@ -32,9 +32,20 @@ describe('dummy adapter', () => {
   })
 
   describe('fetch', () => {
+    const progressReportMock = {
+      reportProgress: jest.fn(),
+    }
     it('should return the result of the generateElement command withuot modifications', async () => {
       const fetchResult = await adapter.fetch()
       expect(fetchResult).toEqual({ elements: generator.generateElements(testParams) })
+    })
+    it('should report fetch progress', async () => {
+      await adapter.fetch(progressReportMock)
+      expect(progressReportMock.reportProgress).toHaveBeenCalledTimes(6)
+      expect(progressReportMock.reportProgress).toHaveBeenLastCalledWith({
+        details: 'Generation done',
+        percents: 100,
+      })
     })
   })
 })

--- a/packages/dummy-adapter/test/adapter.test.ts
+++ b/packages/dummy-adapter/test/adapter.test.ts
@@ -44,7 +44,7 @@ describe('dummy adapter', () => {
       expect(progressReportMock.reportProgress).toHaveBeenCalledTimes(6)
       expect(progressReportMock.reportProgress).toHaveBeenLastCalledWith({
         details: 'Generation done',
-        percents: 100,
+        completedPercents: 100,
       })
     })
   })


### PR DESCRIPTION
This change adds a callback that will allow reporting progress events from each adapter operation (currently added for `fetch` operation)
Progress is then emitted to the operation progress emitter along with the operation name and adapter name.
Example reporting in dummy adapter was added.
JIRA: SAAS-931, SAAS-997