### PR TITLE
SAAS-905: fixed go to definition for annotation types

### DIFF
--- a/packages/lang-server/src/definitions.ts
+++ b/packages/lang-server/src/definitions.ts
@@ -30,6 +30,19 @@ export const provideWorkspaceDefinition = async (
     if (values.isDefined<SaltoElemLocation>(staticFileLocation)) {
       return [staticFileLocation]
     }
+  }
+
+  try {
+    const locations = await getLocations(workspace, token)
+    if (locations.length !== 0) {
+      return locations
+    }
+  // eslint-disable-next-line no-empty
+  } catch (e) {
+    // token is not a valid element id
+  }
+
+  if (context.ref) {
     if (isInstanceElement(context.ref.element)) {
       const refPath = context.ref.path
       if (!_.isEmpty(refPath) && _.last(refPath) === token) {
@@ -44,10 +57,6 @@ export const provideWorkspaceDefinition = async (
       )
     }
   }
-  // We are not in instance field, so we can just look the current token
-  try {
-    return getLocations(workspace, token)
-  } catch (e) {
-    return []
-  }
+
+  return []
 }

--- a/packages/lang-server/test/definitions.test.ts
+++ b/packages/lang-server/test/definitions.test.ts
@@ -86,4 +86,14 @@ describe('Test go to definitions', () => {
       expect(defs[0].filename).toBe(`full-${filepath}`)
     })
   })
+
+  it('should give annotation type definition', async () => {
+    const pos = { line: 172, col: 15 }
+    const ctx = await getPositionContext(workspace, naclFileName, pos)
+    const token = 'vs.person'
+    const defs = await provideWorkspaceDefinition(workspace, ctx, token)
+    expect(defs.length).toBe(2)
+    expect(defs[0].range.start.line).toBe(32)
+    expect(defs[1].range.start.line).toBe(127)
+  })
 })


### PR DESCRIPTION
Fixed go to definition for annotation types.

The fix is that if the token is a valid element id, we will always try to go to the element of the token first. Otherwise, we continue to run the usual procedure.

---
__Release Notes:__
Fixed go to definition for annotation types.