### PR TITLE
SALTO-1103 - removed sort of state file

### DIFF
--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -124,11 +124,6 @@ export const serialize = (elements: Element[],
     if (isSaltoSerializable(e)) {
       return saltoClassReplacer(e)
     }
-    // We need to sort objects so that the state file won't change for the same data.
-    if (_.isPlainObject(e)) {
-      return _(e).toPairs().sortBy().fromPairs()
-        .value()
-    }
     return e
   }
 


### PR DESCRIPTION
We currently sort the state file, the logic behind this in the past was so that the state file wouldn't change on identical workspaces. This is irrelevant since we added the fetchTime to the service in state.
Sorting the state causes restore to reorder values in the Nacl file. This causes unnecessary diffs.

---

_Release notes_
Core bug fixes:
- Fixed issue where restore would reorder values even when they were not reordered by the user.