### PR TITLE
SALTO-1093: Only include fields in custom object deploy when necessary

### DIFF
--- a/packages/salesforce-adapter/src/client/types.ts
+++ b/packages/salesforce-adapter/src/client/types.ts
@@ -248,12 +248,16 @@ export class CustomField implements MetadataInfo {
   }
 }
 
+type SharingModelEnum = 'Private' | 'Read' | 'ReadSelect'
+  | 'ReadWrite' | 'ReadWriteTransfer' | 'FullAccess' | 'ControlledByParent'
+  | 'ControlledByLeadOrContact' | 'ControlledByCampaign'
+
 export type CustomObject = MetadataInfo & {
   label: string
   fields?: CustomField | CustomField[]
   pluralLabel?: string
   deploymentStatus?: string
-  sharingModel?: string
+  sharingModel?: SharingModelEnum
   nameField?: Partial<CustomField>
 }
 

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -1017,9 +1017,9 @@ describe('SalesforceAdapter CRUD', () => {
           expect(deployedValues).toBeDefined()
           const updatedObj = deployedValues.CustomObject
           expect(updatedObj.label).toEqual('test2 label')
-          // It should deploy all fields when there is an annotation change
-          expect(updatedObj.fields).toHaveLength(2)
-          const [newField] = updatedObj.fields
+          // It should not deploy all fields when the sharingModel is not ControlledByParent
+          expect(Array.isArray(updatedObj.fields)).toBeFalsy()
+          const newField = updatedObj.fields
           expect(newField.fullName).toEqual('address__c')
           expect(newField.type).toEqual('Text')
           expect(newField.label).toEqual('test2 label')

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -1543,10 +1543,17 @@ describe('Custom Objects filter', () => {
             annotations: { [API_NAME]: 'Test__c.SysField' },
           },
         },
+        annotationTypes: {
+          [METADATA_TYPE]: BuiltinTypes.SERVICE_ID,
+          [API_NAME]: BuiltinTypes.SERVICE_ID,
+          [LABEL]: BuiltinTypes.STRING,
+          sharingModel: BuiltinTypes.STRING,
+        },
         annotations: {
           [METADATA_TYPE]: CUSTOM_OBJECT,
           [API_NAME]: 'Test__c',
           [LABEL]: 'TestObject',
+          sharingModel: 'ControlledByParent',
         },
       })
       parentAnnotation = { [CORE_ANNOTATIONS.PARENT]: [testObject] }
@@ -1650,10 +1657,11 @@ describe('Custom Objects filter', () => {
         beforeAll(async () => {
           await filter.preDeploy(changes)
         })
-        it('should create a custom object instance change with all fields and annotations', () => {
+        it('should create a custom object instance change with annotations and master-detail fields', () => {
           expect(changes).toHaveLength(1)
           const { before, after } = changes[0].data as ModificationChange<InstanceElement>['data']
-          expect(after.value.fields).toHaveLength(Object.keys(testObject.fields).length)
+          expect(after.value.fields).toHaveLength(1)
+          expect(after.value.fields[0].type).toEqual('MasterDetail')
           expect(after.value[LABEL]).toEqual('New Label')
           expect(before.value[LABEL]).toEqual('TestObject')
         })


### PR DESCRIPTION
When deploying a custom object we currently include all fields to handle the case
where sharingModel is controlled by parent (and that requires master-detail fields
to be in the deploy request)

Since this can increase the scope of the deploy significantly, this changes that
behavior such that we will only include master-detail fields and only if the sharing
model is controlled by parent

---

Based on #1685 

_Release Notes_ (same as #1685):
- Improvements to custom object deploy flow to avoid overriding default configuration like sharingModel