### PR TITLE
SALTO-1092: Avoid overriding custom object default sharing model

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -458,7 +458,7 @@ export default class SalesforceAdapter implements AdapterOperations {
     const resolvedChanges = changeGroup.changes
       .map(change => resolveChangeElement(change, getLookUpName))
 
-    resolvedChanges.filter(isAdditionChange).forEach(addDefaults)
+    resolvedChanges.filter(isAdditionChange).map(getChangeElement).forEach(addDefaults)
 
     await this.filtersRunner.preDeploy(resolvedChanges)
 

--- a/packages/salesforce-adapter/src/client/types.ts
+++ b/packages/salesforce-adapter/src/client/types.ts
@@ -248,46 +248,13 @@ export class CustomField implements MetadataInfo {
   }
 }
 
-export class CustomProperties implements MetadataInfo {
-  readonly fields?: CustomField[] | CustomField
-
-  constructor(
-    readonly fullName: string,
-    readonly label: string,
-    fields?: CustomField[]
-  ) {
-    if (fields) {
-      this.fields = fields
-    }
-  }
-}
-
-export class CustomObject extends CustomProperties {
-  readonly pluralLabel: string
-  readonly deploymentStatus = 'Deployed'
-  readonly sharingModel: string
-  readonly nameField = {
-    type: 'Text',
-    label: 'Name',
-  }
-
-  constructor(
-    readonly fullName: string,
-    readonly label: string,
-    fields?: CustomField[]
-  ) {
-    super(fullName, label, fields)
-    this.pluralLabel = `${this.label}s`
-
-    const hasMasterDetailField = (): boolean|undefined => fields
-      && fields.some(field => field.type === FIELD_TYPE_NAMES.MASTER_DETAIL)
-
-    if (hasMasterDetailField()) {
-      this.sharingModel = 'ControlledByParent'
-    } else {
-      this.sharingModel = 'ReadWrite'
-    }
-  }
+export type CustomObject = MetadataInfo & {
+  label: string
+  fields?: CustomField | CustomField[]
+  pluralLabel?: string
+  deploymentStatus?: string
+  sharingModel?: string
+  nameField?: Partial<CustomField>
 }
 
 export interface SfError {

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -23,6 +23,7 @@ import SalesforceAdapter from '../src/adapter'
 import * as constants from '../src/constants'
 import { Types, createInstanceElement, apiName, metadataType } from '../src/transformers/transformer'
 import Connection from '../src/client/jsforce'
+import { CustomObject } from '../src/client/types'
 import mockAdapter from './adapter'
 import { createValueSetEntry } from './utils'
 import { createElement, removeElement } from '../e2e_test/utils'
@@ -202,7 +203,6 @@ describe('SalesforceAdapter CRUD', () => {
             type: stringType,
             annotations: {
               [CORE_ANNOTATIONS.REQUIRED]: false,
-              [constants.LABEL]: 'test label',
             },
           },
           formula: {
@@ -229,10 +229,26 @@ describe('SalesforceAdapter CRUD', () => {
         // Verify object creation
         expect(result).toBeInstanceOf(ObjectType)
         expect(result.annotations[constants.API_NAME]).toBe('Test__c')
+        expect(result.annotationTypes[constants.API_NAME]).toEqual(BuiltinTypes.SERVICE_ID)
+        expect(result.annotations[constants.METADATA_TYPE]).toBe(constants.CUSTOM_OBJECT)
+        expect(result.annotationTypes[constants.METADATA_TYPE]).toEqual(BuiltinTypes.SERVICE_ID)
+        const objAnnotations = result.annotations as CustomObject
+        expect(objAnnotations.label).toEqual('Test')
+        expect(result.annotationTypes.label).toEqual(BuiltinTypes.STRING)
+        expect(objAnnotations.deploymentStatus).toEqual('Deployed')
+        expect(result.annotationTypes.deploymentStatus).toEqual(BuiltinTypes.STRING)
+        expect(objAnnotations.nameField).toEqual({ type: 'Text', label: 'Name' })
+        expect(result.annotationTypes.nameField.elemID).toEqual(
+          new ElemID(constants.SALESFORCE, constants.CUSTOM_FIELD)
+        )
+        expect(objAnnotations.pluralLabel).toEqual('Tests')
+        expect(result.annotationTypes.pluralLabel).toEqual(BuiltinTypes.STRING)
+        expect(objAnnotations.sharingModel).toEqual('ReadWrite')
+        expect(result.annotationTypes.sharingModel).toEqual(BuiltinTypes.STRING)
         expect(
           result.fields.description.annotations[constants.API_NAME]
         ).toBe('Test__c.description__c')
-        expect(result.annotations[constants.METADATA_TYPE]).toBe(constants.CUSTOM_OBJECT)
+        expect(result.fields.description.annotations[constants.LABEL]).toEqual('description')
 
         expect(mockDeploy).toHaveBeenCalledTimes(1)
         const deployedPackage = await getDeployedPackage(mockDeploy.mock.calls[0][0])

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -1,0 +1,191 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, BuiltinTypes, Field, InstanceElement } from '@salto-io/adapter-api'
+import { addDefaults } from '../../src/filters/utils'
+import { SALESFORCE, LABEL, API_NAME, CUSTOM_FIELD, INSTANCE_FULL_NAME_FIELD, METADATA_TYPE, CUSTOM_OBJECT, CUSTOM_SETTINGS_TYPE } from '../../src/constants'
+import { Types } from '../../src/transformers/transformer'
+import { CustomObject } from '../../src/client/types'
+import { mockTypes } from '../mock_elements'
+
+describe('addDefaults', () => {
+  describe('when called with instance', () => {
+    let instance: InstanceElement
+    beforeEach(() => {
+      instance = new InstanceElement('test', mockTypes.Profile)
+      addDefaults(instance)
+    })
+    it('should add api name', () => {
+      expect(instance.value).toHaveProperty(INSTANCE_FULL_NAME_FIELD, 'test')
+    })
+  })
+  describe('when called with field', () => {
+    let field: Field
+    beforeEach(() => {
+      const obj = new ObjectType({
+        elemID: new ElemID(SALESFORCE, 'test'),
+        fields: {
+          a: { type: Types.primitiveDataTypes.Text },
+        },
+        annotations: {
+          [API_NAME]: 'test',
+        },
+      })
+      field = obj.fields.a
+      addDefaults(field)
+    })
+    it('should add api name', () => {
+      expect(field.annotations).toHaveProperty(API_NAME, 'test.a__c')
+    })
+    it('should add label', () => {
+      expect(field.annotations).toHaveProperty(LABEL, 'a')
+    })
+  })
+  describe('when called with custom object', () => {
+    describe('when object has no annotations', () => {
+      let object: ObjectType
+      beforeEach(() => {
+        object = new ObjectType({
+          elemID: new ElemID(SALESFORCE, 'test'),
+          fields: {
+            a: { type: Types.primitiveDataTypes.Text },
+          },
+        })
+
+        addDefaults(object)
+      })
+      it('should add annotation values', () => {
+        expect(object.annotations).toMatchObject({
+          [API_NAME]: 'test__c',
+          [METADATA_TYPE]: CUSTOM_OBJECT,
+          [LABEL]: 'test',
+          deploymentStatus: 'Deployed',
+          pluralLabel: 'tests',
+          nameField: { type: 'Text', label: 'Name' },
+          sharingModel: 'ReadWrite',
+        } as Partial<CustomObject>)
+      })
+      it('should add annotation types', () => {
+        expect(object.annotationTypes).toMatchObject({
+          [API_NAME]: BuiltinTypes.SERVICE_ID,
+          [METADATA_TYPE]: BuiltinTypes.SERVICE_ID,
+          [LABEL]: BuiltinTypes.STRING,
+          deploymentStatus: BuiltinTypes.STRING,
+          pluralLabel: BuiltinTypes.STRING,
+          sharingModel: BuiltinTypes.STRING,
+        })
+        expect(object.annotationTypes.nameField?.elemID).toEqual(
+          new ElemID(SALESFORCE, CUSTOM_FIELD)
+        )
+      })
+      it('should add defaults to fields', () => {
+        expect(object.fields.a.annotations).toMatchObject({
+          [API_NAME]: 'test__c.a__c',
+          [LABEL]: 'a',
+        })
+      })
+    })
+    describe('when object already has annotations', () => {
+      let object: ObjectType
+      beforeEach(() => {
+        object = new ObjectType({
+          elemID: new ElemID(SALESFORCE, 'test'),
+          annotations: {
+            [LABEL]: 'myLabel',
+            nameField: { type: 'AutoNumber', label: 'Name' },
+          },
+          annotationTypes: {
+            sharingModel: BuiltinTypes.HIDDEN_STRING,
+          },
+        })
+        addDefaults(object)
+      })
+      it('should add missing annotations', () => {
+        expect(object.annotations).toMatchObject({
+          [API_NAME]: 'test__c',
+          sharingModel: 'ReadWrite',
+        } as Partial<CustomObject>)
+      })
+      it('should not override existing annotations', () => {
+        expect(object.annotations).toMatchObject({
+          [LABEL]: 'myLabel',
+          nameField: { type: 'AutoNumber', label: 'Name' },
+        } as Partial<CustomObject>)
+      })
+      it('should add plural label according to the label', () => {
+        expect(object.annotations).toHaveProperty('pluralLabel', 'myLabels')
+      })
+      it('should add missing annotation types', () => {
+        expect(object.annotationTypes).toMatchObject({
+          [API_NAME]: BuiltinTypes.SERVICE_ID,
+          [LABEL]: BuiltinTypes.STRING,
+        })
+        expect(object.annotationTypes.nameField?.elemID).toEqual(
+          new ElemID(SALESFORCE, CUSTOM_FIELD)
+        )
+      })
+      it('should not override existing annotation types', () => {
+        expect(object.annotationTypes).toMatchObject({
+          sharingModel: BuiltinTypes.HIDDEN_STRING,
+        })
+      })
+    })
+    describe('when object has a master detail field', () => {
+      let object: ObjectType
+      beforeEach(() => {
+        object = new ObjectType({
+          elemID: new ElemID(SALESFORCE, 'test'),
+          fields: {
+            a: { type: Types.primitiveDataTypes.MasterDetail },
+          },
+        })
+        addDefaults(object)
+      })
+      it('should set sharing model to controlled by parent', () => {
+        expect(object.annotations).toHaveProperty('sharingModel', 'ControlledByParent')
+      })
+    })
+  })
+  describe('when called with custom settings', () => {
+    let object: ObjectType
+    beforeEach(() => {
+      object = new ObjectType({
+        elemID: new ElemID(SALESFORCE, 'test'),
+        annotations: {
+          [CUSTOM_SETTINGS_TYPE]: 'Hierarchical',
+        },
+      })
+      addDefaults(object)
+    })
+    it('should add annotation values', () => {
+      expect(object.annotations).toMatchObject({
+        [API_NAME]: 'test__c',
+        [METADATA_TYPE]: CUSTOM_OBJECT,
+        [LABEL]: 'test',
+      })
+    })
+    it('should add annotation types', () => {
+      expect(object.annotationTypes).toMatchObject({
+        [API_NAME]: BuiltinTypes.SERVICE_ID,
+        [METADATA_TYPE]: BuiltinTypes.SERVICE_ID,
+        [LABEL]: BuiltinTypes.STRING,
+      })
+    })
+    it('should not add custom object annotations', () => {
+      expect(object.annotations).not.toHaveProperty('sharingModel')
+      expect(object.annotations).not.toHaveProperty('deploymentStatus')
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -39,7 +39,7 @@ import {
   WORKFLOW_ACTION_ALERT_METADATA_TYPE, LAYOUT_TYPE_ID_METADATA_TYPE, CPQ_PRODUCT_RULE,
   CPQ_LOOKUP_PRODUCT_FIELD, INTERNAL_ID_ANNOTATION,
 } from '../../src/constants'
-import { CustomField, FilterItem, CustomObject, CustomProperties, CustomPicklistValue,
+import { CustomField, FilterItem, CustomObject, CustomPicklistValue,
   SalesforceRecord } from '../../src/client/types'
 import SalesforceClient from '../../src/client/client'
 import Connection from '../../src/client/jsforce'
@@ -676,7 +676,7 @@ describe('transformer', () => {
         },
       })
 
-      let customObj: CustomProperties
+      let customObj: CustomObject
       beforeEach(() => {
         customObj = toCustomProperties(objType, false)
       })
@@ -717,7 +717,7 @@ describe('transformer', () => {
       })
 
       describe('with fields', () => {
-        let customObj: CustomProperties
+        let customObj: CustomObject
         beforeEach(() => {
           customObj = toCustomProperties(
             objType, true, [objType.fields[ignoredField].annotations[API_NAME]],
@@ -740,7 +740,7 @@ describe('transformer', () => {
       })
 
       describe('without fields', () => {
-        let customObj: CustomProperties
+        let customObj: CustomObject
         beforeEach(() => {
           customObj = toCustomProperties(objType, false)
         })
@@ -750,7 +750,7 @@ describe('transformer', () => {
       })
 
       describe('create a custom settings object', () => {
-        let customObj: CustomProperties
+        let customObj: CustomObject
         beforeEach(() => {
           const customSettingsObj = new ObjectType({
             elemID,
@@ -832,25 +832,6 @@ describe('transformer', () => {
           FIELD_TYPE_NAMES.MASTER_DETAIL, relationshipName, undefined, relatedTo)
         expect(customMasterDetailField.reparentableMasterDetail).toBe(true)
         expect(customMasterDetailField.writeRequiresMasterRead).toBe(true)
-      })
-
-      it('should have ControlledByParent sharing model when having masterdetail field', async () => {
-        objectType.fields[fieldName].type = Types.primitiveDataTypes.MasterDetail
-        const customObjectWithMasterDetailField = toCustomProperties(objectType, true)
-        expect(customObjectWithMasterDetailField).toHaveProperty('sharingModel')
-        expect((customObjectWithMasterDetailField as CustomObject).sharingModel).toEqual('ControlledByParent')
-      })
-
-      it('should have ReadWrite sharing model when not having masterdetail field', async () => {
-        const customObjectWithMasterDetailField = toCustomProperties(objectType, true)
-        expect(customObjectWithMasterDetailField).toHaveProperty('sharingModel')
-        expect((customObjectWithMasterDetailField as CustomObject).sharingModel).toEqual('ReadWrite')
-      })
-
-      it('should have ReadWrite sharing model when not including fields', async () => {
-        const customObjectWithMasterDetailField = toCustomProperties(objectType, false)
-        expect(customObjectWithMasterDetailField).toHaveProperty('sharingModel')
-        expect((customObjectWithMasterDetailField as CustomObject).sharingModel).toEqual('ReadWrite')
       })
     })
 


### PR DESCRIPTION
- Remove custom code that would set a sharing model and plural label on standard
  objects that should not have them set
- Add default sharing model, plural label, deployment status and name field defaults
  only when creating a new custom object (instead of setting them by default on all
  objects)

---

_Release Notes_:
- Improvements to custom object deploy flow to avoid overriding default configuration like sharingModel