### PR TITLE
Changed to use PeekableLexer for getting token

### DIFF
--- a/packages/lang-server/index.ts
+++ b/packages/lang-server/index.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import * as context from './src/context'
+import * as token from './src/token'
 import * as definitions from './src/definitions'
 import * as diagnostics from './src/diagnostics'
 import * as location from './src/location'
@@ -25,6 +26,7 @@ import * as suggestions from './src/completions/suggestions'
 
 export {
   context,
+  token,
   definitions,
   diagnostics,
   location,

--- a/packages/lang-server/src/location.ts
+++ b/packages/lang-server/src/location.ts
@@ -20,6 +20,7 @@ import { Element, ElemID, isObjectType, isInstanceElement, isField } from '@salt
 import { staticFiles } from '@salto-io/workspace'
 import { EditorWorkspace } from './workspace'
 import { EditorRange } from './context'
+import { Token } from './token'
 
 export interface SaltoElemLocation {
   fullname: string
@@ -77,7 +78,7 @@ const extractStaticFileAttributes = (
 export const getStaticLocations = (
   element: Element,
   refPath: string[],
-  token: string
+  token: Token
 ): SaltoElemLocation | undefined => {
   const staticFileAttributes = extractStaticFileAttributes(element, refPath)
 
@@ -86,7 +87,8 @@ export const getStaticLocations = (
   }
 
   if (staticFileAttributes.staticFile instanceof staticFiles.AbsoluteStaticFile
-    && `"${staticFileAttributes.staticFile.filepath}"` === token) {
+    && token.type === 'content'
+    && staticFileAttributes.staticFile.filepath === token.value) {
     return {
       fullname: staticFileAttributes.fullname,
       filename: staticFileAttributes.staticFile.absoluteFilePath,

--- a/packages/lang-server/src/token.ts
+++ b/packages/lang-server/src/token.ts
@@ -28,6 +28,8 @@ export const getToken = (fileContent: string, position: EditorPosition):
   if (lines.length <= position.line) {
     return undefined
   }
+  // This is done to avoid parsing the entire file
+  // and cause us to not support multiline tokens
   const line = lines[position.line]
 
   const lexer = new parser.PeekableLexer(line)
@@ -44,6 +46,7 @@ export const getToken = (fileContent: string, position: EditorPosition):
     }
   // eslint-disable-next-line no-empty
   } catch (e) {
+    // Lexer throws an error when there is nothing left to parse
   }
   return undefined
 }

--- a/packages/lang-server/src/token.ts
+++ b/packages/lang-server/src/token.ts
@@ -1,0 +1,49 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import os from 'os'
+import { parser } from '@salto-io/workspace'
+import { EditorPosition } from './context'
+
+export type Token = {
+  value: string
+  type: string
+}
+
+export const getToken = (fileContent: string, position: EditorPosition):
+  Token | undefined => {
+  const lines = fileContent.split(os.EOL)
+  if (lines.length <= position.line) {
+    return undefined
+  }
+  const line = lines[position.line]
+
+  const lexer = new parser.PeekableLexer(line)
+  try {
+    while (true) {
+      const token = lexer.next()
+      const col = token.col - 1
+      if (col <= position.col && position.col < col + token.value.length) {
+        return { value: token.value, type: token.type }
+      }
+      if (col > position.col) {
+        return undefined
+      }
+    }
+  // eslint-disable-next-line no-empty
+  } catch (e) {
+  }
+  return undefined
+}

--- a/packages/lang-server/src/usage.ts
+++ b/packages/lang-server/src/usage.ts
@@ -20,6 +20,7 @@ import wu from 'wu'
 import { getLocations, SaltoElemLocation } from './location'
 import { EditorWorkspace } from './workspace'
 import { PositionContext } from './context'
+import { Token } from './token'
 
 
 const getElemIDUsages = async (
@@ -108,10 +109,10 @@ export const getUsageInFile = async (
 
 export const provideWorkspaceReferences = async (
   workspace: EditorWorkspace,
-  token: string,
+  token: Token,
   context: PositionContext
 ): Promise<SaltoElemLocation[]> => {
-  const id = getSearchElementFullName(context, token)
+  const id = getSearchElementFullName(context, token.value)
   if (id === undefined) {
     return []
   }

--- a/packages/lang-server/test/definitions.test.ts
+++ b/packages/lang-server/test/definitions.test.ts
@@ -33,7 +33,7 @@ describe('Test go to definitions', () => {
   it('should give a single definition for a type that is defined once', async () => {
     const pos = { line: 40, col: 8 }
     const ctx = await getPositionContext(workspace, naclFileName, pos)
-    const token = 'vs.num'
+    const token = { value: 'vs.num', type: 'word' }
 
     const defs = await provideWorkspaceDefinition(workspace, ctx, token)
     expect(defs.length).toBe(1)
@@ -43,7 +43,7 @@ describe('Test go to definitions', () => {
   it('should give all definitions for a type that is extended', async () => {
     const pos = { line: 86, col: 6 }
     const ctx = await getPositionContext(workspace, naclFileName, pos)
-    const token = 'vs.loan'
+    const token = { value: 'vs.loan', type: 'word' }
     const defs = await provideWorkspaceDefinition(workspace, ctx, token)
     expect(defs.length).toBe(2)
   })
@@ -51,7 +51,8 @@ describe('Test go to definitions', () => {
   it('should give the field definition for an instance attr', async () => {
     const pos = { line: 89, col: 8 }
     const ctx = await getPositionContext(workspace, naclFileName, pos)
-    const token = 'loaner'
+    const token = { value: 'loaner', type: 'word' }
+
     const defs = await provideWorkspaceDefinition(workspace, ctx, token)
     expect(defs.length).toBe(1)
     expect(defs[0].range.start.line).toBe(64)
@@ -60,7 +61,8 @@ describe('Test go to definitions', () => {
   it('should empty list for undefined type', async () => {
     const pos = { line: 74, col: 6 }
     const ctx = await getPositionContext(workspace, naclFileName, pos)
-    const token = 'vs.nope'
+    const token = { value: 'vs.nope', type: 'word' }
+
     const defs = await provideWorkspaceDefinition(workspace, ctx, token)
     expect(defs.length).toBe(0)
   })
@@ -68,7 +70,8 @@ describe('Test go to definitions', () => {
   it('should give annotation definition for annotation values', async () => {
     const pos = { line: 208, col: 8 }
     const ctx = await getPositionContext(workspace, naclFileName, pos)
-    const token = 'loan'
+    const token = { value: 'loan', type: 'word' }
+
     const defs = await provideWorkspaceDefinition(workspace, ctx, token)
     expect(defs.length).toBe(1)
     expect(defs[0].range.start.line).toBe(203)
@@ -80,7 +83,8 @@ describe('Test go to definitions', () => {
       [' nested', { line: 242, col: 31 }, 'path/to/deep_content'],
     ]).it('should give a%s static file its definition', async (_text, pos, filepath) => {
       const ctx = await getPositionContext(workspace, naclFileName, pos)
-      const token = `"${filepath}"`
+      const token = { value: filepath, type: 'content' }
+
       const defs = await provideWorkspaceDefinition(workspace, ctx, token)
       expect(defs.length).toBe(1)
       expect(defs[0].filename).toBe(`full-${filepath}`)
@@ -90,10 +94,19 @@ describe('Test go to definitions', () => {
   it('should give annotation type definition', async () => {
     const pos = { line: 172, col: 15 }
     const ctx = await getPositionContext(workspace, naclFileName, pos)
-    const token = 'vs.person'
+    const token = { value: 'vs.person', type: 'word' }
+
     const defs = await provideWorkspaceDefinition(workspace, ctx, token)
     expect(defs.length).toBe(2)
     expect(defs[0].range.start.line).toBe(32)
     expect(defs[1].range.start.line).toBe(127)
+  })
+
+  it('should give list element type definition', async () => {
+    const pos = { line: 128, col: 15 }
+    const ctx = await getPositionContext(workspace, naclFileName, pos)
+    const token = { value: 'List<vs.str>', type: 'content' }
+    const defs = await provideWorkspaceDefinition(workspace, ctx, token)
+    expect(defs[0].range.start.line).toBe(1)
   })
 })

--- a/packages/lang-server/test/definitions.test.ts
+++ b/packages/lang-server/test/definitions.test.ts
@@ -109,4 +109,12 @@ describe('Test go to definitions', () => {
     const defs = await provideWorkspaceDefinition(workspace, ctx, token)
     expect(defs[0].range.start.line).toBe(1)
   })
+
+  it('should give list of lists element type definition', async () => {
+    const pos = { line: 128, col: 15 }
+    const ctx = await getPositionContext(workspace, naclFileName, pos)
+    const token = { value: 'List<List<vs.str>>', type: 'content' }
+    const defs = await provideWorkspaceDefinition(workspace, ctx, token)
+    expect(defs[0].range.start.line).toBe(1)
+  })
 })

--- a/packages/lang-server/test/token.test.ts
+++ b/packages/lang-server/test/token.test.ts
@@ -1,0 +1,52 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import path from 'path'
+import fs from 'fs'
+import { getToken } from '../src/token'
+
+
+describe('Test go to definitions', () => {
+  let naclFileContent: string
+
+  beforeAll(async () => {
+    const naclPath = path.resolve(`${__dirname}/../../test/test-nacls/all.nacl`)
+    naclFileContent = fs.readFileSync(naclPath).toString()
+  })
+
+  describe('position out of bounds', () => {
+    it('line too high should return undefined', () => {
+      expect(getToken(naclFileContent, { line: 100000, col: 1 })).toBeUndefined()
+    })
+
+    it('line too low should return undefined', () => {
+      expect(getToken(naclFileContent, { line: -100000, col: 1 })).toBeUndefined()
+    })
+
+    it('column too high should return undefined', () => {
+      expect(getToken(naclFileContent, { line: 1, col: 1000000 })).toBeUndefined()
+    })
+
+    it('column too low should return undefined', () => {
+      expect(getToken(naclFileContent, { line: 1, col: -1000000 })).toBeUndefined()
+    })
+  })
+  it('empty position should return undefined', () => {
+    expect(getToken(naclFileContent, { line: 168, col: 0 })).toBeUndefined()
+  })
+  it('For valid token the right token should be return', () => {
+    expect(getToken(naclFileContent, { line: 135, col: 5 })).toEqual({ value: 'vs.person', type: 'word' })
+  })
+})

--- a/packages/lang-server/test/usage.test.ts
+++ b/packages/lang-server/test/usage.test.ts
@@ -33,7 +33,7 @@ describe('Test go to definitions', () => {
   })
 
   it('should give all fields usages of a type', async () => {
-    const token = 'vs.str'
+    const token = { value: 'vs.str', type: 'word' }
     const pos = {
       line: 1,
       col: 8,
@@ -46,7 +46,7 @@ describe('Test go to definitions', () => {
   })
 
   it('should give all instance usages of a type', async () => {
-    const token = 'vs.loan'
+    const token = { value: 'vs.loan', type: 'word' }
     const pos = {
       line: 60,
       col: 10,
@@ -57,7 +57,7 @@ describe('Test go to definitions', () => {
   })
 
   it('should give all instance AND field usages of a type', async () => {
-    const token = 'vs.person'
+    const token = { value: 'vs.person', type: 'word' }
     const pos = {
       line: 32,
       col: 11,
@@ -68,7 +68,7 @@ describe('Test go to definitions', () => {
   })
 
   it('should work on tokens which have no context element', async () => {
-    const token = 'vs.person'
+    const token = { value: 'vs.person', type: 'word' }
     const context: PositionContext = {
       range: GLOBAL_RANGE.range,
       type: 'global',
@@ -78,7 +78,7 @@ describe('Test go to definitions', () => {
   })
 
   it('should give annotation attr usage for annotation def', async () => {
-    const token = 'loan'
+    const token = { value: 'loan', type: 'word' }
     const pos = {
       line: 203,
       col: 19,
@@ -89,7 +89,7 @@ describe('Test go to definitions', () => {
   })
 
   it('should find (goto) refrences of a nested (salto) references', async () => {
-    const token = 'reason'
+    const token = { value: 'reason', type: 'word' }
     const pos = {
       line: 67,
       col: 14,
@@ -105,7 +105,7 @@ describe('Test go to definitions', () => {
   })
 
   it('should find (salto) references to nested type annotations', async () => {
-    const token = 'first_name'
+    const token = { value: 'first_name', type: 'word' }
     const pos = {
       line: 178,
       col: 13,
@@ -119,7 +119,7 @@ describe('Test go to definitions', () => {
   })
 
   it('should find (salto) references to nested field annotations', async () => {
-    const token = 'first_name'
+    const token = { value: 'first_name', type: 'word' }
     const pos = {
       line: 187,
       col: 23,

--- a/packages/vscode/e2e_test/extension.test.ts
+++ b/packages/vscode/e2e_test/extension.test.ts
@@ -77,7 +77,7 @@ describe.skip('extension e2e', () => {
       const pos = { line: 6, col: 9 }
       const filename = 'extra.nacl'
       const ctx = await context.getPositionContext(workspace, filename, pos)
-      const defs = await definitions.provideWorkspaceDefinition(workspace, ctx, '@salto-io/core_complex')
+      const defs = await definitions.provideWorkspaceDefinition(workspace, ctx, { value: '@salto-io/core_complex', type: 'word' })
       expect(defs.length).toBe(2)
       expect(defs[0].fullname).toBe('@salto-io/core.complex')
       expect(defs[0].filename).toBe('complex_type.nacl')

--- a/packages/workspace/src/parser/index.ts
+++ b/packages/workspace/src/parser/index.ts
@@ -13,7 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import PeekableLexer, { LexerToken } from './internal/native/lexer'
+
 export { parse, SourceRange, parseElemID } from './parse'
 export { ParseResult, ParseError } from './types'
 export { dumpElements, dumpElemID, dumpValues } from './dump'
 export { SourceMap } from './source_map'
+export { PeekableLexer, LexerToken }


### PR DESCRIPTION
Changed to use PeekableLexer to get the token
Moved the token mechanism to the language server
Fixed go to definition for container tokens (e.g., "List<salesforce.Accout>")

---
__Release Notes:__
Language Server (impact on VSCode extension and SAAS editor): Fixed right-click actions for tokens with '@'.

