### PR TITLE
SALTO-1042: added go to service button in the extension

### DIFF
--- a/packages/lang-server/src/workspace.ts
+++ b/packages/lang-server/src/workspace.ts
@@ -85,8 +85,7 @@ export class EditorWorkspace {
   }
 
   private hasPendingUpdates(): boolean {
-    return !(_.isEmpty(this.pendingSets)
-      && _.isEmpty(this.pendingDeletes))
+    return !(_.isEmpty(this.pendingSets) && _.isEmpty(this.pendingDeletes))
   }
 
   private addPendingNaclFiles(naclFiles: nacl.NaclFile[]): void {
@@ -190,7 +189,7 @@ export class EditorWorkspace {
   }
 
   async awaitAllUpdates(): Promise<void> {
-    await this.runningWorkspaceOperation
+    await this.runningSetOperation
   }
 
   private async waitForOperation(operationPromise: Promise<unknown>): Promise<void> {
@@ -201,11 +200,10 @@ export class EditorWorkspace {
   async runOperationWithWorkspace<T>(operation: WorkspaceOperation<T>): Promise<T> {
     while (this.runningWorkspaceOperation !== undefined) {
       // eslint-disable-next-line no-await-in-loop
-      await this.awaitAllUpdates()
+      await this.runningWorkspaceOperation
     }
     const operationPromise = operation(this.workspace)
     this.runningWorkspaceOperation = this.waitForOperation(operationPromise)
-    await this.runningWorkspaceOperation
     return operationPromise
   }
 }

--- a/packages/lang-server/test/workspace.test.ts
+++ b/packages/lang-server/test/workspace.test.ts
@@ -13,7 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
 import * as path from 'path'
 import { EditorWorkspace } from '../src/workspace'
 import { mockWorkspace } from './workspace'
@@ -69,8 +68,10 @@ describe('workspace', () => {
   it('should call workspace opearation', async () => {
     const baseWs = await mockWorkspace(naclFileName)
     const workspace = new EditorWorkspace(workspaceBaseDir, baseWs)
-    expect(await workspace.runOperationWithWorkspace(async _innerWorkspace =>
-      baseWs === _innerWorkspace)).toBeTruthy()
+
+    const mockFunc = jest.fn().mockReturnValue(Promise.resolve('value'))
+    expect(await workspace.runOperationWithWorkspace(mockFunc)).toBe('value')
+    expect(mockFunc).toHaveBeenCalledWith(baseWs)
   })
 
   it('should not run two workspace opearations in parallel', async () => {
@@ -94,6 +95,6 @@ describe('workspace', () => {
     await firstPromise
     await secondPromise
 
-    expect(_.isEqual(arr, ['second', 'second', 'first', 'first']) || _.isEqual(arr, ['first', 'first', 'second', 'second'])).toBeTruthy()
+    expect(arr).toEqual(['first', 'first', 'second', 'second'])
   })
 })

--- a/packages/lang-server/test/workspace.test.ts
+++ b/packages/lang-server/test/workspace.test.ts
@@ -64,4 +64,9 @@ describe('workspace', () => {
     const removeNaclFilesMock = baseWs.removeNaclFiles as jest.Mock
     expect(removeNaclFilesMock.mock.calls[0][0]).toContain('all.nacl')
   })
+
+  it('should call workspace opearation', async () => {
+    const workspace = new EditorWorkspace(workspaceBaseDir, await mockWorkspace(naclFileName))
+    expect(await workspace.runOperationWithWorkspace(async _innerWorkspace => 'some value')).toBe('some value')
+  })
 })

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -47,7 +47,7 @@
                 {
                     "command": "salto.goToService",
                     "group": "navigation@3",
-                    "when": "resourceExtname == .nacl && isGoToServiceSupported"
+                    "when": "resourceExtname == .nacl"
                 }
             ]
         },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -31,6 +31,10 @@
             {
                 "command": "salto.copyReference",
                 "title": "Copy Salto Reference"
+            },
+            {
+                "command": "salto.goToService",
+                "title": "Go To Service"
             }
         ],
         "menus": {
@@ -39,6 +43,11 @@
                     "command": "salto.copyReference",
                     "group": "9_cutcopypaste",
                     "when": "resourceExtname == .nacl"
+                },
+                {
+                    "command": "salto.goToService",
+                    "group": "navigation@3",
+                    "when": "resourceExtname == .nacl && isGoToServiceSupported"
                 }
             ]
         },
@@ -122,6 +131,7 @@
         "@salto-io/workspace": "0.2.0",
         "copy-paste": "^1.3.0",
         "lodash": "^4.17.19",
+        "open": "^7.2.0",
         "wu": "^2.1.0"
     },
     "devDependencies": {

--- a/packages/vscode/src/events.ts
+++ b/packages/vscode/src/events.ts
@@ -57,6 +57,22 @@ export const onFileOpen = (): void => {
   vscode.commands.executeCommand('editor.foldAllMarkerRegions')
 }
 
+export const onActiveTextEditorChange = async (
+  document: vscode.TextDocument | undefined,
+  workspace: ws.EditorWorkspace
+): Promise<void> => {
+  let isGoToServiceSupported: boolean
+  if (document === undefined || path.extname(document.fileName) !== FILE_EXTENSION) {
+    isGoToServiceSupported = false
+  } else {
+    const elements = await workspace.getElements(document.fileName)
+    isGoToServiceSupported = elements.some(e => e.elemID.adapter === 'salesforce')
+  }
+
+  vscode.commands.executeCommand('setContext', 'isGoToServiceSupported', isGoToServiceSupported)
+}
+
+
 const showReloadWSPrompt = _.debounce(async (): Promise<void> => {
   const msg = 'Some workspace files have changed. Reload vs-code for the change to take effect.'
   const action = 'Reload'

--- a/packages/vscode/src/events.ts
+++ b/packages/vscode/src/events.ts
@@ -57,22 +57,6 @@ export const onFileOpen = (): void => {
   vscode.commands.executeCommand('editor.foldAllMarkerRegions')
 }
 
-export const onActiveTextEditorChange = async (
-  document: vscode.TextDocument | undefined,
-  workspace: ws.EditorWorkspace
-): Promise<void> => {
-  let isGoToServiceSupported: boolean
-  if (document === undefined || path.extname(document.fileName) !== FILE_EXTENSION) {
-    isGoToServiceSupported = false
-  } else {
-    const elements = await workspace.getElements(document.fileName)
-    isGoToServiceSupported = elements.some(e => e.elemID.adapter === 'salesforce')
-  }
-
-  vscode.commands.executeCommand('setContext', 'isGoToServiceSupported', isGoToServiceSupported)
-}
-
-
 const showReloadWSPrompt = _.debounce(async (): Promise<void> => {
   const msg = 'Some workspace files have changed. Reload vs-code for the change to take effect.'
   const action = 'Reload'

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -16,7 +16,7 @@
 import * as vscode from 'vscode'
 import { loadLocalWorkspace } from '@salto-io/core'
 import { diagnostics, workspace as ws } from '@salto-io/lang-server'
-import { onTextChangeEvent, onFileChange, onFileOpen, onActiveTextEditorChange, createReportErrorsEventListener } from './events'
+import { onTextChangeEvent, onFileChange, onFileOpen, createReportErrorsEventListener } from './events'
 import {
   createCompletionsProvider, createDefinitionsProvider, createReferenceProvider,
   createDocumentSymbolsProvider,
@@ -68,8 +68,6 @@ const onActivate = async (context: vscode.ExtensionContext): Promise<void> => {
       createFoldingProvider(workspace)
     )
 
-    onActiveTextEditorChange(vscode.window.activeTextEditor?.document, workspace)
-
     context.subscriptions.push(
       completionProvider,
       definitionProvider,
@@ -84,8 +82,6 @@ const onActivate = async (context: vscode.ExtensionContext): Promise<void> => {
         createReportErrorsEventListener(workspace, diagCollection)
       ),
       vscode.workspace.onDidOpenTextDocument(onFileOpen),
-      vscode.window.onDidChangeActiveTextEditor(e =>
-        onActiveTextEditorChange(e?.document, workspace)),
       vscode.commands.registerCommand('salto.copyReference', createCopyReferenceCommand(workspace)),
       vscode.commands.registerCommand('salto.goToService', createGoToServiceCommand(workspace))
     )


### PR DESCRIPTION
Implemented go to service right-click button in VSCode.

---
__Release Notes:__
VSCode Extension:
Added go to service right-click menu option to go to the service page in the browser of a certain element (Currently only supported for salesforce elements).