### PR TITLE
fixed workspace dependencies

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -40,6 +40,7 @@
     "jest-each": "^26.5.0",
     "lodash": "^4.17.19",
     "moo": "^0.5.1",
+    "@types/moo": "^0.5.0",
     "nearley": "2.19.2",
     "wu": "^2.1.0"
   },
@@ -48,7 +49,6 @@
     "@salto-io/salesforce-adapter": "0.2.0",
     "@types/jest": "^24.0.0",
     "@types/lodash": "^4.14.133",
-    "@types/moo": "^0.5.0",
     "@types/nearley": "^2.11.0",
     "@types/node": "^12.7.1",
     "@types/supertest": "^2.0.4",


### PR DESCRIPTION
In https://github.com/salto-io/salto/pull/1687, I exported a class from Workspace packages, which contains a type from the moo package. Therefore, the dependency @types/moo needs to move from dev dependencies to dependencies.

---
__Release Notes:__ None