### PR TITLE
Remove named escape sequences from salesforce XML transformer

### DIFF
--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -306,7 +306,7 @@ const toMetadataXml = (name: string, values: Values): string =>
   new parser.j2xParser({
     attributeNamePrefix: XML_ATTRIBUTE_PREFIX,
     ignoreAttributes: false,
-    tagValueProcessor: val => he.encode(String(val), { useNamedReferences: true }),
+    tagValueProcessor: val => he.encode(String(val)),
   }).parse({ [name]: _.omit(values, INSTANCE_FULL_NAME_FIELD) })
 
 const cloneValuesWithAttributePrefixes = (instance: InstanceElement): Values => {

--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -121,7 +121,7 @@ describe('XML Transformer', () => {
           expect(values).toMatchObject({ Profile: _.omit(profileValues, ['fullName', 'str']) })
         })
         it('should encode special XML characters', () => {
-          expect(values.Profile.str).toEqual('str &lt;&gt; bla')
+          expect(values.Profile.str).toEqual('str &#x3C;&#x3E; bla')
         })
       })
     })


### PR DESCRIPTION
Seems like salesforce does not know how to parse all names like &gt; and &eq;
Specifically &rsquot; was failing in an example deploy

---
_Release Notes_
_Salesforce Adapter_
- Fix deployment of values that contain special characters (non standard quotes in strings)