### PR TITLE
Add SiteDotCom to default salesforce skip list

### DIFF
--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -316,6 +316,7 @@ export const configType = new ObjectType({
           'DashboardFolder',
           'Profile',
           'PermissionSet',
+          'SiteDotCom', // Fetched as a binary blob and seems to change on each fetch
         ],
       },
     },


### PR DESCRIPTION
Seems like the data we fetch for SiteDotCom instances is different on each fetch and it looks like just a binary blob that we can't do too much with.
pending further investigation into properly supporting it, adding it to the default skip list seems like the way to go for now

---

_Release Notes_
_Salesforce Adapter_
- Added `SiteDotCom` to default skip list