### PR TITLE
SALTO-1100: Support changing field type

### DIFF
--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -125,6 +125,12 @@ const getElementHiddenParts = <T extends Element>(
       .forEach(field => {
         const workspaceField = workspaceElement.fields[field.name]
         if (!field.type.elemID.isEqual(workspaceField.type.elemID)) {
+          log.debug(
+            'Field type mismatch on %s, overriding state type %s with workspace type %s',
+            field.elemID.getFullName(),
+            field.type.elemID.getFullName(),
+            workspaceField.type.elemID.getFullName(),
+          )
           field.type = workspaceField.type
         }
       })

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -119,6 +119,15 @@ const getElementHiddenParts = <T extends Element>(
       hidden.fields,
       (field, key) => workspaceFields.has(key) || isHidden(field)
     )
+    // Keep field types from the workspace element to avoid merge conflicts
+    Object.values(hidden.fields)
+      .filter(field => !isHidden(field))
+      .forEach(field => {
+        const workspaceField = workspaceElement.fields[field.name]
+        if (!field.type.elemID.isEqual(workspaceField.type.elemID)) {
+          field.type = workspaceField.type
+        }
+      })
   }
   return hidden
 }


### PR DESCRIPTION
Before this change when a field type was changed in the nacl we would get a merge error
This is because the same field would exist in the state file with a different type and
when we tried to merge the definitions (to merge the hidden annotations into the field)
we would get a type conflict

---

_Release Notes_:
(general bug fixes section)
- Fix incorrect merge error when changing a field's type in nacl