### PR TITLE
split provideWorkspaceReferences in order to export its get references logic

### DIFF
--- a/packages/lang-server/src/usage.ts
+++ b/packages/lang-server/src/usage.ts
@@ -110,10 +110,10 @@ export const getUsageInFile = async (
 
 export const getWorkspaceReferences = async (
   workspace: EditorWorkspace,
-  token: string,
+  tokenValue: string,
   context: PositionContext
 ): Promise<SaltoElemFileLocation[]> => {
-  const id = getSearchElementFullName(context, token)
+  const id = getSearchElementFullName(context, tokenValue)
   if (id === undefined) {
     return []
   }


### PR DESCRIPTION
Split provideWorkspaceReferences in order to export its `getWorkspaceReferences` logic (for saas usage)

---
No release notes