### PR TITLE
SALTO-1105: fixed getToken for first characters of a token

### DIFF
--- a/packages/lang-server/src/token.ts
+++ b/packages/lang-server/src/token.ts
@@ -32,7 +32,7 @@ export const getToken = (fileContent: string, position: EditorPosition):
   const line = lines[position.line]
 
   const lexerToken = wu(parser.tokenizeContent(line)).find(
-    token => token.col < position.col && position.col < token.col + token.value.length - 1,
+    token => token.col - 1 <= position.col && position.col < token.col + token.value.length - 1,
   )
   if (lexerToken === undefined) {
     return undefined

--- a/packages/lang-server/test/token.test.ts
+++ b/packages/lang-server/test/token.test.ts
@@ -49,4 +49,10 @@ describe('Test go to definitions', () => {
   it('For valid token the right token should be return', () => {
     expect(getToken(naclFileContent, { line: 135, col: 5 })).toEqual({ value: 'vs.person', type: 'word' })
   })
+  it('For a position of the first character of a valid token the right token should be return', () => {
+    expect(getToken(naclFileContent, { line: 135, col: 0 })).toEqual({ value: 'vs.person', type: 'word' })
+  })
+  it('For a position of the last character of a valid token the right token should be return', () => {
+    expect(getToken(naclFileContent, { line: 135, col: 8 })).toEqual({ value: 'vs.person', type: 'word' })
+  })
 })


### PR DESCRIPTION
Fixed a bug in getToken that it would not return a token if the position is the first or second characters of the token.

---
__Release Notes:__ 
VSCode Extension:
Fixed editor operation (Go To Definition, Go To References, etc...) when the position is the first or second character of the selected token. 