### PR TITLE
fixed filterByFile for unmergeable values (SALTO-1104)

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -405,7 +405,7 @@ export const routeIsolated = async (
   const currentEnvChanges = await projectChange(change, primarySource)
   return {
     // No need to apply addToSource to primary env changes since it was handled by the original plan
-    primarySource: [...addCommonProjectionToCurrentChanges, ...currentEnvChanges],
+    primarySource: [...currentEnvChanges, ...addCommonProjectionToCurrentChanges],
     commonSource: [createRemoveChange(currentCommonElement, change.id, pathHint)],
     secondarySources: secondaryChanges,
   }

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -32,6 +32,17 @@ export interface RoutedChanges {
   secondarySources?: Record<string, DetailedChange[]>
 }
 
+const getMergeableParentID = (id: ElemID): {mergeableID: ElemID; path: string[]} => {
+  const isListPart = (part: string): boolean => !Number.isNaN(Number(part))
+  const firstListNamePart = id.getFullNameParts().findIndex(isListPart)
+  if (firstListNamePart < 0) return { mergeableID: id, path: [] }
+  const mergeableNameParts = id.getFullNameParts().slice(0, firstListNamePart)
+  return {
+    mergeableID: ElemID.fromFullNameParts(mergeableNameParts),
+    path: id.getFullNameParts().slice(firstListNamePart),
+  }
+}
+
 const filterByFile = (
   valueID: ElemID,
   value: Value,
@@ -39,7 +50,12 @@ const filterByFile = (
 ): Value => filterByID(
   valueID,
   value,
-  id => !_.isEmpty((fileElements).filter(e => resolvePath(e, id) !== undefined))
+  id => !_.isEmpty((fileElements).filter(
+    e => resolvePath(
+      e,
+      getMergeableParentID(id).mergeableID
+    ) !== undefined
+  ))
 )
 
 const toPathHint = (filename: string): string[] => {
@@ -116,17 +132,6 @@ const createUpdateChanges = async (
     ...otherChanges,
     ..._.flatten(modifiedAdditions),
   ]
-}
-
-const getMergeableParentID = (id: ElemID): {mergeableID: ElemID; path: string[]} => {
-  const isListPart = (part: string): boolean => !Number.isNaN(Number(part))
-  const firstListNamePart = id.getFullNameParts().findIndex(isListPart)
-  if (firstListNamePart < 0) return { mergeableID: id, path: [] }
-  const mergeableNameParts = id.getFullNameParts().slice(0, firstListNamePart)
-  return {
-    mergeableID: ElemID.fromFullNameParts(mergeableNameParts),
-    path: id.getFullNameParts().slice(firstListNamePart),
-  }
 }
 
 const createMergeableChange = async (
@@ -400,7 +405,7 @@ export const routeIsolated = async (
   const currentEnvChanges = await projectChange(change, primarySource)
   return {
     // No need to apply addToSource to primary env changes since it was handled by the original plan
-    primarySource: [...currentEnvChanges, ...addCommonProjectionToCurrentChanges],
+    primarySource: [...addCommonProjectionToCurrentChanges, ...currentEnvChanges],
     commonSource: [createRemoveChange(currentCommonElement, change.id, pathHint)],
     secondarySources: secondaryChanges,
   }


### PR DESCRIPTION
This fix fixes a bug that took place when and item was fetch isolated mode and:
1. The diff between the existing item and the fetched item was a list value
2. The list value was defined in common
3. The new list value contained more items then the existing list vaue

This was caused by the the filterByFile function that checked for the each nested id in which file it is defined. For elements in the new value who's index was greater than the existing value - no value was returned.

This only happens in lists since it in not mergeable. The solution is to search for the parent mergeable id (which will always be defined)