### PR TITLE
SALTO-1107: fixed SDF dependencies bug

### DIFF
--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -84,6 +84,9 @@ export const fileCabinetTopLevelFolders = [
 ]
 const MINUTE_IN_MILLISECONDS = 1000 * 60
 
+const INVALID_DEPENDENCIES = ['ADVANCEDEXPENSEMANAGEMENT', 'SUBSCRIPTIONBILLING', 'WMSSYSTEM', 'BILLINGACCOUNTS']
+const INVALID_DEPENDENCIES_PATTERN = new RegExp(`^.*(<feature required="true">${INVALID_DEPENDENCIES.join('|')})</feature>.*\n`, 'gm')
+
 const baseExecutionPath = os.tmpdir()
 
 export interface CustomizationInfo {
@@ -182,6 +185,7 @@ const writeFileInFolder = async (folderPath: string, filename: string, content: 
 
 type Project = {
   projectName: string
+  projectPath: string
   executor: CommandActionExecutor
   authId: string
 }
@@ -329,10 +333,11 @@ export default class NetsuiteClient {
     const authId = uuidv4()
     const projectName = `TempSdfProject-${authId}`
     await this.createProject(projectName)
+    const projectPath = NetsuiteClient.getProjectPath(projectName)
     const executor = NetsuiteClient
-      .initCommandActionExecutor(NetsuiteClient.getProjectPath(projectName))
+      .initCommandActionExecutor(projectPath)
     await this.setupAccount(executor, authId)
-    return { projectName, executor, authId }
+    return { projectName, projectPath, executor, authId }
   }
 
   private static async deleteProject(projectName: string): Promise<void> {
@@ -604,8 +609,18 @@ export default class NetsuiteClient {
     await this.projectCleanup(project.projectName, project.authId)
   }
 
-  private async runDeployCommands({ executor }: Project): Promise<void> {
+  private static async cleanInvalidDependencies(projectPath: string): Promise<void> {
+    // This is done due to an SDF bug described in SALTO-1107.
+    // This function should be removed once the bug is fixed.
+    const manifestPath = osPath.join(projectPath, 'src', 'manifest.xml')
+    const manifestContent = await readFile(manifestPath)
+    const fixedManifestContent = manifestContent.toString().replace(INVALID_DEPENDENCIES_PATTERN, '')
+    await writeFile(manifestPath, fixedManifestContent)
+  }
+
+  private async runDeployCommands({ executor, projectPath }: Project): Promise<void> {
     await this.executeProjectAction(COMMANDS.ADD_PROJECT_DEPENDENCIES, {}, executor)
+    await NetsuiteClient.cleanInvalidDependencies(projectPath)
     await this.executeProjectAction(COMMANDS.DEPLOY_PROJECT, {}, executor)
   }
 

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -85,7 +85,7 @@ export const fileCabinetTopLevelFolders = [
 const MINUTE_IN_MILLISECONDS = 1000 * 60
 
 const INVALID_DEPENDENCIES = ['ADVANCEDEXPENSEMANAGEMENT', 'SUBSCRIPTIONBILLING', 'WMSSYSTEM', 'BILLINGACCOUNTS']
-const INVALID_DEPENDENCIES_PATTERN = new RegExp(`^.*(<feature required="true">${INVALID_DEPENDENCIES.join('|')})</feature>.*\n`, 'gm')
+const INVALID_DEPENDENCIES_PATTERN = new RegExp(`^.*(<feature required=".*">${INVALID_DEPENDENCIES.join('|')})</feature>.*\n`, 'gm')
 
 const baseExecutionPath = os.tmpdir()
 


### PR DESCRIPTION
Fixed a bug caused by SDF where during deployment, SDF would raise an error about features that are not enabled in the account although they are not necessary for the deployment. 

---
__Release Notes:__
Netsuite Adapter:
Fixed a bug where during deployment, an error about features that must be enabled in the account would occur, although those features are not necessary for the deployment (ADVANCEDEXPENSEMANAGEMENT, SUBSCRIPTIONBILLING...).