### PR TITLE
SALTO-1108: Add config override option to CLI commands

### DIFF
--- a/packages/cli/src/commands/common/config_override.ts
+++ b/packages/cli/src/commands/common/config_override.ts
@@ -24,7 +24,7 @@ export const CONFIG_OVERRIDE_OPTION: KeyedOption<ConfigOverrideArg> = {
   name: 'config',
   alias: 'C',
   required: false,
-  description: 'Overriding values for configuration (format: <service>.<key>=<value>)',
+  description: 'Overriding values for configuration (format: <service>.<path>=<value>)',
   type: 'stringsList',
 }
 
@@ -64,7 +64,7 @@ const getConfigOverridesFromEnv = (): DetailedChange[] => (
 const createChangeFromArg = (overrideArg: string): DetailedChange => {
   const match = overrideArg.match(/^(\w+)\.([\w.]+)=(.+)$/)
   if (match === null) {
-    throw new Error(`Invalid format for config override: ${overrideArg}. should be <service>.<key>=<value>`)
+    throw new Error(`Invalid format for config override: ${overrideArg}. should be <service>.<path>=<value>`)
   }
   const [adapter, idPath, value] = match.slice(1)
   const id = new ElemID(

--- a/packages/cli/src/commands/common/config_override.ts
+++ b/packages/cli/src/commands/common/config_override.ts
@@ -1,0 +1,79 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { DetailedChange, Value, ElemID } from '@salto-io/adapter-api'
+import { KeyedOption } from '../../command_builder'
+
+export type ConfigOverrideArg = {
+  config?: string[]
+}
+
+export const CONFIG_OVERRIDE_OPTION: KeyedOption<ConfigOverrideArg> = {
+  name: 'config',
+  alias: 'C',
+  required: false,
+  description: 'Overriding values for configuration (format: <service>.<key>=<value>)',
+  type: 'stringsList',
+}
+
+const SALTO_ENV_PREFIX = 'SALTO'
+const SALTO_ENV_CONFIG_PREFIX = `${SALTO_ENV_PREFIX}_CONFIG_`
+
+const convertValueType = (value: string): Value => {
+  try {
+    return JSON.parse(value)
+  } catch (e) {
+    return value
+  }
+}
+
+const createChangeFromEnv = ([name, value]: [string, string]): DetailedChange => {
+  const [adapter, ...idPath] = name.slice(SALTO_ENV_CONFIG_PREFIX.length).split('_')
+  const id = new ElemID(adapter, ElemID.CONFIG_NAME, 'instance', ElemID.CONFIG_NAME, ...idPath)
+  return { id, action: 'add', data: { after: convertValueType(value) } }
+}
+
+const isSaltoConfigEnv = (entry: [string, string?]): entry is [string, string] => {
+  const [name, value] = entry
+  return (
+    name.length > SALTO_ENV_CONFIG_PREFIX.length
+    && name.startsWith(SALTO_ENV_CONFIG_PREFIX)
+    && value !== undefined
+    && value.length > 0
+  )
+}
+
+const getConfigOverridesFromEnv = (): DetailedChange[] => (
+  Object.entries(process.env)
+    .filter(isSaltoConfigEnv)
+    .map(createChangeFromEnv)
+)
+
+const createChangeFromArg = (overrideArg: string): DetailedChange => {
+  const match = overrideArg.match(/^(\w+)\.([\w.]+)=(.+)$/)
+  if (match === null) {
+    throw new Error(`Invalid format for config override: ${overrideArg}. should be <service>.<key>=<value>`)
+  }
+  const [adapter, idPath, value] = match.slice(1)
+  const id = new ElemID(
+    adapter, ElemID.CONFIG_NAME, 'instance', ElemID.CONFIG_NAME, ...idPath.split('.')
+  )
+  return { id, action: 'add', data: { after: convertValueType(value) } }
+}
+
+export const getConfigOverrideChanges = ({ config }: ConfigOverrideArg): DetailedChange[] => [
+  ...getConfigOverridesFromEnv(),
+  ...(config ?? []).map(createChangeFromArg),
+]

--- a/packages/cli/src/commands/common/env.ts
+++ b/packages/cli/src/commands/common/env.ts
@@ -19,7 +19,7 @@ export type EnvArg = {
     env?: string
 }
 
-export const ENVIORMENT_OPTION: KeyedOption<EnvArg> = {
+export const ENVIRONMENT_OPTION: KeyedOption<EnvArg> = {
   name: 'env',
   alias: 'e',
   required: false,

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -21,13 +21,14 @@ import { logger } from '@salto-io/logging'
 import { Workspace } from '@salto-io/workspace'
 import { createPublicCommandDef, CommandDefAction } from '../command_builder'
 import { ServicesArg, SERVICES_OPTION, getAndValidateActiveServices } from './common/services'
-import { EnvArg, ENVIORMENT_OPTION } from './common/env'
+import { EnvArg, ENVIRONMENT_OPTION } from './common/env'
 import { CliOutput, CliExitCode, CliTelemetry } from '../types'
 import { outputLine, errorOutputLine } from '../outputer'
 import { header, formatExecutionPlan, deployPhaseHeader, cancelDeployOutput, formatItemDone, formatItemError, formatCancelAction, formatActionInProgress, formatActionStart, deployPhaseEpilogue } from '../formatter'
 import Prompts from '../prompts'
 import { getUserBooleanInput } from '../callbacks'
 import { loadWorkspace, getWorkspaceTelemetryTags, updateWorkspace } from '../workspace/workspace'
+import { ConfigOverrideArg, getConfigOverrideChanges, CONFIG_OVERRIDE_OPTION } from './common/config_override'
 
 const log = logger(module)
 
@@ -74,7 +75,7 @@ type DeployArgs = {
   force: boolean
   dryRun: boolean
   detailedPlan: boolean
-} & ServicesArg & EnvArg
+} & ServicesArg & EnvArg & ConfigOverrideArg
 
 const deployPlan = async (
   actionPlan: Plan,
@@ -185,6 +186,7 @@ export const action: CommandDefAction<DeployArgs> = async ({
       recommendStateStatus: true,
       spinnerCreator,
       sessionEnv: env,
+      configOverrides: getConfigOverrideChanges(input),
     })
   if (errored) {
     cliTelemetry.failure()
@@ -252,7 +254,8 @@ const deployDef = createPublicCommandDef({
         type: 'boolean',
       },
       SERVICES_OPTION,
-      ENVIORMENT_OPTION,
+      ENVIRONMENT_OPTION,
+      CONFIG_OVERRIDE_OPTION,
     ],
   },
   action,

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -23,7 +23,7 @@ import { errorOutputLine, outputLine } from '../outputer'
 import { formatTargetEnvRequired, formatUnknownTargetEnv, formatInvalidEnvTargetCurrent, formatCloneToEnvFailed, formatInvalidFilters, formatMoveFailed, emptyLine, formatListUnresolvedFound, formatListUnresolvedMissing, formatElementListUnresolvedFailed } from '../formatter'
 import { loadWorkspace, getWorkspaceTelemetryTags } from '../workspace/workspace'
 import Prompts from '../prompts'
-import { EnvArg, ENVIORMENT_OPTION } from './common/env'
+import { EnvArg, ENVIRONMENT_OPTION } from './common/env'
 
 const log = logger(module)
 
@@ -122,7 +122,7 @@ const moveToCommonDef = createPublicCommandDef({
       },
     ],
     keyedOptions: [
-      ENVIORMENT_OPTION,
+      ENVIRONMENT_OPTION,
     ],
   },
   action: moveToCommonAction,
@@ -245,7 +245,7 @@ const cloneDef = createPublicCommandDef({
         type: 'stringsList',
         required: true,
       },
-      ENVIORMENT_OPTION,
+      ENVIRONMENT_OPTION,
       // TODO: Check if needed
       {
         name: 'force',
@@ -334,7 +334,7 @@ const listUnresolvedDef = createPublicCommandDef({
         type: 'string',
         required: false,
       },
-      ENVIORMENT_OPTION,
+      ENVIRONMENT_OPTION,
     ],
   },
   action: listUnresolvedAction,

--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -26,7 +26,7 @@ import { loadWorkspace, getWorkspaceTelemetryTags, updateWorkspace } from '../wo
 import { getApprovedChanges } from '../callbacks'
 import { createPublicCommandDef, CommandDefAction } from '../command_builder'
 import { ServicesArg, SERVICES_OPTION, getAndValidateActiveServices } from './common/services'
-import { EnvArg, ENVIORMENT_OPTION } from './common/env'
+import { EnvArg, ENVIRONMENT_OPTION } from './common/env'
 
 const log = logger(module)
 
@@ -218,7 +218,7 @@ const restoreDef = createPublicCommandDef({
         type: 'boolean',
       },
       SERVICES_OPTION,
-      ENVIORMENT_OPTION,
+      ENVIRONMENT_OPTION,
       {
         name: 'mode',
         alias: 'm',

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -25,7 +25,7 @@ import { createCommandGroupDef, createPublicCommandDef, CommandDefAction, KeyedO
 import { formatServiceAlreadyAdded, formatServiceAdded, formatLoginToServiceFailed, formatCredentialsHeader, formatLoginUpdated, formatConfiguredServices, formatServiceNotConfigured, formatLoginOverride } from '../formatter'
 import { errorOutputLine, outputLine } from '../outputer'
 import { processOauthCredentials } from '../cli_oauth_authenticator'
-import { EnvArg, ENVIORMENT_OPTION } from './common/env'
+import { EnvArg, ENVIRONMENT_OPTION } from './common/env'
 
 const log = logger(module)
 
@@ -150,7 +150,7 @@ const serviceAddDef = createPublicCommandDef({
         required: false,
       },
       AUTH_TYPE_OPTION,
-      ENVIORMENT_OPTION,
+      ENVIRONMENT_OPTION,
     ],
     positionalOptions: [
       {
@@ -182,7 +182,7 @@ const serviceListDef = createPublicCommandDef({
     name: 'list',
     description: 'List all environment services',
     keyedOptions: [
-      ENVIORMENT_OPTION,
+      ENVIRONMENT_OPTION,
     ],
   },
   action: listAction,
@@ -227,7 +227,7 @@ const serviceLoginDef = createPublicCommandDef({
     description: 'Set the environment service credentials',
     keyedOptions: [
       AUTH_TYPE_OPTION,
-      ENVIORMENT_OPTION,
+      ENVIRONMENT_OPTION,
     ],
     positionalOptions: [
       {

--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -18,7 +18,7 @@ import _ from 'lodash'
 import wu from 'wu'
 import semver from 'semver'
 import { FetchChange, Tags, loadLocalWorkspace, StepEmitter } from '@salto-io/core'
-import { SaltoError } from '@salto-io/adapter-api'
+import { SaltoError, DetailedChange } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { Workspace, nacl, StateRecency, validator as wsValidator } from '@salto-io/workspace'
 import { EventEmitter } from 'pietile-eventemitter'
@@ -61,6 +61,7 @@ export type LoadWorkspaceOptions = {
   sessionEnv?: string
   services?: string[]
   ignoreUnresolvedRefs?: boolean
+  configOverrides?: DetailedChange[]
 }
 
 type ApplyProgressEvents = {
@@ -181,13 +182,14 @@ export const loadWorkspace = async (
     sessionEnv = undefined,
     services = undefined,
     ignoreUnresolvedRefs = false,
+    configOverrides,
   }: Partial<LoadWorkspaceOptions> = {}
 ): Promise<LoadWorkspaceResult> => {
   const spinner = spinnerCreator
     ? spinnerCreator(Prompts.LOADING_WORKSPACE, {})
     : { succeed: () => undefined, fail: () => undefined }
 
-  const workspace = await loadLocalWorkspace(workingDir)
+  const workspace = await loadLocalWorkspace(workingDir, configOverrides)
   if (!_.isUndefined(sessionEnv)) {
     if (!(workspace.envs().includes(sessionEnv))) {
       spinner.fail(`Environment ${sessionEnv} isn't configured. Use salto env create.`)

--- a/packages/cli/test/commands/commons.test.ts
+++ b/packages/cli/test/commands/commons.test.ts
@@ -13,8 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { DetailedChange, ElemID, Value } from '@salto-io/adapter-api'
 import * as mocks from '../mocks'
 import { getAndValidateActiveServices } from '../../src/commands/common/services'
+import { getConfigOverrideChanges } from '../../src/commands/common/config_override'
 
 describe('Commands commons tests', () => {
   describe('getAndValidateActiveServices with workspace with services', () => {
@@ -42,6 +44,89 @@ describe('Commands commons tests', () => {
 
     it('Should throw an error if input services were provided', () => {
       expect(() => getAndValidateActiveServices(mockWorkspace, ['wtfService'])).toThrow()
+    })
+  })
+  describe('getConfigOverrideChanges', () => {
+    const getConfigId = (adapter: string, ...idParts: string[]): ElemID => (
+      new ElemID(adapter, ElemID.CONFIG_NAME, 'instance', ElemID.CONFIG_NAME, ...idParts)
+    )
+    const getConfigChange = (id: ElemID, value: Value): DetailedChange => (
+      { id, action: 'add', data: { after: value } }
+    )
+    describe('with valid arguments from command line and env vars', () => {
+      let changes: ReadonlyArray<DetailedChange>
+      const envConfig = {
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        SALTO_CONFIG_env_str: 'str',
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        SALTO_CONFIG_env_num: '12',
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        SALTO_CONFIG_env_nested_bool: 'false',
+      }
+      beforeEach(() => {
+        Object.assign(process.env, envConfig)
+        const config = [
+          'arg.str=str',
+          'arg.nested.obj={"num": 1, "complex": {"a": true}}',
+        ]
+        changes = getConfigOverrideChanges({ config })
+      })
+      afterEach(() => {
+        Object.keys(envConfig).forEach(key => {
+          delete process.env[key]
+        })
+      })
+      it('should create changes from command line arguments', () => {
+        expect(changes).toContainEqual(getConfigChange(getConfigId('arg', 'str'), 'str'))
+        expect(changes).toContainEqual(
+          getConfigChange(getConfigId('arg', 'nested', 'obj'), { num: 1, complex: { a: true } })
+        )
+      })
+      it('should create changes from environment variables', () => {
+        expect(changes).toContainEqual(getConfigChange(getConfigId('env', 'str'), 'str'))
+        expect(changes).toContainEqual(getConfigChange(getConfigId('env', 'num'), 12))
+        expect(changes).toContainEqual(getConfigChange(getConfigId('env', 'nested', 'bool'), false))
+      })
+      it('should put command line arguments after environment variables', () => {
+        // This is important because we want values from the command line to override values
+        // from the environment
+        const firstEnvChange = changes.findIndex(change => change.id.adapter === 'env')
+        const argChangeIndices = changes
+          .map((change, idx) => ({ idx, src: change.id.adapter }))
+          .filter(({ src }) => src === 'arg')
+          .map(({ idx }) => idx)
+
+        argChangeIndices.forEach(idx => expect(idx).toBeGreaterThan(firstEnvChange))
+      })
+    })
+    describe('with invalid command arg format', () => {
+      it('should throw an error', () => {
+        const config = ['bla.foo']
+        expect(() => getConfigOverrideChanges({ config })).toThrow()
+      })
+    })
+    describe('with invalid environment variable format', () => {
+      let changes: DetailedChange[]
+      const envConfig = {
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        SALTO_CONFIG_empty: '',
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        NOT_SALTO_CONFIG_env_num: '12',
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        SALTO_CONFIG: 'false',
+      }
+      beforeEach(() => {
+        Object.assign(process.env, envConfig)
+        changes = getConfigOverrideChanges({})
+      })
+      afterEach(() => {
+        Object.keys(envConfig).forEach(key => {
+          delete process.env[key]
+        })
+      })
+      it('should not set the variable', () => {
+        expect(changes).toHaveLength(0)
+      })
     })
   })
 })

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -16,6 +16,7 @@
 import _ from 'lodash'
 import path from 'path'
 import uuidv4 from 'uuid/v4'
+import { DetailedChange } from '@salto-io/adapter-api'
 import { exists, isEmptyDir, rm } from '@salto-io/file'
 import { Workspace, loadWorkspace, EnvironmentsSources, initWorkspace, nacl,
   configSource as cs, parseCache, staticFiles, dirStore, WorkspaceComponents } from '@salto-io/workspace'
@@ -167,13 +168,14 @@ const credentialsSource = (localStorage: string): cs.ConfigSource =>
     encoding: 'utf8',
   }))
 
-export const loadLocalWorkspace = async (lookupDir: string):
-Promise<Workspace> => {
+export const loadLocalWorkspace = async (
+  lookupDir: string, configOverrides?: DetailedChange[],
+): Promise<Workspace> => {
   const baseDir = await locateWorkspaceRoot(path.resolve(lookupDir))
   if (_.isUndefined(baseDir)) {
     throw new NotAWorkspaceError()
   }
-  const workspaceConfig = await workspaceConfigSource(baseDir)
+  const workspaceConfig = await workspaceConfigSource(baseDir, undefined, configOverrides)
   const envs = (await workspaceConfig.getWorkspaceConfig()).envs.map(e => e.name)
   const credentials = credentialsSource(workspaceConfig.localStorage)
   const elemSources = loadLocalElementsSources(baseDir, workspaceConfig.localStorage, envs)

--- a/packages/core/src/local-workspace/workspace_config.ts
+++ b/packages/core/src/local-workspace/workspace_config.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import path from 'path'
 import { workspaceConfigSource as wcs,
   WorkspaceConfig, configSource } from '@salto-io/workspace'
-import { InstanceElement } from '@salto-io/adapter-api'
+import { InstanceElement, DetailedChange } from '@salto-io/adapter-api'
 import { localDirectoryStore } from './dir_store'
 import { getSaltoHome, CONFIG_DIR_NAME } from '../app_config'
 import { WORKSPACE_CONFIG_NAME, ENVS_CONFIG_NAME, EnvsConfig,
@@ -29,10 +29,12 @@ export type WorkspaceConfigSource = wcs.WorkspaceConfigSource & {
   localStorage: string
 }
 
-export const workspaceConfigSource = async (baseDir: string, localStorage?: string):
-Promise<WorkspaceConfigSource> => {
+export const workspaceConfigSource = async (
+  baseDir: string, localStorage?: string, configOverrides?: DetailedChange[]
+): Promise<WorkspaceConfigSource> => {
   const repoCs = configSource.configSource(
-    localDirectoryStore({ baseDir, name: CONFIG_DIR_NAME, encoding: 'utf8' })
+    localDirectoryStore({ baseDir, name: CONFIG_DIR_NAME, encoding: 'utf8' }),
+    configOverrides,
   )
   const workspaceConf = (await repoCs.get(WORKSPACE_CONFIG_NAME))?.value
 
@@ -43,7 +45,8 @@ Promise<WorkspaceConfigSource> => {
   const computedLocalStorage = localStorage
   || path.join(getSaltoHome(), `${workspaceConf?.name}-${workspaceConf?.uid}`)
   const localCs = configSource.configSource(
-    localDirectoryStore({ baseDir: computedLocalStorage, name: '', encoding: 'utf8' })
+    localDirectoryStore({ baseDir: computedLocalStorage, name: '', encoding: 'utf8' }),
+    configOverrides,
   )
   return {
     localStorage: computedLocalStorage,

--- a/packages/workspace/test/workspace/config_source.test.ts
+++ b/packages/workspace/test/workspace/config_source.test.ts
@@ -1,0 +1,93 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { DetailedChange, ElemID, Value, InstanceElement } from '@salto-io/adapter-api'
+import { configSource, ConfigSource } from '../../src/workspace/config_source'
+import { mockDirStore } from '../common/nacl_file_store'
+
+describe('configSource', () => {
+  let source: ConfigSource
+  const createConfigOverride = (name: string, path: string[], value: Value): DetailedChange => ({
+    id: new ElemID(name, ElemID.CONFIG_NAME, 'instance', ElemID.CONFIG_NAME, ...path),
+    action: 'add',
+    data: { after: value },
+  })
+  beforeEach(() => {
+    const overrides: DetailedChange[] = [
+      createConfigOverride('valid', ['val'], 2),
+      createConfigOverride('valid', ['new'], { a: true }),
+    ]
+    const dirStore = mockDirStore(
+      undefined,
+      undefined,
+      {
+        'valid.nacl': `valid {
+          val = 1
+          other = 3
+        }`,
+        'empty.nacl': '',
+        'noInst.nacl': `type bla {
+        }`,
+        'multipleInst.nacl': `first {
+          val = 1
+        }
+        second {
+          val = 2
+        }`,
+        'error.nacl': 'asd',
+      },
+    )
+    source = configSource(dirStore, overrides)
+  })
+  describe('get', () => {
+    describe('with valid config', () => {
+      let inst: InstanceElement | undefined
+      beforeEach(async () => {
+        inst = await source.get('valid')
+      })
+      it('should return the config instance', () => {
+        expect(inst).toBeInstanceOf(InstanceElement)
+      })
+      it('should have instance values when they are not overridden', () => {
+        expect(inst?.value).toMatchObject({
+          other: 3,
+        })
+      })
+      it('should apply config overrides', () => {
+        expect(inst?.value).toMatchObject({
+          val: 2,
+          new: { a: true },
+        })
+      })
+    })
+    it('should return undefined when there is no file', async () => {
+      expect(await source.get('noSuchFile')).toBeUndefined()
+    })
+    it('should return undefined for an empty file', async () => {
+      expect(await source.get('empty')).toBeUndefined()
+    })
+    it('should return undefined for a file with no instance', async () => {
+      expect(await source.get('noInst')).toBeUndefined()
+    })
+    it('should return the first instance if there is more than one', async () => {
+      const inst = await source.get('multipleInst')
+      expect(inst).toBeDefined()
+      expect(inst?.elemID.adapter).toEqual('first')
+    })
+    it('should fail if the config file has parse errors', async () => {
+      await expect(source.get('error')).rejects.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
---

_Release Notes_
CLI new feature:
- Allow overriding configuration values with `--config` and/or `SALTO_CONFIG_` environment variables in `fetch` and `deploy` commands
