### PR TITLE
SALTO-1081 Deploy Settings

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -45,7 +45,7 @@ import flowFilter from './filters/flow'
 import addMissingIdsFilter from './filters/add_missing_ids'
 import animationRulesFilter from './filters/animation_rules'
 import samlInitMethodFilter from './filters/saml_initiation_method'
-import settingsFilter, { SETTINGS_METADATA_TYPE } from './filters/settings_type'
+import settingsFilter from './filters/settings_type'
 import workflowFilter, { WORKFLOW_FIELD_TO_TYPE } from './filters/workflow'
 import topicsForObjectsFilter from './filters/topics_for_objects'
 import globalValueSetFilter from './filters/global_value_sets'
@@ -255,7 +255,7 @@ export default class SalesforceAdapter implements AdapterOperations {
   public constructor({
     metadataTypesSkippedList = [
       'CustomField', // We have special treatment for this type
-      SETTINGS_METADATA_TYPE,
+      constants.SETTINGS_METADATA_TYPE,
       'NetworkBranding',
       'FlowDefinition', // Only has the active flow version but we cant get flow versions anyway
       'CustomIndex', // readMetadata and retrieve fail on this type when fetching by name

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -307,6 +307,7 @@ export const WORKFLOW_RULE_METADATA_TYPE = 'WorkflowRule'
 export const WORKFLOW_TASK_METADATA_TYPE = 'WorkflowTask'
 export const WEBLINK_METADATA_TYPE = 'WebLink'
 export const BUSINESS_HOURS_METADATA_TYPE = 'BusinessHoursSettings'
+export const SETTINGS_METADATA_TYPE = 'Settings'
 
 // Retrieve constants
 export const RETRIEVE_LOAD_OF_METADATA_ERROR_REGEX = /Load of metadata from db failed for metadata of type:(?<type>\w+) and file name:(?<instance>\w+).$/

--- a/packages/salesforce-adapter/src/filters/settings_type.ts
+++ b/packages/salesforce-adapter/src/filters/settings_type.ts
@@ -17,16 +17,13 @@ import _ from 'lodash'
 import { Element, isObjectType, ObjectType, TypeElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
-import {
-  createMetadataTypeElements, apiName,
-} from '../transformers/transformer'
+import { createMetadataTypeElements, apiName } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
 import { ConfigChangeSuggestion } from '../types'
+import { SETTINGS_METADATA_TYPE } from '../constants'
 import { fetchMetadataInstances, listMetadataObjects } from '../fetch'
 
 const log = logger(module)
-
-export const SETTINGS_METADATA_TYPE = 'Settings'
 
 // This method receiving settings type name and call to describeMetadataType
 // And creating the new (settings) type
@@ -46,6 +43,10 @@ const createSettingsType = async (
       childTypeNames: new Set(),
       client,
       isSettings: true,
+      annotations: {
+        suffix: SETTINGS_METADATA_TYPE.toLowerCase(),
+        dirName: SETTINGS_METADATA_TYPE.toLowerCase(),
+      },
     })
   } catch (e) {
     log.error('failed to fetch settings type %s reason: %o', settingsTypesName, e)

--- a/packages/salesforce-adapter/src/filters/settings_type.ts
+++ b/packages/salesforce-adapter/src/filters/settings_type.ts
@@ -44,8 +44,8 @@ const createSettingsType = async (
       client,
       isSettings: true,
       annotations: {
-        suffix: SETTINGS_METADATA_TYPE.toLowerCase(),
-        dirName: SETTINGS_METADATA_TYPE.toLowerCase(),
+        suffix: 'settings',
+        dirName: 'settings',
       },
     })
   } catch (e) {
@@ -109,6 +109,14 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
 
     return [...instancesConfigChanges, ...listObjectsConfigChanges]
   },
+
+  // after onFetch, the settings types have annotations.metadataType === '<name>Settings',
+  // which causes deploy to fail (SALTO-1081).
+  // We currently don't fix the metadata type in a preDeploy & onDeploy mechanism,
+  // since the '<name>Settings' format is required for comparison with the type specified in the
+  // deploy response, which is also in this format (after preDeploy and before onDeploy).
+  // instead, we change the type in the deploy pkg (PR #1727).
+
 })
 
 export default filterCreator

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -77,7 +77,7 @@ const addNestedInstancesToPackageManifest = (
       .map(getNestedInstanceApiName)
 
     idsToDelete.forEach(nestedInstName => {
-      pkg.delete(fieldType, nestedInstName)
+      pkg.delete(fieldType, nestedInstName, changeElem.type.isSettings)
     })
 
     const idsToAdd = addNestedAfterInstances
@@ -111,7 +111,7 @@ const addChangeToPackage = (
     : {}
 
   if (isRemovalChange(change)) {
-    pkg.delete(instance.type, apiName(instance))
+    pkg.delete(instance.type, apiName(instance), instance.type.isSettings)
   } else {
     pkg.add(instance, addInstanceToManifest)
   }

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -77,7 +77,7 @@ const addNestedInstancesToPackageManifest = (
       .map(getNestedInstanceApiName)
 
     idsToDelete.forEach(nestedInstName => {
-      pkg.delete(fieldType, nestedInstName, changeElem.type.isSettings)
+      pkg.delete(fieldType, nestedInstName)
     })
 
     const idsToAdd = addNestedAfterInstances
@@ -111,7 +111,7 @@ const addChangeToPackage = (
     : {}
 
   if (isRemovalChange(change)) {
-    pkg.delete(instance.type, apiName(instance), instance.type.isSettings)
+    pkg.delete(instance.type, apiName(instance))
   } else {
     pkg.add(instance, addInstanceToManifest)
   }

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -26,7 +26,7 @@ import { API_VERSION } from '../client/client'
 import {
   INSTANCE_FULL_NAME_FIELD, IS_ATTRIBUTE, METADATA_CONTENT_FIELD, SALESFORCE, XML_ATTRIBUTE_PREFIX,
   RECORDS_PATH, INSTALLED_PACKAGES_PATH, NAMESPACE_SEPARATOR, INTERNAL_ID_FIELD,
-  LIGHTNING_COMPONENT_BUNDLE_METADATA_TYPE,
+  LIGHTNING_COMPONENT_BUNDLE_METADATA_TYPE, SETTINGS_METADATA_TYPE,
 } from '../constants'
 import {
   apiName, metadataType, MetadataValues, MetadataInstanceElement, MetadataObjectType,
@@ -54,9 +54,11 @@ const TARGET_CONFIGS = 'targetConfigs'
 const LWC_RESOURCES = 'lwcResources'
 const LWC_RESOURCE = 'lwcResource'
 
-export const getManifestTypeName = (type: MetadataObjectType): string => (
+export const getManifestTypeName = (type: MetadataObjectType, isSettings?: boolean): string => (
   // Salesforce quirk - folder instances are listed under their content's type in the manifest
-  type.annotations.folderContentType ?? type.annotations.metadataType
+  isSettings
+    ? SETTINGS_METADATA_TYPE
+    : (type.annotations.folderContentType ?? type.annotations.metadataType)
 )
 
 export const toRetrieveRequest = (files: ReadonlyArray<FileProperties>): RetrieveRequest => ({
@@ -353,8 +355,8 @@ const toPackageXml = (manifest: Map<string, string[]>): string => (
 
 export type DeployPackage = {
   add(instance: MetadataInstanceElement, withManifest?: boolean): void
-  addToManifest(type: MetadataObjectType, name: string): void
-  delete(type: MetadataObjectType, name: string): void
+  addToManifest(type: MetadataObjectType, name: string, isSettings?: boolean): void
+  delete(type: MetadataObjectType, name: string, isSettings?: boolean): void
   getZip(): Promise<Buffer>
   getDeletionsPackageName(): string
 }
@@ -365,15 +367,15 @@ export const createDeployPackage = (deleteBeforeUpdate?: boolean): DeployPackage
   const deleteManifest = new collections.map.DefaultMap<string, string[]>(() => [])
   const deletionsPackageName = deleteBeforeUpdate ? 'destructiveChanges.xml' : 'destructiveChangesPost.xml'
 
-  const addToManifest: DeployPackage['addToManifest'] = (type, name) => {
-    const typeName = getManifestTypeName(type)
+  const addToManifest: DeployPackage['addToManifest'] = (type, name, isSettings) => {
+    const typeName = getManifestTypeName(type, isSettings)
     addManifest.get(typeName).push(name)
   }
   return {
     add: (instance, withManifest = true) => {
       const instanceName = apiName(instance)
       if (withManifest) {
-        addToManifest(instance.type, instanceName)
+        addToManifest(instance.type, instanceName, instance.type.isSettings)
       }
       // Add instance file(s) to zip
       const typeName = metadataType(instance)
@@ -418,8 +420,8 @@ export const createDeployPackage = (deleteBeforeUpdate?: boolean): DeployPackage
       }
     },
     addToManifest,
-    delete: (type, name) => {
-      const typeName = getManifestTypeName(type)
+    delete: (type, name, isSettings) => {
+      const typeName = getManifestTypeName(type, isSettings)
       deleteManifest.get(typeName).push(name)
     },
     getZip: () => {

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -56,7 +56,10 @@ const LWC_RESOURCE = 'lwcResource'
 
 export const getManifestTypeName = (type: MetadataObjectType): string => (
   // Salesforce quirk - folder instances are listed under their content's type in the manifest
-  type.isSettings
+
+  // Salesforce quirk - settings intances should be deployed under Settings type,
+  // although their recieved type is "<name>Settings"
+  type.annotations.dirName === 'settings'
     ? SETTINGS_METADATA_TYPE
     : (type.annotations.folderContentType ?? type.annotations.metadataType)
 )

--- a/packages/salesforce-adapter/test/filters/convert_types.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_types.test.ts
@@ -22,7 +22,6 @@ import {
 import makeFilter from '../../src/filters/convert_types'
 import * as constants from '../../src/constants'
 import { FilterWith } from '../../src/filter'
-import { SETTINGS_METADATA_TYPE } from '../../src/filters/settings_type'
 import mockClient from '../client'
 
 describe('convert types filter', () => {
@@ -104,7 +103,7 @@ describe('convert types filter', () => {
   const mockSettings = new InstanceElement(
     'test_settings',
     new ObjectType({
-      elemID: new ElemID(constants.SALESFORCE, SETTINGS_METADATA_TYPE),
+      elemID: new ElemID(constants.SALESFORCE, constants.SETTINGS_METADATA_TYPE),
     }),
     {},
   )

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { ObjectType, ElemID, TypeElement, BuiltinTypes, ListType } from '@salto-io/adapter-api'
-import { SALESFORCE, INSTANCE_FULL_NAME_FIELD, ASSIGNMENT_RULES_METADATA_TYPE, WORKFLOW_METADATA_TYPE, LIGHTNING_COMPONENT_BUNDLE_METADATA_TYPE } from '../src/constants'
+import { SALESFORCE, INSTANCE_FULL_NAME_FIELD, ASSIGNMENT_RULES_METADATA_TYPE, WORKFLOW_METADATA_TYPE, LIGHTNING_COMPONENT_BUNDLE_METADATA_TYPE, SETTINGS_METADATA_TYPE } from '../src/constants'
 import { MetadataTypeAnnotations, MetadataObjectType } from '../src/transformers/transformer'
 import { allMissingSubTypes } from '../src/transformers/salesforce_types'
 import { API_VERSION } from '../src/client/client'
@@ -132,6 +132,14 @@ export const mockTypes = {
         type: new ListType(createMetadataObjectType({ annotations: { metadataType: typeName } })),
       }),
     ),
+  }),
+  TestSettings: createMetadataObjectType({
+    annotations: {
+      metadataType: 'TestSettings',
+      dirName: SETTINGS_METADATA_TYPE.toLowerCase(), // set to this value upon fetch
+      suffix: SETTINGS_METADATA_TYPE.toLowerCase(), // set to this value upon fetch
+    },
+    isSettings: true,
   }),
 }
 

--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -245,13 +245,16 @@ describe('XML Transformer', () => {
         zipFiles = await getZipFiles(pkg)
       })
       it('manifest should include "Settings"', () => {
-        expect(zipFiles).toHaveProperty(
-          [addManifestPath],
-          `<Package><version>${API_VERSION}</version><types><name>Settings</name><members>TestSettings</members></types></Package>`
-        )
+        expect(zipFiles).toHaveProperty([addManifestPath])
+        const manifest = xmlParser.parse(zipFiles[addManifestPath])
+        expect(manifest).toHaveProperty('Package.types')
+        expect(manifest.Package.types).toMatchObject({ name: 'Settings', members: 'TestSettings' })
+
         const filePath = `${packageName}/settings/TestSettings.settings`
         expect(zipFiles).toHaveProperty([filePath])
-        expect(zipFiles[filePath]).toMatch('<TestSettings><testField>true</testField></TestSettings>')
+        const manifest2 = xmlParser.parse(zipFiles[filePath])
+        expect(manifest2).toHaveProperty('TestSettings.testField')
+        expect(manifest2.TestSettings.testField).toEqual(true)
       })
     })
   })

--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -239,6 +239,21 @@ describe('XML Transformer', () => {
         })
       })
     })
+    describe('with Settings types', () => {
+      beforeEach(async () => {
+        pkg.add(createInstanceElement({ fullName: 'TestSettings', testField: true }, mockTypes.TestSettings))
+        zipFiles = await getZipFiles(pkg)
+      })
+      it('manifest should include "Settings"', () => {
+        expect(zipFiles).toHaveProperty(
+          [addManifestPath],
+          `<Package><version>${API_VERSION}</version><types><name>Settings</name><members>TestSettings</members></types></Package>`
+        )
+        const filePath = `${packageName}/settings/TestSettings.settings`
+        expect(zipFiles).toHaveProperty([filePath])
+        expect(zipFiles[filePath]).toMatch('<TestSettings><testField>true</testField></TestSettings>')
+      })
+    })
   })
 
   describe('fromRetrieveResult', () => {


### PR DESCRIPTION
1. added annotations to Settings types on fetch: 
dirName = 'settings'
suffix = 'settings'
2. changed the manifest type name to 'Settings' for all settings types

---
__Release Notes:__
 bug fixed - changes in Settings instances can now be deployed properly (attempting to deploy raised an error).