### PR TITLE
fixed hidden_string type on instance annotations

### DIFF
--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -28,8 +28,12 @@ import { createAddChange, createRemoveChange } from './nacl_files/multi_env/proj
 
 const log = logger(module)
 
+const hasHiddenValueAnnotation = (element?: Element): boolean =>
+  (element?.annotations?.[CORE_ANNOTATIONS.HIDDEN_VALUE] === true)
+
 const isHiddenValue = (element?: Element): boolean => (
-  element?.annotations?.[CORE_ANNOTATIONS.HIDDEN_VALUE] === true
+  hasHiddenValueAnnotation(element)
+  || (isField(element) && hasHiddenValueAnnotation(element.type))
 )
 
 const isHidden = (element?: Element): boolean => (


### PR DESCRIPTION
In a previous PR, I created a built-in instance annotation `_service_url` with a type of `hidden_string`.
In instances, we treat annotations as values, and It seems we don't support `hidden_string` in this case because, for values of instances, we expect the `hidden_value` annotation to be on the field itself and not the type of the field. In this PR, I also check the type of the field.

---
__Release Notes:__ None (Bug was not released)