### PR TITLE
fixed hidden instances annotations

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -80,9 +80,13 @@ const fieldMapperGenerator = (
     return name => objType.fields[name]
   }
   const objType = new ObjectType({ elemID: new ElemID('') })
-  return name => (type[name] !== undefined
-    // we set the annotations as type[name].annotations to support hidden_string (or any other type with hidden_value) in instance annotation types.
-    ? new Field(objType, name, type[name], type[name].annotations) : undefined)
+  return name => (
+    type[name] !== undefined
+      // we set the annotations as type[name].annotations to support hidden_string
+      // (or any other type with hidden_value) in instance annotation types.
+      ? new Field(objType, name, type[name], type[name].annotations)
+      : undefined
+  )
 }
 
 export type TransformFuncArgs = {

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -80,7 +80,9 @@ const fieldMapperGenerator = (
     return name => objType.fields[name]
   }
   const objType = new ObjectType({ elemID: new ElemID('') })
-  return name => (type[name] !== undefined ? new Field(objType, name, type[name]) : undefined)
+  return name => (type[name] !== undefined
+    // we set the annotations as type[name].annotations to support hidden_string (or any other type with hidden_value) in instance annotation types.
+    ? new Field(objType, name, type[name], type[name].annotations) : undefined)
 }
 
 export type TransformFuncArgs = {

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -700,7 +700,10 @@ describe('Test utils.ts', () => {
         objType,
         { f1: 'a', f2: [1, 2, 3], f3: false },
         undefined,
-        { [CORE_ANNOTATIONS.PARENT]: ['me'] },
+        {
+          [CORE_ANNOTATIONS.PARENT]: ['me'],
+          [CORE_ANNOTATIONS.SERVICE_URL]: 'someUrl',
+        },
       )
       transformFunc = mockFunction<TransformFunc>().mockImplementation(({ value }) => value)
     })
@@ -854,6 +857,13 @@ describe('Test utils.ts', () => {
           field: expect.any(Field),
           path: inst.elemID.createNestedID(CORE_ANNOTATIONS.PARENT, '0'),
         })
+      })
+
+      it('should copy the annotation type annotations to the field annotations', () => {
+        const callArgs = transformFunc.mock.calls.flat().find(args => args.value === 'someUrl')
+        expect(callArgs?.field).toBeDefined()
+        expect(callArgs?.field?.annotations).toEqual(callArgs?.field?.type.annotations)
+        expect(_.isEmpty(callArgs?.field?.annotations)).toBeFalsy()
       })
     })
   })

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -28,12 +28,8 @@ import { createAddChange, createRemoveChange } from './nacl_files/multi_env/proj
 
 const log = logger(module)
 
-const hasHiddenValueAnnotation = (element?: Element): boolean =>
-  (element?.annotations?.[CORE_ANNOTATIONS.HIDDEN_VALUE] === true)
-
 const isHiddenValue = (element?: Element): boolean => (
-  hasHiddenValueAnnotation(element)
-  || (isField(element) && hasHiddenValueAnnotation(element.type))
+  element?.annotations?.[CORE_ANNOTATIONS.HIDDEN_VALUE] === true
 )
 
 const isHidden = (element?: Element): boolean => (


### PR DESCRIPTION
revert https://github.com/salto-io/salto/pull/1734 to not support hidden string as a field type and handles hidden_string instance annotations by copying the annotation from the type to the field when creating the instance annotations.

---
__Release Notes:__ None
