### PR TITLE
SALTO-1081: add deploy of settings to E2E tests

### DIFF
--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -3580,5 +3580,30 @@ describe('Salesforce adapter E2E with real account', () => {
         expect(childRole.value.parentRole.elemId.typeName).toEqual('Role')
       })
     })
+    describe('Deploy BusinessHoursSettings', () => {
+      let oldElement: InstanceElement
+      beforeAll(() => {
+        oldElement = result.find(
+          e => metadataType(e) === constants.BUSINESS_HOURS_METADATA_TYPE && isInstanceElement(e)
+        ) as InstanceElement
+      })
+      it('should modify BusinessHoursSettings', async () => {
+        const newElement = oldElement.clone()
+        const timeZone = newElement.value.businessHours.Default.timeZoneId
+        newElement.value.businessHours.Default.timeZoneId = (timeZone === 'America/Los_Angeles') ? 'America/Tijuana' : 'America/Los_Angeles'
+        const changes: Change[] = [{
+          action: 'modify',
+          data: { before: oldElement, after: newElement },
+        }]
+        const modificationResult = await adapter.deploy({
+          groupID: oldElement.elemID.getFullName(),
+          changes,
+        })
+
+        expect(modificationResult.errors).toHaveLength(0)
+        expect(modificationResult.appliedChanges).toEqual(changes)
+        expect(await objectExists(client, constants.BUSINESS_HOURS_METADATA_TYPE, 'BusinessHours')).toBe(true)
+      })
+    })
   })
 })


### PR DESCRIPTION
Deploy of any instance of settings failed before [https://github.com/salto-io/salto/pull/1727](url) was merged, but E2E did not catch this bug.
__
Release Notes: None
