### PR TITLE
SALTO-1045: Layout name optimization

### DIFF
--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -42,6 +42,7 @@ import {
   COMPOUND_FIELDS_SOAP_TYPE_NAMES, CUSTOM_OBJECT_ID_FIELD, FOREIGN_KEY_DOMAIN,
   XML_ATTRIBUTE_PREFIX, INTERNAL_ID_FIELD, INTERNAL_FIELD_TYPE_NAMES, CUSTOM_SETTINGS_TYPE,
   LOCATION_INTERNAL_COMPOUND_FIELD_TYPE_NAME, INTERNAL_ID_ANNOTATION,
+  LAYOUT_TYPE_ID_METADATA_TYPE,
 } from '../constants'
 import SalesforceClient from '../client/client'
 import { allMissingSubTypes } from './salesforce_types'
@@ -1282,11 +1283,14 @@ export const createInstanceElement = (
   }
 
   const typeName = pathNaclCase(type.elemID.name)
-  const { name } = Types.getElemId(
-    fullName,
-    true,
-    createInstanceServiceIds(_.pick(values, INSTANCE_FULL_NAME_FIELD), type)
-  )
+  const name = (metadataType(type) === LAYOUT_TYPE_ID_METADATA_TYPE)
+    ? pathNaclCase(naclCase(fullName)) // prettify Layout names
+    : Types.getElemId(
+      fullName,
+      true,
+      createInstanceServiceIds(_.pick(values, INSTANCE_FULL_NAME_FIELD), type)
+    ).name
+
   return new InstanceElement(
     type.isSettings ? ElemID.CONFIG_NAME : name,
     type,

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -422,7 +422,7 @@ describe('SalesforceAdapter fetch', () => {
 
       it('should fetch complicated metadata instance', async () => {
         const { elements: result } = await adapter.fetch(mockFetchOpts)
-        const layout = findElements(result, 'Layout', 'Order_Order_Layout@bs').pop() as InstanceElement
+        const layout = findElements(result, 'Layout', 'Order_Order_Layout').pop() as InstanceElement
         expect(layout).toBeDefined()
         expect(layout.type.elemID).toEqual(LAYOUT_TYPE_ID)
         expect(layout.value[constants.INSTANCE_FULL_NAME_FIELD]).toBe(layoutName)


### PR DESCRIPTION
---
__Release Notes:__
Layout names will now be clean from any duplication-indicating suffixes (e.g `Asset_Asset_Layout@bs` becomes `Asset_Asset_Layout`).
In an existing workspace, the change will only appear after `salto clean` followed by fetch.