### PR TITLE
SALTO-1125 - fix hidden annotation discovery in fields with container types

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -206,9 +206,18 @@ export const elementAnnotationTypes = (element: Element): TypeMap => {
     return InstanceAnnotationTypes
   }
 
+  const getAnnotationTypes = (type: TypeElement): TypeMap => (
+    isContainerType(type)
+      ? {
+        ...type.annotationTypes,
+        ...type.innerType.annotationTypes,
+      }
+      : type.annotationTypes
+  )
+
   return {
     ...CoreAnnotationTypes,
-    ...(isField(element) ? element.type.annotationTypes : element.annotationTypes),
+    ...(isField(element) ? getAnnotationTypes(element.type) : element.annotationTypes),
   }
 }
 


### PR DESCRIPTION
There was a missing case in how `transformElements` looks for annotation types in field annotations, that meant that for custom fields with container types (the only realistic one is list), it did not find the definition of `internalId` and therefore did not mark it as hidden. This only seems to have had (presentation-only) side-effects on the deploy side because the fetch side uses a different path ~that was already fixed in https://github.com/salto-io/salto/pull/1741~ (edit: checked with an earlier version, seems like that fix was not needed for these fields).
In practice, it seems this can only happen in CPQ custom fields with list type.

_Release Notes_
Salesforce - fix plan items that incorrectly showed removals of internal properties in rare scenarios in CPQ custom fields (no impact on the actual deploy).