### PR TITLE
fixed lightining url for domains without 'my' in them

### DIFF
--- a/packages/salesforce-adapter/src/elements_url_retreiver/elements_url_retreiver.ts
+++ b/packages/salesforce-adapter/src/elements_url_retreiver/elements_url_retreiver.ts
@@ -28,7 +28,7 @@ export type ElementsUrlRetreiver = {
 
 export const lightiningElementsUrlRetreiver = (baseUrl: URL, elementIDResolver: ElementIDResolver):
   ElementsUrlRetreiver | undefined => {
-  const suffix = baseUrl.origin.match(/my.salesforce.com$/)
+  const suffix = baseUrl.origin.match(/(my\.)?salesforce\.com$/)
   if (suffix === null) {
     log.error(`Received invalid salesforce url: '${baseUrl.origin}'`)
     return undefined

--- a/packages/salesforce-adapter/test/elements_url_retreiver.test.ts
+++ b/packages/salesforce-adapter/test/elements_url_retreiver.test.ts
@@ -39,8 +39,19 @@ describe('lightiningElementsUrlRetreiver', () => {
       }
     )
 
-    it('valid elementUrlRetreiver is returned', () => {
-      expect(elementUrlRetreiver).toBeDefined()
+    describe('lightiningElementsUrlRetreiver creation', () => {
+      it('valid baseUrl with my subdomain', () => {
+        expect(elementUrlRetreiver).toBeDefined()
+      })
+
+      it('valid baseUrl without my subdomain', () => {
+        const urlRetreiver = lightiningElementsUrlRetreiver(
+          new URL('https://salto5-dev-ed.salesforce.com'),
+          () => undefined
+        )
+
+        expect(urlRetreiver).toBeDefined()
+      })
     })
 
     describe('retreiveUrl', () => {


### PR DESCRIPTION
Fixed the elements URL generation to work for Salesforce URLs with 'my' subdomain in them.

---
__Release Note:__
VSCode Extension:
Fixed "Go to service" not working for some users.