### PR TITLE
SALTO-1131: added support for partial results from adapters

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -26,6 +26,7 @@ import { ChangeGroup, ChangeGroupIdFunction } from './change_group'
 export interface FetchResult {
   elements: Element[]
   updatedConfig?: { config: InstanceElement; message: string }
+  isPartial?: boolean
 }
 
 export type DeployResult = {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -161,7 +161,7 @@ export const deploy = async (
   const changes = wu(await getDetailedChanges(
     relevantWorkspaceElements,
     [...changedElements.values()],
-    workspaceElements
+    { before: workspaceElements, after: workspaceElements }
   )).map(change => ({ change, serviceChange: change }))
     .map(toChangesWithPath(name => collections.array.makeArray(changedElements.get(name))))
     .flatten()

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -265,7 +265,7 @@ const fetchAndProcessMergeErrors = async (
       .filter(c => !_.isUndefined(c)) as UpdatedConfig[]
 
     const partiallyFetchedAdapters = new Set(
-      wu(fetchResults)
+      fetchResults
         .filter(result => result.isPartial)
         .map(result => result.adapterName)
     )
@@ -401,7 +401,8 @@ export const fetchChanges = async (
       // should be calculated with them in mind.
       _.isEmpty(filteredStateElements) ? filteredWorkspaceElements : filteredStateElements,
       filteredWorkspaceElements,
-      workspaceElements
+      // additionalResolveContext is only required when there is a partial fetch
+      !_.isEmpty(partiallyFetchedAdapters) ? workspaceElements : []
     )
 
   log.debug('finished to calculate fetch changes')

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -430,9 +430,17 @@ export const fetchChanges = async (
   })
   const adapterNameToConfigMessage = _
     .fromPairs(updatedConfigs.map(c => [c.config.elemID.adapter, c.message]))
+
+  const elements = partiallyFetchedAdapters.size !== 0
+    ? _(stateElements)
+      .filter(e => partiallyFetchedAdapters.has(e.elemID.adapter))
+      .unshift(...processErrorsResult.keptElements)
+      .uniqBy(e => e.elemID.getFullName())
+      .value()
+    : processErrorsResult.keptElements
   return {
     changes,
-    elements: processErrorsResult.keptElements,
+    elements,
     unmergedElements: serviceElements,
     mergeErrors: processErrorsResult.errorsWithDroppedElements,
     configChanges,

--- a/packages/core/src/core/plan/index.ts
+++ b/packages/core/src/core/plan/index.ts
@@ -13,5 +13,5 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { Plan, getPlan } from './plan'
+export { Plan, getPlan, AdditionalResolveContext } from './plan'
 export { PlanItem, PlanItemId } from './plan_item'

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -192,7 +192,6 @@ type GetPlanParameters = {
   changeValidators?: Record<string, ChangeValidator>
   dependencyChangers?: ReadonlyArray<DependencyChanger>
   customGroupIdFunctions?: Record<string, ChangeGroupIdFunction>
-  beforeAdditionalResolveContext?: ReadonlyArray<Element>
   additionalResolveContext?: AdditionalResolveContext
 }
 export const getPlan = async ({

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -181,13 +181,19 @@ const removeRedundantFieldChanges = (
   )
 )
 
+export type AdditionalResolveContext = {
+  before: ReadonlyArray<Element>
+  after: ReadonlyArray<Element>
+}
+
 type GetPlanParameters = {
   before: ReadonlyArray<Element>
   after: ReadonlyArray<Element>
   changeValidators?: Record<string, ChangeValidator>
   dependencyChangers?: ReadonlyArray<DependencyChanger>
   customGroupIdFunctions?: Record<string, ChangeGroupIdFunction>
-  additionalResolveContext?: ReadonlyArray<Element>
+  beforeAdditionalResolveContext?: ReadonlyArray<Element>
+  additionalResolveContext?: AdditionalResolveContext
 }
 export const getPlan = async ({
   before,
@@ -198,8 +204,8 @@ export const getPlan = async ({
   additionalResolveContext,
 }: GetPlanParameters): Promise<Plan> => log.time(async () => {
   // Resolve elements before adding them to the graph
-  const resolvedBefore = resolve(before, additionalResolveContext)
-  const resolvedAfter = resolve(after, additionalResolveContext)
+  const resolvedBefore = resolve(before, additionalResolveContext?.before)
+  const resolvedAfter = resolve(after, additionalResolveContext?.after)
 
   const diffGraph = await buildDiffGraph(
     addElements(resolvedBefore, 'remove'),

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -149,6 +149,36 @@ describe('fetch', () => {
         expect(resultChanges.length).toBe(1)
         expect(resultChanges[0].change.action).toBe('remove')
       })
+
+      describe('multiple adapters', async () => {
+        const adapters = {
+          dummy1: {
+            fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [], isPartial: true }),
+            deploy: mockFunction<AdapterOperations['deploy']>(),
+          },
+          dummy2: {
+            fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [], isPartial: false }),
+            deploy: mockFunction<AdapterOperations['deploy']>(),
+          },
+        }
+
+        it('should ignore deletions only for adapter with partial results', async () => {
+          const fetchChangesResult = await fetchChanges(
+            adapters,
+            [
+              new ObjectType({ elemID: new ElemID('dummy1', 'type') }),
+              new ObjectType({ elemID: new ElemID('dummy2', 'type') }),
+            ],
+            [],
+            [],
+          )
+          const resultChanges = Array.from(fetchChangesResult.changes)
+          expect(resultChanges.length).toBe(1)
+          expect(resultChanges[0].change.action).toBe('remove')
+          expect(getChangeElement(resultChanges[0].change).elemID.adapter).toBe('dummy2')
+        })
+      })
+
       describe('getAdaptersFirstFetchPartial', () => {
         const elements = [
           new ObjectType({ elemID: new ElemID('adapter1', 'type') }),

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -123,31 +123,61 @@ describe('fetch', () => {
       })
     })
     describe('partial fetch results', () => {
-      it('should ignore deletions when isPartial is true', async () => {
-        mockAdapters.dummy.fetch.mockResolvedValueOnce(
-          { elements: [newTypeBaseModified], isPartial: true },
-        )
-        const fetchChangesResult = await fetchChanges(
-          mockAdapters,
-          [newTypeBaseModified, typeWithField],
-          [],
-          [],
-        )
-        expect(Array.from(fetchChangesResult.changes).length).toBe(0)
+      describe('fetch is partial', () => {
+        it('should ignore deletions', async () => {
+          mockAdapters.dummy.fetch.mockResolvedValueOnce(
+            { elements: [newTypeBaseModified], isPartial: true },
+          )
+          const fetchChangesResult = await fetchChanges(
+            mockAdapters,
+            [newTypeBaseModified, typeWithField],
+            [],
+            [],
+          )
+          expect(Array.from(fetchChangesResult.changes).length).toBe(0)
+        })
+
+        it('should return the state elements with the service elements', async () => {
+          mockAdapters.dummy.fetch.mockResolvedValueOnce(
+            { elements: [newTypeBaseModified], isPartial: true },
+          )
+          const fetchChangesResult = await fetchChanges(
+            mockAdapters,
+            [],
+            [newTypeBase, typeWithField],
+            [],
+          )
+          expect(fetchChangesResult.elements).toEqual([newTypeBaseModified, typeWithField])
+        })
       })
-      it('should not ignore deletions when isPartial is false', async () => {
-        mockAdapters.dummy.fetch.mockResolvedValueOnce(
-          { elements: [newTypeBaseModified], isPartial: false },
-        )
-        const fetchChangesResult = await fetchChanges(
-          mockAdapters,
-          [newTypeBaseModified, typeWithField],
-          [],
-          [],
-        )
-        const resultChanges = Array.from(fetchChangesResult.changes)
-        expect(resultChanges.length).toBe(1)
-        expect(resultChanges[0].change.action).toBe('remove')
+      describe('fetch is not partial', () => {
+        it('should not ignore deletions', async () => {
+          mockAdapters.dummy.fetch.mockResolvedValueOnce(
+            { elements: [newTypeBaseModified], isPartial: false },
+          )
+          const fetchChangesResult = await fetchChanges(
+            mockAdapters,
+            [newTypeBaseModified, typeWithField],
+            [],
+            [],
+          )
+          const resultChanges = Array.from(fetchChangesResult.changes)
+          expect(resultChanges.length).toBe(1)
+          expect(resultChanges[0].change.action).toBe('remove')
+        })
+
+        it('should return the only the service elements', async () => {
+          mockAdapters.dummy.fetch.mockResolvedValueOnce(
+            { elements: [newTypeBaseModified], isPartial: false },
+          )
+          const fetchChangesResult = await fetchChanges(
+            mockAdapters,
+            [],
+            [newTypeBase, typeWithField],
+            [],
+          )
+          expect(fetchChangesResult.elements).toEqual([newTypeBaseModified])
+        })
       })
 
       it('should use the whole workspace to resolve elements when calculcating changes', async () => {

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -153,16 +153,12 @@ describe('fetch', () => {
         const elements = [
           new ObjectType({ elemID: new ElemID('adapter1', 'type') }),
         ]
-        const adapterToPartial = {
-          adapter1: true,
-          adapter2: false,
-          adapter3: true,
-        }
+        const partiallyFetchedAdapters = new Set(['adapter1', 'adapter3'])
 
-        const resultAdapters = getAdaptersFirstFetchPartial(elements, adapterToPartial)
+        const resultAdapters = getAdaptersFirstFetchPartial(elements, partiallyFetchedAdapters)
 
         it('results should only include adapter which is first fetch is partial', () => {
-          expect(resultAdapters).toEqual(['adapter3'])
+          expect(resultAdapters).toEqual(new Set(['adapter3']))
         })
       })
     })


### PR DESCRIPTION
In order to support partial fetch in adapters, now when an adapter will return that its results are partial by setting `isPartial` to true, the core will ignore deletion changes.

---
__Release Notes__: None