### PR TITLE
SALTO-745 - Salto init error flow

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import * as path from 'path'
-import { initLocalWorkspace, loadLocalWorkspace } from '@salto-io/core'
+import { initLocalWorkspace } from '@salto-io/core'
 import { logger } from '@salto-io/logging'
 import { outputLine, errorOutputLine } from '../outputer'
 import Prompts from '../prompts'
@@ -29,25 +29,14 @@ type InitArgs = {
     workspaceName?: string
   }
 
-class WorkspaceAlreadyExistsError extends Error {
-  constructor() {
-    super('existing salto workspace')
-  }
-}
-
 export const action: CommandDefAction<InitArgs> = async (
   { input: { workspaceName }, cliTelemetry, output },
 ): Promise<CliExitCode> => {
   log.debug('running env init command on \'%s\'', workspaceName)
   cliTelemetry.start()
   try {
-    const baseDir = path.resolve('.')
-    const doesWorkspaceExists: boolean = await loadLocalWorkspace(baseDir)
-      .then(() => true).catch(() => false)
-    if (doesWorkspaceExists) {
-      throw new WorkspaceAlreadyExistsError()
-    }
     const defaultEnvName = await getEnvName()
+    const baseDir = path.resolve('.')
     const workspace = await initLocalWorkspace(baseDir, workspaceName, defaultEnvName)
     const workspaceTags = await getWorkspaceTelemetryTags(workspace)
     cliTelemetry.success(workspaceTags)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import * as path from 'path'
-import { initLocalWorkspace } from '@salto-io/core'
+import { initLocalWorkspace, loadLocalWorkspace } from '@salto-io/core'
 import { logger } from '@salto-io/logging'
 import { outputLine, errorOutputLine } from '../outputer'
 import Prompts from '../prompts'
@@ -29,14 +29,25 @@ type InitArgs = {
     workspaceName?: string
   }
 
+class WorkspaceAlreadyExistsError extends Error {
+  constructor() {
+    super('existing salto workspace')
+  }
+}
+
 export const action: CommandDefAction<InitArgs> = async (
   { input: { workspaceName }, cliTelemetry, output },
 ): Promise<CliExitCode> => {
   log.debug('running env init command on \'%s\'', workspaceName)
   cliTelemetry.start()
   try {
-    const defaultEnvName = await getEnvName()
     const baseDir = path.resolve('.')
+    const doesWorkspaceExists: boolean = await loadLocalWorkspace(baseDir)
+      .then(() => true).catch(() => false)
+    if (doesWorkspaceExists) {
+      throw new WorkspaceAlreadyExistsError()
+    }
+    const defaultEnvName = await getEnvName()
     const workspace = await initLocalWorkspace(baseDir, workspaceName, defaultEnvName)
     const workspaceTags = await getWorkspaceTelemetryTags(workspace)
     cliTelemetry.success(workspaceTags)

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -64,7 +64,7 @@ export default class Prompts {
   public static readonly DESCRIBE_NOT_FOUND = 'Unknown element type.'
 
   public static initFailed(msg: string): string {
-    return `Could not initiate workspace: ${msg}\n`
+    return `Could not initiate workspace: ${msg}`
   }
 
   private static readonly SERVICE_ADD_HELP = 'Use `salto service add <service-name>` to add services to the environment'

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -64,7 +64,7 @@ export default class Prompts {
   public static readonly DESCRIBE_NOT_FOUND = 'Unknown element type.'
 
   public static initFailed(msg: string): string {
-    return `Could not initiate workspace: ${msg}`
+    return `Could not initiate workspace: ${msg}\n`
   }
 
   private static readonly SERVICE_ADD_HELP = 'Use `salto service add <service-name>` to add services to the environment'

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { Workspace } from '@salto-io/workspace'
+import { locateWorkspaceRoot } from '@salto-io/core'
 import * as mocks from '../mocks'
 import { action } from '../../src/commands/init'
 import { buildEventName, getCliTelemetry } from '../../src/telemetry'
@@ -32,10 +33,12 @@ jest.mock('@salto-io/core', () => ({
       } as unknown as Workspace
     }
   ),
+  locateWorkspaceRoot: jest.fn(),
 }))
 
 const mockGetEnv = mocks.createMockEnvNameGetter()
-
+const mockLocateWorkspaceRoot = locateWorkspaceRoot as
+  jest.MockedFunction<typeof locateWorkspaceRoot>
 jest.mock('../../src/callbacks', () => ({
   ...jest.requireActual('../../src/callbacks'),
   getEnvName: () => mockGetEnv(),
@@ -55,6 +58,7 @@ describe('init command', () => {
   const config = { shouldCalcTotalSize: false }
 
   beforeEach(async () => {
+    mockLocateWorkspaceRoot.mockImplementation(() => Promise.resolve(undefined))
     output = { stdout: new mocks.MockWriteStream(), stderr: new mocks.MockWriteStream() }
     telemetry = mocks.getMockTelemetry()
     cliTelemetry = getCliTelemetry(telemetry, 'init')
@@ -90,5 +94,21 @@ describe('init command', () => {
     expect(telemetry.getEventsMap()[eventsNames.success]).toBeUndefined()
     expect(telemetry.getEventsMap()[eventsNames.failure]).not.toBeUndefined()
     expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
+  })
+
+  it('should avoid initiating a workspace which already exists', async () => {
+    const path = '/some/path/to/workspace'
+    const errorMessage = `existing salto workspace in ${path}`
+    mockLocateWorkspaceRoot.mockImplementation(() => Promise.resolve(path))
+    await action({
+      input: {
+        workspaceName: 'test',
+      },
+      config,
+      cliTelemetry,
+      output,
+    })
+    expect(output.stderr.content).toEqual(`Could not initiate workspace: ${errorMessage}\n\n`)
+    expect(output.stdout.content).toEqual('')
   })
 })

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -58,7 +58,7 @@ describe('init command', () => {
   const config = { shouldCalcTotalSize: false }
 
   beforeEach(async () => {
-    mockLocateWorkspaceRoot.mockImplementation(() => Promise.resolve(undefined))
+    mockLocateWorkspaceRoot.mockResolvedValue(undefined)
     output = { stdout: new mocks.MockWriteStream(), stderr: new mocks.MockWriteStream() }
     telemetry = mocks.getMockTelemetry()
     cliTelemetry = getCliTelemetry(telemetry, 'init')
@@ -98,8 +98,7 @@ describe('init command', () => {
 
   it('should avoid initiating a workspace which already exists', async () => {
     const path = '/some/path/to/workspace'
-    const errorMessage = `existing salto workspace in ${path}`
-    mockLocateWorkspaceRoot.mockImplementation(() => Promise.resolve(path))
+    mockLocateWorkspaceRoot.mockResolvedValue(path)
     await action({
       input: {
         workspaceName: 'test',
@@ -108,7 +107,7 @@ describe('init command', () => {
       cliTelemetry,
       output,
     })
-    expect(output.stderr.content).toEqual(`Could not initiate workspace: ${errorMessage}\n\n`)
+    expect(output.stderr.content).toEqual(`Could not initiate workspace: existing salto workspace in ${path}\n\n`)
     expect(output.stdout.content).toEqual('')
   })
 })

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { Workspace } from '@salto-io/workspace'
+import { loadLocalWorkspace } from '@salto-io/core'
 import * as mocks from '../mocks'
 import { action } from '../../src/commands/init'
 import { buildEventName, getCliTelemetry } from '../../src/telemetry'
@@ -32,10 +33,12 @@ jest.mock('@salto-io/core', () => ({
       } as unknown as Workspace
     }
   ),
+  loadLocalWorkspace: jest.fn(),
 }))
+const { loadLocalWorkspace: loadLocalWorkspaceOriginalImpel } = jest.requireActual('@salto-io/core')
 
 const mockGetEnv = mocks.createMockEnvNameGetter()
-
+const mockLoadLocalWorkspace = loadLocalWorkspace as jest.MockedFunction<typeof loadLocalWorkspace>
 jest.mock('../../src/callbacks', () => ({
   ...jest.requireActual('../../src/callbacks'),
   getEnvName: () => mockGetEnv(),
@@ -55,6 +58,7 @@ describe('init command', () => {
   const config = { shouldCalcTotalSize: false }
 
   beforeEach(async () => {
+    mockLoadLocalWorkspace.mockImplementation((...args) => loadLocalWorkspaceOriginalImpel(args))
     output = { stdout: new mocks.MockWriteStream(), stderr: new mocks.MockWriteStream() }
     telemetry = mocks.getMockTelemetry()
     cliTelemetry = getCliTelemetry(telemetry, 'init')
@@ -90,5 +94,23 @@ describe('init command', () => {
     expect(telemetry.getEventsMap()[eventsNames.success]).toBeUndefined()
     expect(telemetry.getEventsMap()[eventsNames.failure]).not.toBeUndefined()
     expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
+  })
+
+  it('should avoid initiating a workspace which already exists', async () => {
+    const errorMessage = 'existing salto workspace'
+    const workspaceName = 'initiatedWorkspace'
+    mockLoadLocalWorkspace.mockImplementation(() => Promise.resolve(
+      ({ name: workspaceName, uid: 'id' }) as unknown as Workspace
+    ))
+    await action({
+      input: {
+        workspaceName,
+      },
+      config,
+      cliTelemetry,
+      output,
+    })
+    expect(output.stderr.content).toEqual(`Could not initiate workspace: ${errorMessage}\n`)
+    expect(output.stdout.content).toEqual('')
   })
 })

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -20,7 +20,7 @@ export { ItemStatus } from './src/core/deploy'
 export { getAdaptersCredentialsTypes, getDefaultAdapterConfig } from './src/core/adapters/adapters'
 export {
   loadLocalWorkspace, initLocalWorkspace, loadLocalElementsSources, getNaclFilesSourceParams,
-  CACHE_DIR_NAME, envFolderExists, COMMON_ENV_PREFIX,
+  CACHE_DIR_NAME, envFolderExists, COMMON_ENV_PREFIX, locateWorkspaceRoot,
 } from './src/local-workspace/workspace'
 export {
   workspaceConfigSource as localWorkspaceConfigSource,

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -148,7 +148,7 @@ export const loadLocalElementsSources = (baseDir: string, localStorage: string,
   },
 })
 
-const locateWorkspaceRoot = async (lookupDir: string): Promise<string|undefined> => {
+export const locateWorkspaceRoot = async (lookupDir: string): Promise<string|undefined> => {
   if (await exists(path.join(lookupDir, CONFIG_DIR_NAME))) {
     return lookupDir
   }

--- a/packages/core/test/workspace/local/workspace.test.ts
+++ b/packages/core/test/workspace/local/workspace.test.ts
@@ -20,7 +20,7 @@ import * as file from '@salto-io/file'
 import {
   initLocalWorkspace, ExistingWorkspaceError, NotAnEmptyWorkspaceError, NotAWorkspaceError,
   loadLocalWorkspace, COMMON_ENV_PREFIX, CREDENTIALS_CONFIG_PATH,
-  loadLocalElementsSources,
+  loadLocalElementsSources, locateWorkspaceRoot,
 } from '../../../src/local-workspace/workspace'
 import { getSaltoHome } from '../../../src/app_config'
 import * as mockDirStore from '../../../src/local-workspace/dir_store'
@@ -78,6 +78,24 @@ describe('local workspace', () => {
   }
 
   beforeEach(() => jest.clearAllMocks())
+
+  describe('locateWorkspaceRoot', () => {
+    it('should return undefined if no workspaceRoot exists in path', async () => {
+      mockExists.mockResolvedValue(false)
+      const workspacePath = await locateWorkspaceRoot('/some/path')
+      expect(workspacePath).toEqual(undefined)
+    })
+    it('should return current folder if salto.config exists in it', async () => {
+      mockExists.mockResolvedValue(true)
+      const workspacePath = await locateWorkspaceRoot('/some/path')
+      await expect(workspacePath).toEqual('/some/path')
+    })
+    it('should find the corret folder in which salto.config exists in path', async () => {
+      mockExists.mockImplementationOnce(() => false).mockImplementationOnce(() => true)
+      const workspacePath = await locateWorkspaceRoot('/some/path')
+      await expect(workspacePath).toEqual('/some')
+    })
+  })
 
   describe('load elements  sources', () => {
     it('should build the appropriate nacl source', () => {

--- a/packages/core/test/workspace/local/workspace.test.ts
+++ b/packages/core/test/workspace/local/workspace.test.ts
@@ -91,7 +91,7 @@ describe('local workspace', () => {
       await expect(workspacePath).toEqual('/some/path')
     })
     it('should find the corret folder in which salto.config exists in path', async () => {
-      mockExists.mockImplementationOnce(() => false).mockImplementationOnce(() => true)
+      mockExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
       const workspacePath = await locateWorkspaceRoot('/some/path')
       await expect(workspacePath).toEqual('/some')
     })


### PR DESCRIPTION
# Description

Whenever performing `salto init` command on an already instantiated workspace, the user is prompted to enter an env name before receiving the message 'workspace already exists'.
This PR removes the redundant question and presents the error immediately.

___
__Release Note:__
CLI:
Initiating a workspace twice will prompt an error to the user without asking for env name first.



## Tests done to verify this PR works
- [x] Unit tests
- [x] Manual tests ( attached console output before and after)

## Console output before
```
> salto init
? Enter a name for the first environment in the workspace env2
Could not initiate workspace: existing salto workspace

``` 

# Console output after
```
> salto init
Could not initiate workspace: existing salto workspace in /work/git/workspace
```
