### PR TITLE
SALTO-1125: Fix deserialization of container type annotations

### DIFF
--- a/packages/workspace/test/serializer/serializer.test.ts
+++ b/packages/workspace/test/serializer/serializer.test.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import {
   PrimitiveType, PrimitiveTypes, ElemID, isInstanceElement, ListType,
   ObjectType, InstanceElement, TemplateExpression, ReferenceExpression, Variable,
-  VariableExpression, StaticFile, MapType,
+  VariableExpression, StaticFile, MapType, BuiltinTypes,
 } from '@salto-io/adapter-api'
 import { TestFuncImpl } from '../utils'
 
@@ -30,6 +30,14 @@ describe('State/cache serialization', () => {
   const strType = new PrimitiveType({
     elemID: new ElemID('salesforce', 'string'),
     primitive: PrimitiveTypes.STRING,
+    annotationTypes: {
+      anno: BuiltinTypes.STRING,
+      hiddenAnno: BuiltinTypes.HIDDEN_STRING,
+    },
+    annotations: {
+      anno: 'type annotation',
+      hiddenAnno: 'hidden',
+    },
   })
 
   const numType = new PrimitiveType({
@@ -223,7 +231,6 @@ describe('State/cache serialization', () => {
   })
 
   describe('functions', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let funcElement: InstanceElement
     beforeAll(async () => {
       const elementsToSerialize = elements.filter(e => e.elemID.name === 'also_me_function')

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -172,7 +172,7 @@ describe('handleHiddenChanges', () => {
     })
   })
 
-  describe('hidden annnotation of field', async () => {
+  describe('hidden annotation of field', () => {
     const object = new ObjectType({
       elemID: new ElemID('test', 'type'),
       fields: {


### PR DESCRIPTION
This fixes an issue where container types would not get their inner type's annotations
and annotation types when deserialized.

---
_Release Notes_
(salesforce bug fix)
- Fix deploy plan incorrectly showing removals of internalId in CPQ CustomScript fields.