### PR TITLE
Move empty env logic from core into workspace

### DIFF
--- a/packages/cli/test/commands/env.test.ts
+++ b/packages/cli/test/commands/env.test.ts
@@ -56,7 +56,6 @@ describe('env command group', () => {
         jest.spyOn(callbacks, 'cliApproveIsolateBeforeMultiEnv').mockImplementation(
           () => Promise.resolve(false)
         )
-        jest.spyOn(core, 'envFolderExists').mockImplementation(() => Promise.resolve(false))
       })
 
       afterEach(() => {
@@ -163,7 +162,11 @@ describe('env command group', () => {
       })
 
       it('should not prompt on 2nd environment creation if env1 folder exists', async () => {
-        jest.spyOn(core, 'envFolderExists').mockImplementationOnce(() => Promise.resolve(true))
+        jest.spyOn(core, 'loadLocalWorkspace').mockImplementation(baseDir => {
+          lastWorkspace = mocks.mockLoadWorkspace(baseDir, ['me1'])
+          lastWorkspace.hasElementsInEnv = jest.fn().mockResolvedValue(true)
+          return Promise.resolve(lastWorkspace)
+        })
 
         await createAction({
           input: {

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -275,6 +275,7 @@ export const mockLoadWorkspace = (
     updateNaclFiles: mockFunction<Workspace['updateNaclFiles']>(),
     clear: jest.fn().mockResolvedValue(undefined),
     updateServiceConfig: jest.fn().mockResolvedValue(undefined),
+    hasElementsInEnv: jest.fn().mockResolvedValue(false),
   } as unknown as Workspace)
 
 export const withoutEnvironmentParam = 'active'

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -20,7 +20,7 @@ export { ItemStatus } from './src/core/deploy'
 export { getAdaptersCredentialsTypes, getDefaultAdapterConfig } from './src/core/adapters/adapters'
 export {
   loadLocalWorkspace, initLocalWorkspace, loadLocalElementsSources, getNaclFilesSourceParams,
-  CACHE_DIR_NAME, envFolderExists, COMMON_ENV_PREFIX, locateWorkspaceRoot,
+  CACHE_DIR_NAME, COMMON_ENV_PREFIX, locateWorkspaceRoot,
 } from './src/local-workspace/workspace'
 export {
   workspaceConfigSource as localWorkspaceConfigSource,

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -117,10 +117,6 @@ const getLocalEnvName = (env: string): string => (env === COMMON_ENV_PREFIX
   ? env
   : path.join(ENVS_PREFIX, env))
 
-const getEnvPath = (baseDir: string, env: string): string => (
-  path.resolve(baseDir, getLocalEnvName(env))
-)
-
 export const loadLocalElementsSources = (baseDir: string, localStorage: string,
   envs: ReadonlyArray<string>): EnvironmentsSources => ({
   commonSourceName: COMMON_ENV_PREFIX,
@@ -154,11 +150,6 @@ export const locateWorkspaceRoot = async (lookupDir: string): Promise<string|und
   }
   const parentDir = lookupDir.substr(0, lookupDir.lastIndexOf(path.sep))
   return parentDir ? locateWorkspaceRoot(parentDir) : undefined
-}
-
-export const envFolderExists = async (workspaceDir: string, env: string): Promise<boolean> => {
-  const baseDir = await locateWorkspaceRoot(path.resolve(workspaceDir))
-  return (baseDir !== undefined) && exists(getEnvPath(baseDir, env))
 }
 
 const credentialsSource = (localStorage: string): cs.ConfigSource =>

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -86,6 +86,7 @@ export type Workspace = {
 
   isEmpty(naclFilesOnly?: boolean): Promise<boolean>
   hasElementsInServices(serviceNames: string[]): Promise<boolean>
+  hasElementsInEnv(envName: string): Promise<boolean>
   getSourceFragment(sourceRange: SourceRange): Promise<SourceFragment>
   hasErrors(): Promise<boolean>
   errors(): Promise<Readonly<Errors>>
@@ -308,6 +309,13 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
         elemId => serviceNames.includes(elemId.adapter)
       )
     ),
+    hasElementsInEnv: async envName => {
+      const envSource = elementsSources.sources[envName]
+      if (envSource === undefined) {
+        return false
+      }
+      return !(await envSource.naclFiles.isEmpty())
+    },
     // Returning the functions from the nacl file source directly (eg: promote: src.promote)
     // may seem better, but the setCurrentEnv method replaced the naclFileSource.
     // Passing direct pointer for these functions would have resulted in pointers to a nullified

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -1756,6 +1756,37 @@ describe('workspace', () => {
       expect(attrRefFiles).toContain('unmerged.nacl')
     })
   })
+
+  describe('hasElementsInEnv', () => {
+    let workspace: Workspace
+    beforeEach(async () => {
+      workspace = await createWorkspace(
+        undefined, undefined, undefined, undefined, undefined,
+        {
+          '': {
+            naclFiles: naclFilesSource(mockDirStore(), mockParseCache(), mockStaticFilesSource()),
+          },
+          empty: {
+            naclFiles: createMockNaclFileSource([]),
+            state: createState([]),
+          },
+          full: {
+            naclFiles: createMockNaclFileSource([new ObjectType({ elemID: new ElemID('test', 'type') })]),
+            state: createState([]),
+          },
+        }
+      )
+    })
+    it('should return false for empty env', async () => {
+      await expect(workspace.hasElementsInEnv('empty')).resolves.toBeFalsy()
+    })
+    it('should return true for non empty env', async () => {
+      await expect(workspace.hasElementsInEnv('full')).resolves.toBeTruthy()
+    })
+    it('should return false for environments that do no exist', async () => {
+      await expect(workspace.hasElementsInEnv('noSuchEnv')).resolves.toBeFalsy()
+    })
+  })
 })
 
 describe('getElementNaclFiles', () => {


### PR DESCRIPTION
Needed for a separate refactor so that commands don't need to be exposed to the workspace path, only the workspace.
basically this logic can be implemented semantically on the workspace rather than rely on folder structure

---

_Release Notes_: None