### PR TITLE
SALTO-1108: Support config override in all CLI commands

### DIFF
--- a/packages/cli/e2e_test/helpers/workspace.ts
+++ b/packages/cli/e2e_test/helpers/workspace.ts
@@ -14,10 +14,9 @@
 * limitations under the License.
 */
 import glob from 'glob'
-import { Plan, telemetrySender, preview, loadLocalWorkspace } from '@salto-io/core'
-import { parser, Workspace, WorkspaceComponents } from '@salto-io/workspace'
+import { Plan, telemetrySender, preview, loadLocalWorkspace, AppConfig } from '@salto-io/core'
+import { parser, Workspace } from '@salto-io/workspace'
 import { readTextFile, writeFile } from '@salto-io/file'
-import _ from 'lodash'
 import {
   ActionName, Change, ElemID, getChangeElement, InstanceElement, ObjectType, Values,
   Element, TypeMap,
@@ -25,15 +24,11 @@ import {
 import {
   findElement,
 } from '@salto-io/adapter-utils'
-import { action as fetchAction } from '../../src/commands/fetch'
+import commandDefs from '../../src/commands'
+import cli from '../../src/cli'
 import { mockSpinnerCreator, MockWriteStream } from '../../test/mocks'
-import { CliOutput, CliExitCode, CliTelemetry } from '../../src/types'
-import { loadWorkspace } from '../../src/workspace/workspace'
-import { action as deployAction } from '../../src/commands/deploy'
-import { addAction, loginAction } from '../../src/commands/service'
-import { action as initAction } from '../../src/commands/init'
-import { createAction, setAction, deleteAction } from '../../src/commands/env'
-import { action as cleanAction } from '../../src/commands/clean'
+import { CliOutput, CliExitCode } from '../../src/types'
+import { validateWorkspace } from '../../src/workspace/workspace'
 
 declare global {
   // eslint-disable-next-line
@@ -70,20 +65,14 @@ const services = ['salesforce']
 const mockCliOutput = (): CliOutput =>
   ({ stdout: new MockWriteStream(), stderr: new MockWriteStream() })
 
-const config = { shouldCalcTotalSize: true }
-
-const cliTelemetry: CliTelemetry = {
-  start: () => jest.fn(),
-  failure: () => jest.fn(),
-  success: () => jest.fn(),
-  mergeErrors: () => jest.fn(),
-  changes: () => jest.fn(),
-  changesToApply: () => jest.fn(),
-  errors: () => jest.fn(),
-  actionsSuccess: () => jest.fn(),
-  actionsFailure: () => jest.fn(),
-  workspaceSize: () => jest.fn(),
-  stacktrace: () => jest.fn(),
+const config: AppConfig = {
+  installationID: 'abcd',
+  telemetry: {
+    enabled: false,
+    token: '1234',
+    url: 'http://0.0.0.0',
+  },
+  command: { shouldCalcTotalSize: true },
 }
 
 const telemetry = telemetrySender(
@@ -92,33 +81,6 @@ const telemetry = telemetrySender(
 )
 
 export const cleanup = async (): Promise<void> => telemetry.stop(0)
-
-export const runAddSalesforceService = async (workspacePath: string): Promise<void> => {
-  await addAction({
-    input: {
-      login: true,
-      serviceName: 'salesforce',
-      authType: 'basic',
-    },
-    config,
-    output: mockCliOutput(),
-    cliTelemetry,
-    workspacePath,
-  })
-}
-
-export const runSalesforceLogin = async (workspacePath: string): Promise<void> => {
-  await loginAction({
-    input: {
-      serviceName: 'salesforce',
-      authType: 'basic',
-    },
-    cliTelemetry,
-    config,
-    output: mockCliOutput(),
-    workspacePath,
-  })
-}
 
 export const editNaclFile = async (filename: string, replacements: ReplacementPair[]):
   Promise<void> => {
@@ -135,26 +97,47 @@ export const getNaclFileElements = async (filename: string):
   return (await parse(Buffer.from(fileAsString), filename)).elements
 }
 
-export const runInit = async (
-  workspacePath: string,
-  baseDir?: string
-): Promise<void> => {
-  const origDir = process.cwd()
-  if (baseDir) {
-    process.chdir(baseDir)
-  }
-  await initAction({
+export const runCommand = ({
+  workspacePath,
+  args,
+  cliOutput,
+}: {
+  workspacePath: string
+  args: string[]
+  cliOutput?: CliOutput
+}): Promise<CliExitCode> => (
+  cli({
     input: {
-      workspaceName: workspacePath,
+      args,
+      config: config.command,
+      telemetry,
     },
-    cliTelemetry,
-    config,
-    output: mockCliOutput(),
+    commandDefs,
     workspacePath,
+    output: cliOutput ?? mockCliOutput(),
+    spinnerCreator: mockSpinnerCreator([]),
   })
-  if (baseDir) {
-    process.chdir(origDir)
-  }
+)
+
+export const runInit = async (
+  workspaceName: string,
+  workspacePath: string,
+): Promise<void> => {
+  await runCommand({
+    workspacePath, args: ['init', workspaceName],
+  })
+}
+
+export const runAddSalesforceService = async (workspacePath: string): Promise<void> => {
+  await runCommand({
+    workspacePath, args: ['service', 'add', 'salesforce'],
+  })
+}
+
+export const runSalesforceLogin = async (workspacePath: string): Promise<void> => {
+  await runCommand({
+    workspacePath, args: ['service', 'login', 'salesforce'],
+  })
 }
 
 export const runCreateEnv = async (
@@ -162,39 +145,20 @@ export const runCreateEnv = async (
   envName: string,
   force?: boolean,
 ): Promise<void> => {
-  await createAction({
-    input: {
-      envName,
-      force,
-    },
-    config,
-    cliTelemetry,
-    output: mockCliOutput(),
-    workspacePath,
+  await runCommand({
+    workspacePath, args: ['env', 'create', envName, ...force ? ['-f'] : []],
   })
 }
 
 export const runSetEnv = async (workspacePath: string, envName: string): Promise<void> => {
-  await setAction({
-    input: {
-      envName,
-    },
-    config,
-    cliTelemetry,
-    output: mockCliOutput(),
-    workspacePath,
+  await runCommand({
+    workspacePath, args: ['env', 'set', envName],
   })
 }
 
 export const runDeleteEnv = async (workspacePath: string, envName: string): Promise<void> => {
-  await deleteAction({
-    input: {
-      envName,
-    },
-    config,
-    cliTelemetry,
-    output: mockCliOutput(),
-    workspacePath,
+  await runCommand({
+    workspacePath, args: ['env', 'delete', envName],
   })
 }
 
@@ -208,56 +172,37 @@ export const runFetch = async (
   isolated = false,
   inputEnvironment?: string,
 ): Promise<void> => {
-  const result = await fetchAction({
-    input: {
-      services,
-      env: inputEnvironment,
-      mode: isolated ? 'isolated' : 'override',
-      force: true,
-      interactive: false,
-      stateOnly: false,
-    },
-    config,
-    cliTelemetry,
-    output: mockCliOutput(),
+  const result = await runCommand({
     workspacePath: fetchOutputDir,
+    args: [
+      'fetch',
+      '-f',
+      ...inputEnvironment ? ['-e', inputEnvironment] : [],
+      '-m', isolated ? 'isolated' : 'override',
+    ],
   })
   expect(result).toEqual(CliExitCode.Success)
 }
 
 export const runDeploy = async ({
   lastPlan,
-  fetchOutputDir,
+  workspacePath,
   allowErrors = false,
-  force = true,
-  dryRun = false,
-  detailedPlan = false,
 }: {
   lastPlan?: Plan | undefined
-  fetchOutputDir: string
+  workspacePath: string
   allowErrors?: boolean
-  force?: boolean
-  dryRun?: boolean
-  detailedPlan?: boolean
 }): Promise<void> => {
   if (lastPlan) {
     lastPlan.clear()
   }
-  const output = mockCliOutput()
-  const result = await deployAction({
-    input: {
-      force,
-      dryRun,
-      detailedPlan,
-      services,
-    },
-    config,
-    cliTelemetry,
-    output: mockCliOutput(),
-    spinnerCreator: mockSpinnerCreator([]),
-    workspacePath: fetchOutputDir,
+  const cliOutput = mockCliOutput()
+  const result = await runCommand({
+    args: ['deploy', '-f'],
+    workspacePath,
+    cliOutput,
   })
-  const errs = (output.stderr as MockWriteStream).content
+  const errs = (cliOutput.stderr as MockWriteStream).content
   // This assert is before result assert so will see the error
   // This is not a mistake, we will have errors on some deployments
   // with delete changes, and its expected.
@@ -267,46 +212,16 @@ export const runDeploy = async ({
   }
 }
 
-export const runPreview = async (fetchOutputDir: string): Promise<void> => (
-  runDeploy({ fetchOutputDir, allowErrors: false, dryRun: true })
-)
-
-export const runClean = async (
-  workspaceName: string,
-  cleanArgs: WorkspaceComponents,
-): Promise<void> => {
-  await cleanAction({
-    input: {
-      ...cleanArgs,
-      force: true,
-    },
-    config,
-    cliTelemetry,
-    output: mockCliOutput(),
-    workspacePath: workspaceName,
-  })
-}
-
-export const loadValidWorkspace = async (
-  fetchOutputDir: string,
-  force = true
-): Promise<Workspace> => {
-  const { workspace, errored } = await loadWorkspace(fetchOutputDir, mockCliOutput(), { force })
-  expect(errored).toBeFalsy()
+export const loadValidWorkspace = async (fetchOutputDir: string): Promise<Workspace> => {
+  const workspace = await loadLocalWorkspace(fetchOutputDir)
+  const { errors } = await validateWorkspace(workspace)
+  expect(errors).toHaveLength(0)
   return workspace
 }
 
-export const runPreviewGetPlan = async (fetchOutputDir: string): Promise<Plan | undefined> => {
-  const workspace = await loadValidWorkspace(fetchOutputDir)
+export const runPreviewGetPlan = async (fetchOutputDir: string): Promise<Plan> => {
+  const workspace = await loadLocalWorkspace(fetchOutputDir)
   return preview(workspace, services)
-}
-
-export const runEmptyPreview = async (lastPlan: Plan, fetchOutputDir: string): Promise<void> => {
-  if (lastPlan) {
-    lastPlan.clear()
-  }
-  await runPreview(fetchOutputDir)
-  expect(_.isEmpty(lastPlan)).toBeTruthy()
 }
 
 const getChangedElementName = (change: Change): string => getChangeElement(change).elemID.name
@@ -330,6 +245,11 @@ export const verifyChanges = (plan: Plan,
     .sort(compareChanges)
 
   expect(expectedChanges.sort(compareChanges)).toEqual(changes)
+}
+
+export const runEmptyPreview = async (fetchOutputDir: string): Promise<void> => {
+  const plan = await runPreviewGetPlan(fetchOutputDir)
+  verifyChanges(plan, [])
 }
 
 const findInstance = (elements: ReadonlyArray<Element>, adapter: string, typeName: string,

--- a/packages/cli/e2e_test/multi_env.test.ts
+++ b/packages/cli/e2e_test/multi_env.test.ts
@@ -300,7 +300,7 @@ describe('multi env tests', () => {
       let elementsWithHidden: readonly Element[]
       beforeAll(async () => {
         await runSetEnv(baseDir, ENV2_NAME)
-        const workspace = await loadValidWorkspace(baseDir, true)
+        const workspace = await loadValidWorkspace(baseDir)
         visibleElements = (await workspace.elements(false))
         elementsWithHidden = (await workspace.elements(true))
       })
@@ -382,7 +382,7 @@ describe('multi env tests', () => {
         if (afterOtherEnvFetchPlan && afterOtherEnvFetchPlan.size > 10) {
           throw new Error('Too many unexpected changes. Aborting')
         }
-        await runDeploy({ fetchOutputDir: baseDir })
+        await runDeploy({ workspacePath: baseDir })
       })
 
       it('should have a non empty preview for the target enviornment', () => {
@@ -441,7 +441,7 @@ describe('multi env tests', () => {
         // We fetch it to common
         await runSetEnv(baseDir, ENV2_NAME)
         afterDeleteOtherEnvFetchPlan = await runPreviewGetPlan(baseDir)
-        await runDeploy({ fetchOutputDir: baseDir, allowErrors: true })
+        await runDeploy({ workspacePath: baseDir, allowErrors: true })
       })
 
       it('should have a non empty preview for the target enviornment', () => {
@@ -525,9 +525,9 @@ describe('multi env tests', () => {
         await runSetEnv(baseDir, ENV2_NAME)
         await runPreviewGetPlan(baseDir)
         await runSetEnv(baseDir, ENV1_NAME)
-        await runDeploy({ fetchOutputDir: baseDir, allowErrors: true })
+        await runDeploy({ workspacePath: baseDir, allowErrors: true })
         await runSetEnv(baseDir, ENV2_NAME)
-        await runDeploy({ fetchOutputDir: baseDir, allowErrors: true })
+        await runDeploy({ workspacePath: baseDir, allowErrors: true })
       })
 
       it('should create common elements in both envs', async () => {
@@ -606,9 +606,9 @@ describe('multi env tests', () => {
         await runSetEnv(baseDir, ENV2_NAME)
         await runPreviewGetPlan(baseDir)
         await runSetEnv(baseDir, ENV1_NAME)
-        await runDeploy({ fetchOutputDir: baseDir, allowErrors: true })
+        await runDeploy({ workspacePath: baseDir, allowErrors: true })
         await runSetEnv(baseDir, ENV2_NAME)
-        await runDeploy({ fetchOutputDir: baseDir, allowErrors: true })
+        await runDeploy({ workspacePath: baseDir, allowErrors: true })
       })
 
       it('should remove common elements from nacl change', async () => {

--- a/packages/cli/src/command_register.ts
+++ b/packages/cli/src/command_register.ts
@@ -15,8 +15,8 @@
 */
 import _ from 'lodash'
 import commander from 'commander'
-import { PositionalOption, CommandOrGroupDef, isCommand, CommandDef, CommandsGroupDef, KeyedOption } from './command_builder'
-import { CliArgs } from './types'
+import { CommandOrGroupDef, isCommand, CommandDef, CommandsGroupDef } from './command_builder'
+import { CliArgs, PositionalOption, KeyedOption } from './types'
 import { versionString } from './version'
 
 const LIST_SUFFIX = '...'

--- a/packages/cli/src/commands/common/config_override.ts
+++ b/packages/cli/src/commands/common/config_override.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { DetailedChange, Value, ElemID } from '@salto-io/adapter-api'
-import { KeyedOption } from '../../command_builder'
+import { KeyedOption } from '../../types'
 
 export type ConfigOverrideArg = {
   config?: string[]

--- a/packages/cli/src/commands/common/env.ts
+++ b/packages/cli/src/commands/common/env.ts
@@ -13,7 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { KeyedOption } from '../../command_builder'
+import { Workspace } from '@salto-io/workspace'
+import { errorOutputLine } from '../../outputer'
+import { CliError, CliExitCode, CliOutput, KeyedOption } from '../../types'
 
 export type EnvArg = {
     env?: string
@@ -25,4 +27,18 @@ export const ENVIRONMENT_OPTION: KeyedOption<EnvArg> = {
   required: false,
   description: 'The name of the environment to use (default=current env)',
   type: 'string',
+}
+
+export const validateAndSetEnv = async (
+  workspace: Workspace,
+  envArg: EnvArg,
+  cliOutput: CliOutput,
+): Promise<void> => {
+  if (envArg.env !== undefined) {
+    if (!workspace.envs().includes(envArg.env)) {
+      errorOutputLine(`Unknown environment ${envArg.env}`, cliOutput)
+      throw new CliError(CliExitCode.UserInputError)
+    }
+    await workspace.setCurrentEnv(envArg.env, false)
+  }
 }

--- a/packages/cli/src/commands/common/services.ts
+++ b/packages/cli/src/commands/common/services.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { Workspace } from '@salto-io/workspace'
-import { KeyedOption } from '../../command_builder'
+import { KeyedOption } from '../../types'
 
 export type ServicesArg = {
     services?: string[]

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -183,17 +183,18 @@ export const action: WorkspaceCommandAction<DeployArgs> = async ({
   )
   // Print state recencies
   outputLine(formatStateRecencies(stateRecencies), output)
-  // Validate state recencies
-  const stateSaltoVersion = await workspace.state().getStateSaltoVersion()
-  const invalidRecencies = stateRecencies.filter(recency => recency.status !== 'Valid')
-  if (!force && await shouldRecommendFetch(stateSaltoVersion, invalidRecencies, output)) {
-    return CliExitCode.AppError
-  }
 
   const validWorkspace = await isValidWorkspaceForCommand(
     { workspace, cliOutput: output, spinnerCreator, force }
   )
   if (!validWorkspace) {
+    return CliExitCode.AppError
+  }
+
+  // Validate state recencies
+  const stateSaltoVersion = await workspace.state().getStateSaltoVersion()
+  const invalidRecencies = stateRecencies.filter(recency => recency.status !== 'Valid')
+  if (!force && await shouldRecommendFetch(stateSaltoVersion, invalidRecencies, output)) {
     return CliExitCode.AppError
   }
 

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -16,19 +16,18 @@
 import _ from 'lodash'
 import { EOL } from 'os'
 import { promises } from '@salto-io/lowerdash'
-import { PlanItem, Plan, preview, DeployResult, Tags, ItemStatus, deploy } from '@salto-io/core'
+import { PlanItem, Plan, preview, DeployResult, ItemStatus, deploy } from '@salto-io/core'
 import { logger } from '@salto-io/logging'
 import { Workspace } from '@salto-io/workspace'
-import { createPublicCommandDef, CommandDefAction } from '../command_builder'
+import { WorkspaceCommandAction, createWorkspaceCommand } from '../command_builder'
 import { ServicesArg, SERVICES_OPTION, getAndValidateActiveServices } from './common/services'
-import { EnvArg, ENVIRONMENT_OPTION } from './common/env'
 import { CliOutput, CliExitCode, CliTelemetry } from '../types'
 import { outputLine, errorOutputLine } from '../outputer'
-import { header, formatExecutionPlan, deployPhaseHeader, cancelDeployOutput, formatItemDone, formatItemError, formatCancelAction, formatActionInProgress, formatActionStart, deployPhaseEpilogue } from '../formatter'
+import { header, formatExecutionPlan, deployPhaseHeader, cancelDeployOutput, formatItemDone, formatItemError, formatCancelAction, formatActionInProgress, formatActionStart, deployPhaseEpilogue, formatStateRecencies } from '../formatter'
 import Prompts from '../prompts'
 import { getUserBooleanInput } from '../callbacks'
-import { loadWorkspace, getWorkspaceTelemetryTags, updateWorkspace } from '../workspace/workspace'
-import { ConfigOverrideArg, getConfigOverrideChanges, CONFIG_OVERRIDE_OPTION } from './common/config_override'
+import { getWorkspaceTelemetryTags, updateWorkspace, isValidWorkspaceForCommand, shouldRecommendFetch } from '../workspace/workspace'
+import { ENVIRONMENT_OPTION, EnvArg, validateAndSetEnv } from './common/env'
 
 const log = logger(module)
 
@@ -75,12 +74,11 @@ type DeployArgs = {
   force: boolean
   dryRun: boolean
   detailedPlan: boolean
-} & ServicesArg & EnvArg & ConfigOverrideArg
+} & ServicesArg & EnvArg
 
 const deployPlan = async (
   actionPlan: Plan,
   workspace: Workspace,
-  workspaceTags: Tags,
   cliTelemetry: CliTelemetry,
   output: CliOutput,
   force: boolean,
@@ -159,9 +157,10 @@ const deployPlan = async (
     result.errors.length,
   ), output)
   output.stdout.write(EOL)
-  log.debug(`${result.errors.length} errors occured:\n${result.errors.map(err => err.message).join('\n')}`)
+  log.debug(`${result.errors.length} errors occurred:\n${result.errors.map(err => err.message).join('\n')}`)
 
   if (executingDeploy) {
+    const workspaceTags = await getWorkspaceTelemetryTags(workspace)
     cliTelemetry.actionsSuccess(nonErroredActions.length, workspaceTags)
     cliTelemetry.actionsFailure(result.errors.length, workspaceTags)
   }
@@ -169,32 +168,34 @@ const deployPlan = async (
   return result
 }
 
-export const action: CommandDefAction<DeployArgs> = async ({
+export const action: WorkspaceCommandAction<DeployArgs> = async ({
   input,
   cliTelemetry,
   output,
   spinnerCreator,
-  workspacePath = '.',
+  workspace,
 }): Promise<CliExitCode> => {
-  log.debug('running deploy command on \'%s\' %o', workspacePath, input)
-  const { force, dryRun, detailedPlan, env, services } = input
-  const { workspace, errored } = await loadWorkspace(workspacePath,
-    output,
-    {
-      force,
-      printStateRecency: true,
-      recommendStateStatus: true,
-      spinnerCreator,
-      sessionEnv: env,
-      configOverrides: getConfigOverrideChanges(input),
-    })
-  if (errored) {
-    cliTelemetry.failure()
+  const { force, dryRun, detailedPlan, services } = input
+  await validateAndSetEnv(workspace, input, output)
+  const actualServices = getAndValidateActiveServices(workspace, services)
+  const stateRecencies = await Promise.all(
+    actualServices.map(service => workspace.getStateRecency(service))
+  )
+  // Print state recencies
+  outputLine(formatStateRecencies(stateRecencies), output)
+  // Validate state recencies
+  const stateSaltoVersion = await workspace.state().getStateSaltoVersion()
+  const invalidRecencies = stateRecencies.filter(recency => recency.status !== 'Valid')
+  if (!force && await shouldRecommendFetch(stateSaltoVersion, invalidRecencies, output)) {
     return CliExitCode.AppError
   }
-  const actualServices = getAndValidateActiveServices(workspace, services)
-  const workspaceTags = await getWorkspaceTelemetryTags(workspace)
-  cliTelemetry.start(workspaceTags)
+
+  const validWorkspace = await isValidWorkspaceForCommand(
+    { workspace, cliOutput: output, spinnerCreator, force }
+  )
+  if (!validWorkspace) {
+    return CliExitCode.AppError
+  }
 
   const actionPlan = await preview(workspace, actualServices)
   await printPlan(actionPlan, output, workspace, detailedPlan)
@@ -202,7 +203,6 @@ export const action: CommandDefAction<DeployArgs> = async ({
   const result = dryRun ? { success: true, errors: [] } : await deployPlan(
     actionPlan,
     workspace,
-    workspaceTags,
     cliTelemetry,
     output,
     force,
@@ -221,16 +221,10 @@ export const action: CommandDefAction<DeployArgs> = async ({
     }
   }
 
-  if (cliExitCode === CliExitCode.Success) {
-    cliTelemetry.success(workspaceTags)
-  } else {
-    cliTelemetry.failure(workspaceTags)
-  }
-
   return cliExitCode
 }
 
-const deployDef = createPublicCommandDef({
+const deployDef = createWorkspaceCommand({
   properties: {
     name: 'deploy',
     description: 'Update the upstream services from the workspace configuration elements',
@@ -255,7 +249,6 @@ const deployDef = createPublicCommandDef({
       },
       SERVICES_OPTION,
       ENVIRONMENT_OPTION,
-      CONFIG_OVERRIDE_OPTION,
     ],
   },
   action,

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -15,17 +15,17 @@
 */
 import _ from 'lodash'
 import open from 'open'
-import { listUnresolvedReferences, Tags } from '@salto-io/core'
-import { CORE_ANNOTATIONS, isElement, Element, ElemID } from '@salto-io/adapter-api'
+import { ElemID, isElement, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { listUnresolvedReferences } from '@salto-io/core'
 import { Workspace, ElementSelector, createElementSelectors } from '@salto-io/workspace'
 import { logger } from '@salto-io/logging'
-import { createCommandGroupDef, createPublicCommandDef, CommandDefAction } from '../command_builder'
-import { CliOutput, CliExitCode, CliTelemetry } from '../types'
+import { createCommandGroupDef, createWorkspaceCommand, WorkspaceCommandAction } from '../command_builder'
+import { CliOutput, CliExitCode } from '../types'
 import { errorOutputLine, outputLine } from '../outputer'
 import { formatTargetEnvRequired, formatUnknownTargetEnv, formatInvalidEnvTargetCurrent, formatCloneToEnvFailed, formatInvalidFilters, formatMoveFailed, emptyLine, formatListUnresolvedFound, formatListUnresolvedMissing, formatElementListUnresolvedFailed } from '../formatter'
-import { loadWorkspace, getWorkspaceTelemetryTags } from '../workspace/workspace'
+import { isValidWorkspaceForCommand } from '../workspace/workspace'
 import Prompts from '../prompts'
-import { EnvArg, ENVIRONMENT_OPTION } from './common/env'
+import { EnvArg, ENVIRONMENT_OPTION, validateAndSetEnv } from './common/env'
 
 const log = logger(module)
 
@@ -54,9 +54,7 @@ const validateEnvs = (
 
 const moveElement = async (
   workspace: Workspace,
-  workspaceTags: Tags,
   output: CliOutput,
-  cliTelemetry: CliTelemetry,
   to: CommonOrEnvs,
   elmSelectors: ElementSelector[],
 ): Promise<CliExitCode> => {
@@ -69,10 +67,8 @@ const moveElement = async (
       await workspace.demote(await workspace.getElementIdsBySelectors(elmSelectors, true))
     }
     await workspace.flush()
-    cliTelemetry.success(workspaceTags)
     return CliExitCode.Success
   } catch (e) {
-    cliTelemetry.failure(workspaceTags)
     errorOutputLine(formatMoveFailed(e.message), output)
     return CliExitCode.AppError
   }
@@ -83,35 +79,32 @@ type ElementMoveToCommonArgs = {
   elementSelector: string[]
 } & EnvArg
 
-export const moveToCommonAction: CommandDefAction<ElementMoveToCommonArgs> = async ({
+export const moveToCommonAction: WorkspaceCommandAction<ElementMoveToCommonArgs> = async ({
   input,
-  cliTelemetry,
   output,
   spinnerCreator,
-  workspacePath = '.',
+  workspace,
 }): Promise<CliExitCode> => {
-  log.debug('running move-to-common command on \'%s\' %o', workspacePath, input)
-  const { elementSelector, env } = input
+  const { elementSelector } = input
   const { validSelectors, invalidSelectors } = createElementSelectors(elementSelector)
   if (!_.isEmpty(invalidSelectors)) {
     errorOutputLine(formatInvalidFilters(invalidSelectors), output)
     return CliExitCode.UserInputError
   }
-  const { workspace, errored } = await loadWorkspace(
-    workspacePath,
-    output,
-    { force: false, spinnerCreator, sessionEnv: env },
+
+  await validateAndSetEnv(workspace, input, output)
+
+  const validWorkspace = await isValidWorkspaceForCommand(
+    { workspace, cliOutput: output, spinnerCreator, force: false }
   )
-  if (errored) {
-    cliTelemetry.failure()
+  if (!validWorkspace) {
     return CliExitCode.AppError
   }
-  const workspaceTags = await getWorkspaceTelemetryTags(workspace)
-  cliTelemetry.start(workspaceTags)
-  return moveElement(workspace, workspaceTags, output, cliTelemetry, 'common', validSelectors)
+
+  return moveElement(workspace, output, 'common', validSelectors)
 }
 
-const moveToCommonDef = createPublicCommandDef({
+const moveToCommonDef = createWorkspaceCommand({
   properties: {
     name: 'move-to-common',
     description: 'Move configuration elements to the common configuration',
@@ -135,35 +128,29 @@ type ElementMoveToEnvsArgs = {
   elementSelector: string[]
 }
 
-export const moveToEnvsAction: CommandDefAction<ElementMoveToEnvsArgs> = async ({
+export const moveToEnvsAction: WorkspaceCommandAction<ElementMoveToEnvsArgs> = async ({
   input,
-  cliTelemetry,
   output,
   spinnerCreator,
-  workspacePath = '.',
+  workspace,
 }): Promise<CliExitCode> => {
-  log.debug('running move-to-envs command on \'%s\' %o', workspacePath, input)
   const { elementSelector } = input
   const { validSelectors, invalidSelectors } = createElementSelectors(elementSelector)
   if (!_.isEmpty(invalidSelectors)) {
     errorOutputLine(formatInvalidFilters(invalidSelectors), output)
     return CliExitCode.UserInputError
   }
-  const { workspace, errored } = await loadWorkspace(
-    workspacePath,
-    output,
-    { force: false, spinnerCreator, sessionEnv: undefined },
+
+  const validWorkspace = await isValidWorkspaceForCommand(
+    { workspace, cliOutput: output, spinnerCreator, force: false }
   )
-  if (errored) {
-    cliTelemetry.failure()
+  if (!validWorkspace) {
     return CliExitCode.AppError
   }
-  const workspaceTags = await getWorkspaceTelemetryTags(workspace)
-  cliTelemetry.start(workspaceTags)
-  return moveElement(workspace, workspaceTags, output, cliTelemetry, 'envs', validSelectors)
+  return moveElement(workspace, output, 'envs', validSelectors)
 }
 
-const moveToEnvsDef = createPublicCommandDef({
+const moveToEnvsDef = createWorkspaceCommand({
   properties: {
     name: 'move-to-envs',
     description: 'Move configuration elements to the env-specific configuration',
@@ -186,49 +173,42 @@ type ElementCloneArgs = {
   force?: boolean
 } & EnvArg
 
-export const cloneAction: CommandDefAction<ElementCloneArgs> = async ({
+export const cloneAction: WorkspaceCommandAction<ElementCloneArgs> = async ({
   input,
-  cliTelemetry,
   output,
   spinnerCreator,
-  workspacePath = '.',
+  workspace,
 }): Promise<CliExitCode> => {
-  log.debug('running clone command on \'%s\' %o', workspacePath, input)
-  const { toEnvs, env, elementSelector, force } = input
+  const { toEnvs, elementSelector, force } = input
   const { validSelectors, invalidSelectors } = createElementSelectors(elementSelector)
   if (!_.isEmpty(invalidSelectors)) {
     errorOutputLine(formatInvalidFilters(invalidSelectors), output)
     return CliExitCode.UserInputError
   }
-  const { workspace, errored } = await loadWorkspace(
-    workspacePath,
-    output,
-    { force, spinnerCreator, sessionEnv: env },
-  )
-  if (errored) {
-    cliTelemetry.failure()
-    return CliExitCode.AppError
-  }
+  await validateAndSetEnv(workspace, input, output)
   if (!validateEnvs(output, workspace, toEnvs)) {
-    cliTelemetry.failure()
     return CliExitCode.UserInputError
   }
-  const workspaceTags = await getWorkspaceTelemetryTags(workspace)
-  cliTelemetry.start(workspaceTags)
+
+  const validWorkspace = await isValidWorkspaceForCommand(
+    { workspace, cliOutput: output, spinnerCreator, force }
+  )
+  if (!validWorkspace) {
+    return CliExitCode.AppError
+  }
+
   try {
     outputLine(Prompts.CLONE_TO_ENV_START(toEnvs), output)
     await workspace.copyTo(await workspace.getElementIdsBySelectors(validSelectors), toEnvs)
     await workspace.flush()
-    cliTelemetry.success(workspaceTags)
     return CliExitCode.Success
   } catch (e) {
-    cliTelemetry.failure()
     errorOutputLine(formatCloneToEnvFailed(e.message), output)
     return CliExitCode.AppError
   }
 }
 
-const cloneDef = createPublicCommandDef({
+const cloneDef = createWorkspaceCommand({
   properties: {
     name: 'clone',
     description: 'Clone elements from one env-specific configuration to others',
@@ -266,37 +246,26 @@ type ElementListUnresolvedArgs = {
   completeFrom?: string
 } & EnvArg
 
-export const listUnresolvedAction: CommandDefAction<ElementListUnresolvedArgs> = async ({
+export const listUnresolvedAction: WorkspaceCommandAction<ElementListUnresolvedArgs> = async ({
   input,
-  cliTelemetry,
   output,
   spinnerCreator,
-  workspacePath = '.',
+  workspace,
 }): Promise<CliExitCode> => {
-  log.debug('running element list-unresolved command on \'%s\' %o', workspacePath, input)
-  const { completeFrom, env } = input
-  const { workspace, errored } = await loadWorkspace(
-    workspacePath,
-    output,
-    {
-      force: false,
-      spinnerCreator,
-      sessionEnv: env,
-      ignoreUnresolvedRefs: true,
-    }
+  const { completeFrom } = input
+  await validateAndSetEnv(workspace, input, output)
+
+  const validWorkspace = await isValidWorkspaceForCommand(
+    { workspace, cliOutput: output, spinnerCreator, force: false, ignoreUnresolvedRefs: true }
   )
-  if (errored) {
-    cliTelemetry.failure()
+  if (!validWorkspace) {
     return CliExitCode.AppError
   }
-  const workspaceTags = await getWorkspaceTelemetryTags(workspace)
 
   if (completeFrom !== undefined && !validateEnvs(output, workspace, [completeFrom])) {
-    cliTelemetry.failure(workspaceTags)
     return CliExitCode.UserInputError
   }
 
-  cliTelemetry.start(workspaceTags)
   outputLine(Prompts.LIST_UNRESOLVED_START(workspace.currentEnv()), output)
   outputLine(emptyLine(), output)
 
@@ -314,17 +283,15 @@ export const listUnresolvedAction: CommandDefAction<ElementListUnresolvedArgs> =
       }
     }
 
-    cliTelemetry.success(workspaceTags)
     return CliExitCode.Success
   } catch (e) {
     log.error(`Error listing elements: ${e}`)
     errorOutputLine(formatElementListUnresolvedFailed(e.message), output)
-    cliTelemetry.failure(workspaceTags)
     return CliExitCode.AppError
   }
 }
 
-const listUnresolvedDef = createPublicCommandDef({
+const listUnresolvedDef = createWorkspaceCommand({
   properties: {
     name: 'list-unresolved',
     description: 'Lists unresolved references to configuration elements',
@@ -348,57 +315,47 @@ type OpenActionArgs = {
   elementId: string
 } & EnvArg
 
-const safeGetElementId = (maybeElementIdPath: string): ElemID | undefined => {
+const safeGetElementID = (maybeElementIdPath: string, output: CliOutput): ElemID | undefined => {
   try {
     return ElemID.fromFullName(maybeElementIdPath)
   } catch (e) {
+    errorOutputLine(e.message, output)
     return undefined
   }
 }
 
-export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliTelemetry, spinnerCreator, output, workspacePath = '.' }): Promise<CliExitCode> => {
-  log.debug('running element open command on \'%s\' %o', workspacePath, input)
-  const getServiceUrlAnnotation = (element: Element): string|undefined =>
-    _.get(element, ['annotations', CORE_ANNOTATIONS.SERVICE_URL])
-  const { elementId, env } = input
-  const { errored, workspace } = await loadWorkspace(workspacePath, output, {
-    spinnerCreator, sessionEnv: env,
-  })
-  const workspaceTags = await getWorkspaceTelemetryTags(workspace)
+export const openAction: WorkspaceCommandAction<OpenActionArgs> = async ({
+  input,
+  output,
+  workspace,
+}) => {
+  const { elementId } = input
+  await validateAndSetEnv(workspace, input, output)
 
-  if (errored) {
-    cliTelemetry.failure(workspaceTags)
-    return CliExitCode.AppError
-  }
-
-  const elemId = safeGetElementId(elementId)
+  const elemId = safeGetElementID(elementId, output)
   if (elemId === undefined) {
-    errorOutputLine(Prompts.NO_MATCHES_FOUND_FOR_ELEMENT(elementId), output)
-    cliTelemetry.failure(workspaceTags)
     return CliExitCode.UserInputError
   }
 
   const element = await workspace.getValue(elemId)
-  if (!isElement(element)) {
+  if (element === undefined) {
     errorOutputLine(Prompts.NO_MATCHES_FOUND_FOR_ELEMENT(elementId), output)
-    cliTelemetry.failure(workspaceTags)
     return CliExitCode.UserInputError
   }
 
-  const serviceUrl = getServiceUrlAnnotation(element)
-
+  const serviceUrl = isElement(element)
+    ? element.annotations[CORE_ANNOTATIONS.SERVICE_URL]
+    : undefined
   if (serviceUrl === undefined) {
     errorOutputLine(Prompts.GO_TO_SERVICE_NOT_SUPPORTED_FOR_ELEMENT(elementId), output)
-    cliTelemetry.failure(workspaceTags)
     return CliExitCode.AppError
   }
 
   await open(serviceUrl)
-  cliTelemetry.success(workspaceTags)
   return CliExitCode.Success
 }
 
-const elementOpenDef = createPublicCommandDef({
+const elementOpenDef = createWorkspaceCommand({
   properties: {
     name: 'open',
     description: 'Opens the service page of an element',

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -315,7 +315,7 @@ type OpenActionArgs = {
   elementId: string
 } & EnvArg
 
-const safeGetElementID = (maybeElementIdPath: string, output: CliOutput): ElemID | undefined => {
+const safeGetElementId = (maybeElementIdPath: string, output: CliOutput): ElemID | undefined => {
   try {
     return ElemID.fromFullName(maybeElementIdPath)
   } catch (e) {
@@ -332,7 +332,7 @@ export const openAction: WorkspaceCommandAction<OpenActionArgs> = async ({
   const { elementId } = input
   await validateAndSetEnv(workspace, input, output)
 
-  const elemId = safeGetElementID(elementId, output)
+  const elemId = safeGetElementId(elementId, output)
   if (elemId === undefined) {
     return CliExitCode.UserInputError
   }

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import { EOL } from 'os'
 import chalk from 'chalk'
 import wu, { WuIterable } from 'wu'
 import {
@@ -23,7 +24,7 @@ import {
   isStaticFile,
 } from '@salto-io/adapter-api'
 import { Plan, PlanItem, FetchChange, FetchResult, LocalChange } from '@salto-io/core'
-import { errors, SourceFragment, parser, WorkspaceComponents } from '@salto-io/workspace'
+import { errors, SourceFragment, parser, WorkspaceComponents, StateRecency } from '@salto-io/workspace'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import Prompts from './prompts'
 
@@ -673,3 +674,11 @@ export const formatEnvDiff = (
     emptyLine(),
   ].join('\n')
 }
+
+export const formatStateRecencies = (stateRecencies: StateRecency[]): string => (
+  stateRecencies.map(
+    recency => (recency.status === 'Nonexistent'
+      ? Prompts.NONEXISTENT_STATE(recency.serviceName)
+      : Prompts.STATE_RECENCY(recency.serviceName, recency.date as Date))
+  ).join(EOL)
+)

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -74,7 +74,6 @@ export interface CliOutput {
 
 export interface CliInput {
   args: string[]
-  // stdin: ReadStream
   telemetry: Telemetry
   config: CommandConfig
 

--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -174,7 +174,7 @@ export const isValidWorkspaceForCommand = async ({
   workspace,
   cliOutput,
   spinnerCreator,
-  force = false,
+  force,
   ignoreUnresolvedRefs = false,
 }: {
   workspace: Workspace

--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -13,11 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { EOL } from 'os'
 import _ from 'lodash'
 import wu from 'wu'
 import semver from 'semver'
-import { FetchChange, Tags, loadLocalWorkspace, StepEmitter } from '@salto-io/core'
+import { FetchChange, Tags, StepEmitter } from '@salto-io/core'
 import { SaltoError, DetailedChange } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { Workspace, nacl, StateRecency, validator as wsValidator } from '@salto-io/workspace'
@@ -145,7 +144,7 @@ const logWorkspaceUpdates = async (
   }
 }
 
-const shouldRecommendFetch = async (
+export const shouldRecommendFetch = async (
   stateSaltoVersion: string | undefined,
   invalidRecencies: StateRecency[],
   cliOutput: CliOutput
@@ -171,71 +170,35 @@ const shouldRecommendFetch = async (
   return false
 }
 
-export const loadWorkspace = async (
-  workingDir: string,
-  cliOutput: CliOutput,
-  {
-    force = false,
-    printStateRecency = false,
-    recommendStateStatus: recommendStateRecency = false,
-    spinnerCreator = undefined,
-    sessionEnv = undefined,
-    services = undefined,
-    ignoreUnresolvedRefs = false,
-    configOverrides,
-  }: Partial<LoadWorkspaceOptions> = {}
-): Promise<LoadWorkspaceResult> => {
-  const spinner = spinnerCreator
-    ? spinnerCreator(Prompts.LOADING_WORKSPACE, {})
-    : { succeed: () => undefined, fail: () => undefined }
-
-  const workspace = await loadLocalWorkspace(workingDir, configOverrides)
-  if (!_.isUndefined(sessionEnv)) {
-    if (!(workspace.envs().includes(sessionEnv))) {
-      spinner.fail(`Environment ${sessionEnv} isn't configured. Use salto env create.`)
-      return { workspace, errored: true, stateRecencies: [] }
-    }
-    await workspace.setCurrentEnv(sessionEnv, false)
-  }
-
+export const isValidWorkspaceForCommand = async ({
+  workspace,
+  cliOutput,
+  spinnerCreator,
+  force = false,
+  ignoreUnresolvedRefs = false,
+}: {
+  workspace: Workspace
+  cliOutput: CliOutput
+  spinnerCreator: SpinnerCreator
+  force?: boolean
+  ignoreUnresolvedRefs?: boolean
+}): Promise<boolean> => {
+  const spinner = spinnerCreator(Prompts.LOADING_WORKSPACE, {})
   const { status, errors } = await validateWorkspace(workspace, ignoreUnresolvedRefs)
-  // Stop the spinner
+  await printWorkspaceErrors(status, await formatWorkspaceErrors(workspace, errors), cliOutput)
+
   if (status === 'Error') {
     spinner.fail(formatWorkspaceLoadFailed(errors.length))
-  } else {
-    spinner.succeed(formatFinishedLoading(workspace.currentEnv()))
-  }
-  // Print state's recency
-  const stateRecencies = await Promise.all((services || workspace.services())
-    .map(service => workspace.getStateRecency(service)))
-
-  if (printStateRecency) {
-    const prompt = stateRecencies.map(recency => (recency.status === 'Nonexistent'
-      ? Prompts.NONEXISTENT_STATE(recency.serviceName)
-      : Prompts.STATE_RECENCY(recency.serviceName, recency.date as Date))).join(EOL)
-    cliOutput.stdout.write(prompt + EOL)
-  }
-
-  // Offer to cancel because of stale status (stale or version)
-  const stateSaltoVersion = await workspace.state().getStateSaltoVersion()
-  const invalidRecencies = stateRecencies.filter(recency => recency.status !== 'Valid')
-  if (recommendStateRecency && !force
-    && status !== 'Error'
-    && await shouldRecommendFetch(stateSaltoVersion, invalidRecencies, cliOutput)
-  ) {
-    return { workspace, errored: true, stateRecencies }
-  }
-
-  // Handle warnings/errors
-  await printWorkspaceErrors(status, await formatWorkspaceErrors(workspace, errors), cliOutput)
-  if (status === 'Warning' && !force) {
-    const shouldContinue = await shouldContinueInCaseOfWarnings(errors.length, cliOutput)
-    return { workspace, errored: !shouldContinue, stateRecencies }
-  }
-  if (status === 'Error') {
     cliOutput.stdout.write(formatWorkspaceAbort(errors.length))
+    return false
   }
-  return { workspace, errored: status === 'Error', stateRecencies }
+
+  spinner.succeed(formatFinishedLoading(workspace.currentEnv()))
+  if (status === 'Warning' && !force) {
+    return shouldContinueInCaseOfWarnings(errors.length, cliOutput)
+  }
+
+  return true
 }
 
 export const updateStateOnly = async (ws: Workspace,

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -20,7 +20,7 @@ import * as env from '../src/commands/env'
 import { CliExitCode, CliError } from '../src/types'
 
 describe('cli as a whole', () => {
-  let o: mocks.MockCliOutput
+  let o: mocks.MockCliReturn
 
   jest.setTimeout(200)
   jest.spyOn(logger, 'end').mockResolvedValue(undefined)

--- a/packages/cli/test/commands/commons.test.ts
+++ b/packages/cli/test/commands/commons.test.ts
@@ -20,7 +20,7 @@ import { getConfigOverrideChanges } from '../../src/commands/common/config_overr
 
 describe('Commands commons tests', () => {
   describe('getAndValidateActiveServices with workspace with services', () => {
-    const mockWorkspace = mocks.mockLoadWorkspace('ws', undefined, undefined, undefined, ['service1', 'service2', 'service3'])
+    const mockWorkspace = mocks.mockWorkspace({ services: ['service1', 'service2', 'service3'] })
 
     it('Should return the workspaces\' services if no input services provided', () => {
       const result = getAndValidateActiveServices(mockWorkspace, undefined)
@@ -37,7 +37,7 @@ describe('Commands commons tests', () => {
     })
   })
   describe('getAndValidateActiveServices with workspace with no services', () => {
-    const mockWorkspace = mocks.mockLoadWorkspace('ws', undefined, undefined, undefined, [])
+    const mockWorkspace = mocks.mockWorkspace({ services: [] })
     it('Should throw an error if no input services provided', () => {
       expect(() => getAndValidateActiveServices(mockWorkspace, undefined)).toThrow()
     })

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -723,13 +723,13 @@ describe('Element command group', () => {
           ...mocks.mockCliCommandArgs(commandName),
           input: {
             elementId: 'salesforce.Lead',
-            env: 'otherEnv',
+            env: mocks.withEnvironmentParam,
           },
           workspace,
         })
       })
       it('should set the requested environment', () => {
-        expect(workspace.setCurrentEnv).toHaveBeenCalledWith('otherEnv', false)
+        expect(workspace.setCurrentEnv).toHaveBeenCalledWith(mocks.withEnvironmentParam, false)
       })
       it('should call open with the url', () => {
         expect(open).toHaveBeenCalledWith(serviceUrlAccount)
@@ -801,8 +801,7 @@ describe('Element command group', () => {
         })
       })
       it('should print the id is invalid', () => {
-        // TODO:ORI - fix this
-        expect(output.stderr.content).toEqual('asd')
+        expect(output.stderr.content).toEqual('Cannot create ID foo.bla.bar.buzz - Invalid ID type bar\n')
       })
       it('should return error exit code', () => {
         expect(result).toEqual(CliExitCode.UserInputError)
@@ -819,13 +818,13 @@ describe('Element command group', () => {
         result = await openAction({
           ...mocks.mockCliCommandArgs(commandName, cliArgs),
           input: {
-            elementId: 'salesforce.Lead.fields.Account.label',
+            elementId: 'salesforce.Lead.field.Account.label',
           },
           workspace,
         })
       })
       it('should print element does not have a url', () => {
-        expect(output.stderr.content).toEqual('Go to service is not supported for element salesforce.Lead.fields.Account.label\n')
+        expect(output.stderr.content).toEqual('Go to service is not supported for element salesforce.Lead.field.Account.label\n')
       })
       it('should return error exit code', () => {
         expect(result).toEqual(CliExitCode.AppError)

--- a/packages/cli/test/commands/env.test.ts
+++ b/packages/cli/test/commands/env.test.ts
@@ -13,46 +13,37 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import * as core from '@salto-io/core'
-import { Workspace } from '@salto-io/workspace'
 import * as callbacks from '../../src/callbacks'
 import * as mocks from '../mocks'
 import { createAction, setAction, currentAction, listAction, deleteAction, renameAction } from '../../src/commands/env'
-import { CliExitCode, CliTelemetry } from '../../src/types'
+import { CliExitCode } from '../../src/types'
 
-jest.mock('@salto-io/core')
 describe('env command group', () => {
-  let output: { stdout: mocks.MockWriteStream; stderr: mocks.MockWriteStream }
-  const config = { shouldCalcTotalSize: true }
-  let cliTelemetry: CliTelemetry
+  let cliArgs: mocks.MockCliArgs
+  let output: mocks.MockCliOutput
 
   beforeEach(async () => {
-    output = { stdout: new mocks.MockWriteStream(), stderr: new mocks.MockWriteStream() }
-    jest.spyOn(core, 'loadLocalWorkspace').mockImplementation(
-      baseDir => Promise.resolve(mocks.mockLoadWorkspace(baseDir))
-    )
+    cliArgs = mocks.mockCliArgs()
+    output = cliArgs.output
   })
 
   describe('create command', () => {
+    const commandName = 'create'
     it('should create a new environment', async () => {
       await createAction({
+        ...mocks.mockCliCommandArgs(commandName, cliArgs),
         input: {
           envName: 'new-env',
         },
-        output,
-        config,
-        cliTelemetry,
+        workspace: mocks.mockWorkspace({}),
       })
       expect(output.stdout.content.search('new-env')).toBeGreaterThan(0)
     })
 
     describe('create multiple environments', () => {
-      let lastWorkspace: Workspace
+      let workspace: mocks.MockWorkspace
       beforeEach(() => {
-        jest.spyOn(core, 'loadLocalWorkspace').mockImplementation(baseDir => {
-          lastWorkspace = mocks.mockLoadWorkspace(baseDir, ['me1'])
-          return Promise.resolve(lastWorkspace)
-        })
+        workspace = mocks.mockWorkspace({ envs: ['me1'] })
         jest.spyOn(callbacks, 'cliApproveIsolateBeforeMultiEnv').mockImplementation(
           () => Promise.resolve(false)
         )
@@ -64,17 +55,16 @@ describe('env command group', () => {
 
       it('should prompt on 2nd environment creation, and do nothing if false', async () => {
         await createAction({
+          ...mocks.mockCliCommandArgs(commandName, cliArgs),
           input: {
             envName: 'me2',
           },
-          output,
-          config,
-          cliTelemetry,
+          workspace,
         })
         expect(output.stdout.content.search('me2')).toBeGreaterThan(0)
         expect(callbacks.cliApproveIsolateBeforeMultiEnv).toHaveBeenCalledTimes(1)
         expect(callbacks.cliApproveIsolateBeforeMultiEnv).toHaveBeenCalledWith('me1')
-        expect(lastWorkspace.demoteAll).not.toHaveBeenCalled()
+        expect(workspace.demoteAll).not.toHaveBeenCalled()
       })
 
       it('should prompt on 2nd environment creation, and isolate if true', async () => {
@@ -83,158 +73,141 @@ describe('env command group', () => {
         )
 
         await createAction({
+          ...mocks.mockCliCommandArgs(commandName, cliArgs),
           input: {
             envName: 'me2',
           },
-          output,
-          config,
-          cliTelemetry,
+          workspace,
         })
         expect(output.stdout.content.search('me2')).toBeGreaterThan(0)
         expect(callbacks.cliApproveIsolateBeforeMultiEnv).toHaveBeenCalledTimes(1)
         expect(callbacks.cliApproveIsolateBeforeMultiEnv).toHaveBeenCalledWith('me1')
-        expect(lastWorkspace.demoteAll).toHaveBeenCalled()
+        expect(workspace.demoteAll).toHaveBeenCalled()
       })
 
       it('should not prompt if force=true and acceptSuggestions=false, and do nothing', async () => {
         await createAction({
+          ...mocks.mockCliCommandArgs(commandName, cliArgs),
           input: {
             envName: 'me2',
             force: true,
             yesAll: false,
           },
-          output,
-          config,
-          cliTelemetry,
+          workspace,
         })
         expect(output.stdout.content.search('me2')).toBeGreaterThan(0)
         expect(callbacks.cliApproveIsolateBeforeMultiEnv).not.toHaveBeenCalled()
-        expect(lastWorkspace.demoteAll).not.toHaveBeenCalled()
+        expect(workspace.demoteAll).not.toHaveBeenCalled()
       })
 
       it('should isolate without prompting if acceptSuggestions=true', async () => {
         await createAction({
+          ...mocks.mockCliCommandArgs(commandName, cliArgs),
           input: {
             envName: 'me2',
             yesAll: true,
           },
-          output,
-          config,
-          cliTelemetry,
+          workspace,
         })
         expect(output.stdout.content.search('me2')).toBeGreaterThan(0)
         expect(callbacks.cliApproveIsolateBeforeMultiEnv).not.toHaveBeenCalled()
-        expect(lastWorkspace.demoteAll).toHaveBeenCalled()
+        expect(workspace.demoteAll).toHaveBeenCalled()
       })
       it('should isolate without prompting if acceptSuggestions=true and force=true', async () => {
         await createAction({
+          ...mocks.mockCliCommandArgs(commandName, cliArgs),
           input: {
             envName: 'me2',
             force: true,
             yesAll: true,
           },
-          output,
-          config,
-          cliTelemetry,
+          workspace,
         })
         expect(output.stdout.content.search('me2')).toBeGreaterThan(0)
         expect(callbacks.cliApproveIsolateBeforeMultiEnv).not.toHaveBeenCalled()
-        expect(lastWorkspace.demoteAll).toHaveBeenCalled()
+        expect(workspace.demoteAll).toHaveBeenCalled()
       })
 
       it('should not prompt on 2nd environment creation if workspace is empty', async () => {
-        jest.spyOn(core, 'loadLocalWorkspace').mockImplementationOnce(baseDir => {
-          lastWorkspace = mocks.mockLoadWorkspace(baseDir, ['me1'], true)
-          return Promise.resolve(lastWorkspace)
-        })
+        workspace.isEmpty.mockResolvedValue(true)
 
         await createAction({
+          ...mocks.mockCliCommandArgs(commandName, cliArgs),
           input: {
             envName: 'me2',
           },
-          output,
-          config,
-          cliTelemetry,
+          workspace,
         })
         expect(output.stdout.content.search('me2')).toBeGreaterThan(0)
         expect(callbacks.cliApproveIsolateBeforeMultiEnv).not.toHaveBeenCalled()
-        expect(lastWorkspace.demoteAll).not.toHaveBeenCalled()
+        expect(workspace.demoteAll).not.toHaveBeenCalled()
       })
 
       it('should not prompt on 2nd environment creation if env1 folder exists', async () => {
-        jest.spyOn(core, 'loadLocalWorkspace').mockImplementation(baseDir => {
-          lastWorkspace = mocks.mockLoadWorkspace(baseDir, ['me1'])
-          lastWorkspace.hasElementsInEnv = jest.fn().mockResolvedValue(true)
-          return Promise.resolve(lastWorkspace)
-        })
+        workspace.hasElementsInEnv.mockResolvedValue(true)
 
         await createAction({
+          ...mocks.mockCliCommandArgs(commandName, cliArgs),
           input: {
             envName: 'me2',
           },
-          output,
-          config,
-          cliTelemetry,
+          workspace,
         })
         expect(output.stdout.content.search('me2')).toBeGreaterThan(0)
         expect(callbacks.cliApproveIsolateBeforeMultiEnv).not.toHaveBeenCalled()
-        expect(lastWorkspace.demoteAll).not.toHaveBeenCalled()
+        expect(workspace.demoteAll).not.toHaveBeenCalled()
       })
 
       it('should not prompt on 3rd environment creation', async () => {
-        jest.spyOn(core, 'loadLocalWorkspace').mockImplementationOnce(baseDir => {
-          lastWorkspace = mocks.mockLoadWorkspace(baseDir, ['me1', 'me2'], true)
-          return Promise.resolve(lastWorkspace)
-        })
+        workspace = mocks.mockWorkspace({ envs: ['me1', 'me2'] })
 
         await createAction({
+          ...mocks.mockCliCommandArgs(commandName, cliArgs),
           input: {
             envName: 'me3',
           },
-          output,
-          config,
-          cliTelemetry,
+          workspace,
         })
         expect(output.stdout.content.search('me3')).toBeGreaterThan(0)
         expect(callbacks.cliApproveIsolateBeforeMultiEnv).not.toHaveBeenCalled()
-        expect(lastWorkspace.demoteAll).not.toHaveBeenCalled()
+        expect(workspace.demoteAll).not.toHaveBeenCalled()
       })
     })
   })
 
   describe('set command', () => {
+    const commandName = 'set'
     it('should set an environment', async () => {
       await setAction({
+        ...mocks.mockCliCommandArgs(commandName, cliArgs),
         input: {
           envName: 'active',
         },
-        output,
-        cliTelemetry,
-        config,
+        workspace: mocks.mockWorkspace({}),
       })
       expect(output.stdout.content.search('active')).toBeGreaterThan(0)
     })
   })
 
   describe('current command', () => {
+    const commandName = 'current'
     it('should display the current environment', async () => {
       await currentAction({
+        ...mocks.mockCliCommandArgs(commandName, cliArgs),
         input: {},
-        output,
-        cliTelemetry,
-        config,
+        workspace: mocks.mockWorkspace({}),
       })
       expect(output.stdout.content.search('active')).toBeGreaterThan(0)
     })
   })
 
   describe('list command', () => {
+    const commandName = 'list'
     it('should list all environments', async () => {
       await listAction({
+        ...mocks.mockCliCommandArgs(commandName, cliArgs),
         input: {},
-        output,
-        cliTelemetry,
-        config,
+        workspace: mocks.mockWorkspace({}),
       })
       expect(output.stdout.content.search('active')).toBeGreaterThan(0)
       expect(output.stdout.content.search('inactive')).toBeGreaterThan(0)
@@ -242,29 +215,29 @@ describe('env command group', () => {
   })
 
   describe('delete command', () => {
+    const commandName = 'delete'
     it('should display the deleted environment', async () => {
       await deleteAction({
+        ...mocks.mockCliCommandArgs(commandName, cliArgs),
         input: {
           envName: 'inactive',
         },
-        output,
-        cliTelemetry,
-        config,
+        workspace: mocks.mockWorkspace({}),
       })
       expect(output.stdout.content.search('inactive')).toBeGreaterThan(0)
     })
   })
 
   describe('rename command', () => {
+    const commandName = 'rename'
     it('should display renamed environment', async () => {
       const result = await renameAction({
+        ...mocks.mockCliCommandArgs(commandName, cliArgs),
         input: {
           oldName: 'inactive',
           newName: 'new-inactive',
         },
-        output,
-        cliTelemetry,
-        config,
+        workspace: mocks.mockWorkspace({}),
       })
       expect(result).toBe(CliExitCode.Success)
       expect(output.stdout.content.search('inactive')).toBeGreaterThan(0)

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -13,20 +13,16 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
 import { EventEmitter } from 'pietile-eventemitter'
-import { Element, InstanceElement,
-  DetailedChange } from '@salto-io/adapter-api'
+import { InstanceElement, DetailedChange } from '@salto-io/adapter-api'
 import { fetch, FetchChange, FetchProgressEvents, StepEmitter, FetchFunc } from '@salto-io/core'
 import { Workspace } from '@salto-io/workspace'
-import { Spinner, SpinnerCreator, CliExitCode, CliTelemetry } from '../../src/types'
+import { CliExitCode, CliTelemetry } from '../../src/types'
 import * as fetchCmd from '../../src/commands/fetch'
 import { action, fetchCommand, FetchCommandArgs } from '../../src/commands/fetch'
 import * as callbacks from '../../src/callbacks'
 import * as mocks from '../mocks'
-import Prompts from '../../src/prompts'
-import * as mockCliWorkspace from '../../src/workspace/workspace'
-import { buildEventName, getCliTelemetry } from '../../src/telemetry'
+import { buildEventName } from '../../src/telemetry'
 
 const commandName = 'fetch'
 const eventsNames = {
@@ -46,49 +42,31 @@ jest.mock('@salto-io/core', () => ({
     success: true,
   })),
 }))
-jest.mock('../../src/workspace/workspace')
 describe('fetch command', () => {
-  let spinners: Spinner[]
-  let spinnerCreator: SpinnerCreator
   const services = ['salesforce']
-  const config = { shouldCalcTotalSize: true }
-  let output: { stdout: mocks.MockWriteStream; stderr: mocks.MockWriteStream }
-  const mockLoadWorkspace = mockCliWorkspace.loadWorkspace as jest.Mock
-  const mockApplyChangesToWorkspace = mockCliWorkspace.applyChangesToWorkspace as jest.Mock
-  const mockUpdateWorkspace = mockCliWorkspace.updateWorkspace as jest.Mock
-  const mockUpdateStateOnly = mockCliWorkspace.updateStateOnly as jest.Mock
-  mockApplyChangesToWorkspace.mockImplementation(
-    ({ workspace, cliOutput, changes, mode }) => (
-      mockUpdateWorkspace(workspace, cliOutput, changes, mode)
-    )
-  )
-  mockUpdateWorkspace.mockImplementation(ws =>
-    Promise.resolve(ws.name !== 'exist-on-error'))
-  const findWsUpdateCalls = (name: string): unknown[][][] =>
-    mockUpdateWorkspace.mock.calls.filter(args => args[0].name === name)
-  mockUpdateStateOnly.mockResolvedValue(true)
+  let cliCommandArgs: mocks.MockCommandArgs
+  let telemetry: mocks.MockTelemetry
+  let cliTelemetry: CliTelemetry
+  let output: mocks.MockCliOutput
 
   beforeEach(() => {
-    output = { stdout: new mocks.MockWriteStream(), stderr: new mocks.MockWriteStream() }
-    spinners = []
-    spinnerCreator = mocks.mockSpinnerCreator(spinners)
+    const cliArgs = mocks.mockCliArgs()
+    cliCommandArgs = mocks.mockCliCommandArgs(commandName, cliArgs)
+    telemetry = cliArgs.telemetry
+    output = cliArgs.output
+    cliTelemetry = cliCommandArgs.cliTelemetry
   })
 
   describe('execute', () => {
     let result: number
-    let telemetry: mocks.MockTelemetry
-    let cliTelemetry: CliTelemetry
     describe('with errored workspace', () => {
       beforeEach(async () => {
-        telemetry = mocks.getMockTelemetry()
-        cliTelemetry = getCliTelemetry(telemetry, commandName)
-        const erroredWorkspace = {
-          hasErrors: () => true,
-          errors: { strings: () => ['some error'] },
-          config: { services },
-        } as unknown as Workspace
-        mockLoadWorkspace.mockResolvedValueOnce({ workspace: erroredWorkspace, errored: true })
+        const workspace = mocks.mockWorkspace({})
+        workspace.errors.mockResolvedValue(
+          mocks.mockErrors([{ severity: 'Error', message: 'some error' }])
+        )
         result = await action({
+          ...cliCommandArgs,
           input: {
             force: true,
             interactive: false,
@@ -96,32 +74,22 @@ describe('fetch command', () => {
             services,
             stateOnly: false,
           },
-          cliTelemetry,
-          config,
-          output,
-          spinnerCreator,
+          workspace,
         })
       })
 
       it('should fail', async () => {
         expect(result).toBe(CliExitCode.AppError)
         expect(fetch).not.toHaveBeenCalled()
-        expect(telemetry.getEvents().length).toEqual(1)
-        expect(telemetry.getEventsMap()[eventsNames.failure]).toHaveLength(1)
-        expect(telemetry.getEventsMap()[eventsNames.failure][0].value).toEqual(1)
       })
     })
 
-    describe('with valid workspace', () => {
-      const workspacePath = 'valid-ws'
-      beforeAll(async () => {
-        telemetry = mocks.getMockTelemetry()
-        cliTelemetry = getCliTelemetry(telemetry, commandName)
-        mockLoadWorkspace.mockResolvedValue({
-          workspace: mocks.mockLoadWorkspace(workspacePath),
-          errored: false,
-        })
+    describe('with valid workspace and no changes', () => {
+      let workspace: mocks.MockWorkspace
+      beforeEach(async () => {
+        workspace = mocks.mockWorkspace({})
         result = await action({
+          ...cliCommandArgs,
           input: {
             force: true,
             interactive: false,
@@ -129,11 +97,7 @@ describe('fetch command', () => {
             services,
             stateOnly: false,
           },
-          cliTelemetry,
-          config,
-          output,
-          spinnerCreator,
-          workspacePath,
+          workspace,
         })
       })
 
@@ -143,17 +107,7 @@ describe('fetch command', () => {
       it('should call fetch', () => {
         expect(fetch).toHaveBeenCalled()
       })
-
-      it('should update changes', () => {
-        const calls = findWsUpdateCalls(workspacePath)
-        expect(calls).toHaveLength(1)
-        expect(_.isEmpty(calls[0][2])).toBeTruthy()
-      })
-
       it('should send telemetry events', () => {
-        expect(telemetry.getEvents()).toHaveLength(3)
-        expect(telemetry.getEventsMap()[eventsNames.start]).toHaveLength(1)
-        expect(telemetry.getEventsMap()[eventsNames.start]).toHaveLength(1)
         expect(telemetry.getEventsMap()[eventsNames.changes]).toHaveLength(1)
       })
     })
@@ -167,29 +121,6 @@ describe('fetch command', () => {
       )
       const mockEmptyApprove = jest.fn().mockResolvedValue([])
       const mockUpdateConfig = jest.fn().mockResolvedValue(true)
-
-      const mockWorkspace = (
-        elements?: Element[],
-        name?: string,
-        existingServices: Record<string, string[]> = { default: [] },
-        currentEnv = 'default'
-      ): Workspace => ({
-        name,
-        hasErrors: () => false,
-        elements: () => (elements || []),
-        services: () => services,
-        updateNaclFiles: jest.fn(),
-        flush: jest.fn(),
-        state: (envName? : string) => ({
-          existingServices: jest.fn().mockResolvedValue(existingServices[envName || currentEnv]),
-        }),
-        getTotalSize: jest.fn().mockResolvedValue(0),
-        isEmpty: () => (elements || []).length === 0,
-        updateServiceConfig: jest.fn(),
-        servicesCredentials: jest.fn().mockResolvedValue({}),
-        envs: () => _.keys(existingServices),
-        currentEnv: () => currentEnv,
-      } as unknown as Workspace)
 
       describe('with emitters called', () => {
         const mockFetchWithEmitter: jest.Mock = jest.fn((
@@ -208,10 +139,8 @@ describe('fetch command', () => {
           )
         })
         beforeEach(async () => {
-          telemetry = mocks.getMockTelemetry()
-          cliTelemetry = getCliTelemetry(telemetry, 'fetch')
           await fetchCommand({
-            workspace: mockWorkspace(),
+            workspace: mocks.mockWorkspace({}),
             force: true,
             interactive: false,
             output,
@@ -237,11 +166,8 @@ describe('fetch command', () => {
       })
       describe('with no upstream changes', () => {
         let workspace: Workspace
-        const workspaceName = 'no-changes'
         beforeEach(async () => {
-          telemetry = mocks.getMockTelemetry()
-          cliTelemetry = getCliTelemetry(telemetry, 'fetch')
-          workspace = mockWorkspace(undefined, workspaceName)
+          workspace = mocks.mockWorkspace({})
           await fetchCommand({
             workspace,
             force: true,
@@ -258,10 +184,7 @@ describe('fetch command', () => {
           })
         })
         it('should not update workspace', () => {
-          const calls = findWsUpdateCalls(workspaceName)
-          expect(calls[0][2]).toHaveLength(0)
-          expect(telemetry.getEvents()).toHaveLength(3)
-          expect(telemetry.getEventsMap()[eventsNames.changes]).not.toBeUndefined()
+          expect(workspace.updateNaclFiles).not.toHaveBeenCalled()
           expect(telemetry.getEventsMap()[eventsNames.changes]).toHaveLength(1)
           expect(telemetry.getEventsMap()[eventsNames.changes][0].value).toEqual(0)
         })
@@ -272,7 +195,6 @@ describe('fetch command', () => {
         let newConfig: InstanceElement
 
         beforeEach(async () => {
-          const workspaceName = 'with-config-changes'
           const { plan, updatedConfig } = mocks.configChangePlan()
           newConfig = updatedConfig
           const mockFetchWithChanges = jest.fn().mockResolvedValue(
@@ -283,9 +205,7 @@ describe('fetch command', () => {
               success: true,
             }
           )
-          telemetry = mocks.getMockTelemetry()
-          cliTelemetry = getCliTelemetry(telemetry, 'fetch')
-          const workspace = mockWorkspace(undefined, workspaceName)
+          const workspace = mocks.mockWorkspace({})
           fetchArgs = {
             workspace,
             force: false,
@@ -328,12 +248,9 @@ describe('fetch command', () => {
           }
         )
         describe('when called with force', () => {
-          const workspaceName = 'with-force'
           let workspace: Workspace
           beforeEach(async () => {
-            telemetry = mocks.getMockTelemetry()
-            cliTelemetry = getCliTelemetry(telemetry, 'fetch')
-            workspace = mockWorkspace(undefined, workspaceName)
+            workspace = mocks.mockWorkspace({})
             result = await fetchCommand({
               workspace,
               force: true,
@@ -351,18 +268,15 @@ describe('fetch command', () => {
             expect(result).toBe(CliExitCode.Success)
           })
           it('should deploy all changes', () => {
-            const calls = findWsUpdateCalls(workspaceName)
-            expect(calls).toHaveLength(1)
-            expect(calls[0].slice(2)).toEqual([changes, 'default'])
+            expect(workspace.updateNaclFiles).toHaveBeenCalledWith(
+              changes.map(change => change.change), 'default',
+            )
           })
         })
         describe('when called with isolated', () => {
-          const workspaceName = 'with-strict'
           let workspace: Workspace
           beforeEach(async () => {
-            telemetry = mocks.getMockTelemetry()
-            cliTelemetry = getCliTelemetry(telemetry, 'fetch')
-            workspace = mockWorkspace(undefined, workspaceName)
+            workspace = mocks.mockWorkspace({})
             result = await fetchCommand({
               workspace,
               force: true,
@@ -380,18 +294,15 @@ describe('fetch command', () => {
             expect(result).toBe(CliExitCode.Success)
           })
           it('should forward strict mode', () => {
-            const calls = findWsUpdateCalls(workspaceName)
-            expect(calls).toHaveLength(1)
-            expect(calls[0].slice(2)).toEqual([changes, 'isolated'])
+            expect(workspace.updateNaclFiles).toHaveBeenCalledWith(
+              changes.map(change => change.change), 'isolated',
+            )
           })
         })
         describe('when called with align', () => {
-          const workspaceName = 'with-align'
           let workspace: Workspace
           beforeEach(async () => {
-            telemetry = mocks.getMockTelemetry()
-            cliTelemetry = getCliTelemetry(telemetry, 'fetch')
-            workspace = mockWorkspace(undefined, workspaceName)
+            workspace = mocks.mockWorkspace({})
             result = await fetchCommand({
               workspace,
               force: true,
@@ -409,18 +320,15 @@ describe('fetch command', () => {
             expect(result).toBe(CliExitCode.Success)
           })
           it('should forward align mode', () => {
-            const calls = findWsUpdateCalls(workspaceName)
-            expect(calls).toHaveLength(1)
-            expect(calls[0].slice(2)).toEqual([changes, 'align'])
+            expect(workspace.updateNaclFiles).toHaveBeenCalledWith(
+              changes.map(change => change.change), 'align',
+            )
           })
         })
         describe('when called with override', () => {
-          const workspaceName = 'with-override'
           let workspace: Workspace
           beforeEach(async () => {
-            telemetry = mocks.getMockTelemetry()
-            cliTelemetry = getCliTelemetry(telemetry, 'fetch')
-            workspace = mockWorkspace(undefined, workspaceName)
+            workspace = mocks.mockWorkspace({})
             result = await fetchCommand({
               workspace,
               force: true,
@@ -438,17 +346,15 @@ describe('fetch command', () => {
             expect(result).toBe(CliExitCode.Success)
           })
           it('should forward override mode', () => {
-            const calls = findWsUpdateCalls(workspaceName)
-            expect(calls).toHaveLength(1)
-            expect(calls[0].slice(2)).toEqual([changes, 'override'])
+            expect(workspace.updateNaclFiles).toHaveBeenCalledWith(
+              changes.map(change => change.change), 'override',
+            )
           })
         })
         describe('when called with state only', () => {
-          const workspaceName = 'with-state-only'
-          let workspace: Workspace
           describe('should error if mode is not default', () => {
             it('should throw an error', () => expect(fetchCommand({
-              workspace,
+              workspace: mocks.mockWorkspace({}),
               force: true,
               interactive: false,
               services,
@@ -463,10 +369,9 @@ describe('fetch command', () => {
             })).rejects.toThrow())
           })
           describe('when state is updated', () => {
-            beforeAll(async () => {
-              telemetry = mocks.getMockTelemetry()
-              cliTelemetry = getCliTelemetry(telemetry, 'fetch')
-              workspace = mockWorkspace(undefined, workspaceName)
+            let workspace: Workspace
+            beforeEach(async () => {
+              workspace = mocks.mockWorkspace({})
               result = await fetchCommand({
                 workspace,
                 force: true,
@@ -486,16 +391,14 @@ describe('fetch command', () => {
               expect(result).toBe(CliExitCode.Success)
             })
             it('should not apply any changes', async () => {
-              const calls = findWsUpdateCalls(workspaceName)
-              expect(calls).toHaveLength(0)
+              expect(workspace.updateNaclFiles).not.toHaveBeenCalled()
             })
           })
           describe('when state failed to update', () => {
-            beforeAll(async () => {
-              mockUpdateStateOnly.mockResolvedValueOnce(false)
-              telemetry = mocks.getMockTelemetry()
-              cliTelemetry = getCliTelemetry(telemetry, 'fetch')
-              workspace = mockWorkspace(undefined, workspaceName)
+            let workspace: mocks.MockWorkspace
+            beforeEach(async () => {
+              workspace = mocks.mockWorkspace({})
+              workspace.flush.mockImplementation(() => { throw new Error('failed to flush') })
               result = await fetchCommand({
                 workspace,
                 force: true,
@@ -515,17 +418,15 @@ describe('fetch command', () => {
               expect(result).toBe(CliExitCode.AppError)
             })
             it('should not apply any changes', async () => {
-              const calls = findWsUpdateCalls(workspaceName)
-              expect(calls).toHaveLength(0)
+              expect(workspace.updateNaclFiles).not.toHaveBeenCalled()
             })
           })
         })
         describe('when initial workspace is empty', () => {
-          const workspaceName = 'ws-empty'
-          const workspace = mockWorkspace(undefined, workspaceName)
+          let workspace: mocks.MockWorkspace
           beforeEach(async () => {
-            telemetry = mocks.getMockTelemetry()
-            cliTelemetry = getCliTelemetry(telemetry, 'fetch')
+            workspace = mocks.mockWorkspace({})
+            workspace.isEmpty.mockResolvedValue(true)
             await fetchCommand({
               workspace,
               force: false,
@@ -542,9 +443,9 @@ describe('fetch command', () => {
             })
           })
           it('should deploy all changes', () => {
-            const calls = findWsUpdateCalls(workspaceName)
-            expect(calls).toHaveLength(1)
-            expect(calls[0].slice(2)).toEqual([changes, 'default'])
+            expect(workspace.updateNaclFiles).toHaveBeenCalledWith(
+              changes.map(change => change.change), 'default',
+            )
           })
         })
         describe('when initial workspace is not empty', () => {
@@ -553,10 +454,7 @@ describe('fetch command', () => {
               Promise.resolve([cs[0]]))
 
             it('should update workspace only with approved changes', async () => {
-              const workspaceName = 'single-approve'
-              const workspace = mockWorkspace(mocks.elements(), workspaceName)
-              telemetry = mocks.getMockTelemetry()
-              cliTelemetry = getCliTelemetry(telemetry, 'fetch')
+              const workspace = mocks.mockWorkspace({})
               await fetchCommand({
                 workspace,
                 force: false,
@@ -571,18 +469,20 @@ describe('fetch command', () => {
                 shouldCalcTotalSize: true,
                 stateOnly: false,
               })
-              const calls = findWsUpdateCalls(workspaceName)
-              expect(calls).toHaveLength(1)
-              expect(calls[0][2][0]).toEqual(changes[0])
+              expect(workspace.updateNaclFiles).toHaveBeenCalledWith([changes[0].change], 'default')
             })
 
             it('should exit if errors identified in workspace after update', async () => {
-              const workspaceName = 'exist-on-error'
-              const workspace = mockWorkspace(mocks.elements(), workspaceName)
-              workspace.errors = async () => mocks.mockErrors([
-                { message: 'BLA Error', severity: 'Error' },
-              ])
-              workspace.hasErrors = () => Promise.resolve(true)
+              const abortIfErrorCallback = jest.spyOn(callbacks, 'shouldAbortWorkspaceInCaseOfValidationError')
+              abortIfErrorCallback.mockResolvedValue(true)
+
+              const workspace = mocks.mockWorkspace({})
+              workspace.updateNaclFiles.mockImplementation(async () => {
+                // Make the workspace errored after updateNaclFiles is called
+                workspace.errors.mockResolvedValue(
+                  mocks.mockErrors([{ severity: 'Error', message: 'BLA Error' }])
+                )
+              })
 
               const res = await fetchCommand({
                 workspace,
@@ -598,18 +498,19 @@ describe('fetch command', () => {
                 shouldCalcTotalSize: true,
                 stateOnly: false,
               })
-              const calls = findWsUpdateCalls(workspaceName)
-              expect(calls).toHaveLength(1)
-              expect(calls[0][2][0]).toEqual(changes[0])
+              expect(workspace.updateNaclFiles).toHaveBeenCalledWith([changes[0].change], 'default')
               expect(res).toBe(CliExitCode.AppError)
+
+              abortIfErrorCallback.mockRestore()
             })
             it('should not exit if warning identified in workspace after update', async () => {
-              const workspaceName = 'warn'
-              const workspace = mockWorkspace(mocks.elements(), workspaceName)
-              workspace.errors = async () => mocks.mockErrors([
-                { message: 'BLA Warning', severity: 'Warning' },
-              ])
-              workspace.hasErrors = () => Promise.resolve(true)
+              const workspace = mocks.mockWorkspace({})
+              workspace.updateNaclFiles.mockImplementation(async () => {
+                // Make the workspace errored after updateNaclFiles is called
+                workspace.errors.mockResolvedValue(
+                  mocks.mockErrors([{ severity: 'Warning', message: 'BLA Error' }])
+                )
+              })
 
               const res = await fetchCommand({
                 workspace,
@@ -625,18 +526,11 @@ describe('fetch command', () => {
                 shouldCalcTotalSize: true,
                 stateOnly: false,
               })
-              const calls = findWsUpdateCalls(workspaceName)
-              expect(calls).toHaveLength(1)
-              expect(calls[0][2][0]).toEqual(changes[0])
-              expect(output.stderr.content).not.toContain(Prompts.SHOULD_CONTINUE(1))
-              expect(output.stdout.content).not.toContain(Prompts.SHOULD_CONTINUE(1))
+              expect(workspace.updateNaclFiles).toHaveBeenCalledWith([changes[0].change], 'default')
               expect(res).toBe(CliExitCode.Success)
             })
             it('should not update workspace if fetch failed', async () => {
-              const workspaceName = 'fail'
-              const workspace = mockWorkspace(mocks.elements(), workspaceName)
-              telemetry = mocks.getMockTelemetry()
-              cliTelemetry = getCliTelemetry(telemetry, 'fetch')
+              const workspace = mocks.mockWorkspace({})
               await fetchCommand({
                 workspace,
                 force: false,
@@ -652,11 +546,7 @@ describe('fetch command', () => {
                 stateOnly: false,
               })
               expect(output.stderr.content).toContain('Error')
-              const calls = findWsUpdateCalls(workspaceName)
-              expect(calls).toHaveLength(0)
-              expect(telemetry.getEventsMap()[eventsNames.failure]).not.toBeUndefined()
-              expect(telemetry.getEventsMap()[eventsNames.failure]).toHaveLength(1)
-              expect(telemetry.getEventsMap()[eventsNames.workspaceSize]).toBeUndefined()
+              expect(workspace.updateNaclFiles).not.toHaveBeenCalled()
             })
           })
         })
@@ -680,9 +570,7 @@ describe('fetch command', () => {
           }
         )
         beforeEach(async () => {
-          telemetry = mocks.getMockTelemetry()
-          cliTelemetry = getCliTelemetry(telemetry, 'fetch')
-          const workspace = mockWorkspace()
+          const workspace = mocks.mockWorkspace({})
           result = await fetchCommand({
             workspace,
             force: true,
@@ -709,15 +597,13 @@ describe('fetch command', () => {
     })
   })
   describe('multienv - new service in env, with existing common elements', () => {
-    const telemetry: mocks.MockTelemetry = mocks.getMockTelemetry()
-    const cliTelemetry = getCliTelemetry(telemetry, commandName)
-    const workspacePath = 'valid-ws'
+    let workspace: mocks.MockWorkspace
     beforeEach(() => {
-      mockLoadWorkspace.mockResolvedValue({
-        workspace: mocks.mockLoadWorkspace(workspacePath, undefined, false, true),
-        errored: false,
-        stateRecencies: [{ serviceName: 'salesforce', status: 'Nonexistent' }],
-      })
+      workspace = mocks.mockWorkspace({})
+      workspace.hasElementsInServices.mockResolvedValue(true)
+      workspace.getStateRecency.mockResolvedValue(
+        { serviceName: 'salesforce', status: 'Nonexistent', date: undefined }
+      )
       jest.spyOn(fetchCmd, 'fetchCommand').mockImplementationOnce(() => Promise.resolve(
         CliExitCode.Success
       ))
@@ -734,6 +620,7 @@ describe('fetch command', () => {
         () => Promise.resolve('no')
       )
       await action({
+        ...cliCommandArgs,
         input: {
           force: false,
           interactive: false,
@@ -741,11 +628,7 @@ describe('fetch command', () => {
           services,
           stateOnly: false,
         },
-        cliTelemetry,
-        config,
-        output,
-        spinnerCreator,
-        workspacePath,
+        workspace,
       })
 
       expect(callbacks.getChangeToAlignAction).toHaveBeenCalledTimes(1)
@@ -758,6 +641,7 @@ describe('fetch command', () => {
       )
 
       await action({
+        ...cliCommandArgs,
         input: {
           force: false,
           interactive: false,
@@ -765,11 +649,7 @@ describe('fetch command', () => {
           services,
           stateOnly: false,
         },
-        cliTelemetry,
-        config: { shouldCalcTotalSize: true },
-        output,
-        spinnerCreator,
-        workspacePath,
+        workspace,
       })
 
       expect(callbacks.getChangeToAlignAction).toHaveBeenCalledTimes(1)
@@ -781,6 +661,7 @@ describe('fetch command', () => {
         () => Promise.resolve('cancel operation')
       )
       await action({
+        ...cliCommandArgs,
         input: {
           force: false,
           interactive: false,
@@ -788,11 +669,7 @@ describe('fetch command', () => {
           services,
           stateOnly: false,
         },
-        cliTelemetry,
-        config,
-        output,
-        spinnerCreator,
-        workspacePath,
+        workspace,
       })
 
       expect(callbacks.getChangeToAlignAction).toHaveBeenCalledTimes(1)
@@ -803,6 +680,7 @@ describe('fetch command', () => {
         () => Promise.resolve('no')
       )
       await action({
+        ...cliCommandArgs,
         input: {
           force: true,
           interactive: false,
@@ -810,11 +688,7 @@ describe('fetch command', () => {
           services,
           stateOnly: false,
         },
-        cliTelemetry,
-        config,
-        output,
-        spinnerCreator,
-        workspacePath,
+        workspace,
       })
 
       expect(callbacks.getChangeToAlignAction).not.toHaveBeenCalled()
@@ -825,12 +699,11 @@ describe('fetch command', () => {
       jest.spyOn(callbacks, 'getChangeToAlignAction').mockImplementationOnce(
         () => Promise.resolve('no')
       )
-      mockLoadWorkspace.mockResolvedValue({
-        workspace: mocks.mockLoadWorkspace(workspacePath, undefined, false, true),
-        errored: false,
-        stateRecencies: [{ serviceName: 'salesforce', status: 'Valid' }],
-      })
+      workspace.getStateRecency.mockResolvedValue(
+        { serviceName: 'salesforce', status: 'Valid', date: new Date() }
+      )
       await action({
+        ...cliCommandArgs,
         input: {
           force: false,
           interactive: false,
@@ -838,11 +711,7 @@ describe('fetch command', () => {
           services,
           stateOnly: false,
         },
-        cliTelemetry,
-        config,
-        output,
-        spinnerCreator,
-        workspacePath,
+        workspace,
       })
 
       expect(callbacks.getChangeToAlignAction).not.toHaveBeenCalled()
@@ -854,6 +723,7 @@ describe('fetch command', () => {
         () => Promise.resolve('no')
       )
       await action({
+        ...cliCommandArgs,
         input: {
           force: false,
           interactive: false,
@@ -861,11 +731,7 @@ describe('fetch command', () => {
           services,
           stateOnly: false,
         },
-        cliTelemetry,
-        config,
-        output,
-        spinnerCreator,
-        workspacePath,
+        workspace,
       })
       expect(callbacks.getChangeToAlignAction).not.toHaveBeenCalled()
       expect(fetchCmd.fetchCommand).toHaveBeenCalledTimes(1)
@@ -875,12 +741,9 @@ describe('fetch command', () => {
       jest.spyOn(callbacks, 'getChangeToAlignAction').mockImplementation(
         () => Promise.resolve('no')
       )
-      mockLoadWorkspace.mockResolvedValue({
-        workspace: mocks.mockLoadWorkspace(workspacePath, undefined, false, false),
-        errored: false,
-        stateRecencies: [{ serviceName: 'salesforce', status: 'Nonexistent' }],
-      })
+      workspace.hasElementsInServices.mockResolvedValue(false)
       await action({
+        ...cliCommandArgs,
         input: {
           force: false,
           interactive: false,
@@ -888,11 +751,7 @@ describe('fetch command', () => {
           services,
           stateOnly: false,
         },
-        cliTelemetry,
-        config,
-        output,
-        spinnerCreator,
-        workspacePath,
+        workspace,
       })
       expect(callbacks.getChangeToAlignAction).not.toHaveBeenCalled()
       expect(fetchCmd.fetchCommand).toHaveBeenCalledTimes(1)
@@ -903,27 +762,20 @@ describe('fetch command', () => {
       jest.spyOn(callbacks, 'getChangeToAlignAction').mockImplementationOnce(
         () => Promise.resolve('no')
       )
-      mockLoadWorkspace.mockResolvedValue({
-        workspace: mocks.mockLoadWorkspace(workspacePath, undefined, false, false),
-        errored: false,
-        stateRecencies: [
-          { serviceName: 'salesforce', status: 'Nonexistent' },
-          { serviceName: 'netsuite', status: 'Valid' },
-        ],
-      })
+      workspace.getStateRecency.mockImplementation(async serviceName => ({
+        serviceName,
+        status: serviceName === 'salesforce' ? 'Nonexistent' : 'Valid',
+        date: serviceName === 'salesforce' ? undefined : new Date(),
+      }))
       await action({
+        ...cliCommandArgs,
         input: {
           force: false,
           interactive: false,
           mode: 'override',
-          services,
           stateOnly: false,
         },
-        cliTelemetry,
-        config,
-        output,
-        spinnerCreator,
-        workspacePath,
+        workspace,
       })
       expect(callbacks.getChangeToAlignAction).not.toHaveBeenCalled()
       expect(fetchCmd.fetchCommand).toHaveBeenCalledTimes(1)
@@ -932,15 +784,10 @@ describe('fetch command', () => {
   })
 
   describe('Verify using env command', () => {
-    const telemetry: mocks.MockTelemetry = mocks.getMockTelemetry()
-    const cliTelemetry = getCliTelemetry(telemetry, commandName)
-    const workspacePath = 'valid-ws'
-    beforeEach(() => {
-      mockLoadWorkspace.mockImplementation(mocks.mockLoadWorkspaceEnvironment)
-      mockLoadWorkspace.mockClear()
-    })
     it('should use current env when env is not provided', async () => {
+      const workspace = mocks.mockWorkspace({})
       await action({
+        ...cliCommandArgs,
         input: {
           force: true,
           interactive: false,
@@ -948,19 +795,14 @@ describe('fetch command', () => {
           services,
           stateOnly: false,
         },
-        cliTelemetry,
-        config,
-        output,
-        spinnerCreator,
-        workspacePath,
+        workspace,
       })
-      expect(mockLoadWorkspace).toHaveBeenCalledTimes(1)
-      expect(mockLoadWorkspace.mock.results[0].value.workspace.currentEnv()).toEqual(
-        mocks.withoutEnvironmentParam
-      )
+      expect(workspace.setCurrentEnv).not.toHaveBeenCalled()
     })
     it('should use provided env', async () => {
+      const workspace = mocks.mockWorkspace({})
       await action({
+        ...cliCommandArgs,
         input: {
           force: true,
           interactive: false,
@@ -969,16 +811,9 @@ describe('fetch command', () => {
           stateOnly: false,
           env: mocks.withEnvironmentParam,
         },
-        cliTelemetry,
-        config,
-        output,
-        spinnerCreator,
-        workspacePath,
+        workspace,
       })
-      expect(mockLoadWorkspace).toHaveBeenCalledTimes(1)
-      expect(mockLoadWorkspace.mock.results[0].value.workspace.currentEnv()).toEqual(
-        mocks.withEnvironmentParam
-      )
+      expect(workspace.setCurrentEnv).toHaveBeenCalledWith(mocks.withEnvironmentParam, false)
     })
   })
 })

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -17,7 +17,7 @@ import { EventEmitter } from 'pietile-eventemitter'
 import { InstanceElement, DetailedChange } from '@salto-io/adapter-api'
 import { fetch, FetchChange, FetchProgressEvents, StepEmitter, FetchFunc } from '@salto-io/core'
 import { Workspace } from '@salto-io/workspace'
-import { CliExitCode, CliTelemetry } from '../../src/types'
+import { CliExitCode, CliTelemetry, CliError } from '../../src/types'
 import * as fetchCmd from '../../src/commands/fetch'
 import { action, fetchCommand, FetchCommandArgs } from '../../src/commands/fetch'
 import * as callbacks from '../../src/callbacks'
@@ -814,6 +814,20 @@ describe('fetch command', () => {
         workspace,
       })
       expect(workspace.setCurrentEnv).toHaveBeenCalledWith(mocks.withEnvironmentParam, false)
+    })
+    it('should fail if provided env does not exist', async () => {
+      await expect(action({
+        ...cliCommandArgs,
+        input: {
+          force: false,
+          interactive: false,
+          mode: 'default',
+          services,
+          stateOnly: false,
+          env: 'envThatDoesNotExist',
+        },
+        workspace: mocks.mockWorkspace({}),
+      })).rejects.toThrow(new CliError(CliExitCode.AppError))
     })
   })
 })

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -25,15 +25,28 @@ import {
   Plan, PlanItem, EVENT_TYPES, DeployResult,
   telemetrySender, Telemetry, Tags, TelemetryEvent, CommandConfig,
 } from '@salto-io/core'
-import { Workspace, errors as wsErrors } from '@salto-io/workspace'
-import * as workspace from '../src/workspace/workspace'
+import { Workspace, errors as wsErrors, state as wsState, pathIndex, parser } from '@salto-io/workspace'
 import realCli from '../src/cli'
 import commandDefinitions from '../src/commands/index'
-import { CommandOrGroupDef } from '../src/command_builder'
-import { Spinner, SpinnerCreator, CliOutput } from '../src/types'
+import { CommandOrGroupDef, CommandArgs } from '../src/command_builder'
+import { Spinner, SpinnerCreator } from '../src/types'
+import { getCliTelemetry } from '../src/telemetry'
 
-export const mockFunction = <T extends (...args: never[]) => unknown>():
-  jest.Mock<ReturnType<T>, Parameters<T>> => jest.fn()
+export type MockFunction<T extends (...args: never[]) => unknown> =
+  jest.Mock<ReturnType<T>, Parameters<T>>
+
+export type SpiedFunction<T extends (...args: never[]) => unknown> =
+  jest.SpyInstance<ReturnType<T>, Parameters<T>>
+
+export type MockInterface<T extends {}> = {
+  [k in keyof T]: T[k] extends (...args: never[]) => unknown
+    ? MockFunction<T[k]>
+    : MockInterface<T[k]>
+}
+
+export const mockFunction = <T extends (...args: never[]) => unknown>(): MockFunction<T> => (
+  jest.fn()
+)
 
 export interface MockWriteStreamOpts { isTTY?: boolean; hasColors?: boolean }
 
@@ -50,8 +63,9 @@ export class MockWriteStream {
   write(s: string): void { this.content += s }
 }
 
-export type MockWritableStream = NodeJS.WritableStream & {
-  contents(): string
+export type MockCliOutput = {
+  stdout: MockWriteStream
+  stderr: MockWriteStream
 }
 
 export const mockSpinnerCreator = (spinners: Spinner[]): SpinnerCreator => jest.fn(() => {
@@ -63,7 +77,7 @@ export const mockSpinnerCreator = (spinners: Spinner[]): SpinnerCreator => jest.
   return result
 })
 
-export interface MockCliOutput {
+export interface MockCliReturn {
   err: string
   out: string
   exitCode: number
@@ -106,6 +120,30 @@ const getMockCommandConfig = (): CommandConfig => ({
   shouldCalcTotalSize: true,
 })
 
+export type MockCliArgs = {
+  telemetry: MockTelemetry
+  config: CommandConfig
+  output: MockCliOutput
+  spinnerCreator: SpinnerCreator
+}
+export const mockCliArgs = (): MockCliArgs => ({
+  telemetry: getMockTelemetry(),
+  config: getMockCommandConfig(),
+  output: { stdout: new MockWriteStream(), stderr: new MockWriteStream() },
+  spinnerCreator: mockSpinnerCreator([]),
+})
+
+export type MockCommandArgs = Omit<CommandArgs, 'workspacePath'>
+export const mockCliCommandArgs = (commandName: string, cliArgs?: MockCliArgs): MockCommandArgs => {
+  const { telemetry, config, output, spinnerCreator } = cliArgs ?? mockCliArgs()
+  return {
+    cliTelemetry: getCliTelemetry(telemetry, commandName),
+    config,
+    output,
+    spinnerCreator,
+  }
+}
+
 export const cli = async ({
   commandDefs = commandDefinitions,
   args = [],
@@ -116,7 +154,7 @@ export const cli = async ({
   args?: string[]
   out?: MockWriteStreamOpts
   err?: MockWriteStreamOpts
-} = {}): Promise<MockCliOutput> => {
+} = {}): Promise<MockCliReturn> => {
   const input = {
     args,
     stdin: {},
@@ -131,17 +169,7 @@ export const cli = async ({
   const spinners: Spinner[] = []
   const spinnerCreator = mockSpinnerCreator(spinners)
 
-  const config = { installationID: 'installationID',
-    telemetry: {
-      url: 'url',
-      token: 'token',
-      enabled: false,
-    },
-    command: {
-      shouldCalcTotalSize: false,
-    } }
-
-  const exitCode = await realCli({ input, output, commandDefs, spinnerCreator, config })
+  const exitCode = await realCli({ input, output, commandDefs, spinnerCreator, workspacePath: '.' })
 
   return { err: output.stderr.content, out: output.stdout.content, exitCode }
 }
@@ -234,82 +262,86 @@ export const mockErrors = (errors: SaltoError[]): wsErrors.Errors => ({
   strings: () => errors.map(err => err.message),
 })
 
-export const mockLoadWorkspace = (
-  name: string,
-  envs = ['active', 'inactive'],
-  isEmpty = false,
-  hasElementsInServices = true,
-  services = ['salesforce', 'hubspot']
-): Workspace =>
-  ({
-    uid: '123',
-    name,
-    currentEnv: () => 'active',
-    envs: () => envs,
-    services: () => services,
-    elements: jest.fn().mockResolvedValue([] as ReadonlyArray<Element>),
-    hasErrors: () => jest.fn().mockResolvedValue(false),
-    errors: () => jest.fn().mockResolvedValue(mockErrors([])),
-    isEmpty: jest.fn().mockResolvedValue(isEmpty),
-    hasElementsInServices: jest.fn().mockResolvedValue(hasElementsInServices),
-    getElementIdsBySelectors: jest.fn(),
-    getTotalSize: jest.fn().mockResolvedValue(0),
-    addEnvironment: jest.fn(),
-    deleteEnvironment: jest.fn(),
-    renameEnvironment: jest.fn(),
-    setCurrentEnv: jest.fn().mockReturnValue('active'),
-    transformToWorkspaceError: () => ({
-      sourceFragments: [],
-      message: 'Error',
-      severity: 'Error',
-    }),
-    state: jest.fn().mockImplementation(() => ({
-      existingServices: jest.fn().mockResolvedValue(services),
-    })),
-    fetchedServices: jest.fn().mockResolvedValue([]),
-    promote: jest.fn().mockResolvedValue(undefined),
-    demote: jest.fn().mockResolvedValue(undefined),
-    demoteAll: jest.fn().mockResolvedValue(undefined),
-    copyTo: jest.fn().mockResolvedValue(undefined),
-    flush: jest.fn().mockResolvedValue(undefined),
-    updateNaclFiles: mockFunction<Workspace['updateNaclFiles']>(),
-    clear: jest.fn().mockResolvedValue(undefined),
-    updateServiceConfig: jest.fn().mockResolvedValue(undefined),
-    hasElementsInEnv: jest.fn().mockResolvedValue(false),
-  } as unknown as Workspace)
+// Mock interface does not handle template functions well
+export type MockWorkspace = MockInterface<Omit<Workspace, 'transformToWorkspaceError'>>
+  & Pick<Workspace, 'transformToWorkspaceError'>
 
 export const withoutEnvironmentParam = 'active'
 export const withEnvironmentParam = 'inactive'
 
-export const mockLoadWorkspaceEnvironment = (
-  baseDir: string,
-  _cliOutput: CliOutput,
-  { sessionEnv = withoutEnvironmentParam }: Partial<workspace.LoadWorkspaceOptions>
-): workspace.LoadWorkspaceResult => {
-  if (baseDir === 'errorDir') {
-    return {
-      workspace: ({}) as unknown as Workspace,
-      errored: true,
-      stateRecencies: [],
-    }
-  }
-  if (sessionEnv === withEnvironmentParam) {
-    return {
-      workspace: {
-        ...mockLoadWorkspace(baseDir),
-        currentEnv: () => withEnvironmentParam,
-      },
-      errored: false,
-      stateRecencies: [],
-    }
-  }
+type MockWorkspaceArgs = {
+  uid?: string
+  name?: string
+  envs?: string[]
+  services?: string[]
+}
+export const mockWorkspace = ({
+  uid = '123',
+  name = '',
+  envs = ['active', 'inactive'],
+  services = ['salesforce', 'hubspot'],
+}: MockWorkspaceArgs): MockWorkspace => {
+  const state = wsState.buildInMemState(
+    async () => ({
+      elements: {},
+      pathIndex: new pathIndex.PathIndex(),
+      servicesUpdateDate: {},
+    })
+  )
   return {
-    workspace: {
-      ...mockLoadWorkspace(baseDir),
-      currentEnv: () => withoutEnvironmentParam,
-    },
-    errored: false,
-    stateRecencies: [],
+    uid,
+    name,
+    elements: mockFunction<Workspace['elements']>().mockResolvedValue(elements()),
+    state: mockFunction<Workspace['state']>().mockReturnValue(state),
+    envs: mockFunction<Workspace['envs']>().mockReturnValue(envs),
+    currentEnv: mockFunction<Workspace['currentEnv']>().mockReturnValue(envs[0]),
+    services: mockFunction<Workspace['services']>().mockReturnValue(services),
+    servicesCredentials: mockFunction<Workspace['servicesCredentials']>().mockResolvedValue({}),
+    servicesConfig: mockFunction<Workspace['servicesConfig']>().mockResolvedValue({}),
+    isEmpty: mockFunction<Workspace['isEmpty']>().mockResolvedValue(false),
+    hasElementsInServices: mockFunction<Workspace['hasElementsInServices']>().mockResolvedValue(true),
+    hasElementsInEnv: mockFunction<Workspace['hasElementsInEnv']>().mockResolvedValue(false),
+    getSourceFragment: mockFunction<Workspace['getSourceFragment']>().mockImplementation(
+      async sourceRange => ({ sourceRange, fragment: '' })
+    ),
+    hasErrors: mockFunction<Workspace['hasErrors']>().mockResolvedValue(false),
+    errors: mockFunction<Workspace['errors']>().mockResolvedValue(mockErrors([])),
+    transformToWorkspaceError: mockFunction<Workspace['transformToWorkspaceError']>().mockImplementation(
+      async error => ({ ...error, sourceFragments: [] })
+    ) as Workspace['transformToWorkspaceError'],
+    transformError: mockFunction<Workspace['transformError']>().mockImplementation(
+      async error => ({ ...error, sourceFragments: [] })
+    ),
+    updateNaclFiles: mockFunction<Workspace['updateNaclFiles']>(),
+    listNaclFiles: mockFunction<Workspace['listNaclFiles']>().mockResolvedValue([]),
+    getTotalSize: mockFunction<Workspace['getTotalSize']>().mockResolvedValue(0),
+    getNaclFile: mockFunction<Workspace['getNaclFile']>(),
+    setNaclFiles: mockFunction<Workspace['setNaclFiles']>(),
+    removeNaclFiles: mockFunction<Workspace['removeNaclFiles']>(),
+    getSourceMap: mockFunction<Workspace['getSourceMap']>().mockResolvedValue(new parser.SourceMap()),
+    getSourceRanges: mockFunction<Workspace['getSourceRanges']>().mockResolvedValue([]),
+    getElementReferencedFiles: mockFunction<Workspace['getElementReferencedFiles']>().mockResolvedValue([]),
+    getElementNaclFiles: mockFunction<Workspace['getElementNaclFiles']>().mockResolvedValue([]),
+    getElementIdsBySelectors: mockFunction<Workspace['getElementIdsBySelectors']>().mockResolvedValue([]),
+    getParsedNaclFile: mockFunction<Workspace['getParsedNaclFile']>(),
+    flush: mockFunction<Workspace['flush']>(),
+    clone: mockFunction<Workspace['clone']>(),
+    clear: mockFunction<Workspace['clear']>(),
+    addService: mockFunction<Workspace['addService']>(),
+    addEnvironment: mockFunction<Workspace['addEnvironment']>(),
+    deleteEnvironment: mockFunction<Workspace['deleteEnvironment']>(),
+    renameEnvironment: mockFunction<Workspace['renameEnvironment']>(),
+    setCurrentEnv: mockFunction<Workspace['setCurrentEnv']>(),
+    updateServiceCredentials: mockFunction<Workspace['updateServiceCredentials']>(),
+    updateServiceConfig: mockFunction<Workspace['updateServiceConfig']>(),
+    getStateRecency: mockFunction<Workspace['getStateRecency']>().mockImplementation(
+      async serviceName => ({ serviceName, status: 'Nonexistent', date: undefined })
+    ),
+    promote: mockFunction<Workspace['promote']>(),
+    demote: mockFunction<Workspace['demote']>(),
+    demoteAll: mockFunction<Workspace['demoteAll']>(),
+    copyTo: mockFunction<Workspace['copyTo']>(),
+    getValue: mockFunction<Workspace['getValue']>(),
   }
 }
 
@@ -569,10 +601,3 @@ export const deploy = async (
     errors: [],
   }
 }
-
-export const createMockEnvNameGetter = (
-  newEnvName = 'default'
-): (
-) => Promise<string> => (
-  () => Promise.resolve(newEnvName)
-)

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -31,6 +31,7 @@ import commandDefinitions from '../src/commands/index'
 import { CommandOrGroupDef, CommandArgs } from '../src/command_builder'
 import { Spinner, SpinnerCreator } from '../src/types'
 import { getCliTelemetry } from '../src/telemetry'
+import { version as currentVersion } from '../src/generated/version.json'
 
 export type MockFunction<T extends (...args: never[]) => unknown> =
   jest.Mock<ReturnType<T>, Parameters<T>>
@@ -286,6 +287,7 @@ export const mockWorkspace = ({
       elements: {},
       pathIndex: new pathIndex.PathIndex(),
       servicesUpdateDate: {},
+      saltoVersion: currentVersion,
     })
   )
   return {


### PR DESCRIPTION
- added createWorkspaceCommand to extract code that is common to most CLI commands
- moved config override support into the common code so it applies to all commands

---
_Release Notes_
- Extend support of `--config/-C` flag to all CLI commands (except `salto init`)