### PR TITLE
SALTO-1138 - end invalid parser tokens on newline

### DIFF
--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -60,7 +60,7 @@ export const rules: Record<string, moo.Rules> = {
     [TOKEN_TYPES.COMMENT]: /\/\//,
     [TOKEN_TYPES.WHITESPACE]: { match: /[ \t]+/ },
     [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true },
-    [TOKEN_TYPES.INVALID]: { match: /[^ ]+/, error: true },
+    [TOKEN_TYPES.INVALID]: { match: /[^ \n]+/, error: true },
   },
   string: {
     [TOKEN_TYPES.REFERENCE]: { match: /\$\{[ \t]*[\d\w.]+[ \t]*\}/, value: s => s.slice(2, -1).trim() },

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -53,12 +53,12 @@ each([true, false]).describe('Salto parser', (useLegacyParser: boolean) => {
       }
       // comment between top level blocks
       type salesforce.obj {
-        // comments inside a block
+        // comments inside a block with invalid ending characters ?
         salesforce.number num {}
       }
 
       type salesforce.test {
-        salesforce.string name { // comment after block def line end
+        salesforce.string name { // comment after block def line end with questionmark?
           // comment inside a field
           label = "Name"
           _required = true //comment after attribute


### PR DESCRIPTION
Invalid tokens in comments should not continue to the next line - that can cause it to treat valid tokens in that line as invalid.
(the breakage was in https://github.com/salto-io/salto/blob/master/packages/workspace/src/parser/internal/native/lexer.ts#L117)

---

_Release notes_
Fix handling of comments ending in unexpected characters