### PR TITLE
SALTO-786: add open element command

### DIFF
--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -351,13 +351,11 @@ type OpenActionArgs = {
 const isServiceDefined = (workspace: Workspace, serviceName: string): boolean =>
   workspace.services().includes(serviceName)
 
-const isValidElementId = (maybeElementIdPath: string):
-  boolean => {
+const safeGetElementId = (maybeElementIdPath: string): ElemID | undefined => {
   try {
-    ElemID.fromFullName(maybeElementIdPath)
-    return true
+    return ElemID.fromFullName(maybeElementIdPath)
   } catch (e) {
-    return false
+    return undefined
   }
 }
 type NoElementsFound = {
@@ -427,10 +425,10 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
     return reportAppError()
   }
   const envName = env || workspace.currentEnv()
-  if (!isValidElementId(elementId)) {
+  const elemId = safeGetElementId(elementId)
+  if (elemId === undefined) {
     return reportUserError(Prompts.NO_MATCHES_FOUND_FOR_ELEMENT(elementId))
   }
-  const elemId = ElemID.fromFullName(elementId)
   const serviceName = elemId.adapter
   if (!isServiceDefined(workspace, serviceName)) {
     return reportUserError(Prompts.SERVICE_IS_NOT_CONFIGURED_FOR_ENV(serviceName, envName))

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -22,7 +22,7 @@ import { logger } from '@salto-io/logging'
 import { createCommandGroupDef, createPublicCommandDef, CommandDefAction } from '../command_builder'
 import { CliOutput, CliExitCode, CliTelemetry } from '../types'
 import { errorOutputLine, outputLine } from '../outputer'
-import { formatTargetEnvRequired, formatUnknownTargetEnv, formatInvalidEnvTargetCurrent, formatCloneToEnvFailed, formatInvalidFilters, formatMoveFailed, emptyLine, formatListUnresolvedFound, formatListUnresolvedMissing, formatElementListUnresolvedFailed, formatServiceNotConfigured } from '../formatter'
+import { formatTargetEnvRequired, formatUnknownTargetEnv, formatInvalidEnvTargetCurrent, formatCloneToEnvFailed, formatInvalidFilters, formatMoveFailed, emptyLine, formatListUnresolvedFound, formatListUnresolvedMissing, formatElementListUnresolvedFailed } from '../formatter'
 import { loadWorkspace, getWorkspaceTelemetryTags } from '../workspace/workspace'
 import Prompts from '../prompts'
 import { EnvArg, ENVIRONMENT_OPTION } from './common/env'
@@ -348,9 +348,6 @@ type OpenActionArgs = {
   elementId: string
 } & EnvArg
 
-const isServiceDefined = (workspace: Workspace, serviceName: string): boolean =>
-  workspace.services().includes(serviceName)
-
 const safeGetElementId = (maybeElementIdPath: string): ElemID | undefined => {
   try {
     return ElemID.fromFullName(maybeElementIdPath)
@@ -377,13 +374,6 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
   const elemId = safeGetElementId(elementId)
   if (elemId === undefined) {
     errorOutputLine(Prompts.NO_MATCHES_FOUND_FOR_ELEMENT(elementId), output)
-    cliTelemetry.failure(workspaceTags)
-    return CliExitCode.UserInputError
-  }
-
-  const serviceName = elemId.adapter
-  if (!isServiceDefined(workspace, serviceName)) {
-    errorOutputLine(formatServiceNotConfigured(serviceName), output)
     cliTelemetry.failure(workspaceTags)
     return CliExitCode.UserInputError
   }

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -359,12 +359,14 @@ const safeGetElementId = (maybeElementIdPath: string): ElemID | undefined => {
   }
 }
 
-export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliTelemetry, output, workspacePath = '.' }): Promise<CliExitCode> => {
+export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliTelemetry, spinnerCreator, output, workspacePath = '.' }): Promise<CliExitCode> => {
   log.debug('running element open command on \'%s\' %o', workspacePath, input)
   const getServiceUrlAnnotation = (element: Element): string|undefined =>
     _.get(element, ['annotations', CORE_ANNOTATIONS.SERVICE_URL])
-  const { elementId } = input
-  const { errored, workspace } = await loadWorkspace(workspacePath, output)
+  const { elementId, env } = input
+  const { errored, workspace } = await loadWorkspace(workspacePath, output, {
+    spinnerCreator, sessionEnv: env,
+  })
   const workspaceTags = await getWorkspaceTelemetryTags(workspace)
 
   const reportUserError = (error: string): CliExitCode => {

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -22,7 +22,7 @@ import { logger } from '@salto-io/logging'
 import { createCommandGroupDef, createPublicCommandDef, CommandDefAction } from '../command_builder'
 import { CliOutput, CliExitCode, CliTelemetry } from '../types'
 import { errorOutputLine, outputLine } from '../outputer'
-import { formatTargetEnvRequired, formatUnknownTargetEnv, formatInvalidEnvTargetCurrent, formatCloneToEnvFailed, formatInvalidFilters, formatMoveFailed, emptyLine, formatListUnresolvedFound, formatListUnresolvedMissing, formatElementListUnresolvedFailed } from '../formatter'
+import { formatTargetEnvRequired, formatUnknownTargetEnv, formatInvalidEnvTargetCurrent, formatCloneToEnvFailed, formatInvalidFilters, formatMoveFailed, emptyLine, formatListUnresolvedFound, formatListUnresolvedMissing, formatElementListUnresolvedFailed, formatServiceNotConfigured } from '../formatter'
 import { loadWorkspace, getWorkspaceTelemetryTags } from '../workspace/workspace'
 import Prompts from '../prompts'
 import { EnvArg, ENVIRONMENT_OPTION } from './common/env'
@@ -363,7 +363,7 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
   log.debug('running element open command on \'%s\' %o', workspacePath, input)
   const getServiceUrlAnnotation = (element: Element): string|undefined =>
     _.get(element, ['annotations', CORE_ANNOTATIONS.SERVICE_URL])
-  const { elementId, env } = input
+  const { elementId } = input
   const { errored, workspace } = await loadWorkspace(workspacePath, output)
   const workspaceTags = await getWorkspaceTelemetryTags(workspace)
 
@@ -384,14 +384,13 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
   if (errored) {
     return reportAppError()
   }
-  const envName = env || workspace.currentEnv()
   const elemId = safeGetElementId(elementId)
   if (elemId === undefined) {
     return reportUserError(Prompts.NO_MATCHES_FOUND_FOR_ELEMENT(elementId))
   }
   const serviceName = elemId.adapter
   if (!isServiceDefined(workspace, serviceName)) {
-    return reportUserError(Prompts.SERVICE_IS_NOT_CONFIGURED_FOR_ENV(serviceName, envName))
+    return reportUserError(formatServiceNotConfigured(serviceName))
   }
   const elementValue = await workspace.getValue(elemId)
   const maybeServiceUrl = getServiceUrlAnnotation(elementValue)

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -452,7 +452,7 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
 const elementOpenDef = createPublicCommandDef({
   properties: {
     name: 'open',
-    description: 'Opens a logged-in session of the element UI',
+    description: 'Opens the service page of an element',
     keyedOptions: [
       ENVIRONMENT_OPTION,
     ],
@@ -460,7 +460,7 @@ const elementOpenDef = createPublicCommandDef({
       {
         name: 'elementId',
         type: 'string',
-        description: 'an ElementId',
+        description: 'an Element ID',
         required: true,
       },
     ],

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -378,13 +378,14 @@ type ElementUrl = {
 type FindServiceUrlResponse = NoElementsFound | ElementUrl
 
 const getServiceUrlAnnotation = (element: Element):
-  string|undefined => element.annotations[CORE_ANNOTATIONS.SERVICE_URL]
+  string|undefined => _.get(element, ['annotations', CORE_ANNOTATIONS.SERVICE_URL])
 
 const findServiceUrlAnnotation = async (elementId: ElemID, workspace: Workspace):
   Promise<FindServiceUrlResponse> => {
   const elementValue = await workspace.getValue(elementId)
-  if (elementValue && isField(elementValue)) {
-    return { type: 'ElementUrlFound', url: getServiceUrlAnnotation(elementValue) }
+  const maybeServiceUrl = getServiceUrlAnnotation(elementValue)
+  if (isField(elementValue) && maybeServiceUrl) {
+    return { type: 'ElementUrlFound', url: maybeServiceUrl }
   }
   const parentElement = await workspace.getValue(elementId.createTopLevelParentID().parent)
   if (!isElement(parentElement)) {

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -358,19 +358,21 @@ const safeGetElementId = (maybeElementIdPath: string): ElemID | undefined => {
     return undefined
   }
 }
-const getServiceUrlAnnotation = (element: Element):
-  string|undefined => _.get(element, ['annotations', CORE_ANNOTATIONS.SERVICE_URL])
 
 export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliTelemetry, output, workspacePath = '.' }): Promise<CliExitCode> => {
   log.debug('running element open command on \'%s\' %o', workspacePath, input)
+  const getServiceUrlAnnotation = (element: Element): string|undefined =>
+    _.get(element, ['annotations', CORE_ANNOTATIONS.SERVICE_URL])
   const { elementId, env } = input
   const { errored, workspace } = await loadWorkspace(workspacePath, output)
   const workspaceTags = await getWorkspaceTelemetryTags(workspace)
+
   const reportUserError = (error: string): CliExitCode => {
     errorOutputLine(error, output)
     cliTelemetry.failure(workspaceTags)
     return CliExitCode.UserInputError
   }
+
   const reportAppError = (error?: string): CliExitCode => {
     if (error) {
       errorOutputLine(error, output)
@@ -378,6 +380,7 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
     cliTelemetry.failure(workspaceTags)
     return CliExitCode.AppError
   }
+
   if (errored) {
     return reportAppError()
   }

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import open from 'open'
 import { listUnresolvedReferences, Tags } from '@salto-io/core'
-import { CORE_ANNOTATIONS, isElement, Element, ElemID, isField } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, isElement, Element, ElemID } from '@salto-io/adapter-api'
 import { Workspace, ElementSelector, createElementSelectors } from '@salto-io/workspace'
 import { logger } from '@salto-io/logging'
 import { createCommandGroupDef, createPublicCommandDef, CommandDefAction } from '../command_builder'
@@ -379,29 +379,20 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
   }
 
   const element = await workspace.getValue(elemId)
-  const serviceUrl = getServiceUrlAnnotation(element)
-  if (isField(element) && serviceUrl !== undefined) {
-    await open(serviceUrl)
-    cliTelemetry.success(workspaceTags)
-    return CliExitCode.Success
-  }
-
-  const parentElement = await workspace.getValue(elemId.createTopLevelParentID().parent)
-
-  if (!isElement(parentElement)) {
+  if (!isElement(element)) {
     errorOutputLine(Prompts.NO_MATCHES_FOUND_FOR_ELEMENT(elementId), output)
     cliTelemetry.failure(workspaceTags)
     return CliExitCode.UserInputError
   }
+  const serviceUrl = getServiceUrlAnnotation(element)
 
-  const parentServiceUrl = getServiceUrlAnnotation(parentElement)
-  if (parentServiceUrl === undefined) {
+  if (serviceUrl === undefined) {
     errorOutputLine(Prompts.GO_TO_SERVICE_NOT_SUPPORTED_FOR_ELEMENT(elementId), output)
     cliTelemetry.failure(workspaceTags)
     return CliExitCode.AppError
   }
 
-  await open(parentServiceUrl)
+  await open(serviceUrl)
   cliTelemetry.success(workspaceTags)
   return CliExitCode.Success
 }

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -396,7 +396,7 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
   }
   const elementValue = await workspace.getValue(elemId)
   const maybeServiceUrl = getServiceUrlAnnotation(elementValue)
-  if (isField(elementValue) && maybeServiceUrl) {
+  if (isField(elementValue) && maybeServiceUrl !== undefined) {
     await open(maybeServiceUrl)
     cliTelemetry.success(workspaceTags)
     return CliExitCode.Success
@@ -407,7 +407,7 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
     return reportUserError(Prompts.NO_MATCHES_FOUND_FOR_ELEMENT(elementId))
   }
   const url = getServiceUrlAnnotation(parentElement)
-  if (!url) {
+  if (url === undefined) {
     return reportAppError(Prompts.GO_TO_SERVICE_NOT_SUPPORTED_FOR_ELEMENT(elementId))
   }
   await open(url)

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -394,10 +394,10 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
   if (!isServiceDefined(workspace, serviceName)) {
     return reportUserError(formatServiceNotConfigured(serviceName))
   }
-  const elementValue = await workspace.getValue(elemId)
-  const maybeServiceUrl = getServiceUrlAnnotation(elementValue)
-  if (isField(elementValue) && maybeServiceUrl !== undefined) {
-    await open(maybeServiceUrl)
+  const element = await workspace.getValue(elemId)
+  const serviceUrl = getServiceUrlAnnotation(element)
+  if (isField(element) && serviceUrl !== undefined) {
+    await open(serviceUrl)
     cliTelemetry.success(workspaceTags)
     return CliExitCode.Success
   }
@@ -406,11 +406,11 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
   if (!isElement(parentElement)) {
     return reportUserError(Prompts.NO_MATCHES_FOUND_FOR_ELEMENT(elementId))
   }
-  const url = getServiceUrlAnnotation(parentElement)
-  if (url === undefined) {
+  const parentServiceUrl = getServiceUrlAnnotation(parentElement)
+  if (parentServiceUrl === undefined) {
     return reportAppError(Prompts.GO_TO_SERVICE_NOT_SUPPORTED_FOR_ELEMENT(elementId))
   }
-  await open(url)
+  await open(parentServiceUrl)
   cliTelemetry.success(workspaceTags)
   return CliExitCode.Success
 }

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -386,14 +386,17 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
   if (errored) {
     return reportAppError()
   }
+
   const elemId = safeGetElementId(elementId)
   if (elemId === undefined) {
     return reportUserError(Prompts.NO_MATCHES_FOUND_FOR_ELEMENT(elementId))
   }
+
   const serviceName = elemId.adapter
   if (!isServiceDefined(workspace, serviceName)) {
     return reportUserError(formatServiceNotConfigured(serviceName))
   }
+
   const element = await workspace.getValue(elemId)
   const serviceUrl = getServiceUrlAnnotation(element)
   if (isField(element) && serviceUrl !== undefined) {
@@ -401,15 +404,18 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
     cliTelemetry.success(workspaceTags)
     return CliExitCode.Success
   }
+
   const parentElement = await workspace.getValue(elemId.createTopLevelParentID().parent)
 
   if (!isElement(parentElement)) {
     return reportUserError(Prompts.NO_MATCHES_FOUND_FOR_ELEMENT(elementId))
   }
+
   const parentServiceUrl = getServiceUrlAnnotation(parentElement)
   if (parentServiceUrl === undefined) {
     return reportAppError(Prompts.GO_TO_SERVICE_NOT_SUPPORTED_FOR_ELEMENT(elementId))
   }
+
   await open(parentServiceUrl)
   cliTelemetry.success(workspaceTags)
   return CliExitCode.Success

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import open from 'open'
-import { getLoginStatuses, listUnresolvedReferences, LoginStatus, Tags } from '@salto-io/core'
+import { listUnresolvedReferences, Tags } from '@salto-io/core'
 import { CORE_ANNOTATIONS, isElement, Element, ElemID, isField } from '@salto-io/adapter-api'
 import { Workspace, ElementSelector, createElementSelectors } from '@salto-io/workspace'
 import { logger } from '@salto-io/logging'
@@ -351,14 +351,6 @@ type OpenActionArgs = {
 const isServiceDefined = (workspace: Workspace, serviceName: string): boolean =>
   workspace.services().includes(serviceName)
 
-const isServiceLoggedIn = async (workspace: Workspace, serviceName: string): Promise<boolean> => {
-  const serviceLoginStatus = (await getLoginStatuses(
-    workspace,
-    [serviceName]
-  ))[serviceName] as LoginStatus
-  return serviceLoginStatus.isLoggedIn
-}
-
 const isValidElementId = (maybeElementIdPath: string):
   boolean => {
   try {
@@ -442,9 +434,6 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
   const serviceName = elemId.adapter
   if (!isServiceDefined(workspace, serviceName)) {
     return reportUserError(Prompts.SERVICE_IS_NOT_CONFIGURED_FOR_ENV(serviceName, envName))
-  }
-  if (!await isServiceLoggedIn(workspace, serviceName)) {
-    return reportUserError(Prompts.SERVICE_IS_NOT_LOGGED_IN(serviceName, envName))
   }
   const response = await findServiceUrlAnnotation(elemId, workspace)
   return processFindServiceUrlResponse(response)

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -402,6 +402,7 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
     return CliExitCode.Success
   }
   const parentElement = await workspace.getValue(elemId.createTopLevelParentID().parent)
+
   if (!isElement(parentElement)) {
     return reportUserError(Prompts.NO_MATCHES_FOUND_FOR_ELEMENT(elementId))
   }

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -384,6 +384,7 @@ export const openAction: CommandDefAction<OpenActionArgs> = async ({ input, cliT
     cliTelemetry.failure(workspaceTags)
     return CliExitCode.UserInputError
   }
+
   const serviceUrl = getServiceUrlAnnotation(element)
 
   if (serviceUrl === undefined) {

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -283,4 +283,16 @@ ${Prompts.SERVICE_ADD_HELP}`
   public static readonly CLEAN_FAILED = (
     err: string
   ): string => `Error encountered while cleaning the workspace: ${err}.`
+
+  public static readonly SERVICE_IS_NOT_CONFIGURED_FOR_ENV =
+    (serviceName: string, env: string): string => `Service ${serviceName} is not configured for env ${env}. Use 'salto service add <service-name>'`
+
+  public static readonly SERVICE_IS_NOT_LOGGED_IN =
+    (serviceName: string, env: string): string => `Service ${serviceName} in env ${env} is not logged. Please run 'salto service login'`
+
+  public static readonly NO_MATCHES_FOUND_FOR_ELEMENT =
+    (elementId: string): string => `Did not find any matches for element ${elementId}`
+
+  public static readonly GO_TO_SERVICE_NOT_SUPPORTED_FOR_ELEMENT =
+    (elementId: string): string => `Go to service is not supported for element ${elementId}`
 }

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -284,9 +284,6 @@ ${Prompts.SERVICE_ADD_HELP}`
     err: string
   ): string => `Error encountered while cleaning the workspace: ${err}.`
 
-  public static readonly SERVICE_IS_NOT_CONFIGURED_FOR_ENV =
-    (serviceName: string, env: string): string => `Service ${serviceName} is not configured for env ${env}. Use 'salto service add <service-name>'`
-
   public static readonly NO_MATCHES_FOUND_FOR_ELEMENT =
     (elementId: string): string => `Did not find any matches for element ${elementId}`
 

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -287,9 +287,6 @@ ${Prompts.SERVICE_ADD_HELP}`
   public static readonly SERVICE_IS_NOT_CONFIGURED_FOR_ENV =
     (serviceName: string, env: string): string => `Service ${serviceName} is not configured for env ${env}. Use 'salto service add <service-name>'`
 
-  public static readonly SERVICE_IS_NOT_LOGGED_IN =
-    (serviceName: string, env: string): string => `Service ${serviceName} in env ${env} is not logged. Please run 'salto service login'`
-
   public static readonly NO_MATCHES_FOUND_FOR_ELEMENT =
     (elementId: string): string => `Did not find any matches for element ${elementId}`
 

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -1078,7 +1078,7 @@ describe('Element command group', () => {
         cliTelemetry,
         config,
       })
-      expect(output.stderr.content).toContain('Service nonExistingServiceName is not configured for env env1. Use \'salto service add <service-name>\'')
+      expect(output.stderr.content).toContain('nonExistingServiceName is not configured in this environment')
       expect(openActionResult).toEqual(CliExitCode.UserInputError)
       expect(telemetry.getEvents()).toContainEqual({ name: 'workspace.open.failure', tags: {}, timestamp: '', type: 'counter', value: 1 })
     })
@@ -1089,7 +1089,7 @@ describe('Element command group', () => {
         cliTelemetry,
         config,
       })
-      expect(output.stderr.content).toContain('Service nonExistingServiceName is not configured for env env. Use \'salto service add <service-name>\'')
+      expect(output.stderr.content).toContain('nonExistingServiceName is not configured in this environment')
       expect(openActionResult).toEqual(CliExitCode.UserInputError)
       expect(telemetry.getEvents()).toContainEqual({ name: 'workspace.open.failure', tags: {}, timestamp: '', type: 'counter', value: 1 })
     })

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -993,6 +993,20 @@ describe('Element command group', () => {
       setCurrentEnv: () => Promise.resolve(),
       currentEnv: () => 'env',
       getValue: (elemId: ElemID) => {
+        if (elemId.getFullName() === 'salesforce.Account.instance.variable.variable2') {
+          return Promise.resolve(new ObjectType({
+            elemID: new ElemID('salesforce', 'Account', 'instance', 'variable', 'variable2'),
+            // eslint-disable-next-line quote-props
+            annotations: { },
+          }))
+        }
+        if (elemId.getFullName() === 'salesforce.Account.instance.variable') {
+          return Promise.resolve(new ObjectType({
+            elemID: new ElemID('salesforce', 'Account', 'instance', 'variable'),
+            // eslint-disable-next-line quote-props
+            annotations: { '_service_url': serviceUrlAccount },
+          }))
+        }
         if (elemId.getFullName() === 'salesforce.Account') {
           return Promise.resolve(new ObjectType({
             elemID: new ElemID('salesforce', 'Account'),
@@ -1124,6 +1138,18 @@ describe('Element command group', () => {
       expect(output.stderr.content).toEqual('Did not find any matches for element salesforce.element.invalidType\n')
       expect(openActionResult).toEqual(CliExitCode.UserInputError)
       expect(telemetry.getEvents()).toContainEqual({ name: 'workspace.open.failure', tags: {}, timestamp: '', type: 'counter', value: 1 })
+    })
+    it('should return the service URL from the top level parent if one does not exists on the elementId', async () => {
+      const openActionResult = await openAction({
+        input: { elementId: 'salesforce.Account.instance.variable.variable2', env: 'env' },
+        output,
+        cliTelemetry,
+        config,
+      })
+      expect(output.stderr.content).toEqual('')
+      expect(mockOpen).toHaveBeenCalledWith(serviceUrlAccount)
+      expect(openActionResult).toEqual(CliExitCode.Success)
+      expect(telemetry.getEvents()).toContainEqual({ name: 'workspace.open.success', tags: {}, timestamp: '', type: 'counter', value: 1 })
     })
     it('should return an error when trying to open an elementId that is not of type Element', async () => {
       const openActionResult = await openAction({

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -991,20 +991,6 @@ describe('Element command group', () => {
       ...mocks.mockLoadWorkspace('workspacePath', ['env'], false, true, ['netsuite', 'salesforceNotLoggedIn', 'salesforce']),
       currentEnv: () => 'env',
       getValue: (elemId: ElemID) => {
-        if (elemId.getFullName() === 'salesforce.Account.instance.variable.variable2') {
-          return Promise.resolve(new ObjectType({
-            elemID: new ElemID('salesforce', 'Account', 'instance', 'variable', 'variable2'),
-            // eslint-disable-next-line quote-props
-            annotations: {},
-          }))
-        }
-        if (elemId.getFullName() === 'salesforce.Account.instance.variable') {
-          return Promise.resolve(new ObjectType({
-            elemID: new ElemID('salesforce', 'Account', 'instance', 'variable'),
-            // eslint-disable-next-line quote-props
-            annotations: { '_service_url': serviceUrlAccount },
-          }))
-        }
         if (elemId.getFullName() === 'salesforce.Account') {
           return Promise.resolve(new ObjectType({
             elemID: new ElemID('salesforce', 'Account'),
@@ -1065,18 +1051,6 @@ describe('Element command group', () => {
       expect(openActionResult).toEqual(CliExitCode.Success)
       expect(telemetry.getEvents()).toContainEqual({ name: 'workspace.open.success', tags: {}, timestamp: '', type: 'counter', value: 1 })
     })
-    it('should return a valid URL for a given elementID of Field type', async () => {
-      const openActionResult = await openAction({
-        input: { elementId: 'salesforce.Account.instance.field', env: 'env1' },
-        output,
-        cliTelemetry,
-        config,
-      })
-      expect(output.stderr.content).toEqual('')
-      expect(mockOpen).toHaveBeenCalledWith(serviceUrlAccount)
-      expect(openActionResult).toEqual(CliExitCode.Success)
-      expect(telemetry.getEvents()).toContainEqual({ name: 'workspace.open.success', tags: {}, timestamp: '', type: 'counter', value: 1 })
-    })
     it('should error out when loading workspace fails', async () => {
       mockLoadWorkspace.mockResolvedValue(
         {
@@ -1125,18 +1099,6 @@ describe('Element command group', () => {
       expect(output.stderr.content).toEqual('Did not find any matches for element salesforce.element.invalidType\n')
       expect(openActionResult).toEqual(CliExitCode.UserInputError)
       expect(telemetry.getEvents()).toContainEqual({ name: 'workspace.open.failure', tags: {}, timestamp: '', type: 'counter', value: 1 })
-    })
-    it('should return the service URL from the top level parent if one does not exists on the elementId', async () => {
-      const openActionResult = await openAction({
-        input: { elementId: 'salesforce.Account.instance.variable.variable2', env: 'env' },
-        output,
-        cliTelemetry,
-        config,
-      })
-      expect(output.stderr.content).toEqual('')
-      expect(mockOpen).toHaveBeenCalledWith(serviceUrlAccount)
-      expect(openActionResult).toEqual(CliExitCode.Success)
-      expect(telemetry.getEvents()).toContainEqual({ name: 'workspace.open.success', tags: {}, timestamp: '', type: 'counter', value: 1 })
     })
     it('should return an error when trying to open an elementId that is not of type Element', async () => {
       const openActionResult = await openAction({

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -1071,17 +1071,6 @@ describe('Element command group', () => {
       expect(openActionResult).toEqual(CliExitCode.AppError)
       expect(telemetry.getEvents()).toContainEqual({ name: 'workspace.open.failure', tags: {}, timestamp: '', type: 'counter', value: 1 })
     })
-    it('should return an error when trying to open an non logged in service', async () => {
-      const openActionResult = await openAction({
-        input: { elementId: 'salesforceNotLoggedIn', env: 'env2' },
-        output,
-        cliTelemetry,
-        config,
-      })
-      expect(output.stderr.content).toContain('Service salesforceNotLoggedIn in env env2 is not logged. Please run \'salto service login\'')
-      expect(openActionResult).toEqual(CliExitCode.UserInputError)
-      expect(telemetry.getEvents()).toContainEqual({ name: 'workspace.open.failure', tags: {}, timestamp: '', type: 'counter', value: 1 })
-    })
     it('should return an error message when opening an non existing service', async () => {
       const openActionResult = await openAction({
         input: { elementId: 'nonExistingServiceName', env: 'env1' },

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -1093,17 +1093,6 @@ describe('Element command group', () => {
       expect(openActionResult).toEqual(CliExitCode.AppError)
       expect(telemetry.getEvents()).toContainEqual({ name: 'workspace.open.failure', tags: {}, timestamp: '', type: 'counter', value: 1 })
     })
-    it('should return an error message when opening an non existing service', async () => {
-      const openActionResult = await openAction({
-        input: { elementId: 'nonExistingServiceName', env: 'env1' },
-        output,
-        cliTelemetry,
-        config,
-      })
-      expect(output.stderr.content).toContain('nonExistingServiceName is not configured in this environment')
-      expect(openActionResult).toEqual(CliExitCode.UserInputError)
-      expect(telemetry.getEvents()).toContainEqual({ name: 'workspace.open.failure', tags: {}, timestamp: '', type: 'counter', value: 1 })
-    })
     it('should return an error when elementId does not contain ServiceURL annotation', async () => {
       const openActionResult = await openAction({
         input: { elementId: 'salesforce.Date', env: 'env1' },

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -766,7 +766,7 @@ describe('Element command group', () => {
   describe('list-unresolved command', () => {
     const listUnresolvedName = 'list-unresolved'
     const mockListUnresolved = core.listUnresolvedReferences as jest.MockedFunction<
-            typeof core.listUnresolvedReferences>
+      typeof core.listUnresolvedReferences>
 
     describe('success - all unresolved references are found in complete-from', () => {
       const workspacePath = 'valid-ws'
@@ -987,17 +987,15 @@ describe('Element command group', () => {
     })
   })
   describe('open command', () => {
-    const mockWorkspaceForOpenCommand: Workspace = ({
-      services: () => ['netsuite', 'salesforceNotLoggedIn', 'salesforce'],
-      hasErrors: () => Promise.resolve(false),
-      setCurrentEnv: () => Promise.resolve(),
+    const mockWorkspaceForOpenCommand = {
+      ...mocks.mockLoadWorkspace('workspacePath', ['env'], false, true, ['netsuite', 'salesforceNotLoggedIn', 'salesforce']),
       currentEnv: () => 'env',
       getValue: (elemId: ElemID) => {
         if (elemId.getFullName() === 'salesforce.Account.instance.variable.variable2') {
           return Promise.resolve(new ObjectType({
             elemID: new ElemID('salesforce', 'Account', 'instance', 'variable', 'variable2'),
             // eslint-disable-next-line quote-props
-            annotations: { },
+            annotations: {},
           }))
         }
         if (elemId.getFullName() === 'salesforce.Account.instance.variable') {
@@ -1033,7 +1031,7 @@ describe('Element command group', () => {
         }
         return Promise.resolve(undefined)
       },
-    }) as unknown as Workspace
+    }
     beforeEach(() => {
       output = { stdout: new mocks.MockWriteStream(), stderr: new mocks.MockWriteStream() }
       telemetry = mocks.getMockTelemetry()

--- a/packages/vscode/src/commands.ts
+++ b/packages/vscode/src/commands.ts
@@ -70,7 +70,7 @@ export const createGoToServiceCommand = (
 ) => Promise<void> => async () => {
   const url = await getServiceUrl(workspace)
   if (url === undefined) {
-    vscode.window.showErrorMessage('Go to service is not supported for the chosen token')
+    vscode.window.showErrorMessage('Go to service is not supported for the chosen element')
     return
   }
   // Using this library instead of vscode.env.openExternal because of issue: https://github.com/microsoft/vscode/issues/112577


### PR DESCRIPTION
## Description
Today's in our vs-code extension and saas, users can right-click on an element and apply `go to service` command on it.
![image](https://user-images.githubusercontent.com/11272438/104843527-ca481f00-58d3-11eb-8b17-90e40a5f121c.png)


This PR adds similar basic functionality to the CLI under the `element` command.

Usage example:
```bash
salto element open salesforce.Account
```

## Release notes
Add `element open` command to the CLI - which allows opening the service page of an element

## Tests done to verify this PR works
- [x] UT
- [x] Random manual tests comparing the saas result with this command vs the vs-code extension results, to the CLI.
- [x] Check vs-code error message looks good