### PR TITLE
SALTO-1133: added fetchTarget to netsuite

### DIFF
--- a/packages/adapter-utils/test/elements.test.ts
+++ b/packages/adapter-utils/test/elements.test.ts
@@ -18,7 +18,6 @@ import { ElemID, ObjectType } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { buildElementsSourceFromElements } from '../src/elements'
 
-
 describe('buildElementsSourceFromElements', () => {
   const elements = [
     new ObjectType({ elemID: new ElemID('adapter', 'type1') }),

--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -26,7 +26,6 @@ netsuite {
 | filePathRegexSkipList                               | [] (fetch all files)    | Matching file-cabinet file paths will not be fetched from the service
 | deployReferencedElements                            | false                   | Deployment of a certain configuration element will include all elements referred by it
 | [client](#client-configuration-options)             | {} (no overrides)       | Configuration relating to the client used to interact with netsuite
-| [fetchTarget](#fetch-target-configuration-options)  | undefined (fetch all)   | A query to determine what elements to fetch from the service
 
 ### Client configuration options
 
@@ -36,9 +35,3 @@ netsuite {
 | fetchTypeTimeoutInMinutes      | 20                      | The max number of minutes a single type's fetch can run
 | maxItemsInImportObjectsRequest | 30                      | Limits the max number of requested items a single import-objects request
 | sdfConcurrencyLimit            | 4                       | Limits the max number of concurrent SDF API calls. The number should not exceed the concurrency limit enforced by the upstream service.
-
-### Fetch Target configuration options
-| Name                           | Default when undefined  | Description
-| -------------------------------| ------------------------| -----------
-| types                          | {}                      | A map of a type name to a list of regexes of script ids. Any object whose script id matches any of the regexes of its type will be fetched
-| filePaths                      | []                      | A list of regexes of file paths. Any file whose path matches any of the regexes will be fetched

--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -20,12 +20,13 @@ netsuite {
 
 ## Configuration options
 
-| Name                                    | Default when undefined  | Description
-| ----------------------------------------| ------------------------| -----------
-| typesToSkip                             | [] (fetch all types)    | Specified types that their instances will not be fetched from the service
-| filePathRegexSkipList                   | [] (fetch all files)    | Matching file-cabinet file paths will not be fetched from the service
-| deployReferencedElements                | false                   | Deployment of a certain configuration element will include all elements referred by it
-| [client](#client-configuration-options) | {} (no overrides)       | Configuration relating to the client used to interact with netsuite
+| Name                                                | Default when undefined  | Description
+| ----------------------------------------------------| ------------------------| -----------
+| typesToSkip                                         | [] (fetch all types)    | Specified types that their instances will not be fetched from the service
+| filePathRegexSkipList                               | [] (fetch all files)    | Matching file-cabinet file paths will not be fetched from the service
+| deployReferencedElements                            | false                   | Deployment of a certain configuration element will include all elements referred by it
+| [client](#client-configuration-options)             | {} (no overrides)       | Configuration relating to the client used to interact with netsuite
+| [fetchTarget](#fetch-target-configuration-options)  | undefined (fetch all)   | A query to determine what elements to fetch from the service
 
 ### Client configuration options
 
@@ -35,3 +36,9 @@ netsuite {
 | fetchTypeTimeoutInMinutes      | 20                      | The max number of minutes a single type's fetch can run
 | maxItemsInImportObjectsRequest | 30                      | Limits the max number of requested items a single import-objects request
 | sdfConcurrencyLimit            | 4                       | Limits the max number of concurrent SDF API calls. The number should not exceed the concurrency limit enforced by the upstream service.
+
+### Fetch Target configuration options
+| Name                           | Default when undefined  | Description
+| -------------------------------| ------------------------| -----------
+| types                          | {}                      | A map of a type name to a list of regexes of script ids. Any object whose script id matches any of the regexes of its type will be fetched
+| filePaths                      | []                      | A list of regexes of file paths. Any file whose path matches any of the regexes will be fetched

--- a/packages/netsuite-adapter/e2e_test/adapter.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.ts
@@ -16,6 +16,7 @@
 
 import { logger } from '@salto-io/logging'
 import { creds, CredsLease } from '@salto-io/e2e-credentials-store'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import NetsuiteClient, { Credentials } from '../src/client/client'
 import NetsuiteAdapter, { NetsuiteAdapterParams } from '../src/adapter'
 import { NetsuiteConfig } from '../src/config'
@@ -39,6 +40,7 @@ export const realAdapter = ({ adapterParams, credentials }: Opts, config?: Netsu
   })
   const adapter = new NetsuiteAdapter({
     client,
+    elementsSource: buildElementsSourceFromElements([]),
     config: config ?? {},
     ...adapterParams || { getElemIdFunc: mockGetElemIdFunc },
   })

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -38,7 +38,7 @@ import {
   DEFAULT_DEPLOY_REFERENCED_ELEMENTS,
 } from './config'
 import { getAllReferencedInstances, getRequiredReferencedInstances } from './reference_dependencies'
-import { andQuery, buildNetsuiteQuery, NetsuiteQuery, notQuery } from './query'
+import { andQuery, buildNetsuiteQuery, NetsuiteQueryParameters, notQuery } from './query'
 
 const { makeArray } = collections.array
 
@@ -69,7 +69,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
   private readonly deployReferencedElements: boolean
   private readonly userConfig: NetsuiteConfig
   private getElemIdFunc?: ElemIdGetter
-  private readonly fetchTarget?: NetsuiteQuery
+  private readonly fetchTarget?: NetsuiteQueryParameters
 
   public constructor({
     client,
@@ -112,7 +112,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     }))
 
     const fetchQuery = this.fetchTarget !== undefined
-      ? andQuery(this.fetchTarget, skipListQuery)
+      ? andQuery(buildNetsuiteQuery(this.fetchTarget), skipListQuery)
       : skipListQuery
 
     const getCustomObjectsResult = this.client.getCustomObjects(

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 import {
-  FetchResult, isInstanceElement, ObjectType, AdapterOperations, DeployResult, DeployOptions,
-  ElemIdGetter, Element, getChangeElement, InstanceElement,
+  FetchResult, isInstanceElement, AdapterOperations, DeployResult, DeployOptions,
+  ElemIdGetter, Element, getChangeElement, InstanceElement, ReadOnlyElementsSource,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
@@ -28,7 +28,7 @@ import {
   customTypes, getAllTypes, fileCabinetTypes,
 } from './types'
 import {
-  TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST, DEPLOY_REFERENCED_ELEMENTS, INTEGRATION,
+  TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST, DEPLOY_REFERENCED_ELEMENTS, INTEGRATION, FETCH_TARGET,
 } from './constants'
 import replaceInstanceReferencesFilter from './filters/instance_references'
 import convertLists from './filters/convert_lists'
@@ -38,11 +38,13 @@ import {
   DEFAULT_DEPLOY_REFERENCED_ELEMENTS,
 } from './config'
 import { getAllReferencedInstances, getRequiredReferencedInstances } from './reference_dependencies'
+import { andQuery, buildNetsuiteQuery, NetsuiteQuery, notQuery } from './query'
 
 const { makeArray } = collections.array
 
 export interface NetsuiteAdapterParams {
   client: NetsuiteClient
+  elementsSource: ReadOnlyElementsSource
   // Filters to support special cases upon fetch
   filtersCreators?: FilterCreator[]
   // Types that we skip their deployment and fetch
@@ -60,15 +62,18 @@ export interface NetsuiteAdapterParams {
 
 export default class NetsuiteAdapter implements AdapterOperations {
   private readonly client: NetsuiteClient
+  private readonly elementsSource: ReadOnlyElementsSource
   private filtersCreators: FilterCreator[]
   private readonly typesToSkip: string[]
-  private readonly filePathRegexSkipList: RegExp[]
+  private readonly filePathRegexSkipList: string[]
   private readonly deployReferencedElements: boolean
   private readonly userConfig: NetsuiteConfig
   private getElemIdFunc?: ElemIdGetter
+  private readonly fetchTarget?: NetsuiteQuery
 
   public constructor({
     client,
+    elementsSource,
     filtersCreators = [
       convertLists,
       replaceInstanceReferencesFilter,
@@ -85,14 +90,15 @@ export default class NetsuiteAdapter implements AdapterOperations {
     config,
   }: NetsuiteAdapterParams) {
     this.client = client
+    this.elementsSource = elementsSource
     this.filtersCreators = filtersCreators
     this.typesToSkip = typesToSkip.concat(makeArray(config[TYPES_TO_SKIP]))
     this.filePathRegexSkipList = filePathRegexSkipList
       .concat(makeArray(config[FILE_PATHS_REGEX_SKIP_LIST]))
-      .map(e => new RegExp(e))
     this.deployReferencedElements = config[DEPLOY_REFERENCED_ELEMENTS] ?? deployReferencedElements
     this.userConfig = config
     this.getElemIdFunc = getElemIdFunc
+    this.fetchTarget = config[FETCH_TARGET]
   }
 
   /**
@@ -100,9 +106,17 @@ export default class NetsuiteAdapter implements AdapterOperations {
    * Account credentials were given in the constructor.
    */
   public async fetch(): Promise<FetchResult> {
-    const customTypesToFetch = _.pull(Object.keys(customTypes), ...this.typesToSkip)
-    const getCustomObjectsResult = this.client.getCustomObjects(customTypesToFetch)
-    const importFileCabinetResult = this.client.importFileCabinetContent(this.filePathRegexSkipList)
+    const skipListQuery = notQuery(buildNetsuiteQuery({
+      types: Object.fromEntries(this.typesToSkip.map(typeName => [typeName, ['.*']])),
+      filePaths: this.filePathRegexSkipList.map(reg => `.*${reg}.*`),
+    }))
+
+    const fetchQuery = this.fetchTarget !== undefined
+      ? andQuery(this.fetchTarget, skipListQuery)
+      : skipListQuery
+
+    const getCustomObjectsResult = this.client.getCustomObjects(fetchQuery)
+    const importFileCabinetResult = this.client.importFileCabinetContent(fetchQuery)
     const {
       elements: customObjects,
       failedTypes,
@@ -117,21 +131,20 @@ export default class NetsuiteAdapter implements AdapterOperations {
     const instances = customizationInfos.map(customizationInfo => {
       const type = customTypes[customizationInfo.typeName]
         ?? fileCabinetTypes[customizationInfo.typeName]
-      return type && !this.shouldSkipType(type)
-        ? createInstanceElement(customizationInfo, type, this.getElemIdFunc) : undefined
+      return type ? createInstanceElement(customizationInfo, type, this.getElemIdFunc) : undefined
     }).filter(isInstanceElement)
     const elements = [...getAllTypes(), ...instances]
-    await this.runFiltersOnFetch(elements)
+
+    const isPartial = this.fetchTarget !== undefined
+
+    await this.runFiltersOnFetch(elements, this.elementsSource, isPartial)
     const config = getConfigFromConfigChanges(failedToFetchAllAtOnce, failedTypes, failedFilePaths,
       this.userConfig)
-    if (_.isUndefined(config)) {
-      return { elements }
-    }
-    return { elements, updatedConfig: { config, message: STOP_MANAGING_ITEMS_MSG } }
-  }
 
-  private shouldSkipType(type: ObjectType): boolean {
-    return this.typesToSkip.includes(type.elemID.name)
+    if (_.isUndefined(config)) {
+      return { elements, isPartial }
+    }
+    return { elements, updatedConfig: { config, message: STOP_MANAGING_ITEMS_MSG }, isPartial }
   }
 
   private getAllRequiredReferencedInstances(
@@ -156,10 +169,15 @@ export default class NetsuiteAdapter implements AdapterOperations {
     return { errors: [], appliedChanges: changeGroup.changes }
   }
 
-  private async runFiltersOnFetch(elements: Element[]): Promise<void> {
+  private async runFiltersOnFetch(
+    elements: Element[],
+    elementsSource: ReadOnlyElementsSource,
+    isPartial: boolean
+  ): Promise<void> {
     // Fetch filters order is important so they should run one after the other
     return this.filtersCreators.map(filterCreator => filterCreator()).reduce(
-      (prevRes, filter) => prevRes.then(() => filter.onFetch(elements)),
+      (prevRes, filter) => prevRes.then(() =>
+        filter.onFetch({ elements, elementsSource, isPartial })),
       Promise.resolve(),
     )
   }

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -115,7 +115,10 @@ export default class NetsuiteAdapter implements AdapterOperations {
       ? andQuery(this.fetchTarget, skipListQuery)
       : skipListQuery
 
-    const getCustomObjectsResult = this.client.getCustomObjects(fetchQuery)
+    const getCustomObjectsResult = this.client.getCustomObjects(
+      Object.keys(customTypes),
+      fetchQuery
+    )
     const importFileCabinetResult = this.client.importFileCabinetContent(fetchQuery)
     const {
       elements: customObjects,

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -31,7 +31,7 @@ import {
   FETCH_TARGET,
   FETCH_ALL_TYPES_AT_ONCE,
 } from './constants'
-import { buildNetsuiteQuery } from './query'
+import { validateParameters } from './query'
 
 const log = logger(module)
 const { makeArray } = collections.array
@@ -69,12 +69,15 @@ const netsuiteConfigFromConfig = (config: Readonly<InstanceElement> | undefined)
   }
   try {
     validateRegularExpressions(filePathsRegexSkipList)
+    if (fetchTargetParameters !== undefined) {
+      validateParameters(fetchTargetParameters)
+    }
     const netsuiteConfig: { [K in keyof Required<NetsuiteConfig>]: NetsuiteConfig[K] } = {
       [TYPES_TO_SKIP]: makeArray(config?.value?.[TYPES_TO_SKIP]),
       [DEPLOY_REFERENCED_ELEMENTS]: config?.value?.[DEPLOY_REFERENCED_ELEMENTS],
       [FILE_PATHS_REGEX_SKIP_LIST]: filePathsRegexSkipList,
       [CLIENT_CONFIG]: config?.value?.[CLIENT_CONFIG],
-      [FETCH_TARGET]: fetchTargetParameters && buildNetsuiteQuery(fetchTargetParameters),
+      [FETCH_TARGET]: fetchTargetParameters,
     }
 
     Object.keys(config?.value ?? {})

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -24,7 +24,7 @@ import {
   SDF_CONCURRENCY_LIMIT, SAVED_SEARCH, DEPLOY_REFERENCED_ELEMENTS, FETCH_TYPE_TIMEOUT_IN_MINUTES,
   CLIENT_CONFIG, MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST, FETCH_TARGET,
 } from './constants'
-import { NetsuiteQuery } from './query'
+import { NetsuiteQueryParameters } from './query'
 
 const { makeArray } = collections.array
 
@@ -142,7 +142,7 @@ export type NetsuiteConfig = {
   [FILE_PATHS_REGEX_SKIP_LIST]?: string[]
   [DEPLOY_REFERENCED_ELEMENTS]?: boolean
   [CLIENT_CONFIG]?: NetsuiteClientConfig
-  [FETCH_TARGET]?: NetsuiteQuery
+  [FETCH_TARGET]?: NetsuiteQueryParameters
 }
 
 export const STOP_MANAGING_ITEMS_MSG = 'Salto failed to fetch some items from NetSuite. '

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
 import {
   InstanceElement, ElemID, Value, ObjectType, ListType, BuiltinTypes, CORE_ANNOTATIONS,
-  createRestriction,
+  createRestriction, MapType,
 } from '@salto-io/adapter-api'
 import {
   FETCH_ALL_TYPES_AT_ONCE, TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST, NETSUITE,
@@ -75,6 +75,25 @@ const clientConfigType = new ObjectType({
   },
 })
 
+const queryConfigType = new ObjectType({
+  elemID: new ElemID(NETSUITE, 'queryConfig'),
+  fields: {
+    types: {
+      type: new MapType(new ListType(BuiltinTypes.STRING)),
+      annotations: {
+        [CORE_ANNOTATIONS.DEFAULT]: {},
+      },
+    },
+
+    filePaths: {
+      type: new ListType(BuiltinTypes.STRING),
+      annotations: {
+        [CORE_ANNOTATIONS.DEFAULT]: [],
+      },
+    },
+  },
+})
+
 const configID = new ElemID(NETSUITE)
 export const configType = new ObjectType({
   elemID: configID,
@@ -103,6 +122,10 @@ export const configType = new ObjectType({
     },
     [CLIENT_CONFIG]: {
       type: clientConfigType,
+    },
+
+    [FETCH_TARGET]: {
+      type: queryConfigType,
     },
   },
 })

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -22,8 +22,9 @@ import {
 import {
   FETCH_ALL_TYPES_AT_ONCE, TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST, NETSUITE,
   SDF_CONCURRENCY_LIMIT, SAVED_SEARCH, DEPLOY_REFERENCED_ELEMENTS, FETCH_TYPE_TIMEOUT_IN_MINUTES,
-  CLIENT_CONFIG, MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST,
+  CLIENT_CONFIG, MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST, FETCH_TARGET,
 } from './constants'
+import { NetsuiteQuery } from './query'
 
 const { makeArray } = collections.array
 
@@ -118,6 +119,7 @@ export type NetsuiteConfig = {
   [FILE_PATHS_REGEX_SKIP_LIST]?: string[]
   [DEPLOY_REFERENCED_ELEMENTS]?: boolean
   [CLIENT_CONFIG]?: NetsuiteClientConfig
+  [FETCH_TARGET]?: NetsuiteQuery
 }
 
 export const STOP_MANAGING_ITEMS_MSG = 'Salto failed to fetch some items from NetSuite. '

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -64,6 +64,7 @@ export const MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST = 'maxItemsInImportObjectsReque
 export const DEPLOY_REFERENCED_ELEMENTS = 'deployReferencedElements'
 export const SDF_CONCURRENCY_LIMIT = 'sdfConcurrencyLimit'
 export const CLIENT_CONFIG = 'client'
+export const FETCH_TARGET = 'fetchTarget'
 
 export const CAPTURE = 'capture'
 // e.g. '[scriptid=customworkflow1]' & '[scriptid=customworkflow1.workflowstate17.workflowaction33]'

--- a/packages/netsuite-adapter/src/filter.ts
+++ b/packages/netsuite-adapter/src/filter.ts
@@ -13,12 +13,18 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element } from '@salto-io/adapter-api'
+import { Element, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+
+export type OnFetchParameters = {
+  elements: Element[]
+  elementsSource: ReadOnlyElementsSource
+  isPartial: boolean
+}
 
 // Filter interface, filters will be activated upon adapter fetch operations.
 // The filter will be responsible for specific business logic.
 export type OnFetchFilter = {
-  onFetch(elements: Element[]): Promise<void>
+  onFetch(parameters: OnFetchParameters): Promise<void>
 }
 
 export type FilterCreator = () => OnFetchFilter

--- a/packages/netsuite-adapter/src/filters/convert_lists.ts
+++ b/packages/netsuite-adapter/src/filters/convert_lists.ts
@@ -15,7 +15,7 @@
 */
 /* eslint-disable @typescript-eslint/camelcase */
 import {
-  Element, Field, isInstanceElement, isListType, ObjectType, Values, Value,
+  Field, isInstanceElement, isListType, ObjectType, Values, Value,
 } from '@salto-io/adapter-api'
 import { applyRecursive } from '@salto-io/adapter-utils'
 import _ from 'lodash'
@@ -63,7 +63,7 @@ const filterCreator: FilterCreator = () => ({
    *
    * @param elements the already fetched elements
    */
-  onFetch: async (elements: Element[]) => {
+  onFetch: async ({ elements }) => {
     elements
       .filter(isInstanceElement)
       .forEach(inst => castAndOrderListsRecursively(inst.type, inst.value))

--- a/packages/netsuite-adapter/src/filters/instance_references.ts
+++ b/packages/netsuite-adapter/src/filters/instance_references.ts
@@ -132,6 +132,9 @@ const createElementsSourceServiceIdToElemID = async (
     return elementsSourceServiceIdToElemID
   }
 
+  // TODO: Replace this loop style with the same style that is
+  // used in generateServiceIdToElemID when ".map" and "".filter" for async iterables
+  // will be available in lowerdash.
   for await (const element of await elementsSource.getAll()) {
     if (isInstanceElement(element)) {
       elementsSourceServiceIdToElemID = _.assign(

--- a/packages/netsuite-adapter/src/filters/instance_references.ts
+++ b/packages/netsuite-adapter/src/filters/instance_references.ts
@@ -78,10 +78,10 @@ const customTypeServiceIdsToElemIds = (instance: InstanceElement): Record<string
   return serviceIdsToElemIds
 }
 
-const getInstanceServiceIdRecords = (element: InstanceElement): Record<string, ElemID> => (
-  isCustomType(element.type)
-    ? customTypeServiceIdsToElemIds(element)
-    : { [serviceId(element)]: element.elemID.createNestedID(PATH) }
+const getInstanceServiceIdRecords = (instance: InstanceElement): Record<string, ElemID> => (
+  isCustomType(instance.type)
+    ? customTypeServiceIdsToElemIds(instance)
+    : { [serviceId(instance)]: instance.elemID.createNestedID(PATH) }
 )
 
 const generateServiceIdToElemID = (elements: Element[]): Record<string, ElemID> =>

--- a/packages/netsuite-adapter/src/query.ts
+++ b/packages/netsuite-adapter/src/query.ts
@@ -1,0 +1,88 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { collections, regex } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { FETCH_TARGET } from './constants'
+import { customTypes } from './types'
+
+export interface ObjectID {
+  type: string
+  scriptId: string
+}
+
+export type NetsuiteQueryParameters = {
+  types: Record<string, Array<string>>
+  filePaths: Array<string>
+}
+
+export type NetsuiteQuery = {
+  isTypeMatch: (typeName: string) => boolean
+  isObjectMatch: (objectID: ObjectID) => boolean
+  isFileMatch: (filePath: string) => boolean
+}
+
+const validateParameters = (parameters: NetsuiteQueryParameters): void => {
+  const existingTypes = new Set(Object.keys(customTypes))
+  const receivedTypes = new Set(Object.keys(parameters.types))
+
+  const invalidTypes = collections.set.difference(receivedTypes, existingTypes)
+
+  const invalidRegexes = _.flatten(Object.values(parameters.types))
+    .concat(parameters.filePaths)
+    .filter(reg => !regex.isValidRegex(reg))
+
+  if (invalidRegexes.length !== 0 || invalidTypes.size !== 0) {
+    const invalidRegexesMessage = invalidRegexes.length !== 0 ? ` The following regular expressions are invalid: ${invalidRegexes}.` : ''
+    const invalidTypesMessage = invalidTypes.size !== 0 ? ` The following types do not exist: ${Array.from(invalidTypes)}.` : ''
+    const message = `received invalid ${FETCH_TARGET} input.${invalidRegexesMessage}${invalidTypesMessage}`
+    throw new Error(message)
+  }
+}
+
+export const buildNetsuiteQuery = (
+  { types = {}, filePaths = [] }: Partial<NetsuiteQueryParameters>
+): NetsuiteQuery => {
+  const parameters = { types, filePaths }
+  validateParameters(parameters)
+  return {
+    isTypeMatch: typeName => parameters.types[typeName] !== undefined,
+    isObjectMatch: objectID => {
+      const regexes = parameters.types[objectID.type]
+      if (regexes === undefined) {
+        return false
+      }
+      return regexes.some(reg => new RegExp(`^${reg}$`).test(objectID.scriptId))
+    },
+    isFileMatch: filePath =>
+      parameters.filePaths.some(reg => new RegExp(`^${reg}$`).test(filePath)),
+  }
+}
+
+export const andQuery = (firstQuery: NetsuiteQuery, secondQuery: NetsuiteQuery): NetsuiteQuery => ({
+  isTypeMatch: typeName =>
+    firstQuery.isTypeMatch(typeName) && secondQuery.isTypeMatch(typeName),
+  isObjectMatch: objectID =>
+    firstQuery.isObjectMatch(objectID) && secondQuery.isObjectMatch(objectID),
+  isFileMatch: filePath =>
+    firstQuery.isFileMatch(filePath) && secondQuery.isFileMatch(filePath),
+})
+
+export const notQuery = (query: NetsuiteQuery): NetsuiteQuery => ({
+  isTypeMatch: typeName => !query.isTypeMatch(typeName),
+  isObjectMatch: objectID => !query.isObjectMatch(objectID),
+  isFileMatch: filePath => !query.isFileMatch(filePath),
+})

--- a/packages/netsuite-adapter/src/query.ts
+++ b/packages/netsuite-adapter/src/query.ts
@@ -35,7 +35,10 @@ export type NetsuiteQuery = {
   isFileMatch: (filePath: string) => boolean
 }
 
-const validateParameters = (parameters: NetsuiteQueryParameters): void => {
+export const validateParameters = ({ types = {}, filePaths = [] }:
+  Partial<NetsuiteQueryParameters>): void => {
+  const parameters = { types, filePaths }
+
   const existingTypes = new Set(Object.keys(customTypes))
   const receivedTypes = new Set(Object.keys(parameters.types))
 
@@ -57,7 +60,6 @@ export const buildNetsuiteQuery = (
   { types = {}, filePaths = [] }: Partial<NetsuiteQueryParameters>
 ): NetsuiteQuery => {
   const parameters = { types, filePaths }
-  validateParameters(parameters)
   return {
     isTypeMatch: typeName => parameters.types[typeName] !== undefined,
     isObjectMatch: objectID => {

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -35,7 +35,6 @@ import { FilterCreator } from '../src/filter'
 import { configType, getConfigFromConfigChanges } from '../src/config'
 import { mockGetElemIdFunc } from './utils'
 import * as referenceDependenciesModule from '../src/reference_dependencies'
-import { buildNetsuiteQuery } from '../src/query'
 
 jest.mock('../src/config', () => ({
   ...jest.requireActual('../src/config'),
@@ -156,13 +155,13 @@ describe('Adapter', () => {
       const conf = {
         [TYPES_TO_SKIP]: [SAVED_SEARCH, TRANSACTION_FORM],
         [FILE_PATHS_REGEX_SKIP_LIST]: [filePathRegexStr],
-        [FETCH_TARGET]: buildNetsuiteQuery({
+        [FETCH_TARGET]: {
           types: {
             [SAVED_SEARCH]: ['.*'],
             addressForm: ['.*'],
           },
           filePaths: ['Some/File/.*'],
-        }),
+        },
       }
       const adapter = new NetsuiteAdapter({
         client,

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -128,7 +128,7 @@ describe('Adapter', () => {
       })
       const { elements, isPartial } = await netsuiteAdapter.fetch()
       expect(isPartial).toBeFalsy()
-      const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][0]
+      const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][1]
       const typesToSkip = [SAVED_SEARCH, TRANSACTION_FORM, INTEGRATION]
       expect(_.pull(Object.keys(customTypes), ...typesToSkip).every(customObjectsQuery.isTypeMatch))
         .toBeTruthy()
@@ -180,7 +180,7 @@ describe('Adapter', () => {
       it('should match the types that match fetchTarget and not in typesToSkip', async () => {
         await adapter.fetch()
 
-        const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][0]
+        const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][1]
         expect(customObjectsQuery.isTypeMatch('addressForm')).toBeTruthy()
         expect(_.pull(Object.keys(customTypes), 'addressForm').some(customObjectsQuery.isTypeMatch)).toBeFalsy()
         expect(customObjectsQuery.isTypeMatch(INTEGRATION)).toBeFalsy()
@@ -232,7 +232,7 @@ describe('Adapter', () => {
 
     it('should call getCustomObjects with query that only matches types that are not in typesToSkip', async () => {
       await netsuiteAdapter.fetch()
-      const query = (client.getCustomObjects as jest.Mock).mock.calls[0][0]
+      const query = (client.getCustomObjects as jest.Mock).mock.calls[0][1]
       expect(query.isTypeMatch(ENTITY_CUSTOM_FIELD)).toBeTruthy()
       expect(query.isTypeMatch(SAVED_SEARCH)).toBeFalsy()
     })

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -18,13 +18,14 @@ import {
   ElemID, InstanceElement, StaticFile, ChangeDataType, DeployResult, getChangeElement,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import createClient from './client/client'
 import NetsuiteAdapter from '../src/adapter'
 import { customTypes, fileCabinetTypes, getAllTypes } from '../src/types'
 import {
   ENTITY_CUSTOM_FIELD, SCRIPT_ID, SAVED_SEARCH, FILE, FOLDER, PATH, TRANSACTION_FORM, TYPES_TO_SKIP,
   FILE_PATHS_REGEX_SKIP_LIST, FETCH_ALL_TYPES_AT_ONCE, DEPLOY_REFERENCED_ELEMENTS,
-  FETCH_TYPE_TIMEOUT_IN_MINUTES, INTEGRATION, CLIENT_CONFIG,
+  FETCH_TYPE_TIMEOUT_IN_MINUTES, INTEGRATION, CLIENT_CONFIG, FETCH_TARGET,
 } from '../src/constants'
 import { createInstanceElement, toCustomizationInfo } from '../src/transformer'
 import {
@@ -34,6 +35,7 @@ import { FilterCreator } from '../src/filter'
 import { configType, getConfigFromConfigChanges } from '../src/config'
 import { mockGetElemIdFunc } from './utils'
 import * as referenceDependenciesModule from '../src/reference_dependencies'
+import { buildNetsuiteQuery } from '../src/query'
 
 jest.mock('../src/config', () => ({
   ...jest.requireActual('../src/config'),
@@ -73,6 +75,7 @@ describe('Adapter', () => {
   }
   const netsuiteAdapter = new NetsuiteAdapter({
     client,
+    elementsSource: buildElementsSourceFromElements([]),
     filtersCreators: [firstDummyFilter, secondDummyFilter],
     config,
     getElemIdFunc: mockGetElemIdFunc,
@@ -123,11 +126,18 @@ describe('Adapter', () => {
         failedTypes: [],
         failedToFetchAllAtOnce: false,
       })
-      const { elements } = await netsuiteAdapter.fetch()
-      expect(client.getCustomObjects).toHaveBeenCalledWith(
-        _.pull(Object.keys(customTypes), SAVED_SEARCH, TRANSACTION_FORM, INTEGRATION),
-      )
-      expect(client.importFileCabinetContent).toHaveBeenCalledWith([new RegExp(filePathRegexStr)])
+      const { elements, isPartial } = await netsuiteAdapter.fetch()
+      expect(isPartial).toBeFalsy()
+      const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][0]
+      const typesToSkip = [SAVED_SEARCH, TRANSACTION_FORM, INTEGRATION]
+      expect(_.pull(Object.keys(customTypes), ...typesToSkip).every(customObjectsQuery.isTypeMatch))
+        .toBeTruthy()
+      expect(typesToSkip.some(customObjectsQuery.isTypeMatch)).toBeFalsy()
+
+      const fileCabinetQuery = (client.importFileCabinetContent as jest.Mock).mock.calls[0][0]
+      expect(fileCabinetQuery.isFileMatch('Some/File/Regex')).toBeFalsy()
+      expect(fileCabinetQuery.isFileMatch('Some/anotherFile/Regex')).toBeTruthy()
+
       expect(elements).toHaveLength(getAllTypes().length + 3)
       const customFieldType = customTypes[ENTITY_CUSTOM_FIELD]
       expect(elements).toContainEqual(customFieldType)
@@ -140,6 +150,50 @@ describe('Adapter', () => {
       expect(elements).toContainEqual(
         createInstanceElement(folderCustomizationInfo, fileCabinetTypes[FOLDER], mockGetElemIdFunc)
       )
+    })
+
+    describe('fetchTarget', () => {
+      const conf = {
+        [TYPES_TO_SKIP]: [SAVED_SEARCH, TRANSACTION_FORM],
+        [FILE_PATHS_REGEX_SKIP_LIST]: [filePathRegexStr],
+        [FETCH_TARGET]: buildNetsuiteQuery({
+          types: {
+            [SAVED_SEARCH]: ['.*'],
+            addressForm: ['.*'],
+          },
+          filePaths: ['Some/File/.*'],
+        }),
+      }
+      const adapter = new NetsuiteAdapter({
+        client,
+        elementsSource: buildElementsSourceFromElements([]),
+        filtersCreators: [firstDummyFilter, secondDummyFilter],
+        config: conf,
+        getElemIdFunc: mockGetElemIdFunc,
+      })
+
+      it('isPartial should be true', async () => {
+        const { isPartial } = await adapter.fetch()
+        expect(isPartial).toBeTruthy()
+      })
+
+      it('should match the types that match fetchTarget and not in typesToSkip', async () => {
+        await adapter.fetch()
+
+        const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][0]
+        expect(customObjectsQuery.isTypeMatch('addressForm')).toBeTruthy()
+        expect(_.pull(Object.keys(customTypes), 'addressForm').some(customObjectsQuery.isTypeMatch)).toBeFalsy()
+        expect(customObjectsQuery.isTypeMatch(INTEGRATION)).toBeFalsy()
+      })
+
+      it('should match the files that match fetchTarget and not in filePathRegexSkipList', async () => {
+        await adapter.fetch()
+
+        const fileCabinetQuery = (client.importFileCabinetContent as jest.Mock).mock.calls[0][0]
+        expect(fileCabinetQuery.isFileMatch('Some/File/Regex')).toBeFalsy()
+        expect(fileCabinetQuery.isFileMatch('Some/AnotherFile/another')).toBeFalsy()
+        expect(fileCabinetQuery.isFileMatch('Some/File/another')).toBeTruthy()
+      })
     })
 
     it('should fail when getCustomObjects fails', async () => {
@@ -170,32 +224,17 @@ describe('Adapter', () => {
       expect(elements).toHaveLength(getAllTypes().length)
     })
 
-    it('should ignore instances from typesToSkip', async () => {
-      const customizationInfo = {
-        typeName: SAVED_SEARCH,
-        values: {},
-      }
-      client.getCustomObjects = jest.fn().mockImplementation(async () => ({
-        elements: [customizationInfo],
-        failedTypes: [],
-        failedToFetchAllAtOnce: false,
-      }))
-      const { elements } = await netsuiteAdapter.fetch()
-      expect(elements).toHaveLength(getAllTypes().length)
-    })
-
     it('should call filters by their order', async () => {
       await netsuiteAdapter.fetch()
       expect(onFetchMock).toHaveBeenNthCalledWith(1, 1)
       expect(onFetchMock).toHaveBeenNthCalledWith(2, 2)
     })
 
-    it('should call getCustomObjects only with types that are not in typesToSkip', async () => {
+    it('should call getCustomObjects with query that only matches types that are not in typesToSkip', async () => {
       await netsuiteAdapter.fetch()
-      expect(client.getCustomObjects)
-        .toHaveBeenCalledWith(expect.arrayContaining([ENTITY_CUSTOM_FIELD]))
-      expect(client.getCustomObjects)
-        .not.toHaveBeenCalledWith(expect.arrayContaining([SAVED_SEARCH]))
+      const query = (client.getCustomObjects as jest.Mock).mock.calls[0][0]
+      expect(query.isTypeMatch(ENTITY_CUSTOM_FIELD)).toBeTruthy()
+      expect(query.isTypeMatch(SAVED_SEARCH)).toBeFalsy()
     })
 
     it('should return only the elements when having no config changes', async () => {
@@ -421,6 +460,7 @@ describe('Adapter', () => {
       }
       const netsuiteAdapterWithDeployReferencedElements = new NetsuiteAdapter({
         client,
+        elementsSource: buildElementsSourceFromElements([]),
         filtersCreators: [firstDummyFilter, secondDummyFilter],
         config: configWithDeployReferencedElements,
         getElemIdFunc: mockGetElemIdFunc,

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -165,6 +165,8 @@ describe('netsuite client', () => {
     { type: 'advancedpdftemplate', scriptId: 'IdB' },
   ]
 
+  const typeNames = instancesIds.map(instance => instance.type)
+
   const typeNamesQuery = buildNetsuiteQuery({
     types: Object.fromEntries(instancesIds.map(id => [id.type, ['.*']])),
   })
@@ -223,7 +225,7 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ isSuccess: () => true })
       })
-      await expect(mockClient().getCustomObjects(typeNamesQuery)).rejects.toThrow()
+      await expect(mockClient().getCustomObjects(typeNames, typeNamesQuery)).rejects.toThrow()
       expect(mockExecuteAction).toHaveBeenCalledWith(createProjectCommandMatcher)
       expect(mockExecuteAction).not.toHaveBeenCalledWith(saveTokenCommandMatcher)
       expect(mockExecuteAction).not.toHaveBeenCalledWith(importObjectsCommandMatcher)
@@ -236,7 +238,7 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ isSuccess: () => true })
       })
-      await expect(mockClient().getCustomObjects(typeNamesQuery)).rejects.toThrow()
+      await expect(mockClient().getCustomObjects(typeNames, typeNamesQuery)).rejects.toThrow()
       expect(mockExecuteAction).toHaveBeenCalledWith(createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenCalledWith(saveTokenCommandMatcher)
       expect(mockExecuteAction).not.toHaveBeenCalledWith(importObjectsCommandMatcher)
@@ -257,7 +259,7 @@ describe('netsuite client', () => {
         return Promise.resolve({ isSuccess: () => true })
       })
       const client = mockClient({ fetchAllTypesAtOnce: true })
-      const getCustomObjectsResult = await client.getCustomObjects(typeNamesQuery)
+      const getCustomObjectsResult = await client.getCustomObjects(typeNames, typeNamesQuery)
       expect(mockExecuteAction).toHaveBeenCalledTimes(
         7
       )
@@ -286,7 +288,7 @@ describe('netsuite client', () => {
         return Promise.resolve({ isSuccess: () => true })
       })
       const client = mockClient({ fetchAllTypesAtOnce: false })
-      const getCustomObjectsResult = await client.getCustomObjects(typeNamesQuery)
+      const getCustomObjectsResult = await client.getCustomObjects(typeNames, typeNamesQuery)
       // createProject & setupAccount & listObjects & importObjects & deleteAuthId
       const numberOfExecuteActions = 6
       expect(mockExecuteAction).toHaveBeenCalledTimes(numberOfExecuteActions)
@@ -321,7 +323,7 @@ describe('netsuite client', () => {
       })
 
       const client = mockClient({ fetchAllTypesAtOnce: false, maxItemsInImportObjectsRequest: 2 })
-      await client.getCustomObjects(typeNamesQuery)
+      await client.getCustomObjects(typeNames, typeNamesQuery)
       // createProject & setupAccount & listObjects & importObjects & deleteAuthId
       const numberOfExecuteActions = 7
       expect(mockExecuteAction).toHaveBeenCalledTimes(numberOfExecuteActions)
@@ -377,7 +379,7 @@ describe('netsuite client', () => {
         // so the failure of the first chunk won't results skipping the second.
         sdfConcurrencyLimit: 1,
       })
-      await client.getCustomObjects(typeNamesQuery)
+      await client.getCustomObjects(typeNames, typeNamesQuery)
       // createProject & setupAccount & importObjects & deleteAuthId
       const numberOfExecuteActions = 6
       expect(mockExecuteAction).toHaveBeenCalledTimes(numberOfExecuteActions)
@@ -418,7 +420,7 @@ describe('netsuite client', () => {
         return Promise.resolve({ isSuccess: () => true })
       })
       const client = mockClient({ fetchAllTypesAtOnce: false, fetchTypeTimeoutInMinutes: 0.001 })
-      const getCustomObjectsResult = await client.getCustomObjects(typeNamesQuery)
+      const getCustomObjectsResult = await client.getCustomObjects(typeNames, typeNamesQuery)
       expect(getCustomObjectsResult.failedTypes).toEqual(['addressForm'])
       expect(getCustomObjectsResult.failedToFetchAllAtOnce).toEqual(false)
     })
@@ -445,7 +447,7 @@ describe('netsuite client', () => {
           addressForm: ['.*'],
         },
       })
-      const getCustomObjectsResult = await client.getCustomObjects(query)
+      const getCustomObjectsResult = await client.getCustomObjects(typeNames, query)
       expect(getCustomObjectsResult.failedTypes).toEqual([])
       expect(getCustomObjectsResult.failedToFetchAllAtOnce).toEqual(true)
     })
@@ -465,7 +467,7 @@ describe('netsuite client', () => {
         elements: customizationInfos,
         failedToFetchAllAtOnce,
         failedTypes,
-      } = await mockClient().getCustomObjects(typeNamesQuery)
+      } = await mockClient().getCustomObjects(typeNames, typeNamesQuery)
       expect(failedToFetchAllAtOnce).toBe(false)
       expect(failedTypes).toHaveLength(0)
       expect(readDirMock).toHaveBeenCalledTimes(1)
@@ -514,7 +516,7 @@ describe('netsuite client', () => {
           addressForm: ['a'],
         },
       })
-      await mockClient().getCustomObjects(query)
+      await mockClient().getCustomObjects(typeNames, query)
       expect(mockExecuteAction).toHaveBeenCalledWith(expect.objectContaining({
         commandName: COMMANDS.LIST_OBJECTS,
         arguments: {

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -16,6 +16,7 @@
 import _ from 'lodash'
 import { readFile, readDir, writeFile, mkdirp, rm } from '@salto-io/file'
 import osPath from 'path'
+import { buildNetsuiteQuery, notQuery } from '../../src/query'
 import mockClient, { DUMMY_CREDENTIALS } from './client'
 import NetsuiteClient, {
   ATTRIBUTES_FILE_SUFFIX, ATTRIBUTES_FOLDER_NAME, COMMANDS, CustomTypeInfo,
@@ -109,7 +110,7 @@ jest.mock('@salto-io/file', () => ({
     if (filePath.endsWith('manifest.xml')) {
       return MOCK_MANIFEST_INVALID_DEPENDENCIES
     }
-    return `<TypeA filename="${filePath.split('/').pop()}">`
+    return `<addressForm filename="${filePath.split('/').pop()}">`
   }),
   writeFile: jest.fn(),
   mkdirp: jest.fn(),
@@ -160,11 +161,13 @@ describe('netsuite client', () => {
   })
 
   const instancesIds = [
-    { type: 'TypeA', scriptId: 'IdA' },
-    { type: 'TypeB', scriptId: 'IdB' },
+    { type: 'addressForm', scriptId: 'IdA' },
+    { type: 'advancedpdftemplate', scriptId: 'IdB' },
   ]
 
-  const typeNames = Array.from(new Set(instancesIds.map(id => id.type)))
+  const typeNamesQuery = buildNetsuiteQuery({
+    types: Object.fromEntries(instancesIds.map(id => [id.type, ['.*']])),
+  })
 
   const importObjectsCommandMatcher = expect
     .objectContaining({ commandName: COMMANDS.IMPORT_OBJECTS })
@@ -220,7 +223,7 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ isSuccess: () => true })
       })
-      await expect(mockClient().getCustomObjects(typeNames)).rejects.toThrow()
+      await expect(mockClient().getCustomObjects(typeNamesQuery)).rejects.toThrow()
       expect(mockExecuteAction).toHaveBeenCalledWith(createProjectCommandMatcher)
       expect(mockExecuteAction).not.toHaveBeenCalledWith(saveTokenCommandMatcher)
       expect(mockExecuteAction).not.toHaveBeenCalledWith(importObjectsCommandMatcher)
@@ -233,7 +236,7 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ isSuccess: () => true })
       })
-      await expect(mockClient().getCustomObjects(typeNames)).rejects.toThrow()
+      await expect(mockClient().getCustomObjects(typeNamesQuery)).rejects.toThrow()
       expect(mockExecuteAction).toHaveBeenCalledWith(createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenCalledWith(saveTokenCommandMatcher)
       expect(mockExecuteAction).not.toHaveBeenCalledWith(importObjectsCommandMatcher)
@@ -248,13 +251,13 @@ describe('netsuite client', () => {
           })
         }
         if (context.commandName === COMMANDS.IMPORT_OBJECTS
-          && ['TypeA', 'ALL'].includes(context.arguments.type)) {
+          && ['addressForm', 'ALL'].includes(context.arguments.type)) {
           return Promise.resolve({ isSuccess: () => false })
         }
         return Promise.resolve({ isSuccess: () => true })
       })
       const client = mockClient({ fetchAllTypesAtOnce: true })
-      const getCustomObjectsResult = await client.getCustomObjects(typeNames)
+      const getCustomObjectsResult = await client.getCustomObjects(typeNamesQuery)
       expect(mockExecuteAction).toHaveBeenCalledTimes(
         7
       )
@@ -265,7 +268,7 @@ describe('netsuite client', () => {
       expect(mockExecuteAction).toHaveBeenNthCalledWith(5, importObjectsCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(6, importObjectsCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(7, deleteAuthIdCommandMatcher)
-      expect(getCustomObjectsResult.failedTypes).toEqual(['TypeA'])
+      expect(getCustomObjectsResult.failedTypes).toEqual(['addressForm'])
       expect(getCustomObjectsResult.failedToFetchAllAtOnce).toEqual(true)
     })
 
@@ -277,13 +280,13 @@ describe('netsuite client', () => {
             data: instancesIds,
           })
         }
-        if (context.commandName === COMMANDS.IMPORT_OBJECTS && context.arguments.type === 'TypeA') {
+        if (context.commandName === COMMANDS.IMPORT_OBJECTS && context.arguments.type === 'addressForm') {
           return Promise.resolve({ isSuccess: () => false })
         }
         return Promise.resolve({ isSuccess: () => true })
       })
       const client = mockClient({ fetchAllTypesAtOnce: false })
-      const getCustomObjectsResult = await client.getCustomObjects(typeNames)
+      const getCustomObjectsResult = await client.getCustomObjects(typeNamesQuery)
       // createProject & setupAccount & listObjects & importObjects & deleteAuthId
       const numberOfExecuteActions = 6
       expect(mockExecuteAction).toHaveBeenCalledTimes(numberOfExecuteActions)
@@ -296,16 +299,16 @@ describe('netsuite client', () => {
       }
       expect(mockExecuteAction)
         .toHaveBeenNthCalledWith(numberOfExecuteActions, deleteAuthIdCommandMatcher)
-      expect(getCustomObjectsResult.failedTypes).toEqual(['TypeA'])
+      expect(getCustomObjectsResult.failedTypes).toEqual(['addressForm'])
       expect(getCustomObjectsResult.failedToFetchAllAtOnce).toEqual(false)
     })
 
     it('should split to chunks without mixing different types in the same chunk', async () => {
       const ids = [
-        { type: 'typeA', scriptId: 'a' },
-        { type: 'typeA', scriptId: 'b' },
-        { type: 'typeA', scriptId: 'c' },
-        { type: 'typeB', scriptId: 'd' },
+        { type: 'addressForm', scriptId: 'a' },
+        { type: 'addressForm', scriptId: 'b' },
+        { type: 'addressForm', scriptId: 'c' },
+        { type: 'advancedpdftemplate', scriptId: 'd' },
       ]
       mockExecuteAction.mockImplementation(context => {
         if (context.commandName === COMMANDS.LIST_OBJECTS) {
@@ -318,7 +321,7 @@ describe('netsuite client', () => {
       })
 
       const client = mockClient({ fetchAllTypesAtOnce: false, maxItemsInImportObjectsRequest: 2 })
-      await client.getCustomObjects(['typeA', 'typeB'])
+      await client.getCustomObjects(typeNamesQuery)
       // createProject & setupAccount & listObjects & importObjects & deleteAuthId
       const numberOfExecuteActions = 7
       expect(mockExecuteAction).toHaveBeenCalledTimes(numberOfExecuteActions)
@@ -327,19 +330,19 @@ describe('netsuite client', () => {
       expect(mockExecuteAction).toHaveBeenNthCalledWith(3, listObjectsCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(4, importObjectsCommandMatcher)
       expect(mockExecuteAction.mock.calls[3][0].arguments).toEqual(expect.objectContaining({
-        type: 'typeA',
+        type: 'addressForm',
         scriptid: 'a b',
       }))
 
       expect(mockExecuteAction).toHaveBeenNthCalledWith(5, importObjectsCommandMatcher)
       expect(mockExecuteAction.mock.calls[4][0].arguments).toEqual(expect.objectContaining({
-        type: 'typeA',
+        type: 'addressForm',
         scriptid: 'c',
       }))
 
       expect(mockExecuteAction).toHaveBeenNthCalledWith(6, importObjectsCommandMatcher)
       expect(mockExecuteAction.mock.calls[5][0].arguments).toEqual(expect.objectContaining({
-        type: 'typeB',
+        type: 'advancedpdftemplate',
         scriptid: 'd',
       }))
 
@@ -349,10 +352,10 @@ describe('netsuite client', () => {
 
     it('should skip chunks if the type has failed', async () => {
       const ids = [
-        { type: 'typeA', scriptId: 'a' },
-        { type: 'typeA', scriptId: 'b' },
-        { type: 'typeA', scriptId: 'c' },
-        { type: 'typeB', scriptId: 'd' },
+        { type: 'addressForm', scriptId: 'a' },
+        { type: 'addressForm', scriptId: 'b' },
+        { type: 'addressForm', scriptId: 'c' },
+        { type: 'advancedpdftemplate', scriptId: 'd' },
       ]
       mockExecuteAction.mockImplementation(context => {
         if (context.commandName === COMMANDS.LIST_OBJECTS) {
@@ -374,7 +377,7 @@ describe('netsuite client', () => {
         // so the failure of the first chunk won't results skipping the second.
         sdfConcurrencyLimit: 1,
       })
-      await client.getCustomObjects(['typeA', 'typeB'])
+      await client.getCustomObjects(typeNamesQuery)
       // createProject & setupAccount & importObjects & deleteAuthId
       const numberOfExecuteActions = 6
       expect(mockExecuteAction).toHaveBeenCalledTimes(numberOfExecuteActions)
@@ -384,13 +387,13 @@ describe('netsuite client', () => {
 
       expect(mockExecuteAction).toHaveBeenNthCalledWith(4, importObjectsCommandMatcher)
       expect(mockExecuteAction.mock.calls[3][0].arguments).toEqual(expect.objectContaining({
-        type: 'typeA',
+        type: 'addressForm',
         scriptid: 'a b',
       }))
 
       expect(mockExecuteAction).toHaveBeenNthCalledWith(5, importObjectsCommandMatcher)
       expect(mockExecuteAction.mock.calls[4][0].arguments).toEqual(expect.objectContaining({
-        type: 'typeB',
+        type: 'advancedpdftemplate',
         scriptid: 'd',
       }))
 
@@ -408,15 +411,15 @@ describe('netsuite client', () => {
             data: instancesIds,
           })
         }
-        if (context.commandName === COMMANDS.IMPORT_OBJECTS && context.arguments.type === 'TypeA') {
+        if (context.commandName === COMMANDS.IMPORT_OBJECTS && context.arguments.type === 'addressForm') {
           await new Promise(resolve => setTimeout(resolve, 100))
           return Promise.resolve({ isSuccess: () => true })
         }
         return Promise.resolve({ isSuccess: () => true })
       })
       const client = mockClient({ fetchAllTypesAtOnce: false, fetchTypeTimeoutInMinutes: 0.001 })
-      const getCustomObjectsResult = await client.getCustomObjects(typeNames)
-      expect(getCustomObjectsResult.failedTypes).toEqual(['TypeA'])
+      const getCustomObjectsResult = await client.getCustomObjects(typeNamesQuery)
+      expect(getCustomObjectsResult.failedTypes).toEqual(['addressForm'])
       expect(getCustomObjectsResult.failedToFetchAllAtOnce).toEqual(false)
     })
 
@@ -431,10 +434,18 @@ describe('netsuite client', () => {
           await new Promise(resolve => setTimeout(resolve, 1))
           return Promise.resolve({ isSuccess: () => true })
         }
+        if (context.commandName === COMMANDS.LIST_OBJECTS) {
+          return Promise.resolve({ isSuccess: () => true, data: [{ scriptId: 'id', type: 'type' }] })
+        }
         return Promise.resolve({ isSuccess: () => true })
       })
       const client = mockClient({ fetchAllTypesAtOnce: true, fetchTypeTimeoutInMinutes: 0.0001 })
-      const getCustomObjectsResult = await client.getCustomObjects(['someType'])
+      const query = buildNetsuiteQuery({
+        types: {
+          addressForm: ['.*'],
+        },
+      })
+      const getCustomObjectsResult = await client.getCustomObjects(query)
       expect(getCustomObjectsResult.failedTypes).toEqual([])
       expect(getCustomObjectsResult.failedToFetchAllAtOnce).toEqual(true)
     })
@@ -444,7 +455,7 @@ describe('netsuite client', () => {
         if (context.commandName === COMMANDS.LIST_OBJECTS) {
           return Promise.resolve({
             isSuccess: () => true,
-            data: [{ type: 'TypeA', scriptId: 'a' }],
+            data: [{ type: 'addressForm', scriptId: 'a' }],
           })
         }
         return Promise.resolve({ isSuccess: () => true })
@@ -454,7 +465,7 @@ describe('netsuite client', () => {
         elements: customizationInfos,
         failedToFetchAllAtOnce,
         failedTypes,
-      } = await mockClient().getCustomObjects(typeNames)
+      } = await mockClient().getCustomObjects(typeNamesQuery)
       expect(failedToFetchAllAtOnce).toBe(false)
       expect(failedTypes).toHaveLength(0)
       expect(readDirMock).toHaveBeenCalledTimes(1)
@@ -462,7 +473,7 @@ describe('netsuite client', () => {
       expect(rmMock).toHaveBeenCalledTimes(1)
       expect(customizationInfos).toHaveLength(2)
       expect(customizationInfos).toEqual([{
-        typeName: 'TypeA',
+        typeName: 'addressForm',
         scriptId: 'a',
         values: {
           '@_filename': 'a.xml',
@@ -471,7 +482,7 @@ describe('netsuite client', () => {
         fileExtension: 'html',
       },
       {
-        typeName: 'TypeA',
+        typeName: 'addressForm',
         scriptId: 'b',
         values: {
           '@_filename': 'b.xml',
@@ -483,9 +494,57 @@ describe('netsuite client', () => {
       expect(mockExecuteAction).toHaveBeenNthCalledWith(3, listObjectsCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(4, importObjectsCommandMatcher)
     })
+
+    it('should list and import only objects that match the query', async () => {
+      mockExecuteAction.mockImplementation(context => {
+        if (context.commandName === COMMANDS.LIST_OBJECTS) {
+          return Promise.resolve({
+            isSuccess: () => true,
+            data: [
+              { type: 'addressForm', scriptId: 'a' },
+              { type: 'addressForm', scriptId: 'b' },
+            ],
+          })
+        }
+        return Promise.resolve({ isSuccess: () => true })
+      })
+
+      const query = buildNetsuiteQuery({
+        types: {
+          addressForm: ['a'],
+        },
+      })
+      await mockClient().getCustomObjects(query)
+      expect(mockExecuteAction).toHaveBeenCalledWith(expect.objectContaining({
+        commandName: COMMANDS.LIST_OBJECTS,
+        arguments: {
+          type: 'addressForm',
+        },
+      }))
+
+      expect(mockExecuteAction).toHaveBeenCalledWith(expect.objectContaining({
+        commandName: COMMANDS.IMPORT_OBJECTS,
+        arguments: expect.objectContaining({
+          type: 'addressForm',
+          scriptid: 'a',
+        }),
+      }))
+
+      expect(mockExecuteAction).not.toHaveBeenCalledWith(expect.objectContaining({
+        commandName: COMMANDS.IMPORT_OBJECTS,
+        arguments: expect.objectContaining({
+          type: 'addressForm',
+          scriptid: 'b',
+        }),
+      }))
+    })
   })
 
   describe('importFileCabinetContent', () => {
+    const allFilesQuery = buildNetsuiteQuery({
+      filePaths: ['.*'],
+    })
+
     let client: NetsuiteClient
     beforeEach(() => {
       client = mockClient()
@@ -498,7 +557,7 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ isSuccess: () => true })
       })
-      await expect(client.importFileCabinetContent([])).rejects.toThrow()
+      await expect(client.importFileCabinetContent(allFilesQuery)).rejects.toThrow()
       expect(rmMock).toHaveBeenCalledTimes(0)
     })
 
@@ -509,24 +568,9 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ isSuccess: () => true })
       })
-      const { elements, failedPaths } = await client.importFileCabinetContent([])
+      const { elements, failedPaths } = await client.importFileCabinetContent(allFilesQuery)
       expect(elements).toHaveLength(0)
       expect(failedPaths).toEqual(fileCabinetTopLevelFolders)
-    })
-
-    it('should not call listFiles for folders in skip list', async () => {
-      mockExecuteAction.mockResolvedValue(Promise.resolve({ isSuccess: () => true }))
-      const { elements, failedPaths } = await client
-        .importFileCabinetContent([new RegExp(fileCabinetTopLevelFolders[0])])
-
-      expect(mockExecuteAction).toHaveBeenCalledTimes(5)
-      expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
-      expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
-      expect(mockExecuteAction).toHaveBeenNthCalledWith(3, listFilesCommandMatcher)
-      expect(mockExecuteAction).toHaveBeenNthCalledWith(4, listFilesCommandMatcher)
-      expect(mockExecuteAction).toHaveBeenNthCalledWith(5, deleteAuthIdCommandMatcher)
-      expect(elements).toHaveLength(0)
-      expect(failedPaths).toHaveLength(0)
     })
 
     it('should fail when SETUP_ACCOUNT has failed', async () => {
@@ -536,7 +580,7 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ isSuccess: () => true })
       })
-      await expect(client.importFileCabinetContent([])).rejects.toThrow()
+      await expect(client.importFileCabinetContent(allFilesQuery)).rejects.toThrow()
     })
 
     it('should succeed when having no files', async () => {
@@ -557,7 +601,7 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ isSuccess: () => true })
       })
-      const { elements, failedPaths } = await client.importFileCabinetContent([])
+      const { elements, failedPaths } = await client.importFileCabinetContent(allFilesQuery)
       expect(mockExecuteAction).toHaveBeenCalledTimes(6)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
@@ -618,7 +662,7 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ isSuccess: () => true })
       })
-      const { elements, failedPaths } = await client.importFileCabinetContent([])
+      const { elements, failedPaths } = await client.importFileCabinetContent(allFilesQuery)
       expect(mockExecuteAction).toHaveBeenCalledTimes(9)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
@@ -674,7 +718,7 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ isSuccess: () => true })
       })
-      const { elements, failedPaths } = await client.importFileCabinetContent([])
+      const { elements, failedPaths } = await client.importFileCabinetContent(allFilesQuery)
       expect(readFileMock).toHaveBeenCalledTimes(3)
       expect(elements).toHaveLength(2)
       expect(elements).toEqual([{
@@ -701,7 +745,7 @@ describe('netsuite client', () => {
       expect(mockExecuteAction).toHaveBeenNthCalledWith(6, importFilesCommandMatcher)
     })
 
-    it('should filter out paths that match filePathRegexSkipList', async () => {
+    it('should filter out paths that do not match the query', async () => {
       mockExecuteAction.mockImplementation(context => {
         const filesPathResult = [
           MOCK_FILE_PATH,
@@ -715,9 +759,10 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ isSuccess: () => true })
       })
-      const { elements, failedPaths } = await client.importFileCabinetContent(
-        [new RegExp(MOCK_FILE_PATH)]
-      )
+      const query = notQuery(buildNetsuiteQuery({
+        filePaths: [MOCK_FILE_PATH],
+      }))
+      const { elements, failedPaths } = await client.importFileCabinetContent(query)
       expect(readFileMock).toHaveBeenCalledTimes(0)
       expect(elements).toHaveLength(0)
       expect(failedPaths).toHaveLength(0)
@@ -766,7 +811,7 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ isSuccess: () => true })
       })
-      const { elements, failedPaths } = await client.importFileCabinetContent([])
+      const { elements, failedPaths } = await client.importFileCabinetContent(allFilesQuery)
       expect(readFileMock).toHaveBeenCalledTimes(1)
       expect(elements).toHaveLength(1)
       expect(elements).toEqual([{

--- a/packages/netsuite-adapter/test/filters/instance_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/instance_references.test.ts
@@ -16,88 +16,164 @@
 import {
   ElemID, InstanceElement, ObjectType, ReferenceExpression,
 } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import filterCreator from '../../src/filters/instance_references'
 import { customTypes, fileCabinetTypes } from '../../src/types'
 import { FILE, PATH, SCRIPT_ID, WORKFLOW } from '../../src/constants'
 
 
 describe('instance_references filter', () => {
-  describe('replace values', () => {
-    const fileInstance = new InstanceElement('fileInstance', fileCabinetTypes[FILE], {
-      [PATH]: '/Templates/file.name',
-    })
-    const workflowInstance = new InstanceElement('instanceName', customTypes[WORKFLOW], {
-      [SCRIPT_ID]: 'top_level',
-      workflowstates: {
-        workflowstate: [
-          {
-            [SCRIPT_ID]: 'one_nesting',
-            workflowactions: [
-              {
-                setfieldvalueaction: [
-                  {
-                    [SCRIPT_ID]: 'two_nesting',
-                  },
-                  {
-                    [SCRIPT_ID]: 'two_nesting_with_inner_ref',
-                    field: '[scriptid=top_level.one_nesting.two_nesting]',
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-    })
-    const instanceWithRefs = new InstanceElement(
-      'instanceName',
-      new ObjectType({ elemID: new ElemID('') }),
-      {
-        refToFilePath: '[/Templates/file.name]',
-        refToScriptId: '[scriptid=top_level]',
-        refToOneLevelNestedScriptId: '[scriptid=top_level.one_nesting]',
-        refToTwoLevelNestedScriptId: '[scriptid=top_level.one_nesting.two_nesting]',
-        refToNonExistingScriptId: '[scriptid=non_existing_script_id]',
-        refToNonExistingPath: '[/Templates/non.existing]',
-      },
-    )
+  describe('replace values', async () => {
+    let fileInstance: InstanceElement
+    let instanceInElementsSource: InstanceElement
+    let workflowInstance: InstanceElement
+    let instanceWithRefs: InstanceElement
+    beforeEach(async () => {
+      fileInstance = new InstanceElement('fileInstance', fileCabinetTypes[FILE], {
+        [PATH]: '/Templates/file.name',
+      })
 
-    filterCreator().onFetch([fileInstance, workflowInstance, instanceWithRefs])
+      instanceInElementsSource = new InstanceElement('instanceInElementsSource', fileCabinetTypes[FILE], {
+        [PATH]: '/Templates/instanceInElementsSource',
+      })
 
-    it('should replace path references', () => {
+      workflowInstance = new InstanceElement('instanceName', customTypes[WORKFLOW], {
+        [SCRIPT_ID]: 'top_level',
+        workflowstates: {
+          workflowstate: [
+            {
+              [SCRIPT_ID]: 'one_nesting',
+              workflowactions: [
+                {
+                  setfieldvalueaction: [
+                    {
+                      [SCRIPT_ID]: 'two_nesting',
+                    },
+                    {
+                      [SCRIPT_ID]: 'two_nesting_with_inner_ref',
+                      field: '[scriptid=top_level.one_nesting.two_nesting]',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      instanceWithRefs = new InstanceElement(
+        'instanceName',
+        new ObjectType({ elemID: new ElemID('') }),
+        {
+          refToFilePath: '[/Templates/file.name]',
+          refToScriptId: '[scriptid=top_level]',
+          refToOneLevelNestedScriptId: '[scriptid=top_level.one_nesting]',
+          refToTwoLevelNestedScriptId: '[scriptid=top_level.one_nesting.two_nesting]',
+          refToNonExistingScriptId: '[scriptid=non_existing_script_id]',
+          refToNonExistingPath: '[/Templates/non.existing]',
+          refToInstanceInElementSourcePath: '[/Templates/instanceInElementsSource]',
+        },
+      )
+    })
+
+    it('should replace path references', async () => {
+      await filterCreator().onFetch({
+        elements: [fileInstance, workflowInstance, instanceWithRefs],
+        elementsSource: buildElementsSourceFromElements([]),
+        isPartial: false,
+      })
+
       expect(instanceWithRefs.value.refToFilePath)
         .toEqual(new ReferenceExpression(fileInstance.elemID.createNestedID(PATH)))
     })
 
-    it('should replace scriptid references', () => {
+    it('should replace scriptid references', async () => {
+      await filterCreator().onFetch({
+        elements: [fileInstance, workflowInstance, instanceWithRefs],
+        elementsSource: buildElementsSourceFromElements([]),
+        isPartial: false,
+      })
+
       expect(instanceWithRefs.value.refToScriptId)
         .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID(SCRIPT_ID)))
     })
 
-    it('should replace scriptid with 1 nesting level references', () => {
+    it('should replace scriptid with 1 nesting level references', async () => {
+      await filterCreator().onFetch({
+        elements: [fileInstance, workflowInstance, instanceWithRefs],
+        elementsSource: buildElementsSourceFromElements([]),
+        isPartial: false,
+      })
+
       expect(instanceWithRefs.value.refToOneLevelNestedScriptId)
         .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID('workflowstates', 'workflowstate', '0', SCRIPT_ID)))
     })
 
-    it('should replace scriptid with 2 nesting level references', () => {
+    it('should replace scriptid with 2 nesting level references', async () => {
+      await filterCreator().onFetch({
+        elements: [fileInstance, workflowInstance, instanceWithRefs],
+        elementsSource: buildElementsSourceFromElements([]),
+        isPartial: false,
+      })
+
       expect(instanceWithRefs.value.refToTwoLevelNestedScriptId)
         .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID('workflowstates', 'workflowstate', '0', 'workflowactions', '0', 'setfieldvalueaction', '0', SCRIPT_ID)))
     })
 
-    it('should replace inner scriptid references', () => {
+    it('should replace inner scriptid references', async () => {
+      await filterCreator().onFetch({
+        elements: [fileInstance, workflowInstance, instanceWithRefs],
+        elementsSource: buildElementsSourceFromElements([]),
+        isPartial: false,
+      })
+
       expect(workflowInstance.value.workflowstates.workflowstate[0].workflowactions[0]
         .setfieldvalueaction[1].field)
         .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID('workflowstates', 'workflowstate', '0', 'workflowactions', '0', 'setfieldvalueaction', '0', SCRIPT_ID)))
     })
 
-    it('should not replace scriptid references for unresolved ref', () => {
+    it('should not replace scriptid references for unresolved ref', async () => {
+      await filterCreator().onFetch({
+        elements: [fileInstance, workflowInstance, instanceWithRefs],
+        elementsSource: buildElementsSourceFromElements([]),
+        isPartial: false,
+      })
+
       expect(instanceWithRefs.value.refToNonExistingScriptId)
         .toEqual('[scriptid=non_existing_script_id]')
     })
 
-    it('should not replace path references for unresolved ref', () => {
+    it('should not replace path references for unresolved ref', async () => {
+      await filterCreator().onFetch({
+        elements: [fileInstance, workflowInstance, instanceWithRefs],
+        elementsSource: buildElementsSourceFromElements([]),
+        isPartial: false,
+      })
+
       expect(instanceWithRefs.value.refToNonExistingPath)
         .toEqual('[/Templates/non.existing]')
+    })
+
+    it('should use elements source for creating the references with fetch is partial', async () => {
+      await filterCreator().onFetch({
+        elements: [fileInstance, workflowInstance, instanceWithRefs],
+        elementsSource: buildElementsSourceFromElements([instanceInElementsSource]),
+        isPartial: true,
+      })
+
+      expect(instanceWithRefs.value.refToInstanceInElementSourcePath)
+        .toEqual(new ReferenceExpression(instanceInElementsSource.elemID.createNestedID(PATH)))
+    })
+
+    it('should not use elements source for creating the references when fetch is not partial', async () => {
+      await filterCreator().onFetch({
+        elements: [fileInstance, workflowInstance, instanceWithRefs],
+        elementsSource: buildElementsSourceFromElements([instanceInElementsSource]),
+        isPartial: false,
+      })
+
+      expect(instanceWithRefs.value.refToInstanceInElementSourcePath)
+        .toEqual('[/Templates/instanceInElementsSource]')
     })
   })
 })

--- a/packages/netsuite-adapter/test/query.test.ts
+++ b/packages/netsuite-adapter/test/query.test.ts
@@ -45,7 +45,7 @@ describe('NetsuiteQuery', () => {
         })
 
         it('should not match file paths that do not match the received regexes', () => {
-          expect(query.isTypeMatch('wrongType')).toBeFalsy()
+          expect(query.isFileMatch('aaaaa')).toBeFalsy()
         })
       })
 

--- a/packages/netsuite-adapter/test/query.test.ts
+++ b/packages/netsuite-adapter/test/query.test.ts
@@ -1,0 +1,177 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { describe } from 'jest-circus'
+import { andQuery, buildNetsuiteQuery, notQuery } from '../src/query'
+
+describe('NetsuiteQuery', () => {
+  describe('buildNetsuiteQuery', () => {
+    describe('valid query', () => {
+      const query = buildNetsuiteQuery({
+        types: {
+          addressForm: ['aaa.*', 'bbb.*'],
+          advancedpdftemplate: ['ccc.*', 'ddd.*'],
+        },
+        filePaths: ['eee.*', 'fff.*'],
+      })
+
+      describe('isTypeMatch', () => {
+        it('should match the received types', () => {
+          expect(query.isTypeMatch('addressForm')).toBeTruthy()
+          expect(query.isTypeMatch('advancedpdftemplate')).toBeTruthy()
+        })
+
+        it('should not match types the were not received', () => {
+          expect(query.isTypeMatch('wrongType')).toBeFalsy()
+        })
+      })
+
+      describe('isFileMatch', () => {
+        it('should match file paths that match the received regexes', () => {
+          expect(query.isFileMatch('eeeaaa')).toBeTruthy()
+          expect(query.isFileMatch('ffffqqqq')).toBeTruthy()
+        })
+
+        it('should not match file paths that do not match the received regexes', () => {
+          expect(query.isTypeMatch('wrongType')).toBeFalsy()
+        })
+      })
+
+      describe('isObjectMatch', () => {
+        it('should match objects that match the received regexes', () => {
+          expect(query.isObjectMatch({ scriptId: 'aaaaaa', type: 'addressForm' })).toBeTruthy()
+          expect(query.isObjectMatch({ scriptId: 'cccccc', type: 'advancedpdftemplate' })).toBeTruthy()
+        })
+
+        it('should not match objects that do not match the received regexes', () => {
+          expect(query.isObjectMatch({ scriptId: 'aaaaaa', type: 'notExists' })).toBeFalsy()
+          expect(query.isObjectMatch({ scriptId: 'cccccc', type: 'addressForm' })).toBeFalsy()
+        })
+      })
+    })
+
+    describe('validateParameters', () => {
+      it('Valid query should not throw exception', () => {
+        expect(() => buildNetsuiteQuery({
+          types: {
+            addressForm: ['aaa.*', 'bbb.*'],
+            advancedpdftemplate: ['ccc.*', 'ddd.*'],
+          },
+          filePaths: ['eee.*', 'fff.*'],
+        })).not.toThrow()
+      })
+
+      it('Invalid regexes should throw an error with the regexes', () => {
+        let error: Error | undefined
+        try {
+          buildNetsuiteQuery({
+            types: {
+              addressForm: ['aa(a.*', 'bbb.*'],
+            },
+            filePaths: ['eee.*', 'f(ff.*'],
+          })
+        } catch (e) {
+          error = e
+        }
+
+        expect(error).toBeDefined()
+        expect(error?.message).toContain('aa(a.*')
+        expect(error?.message).toContain('f(ff.*')
+        expect(error?.message).not.toContain('bbb.*')
+        expect(error?.message).not.toContain('eee.*')
+      })
+
+      it('Invalid types should throw an error with the types', () => {
+        let error: Error | undefined
+        try {
+          buildNetsuiteQuery({
+            types: {
+              addressForm: ['.*'],
+              invalidType: ['.*'],
+            },
+          })
+        } catch (e) {
+          error = e
+        }
+
+        expect(error).toBeDefined()
+        expect(error?.message).toContain('invalidType')
+        expect(error?.message).not.toContain('addressForm')
+      })
+    })
+  })
+
+  describe('andQuery', () => {
+    const firstQuery = buildNetsuiteQuery({
+      types: {
+        addressForm: ['aaa.*'],
+        advancedpdftemplate: ['.*'],
+      },
+      filePaths: ['bbb.*'],
+    })
+    const secondQuery = buildNetsuiteQuery({
+      types: {
+        addressForm: ['.*ccc'],
+        bankstatementparserplugin: ['.*'],
+      },
+      filePaths: ['.*ddd'],
+    })
+    const bothQuery = andQuery(firstQuery, secondQuery)
+
+    it('should match only types that match both queries', () => {
+      expect(bothQuery.isTypeMatch('addressForm')).toBeTruthy()
+      expect(bothQuery.isTypeMatch('advancedpdftemplate')).toBeFalsy()
+      expect(bothQuery.isTypeMatch('bankstatementparserplugin')).toBeFalsy()
+    })
+
+    it('should match only files that match both queries', () => {
+      expect(bothQuery.isFileMatch('bbbdddd')).toBeTruthy()
+      expect(bothQuery.isFileMatch('bbb')).toBeFalsy()
+      expect(bothQuery.isFileMatch('ddd')).toBeFalsy()
+    })
+
+    it('should match only objects that match both queries', () => {
+      expect(bothQuery.isObjectMatch({ scriptId: 'aaacccc', type: 'addressForm' })).toBeTruthy()
+      expect(bothQuery.isObjectMatch({ scriptId: 'aaa', type: 'addressForm' })).toBeFalsy()
+      expect(bothQuery.isObjectMatch({ scriptId: 'aaa', type: 'advancedpdftemplate' })).toBeFalsy()
+    })
+  })
+
+  describe('notQuery', () => {
+    const query = buildNetsuiteQuery({
+      types: {
+        addressForm: ['aaa.*'],
+      },
+      filePaths: ['bbb.*'],
+    })
+    const inverseQuery = notQuery(query)
+
+    it('should match only types that do not match the original query', () => {
+      expect(inverseQuery.isTypeMatch('addressForm')).toBeFalsy()
+      expect(inverseQuery.isTypeMatch('advancedpdftemplate')).toBeTruthy()
+    })
+
+    it('should match only files that do not match the original query', () => {
+      expect(inverseQuery.isFileMatch('bbb')).toBeFalsy()
+      expect(inverseQuery.isFileMatch('ddd')).toBeTruthy()
+    })
+
+    it('should match only objects that do not match the original query', () => {
+      expect(inverseQuery.isObjectMatch({ scriptId: 'aaa', type: 'addressForm' })).toBeFalsy()
+      expect(inverseQuery.isObjectMatch({ scriptId: 'aaa', type: 'advancedpdftemplate' })).toBeTruthy()
+      expect(inverseQuery.isObjectMatch({ scriptId: 'bbb', type: 'addressForm' })).toBeTruthy()
+    })
+  })
+})

--- a/packages/netsuite-adapter/test/query.test.ts
+++ b/packages/netsuite-adapter/test/query.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { describe } from 'jest-circus'
-import { andQuery, buildNetsuiteQuery, notQuery } from '../src/query'
+import { andQuery, buildNetsuiteQuery, notQuery, validateParameters } from '../src/query'
 
 describe('NetsuiteQuery', () => {
   describe('buildNetsuiteQuery', () => {
@@ -61,55 +61,55 @@ describe('NetsuiteQuery', () => {
         })
       })
     })
+  })
 
-    describe('validateParameters', () => {
-      it('Valid query should not throw exception', () => {
-        expect(() => buildNetsuiteQuery({
+  describe('validateParameters', () => {
+    it('Valid query should not throw exception', () => {
+      expect(() => validateParameters({
+        types: {
+          addressForm: ['aaa.*', 'bbb.*'],
+          advancedpdftemplate: ['ccc.*', 'ddd.*'],
+        },
+        filePaths: ['eee.*', 'fff.*'],
+      })).not.toThrow()
+    })
+
+    it('Invalid regexes should throw an error with the regexes', () => {
+      let error: Error | undefined
+      try {
+        validateParameters({
           types: {
-            addressForm: ['aaa.*', 'bbb.*'],
-            advancedpdftemplate: ['ccc.*', 'ddd.*'],
+            addressForm: ['aa(a.*', 'bbb.*'],
           },
-          filePaths: ['eee.*', 'fff.*'],
-        })).not.toThrow()
-      })
+          filePaths: ['eee.*', 'f(ff.*'],
+        })
+      } catch (e) {
+        error = e
+      }
 
-      it('Invalid regexes should throw an error with the regexes', () => {
-        let error: Error | undefined
-        try {
-          buildNetsuiteQuery({
-            types: {
-              addressForm: ['aa(a.*', 'bbb.*'],
-            },
-            filePaths: ['eee.*', 'f(ff.*'],
-          })
-        } catch (e) {
-          error = e
-        }
+      expect(error).toBeDefined()
+      expect(error?.message).toContain('aa(a.*')
+      expect(error?.message).toContain('f(ff.*')
+      expect(error?.message).not.toContain('bbb.*')
+      expect(error?.message).not.toContain('eee.*')
+    })
 
-        expect(error).toBeDefined()
-        expect(error?.message).toContain('aa(a.*')
-        expect(error?.message).toContain('f(ff.*')
-        expect(error?.message).not.toContain('bbb.*')
-        expect(error?.message).not.toContain('eee.*')
-      })
+    it('Invalid types should throw an error with the types', () => {
+      let error: Error | undefined
+      try {
+        validateParameters({
+          types: {
+            addressForm: ['.*'],
+            invalidType: ['.*'],
+          },
+        })
+      } catch (e) {
+        error = e
+      }
 
-      it('Invalid types should throw an error with the types', () => {
-        let error: Error | undefined
-        try {
-          buildNetsuiteQuery({
-            types: {
-              addressForm: ['.*'],
-              invalidType: ['.*'],
-            },
-          })
-        } catch (e) {
-          error = e
-        }
-
-        expect(error).toBeDefined()
-        expect(error?.message).toContain('invalidType')
-        expect(error?.message).not.toContain('addressForm')
-      })
+      expect(error).toBeDefined()
+      expect(error?.message).toContain('invalidType')
+      expect(error?.message).not.toContain('addressForm')
     })
   })
 


### PR DESCRIPTION
Implemented partial fetch from Netsuite according to the query here: https://www.notion.so/saltoio/Netsuite-Partial-Fetch-Query-a451486fd54c46ae9770ea295fd86a5b

This PR does not include the API change of typesToSkip and filePathRegexSkipList. This will be done in a different PR.

This PR currently includes some unrelated changes, such as the implementation of build `buildElementsSourceFromElements` I will remove those changes once https://github.com/salto-io/salto/pull/1755 and https://github.com/salto-io/salto/pull/1763 are merged (Also, the CI won't pass until they are merged).

---
__Release Notes__:
Netsuite Adapter:
Added "fetchTarget" to choose what elements to fetch from the service.