### PR TITLE
SALTO-1139 - advance past newlines on lexer recover

### DIFF
--- a/packages/workspace/src/parser/internal/native/consumers/blocks.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/blocks.ts
@@ -45,6 +45,7 @@ export const recoverInvalidItemDefinition = (context: ParseContext): void => {
     TOKEN_TYPES.CCURLY,
     TOKEN_TYPES.EQUAL,
     TOKEN_TYPES.OCURLY,
+    TOKEN_TYPES.NEWLINE,
   ])
   // If we recover to the equal value, we need to consume it and the value it holds...
   if (context.lexer.peek()?.type === TOKEN_TYPES.EQUAL) {

--- a/packages/workspace/src/parser/internal/native/consumers/blocks.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/blocks.ts
@@ -45,7 +45,6 @@ export const recoverInvalidItemDefinition = (context: ParseContext): void => {
     TOKEN_TYPES.CCURLY,
     TOKEN_TYPES.EQUAL,
     TOKEN_TYPES.OCURLY,
-    TOKEN_TYPES.NEWLINE,
   ])
   // If we recover to the equal value, we need to consume it and the value it holds...
   if (context.lexer.peek()?.type === TOKEN_TYPES.EQUAL) {

--- a/packages/workspace/src/parser/internal/native/consumers/values.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/values.ts
@@ -235,7 +235,7 @@ const consumeArrayItems = (
         end: positionAtEnd(token),
         filename: context.filename,
       }))
-      context.lexer.recover([TOKEN_TYPES.COMMA, closingTokenType])
+      context.lexer.recover([TOKEN_TYPES.COMMA, closingTokenType], false)
       if (context.lexer.peek()?.type === TOKEN_TYPES.COMMA) {
         context.lexer.next()
       }

--- a/packages/workspace/src/parser/internal/native/consumers/values.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/values.ts
@@ -360,7 +360,7 @@ const consumeObject = (context: ParseContext, idPrefix?: ElemID): ConsumerReturn
     const tokens = consumeWords(context)
     if (tokens.value?.length !== 1) {
       context.errors.push(invalidAttrKey({ ...tokens.range, filename: context.filename }))
-      context.lexer.recover([TOKEN_TYPES.CCURLY])
+      context.lexer.recover([TOKEN_TYPES.NEWLINE, TOKEN_TYPES.CCURLY])
       return
     }
     const key = tokens.value[0]
@@ -372,7 +372,7 @@ const consumeObject = (context: ParseContext, idPrefix?: ElemID): ConsumerReturn
         end: tokens.range.end,
         filename: context.filename,
       }))
-      context.lexer.recover([TOKEN_TYPES.CCURLY])
+      context.lexer.recover([TOKEN_TYPES.NEWLINE, TOKEN_TYPES.CCURLY])
       return
     }
     // consume the token
@@ -400,7 +400,7 @@ const consumeObject = (context: ParseContext, idPrefix?: ElemID): ConsumerReturn
         end: positionAtStart(nonNewlineToken),
         filename: context.filename,
       }))
-      context.lexer.recover([TOKEN_TYPES.CCURLY])
+      context.lexer.recover([TOKEN_TYPES.NEWLINE, TOKEN_TYPES.CCURLY])
     }
   }
 

--- a/packages/workspace/src/parser/internal/native/consumers/values.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/values.ts
@@ -360,7 +360,7 @@ const consumeObject = (context: ParseContext, idPrefix?: ElemID): ConsumerReturn
     const tokens = consumeWords(context)
     if (tokens.value?.length !== 1) {
       context.errors.push(invalidAttrKey({ ...tokens.range, filename: context.filename }))
-      context.lexer.recover([TOKEN_TYPES.NEWLINE, TOKEN_TYPES.CCURLY])
+      context.lexer.recover([TOKEN_TYPES.CCURLY])
       return
     }
     const key = tokens.value[0]
@@ -372,7 +372,7 @@ const consumeObject = (context: ParseContext, idPrefix?: ElemID): ConsumerReturn
         end: tokens.range.end,
         filename: context.filename,
       }))
-      context.lexer.recover([TOKEN_TYPES.NEWLINE, TOKEN_TYPES.CCURLY])
+      context.lexer.recover([TOKEN_TYPES.CCURLY])
       return
     }
     // consume the token
@@ -400,7 +400,7 @@ const consumeObject = (context: ParseContext, idPrefix?: ElemID): ConsumerReturn
         end: positionAtStart(nonNewlineToken),
         filename: context.filename,
       }))
-      context.lexer.recover([TOKEN_TYPES.NEWLINE, TOKEN_TYPES.CCURLY])
+      context.lexer.recover([TOKEN_TYPES.CCURLY])
     }
   }
 

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -159,8 +159,10 @@ class PeekableLexer {
       return token
     }
 
-    public recover(stopTokens: string[]): void {
-      const allStopTokens = [TOKEN_TYPES.NEWLINE, ...stopTokens]
+    public recover(stopTokens: string[], advancePastNewlines = true): void {
+      const allStopTokens = (advancePastNewlines
+        ? [TOKEN_TYPES.NEWLINE, ...stopTokens]
+        : stopTokens)
       // This is handling a special case in which the recover char
       // is not a new line. In such case, there is a chance that the
       // char is already loaded to the peekNoNewLine attr, which means
@@ -168,7 +170,7 @@ class PeekableLexer {
       while (!allStopTokens.includes(this.peek(false)?.type || '')) {
         this.next(false)
       }
-      if (this.peek(false)?.type === TOKEN_TYPES.NEWLINE) {
+      if (advancePastNewlines && this.peek(false)?.type === TOKEN_TYPES.NEWLINE) {
         this.next(false)
       }
     }

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -160,11 +160,15 @@ class PeekableLexer {
     }
 
     public recover(stopTokens: string[]): void {
+      const allStopTokens = [TOKEN_TYPES.NEWLINE, ...stopTokens]
       // This is handling a special case in which the recover char
       // is not a new line. In such case, there is a chance that the
       // char is already loaded to the peekNoNewLine attr, which means
       // that the lexer has already advanced
-      while (!stopTokens.includes(this.peek(false)?.type || '')) {
+      while (!allStopTokens.includes(this.peek(false)?.type || '')) {
+        this.next(false)
+      }
+      if (this.peek(false)?.type === TOKEN_TYPES.NEWLINE) {
         this.next(false)
       }
     }

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -160,14 +160,11 @@ class PeekableLexer {
     }
 
     public recover(stopTokens: string[], advancePastNewlines = true): void {
-      const allStopTokens = (advancePastNewlines
-        ? [TOKEN_TYPES.NEWLINE, ...stopTokens]
-        : stopTokens)
       // This is handling a special case in which the recover char
       // is not a new line. In such case, there is a chance that the
       // char is already loaded to the peekNoNewLine attr, which means
       // that the lexer has already advanced
-      while (!allStopTokens.includes(this.peek(false)?.type || '')) {
+      while (!stopTokens.includes(this.peek(false)?.type || '')) {
         this.next(false)
       }
       if (advancePastNewlines && this.peek(false)?.type === TOKEN_TYPES.NEWLINE) {

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -715,7 +715,7 @@ each([true, false]).describe('Salto parser', (useLegacyParser: boolean) => {
       expect(result.errors[0].summary).toEqual(expectedErrMsg)
     })
 
-    it('fails on missing list open', async () => {
+    it('fails on missing list open in object', async () => {
       const body = `
       salto {
           {
@@ -732,6 +732,36 @@ each([true, false]).describe('Salto parser', (useLegacyParser: boolean) => {
       const expectedErrMsg = useLegacyParser
         ? 'Unexpected token: {'
         : 'Invalid block item'
+      expect(result.errors[0].summary).toEqual(expectedErrMsg)
+    })
+
+    it('fails on missing list open in object item', async () => {
+      const body = `
+      salto {
+        a = {
+            "abc"
+          ]
+        }
+      }
+      `
+      const result = await parse(Buffer.from(body), 'none', functions)
+      expect(result.errors).not.toHaveLength(0)
+      const expectedErrMsg = useLegacyParser
+        ? 'Unexpected token: ]'
+        : 'Invalid attribute definition'
+      expect(result.errors[0].summary).toEqual(expectedErrMsg)
+    })
+
+    it('fails on invalid object item with unexpected eof', async () => {
+      const body = `
+      salto {
+        a = {
+          {`
+      const result = await parse(Buffer.from(body), 'none', functions)
+      expect(result.errors).not.toHaveLength(0)
+      const expectedErrMsg = useLegacyParser
+        ? 'Unexpected end of file'
+        : 'Invalid attribute key'
       expect(result.errors[0].summary).toEqual(expectedErrMsg)
     })
   })

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -714,6 +714,26 @@ each([true, false]).describe('Salto parser', (useLegacyParser: boolean) => {
         : 'Invalid block item'
       expect(result.errors[0].summary).toEqual(expectedErrMsg)
     })
+
+    it('fails on missing list open', async () => {
+      const body = `
+      salto {
+          {
+            a = 1
+          },
+          {
+            a = 2
+          }
+        ]
+      }
+      `
+      const result = await parse(Buffer.from(body), 'none', functions)
+      expect(result.errors).not.toHaveLength(0)
+      const expectedErrMsg = useLegacyParser
+        ? 'Unexpected token: {'
+        : 'Invalid block item'
+      expect(result.errors[0].summary).toEqual(expectedErrMsg)
+    })
   })
 
   it('fails on invalid top level syntax', async () => {


### PR DESCRIPTION
Some (invalid) nacls could result in an out-of-memory exception instead of being caught earlier as invalid.
The original scenario being fixed is for [this](https://github.com/salto-io/salto/blob/master/packages/workspace/src/parser/internal/native/consumers/values.ts#L363) error, where if the lexer was already at EOL, `recover` did nothing because the peeked character was one of the stop tokens - resulting in an endless loop. Based on a suggestion from @roironn , instead of fixing just this scenario, the `recover` logic was changed to advance past EOLs (with an option to opt-out).

---
_Release Notes_
(can be combined with https://github.com/salto-io/salto/pull/1767)
Fix parser out-of-memory on some invalid nacl formats.