### PR TITLE
SALTO-1097: fixed instancesRegexSkippedList to work with custom objects

### DIFF
--- a/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
+++ b/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  Element, isObjectType, InstanceElement, ObjectType,
+  Element, isObjectType, InstanceElement, ObjectType, ElemID,
 } from '@salto-io/adapter-api'
 import { CredsLease } from '@salto-io/e2e-credentials-store'
 import { SalesforceRecord } from '../src/client/types'
@@ -25,10 +25,10 @@ import SalesforceClient from '../src/client/client'
 import { UsernamePasswordCredentials } from '../src/types'
 import { runFiltersOnFetch, createElement, removeElementAndVerify, createInstance, getRecordOfInstance } from './utils'
 import { apiName, isInstanceOfCustomObject } from '../src/transformers/transformer'
-import customObjectsFilter from '../src/filters/custom_objects'
+import customObjectsFilter, { INSTANCE_REQUIRED_FIELD, INSTANCE_TYPE_FIELD } from '../src/filters/custom_objects'
 import customObjectsInstancesFilter from '../src/filters/custom_objects_instances'
 import { createCustomSettingsObject } from '../test/utils'
-import { LIST_CUSTOM_SETTINGS_TYPE } from '../src/constants'
+import { CUSTOM_OBJECT, INSTANCE_FULL_NAME_FIELD, LIST_CUSTOM_SETTINGS_TYPE, METADATA_TYPE, SALESFORCE } from '../src/constants'
 
 /* eslint-disable @typescript-eslint/camelcase */
 describe('custom object instances e2e', () => {
@@ -58,7 +58,35 @@ describe('custom object instances e2e', () => {
     adapter = adapterParams.adapter
     client = adapterParams.client
 
-    elements = []
+    const leadInstance = new InstanceElement(
+      CUSTOM_OBJECT,
+      new ObjectType(
+        {
+          elemID: new ElemID(SALESFORCE, CUSTOM_OBJECT),
+          annotations: { [METADATA_TYPE]: CUSTOM_OBJECT },
+        },
+      ),
+      {
+        [INSTANCE_FULL_NAME_FIELD]: 'Lead',
+        fields: [
+          {
+            [INSTANCE_FULL_NAME_FIELD]: 'ExtraSalt',
+            [INSTANCE_TYPE_FIELD]: 'Checkbox',
+            [INSTANCE_REQUIRED_FIELD]: 'false',
+          },
+          {
+            [INSTANCE_FULL_NAME_FIELD]: 'WhoKnows',
+          },
+          {
+            [INSTANCE_FULL_NAME_FIELD]: 'Pepper',
+            [INSTANCE_TYPE_FIELD]: 'Location',
+            [INSTANCE_REQUIRED_FIELD]: 'false',
+          },
+        ],
+      },
+    )
+
+    elements = [leadInstance]
     await runFiltersOnFetch(
       client,
       filtersContext,

--- a/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
+++ b/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
@@ -25,7 +25,7 @@ import SalesforceClient from '../src/client/client'
 import { UsernamePasswordCredentials } from '../src/types'
 import { runFiltersOnFetch, createElement, removeElementAndVerify, createInstance, getRecordOfInstance } from './utils'
 import { apiName, isInstanceOfCustomObject } from '../src/transformers/transformer'
-import customObjectsFilter, { INSTANCE_REQUIRED_FIELD, INSTANCE_TYPE_FIELD } from '../src/filters/custom_objects'
+import customObjectsFilter from '../src/filters/custom_objects'
 import customObjectsInstancesFilter from '../src/filters/custom_objects_instances'
 import { createCustomSettingsObject } from '../test/utils'
 import { CUSTOM_OBJECT, INSTANCE_FULL_NAME_FIELD, LIST_CUSTOM_SETTINGS_TYPE, METADATA_TYPE, SALESFORCE } from '../src/constants'
@@ -58,7 +58,7 @@ describe('custom object instances e2e', () => {
     adapter = adapterParams.adapter
     client = adapterParams.client
 
-    const leadInstance = new InstanceElement(
+    const instance = new InstanceElement(
       CUSTOM_OBJECT,
       new ObjectType(
         {
@@ -67,26 +67,11 @@ describe('custom object instances e2e', () => {
         },
       ),
       {
-        [INSTANCE_FULL_NAME_FIELD]: 'Lead',
-        fields: [
-          {
-            [INSTANCE_FULL_NAME_FIELD]: 'ExtraSalt',
-            [INSTANCE_TYPE_FIELD]: 'Checkbox',
-            [INSTANCE_REQUIRED_FIELD]: 'false',
-          },
-          {
-            [INSTANCE_FULL_NAME_FIELD]: 'WhoKnows',
-          },
-          {
-            [INSTANCE_FULL_NAME_FIELD]: 'Pepper',
-            [INSTANCE_TYPE_FIELD]: 'Location',
-            [INSTANCE_REQUIRED_FIELD]: 'false',
-          },
-        ],
+        [INSTANCE_FULL_NAME_FIELD]: 'Product2',
       },
     )
 
-    elements = [leadInstance]
+    elements = [instance]
     await runFiltersOnFetch(
       client,
       filtersContext,

--- a/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
+++ b/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  Element, isObjectType, InstanceElement, ObjectType, ElemID,
+  Element, isObjectType, InstanceElement, ObjectType,
 } from '@salto-io/adapter-api'
 import { CredsLease } from '@salto-io/e2e-credentials-store'
 import { SalesforceRecord } from '../src/client/types'
@@ -23,12 +23,12 @@ import SalesforceAdapter, { testHelpers } from '../index'
 import realAdapter from './adapter'
 import SalesforceClient from '../src/client/client'
 import { UsernamePasswordCredentials } from '../src/types'
-import { runFiltersOnFetch, createElement, removeElementAndVerify, createInstance, getRecordOfInstance } from './utils'
+import { runFiltersOnFetch, createElement, removeElementAndVerify, createInstance, getRecordOfInstance, fetchTypes, getMetadataInstance } from './utils'
 import { apiName, isInstanceOfCustomObject } from '../src/transformers/transformer'
 import customObjectsFilter from '../src/filters/custom_objects'
 import customObjectsInstancesFilter from '../src/filters/custom_objects_instances'
 import { createCustomSettingsObject } from '../test/utils'
-import { CUSTOM_OBJECT, INSTANCE_FULL_NAME_FIELD, LIST_CUSTOM_SETTINGS_TYPE, METADATA_TYPE, SALESFORCE } from '../src/constants'
+import { CUSTOM_OBJECT, LIST_CUSTOM_SETTINGS_TYPE } from '../src/constants'
 
 /* eslint-disable @typescript-eslint/camelcase */
 describe('custom object instances e2e', () => {
@@ -58,20 +58,13 @@ describe('custom object instances e2e', () => {
     adapter = adapterParams.adapter
     client = adapterParams.client
 
-    const instance = new InstanceElement(
-      CUSTOM_OBJECT,
-      new ObjectType(
-        {
-          elemID: new ElemID(SALESFORCE, CUSTOM_OBJECT),
-          annotations: { [METADATA_TYPE]: CUSTOM_OBJECT },
-        },
-      ),
-      {
-        [INSTANCE_FULL_NAME_FIELD]: 'Product2',
-      },
-    )
-
+    const types = await fetchTypes(client, [CUSTOM_OBJECT])
+    const instance = await getMetadataInstance(client, types[0], productTwoMetadataName)
+    if (instance === undefined) {
+      throw new Error(`Failed getting ${productTwoMetadataName} instance`)
+    }
     elements = [instance]
+
     await runFiltersOnFetch(
       client,
       filtersContext,

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -456,16 +456,13 @@ const fetchSObjects = async (
 ): Promise<Record<string, DescribeSObjectResult[]>> => {
   const sobjectsList = await client.listSObjects()
 
-  const sobjectNames = _(sobjectsList)
+  const sobjectNames = sobjectsList
     .map(sobj => sobj.name)
     .filter(name => name in customObjectInstances)
-    .value()
 
   const sobjectsDescriptions = await client.describeSObjects(sobjectNames)
 
-  return _(sobjectsDescriptions)
-    .groupBy(e => e.name)
-    .value()
+  return _.groupBy(sobjectsDescriptions, e => e.name)
 }
 
 const createFromSObjectsAndInstances = (

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -133,7 +133,35 @@ describe('Custom Objects filter', () => {
         },
       }) as typeof filter
       customObjectType = generateCustomObjectType()
-      result = [customObjectType]
+
+      const leadInstance = new InstanceElement(
+        CUSTOM_OBJECT,
+        new ObjectType(
+          {
+            elemID: mockGetElemIdFunc(SALESFORCE, {}, CUSTOM_OBJECT),
+            annotations: { [METADATA_TYPE]: CUSTOM_OBJECT },
+          },
+        ),
+        {
+          [INSTANCE_FULL_NAME_FIELD]: 'Lead',
+          fields: [
+            {
+              [INSTANCE_FULL_NAME_FIELD]: 'ExtraSalt',
+              [INSTANCE_TYPE_FIELD]: 'Checkbox',
+              [INSTANCE_REQUIRED_FIELD]: 'false',
+            },
+            {
+              [INSTANCE_FULL_NAME_FIELD]: 'WhoKnows',
+            },
+            {
+              [INSTANCE_FULL_NAME_FIELD]: 'Pepper',
+              [INSTANCE_TYPE_FIELD]: 'Location',
+              [INSTANCE_REQUIRED_FIELD]: 'false',
+            },
+          ],
+        },
+      )
+      result = [customObjectType, leadInstance]
     })
 
     afterEach(() => {
@@ -247,6 +275,14 @@ describe('Custom Objects filter', () => {
         expect(leadObj.fields.Formula__c.type.elemID.name).toBe('FormulaText')
         expect(leadObj.fields.Formula__c.annotations[FORMULA]).toBe('my formula')
       })
+
+      it('should not fetch sobject if they are not in the received elements', async () => {
+        mockSingleSObject('Lead', [])
+        const elements = [customObjectType]
+        await filter.onFetch(elements)
+        expect(findElements(elements, 'Lead')).toHaveLength(0)
+      })
+
       it('should fetch sobject with Name compound field', async () => {
         mockSingleSObject('Lead', [
           {
@@ -440,34 +476,7 @@ describe('Custom Objects filter', () => {
             nillable: true,
           },
         ])
-        const leadInstance = new InstanceElement(
-          CUSTOM_OBJECT,
-          new ObjectType(
-            {
-              elemID: mockGetElemIdFunc(SALESFORCE, {}, CUSTOM_OBJECT),
-              annotations: { [METADATA_TYPE]: CUSTOM_OBJECT },
-            },
-          ),
-          {
-            [INSTANCE_FULL_NAME_FIELD]: 'Lead',
-            fields: [
-              {
-                [INSTANCE_FULL_NAME_FIELD]: 'ExtraSalt',
-                [INSTANCE_TYPE_FIELD]: 'Checkbox',
-                [INSTANCE_REQUIRED_FIELD]: 'false',
-              },
-              {
-                [INSTANCE_FULL_NAME_FIELD]: 'WhoKnows',
-              },
-              {
-                [INSTANCE_FULL_NAME_FIELD]: 'Pepper',
-                [INSTANCE_TYPE_FIELD]: 'Location',
-                [INSTANCE_REQUIRED_FIELD]: 'false',
-              },
-            ],
-          },
-        )
-        result.push(leadInstance)
+
         await filter.onFetch(result)
 
         const lead = findElements(result, 'Lead').pop() as ObjectType
@@ -509,10 +518,17 @@ describe('Custom Objects filter', () => {
           },
         ])
 
-        const newFilter = filterCreator({ client, config: {} }) as typeof filter
-        await newFilter.onFetch(result)
+        const instance = new InstanceElement(
+          'Custom__c',
+          new ObjectType({ elemID: new ElemID(SALESFORCE, CUSTOM_OBJECT) }),
+          { [INSTANCE_FULL_NAME_FIELD]: 'Custom__c' },
+        )
+        const elements: Element[] = [instance]
 
-        const custom = result.filter(o => o.elemID.name === 'Custom').pop() as ObjectType
+        const newFilter = filterCreator({ client, config: {} }) as typeof filter
+        await newFilter.onFetch(elements)
+
+        const custom = elements.filter(o => o.elemID.name === 'Custom').pop() as ObjectType
         expect(custom.fields.StringField.annotations[API_NAME]).toEqual('Custom__c.StringField__c')
       })
 
@@ -647,7 +663,8 @@ describe('Custom Objects filter', () => {
       it('should fetch packaged custom SObjects', async () => {
         const namespaceName = 'namespaceName'
         const fieldWithNamespaceName = `${namespaceName}${NAMESPACE_SEPARATOR}WithNamespace__c`
-        mockSingleSObject(`${namespaceName}${NAMESPACE_SEPARATOR}Test__c`, [
+        const objectName = `${namespaceName}${NAMESPACE_SEPARATOR}Test__c`
+        mockSingleSObject(objectName, [
           {
             name: 'dummy', label: 'dummy', type: 'string',
           },
@@ -659,9 +676,16 @@ describe('Custom Objects filter', () => {
           },
         ], false, true, true)
 
-        await filter.onFetch(result)
+        const instance = new InstanceElement(
+          objectName,
+          new ObjectType({ elemID: new ElemID(SALESFORCE, CUSTOM_OBJECT) }),
+          { [INSTANCE_FULL_NAME_FIELD]: objectName },
+        )
+        const elements = [instance]
 
-        const testElements = findElements(result, 'namespaceName__Test__c') as ObjectType[]
+        await filter.onFetch(elements)
+
+        const testElements = findElements(elements, 'namespaceName__Test__c') as ObjectType[]
         expect(testElements).toHaveLength(1)
         const object = testElements.find(obj =>
           _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, namespaceName, OBJECTS_PATH,

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -520,7 +520,10 @@ describe('Custom Objects filter', () => {
 
         const instance = new InstanceElement(
           'Custom__c',
-          new ObjectType({ elemID: new ElemID(SALESFORCE, CUSTOM_OBJECT) }),
+          new ObjectType({
+            elemID: new ElemID(SALESFORCE, CUSTOM_OBJECT),
+            annotations: { [METADATA_TYPE]: CUSTOM_OBJECT },
+          }),
           { [INSTANCE_FULL_NAME_FIELD]: 'Custom__c' },
         )
         const elements: Element[] = [instance]
@@ -678,7 +681,10 @@ describe('Custom Objects filter', () => {
 
         const instance = new InstanceElement(
           objectName,
-          new ObjectType({ elemID: new ElemID(SALESFORCE, CUSTOM_OBJECT) }),
+          new ObjectType({
+            elemID: new ElemID(SALESFORCE, CUSTOM_OBJECT),
+            annotations: { [METADATA_TYPE]: CUSTOM_OBJECT },
+          }),
           { [INSTANCE_FULL_NAME_FIELD]: objectName },
         )
         const elements = [instance]


### PR DESCRIPTION
Fixed instancesRegexSkippedList to work with custom objects.

---

Additional context can be found in https://salto-io.atlassian.net/browse/SALTO-1097.

---
_Release Notes_: 
Salesforce Adapter:
Added support for excluding custom objects using the "instancesRegexSkippedList" configuration option.