### PR TITLE
SALTO-1059: Resolve EmailTemplate -> Letterhead reference

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -306,7 +306,6 @@ export const WORKFLOW_OUTBOUND_MESSAGE_METADATA_TYPE = 'WorkflowOutboundMessage'
 export const WORKFLOW_RULE_METADATA_TYPE = 'WorkflowRule'
 export const WORKFLOW_TASK_METADATA_TYPE = 'WorkflowTask'
 export const WEBLINK_METADATA_TYPE = 'WebLink'
-export const LETTERHEAD_TYPE = 'Letterhead'
 export const BUSINESS_HOURS_METADATA_TYPE = 'BusinessHoursSettings'
 export const SETTINGS_METADATA_TYPE = 'Settings'
 

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -306,6 +306,7 @@ export const WORKFLOW_OUTBOUND_MESSAGE_METADATA_TYPE = 'WorkflowOutboundMessage'
 export const WORKFLOW_RULE_METADATA_TYPE = 'WorkflowRule'
 export const WORKFLOW_TASK_METADATA_TYPE = 'WorkflowTask'
 export const WEBLINK_METADATA_TYPE = 'WebLink'
+export const LETTERHEAD_TYPE = 'Letterhead'
 export const BUSINESS_HOURS_METADATA_TYPE = 'BusinessHoursSettings'
 export const SETTINGS_METADATA_TYPE = 'Settings'
 

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -146,7 +146,7 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   },
   {
     src: { field: 'letterhead', parentTypes: ['EmailTemplate'] },
-    target: { parentContext: 'instanceParent', type: 'Letterhead' },
+    target: { type: 'Letterhead' },
   },
   {
     src: { field: 'fields', parentTypes: ['WorkflowOutboundMessage'] },

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -146,7 +146,6 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   },
   {
     src: { field: 'letterhead', parentTypes: ['EmailTemplate'] },
-    serializationStrategy: 'relativeApiName',
     target: { parentContext: 'instanceParent', type: 'Letterhead' },
   },
   {

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -30,7 +30,6 @@ import {
   CPQ_QUOTE_LINE_FIELDS, DEFAULT_OBJECT_TO_API_MAPPING, SCHEDULE_CONTRAINT_FIELD_TO_API_MAPPING,
   TEST_OBJECT_TO_API_MAPPING, CPQ_TESTED_OBJECT, CPQ_PRICE_SCHEDULE, CPQ_DISCOUNT_SCHEDULE,
   CPQ_CONFIGURATION_ATTRIBUTE, CPQ_DEFAULT_OBJECT_FIELD, CPQ_QUOTE, CPQ_CONSTRAINT_FIELD,
-  LETTERHEAD_TYPE,
 } from '../constants'
 
 const log = logger(module)
@@ -148,7 +147,7 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   {
     src: { field: 'letterhead', parentTypes: ['EmailTemplate'] },
     serializationStrategy: 'relativeApiName',
-    target: { parentContext: 'instanceParent', type: LETTERHEAD_TYPE },
+    target: { parentContext: 'instanceParent', type: 'Letterhead' },
   },
   {
     src: { field: 'fields', parentTypes: ['WorkflowOutboundMessage'] },

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -30,6 +30,7 @@ import {
   CPQ_QUOTE_LINE_FIELDS, DEFAULT_OBJECT_TO_API_MAPPING, SCHEDULE_CONTRAINT_FIELD_TO_API_MAPPING,
   TEST_OBJECT_TO_API_MAPPING, CPQ_TESTED_OBJECT, CPQ_PRICE_SCHEDULE, CPQ_DISCOUNT_SCHEDULE,
   CPQ_CONFIGURATION_ATTRIBUTE, CPQ_DEFAULT_OBJECT_FIELD, CPQ_QUOTE, CPQ_CONSTRAINT_FIELD,
+  LETTERHEAD_TYPE,
 } from '../constants'
 
 const log = logger(module)
@@ -143,6 +144,11 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     src: { field: 'field', parentTypes: [WORKFLOW_FIELD_UPDATE_METADATA_TYPE, LAYOUT_ITEM_METADATA_TYPE, SUMMARY_LAYOUT_ITEM_METADATA_TYPE, 'WorkflowEmailRecipient', 'QuickActionLayoutItem'] },
     serializationStrategy: 'relativeApiName',
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
+  },
+  {
+    src: { field: 'letterhead', parentTypes: ['EmailTemplate'] },
+    serializationStrategy: 'relativeApiName',
+    target: { parentContext: 'instanceParent', type: LETTERHEAD_TYPE },
   },
   {
     src: { field: 'fields', parentTypes: ['WorkflowOutboundMessage'] },


### PR DESCRIPTION
Today when we `fetch` email templates from salesforce, the `letterhead` field was resolved as `string` type, which caused the link between Email Template and Letterhead records to break in multi-env scenarios.
 
This PR changes the letterhead type from string to a reference.

---
_Additional information_ : 

Before this change: sharing an  EmailTemplate with a letterhead between envs, and deploying it, showed no validation errors, and we got exceptions from saleforce when trying to deploy it. 

After this change: deploying to a new service will yield a reference error

```
➜  salto-workspace salto deploy
Error validating "salesforce.EmailTemplate.instance.unfiled_public_asd@zcd.letterhead": unresolved reference salesforce.Letterhead.instance.WelcomeMail
 on salesforce/Records/EmailTemplate/unfiled_public_asd.nacl(line: 5)
  letterhead = salesforce.Letterhead.instance.WelcomeMail

? Workspace has a warning - do you want to continue? (Y/n)
```  

And after moving that element to the common folder, the deploy process succeeds.

---
_Release Notes_: 
Salesforce Adapter: Extend support for email templates with letterhead.