### PR TITLE
fix early close of telemetry and logger

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -54,13 +54,14 @@ const main = async (): Promise<CliExitCode> => {
   log.debug('Installation ID: %s', config.installationID)
   log.info('running "%s"', cmdStr)
   try {
-    return cli({
+    const ret = await cli({
       input: { args, telemetry, config: config.command },
       output: { stdout, stderr },
       commandDefs,
       spinnerCreator: oraSpinnerCreator,
       workspacePath: '.',
     })
+    return ret
   } finally {
     await Promise.all([
       telemetry.stop(EVENTS_FLUSH_WAIT_TIME),

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -26,6 +26,7 @@ import {
   telemetrySender, Telemetry, Tags, TelemetryEvent, CommandConfig,
 } from '@salto-io/core'
 import { Workspace, errors as wsErrors, state as wsState, pathIndex, parser } from '@salto-io/workspace'
+import { logger } from '@salto-io/logging'
 import realCli from '../src/cli'
 import commandDefinitions from '../src/commands/index'
 import { CommandOrGroupDef, CommandArgs } from '../src/command_builder'
@@ -171,6 +172,10 @@ export const cli = async ({
   const spinnerCreator = mockSpinnerCreator(spinners)
 
   const exitCode = await realCli({ input, output, commandDefs, spinnerCreator, workspacePath: '.' })
+  await Promise.all([
+    input.telemetry.stop(1000),
+    logger.end(),
+  ])
 
   return { err: output.stderr.content, out: output.stdout.content, exitCode }
 }


### PR DESCRIPTION
Small fix for a recent change (moving the cli teardown from [here](https://github.com/salto-io/salto/pull/1765/files#r557455894) to [here](https://github.com/salto-io/salto/pull/1765/files#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cR65)) that caused a crash due to the telemetry and logger closing right after starting.

---
_Release Notes_: 
None (not released yet)
