### PR TITLE
fixed to use state elements in the adapters elementsSource

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -199,16 +199,17 @@ export const fetch: FetchFunc = async (
   log.debug('fetch starting..')
 
   const state = await workspace.state()
+  const stateElements = await state.getAll()
 
   const fetchServices = services ?? workspace.services()
   const [filteredStateElements, stateElementsNotCoveredByFetch] = partitionElementsByServices(
-    await state.getAll(), fetchServices
+    stateElements, fetchServices
   )
   const adaptersCreatorConfigs = await getAdaptersCreatorConfigs(
     fetchServices,
     await workspace.servicesCredentials(services),
     await workspace.servicesConfig(services),
-    buildElementsSourceFromElements(await state.getAll()),
+    buildElementsSourceFromElements(stateElements),
     createElemIdGetter(filteredStateElements)
   )
   const currentConfigs = Object.values(adaptersCreatorConfigs)


### PR DESCRIPTION
Changed the elementsSource that is passed to each adapter to contain the state elements and not the workspace elements.

---

_Additional context for reviewer_
In https://github.com/salto-io/salto/pull/1763, I passed the adapter an elementsSource with the workspace elements of the adapter. The adapters should not be able to access changes that were not deployed to the service, so the adapter should only get the state elements and not the whole workspace. 

---
_Release Notes_: None