### PR TITLE
SALTO-1133: converted the old format of the skip list to the new format in Netsuite

### DIFF
--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -2,12 +2,14 @@
 ## Configuration example
 ```hcl
 netsuite {
-  typesToSkip = [
-    "savedsearch",
-  ]
-  filePathRegexSkipList = [
-    "^/Web Site Hosting Files.*",
-  ]
+  skipList = {
+    types = {
+      savedsearch = [".*"]
+    }
+    filePaths = [
+      "^/Web Site Hosting Files.*",
+    ]
+  }
   deployReferencedElements = false
   client = {
     fetchAllTypesAtOnce = false

--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -22,8 +22,7 @@ netsuite {
 
 | Name                                                | Default when undefined  | Description
 | ----------------------------------------------------| ------------------------| -----------
-| typesToSkip                                         | [] (fetch all types)    | Specified types that their instances will not be fetched from the service
-| filePathRegexSkipList                               | [] (fetch all files)    | Matching file-cabinet file paths will not be fetched from the service
+| [skipList](#skip-list-configuration-options)        | {} (skip nothing)       | Specified items to skip when fetching from the service
 | deployReferencedElements                            | false                   | Deployment of a certain configuration element will include all elements referred by it
 | [client](#client-configuration-options)             | {} (no overrides)       | Configuration relating to the client used to interact with netsuite
 
@@ -35,3 +34,9 @@ netsuite {
 | fetchTypeTimeoutInMinutes      | 20                      | The max number of minutes a single type's fetch can run
 | maxItemsInImportObjectsRequest | 30                      | Limits the max number of requested items a single import-objects request
 | sdfConcurrencyLimit            | 4                       | Limits the max number of concurrent SDF API calls. The number should not exceed the concurrency limit enforced by the upstream service.
+
+### Skip list configuration options
+| Name                           | Default when undefined  | Description
+| -------------------------------| ------------------------| -----------
+| types                          | {}                      | A map of a type name to a list of regexes of script ids. Any object whose script id matches any of the regexes of its type will be skipped
+| filePaths                      | []                      | A list of regexes of file paths. Any file whose path matches any of the regexes will be skipped

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -209,9 +209,10 @@ const updateConfigFromFailures = (
     if (newSkipList.filePaths === undefined) {
       newSkipList.filePaths = []
     }
-    newSkipList.filePaths.push(
-      ...suggestions[FILE_PATHS_REGEX_SKIP_LIST]
-    )
+    newSkipList.filePaths = [
+      ...makeArray(newSkipList.filePaths),
+      ...suggestions[FILE_PATHS_REGEX_SKIP_LIST],
+    ]
   }
   configToUpdate.value[SKIP_LIST] = newSkipList
   return true

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -66,6 +66,8 @@ export const DEPLOY_REFERENCED_ELEMENTS = 'deployReferencedElements'
 export const SDF_CONCURRENCY_LIMIT = 'sdfConcurrencyLimit'
 export const CLIENT_CONFIG = 'client'
 export const FETCH_TARGET = 'fetchTarget'
+export const SKIP_LIST = 'skipList'
+export const RAW_CONFIG = 'rawConfig'
 
 export const CAPTURE = 'capture'
 // e.g. '[scriptid=customworkflow1]' & '[scriptid=customworkflow1.workflowstate17.workflowaction33]'

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -252,7 +252,7 @@ describe('Adapter', () => {
       })
       const getConfigFromConfigChangesMock = getConfigFromConfigChanges as jest.Mock
       const updatedConfig = new InstanceElement(ElemID.CONFIG_NAME, configType)
-      getConfigFromConfigChangesMock.mockReturnValue(updatedConfig)
+      getConfigFromConfigChangesMock.mockReturnValue({ config: updatedConfig, message: '' })
       const fetchResult = await netsuiteAdapter.fetch()
       expect(getConfigFromConfigChanges).toHaveBeenCalledWith(false, ['/path/to/file'], config)
       expect(fetchResult.updatedConfig?.config.isEqual(updatedConfig)).toBe(true)
@@ -265,7 +265,7 @@ describe('Adapter', () => {
       })
       const getConfigFromConfigChangesMock = getConfigFromConfigChanges as jest.Mock
       const updatedConfig = new InstanceElement(ElemID.CONFIG_NAME, configType)
-      getConfigFromConfigChangesMock.mockReturnValue(updatedConfig)
+      getConfigFromConfigChangesMock.mockReturnValue({ config: updatedConfig, message: '' })
       const fetchResult = await netsuiteAdapter.fetch()
       expect(getConfigFromConfigChangesMock).toHaveBeenCalledWith(true, [], config)
       expect(fetchResult.updatedConfig?.config.isEqual(updatedConfig)).toBe(true)

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -27,6 +27,7 @@ import {
   DEPLOY_REFERENCED_ELEMENTS, FETCH_TYPE_TIMEOUT_IN_MINUTES, CLIENT_CONFIG,
   MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST,
   FETCH_TARGET,
+  SKIP_LIST,
 } from '../src/constants'
 import { mockGetElemIdFunc } from './utils'
 
@@ -66,6 +67,7 @@ describe('NetsuiteAdapter creator', () => {
     ElemID.CONFIG_NAME,
     adapter.configType as ObjectType,
     {
+      [SKIP_LIST]: {},
       [TYPES_TO_SKIP]: ['test1'],
       [FILE_PATHS_REGEX_SKIP_LIST]: ['^/Templates.*'],
       [DEPLOY_REFERENCED_ELEMENTS]: false,
@@ -109,6 +111,7 @@ describe('NetsuiteAdapter creator', () => {
       expect(NetsuiteAdapter).toHaveBeenCalledWith({
         client: expect.any(Object),
         config: {
+          [SKIP_LIST]: {},
           [TYPES_TO_SKIP]: ['test1'],
           [FILE_PATHS_REGEX_SKIP_LIST]: ['^/Templates.*'],
           [DEPLOY_REFERENCED_ELEMENTS]: false,
@@ -142,8 +145,6 @@ describe('NetsuiteAdapter creator', () => {
       expect(NetsuiteAdapter).toHaveBeenCalledWith({
         client: expect.any(Object),
         config: {
-          [TYPES_TO_SKIP]: [],
-          [FILE_PATHS_REGEX_SKIP_LIST]: [],
           [CLIENT_CONFIG]: {
             [FETCH_ALL_TYPES_AT_ONCE]: false,
           },
@@ -162,10 +163,7 @@ describe('NetsuiteAdapter creator', () => {
       })
       expect(NetsuiteAdapter).toHaveBeenCalledWith({
         client: expect.any(Object),
-        config: {
-          [TYPES_TO_SKIP]: [],
-          [FILE_PATHS_REGEX_SKIP_LIST]: [],
-        },
+        config: {},
         elementsSource,
         getElemIdFunc: mockGetElemIdFunc,
       })


### PR DESCRIPTION
This PR converts the format of the old skip list (i.e., `typesToSkip` and `filePathRegexSkipList`) to the same format as the `fetchTarget` in Netsuite. The new format is described in https://www.notion.so/saltoio/Netsuite-Partial-Fetch-Query-a451486fd54c46ae9770ea295fd86a5b

---
_Release Notes_: 
The configuration options `typesToSkip` and `filePathRegexSkipList` were replaced with a new option `skipList` that also allows skipping specific items of a type. On the next fetch, Salto will automatically upgrade the old options to the new option (with the user approval). 