### PR TITLE
Fix JSON.stringify outdated eslint message, apply in all relevant modules

### DIFF
--- a/eslint/adapter-api.rules.js
+++ b/eslint/adapter-api.rules.js
@@ -18,7 +18,7 @@ module.exports = {
         'no-restricted-syntax': [
             {
                 selector: "CallExpression[callee.object.name='JSON'][callee.property.name='stringify'][arguments.length=1]",
-                message: 'JSON.stringify usage without a replacer is disallowed. Use JSONSaltoValue instead.',
+                message: 'JSON.stringify usage without a replacer is disallowed. Use safeJsonStringify instead.',
             }
         ]
     }

--- a/packages/hubspot-adapter/src/transformers/transformer.ts
+++ b/packages/hubspot-adapter/src/transformers/transformer.ts
@@ -16,7 +16,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import _ from 'lodash'
 import { ElemID, ObjectType, PrimitiveType, PrimitiveTypes, Field, isObjectType, getDeepInnerType, BuiltinTypes, InstanceElement, TypeElement, CORE_ANNOTATIONS, isListType, TypeMap, Values, isPrimitiveType, Value, ListType, createRestriction, StaticFile, isContainerType, isMapType } from '@salto-io/adapter-api'
-import { TransformFunc, transformValues, GetLookupNameFunc, toObjectType, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
+import { TransformFunc, transformValues, GetLookupNameFunc, toObjectType, naclCase, pathNaclCase, safeJsonStringify } from '@salto-io/adapter-utils'
 import { isFormInstance } from '../filters/form_field'
 import {
   FIELD_TYPES, FORM_FIELDS, HUBSPOT, OBJECTS_NAMES, FORM_PROPERTY_FIELDS,
@@ -842,7 +842,7 @@ export const transformPrimitive: TransformFunc = ({ value, field, path }) => {
     }
     return new StaticFile({
       filepath: `${path?.getFullNameParts().filter((namePart: string): boolean => namePart !== 'instance').join('/')}.json`,
-      content: Buffer.from(JSON.stringify(value, null, 2)),
+      content: Buffer.from(safeJsonStringify(value, undefined, 2)),
       encoding: 'utf-8',
     })
   }

--- a/packages/netsuite-adapter/.eslintrc.js
+++ b/packages/netsuite-adapter/.eslintrc.js
@@ -19,6 +19,7 @@ const deepMerge = require('../../build_utils/deep_merge')
 
 module.exports = deepMerge(
     require('../../eslintrc.js'),
+    require('../../eslint/adapter-api.rules.js'),
     {
         parserOptions: {
             tsconfigRootDir: __dirname,

--- a/packages/salesforce-adapter/.eslintrc.js
+++ b/packages/salesforce-adapter/.eslintrc.js
@@ -17,6 +17,7 @@ const deepMerge = require('../../build_utils/deep_merge')
 
 module.exports = deepMerge(
   require('../../eslintrc.js'),
+  require('../../eslint/adapter-api.rules.js'),
   {
     parserOptions: {
       tsconfigRootDir: __dirname,

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -20,6 +20,7 @@ import {
   ModificationChange, Field, ObjectType, isObjectType, Values, isAdditionChange, isRemovalChange,
   isModificationChange,
 } from '@salto-io/adapter-api'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { BatchResultInfo } from 'jsforce-types'
 import { isInstanceOfCustomObject, instancesToCreateRecords, apiName,
   instancesToDeleteRecords, instancesToUpdateRecords, Types } from './transformers/transformer'
@@ -199,7 +200,7 @@ const deployAddInstances = async (
     const idFieldsValues = Object.fromEntries(
       idFieldsNames.map(fieldName => [fieldName, vals[fieldName]])
     )
-    return toMD5(JSON.stringify(idFieldsValues))
+    return toMD5(safeJsonStringify(idFieldsValues))
   }
   const computeRecordSaltoIdHash = (record: SalesforceRecord): string => {
     const recordValues = transformRecordToValues(type, record)

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -15,6 +15,7 @@
 */
 import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { DeployResult, Change, getChangeElement, isRemovalChange, isModificationChange, isInstanceChange, isContainerType, isAdditionChange } from '@salto-io/adapter-api'
 import { DeployResult as SFDeployResult, DeployMessage } from 'jsforce'
@@ -272,7 +273,7 @@ export const deployMetadata = async (
 
   const deployRes = await client.deploy(pkgData)
 
-  log.debug('deploy result: %s', JSON.stringify(deployRes, undefined, 2))
+  log.debug('deploy result: %s', safeJsonStringify(deployRes, undefined, 2))
 
   const { errors, successfulFullNames } = processDeployResponse(
     deployRes, pkg.getDeletionsPackageName()

--- a/packages/workspace/.eslintrc.js
+++ b/packages/workspace/.eslintrc.js
@@ -17,6 +17,7 @@ const deepMerge = require('../../build_utils/deep_merge')
 
 module.exports = deepMerge(
   require('../../eslintrc.js'),
+  require('../../eslint/adapter-api.rules.js'),
   {
     parserOptions: {
       tsconfigRootDir: __dirname,

--- a/packages/workspace/src/serializer/parse_result.ts
+++ b/packages/workspace/src/serializer/parse_result.ts
@@ -41,7 +41,7 @@ export const serialize = (parseResult: SerializeableParseResult): string => [
   elementSerializer.serialize(parseResult.elements, 'keepRef'),
   serializeErrors(parseResult.errors),
   parseResult.sourceMap ? serializeSourceMap(parseResult.sourceMap) : undefined,
-  JSON.stringify(parseResult.metadata),
+  safeJsonStringify(parseResult.metadata),
 ].join(EOL)
 
 const deserializeParseErrors = (data: string): ParseError[] =>


### PR DESCRIPTION
Ran into this when moving some code to adapter-utils.
It looks like the function was called `safeJsonStringify` since the rule was added, must have been a last-minute change on the original PR.
Seems `no-restricted-syntax` doesn't support fix suggestions and I didn't want to create a custom rule for it, so hopefully the correct function name won't change too much.
Also applying to adapters / shared libraries where this wasn't enforced.

---
_Release Notes_: 
None
