### PR TITLE
Update CLI documentation to include config override option

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -396,6 +396,8 @@ The following flags are available for all commands:
 * `--version -V` :  Show version number
 * `--help, -h` :    Show help
 * `--verbose, -v` : Output extra logs 
+* `--config, -C` :  Override adapter configuration value. format: `<service>.<path>=<value>`<br>
+  Can also be done by setting an environment variable named `SALTO_<service>_<path>=<value>`
 
 ## Workspace directory structure
 


### PR DESCRIPTION
---

Preview:

### Generic Flags
The following flags are available for all commands:	The following flags are available for all commands:
* `--version -V` :  Show version number	* `--version -V` :  Show version number
* `--help, -h` :    Show help	* `--help, -h` :    Show help
* `--verbose, -v` : Output extra logs 	* `--verbose, -v` : Output extra logs 
* `--config, -C` :  Override adapter configuration value. format: `<service>.<path>=<value>`
  Can also be done by setting an environment variable named `SALTO_<service>_<path>=<value>`

---
_Release Notes_: 
None
