### PR TITLE
Fix salesforce client throttling tests

### DIFF
--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -33,7 +33,7 @@ import {
 import { LAYOUT_TYPE_ID } from '../src/filters/layouts'
 import {
   MockFilePropertiesInput, MockDescribeResultInput, MockDescribeValueResultInput,
-  mockDescribeResult, mockDescribeValueResult, mockFileProperties, mockRetrieveResult,
+  mockDescribeResult, mockDescribeValueResult, mockFileProperties, mockRetrieveLocator,
 } from './connection'
 
 describe('SalesforceAdapter fetch', () => {
@@ -98,7 +98,7 @@ describe('SalesforceAdapter fetch', () => {
         const zipFiles = instances.map(inst => inst.zipFiles).filter(values.isDefined)
         if (!_.isEmpty(zipFiles)) {
           _.chunk(zipFiles, testMaxItemsInRetrieveRequest).forEach(
-            chunkFiles => connection.metadata.retrieve.mockReturnValueOnce(mockRetrieveResult({
+            chunkFiles => connection.metadata.retrieve.mockReturnValueOnce(mockRetrieveLocator({
               zipFiles: _.flatten(chunkFiles),
             })),
           )
@@ -871,7 +871,7 @@ public class MyClass${index} {
         )
         connectionMock.metadata.read.mockRejectedValue(new SFError('sf:UNKNOWN_EXCEPTION'))
 
-        connectionMock.metadata.retrieve.mockReturnValue(mockRetrieveResult({
+        connectionMock.metadata.retrieve.mockReturnValue(mockRetrieveLocator({
           messages: [{
             fileName: 'unpackaged/package.xml',
             problem: 'Metadata API received improper input.'

--- a/packages/salesforce-adapter/test/connection.ts
+++ b/packages/salesforce-adapter/test/connection.ts
@@ -96,16 +96,19 @@ export const mockFileProperties = (
 export type MockRetrieveResultInput = Partial<Omit<RetrieveResult, 'zipFile'>> &{
   zipFiles?: ZipFile[]
 }
-export const mockRetrieveResult = (
+export const mockRetrieveResult = async (
   props: MockRetrieveResultInput
+): Promise<RetrieveResult> => ({
+  fileProperties: [],
+  id: _.uniqueId(),
+  messages: [],
+  zipFile: await createEncodedZipContent(props.zipFiles ?? []),
+  ...props,
+})
+export const mockRetrieveLocator = (
+  props: MockRetrieveResultInput | Promise<RetrieveResult>
 ): RetrieveResultLocator<RetrieveResult> => ({
-  complete: async () => ({
-    fileProperties: [],
-    id: _.uniqueId(),
-    messages: [],
-    zipFile: await createEncodedZipContent(props.zipFiles ?? []),
-    ...props,
-  }),
+  complete: () => (props instanceof Promise ? props : mockRetrieveResult(props)),
 } as RetrieveResultLocator<RetrieveResult>)
 
 export const mockDeployMessage = (params: Partial<DeployMessage>): DeployMessage => ({
@@ -300,7 +303,7 @@ export const mockJsforce: () => MockInterface<Connection> = () => ({
     upsert: mockFunction<Metadata['upsert']>().mockResolvedValue([]),
     delete: mockFunction<Metadata['delete']>().mockResolvedValue([]),
     update: mockFunction<Metadata['update']>().mockResolvedValue([]),
-    retrieve: mockFunction<Metadata['retrieve']>().mockReturnValue(mockRetrieveResult({})),
+    retrieve: mockFunction<Metadata['retrieve']>().mockReturnValue(mockRetrieveLocator({})),
     deploy: mockFunction<Metadata['deploy']>().mockReturnValue(mockDeployResult({})),
   },
   soap: {


### PR DESCRIPTION
- Fix mock functions in client test to return appropriate value types
- Remove type casts that made it possible to return incorrect value types from mocks
- Change mock implementation to work around jest bug which caused the functions to return
  their default value (immediately resolved promise) instead of the return value specified in the tests

---

Jest has a bug (solved in newer versions) where a mock function that has `mockReturnValue` would return that value even if we later set a `mockResolvedValueOnce` on it.
Working around that issue by fixing the test to use `mockReturnValueOnce` (and returning the correct type of answer)

---
_Release Notes_: 
_None_
