### PR TITLE
SALTO-1124 SALTO-1127 - Netsuite: Add import objects retries, don't add types to skiplist, increase default objects chunk size

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -122,7 +122,6 @@ export default class NetsuiteAdapter implements AdapterOperations {
     const importFileCabinetResult = this.client.importFileCabinetContent(fetchQuery)
     const {
       elements: customObjects,
-      failedTypes,
       failedToFetchAllAtOnce,
     } = await getCustomObjectsResult
     const {
@@ -141,7 +140,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     const isPartial = this.fetchTarget !== undefined
 
     await this.runFiltersOnFetch(elements, this.elementsSource, isPartial)
-    const config = getConfigFromConfigChanges(failedToFetchAllAtOnce, failedTypes, failedFilePaths,
+    const config = getConfigFromConfigChanges(failedToFetchAllAtOnce, failedFilePaths,
       this.userConfig)
 
     if (_.isUndefined(config)) {

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -479,9 +479,9 @@ export default class NetsuiteClient {
           .toArray()
     ).flatten(true).toArray()
 
-    log.debug('Fetching custom objects one by one')
+    log.debug('Fetching custom objects by types in chunks')
     await withLimitedConcurrency( // limit the number of open promises
-      idsChunks.map(idsChunk => async () => importObjectsChunk(idsChunk)),
+      idsChunks.map(idsChunk => () => importObjectsChunk(idsChunk)),
       this.sdfConcurrencyLimit
     )
   }

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -32,7 +32,7 @@ const { makeArray } = collections.array
 export const DEFAULT_SDF_CONCURRENCY = 4
 export const DEFAULT_FETCH_ALL_TYPES_AT_ONCE = false
 export const DEFAULT_FETCH_TYPE_TIMEOUT_IN_MINUTES = 20
-export const DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST = 30
+export const DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST = 50
 export const DEFAULT_DEPLOY_REFERENCED_ELEMENTS = false
 
 const clientConfigType = new ObjectType({
@@ -154,20 +154,18 @@ const wrapAsRegex = (str: string): string => `^${_.escapeRegExp(str)}$`
 
 const toConfigSuggestions = (
   failedToFetchAllAtOnce: boolean,
-  failedTypes: string[],
   failedFilePaths: string[]
 ): Partial<Record<keyof Omit<NetsuiteConfig, 'client'> | keyof NetsuiteClientConfig, Value>> => ({
   ...(failedToFetchAllAtOnce ? { [FETCH_ALL_TYPES_AT_ONCE]: false } : {}),
-  ...(!_.isEmpty(failedTypes) ? { [TYPES_TO_SKIP]: failedTypes } : {}),
   ...(!_.isEmpty(failedFilePaths)
     ? { [FILE_PATHS_REGEX_SKIP_LIST]: failedFilePaths.map(wrapAsRegex) }
     : {}),
 })
 
 
-export const getConfigFromConfigChanges = (failedToFetchAllAtOnce: boolean, failedTypes: string[],
+export const getConfigFromConfigChanges = (failedToFetchAllAtOnce: boolean,
   failedFilePaths: string[], currentConfig: NetsuiteConfig): InstanceElement | undefined => {
-  const suggestions = toConfigSuggestions(failedToFetchAllAtOnce, failedTypes, failedFilePaths)
+  const suggestions = toConfigSuggestions(failedToFetchAllAtOnce, failedFilePaths)
   if (_.isEmpty(suggestions)) {
     return undefined
   }
@@ -184,8 +182,6 @@ export const getConfigFromConfigChanges = (failedToFetchAllAtOnce: boolean, fail
     configType,
     _.pickBy({
       ...currentConfig,
-      [TYPES_TO_SKIP]: makeArray(currentConfig[TYPES_TO_SKIP])
-        .concat(makeArray(suggestions[TYPES_TO_SKIP])),
       [FILE_PATHS_REGEX_SKIP_LIST]: makeArray(currentConfig[FILE_PATHS_REGEX_SKIP_LIST])
         .concat(makeArray(suggestions[FILE_PATHS_REGEX_SKIP_LIST])),
       [CLIENT_CONFIG]: clientConfigSuggestion,

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -240,22 +240,8 @@ describe('Adapter', () => {
       const getConfigFromConfigChangesMock = getConfigFromConfigChanges as jest.Mock
       getConfigFromConfigChangesMock.mockReturnValue(undefined)
       const fetchResult = await netsuiteAdapter.fetch()
-      expect(getConfigFromConfigChanges).toHaveBeenCalledWith(false, [], [], config)
+      expect(getConfigFromConfigChanges).toHaveBeenCalledWith(false, [], config)
       expect(fetchResult.updatedConfig).toBeUndefined()
-    })
-
-    it('should call getConfigFromConfigChanges with failed types', async () => {
-      client.getCustomObjects = jest.fn().mockResolvedValue({
-        elements: [],
-        failedTypes: ['TypeA', 'TypeB'],
-        failedToFetchAllAtOnce: false,
-      })
-      const getConfigFromConfigChangesMock = getConfigFromConfigChanges as jest.Mock
-      const updatedConfig = new InstanceElement(ElemID.CONFIG_NAME, configType)
-      getConfigFromConfigChangesMock.mockReturnValue(updatedConfig)
-      const fetchResult = await netsuiteAdapter.fetch()
-      expect(getConfigFromConfigChanges).toHaveBeenCalledWith(false, ['TypeA', 'TypeB'], [], config)
-      expect(fetchResult.updatedConfig?.config.isEqual(updatedConfig)).toBe(true)
     })
 
     it('should call getConfigFromConfigChanges with failed file paths', async () => {
@@ -268,21 +254,20 @@ describe('Adapter', () => {
       const updatedConfig = new InstanceElement(ElemID.CONFIG_NAME, configType)
       getConfigFromConfigChangesMock.mockReturnValue(updatedConfig)
       const fetchResult = await netsuiteAdapter.fetch()
-      expect(getConfigFromConfigChanges).toHaveBeenCalledWith(false, [], ['/path/to/file'], config)
+      expect(getConfigFromConfigChanges).toHaveBeenCalledWith(false, ['/path/to/file'], config)
       expect(fetchResult.updatedConfig?.config.isEqual(updatedConfig)).toBe(true)
     })
 
     it('should call getConfigFromConfigChanges with false for fetchAllAtOnce', async () => {
       client.getCustomObjects = jest.fn().mockResolvedValue({
         elements: [],
-        failedTypes: [],
         failedToFetchAllAtOnce: true,
       })
       const getConfigFromConfigChangesMock = getConfigFromConfigChanges as jest.Mock
       const updatedConfig = new InstanceElement(ElemID.CONFIG_NAME, configType)
       getConfigFromConfigChangesMock.mockReturnValue(updatedConfig)
       const fetchResult = await netsuiteAdapter.fetch()
-      expect(getConfigFromConfigChangesMock).toHaveBeenCalledWith(true, [], [], config)
+      expect(getConfigFromConfigChangesMock).toHaveBeenCalledWith(true, [], config)
       expect(fetchResult.updatedConfig?.config.isEqual(updatedConfig)).toBe(true)
     })
   })

--- a/packages/netsuite-adapter/test/config.test.ts
+++ b/packages/netsuite-adapter/test/config.test.ts
@@ -32,12 +32,11 @@ describe('config', () => {
       [MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST]: 10,
     },
   }
-  const newFailedType = 'test2'
   const newFailedFilePath = '/path/to/file.js'
   const expectedNewFailedFileRegex = '^/path/to/file\\.js$'
 
   it('should return undefined when having no currentConfig suggestions', () => {
-    expect(getConfigFromConfigChanges(false, [], [], currentConfig)).toBeUndefined()
+    expect(getConfigFromConfigChanges(false, [], currentConfig)).toBeUndefined()
   })
 
   it('should have match between generated regex and the failed file', () => {
@@ -52,13 +51,12 @@ describe('config', () => {
   })
 
   it('should return updated currentConfig with defined values when having suggestions and the currentConfig is empty', () => {
-    const configFromConfigChanges = getConfigFromConfigChanges(true, [newFailedType],
+    const configFromConfigChanges = getConfigFromConfigChanges(true,
       [newFailedFilePath], {}) as InstanceElement
     expect(configFromConfigChanges.isEqual(new InstanceElement(
       ElemID.CONFIG_NAME,
       configType,
       {
-        [TYPES_TO_SKIP]: [newFailedType],
         [FILE_PATHS_REGEX_SKIP_LIST]: [expectedNewFailedFileRegex],
         [CLIENT_CONFIG]: {
           [FETCH_ALL_TYPES_AT_ONCE]: false,
@@ -68,12 +66,12 @@ describe('config', () => {
   })
 
   it('should return updated currentConfig when having suggestions and the currentConfig has values', () => {
-    expect(getConfigFromConfigChanges(true, [newFailedType], [newFailedFilePath], currentConfig))
+    expect(getConfigFromConfigChanges(true, [newFailedFilePath], currentConfig))
       .toEqual(new InstanceElement(
         ElemID.CONFIG_NAME,
         configType,
         {
-          [TYPES_TO_SKIP]: ['test1', newFailedType],
+          [TYPES_TO_SKIP]: ['test1'],
           [FILE_PATHS_REGEX_SKIP_LIST]: ['^SomeRegex.*', expectedNewFailedFileRegex],
           [DEPLOY_REFERENCED_ELEMENTS]: false,
           [CLIENT_CONFIG]: {


### PR DESCRIPTION
Until now we used to split the type's objects into chunks and in case a certain chunk has failed we would not return any instance if that type and add it to the skipList using the config suggestions mechanism.
This PR contains a retry mechanism on top of the chunks while dividing the chunk's size by 2 in case of failure in until the chunk has size of 1. In case we fail also when having chunk of size 1, we will fail the fetch operation.
Since we now have a safe fallback, I also increased the default chunk size from 30 to 50 assuming it'll accelerate the fetch.

---
_Release Notes_: 
Netsuite:
1. Do not add types that failed to fetch to typesToSkip automatically, but retry fetching them and fail the fetch operation in case it fails also then.
2. Increase default maxItemsInImportObjectsRequest to 50.
