### PR TITLE
SALTO-1136: added regex to skip packages' records and types to the default salesforce configuration

### DIFF
--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -308,7 +308,7 @@ const INSTANCE_SUFFIXES = [
   'History', 'pc', 'pr', 'hd', 'hqr', 'hst', 'b', 'latitude__s', 'longitude__s', 'e', 'p', 'ChangeEvent', 'chn',
 ]
 
-export const PACKAGES_INSTANCES_REGEX = `^.+\\.(?!standard_)[^_]+__(?!(${INSTANCE_SUFFIXES.join('|')})((?![a-zA-Z\\d]+|__)|$)).+$`
+export const PACKAGES_INSTANCES_REGEX = `^.+\\.(?!standard_)[^_]+__(?!(${INSTANCE_SUFFIXES.join('|')})([^a-zA-Z\\d_]+|$)).+$`
 
 export const configType = new ObjectType({
   elemID: configID,

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -302,6 +302,14 @@ const clientConfigType = new ObjectType({
   } as Record<keyof SalesforceClientConfig, FieldDefinition>,
 })
 
+// Based on the list in https://salesforce.stackexchange.com/questions/101844/what-are-the-object-and-field-name-suffixes-that-salesforce-uses-such-as-c-an
+const INSTANCE_SUFFIXES = [
+  'c', 'r', 'ka', 'kav', 'Feed', 'ViewStat', 'VoteStat', 'DataCategorySelection', 'x', 'xo', 'mdt', 'Share', 'Tag',
+  'History', 'pc', 'pr', 'hd', 'hqr', 'hst', 'b', 'latitude__s', 'longitude__s', 'e', 'p', 'ChangeEvent', 'chn',
+]
+
+export const PACKAGES_INSTANCES_REGEX = `^.+\\.(?!standard_)[^_]+__(?!(${INSTANCE_SUFFIXES.join('|')})((?![a-zA-Z\\d]+|__)|$)).+$`
+
 export const configType = new ObjectType({
   elemID: configID,
   fields: {
@@ -329,6 +337,7 @@ export const configType = new ObjectType({
           // We currently can't deploy them or edit them after they are created:
           '^StandardValueSet.AddressCountryCode',
           '^StandardValueSet.AddressStateCode',
+          PACKAGES_INSTANCES_REGEX,
         ],
       },
     },

--- a/packages/salesforce-adapter/test/types.test.ts
+++ b/packages/salesforce-adapter/test/types.test.ts
@@ -1,0 +1,35 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { PACKAGES_INSTANCES_REGEX } from '../src/types'
+
+
+describe('packages instances regex', () => {
+  const packagesInstanceRegex = new RegExp(PACKAGES_INSTANCES_REGEX)
+  it('should match packages instances', () => {
+    expect(packagesInstanceRegex.test('ApexClass.AVSFQB__cDBSyncUtilTest')).toBeTruthy()
+    expect(packagesInstanceRegex.test('ApexClass.AVSFQB__DBSyncUtilTest__c')).toBeTruthy()
+    expect(packagesInstanceRegex.test('ApexClass.AVSFQB__c__c')).toBeTruthy()
+  })
+
+  it('should not match non-packages instances', () => {
+    expect(packagesInstanceRegex.test('Role.InstallationRepairServices')).toBeFalsy()
+    expect(packagesInstanceRegex.test('CustomObject.testObj3__c')).toBeFalsy()
+    expect(packagesInstanceRegex.test('CustomObjectTranslation.testObj3__c-en_US')).toBeFalsy()
+    expect(packagesInstanceRegex.test('CustomObject.testMeta__mdt')).toBeFalsy()
+    expect(packagesInstanceRegex.test('CustomObject.testObj3__latitude__s')).toBeFalsy()
+    expect(packagesInstanceRegex.test('ApexClass.standard__aaa')).toBeFalsy()
+  })
+})

--- a/packages/salesforce-adapter/test/types.test.ts
+++ b/packages/salesforce-adapter/test/types.test.ts
@@ -22,6 +22,7 @@ describe('packages instances regex', () => {
     expect(packagesInstanceRegex.test('ApexClass.AVSFQB__cDBSyncUtilTest')).toBeTruthy()
     expect(packagesInstanceRegex.test('ApexClass.AVSFQB__DBSyncUtilTest__c')).toBeTruthy()
     expect(packagesInstanceRegex.test('ApexClass.AVSFQB__c__c')).toBeTruthy()
+    expect(packagesInstanceRegex.test('Layout.MyPacakge__Feed_Sales_Layout')).toBeTruthy()
   })
 
   it('should not match non-packages instances', () => {


### PR DESCRIPTION
Added regex to skip packages' records and types to the default salesforce configuration.
Custom fields to existing objects will still be fetched.
The regex that will be added to the configuration is `^.+\\.(?!standard_)[^_]+__(?!(c|r|ka|kav|Feed|ViewStat|VoteStat|DataCategorySelection|x|xo|mdt|Share|Tag|History|pc|pr|hd|hqr|hst|b|latitude__s|longitude__s|e|p|ChangeEvent|chn)([^a-zA-Z\\d_]+|$)).+$`

---

_Release Notes_: 
Added regex to skip external packages' records and types to the default salesforce configuration.
