### PR TITLE
Netsuite: return script deployments in a consistent order

### DIFF
--- a/packages/netsuite-adapter/scripts/types_generator.py
+++ b/packages/netsuite-adapter/scripts/types_generator.py
@@ -507,6 +507,18 @@ inner_types_to_export = {
     'savedcsvimport_filemappings',
     'customsegment_segmentapplication_transactionline_applications',
     'customsegment_segmentapplication_transactionbody_applications',
+    'bundleinstallationscript_scriptdeployments',
+    'clientscript_scriptdeployments',
+    'customrecordactionscript_scriptdeployments',
+    'mapreducescript_scriptdeployments',
+    'massupdatescript_scriptdeployments',
+    'portlet_scriptdeployments',
+    'restlet_scriptdeployments',
+    'scheduledscript_scriptdeployments',
+    'sdfinstallationscript_scriptdeployments',
+    'suitelet_scriptdeployments',
+    'usereventscript_scriptdeployments',
+    'workflowactionscript_scriptdeployments',
 }
 
 should_not_be_required = {

--- a/packages/netsuite-adapter/src/filters/convert_lists.ts
+++ b/packages/netsuite-adapter/src/filters/convert_lists.ts
@@ -26,6 +26,19 @@ import {
   customsegment_segmentapplication_transactionbody_applications,
   customsegment_segmentapplication_transactionline_applications,
 } from '../types/custom_types/customsegment'
+import { SCRIPT_ID } from '../constants'
+import { bundleinstallationscript_scriptdeployments } from '../types/custom_types/bundleinstallationscript'
+import { clientscript_scriptdeployments } from '../types/custom_types/clientscript'
+import { customrecordactionscript_scriptdeployments } from '../types/custom_types/customrecordactionscript'
+import { mapreducescript_scriptdeployments } from '../types/custom_types/mapreducescript'
+import { portlet_scriptdeployments } from '../types/custom_types/portlet'
+import { massupdatescript_scriptdeployments } from '../types/custom_types/massupdatescript'
+import { restlet_scriptdeployments } from '../types/custom_types/restlet'
+import { scheduledscript_scriptdeployments } from '../types/custom_types/scheduledscript'
+import { sdfinstallationscript_scriptdeployments } from '../types/custom_types/sdfinstallationscript'
+import { suitelet_scriptdeployments } from '../types/custom_types/suitelet'
+import { usereventscript_scriptdeployments } from '../types/custom_types/usereventscript'
+import { workflowactionscript_scriptdeployments } from '../types/custom_types/workflowactionscript'
 
 type FieldFullNameToOrderBy = Map<string, string | undefined>
 
@@ -34,6 +47,20 @@ const unorderedListFields: FieldFullNameToOrderBy = new Map([
   [savedcsvimport_filemappings.fields.filemapping.elemID.getFullName(), 'file'],
   [customsegment_segmentapplication_transactionbody_applications.fields.application.elemID.getFullName(), 'id'],
   [customsegment_segmentapplication_transactionline_applications.fields.application.elemID.getFullName(), 'id'],
+  [bundleinstallationscript_scriptdeployments.fields.scriptdeployment.elemID.getFullName(),
+    SCRIPT_ID],
+  [clientscript_scriptdeployments.fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
+  [customrecordactionscript_scriptdeployments.fields.scriptdeployment.elemID.getFullName(),
+    SCRIPT_ID],
+  [mapreducescript_scriptdeployments.fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
+  [massupdatescript_scriptdeployments.fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
+  [portlet_scriptdeployments.fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
+  [restlet_scriptdeployments.fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
+  [scheduledscript_scriptdeployments.fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
+  [sdfinstallationscript_scriptdeployments.fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
+  [suitelet_scriptdeployments.fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
+  [usereventscript_scriptdeployments.fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
+  [workflowactionscript_scriptdeployments.fields.scriptdeployment.elemID.getFullName(), SCRIPT_ID],
 ])
 
 const castAndOrderListsRecursively = (

--- a/packages/netsuite-adapter/src/types/custom_types/bundleinstallationscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/bundleinstallationscript.ts
@@ -454,7 +454,7 @@ bundleinstallationscriptInnerTypes.push(bundleinstallationscript_scriptdeploymen
 
 const bundleinstallationscript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'bundleinstallationscript_scriptdeployments')
 
-const bundleinstallationscript_scriptdeployments = new ObjectType({
+export const bundleinstallationscript_scriptdeployments = new ObjectType({
   elemID: bundleinstallationscript_scriptdeploymentsElemID,
   annotations: {
   },

--- a/packages/netsuite-adapter/src/types/custom_types/clientscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/clientscript.ts
@@ -519,7 +519,7 @@ clientscriptInnerTypes.push(clientscript_scriptdeployments_scriptdeployment)
 
 const clientscript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'clientscript_scriptdeployments')
 
-const clientscript_scriptdeployments = new ObjectType({
+export const clientscript_scriptdeployments = new ObjectType({
   elemID: clientscript_scriptdeploymentsElemID,
   annotations: {
   },

--- a/packages/netsuite-adapter/src/types/custom_types/customrecordactionscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/customrecordactionscript.ts
@@ -499,7 +499,7 @@ customrecordactionscriptInnerTypes.push(customrecordactionscript_scriptdeploymen
 
 const customrecordactionscript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'customrecordactionscript_scriptdeployments')
 
-const customrecordactionscript_scriptdeployments = new ObjectType({
+export const customrecordactionscript_scriptdeployments = new ObjectType({
   elemID: customrecordactionscript_scriptdeploymentsElemID,
   annotations: {
   },

--- a/packages/netsuite-adapter/src/types/custom_types/mapreducescript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/mapreducescript.ts
@@ -860,7 +860,7 @@ mapreducescriptInnerTypes.push(mapreducescript_scriptdeployments_scriptdeploymen
 
 const mapreducescript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'mapreducescript_scriptdeployments')
 
-const mapreducescript_scriptdeployments = new ObjectType({
+export const mapreducescript_scriptdeployments = new ObjectType({
   elemID: mapreducescript_scriptdeploymentsElemID,
   annotations: {
   },

--- a/packages/netsuite-adapter/src/types/custom_types/massupdatescript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/massupdatescript.ts
@@ -462,7 +462,7 @@ massupdatescriptInnerTypes.push(massupdatescript_scriptdeployments_scriptdeploym
 
 const massupdatescript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'massupdatescript_scriptdeployments')
 
-const massupdatescript_scriptdeployments = new ObjectType({
+export const massupdatescript_scriptdeployments = new ObjectType({
   elemID: massupdatescript_scriptdeploymentsElemID,
   annotations: {
   },

--- a/packages/netsuite-adapter/src/types/custom_types/portlet.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/portlet.ts
@@ -504,7 +504,7 @@ portletInnerTypes.push(portlet_scriptdeployments_scriptdeployment)
 
 const portlet_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'portlet_scriptdeployments')
 
-const portlet_scriptdeployments = new ObjectType({
+export const portlet_scriptdeployments = new ObjectType({
   elemID: portlet_scriptdeploymentsElemID,
   annotations: {
   },

--- a/packages/netsuite-adapter/src/types/custom_types/restlet.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/restlet.ts
@@ -494,7 +494,7 @@ restletInnerTypes.push(restlet_scriptdeployments_scriptdeployment)
 
 const restlet_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'restlet_scriptdeployments')
 
-const restlet_scriptdeployments = new ObjectType({
+export const restlet_scriptdeployments = new ObjectType({
   elemID: restlet_scriptdeploymentsElemID,
   annotations: {
   },

--- a/packages/netsuite-adapter/src/types/custom_types/scheduledscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/scheduledscript.ts
@@ -872,7 +872,7 @@ scheduledscriptInnerTypes.push(scheduledscript_scriptdeployments_scriptdeploymen
 
 const scheduledscript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'scheduledscript_scriptdeployments')
 
-const scheduledscript_scriptdeployments = new ObjectType({
+export const scheduledscript_scriptdeployments = new ObjectType({
   elemID: scheduledscript_scriptdeploymentsElemID,
   annotations: {
   },

--- a/packages/netsuite-adapter/src/types/custom_types/sdfinstallationscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/sdfinstallationscript.ts
@@ -412,7 +412,7 @@ sdfinstallationscriptInnerTypes.push(sdfinstallationscript_scriptdeployments_scr
 
 const sdfinstallationscript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'sdfinstallationscript_scriptdeployments')
 
-const sdfinstallationscript_scriptdeployments = new ObjectType({
+export const sdfinstallationscript_scriptdeployments = new ObjectType({
   elemID: sdfinstallationscript_scriptdeploymentsElemID,
   annotations: {
   },

--- a/packages/netsuite-adapter/src/types/custom_types/suitelet.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/suitelet.ts
@@ -561,7 +561,7 @@ suiteletInnerTypes.push(suitelet_scriptdeployments_scriptdeployment)
 
 const suitelet_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'suitelet_scriptdeployments')
 
-const suitelet_scriptdeployments = new ObjectType({
+export const suitelet_scriptdeployments = new ObjectType({
   elemID: suitelet_scriptdeploymentsElemID,
   annotations: {
   },

--- a/packages/netsuite-adapter/src/types/custom_types/usereventscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/usereventscript.ts
@@ -519,7 +519,7 @@ usereventscriptInnerTypes.push(usereventscript_scriptdeployments_scriptdeploymen
 
 const usereventscript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'usereventscript_scriptdeployments')
 
-const usereventscript_scriptdeployments = new ObjectType({
+export const usereventscript_scriptdeployments = new ObjectType({
   elemID: usereventscript_scriptdeploymentsElemID,
   annotations: {
   },

--- a/packages/netsuite-adapter/src/types/custom_types/workflowactionscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/workflowactionscript.ts
@@ -499,7 +499,7 @@ workflowactionscriptInnerTypes.push(workflowactionscript_scriptdeployments_scrip
 
 const workflowactionscript_scriptdeploymentsElemID = new ElemID(constants.NETSUITE, 'workflowactionscript_scriptdeployments')
 
-const workflowactionscript_scriptdeployments = new ObjectType({
+export const workflowactionscript_scriptdeployments = new ObjectType({
   elemID: workflowactionscript_scriptdeploymentsElemID,
   annotations: {
   },


### PR DESCRIPTION
_Release Notes_: 
Netsuite Adapter: fetch script deployments in a consistent order
