### PR TITLE
SALTO-1154 - Use default per-env filename for elements with no path

### DIFF
--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -539,6 +539,6 @@ export const generateElements = (
     ...records,
     ...objects,
     ...profiles,
-    new ObjectType({ elemID: new ElemID(DUMMY_ADAPTER, 'doNotPersist'), fields: {} }),
+    new ObjectType({ elemID: new ElemID(DUMMY_ADAPTER, 'noPath'), fields: {} }),
   ]
 }

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -539,5 +539,6 @@ export const generateElements = (
     ...records,
     ...objects,
     ...profiles,
+    new ObjectType({ elemID: new ElemID(DUMMY_ADAPTER, 'doNotPersist'), fields: {} }),
   ]
 }

--- a/packages/dummy-adapter/test/generator.test.ts
+++ b/packages/dummy-adapter/test/generator.test.ts
@@ -50,7 +50,7 @@ describe('elements generator', () => {
       expect(types).toHaveLength(testParams.numOfTypes)
       expect(
         _.uniq(objects.map(obj => obj.elemID.getFullName()))
-      ).toHaveLength(testParams.numOfObjs + 3) // 3 default types
+      ).toHaveLength(testParams.numOfObjs + 4) // 3 default types + 1 additional type
       expect(profiles).toHaveLength(testParams.numOfProfiles * 4)
       expect(_.uniq(profiles.map(p => p.elemID.getFullName()))).toHaveLength(
         testParams.numOfProfiles

--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -31,10 +31,9 @@ const FILE_EXTENSION = '.nacl'
 
 export type DetailedChangeWithSource = DetailedChange & { location: SourceRange }
 
-const createFileNameFromPath = (pathParts?: ReadonlyArray<string>): string =>
-  (pathParts
-    ? `${path.join(...pathParts)}${FILE_EXTENSION}`
-    : '')
+const createFileNameFromPath = (pathParts?: ReadonlyArray<string>): string => (
+  `${path.join(...(pathParts ?? ['unsorted']))}${FILE_EXTENSION}`
+)
 
 export const getChangeLocations = (
   change: DetailedChange,

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -442,6 +442,11 @@ const buildNaclFilesSource = (
           // Changes might have a different cased filename, we just take the first variation
           const [filename] = fileChanges.map(change => change.location.filename).sort()
           try {
+            if (_.isEmpty(filename)) {
+              log.info('found changes with no filename - not writing to nacl. ids: %s',
+                fileChanges.map(change => change.id.getFullName()))
+              return undefined
+            }
             const naclFileData = await getNaclFileData(filename)
             const buffer = await updateNaclFileData(naclFileData, fileChanges, functions)
             const shouldNotParse = _.isEmpty(naclFileData)

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -442,11 +442,6 @@ const buildNaclFilesSource = (
           // Changes might have a different cased filename, we just take the first variation
           const [filename] = fileChanges.map(change => change.location.filename).sort()
           try {
-            if (_.isEmpty(filename)) {
-              log.info('found changes with no filename - not writing to nacl. ids: %s',
-                fileChanges.map(change => change.id.getFullName()))
-              return undefined
-            }
             const naclFileData = await getNaclFileData(filename)
             const buffer = await updateNaclFileData(naclFileData, fileChanges, functions)
             const shouldNotParse = _.isEmpty(naclFileData)

--- a/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
@@ -84,14 +84,23 @@ describe('getNestedStaticFiles', () => {
 describe('getChangeLocations', () => {
   let result: DetailedChangeWithSource[]
   describe('with addition of top level element', () => {
-    beforeEach(() => {
+    it('should add the element at the end of the file', () => {
       const change: DetailedChange = { ...toChange({ after: mockType }), id: mockType.elemID }
       result = getChangeLocations(change, new Map())
-    })
-    it('should add the element at the end of the file', () => {
       expect(result).toHaveLength(1)
       expect(result[0].location.start).toEqual({ col: 1, line: Infinity, byte: Infinity })
       expect(result[0].location.end).toEqual({ col: 1, line: Infinity, byte: Infinity })
+      expect(result[0].location.filename).toEqual('this/is/happening.nacl')
+    })
+    it('should use the default filename when no path is provided', () => {
+      const noPath = mockType.clone()
+      noPath.path = undefined
+      const change: DetailedChange = { ...toChange({ after: noPath }), id: noPath.elemID }
+      result = getChangeLocations(change, new Map())
+      expect(result).toHaveLength(1)
+      expect(result[0].location.start).toEqual({ col: 1, line: Infinity, byte: Infinity })
+      expect(result[0].location.end).toEqual({ col: 1, line: Infinity, byte: Infinity })
+      expect(result[0].location.filename).toEqual('unsorted.nacl')
     })
   })
 })


### PR DESCRIPTION
(updated after discussing with @roironn and @ori-moisis )
We used to have a default filename for elements that do not specify a path (we cannot expect all elements to specify one). It seems this was changed a while ago (in https://github.com/salto-io/salto/pull/486). In some multienv scenarios, this can result in invalid write attempts that can fail the fetch operation completely (details are in the ticket) - but even in single-env, it seems the current behavior of not persisting these elements anywhere is not the intended one. 

The agreed solution is to bring back the default filename (one per env).

---
_Release Notes_: 
None (not happening in existing adapters)
