### PR TITLE
SALTO-1159-add CustomObjectTranslation to the skipped list

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -11,6 +11,7 @@ salesforce {
     "Profile",
     "ForecastingSettings",
     "PermissionSet",
+    "CustomObjectTranslation",
   ]
   instancesRegexSkippedList = [
     "^EmailTemplate.MarketoEmailTemplates",

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -325,6 +325,7 @@ export const configType = new ObjectType({
           'Profile',
           'PermissionSet',
           'SiteDotCom', // Fetched as a binary blob and seems to change on each fetch
+          constants.CUSTOM_OBJECT_TRANSLATION_METADATA_TYPE,
         ],
       },
     },


### PR DESCRIPTION
Add CustomObjectTranslation to the default skip list

---
---
_Release Notes_: 
Salesforce Adapter: _Add CustomObjectTranslation to the default skip list_
_
