### PR TITLE
SALTO-1158: Fix support for hidden annotation value changes on instances

### DIFF
--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -392,16 +392,16 @@ const filterOutHiddenChanges = async (
         changeType: TypeElement | undefined
         changePath: ReadonlyArray<string>
       } => {
+        if (change.id.isAttrID()) {
+          return {
+            changeType: elementAnnotationTypes(baseElem)[path[0]],
+            changePath: path.slice(1),
+          }
+        }
         if (isInstanceElement(baseElem)) {
           return {
             changeType: baseElem.type,
             changePath: path,
-          }
-        }
-        if (change.id.idType === 'attr') {
-          return {
-            changeType: elementAnnotationTypes(baseElem)[path[0]],
-            changePath: path.slice(1),
           }
         }
 

--- a/packages/workspace/test/common/state.ts
+++ b/packages/workspace/test/common/state.ts
@@ -1,0 +1,30 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { Element } from '@salto-io/adapter-api'
+import { PathIndex } from '../../src/workspace/path_index'
+import { State, buildInMemState } from '../../src/workspace/state'
+
+export const mockState = (
+  elements: Element[] = [],
+): State => (
+  buildInMemState(async () => ({
+    elements: _.keyBy(elements, elem => elem.elemID.getFullName()),
+    pathIndex: new PathIndex(),
+    servicesUpdateDate: {},
+    saltoVersion: '0.0.1',
+  }))
+)


### PR DESCRIPTION
Before this, a change made directly on an instance annotation value would not be removed from nacl

---

Note this scenario is currently impossible because of a bug that prevents us from creating changes on instance annotation values, see the ticket and PR #1805 for more details

---
_Release Notes_: 
_None_ (because the bug this solves is currently impossible)
