### PR TITLE
Netsuite: modify default import types timeout & chunk size

### DIFF
--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -31,8 +31,8 @@ const { makeArray } = collections.array
 // in small Netsuite accounts the concurrency limit per integration can be between 1-4
 export const DEFAULT_SDF_CONCURRENCY = 4
 export const DEFAULT_FETCH_ALL_TYPES_AT_ONCE = false
-export const DEFAULT_FETCH_TYPE_TIMEOUT_IN_MINUTES = 20
-export const DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST = 50
+export const DEFAULT_FETCH_TYPE_TIMEOUT_IN_MINUTES = 8
+export const DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST = 40
 export const DEFAULT_DEPLOY_REFERENCED_ELEMENTS = false
 
 const clientConfigType = new ObjectType({


### PR DESCRIPTION
After seeing some timeout failures due to too big chunk (50) after 20 minutes I reduced the the chunk size to 40 to reduce the probability of failure. The longest chunk that I saw which ended successfully took around 5 minutes, thus I reduced the timeout to 8 minutes to avoid waiting up to 20 minutes in case of failure. This way if a failure will occur we'll retry with a smaller chunk faster.

---
_Release Notes_: 
Netsuite:
1. Reduce default fetchTypeTimeoutInMinutes to 8.
2. Increase default maxItemsInImportObjectsRequest to 40.