### PR TITLE
Throw error when failing to import a certain file from file cabinet

### DIFF
--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -545,6 +545,7 @@ export default class NetsuiteClient {
       return []
     }
     try {
+      log.info(`Going to import ${filePaths.length} files`)
       const actionResult = await this.executeProjectAction(
         COMMANDS.IMPORT_FILES,
         { paths: filePaths },
@@ -559,11 +560,11 @@ export default class NetsuiteClient {
         throw new Error(`Failed to import file: ${filePaths[0]}. Consider to add it to the skip list.`)
       }
       const middle = (filePaths.length + 1) / 2
-      const importResults = await Promise.all([
-        this.importFiles(filePaths.slice(0, middle), executor),
-        this.importFiles(filePaths.slice(middle, filePaths.length), executor),
-      ])
-      return importResults.flat()
+      const firstChunkImportResults = await this.importFiles(filePaths.slice(0, middle), executor)
+      const secondChunkImportResults = await this.importFiles(
+        filePaths.slice(middle, filePaths.length), executor
+      )
+      return [...firstChunkImportResults, ...secondChunkImportResults]
     }
   }
 

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -122,7 +122,6 @@ describe('Adapter', () => {
         })
       client.getCustomObjects = jest.fn().mockResolvedValue({
         elements: [customTypeInfo],
-        failedTypes: [],
         failedToFetchAllAtOnce: false,
       })
       const { elements, isPartial } = await netsuiteAdapter.fetch()
@@ -216,7 +215,6 @@ describe('Adapter', () => {
       const customTypeInfo = convertToCustomTypeInfo(xmlContent, 'unknown')
       client.getCustomObjects = jest.fn().mockResolvedValue({
         elements: [customTypeInfo],
-        failedTypes: [],
         failedToFetchAllAtOnce: false,
       })
       const { elements } = await netsuiteAdapter.fetch()

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -630,7 +630,7 @@ describe('netsuite client', () => {
       expect(failedPaths).toHaveLength(0)
     })
 
-    it('should succeed to importFiles when failing to import a certain file', async () => {
+    it('should fail to importFiles when failing to import a certain file', async () => {
       const failedPath = 'error'
       const filesPathResult = [
         MOCK_FILE_PATH,
@@ -679,8 +679,8 @@ describe('netsuite client', () => {
         }
         return Promise.resolve({ isSuccess: () => true })
       })
-      const { elements, failedPaths } = await client.importFileCabinetContent(allFilesQuery)
-      expect(mockExecuteAction).toHaveBeenCalledTimes(9)
+      await expect(client.importFileCabinetContent(allFilesQuery)).rejects.toThrow()
+      expect(mockExecuteAction).toHaveBeenCalledTimes(8)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(3, listFilesCommandMatcher)
@@ -689,10 +689,6 @@ describe('netsuite client', () => {
       expect(mockExecuteAction).toHaveBeenNthCalledWith(6, importFilesCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(7, importFilesCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(8, importFilesCommandMatcher)
-      expect(mockExecuteAction).toHaveBeenNthCalledWith(9, deleteAuthIdCommandMatcher)
-      expect(elements).toHaveLength(2)
-      expect(failedPaths).toEqual([failedPath])
-      expect(rmMock).toHaveBeenCalledTimes(1)
     })
 
     it('should succeed when having duplicated paths', async () => {

--- a/packages/netsuite-adapter/test/config.test.ts
+++ b/packages/netsuite-adapter/test/config.test.ts
@@ -39,7 +39,7 @@ describe('config', () => {
       [MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST]: 10,
     },
   }
-  const newFailedFilePath = '/path/to/file.js'
+  const newFailedFilePath = '/path/to/file'
 
   it('should return undefined when having no currentConfig suggestions', () => {
     expect(getConfigFromConfigChanges(false, [], currentConfig)).toBeUndefined()


### PR DESCRIPTION
After seeing that fetch might take forever due to the 'add to skipList' approach when encountering a locked file (when having a large file cabinet with a lot of locked files), I decided to throw an indicative error when encountering a locked file.
Having said that, I left the config suggestion when encountering a top level folder that doesn't exist. We saw that case several months ago in a customer's account and there is no reason to throw error in that case.

_Release Notes_: 
Netsuite Adapter: Do not suggest to add locked files to the files skipList but throw an error, in order to prevent potential performance issue.
