### PR TITLE
changed path index creation to avoid dfs when possible

### DIFF
--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -110,15 +110,12 @@ export const validateWorkspace = async (
 export const formatWorkspaceErrors = async (
   workspace: Workspace,
   errors: Iterable<SaltoError>,
-): Promise<string> => {
-  const r = (await Promise.all(
-    wu(errors)
-      .slice(0, MAX_WORKSPACE_ERRORS_TO_LOG)
-      .map(err => workspace.transformError(err))
-      .map(async err => formatWorkspaceError(await err))
-  )).join('\n')
-  return r
-}
+): Promise<string> => (await Promise.all(
+  wu(errors)
+    .slice(0, MAX_WORKSPACE_ERRORS_TO_LOG)
+    .map(err => workspace.transformError(err))
+    .map(async err => formatWorkspaceError(await err))
+)).join('\n')
 
 const printWorkspaceErrors = async (
   status: WorkspaceStatusErrors['status'],

--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -110,14 +110,15 @@ export const validateWorkspace = async (
 export const formatWorkspaceErrors = async (
   workspace: Workspace,
   errors: Iterable<SaltoError>,
-): Promise<string> => (
-  (await Promise.all(
+): Promise<string> => {
+  const r = (await Promise.all(
     wu(errors)
       .slice(0, MAX_WORKSPACE_ERRORS_TO_LOG)
       .map(err => workspace.transformError(err))
       .map(async err => formatWorkspaceError(await err))
   )).join('\n')
-)
+  return r
+}
 
 const printWorkspaceErrors = async (
   status: WorkspaceStatusErrors['status'],

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -446,7 +446,6 @@ const buildNaclFilesSource = (
     const visitedFiles = new Set<string>()
     await awu(cacheFilenames).concat(naclFilenames).forEach(async filename => {
       if (!visitedFiles.has(filename)) {
-        visitedFiles.add(filename)
         const naclFile = await naclFilesStore.get(filename) ?? { filename, buffer: '' }
         const validCache = await cache.get(cacheResultKey(naclFile))
         const latestCache = validCache ?? await cache.get(cacheResultKey(naclFile), true)

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -446,6 +446,7 @@ const buildNaclFilesSource = (
     const visitedFiles = new Set<string>()
     await awu(cacheFilenames).concat(naclFilenames).forEach(async filename => {
       if (!visitedFiles.has(filename)) {
+        visitedFiles.add(filename)
         const naclFile = await naclFilesStore.get(filename) ?? { filename, buffer: '' }
         const validCache = await cache.get(cacheResultKey(naclFile))
         const latestCache = validCache ?? await cache.get(cacheResultKey(naclFile), true)

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -16,9 +16,8 @@
 import { Element, ElemID } from '@salto-io/adapter-api'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections, hash } from '@salto-io/lowerdash'
-import { updatePathIndex, Path, overridePathIndex } from '../path_index'
+import { updatePathIndex, overridePathIndex, PathIndex } from '../path_index'
 import { State, StateData } from './state'
-import { RemoteMap } from '../remote_map'
 
 const { awu } = collections.asynciterable
 const { toMD5 } = hash
@@ -66,7 +65,7 @@ export const buildInMemState = (loadData: () => Promise<StateData>): State => {
         currentStateData.pathIndex, unmergedElements, servicesNotToChange
       )
     },
-    getPathIndex: async (): Promise<RemoteMap<Path[]>> =>
+    getPathIndex: async (): Promise<PathIndex> =>
       (await stateData()).pathIndex,
     clear: async () => {
       const currentStateData = await stateData()

--- a/packages/workspace/src/workspace/state/state.ts
+++ b/packages/workspace/src/workspace/state/state.ts
@@ -15,7 +15,7 @@
 */
 import { Element, ElemID } from '@salto-io/adapter-api'
 import { ElementsSource, RemoteElementSource } from '../elements_source'
-import { Path } from '../path_index'
+import { PathIndex } from '../path_index'
 import { RemoteMap } from '../remote_map'
 
 export type StateMetadataKey = 'version' | 'hash'
@@ -24,7 +24,7 @@ export type StateData = {
   elements: RemoteElementSource
   // The date of the last fetch
   servicesUpdateDate: RemoteMap<Date>
-  pathIndex: RemoteMap<Path[]>
+  pathIndex: PathIndex
   saltoMetadata: RemoteMap<string, StateMetadataKey>
 }
 
@@ -36,7 +36,7 @@ export interface State extends ElementsSource {
   existingServices(): Promise<string[]>
   overridePathIndex(unmergedElements: Element[]): Promise<void>
   updatePathIndex(unmergedElements: Element[], servicesToMaintain: string[]): Promise<void>
-  getPathIndex(): Promise<RemoteMap<Path[]>>
+  getPathIndex(): Promise<PathIndex>
   getHash(): Promise<string>
   setHash(hash: string): Promise<void>
   getStateSaltoVersion(): Promise<string | undefined>

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -128,7 +128,7 @@ describe('updatePathIndex', () => {
         ['salto', 'obj', 'multi', 'anno'],
         ['salto', 'obj', 'multi', 'fields'],
       ])
-    expect(await index.get(multiPathFieldsObj.fields.field.elemID.getFullName()))
+    expect(await index.get(multiPathFieldsObj.elemID.createNestedID('field').getFullName()))
       .toEqual([
         ['salto', 'obj', 'multi', 'fields'],
       ])

--- a/packages/workspace/test/workspace/state.test.ts
+++ b/packages/workspace/test/workspace/state.test.ts
@@ -16,9 +16,9 @@
 import { ObjectType, ElemID } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { StateData, buildInMemState } from '../../src/workspace/state'
-import { Path, getElementsPathHints } from '../../src/workspace/path_index'
+import { PathIndex, getElementsPathHints } from '../../src/workspace/path_index'
 import { createInMemoryElementSource } from '../../src/workspace/elements_source'
-import { InMemoryRemoteMap, RemoteMap } from '../../src/workspace/remote_map'
+import { InMemoryRemoteMap } from '../../src/workspace/remote_map'
 
 const { awu } = collections.asynciterable
 
@@ -26,7 +26,7 @@ describe('state', () => {
   const adapter = 'salesforce'
   const elemID = new ElemID(adapter, 'elem')
   const elem = new ObjectType({ elemID, path: ['test', 'new'] })
-  let pathIndex: RemoteMap<Path[]>
+  let pathIndex: PathIndex
   const updateDate = new Date()
   const servicesUpdateDate = { [adapter]: updateDate }
   const loadStateData = async (): Promise<StateData> => ({


### PR DESCRIPTION
_Optimized path index creation_

---

In the previous implementation, path index was created by performing a DFS on all of the elements and keeping all of the path hints. This caused a few problems:

1. DFS took too long on large data sets.
2. The resulting data structure was to large, resulting in an OOM error.
3. The number of key-value pair in the resulting data structure was too large (usually, about two order of magnitudes from the number of elements) which caused the flush of the path index to be very long.

In order to improve we:

1. Keep only uniq prefixes in the path index, when getting a key - get the closes id prefix defined.
2. Calculate the index by performing a parallel DFS on all of the element fragments, and terminating the DFS if there is only one path defined. (remove the need to DFS in almost all cases)


---
NA
