### PR TITLE
Fix instance comparison

### DIFF
--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -345,9 +345,9 @@ export class InstanceElement extends Element {
   }
 
   isEqual(other: InstanceElement): boolean {
-    return _.isEqual(this.type.elemID, other.type.elemID)
+    return super.isEqual(other)
+      && _.isEqual(this.type.elemID, other.type.elemID)
       && isEqualValues(this.value, other.value)
-      && isEqualValues(this.annotations, other.annotations)
   }
 
   /**

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -168,6 +168,14 @@ describe('Test elements.ts', () => {
       expect(isEqualElements(inst, ot)).toBeFalsy()
     })
 
+    it('should identify different instances with id change', () => {
+      const instClone = new InstanceElement(
+        'different_name',
+        inst.type,
+        inst.value
+      )
+      expect(isEqualElements(inst, instClone)).toBeFalsy()
+    })
     it('should identify different instances with value change', () => {
       const instClone = inst.clone()
       instClone.value.newVal = 1


### PR DESCRIPTION
`InstanceElement.isEqual` did not compare the instance elem ids. This fixes it.

---
_Release Notes_: 
None
