### PR TITLE
SALTO-1175: Fix custom field type validator failure on new fields

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
@@ -18,10 +18,10 @@ import {
   ChangeValidator, Change, isAdditionChange, isFieldChange,
 } from '@salto-io/adapter-api'
 import { CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES } from '../constants'
-import { isFieldOfCustomObject, toCustomField } from '../transformers/transformer'
+import { isFieldOfCustomObject, fieldTypeName } from '../transformers/transformer'
 
 const isInvalidTypeChange = (change: Change<Field>): boolean => {
-  const afterFieldType = toCustomField(getChangeElement(change)).type
+  const afterFieldType = fieldTypeName(getChangeElement(change).type.elemID.name)
   const isAfterTypeAllowed = CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES.includes(afterFieldType)
   if (isAfterTypeAllowed) {
     return false


### PR DESCRIPTION
The validator implicitly assumed all fields have api names which is not correct
in the change validator phase (before addDefaults).

---

`toCustomField` assumes the field is convertible to a salesforce custom field (which must include a fullName).
this is not the case in the change validator since it runs before we `addDefaults` to fields, so we can have fields without an api name here.
since `toCustomField` was only used to get the type name, using the same logic to get the field type name should be sufficient

---

_Release Notes_: 
(salesforce adapter)
- Fix error deploying new fields without specifying apiName and label explicitly
