### PR TITLE
SALTO-1176: fixed bug in number of printed impacts

### DIFF
--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -186,12 +186,11 @@ const formatCountPlanItemTypes = (plan: Plan): string => {
     .flatten(true) as WuIterable<Change<ChangeDataType>>)
     .map(getChangeElement)
     .map(({ elemID }) => ({
-      type: elemID.idType,
-      name: elemID.getFullName(),
+      type: elemID.createTopLevelParentID().parent.idType,
+      name: elemID.createTopLevelParentID().parent.getFullName(),
     }))
-    .unique()
     .toArray()
-  const counter = _.countBy(items, 'type')
+  const counter = _(items).uniqBy(item => item.name).countBy('type').value()
   return `${chalk.bold('Impacts:')} ${singleOrPluralString(counter.type || 0, 'type', 'types')} `
     + `and ${singleOrPluralString(counter.instance || 0, 'instance', 'instances')}.`
 }

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -19,6 +19,7 @@ import {
 } from '@salto-io/adapter-api'
 import { FetchChange } from '@salto-io/core'
 import { errors as wsErrors } from '@salto-io/workspace'
+import chalk from 'chalk'
 import { formatExecutionPlan, formatChange,
   formatFetchChangeForApproval, formatWorkspaceError,
   formatChangeErrors, formatConfigChangeNeeded, formatShouldChangeFetchModeToAlign } from '../src/formatter'
@@ -72,6 +73,9 @@ describe('formatter', () => {
     })
     it('should have titles for all level of nested modifications', () => {
       expect(output).toMatch(/|[^\n]+salesforce.lead.*|[^\n]+how_many_sales_people.*M[^\n]+label/s)
+    })
+    it('should return the number of impacted types and instances', () => {
+      expect(output).toMatch(`${chalk.bold('Impacts:')} 3 types and 1 instance.`)
     })
   })
 

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -514,7 +514,7 @@ export const preview = (): Plan => {
     [
       createChange('add', 'lead', 'do_you_have_a_sales_team'),
       createChange('modify', 'lead', 'how_many_sales_people'),
-      createChange('remove', 'lead', 'status'),
+      createChange('remove', 'lead', 'field', 'status'),
     ],
     [
       detailedChange('modify', ['lead', 'field', 'label'], 'old', 'new'),
@@ -537,6 +537,13 @@ export const preview = (): Plan => {
     ]
   )
   result.addNode(_.uniqueId('account'), [], accountPlanItem)
+
+  const activityPlanItem = toPlanItem(
+    createChange('add', 'activity', 'field', 'name'),
+    [],
+    []
+  )
+  result.addNode(_.uniqueId('activity'), [], activityPlanItem)
 
   const employeeInstance = elements()[4] as InstanceElement
   const updatedEmployee = _.cloneDeep(employeeInstance)
@@ -568,10 +575,11 @@ export const preview = (): Plan => {
   }]
   Object.assign(result, {
     itemsByEvalOrder(): Iterable<PlanItem> {
-      return [leadPlanItem, accountPlanItem, instancePlanItem]
+      return [leadPlanItem, accountPlanItem, activityPlanItem, instancePlanItem]
     },
     getItem(id: string): PlanItem {
       if (id.startsWith('lead')) return leadPlanItem
+      if (id.startsWith('activity')) return activityPlanItem
       return id.startsWith('account') ? accountPlanItem : instancePlanItem
     },
     changeErrors,


### PR DESCRIPTION
Fixed a bug where a change of a field was not counted as an impact on a type when printing the number of impacted types in instances on deploy.

---
_Release Notes_: 
CLI:
Fixed a bug where a change of a field would not be counted in the impacts report printed to the user on deploy.
