### PR TITLE
changed promise all calls to awu to redcue mem foot print

### DIFF
--- a/packages/core/src/core/plan/filter.ts
+++ b/packages/core/src/core/plan/filter.ts
@@ -162,11 +162,10 @@ export const filterInvalidChanges = async (
     change => getChangeElement(change).elemID.adapter,
   )
 
-  const errorPromises = [...changesByAdapter.entries()]
+  const changeErrors = await awu(changesByAdapter.entries())
     .filter(([adapter]) => adapter in changeValidators)
-    .map(([adapter, changes]) => changeValidators[adapter](changes))
-
-  const changeErrors = _.flatten(await Promise.all(errorPromises))
+    .flatMap(([adapter, changes]) => changeValidators[adapter](changes))
+    .toArray()
 
   const invalidChanges = changeErrors.filter(v => v.severity === 'Error')
   const nodeIdsToOmit = new Set(invalidChanges.map(change => change.elemID.getFullName()))

--- a/packages/core/src/core/plan/group.ts
+++ b/packages/core/src/core/plan/group.ts
@@ -18,6 +18,8 @@ import { collections } from '@salto-io/lowerdash'
 import { DataNodeMap, GroupedNodeMap, NodeId, buildGroupedGraph } from '@salto-io/dag'
 import { Change, getChangeElement, isField, ChangeGroupId, ChangeId, ChangeGroupIdFunction } from '@salto-io/adapter-api'
 
+const { awu } = collections.asynciterable
+
 export const getCustomGroupIds = async (
   changes: DataNodeMap<Change>,
   customGroupIdFunctions: Record<string, ChangeGroupIdFunction>,
@@ -31,14 +33,16 @@ export const getCustomGroupIds = async (
     ({ change }) => getChangeElement(change).elemID.adapter,
   )
 
-  const changeGroupIds = wu(changesPerAdapter.entries())
+  const changeGroupIds = awu(changesPerAdapter.entries())
     .filter(([adapterName]) => adapterName in customGroupIdFunctions)
     .map(([name, adapterChanges]) => (
       customGroupIdFunctions[name](new Map(adapterChanges.map(({ id, change }) => [id, change])))
     ))
 
   return new Map(
-    (await Promise.all(changeGroupIds)).flatMap(changeIdsMap => [...changeIdsMap.entries()])
+    await awu(changeGroupIds)
+      .flatMap(changeIdsMap => [...changeIdsMap.entries()])
+      .toArray()
   )
 }
 

--- a/packages/core/src/core/restore.ts
+++ b/packages/core/src/core/restore.ts
@@ -16,8 +16,11 @@
 import _ from 'lodash'
 import { ElemID, DetailedChange } from '@salto-io/adapter-api'
 import { filterByID, applyFunctionToChangeData } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
 import { pathIndex, ElementSelector, elementSource, remoteMap } from '@salto-io/workspace'
 import { createDiffChanges } from './diff'
+
+const { awu } = collections.asynciterable
 
 const splitChangeByPath = async (
   change: DetailedChange,
@@ -56,8 +59,8 @@ export const createRestoreChanges = async (
     elementSelectors,
     [id => (services?.includes(id.adapter) ?? true) || id.adapter === ElemID.VARIABLES_NAMESPACE]
   )
-  const detailedChanges = _.flatten(await Promise.all(
-    changes.map(change => splitChangeByPath(change, index))
-  ))
+  const detailedChanges = awu(changes)
+    .flatMap(change => splitChangeByPath(change, index))
+    .toArray()
   return detailedChanges
 }

--- a/packages/workspace/src/parser/dump.ts
+++ b/packages/workspace/src/parser/dump.ts
@@ -15,7 +15,8 @@
 */
 import _ from 'lodash'
 import { Field, isObjectType, PrimitiveTypes, isPrimitiveType, Element, ReferenceExpression, isInstanceElement, Value, INSTANCE_ANNOTATIONS, isReferenceExpression, isField, ElemID, ReferenceMap } from '@salto-io/adapter-api'
-import { promises } from '@salto-io/lowerdash'
+import { promises, collections } from '@salto-io/lowerdash'
+
 
 import { dump as hclDump, dumpValue } from './internal/dump'
 import { DumpedHclBlock } from './internal/types'
@@ -26,6 +27,7 @@ import {
   FunctionExpression,
 } from './functions'
 
+const { awu } = collections.asynciterable
 const { object: { mapValuesAsync } } = promises
 
 /**
@@ -161,7 +163,7 @@ export const dumpElements = async (
   elements: Element[], functions: Functions = {}, indentationLevel = 0
 ): Promise<string> =>
   hclDump(
-    wrapBlocks(await Promise.all(elements.map(e => dumpElementBlock(e, functions)))),
+    wrapBlocks(await awu(elements).map(e => dumpElementBlock(e, functions)).toArray()),
     indentationLevel
   )
 

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { types } from '@salto-io/lowerdash'
+import { types, collections } from '@salto-io/lowerdash'
 import {
   PrimitiveType, ElemID, Field, Element, ListType, MapType,
   ObjectType, InstanceElement, isType, isElement, isContainerType,
@@ -31,6 +31,7 @@ import { MultiplePrimitiveTypesUnsupportedError } from '../merger/internal/primi
 
 import { InvalidStaticFile } from '../workspace/static_files/common'
 
+const { awu } = collections.asynciterable
 // There are two issues with naive json stringification:
 //
 // 1) The class type information and methods are lost
@@ -304,9 +305,9 @@ export const deserialize = async (
 
   if (staticFileReviver) {
     staticFiles = _.fromPairs(
-      (await Promise.all(
-        _.entries(staticFiles).map(async ([key, val]) => ([key, await staticFileReviver(val)]))
-      ))
+      await awu(Object.entries(staticFiles))
+        .map(async ([key, val]) => ([key, await staticFileReviver(val)]))
+        .toArray()
     )
   }
 

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -239,27 +239,25 @@ const isHiddenChangeOnField = (change: DetailedChange): boolean => (
 const getHiddenTypeChanges = async (
   changes: DetailedChange[],
   state: State,
-): Promise<DetailedChange[]> => (
-  (await Promise.all(
-    changes
-      .filter(c => isHiddenChangeOnElement(c, false))
-      .map(async change => {
-        const elemId = change.id.createTopLevelParentID().parent
-        const elem = await state.get(elemId)
-        if (!isElement(elem)) {
-          // Should never happen
-          log.warn(
-            'Element %s was changed to hidden %s but was not found in state',
-            elemId.getFullName(), isChangeToHidden(change, false),
-          )
-          return change
-        }
-        return isChangeToHidden(change, false)
-          ? createRemoveChange(elem, elemId)
-          : createAddChange(elem, elemId)
-      })
-  )).filter(values.isDefined)
-)
+): Promise<DetailedChange[]> => awu(changes)
+  .filter(c => isHiddenChangeOnElement(c, false))
+  .map(async change => {
+    const elemId = change.id.createTopLevelParentID().parent
+    const elem = await state.get(elemId)
+    if (!isElement(elem)) {
+      // Should never happen
+      log.warn(
+        'Element %s was changed to hidden %s but was not found in state',
+        elemId.getFullName(), isChangeToHidden(change, false),
+      )
+      return change
+    }
+    return isChangeToHidden(change, false)
+      ? createRemoveChange(elem, elemId)
+      : createAddChange(elem, elemId)
+  })
+  .filter(values.isDefined)
+  .toArray()
 
 /**
  * When a field or annotation changes from/to hidden, we need to create changes that add/remove
@@ -490,7 +488,7 @@ const filterOutHiddenChanges = async (
     return change
   }
 
-  return (await Promise.all(changes.map(filterOutHidden))).filter(values.isDefined)
+  return awu(changes).map(filterOutHidden).filter(values.isDefined).toArray()
 }
 
 export const handleHiddenChanges = async (

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -305,12 +305,11 @@ const buildMultiEnvSource = (
   }
 
   const flush = async (): Promise<void> => {
-    // TODO fix?
-    await Promise.all([
-      primarySource().flush(),
-      commonSource().flush(),
-      ..._.values(secondarySources()).map(src => src.flush()),
-    ])
+    await awu([
+      primarySource(),
+      commonSource(),
+      ..._.values(secondarySources()),
+    ]).forEach(src => src.flush())
     await (await getState()).elements.flush()
   }
 

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -104,13 +104,16 @@ const buildMultiEnvSource = (
   const getRelevantElems = async (
     envElemIDsToElems: Record<string, Record<string, Element | undefined>>,
     relevantElementIDs: ElemID[],
-  ): Promise<Element[]> => (await Promise.all(
-    Object.entries(envElemIDsToElems).flatMap(([envName, elemIDToElems]) =>
-      relevantElementIDs.map(async id =>
-        (id.getFullName() in elemIDToElems
+  ): Promise<Element[]> => awu(Object.entries(envElemIDsToElems))
+    .flatMap(
+      ([envName, elemIDToElems]) => awu(relevantElementIDs).map(
+        async id => (id.getFullName() in elemIDToElems
           ? elemIDToElems[id.getFullName()]
-          : sources[envName].get(id))))
-  )).filter(values.isDefined)
+          : sources[envName].get(id))
+      )
+    )
+    .filter(values.isDefined)
+    .toArray()
 
   const buildState = async (env?: string): Promise<MultiEnvState> => {
     const allActiveElements = awu(_.values(getActiveSources(env)))
@@ -302,6 +305,7 @@ const buildMultiEnvSource = (
   }
 
   const flush = async (): Promise<void> => {
+    // TODO fix?
     await Promise.all([
       primarySource().flush(),
       commonSource().flush(),
@@ -361,9 +365,9 @@ const buildMultiEnvSource = (
         : (await buildMultiEnvState({ env })).state.elements
     ),
     listNaclFiles: async (): Promise<string[]> => (
-      _.flatten(await Promise.all(_.entries(getActiveSources())
-        .map(async ([prefix, source]) => (
-          await source.listNaclFiles()).map(p => buidFullPath(prefix, p)))))
+      awu(Object.entries(getActiveSources()))
+        .flatMap(async ([prefix, source]) => (
+          (await source.listNaclFiles()).map(p => buidFullPath(prefix, p)))).toArray()
     ),
     getTotalSize: async (): Promise<number> =>
       _.sum(await Promise.all(Object.values(sources).map(s => s.getTotalSize()))),
@@ -402,13 +406,15 @@ const buildMultiEnvSource = (
         ] as [string, SourceRange[]]))
     },
     getSourceRanges: async (elemID: ElemID): Promise<SourceRange[]> => (
-      _.flatten(await Promise.all(_.entries(getActiveSources())
-        .map(async ([prefix, source]) =>
-          (await source.getSourceRanges(elemID)).map(sourceRange => (
-            { ...sourceRange, filename: buidFullPath(prefix, sourceRange.filename) })))))
+      awu(Object.entries(getActiveSources()))
+        .flatMap(async ([prefix, source]) => (
+          await source.getSourceRanges(elemID)).map(sourceRange => ({
+          ...sourceRange,
+          filename: buidFullPath(prefix, sourceRange.filename),
+        }))).toArray()
     ),
     getErrors: async (): Promise<Errors> => {
-      const srcErrors = _.flatten(await Promise.all(_.entries(getActiveSources())
+      const srcErrors = await awu(_.entries(getActiveSources()))
         .map(async ([prefix, source]) => {
           const errors = await source.getErrors()
           return {
@@ -425,7 +431,8 @@ const buildMultiEnvSource = (
               },
             })),
           }
-        })))
+        })
+        .toArray()
       const { mergeErrors } = await getState()
       return new Errors(_.reduce(srcErrors, (acc, errors) => ({
         ...acc,
@@ -443,14 +450,16 @@ const buildMultiEnvSource = (
       return source.getParsedNaclFile(relPath)
     },
     getElementNaclFiles: async (id: ElemID): Promise<string[]> => (
-      _.flatten(await Promise.all(_.entries(getActiveSources())
-        .map(async ([prefix, source]) => (
-          await source.getElementNaclFiles(id)).map(p => buidFullPath(prefix, p)))))
+      awu(Object.entries(getActiveSources()))
+        .flatMap(async ([prefix, source]) => (
+          await source.getElementNaclFiles(id)).map(p => buidFullPath(prefix, p)))
+        .toArray()
     ),
     getElementReferencedFiles: async (id: ElemID): Promise<string[]> => _.flatten(
-      await Promise.all(_.entries(getActiveSources())
+      await awu(Object.entries(getActiveSources()))
         .map(async ([prefix, source]) => (
-          await source.getElementReferencedFiles(id)).map(p => buidFullPath(prefix, p))))
+          await source.getElementReferencedFiles(id)).map(p => buidFullPath(prefix, p)))
+        .toArray()
     ),
     clear: async (args = { nacl: true, staticResources: true, cache: true }) => {
       // We use series here since we don't want to perform too much delete operation concurrently

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -120,9 +120,10 @@ const createUpdateChanges = async (
         && change.id.nestingLevel > 0
         && !(await targetSource.get(change.id.createTopLevelParentID().parent)))
   )
-  const modifiedAdditions = await Promise.all(_(nestedAdditions)
-    .groupBy(addition => addition.id.createTopLevelParentID().parent.getFullName())
-    .entries()
+  const modifiedAdditions = await awu(Object.entries(_.groupBy(
+    nestedAdditions,
+    addition => addition.id.createTopLevelParentID().parent.getFullName()
+  )))
     .map(async ([parentID, elementAdditions]) => {
       const commonElement = await commonSource.get(ElemID.fromFullName(parentID))
       const targetElement = await targetSource.get(ElemID.fromFullName(parentID))
@@ -131,7 +132,8 @@ const createUpdateChanges = async (
       }
       return elementAdditions
     })
-    .value())
+    .toArray()
+
   return [
     ...otherChanges,
     ..._.flatten(modifiedAdditions),
@@ -302,7 +304,7 @@ const addToSource = async ({
   valuesOverrides?: Record<string, Value>
 }): Promise<DetailedChange[]> => {
   const idsByParent = _.groupBy(ids, id => id.createTopLevelParentID().parent.getFullName())
-  const fullChanges = _.flatten(await Promise.all(Object.values(idsByParent).map(async gids => {
+  const fullChanges = await awu(Object.values(idsByParent)).flatMap(async gids => {
     const topLevelGid = gids[0].createTopLevelParentID().parent
     const topLevelElement = valuesOverrides[topLevelGid.getFullName()]
       ?? await originSource.get(topLevelGid)
@@ -310,10 +312,10 @@ const addToSource = async ({
     if (before === undefined) {
       // If there is no top level element to merge into, we best let the nacl file source
       // handle the nested changes
-      return Promise.all(gids.map(async id => createAddChange(
+      return awu(gids).map(async id => createAddChange(
         valuesOverrides[id.getFullName()] ?? resolvePath(topLevelElement, id),
         id
-      )))
+      ))
     }
     if (topLevelElement === undefined) {
       throw new Error(`ElemID ${gids[0].getFullName()} does not exist in origin`)
@@ -353,11 +355,11 @@ const addToSource = async ({
     }
     const after = await awu(mergeResult.merged.values()).peek() as ChangeDataType
     return detailedCompare(before, after, true)
-  })))
-  return (await Promise.all(fullChanges.map(change => separateChangeByFiles(
+  }).flatMap(change => separateChangeByFiles(
     change,
     change.action === 'remove' ? targetSource : originSource
-  )))).flat()
+  )).toArray()
+  return fullChanges
 }
 
 const getChangePathHint = async (
@@ -453,11 +455,12 @@ const toMergeableChanges = async (
   )
   return [
     ...mergeableChanges,
-    ...await Promise.all(_(nonMergeableChanges)
-      .groupBy(c => getMergeableParentID(c.id).mergeableID.getFullName())
-      .values()
+    ...await awu(Object.values(_.groupBy(
+      nonMergeableChanges,
+      c => getMergeableParentID(c.id).mergeableID.getFullName()
+    )))
       .map(c => createMergeableChange(c, primarySource, commonSource))
-      .value()),
+      .toArray(),
   ]
 }
 
@@ -472,14 +475,14 @@ export const routeChanges = async (
     ? await toMergeableChanges(rawChanges, primarySource, commonSource)
     : rawChanges
 
-  const routedChanges = await Promise.all(changes.map(c => {
+  const routedChanges = await awu(changes).map(c => {
     switch (mode) {
       case 'isolated': return routeIsolated(c, primarySource, commonSource, secondarySources)
       case 'align': return routeAlign(c, primarySource)
       case 'override': return routeOverride(c, primarySource, commonSource, secondarySources)
       default: return routeDefault(c, primarySource, commonSource, secondarySources)
     }
-  }))
+  }).toArray()
 
   const secondaryEnvsChanges = _.mergeWith(
     {},
@@ -515,16 +518,14 @@ const removeFromSource = async (
   targetSource: NaclFilesSource
 ): Promise<DetailedChange[]> => {
   const groupedByTopLevel = _.groupBy(ids, id => id.createTopLevelParentID().parent.getFullName())
-  return (await Promise.all(
-    Object.entries(groupedByTopLevel)
-      .flatMap(async ([key, groupedIds]) => {
-        const targetTopElement = await targetSource.get(ElemID.fromFullName(key))
-        if (targetTopElement === undefined) {
-          return []
-        }
-        return groupedIds.map(id => createRemoveChange(resolvePath(targetTopElement, id), id))
-      })
-  )).flat()
+  return awu(Object.entries(groupedByTopLevel))
+    .flatMap(async ([key, groupedIds]) => {
+      const targetTopElement = await targetSource.get(ElemID.fromFullName(key))
+      if (targetTopElement === undefined) {
+        return []
+      }
+      return groupedIds.map(id => createRemoveChange(resolvePath(targetTopElement, id), id))
+    }).flat().toArray()
 }
 
 export const routePromote = async (

--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -238,8 +238,7 @@ export const updateNaclFileData = async (
   const replaceBufferPart = (data: string, change: BufferChange): string => (
     data.slice(0, change.start) + change.newData + data.slice(change.end)
   )
-
-  const bufferChanges = await Promise.all(changes.map(toBufferChange))
+  const bufferChanges = await awu(changes).map(toBufferChange).toArray()
 
   // We want to replace buffers from last to first, that way we won't have to re-calculate
   // the source locations after every change

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -543,8 +543,8 @@ const buildNaclFilesSource = (
       naclFiles,
       naclFile => _.isEmpty(naclFile.buffer.trim())
     )
-    await Promise.all(nonEmptyNaclFiles.map(naclFile => naclFilesStore.set(naclFile)))
-    await Promise.all(emptyNaclFiles.map(naclFile => naclFilesStore.delete(naclFile.filename)))
+    await awu(nonEmptyNaclFiles).forEach(naclFile => naclFilesStore.set(naclFile))
+    await awu(emptyNaclFiles).forEach(naclFile => naclFilesStore.delete(naclFile.filename))
   }
 
   const updateNaclFiles = async (changes: DetailedChange[]): Promise<Change<Element>[]> => {
@@ -563,10 +563,11 @@ const buildNaclFilesSource = (
         .flat()
         .forEach(file => staticFilesSource.delete(file))
     }
-
-    const naclFiles = _(await Promise.all(changes.map(change => change.id)
-      .map(elemID => getElementNaclFiles(elemID.createTopLevelParentID().parent))))
-      .flatten().uniq().value()
+    const naclFiles = _.uniq(
+      await awu(changes).map(change => change.id)
+        .flatMap(elemID => getElementNaclFiles(elemID.createTopLevelParentID().parent))
+        .toArray()
+    )
     const { parsedNaclFiles } = await getState()
     const changedFileToSourceMap: Record<string, SourceMap> = _.fromPairs(
       await withLimitedConcurrency(naclFiles
@@ -688,7 +689,7 @@ const buildNaclFilesSource = (
     },
 
     removeNaclFiles: async (...names: string[]) => {
-      await Promise.all(names.map(name => naclFilesStore.delete(name)))
+      await awu(names).forEach(name => naclFilesStore.delete(name))
       const res = await buildNaclFilesStateInner(
         await parseNaclFiles(names.map(filename => ({ filename, buffer: '' })), cache, functions),
       )

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -294,8 +294,9 @@ export const loadWorkspace = async (
   const transformToWorkspaceError = async <T extends SaltoElementError>(saltoElemErr: T):
     Promise<Readonly<WorkspaceError<T>>> => {
     const sourceRanges = await naclFilesSource.getSourceRanges(saltoElemErr.elemID)
-
-    const sourceFragments = await Promise.all(sourceRanges.map(range => getSourceFragment(range)))
+    const sourceFragments = await awu(sourceRanges)
+      .map(range => getSourceFragment(range))
+      .toArray()
 
     return {
       ...saltoElemErr,


### PR DESCRIPTION
_Changed promise all calls to `awu` to reduce memory foot print_

---

_Promise all calls can create memory usage bottlenecks without effecting speed (if no significant IO is performed in the promise). One such `Promise.all` invocation created a bottle neck in handleHiddenChanges which causes a crush in a 110K elements fetch._

---
_Release Notes_: 
NA
