### PR TITLE
changed get plan to resolve only added nodes

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -151,6 +151,11 @@ export const isStaticFile = (value: any): value is StaticFile => (
   value instanceof StaticFile
 )
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isReferenceExpression = (value: any): value is ReferenceExpression => (
+  value instanceof ReferenceExpression
+)
+
 export type TemplatePart = string | Expression
 /*
   Benchmarking reveals that looping on strings is extremely expensive.
@@ -169,10 +174,10 @@ export const compareSpecialValues = (
   if (isStaticFile(first) && isStaticFile(second)) {
     return first.isEqual(second)
   }
-  if (first instanceof ReferenceExpression || second instanceof ReferenceExpression) {
-    const fValue = first instanceof ReferenceExpression ? first.value : first
-    const sValue = second instanceof ReferenceExpression ? second.value : second
-    return (first instanceof ReferenceExpression && second instanceof ReferenceExpression)
+  if (isReferenceExpression(first) || isReferenceExpression(second)) {
+    const fValue = isReferenceExpression(first) ? first.value : first
+    const sValue = isReferenceExpression(second) ? second.value : second
+    return (isReferenceExpression(first) && isReferenceExpression(second))
       ? first.elemID.isEqual(second.elemID)
       : _.isEqualWith(fValue, sValue, compareSpecialValues)
   }
@@ -189,11 +194,6 @@ export const isEqualValues = (
   first,
   second,
   compareSpecialValues
-)
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const isReferenceExpression = (value: any): value is ReferenceExpression => (
-  value instanceof ReferenceExpression
 )
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -146,6 +146,11 @@ export class TemplateExpression extends types.Bean<{ parts: TemplatePart[] }> { 
 
 export type Expression = ReferenceExpression | TemplateExpression
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isStaticFile = (value: any): value is StaticFile => (
+  value instanceof StaticFile
+)
+
 export type TemplatePart = string | Expression
 /*
   Benchmarking reveals that looping on strings is extremely expensive.
@@ -161,7 +166,7 @@ export const compareSpecialValues = (
   first: Value,
   second: Value
 ): boolean | undefined => {
-  if (first instanceof StaticFile && second instanceof StaticFile) {
+  if (isStaticFile(first) && isStaticFile(second)) {
     return first.isEqual(second)
   }
   if (first instanceof ReferenceExpression || second instanceof ReferenceExpression) {
@@ -204,11 +209,6 @@ export const isTemplateExpression = (value: any): value is TemplateExpression =>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isExpression = (value: any): value is Expression => (
   isReferenceExpression(value) || isTemplateExpression(value)
-)
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const isStaticFile = (value: any): value is StaticFile => (
-  value instanceof StaticFile
 )
 
 export const isPrimitiveValue = (value: Value): value is PrimitiveValue => (

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -238,9 +238,8 @@ const resolveNodeElements = (
       afterItemsToResolve.push(change.data.after)
     }
   })
-
-  await resolve(awu(beforeItemsToResolve), before)
-  await resolve(awu(afterItemsToResolve), after)
+  await resolve(awu(beforeItemsToResolve), before, true)
+  await resolve(awu(afterItemsToResolve), after, true)
   return graph
 }
 
@@ -348,8 +347,8 @@ export const getPlan = async ({
 }: GetPlanParameters): Promise<Plan> => log.time(async () => {
   const diffGraph = await buildDiffGraph(
     addDifferentElements(before, after, topLevelFilters),
+    resolveNodeElements(before, after),
     addModifyNodes(addNodeDependencies(dependencyChangers)),
-    resolveNodeElements(before, after)
   )
 
   const filterResult = await filterInvalidChanges(

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -50,7 +50,8 @@ const compareValuesAndLazyResolveRefs = async (
   secondSrc: ReadOnlyElementsSource
 ): Promise<boolean> => {
   const shouldResolve = (value: Value): boolean => isReferenceExpression(value)
-    && !(value.elemID.isTopLevel() || value.elemID.idType === 'field')
+    && (!(value.elemID.isTopLevel() || value.elemID.idType === 'field')
+      || value.elemID.idType === 'var')
     && value.value === undefined
 
   const resolvedFirst = shouldResolve(first)
@@ -61,6 +62,9 @@ const compareValuesAndLazyResolveRefs = async (
     : second
 
   const specialCompareRes = compareSpecialValues(resolvedFirst, resolvedSecond)
+  if (specialCompareRes === false) {
+    compareSpecialValues(resolvedFirst, resolvedSecond)
+  }
   if (values.isDefined(specialCompareRes)) {
     return specialCompareRes
   }

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -83,7 +83,7 @@ const compareValuesAndLazyResolveRefs = async (
   }
 
   if (_.isPlainObject(resolvedFirst) && _.isPlainObject(resolvedSecond)) {
-    if (!_.isEqual(Object.keys(resolvedFirst), Object.keys(resolvedSecond))) {
+    if (!_.isEqual(new Set(Object.keys(resolvedFirst)), new Set(Object.keys(resolvedSecond)))) {
       return false
     }
     return !await awu(Object.keys(resolvedFirst)).some(

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -49,11 +49,15 @@ const compareValuesAndLazyResolveRefs = async (
   firstSrc: ReadOnlyElementsSource,
   secondSrc: ReadOnlyElementsSource
 ): Promise<boolean> => {
-  const resolvedFirst = isReferenceExpression(first)
+  const shouldResolve = (value: Value): boolean => isReferenceExpression(value)
+    && !(value.elemID.isTopLevel() && value.elemID.idType === 'field')
+    && value.value === undefined
+
+  const resolvedFirst = shouldResolve(first)
     ? await resolveReferenceExpression(first, firstSrc, {})
     : first
-  const resolvedSecond = isReferenceExpression(first)
-    ? await resolveReferenceExpression(first, secondSrc, {})
+  const resolvedSecond = shouldResolve(second)
+    ? await resolveReferenceExpression(second, secondSrc, {})
     : second
 
   const specialCompareRes = compareSpecialValues(resolvedFirst, resolvedSecond)

--- a/packages/lowerdash/src/collections/asynciterable.ts
+++ b/packages/lowerdash/src/collections/asynciterable.ts
@@ -220,7 +220,7 @@ export const keyByAsync = async<T>(
 
 export const someAsync = async<T>(
   itr: ThenableIterable<T>,
-  func: (t: T) => Thenable<unknown>
+  func: (t: T, i: number) => Thenable<unknown>
 ): Promise<boolean> => await findAsync(mapAsync(itr, func), res => res) !== undefined
 
 export const everyAsync = async<T>(
@@ -254,7 +254,7 @@ export type AwuIterable<T> = AsyncIterable<T> & {
   // This is the way wu handles the flat function types as well...
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   flat(): AwuIterable<any>
-  some(func: (t: T) => Thenable<unknown>): Promise<boolean>
+  some(func: (t: T, i: number) => Thenable<unknown>): Promise<boolean>
   every(func: (t: T) => Thenable<unknown>): Promise<boolean>
   keyBy(keyFunc: (t: T) => Thenable<string>): Promise<Record<string, T>>
   groupBy(keyFunc: (t: T) => Thenable<string>): Promise<Record<string, T[]>>

--- a/packages/lowerdash/test/collections/asynciterable.test.ts
+++ b/packages/lowerdash/test/collections/asynciterable.test.ts
@@ -284,6 +284,14 @@ describe('asynciterable', () => {
         await someAsync(toAsyncIterable([1, 2, 3, 4]), n => Promise.resolve(n === 5))
       ).toBe(false)
     })
+    it('should allow some function to get an index', async () => {
+      expect(
+        await someAsync(toAsyncIterable([1, 2, 3, 4]), (n, i) => Promise.resolve(n === i))
+      ).toBe(false)
+      expect(
+        await someAsync(toAsyncIterable([1, 1, 3, 4]), (n, i) => Promise.resolve(n === i))
+      ).toBe(true)
+    })
   })
 
   describe('everyAsync', () => {

--- a/packages/workspace/src/expressions.ts
+++ b/packages/workspace/src/expressions.ts
@@ -213,30 +213,6 @@ const resolveElement = async (
       resolvedElements,
       resolvedSet,
     ))
-    // element.fields = await mapValuesAsync(
-    //   element.fields,
-    //   async field => {
-    //     const fieldType = await resolveElement(
-    //       await field.getType(contextedElementsGetter),
-    //       elementsSource,
-    //       resolvedElements,
-    //       resolvedSet
-    //     )
-    //     return new Field(
-    //       element,
-    //       field.name,
-    //       fieldType as TypeElement,
-    //       (await transformValues({
-    //         transformFunc: referenceCloner,
-    //         values: field.annotations,
-    //         elementsSource,
-    //         strict: false,
-    //         type: await field.getAnnotationTypes(contextedElementsGetter),
-    //         allowEmpty: true,
-    //       })) ?? {}
-    //     )
-    //   },
-    // )
   }
 
   if (isVariable(element)) {
@@ -253,12 +229,16 @@ export const resolve = async (
   inPlace = false
 ): Promise<AsyncIterable<Element>> => {
   // intentionally shallow clone because in resolve element we replace only top level properties
-  const clonedElements = inPlace
+  const elementsToClone = inPlace
     ? elements
     : await awu(elements).map(_.clone).toArray()
-  const resolvedElements = await awu(clonedElements).keyBy(
+  const resolvedElements = await awu(elementsToClone).keyBy(
     elm => elm.elemID.getFullName()
   )
-  await awu(clonedElements).forEach(e => resolveElement(e, elementsSource, resolvedElements))
-  return awu(clonedElements)
+  await awu(elementsToClone).forEach(e => resolveElement(
+    e,
+    elementsSource,
+    resolvedElements
+  ))
+  return awu(elementsToClone)
 }

--- a/packages/workspace/src/expressions.ts
+++ b/packages/workspace/src/expressions.ts
@@ -229,16 +229,16 @@ export const resolve = async (
   inPlace = false
 ): Promise<AsyncIterable<Element>> => {
   // intentionally shallow clone because in resolve element we replace only top level properties
-  const elementsToClone = inPlace
+  const elementsToResolve = inPlace
     ? elements
     : await awu(elements).map(_.clone).toArray()
-  const resolvedElements = await awu(elementsToClone).keyBy(
+  const resolvedElements = await awu(elementsToResolve).keyBy(
     elm => elm.elemID.getFullName()
   )
-  await awu(elementsToClone).forEach(e => resolveElement(
+  await awu(elementsToResolve).forEach(e => resolveElement(
     e,
     elementsSource,
     resolvedElements
   ))
-  return awu(elementsToClone)
+  return awu(elementsToResolve)
 }

--- a/packages/workspace/src/expressions.ts
+++ b/packages/workspace/src/expressions.ts
@@ -250,11 +250,13 @@ const resolveElement = async (
 export const resolve = async (
   elements: AsyncIterable<Element>,
   elementsSource: ReadOnlyElementsSource,
+  inPlace = false
 ): Promise<AsyncIterable<Element>> => {
   // intentionally shallow clone because in resolve element we replace only top level properties
-  const clonedElements = await awu(elements).map(_.clone).toArray()
-  const resolvedElements = _.keyBy(
-    clonedElements,
+  const clonedElements = inPlace
+    ? elements
+    : await awu(elements).map(_.clone).toArray()
+  const resolvedElements = await awu(clonedElements).keyBy(
     elm => elm.elemID.getFullName()
   )
   await awu(clonedElements).forEach(e => resolveElement(e, elementsSource, resolvedElements))

--- a/packages/workspace/src/expressions.ts
+++ b/packages/workspace/src/expressions.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ElemID, Element, Value, ReferenceExpression, TemplateExpression, isReferenceExpression, isVariableExpression, isElement, ReadOnlyElementsSource, isVariable, isInstanceElement, isObjectType, Field, TypeElement, isContainerType } from '@salto-io/adapter-api'
+import { ElemID, Element, Value, ReferenceExpression, TemplateExpression, isReferenceExpression, isVariableExpression, isElement, ReadOnlyElementsSource, isVariable, isInstanceElement, isObjectType, isContainerType, isField } from '@salto-io/adapter-api'
 import { resolvePath, TransformFunc, createRefToElmWithValue, transformValues } from '@salto-io/adapter-utils'
 import { collections, promises } from '@salto-io/lowerdash'
 
@@ -41,7 +41,6 @@ const getResolvedElement = async (
 ): Promise<Element | undefined> =>
   (resolvedElements[elemID.getFullName()] ?? elementsSource.get(elemID))
 
-let resolveReferenceExpression: Resolver<ReferenceExpression>
 let resolveTemplateExpression: Resolver<TemplateExpression>
 
 const resolveMaybeExpression: Resolver<Value> = async (
@@ -51,6 +50,7 @@ const resolveMaybeExpression: Resolver<Value> = async (
   visited: Set<string> = new Set<string>(),
 ): Promise<Value> => {
   if (isReferenceExpression(value)) {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return resolveReferenceExpression(value, elementsSource, resolvedElements, visited)
   }
 
@@ -67,7 +67,7 @@ const resolveMaybeExpression: Resolver<Value> = async (
   return value
 }
 
-resolveReferenceExpression = async (
+export const resolveReferenceExpression = async (
   expression: ReferenceExpression,
   elementsSource: ReadOnlyElementsSource,
   resolvedElements: Record<string, Element>,
@@ -183,7 +183,8 @@ const resolveElement = async (
     )
   }
 
-  if (isInstanceElement(element)) {
+
+  if (isInstanceElement(element) || isField(element)) {
     element.refType = createRefToElmWithValue(
       await resolveElement(
         await element.getType(contextedElementsGetter),
@@ -192,6 +193,9 @@ const resolveElement = async (
         resolvedSet
       )
     )
+  }
+
+  if (isInstanceElement(element)) {
     element.value = (await transformValues({
       transformFunc: referenceCloner,
       values: element.value,
@@ -203,30 +207,36 @@ const resolveElement = async (
   }
 
   if (isObjectType(element)) {
-    element.fields = await mapValuesAsync(
-      element.fields,
-      async field => {
-        const fieldType = await resolveElement(
-          await field.getType(contextedElementsGetter),
-          elementsSource,
-          resolvedElements,
-          resolvedSet
-        )
-        return new Field(
-          element,
-          field.name,
-          fieldType as TypeElement,
-          (await transformValues({
-            transformFunc: referenceCloner,
-            values: field.annotations,
-            elementsSource,
-            strict: false,
-            type: await field.getAnnotationTypes(contextedElementsGetter),
-            allowEmpty: true,
-          })) ?? {}
-        )
-      },
-    )
+    await awu(Object.values(element.fields)).forEach(field => resolveElement(
+      field,
+      elementsSource,
+      resolvedElements,
+      resolvedSet,
+    ))
+    // element.fields = await mapValuesAsync(
+    //   element.fields,
+    //   async field => {
+    //     const fieldType = await resolveElement(
+    //       await field.getType(contextedElementsGetter),
+    //       elementsSource,
+    //       resolvedElements,
+    //       resolvedSet
+    //     )
+    //     return new Field(
+    //       element,
+    //       field.name,
+    //       fieldType as TypeElement,
+    //       (await transformValues({
+    //         transformFunc: referenceCloner,
+    //         values: field.annotations,
+    //         elementsSource,
+    //         strict: false,
+    //         type: await field.getAnnotationTypes(contextedElementsGetter),
+    //         allowEmpty: true,
+    //       })) ?? {}
+    //     )
+    //   },
+    // )
   }
 
   if (isVariable(element)) {


### PR DESCRIPTION
_Change get plan to resolve only nodes that were added to the graph_

---

_Currently, getPlan resolves all of the elements before comparing them in order to decide which element should be added to the diff graph. This is very wasteful in both run time, and memory usage. The only "resolve" action that needed to be taken in order to compare two elements is resolving references to non element objects. The isEqual method was modified in order to reflect that._

_The deploy command still needs resolved elements though (Since we had yet to modify the deploy command to accept) so a step that resolves nodes that were added to the graph was created. This step will be removed once the deploy API will be modified._

---
_Release Notes_: 
_NA_
