### PR TITLE
SALTO-1128: changed to accept only y or n answers

### DIFF
--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -32,13 +32,14 @@ import Prompts from './prompts'
 import { CliOutput, WriteStream } from './types'
 
 export const getUserBooleanInput = async (prompt: string): Promise<boolean> => {
-  const question = {
+  const question: inquirer.Question = {
     name: 'userInput',
-    message: prompt,
-    type: 'confirm',
+    message: `${prompt} (y/n)`,
+    type: 'input',
+    validate: input => (!['y', 'n'].includes(input.toLowerCase()) ? 'Answer must be \'y\' for yes or \'n\' for no' : true),
   }
   const answers = await inquirer.prompt(question)
-  return answers.userInput
+  return answers.userInput.toLowerCase() === 'y'
 }
 
 type YesNoCancelAnswer = 'yes' | 'no' | 'cancel operation'

--- a/packages/cli/test/workspace/workspace.test.ts
+++ b/packages/cli/test/workspace/workspace.test.ts
@@ -51,7 +51,7 @@ jest.mock('@salto-io/core', () => ({
   loadLocalWorkspace: jest.fn().mockImplementation(() => mockWs),
 }))
 jest.mock('inquirer', () => ({
-  prompt: jest.fn().mockResolvedValue({ userInput: false }),
+  prompt: jest.fn().mockResolvedValue({ userInput: 'n' }),
 }))
 describe('workspace', () => {
   let cliOutput: { stderr: MockWriteStream; stdout: MockWriteStream }


### PR DESCRIPTION
Changed any y/n question in Salto CLI to accept only 'y' or 'n'.
`inquirer` confirm type does not support this, so I changed it to input type and added validation.

---
_Release Notes_: 
CLI:
y/n questions in the CLI will only accept 'y' or 'n' answers.