### PR TITLE
[WIP] SALTO-1185 - Ignore changes in core annotation values in deploy plan

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -103,6 +103,7 @@ export const preview = async (
     changeValidators: getAdapterChangeValidators(),
     dependencyChangers: defaultDependencyChangers.concat(getAdapterDependencyChangers()),
     customGroupIdFunctions: getAdapterChangeGroupIdFunctions(),
+    omitCoreAnnotations: true,
   })
 }
 

--- a/packages/core/src/core/plan/plan_item.ts
+++ b/packages/core/src/core/plan/plan_item.ts
@@ -39,7 +39,10 @@ const getGroupAction = (group: Group<Change>): ActionName => {
     : 'modify'
 }
 
-export const addPlanItemAccessors = (group: Group<Change>): PlanItem => Object.assign(group, {
+export const addPlanItemAccessors = (
+  group: Group<Change>,
+  omitCoreAnnotations = false,
+): PlanItem => Object.assign(group, {
   action: getGroupAction(group),
   changes() {
     return group.items.values()
@@ -51,7 +54,7 @@ export const addPlanItemAccessors = (group: Group<Change>): PlanItem => Object.a
         if (change.action !== 'modify') {
           return { ...change, id: elem.elemID }
         }
-        return detailedCompare(change.data.before, change.data.after)
+        return detailedCompare(change.data.before, change.data.after, false, omitCoreAnnotations)
       })
       .flatten()
   },

--- a/packages/core/test/common/plan.ts
+++ b/packages/core/test/common/plan.ts
@@ -38,7 +38,7 @@ export const createPlan = (changeGroups: Change[][]): Plan => {
     {
       itemsByEvalOrder: () => wu(graph.keys())
         .map(id => graph.getData(id))
-        .map(addPlanItemAccessors),
+        .map(group => addPlanItemAccessors(group)),
       getItem: (id: PlanItemId) => addPlanItemAccessors(graph.getData(id)),
       changeErrors: [],
     }


### PR DESCRIPTION
Workaround for noise in deploy plans coming from changes in generated dependencies (which are not deployed to the service), but can happen for other non-deployable annotations too.

(still missing tests)

---
_Release Notes_: 
None (the previous release did not show these annotation changes in the plan for other reasons)
