### PR TITLE
SALTO-1158: make instance compare check annotations and ID

### DIFF
--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -345,19 +345,9 @@ export class InstanceElement extends Element {
   }
 
   isEqual(other: InstanceElement): boolean {
-    return _.isEqual(this.type.elemID, other.type.elemID)
+    return super.isEqual(other)
+      && _.isEqual(this.type.elemID, other.type.elemID)
       && isEqualValues(this.value, other.value)
-  }
-
-  /**
-   * Find all values that are in this.values and not in prev (this.values / prevValues)
-   * Or different (same key and different value).
-   *
-   * @param prevValues to compare
-   * @return All values which unique (not in prev) or different.
-   */
-  getValuesThatNotInPrevOrDifferent(prevValues: Values): Values {
-    return _.pickBy(this.value, (val, key) => !isEqualValues(val, prevValues[key]))
   }
 
   /**

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -20,7 +20,7 @@ import {
   PrimitiveTypes, ListType, isPrimitiveType, isType, isListType, isEqualElements, Variable,
   isVariable, isMapType, MapType, isContainerType,
 } from '../src/elements'
-import { ElemID } from '../src/element_id'
+import { ElemID, INSTANCE_ANNOTATIONS } from '../src/element_id'
 
 describe('Test elements.ts', () => {
   /**   ElemIDs   * */
@@ -70,87 +70,6 @@ describe('Test elements.ts', () => {
     expect(ot.elemID).toEqual(otID)
     expect(ot.fields.num_field.type).toBeInstanceOf(PrimitiveType)
     expect(ot.fields.str_field.type).toBeInstanceOf(PrimitiveType)
-  })
-
-  it('Should test getValuesThatNotInPrevOrDifferent func', () => {
-    const prevInstance = new InstanceElement('diff', new ObjectType({
-      elemID: new ElemID('test', 'diff'),
-      annotationTypes: {},
-      annotations: {},
-    }),
-    {
-      userPermissions: [
-        {
-          enabled: false,
-          name: 'ConvertLeads',
-        },
-      ],
-      fieldPermissions: [
-        {
-          field: 'Lead.Fax',
-          readable: false,
-          editable: false,
-        },
-      ],
-      description: 'old unit test instance profile',
-    },)
-
-    const newInstance = new InstanceElement('diff', new ObjectType({
-      elemID: new ElemID('test', 'diff'),
-      annotationTypes: {},
-      annotations: {},
-    }),
-    {
-      userPermissions: [
-        {
-          enabled: false,
-          name: 'ConvertLeads',
-        },
-      ],
-      fieldPermissions: [
-        {
-          field: 'Lead.Fax',
-          readable: false,
-          editable: false,
-        },
-        {
-          editable: false,
-          field: 'Account.AccountNumber',
-          readable: false,
-        },
-      ],
-      applicationVisibilities: [
-        {
-          application: 'standard__ServiceConsole',
-          default: false,
-          visible: true,
-        },
-      ],
-      description: 'new unit test instance profile',
-    },)
-
-    expect(newInstance.getValuesThatNotInPrevOrDifferent(prevInstance.value)).toMatchObject({
-      fieldPermissions: [
-        {
-          field: 'Lead.Fax',
-          readable: false,
-          editable: false,
-        },
-        {
-          editable: false,
-          field: 'Account.AccountNumber',
-          readable: false,
-        },
-      ],
-      applicationVisibilities: [
-        {
-          application: 'standard__ServiceConsole',
-          default: false,
-          visible: true,
-        },
-      ],
-      description: 'new unit test instance profile',
-    },)
   })
 
   describe('isEqualElements and type guards', () => {
@@ -247,6 +166,26 @@ describe('Test elements.ts', () => {
 
     it('should identify different elements as false', () => {
       expect(isEqualElements(inst, ot)).toBeFalsy()
+    })
+
+    it('should identify different instances with id change', () => {
+      const instClone = new InstanceElement(
+        'different_name',
+        inst.type,
+        inst.value
+      )
+      expect(isEqualElements(inst, instClone)).toBeFalsy()
+    })
+    it('should identify different instances with value change', () => {
+      const instClone = inst.clone()
+      instClone.value.newVal = 1
+      expect(isEqualElements(inst, instClone)).toBeFalsy()
+    })
+
+    it('should identify different instances with annotation change', () => {
+      const instClone = inst.clone()
+      instClone.annotations[INSTANCE_ANNOTATIONS.SERVICE_URL] = 'asd'
+      expect(isEqualElements(inst, instClone)).toBeFalsy()
     })
 
     it('should identify equal variable elements', () => {

--- a/packages/adapter-utils/src/compare.ts
+++ b/packages/adapter-utils/src/compare.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  ChangeDataType, DetailedChange, isField, isInstanceElement, ElemID, Value, ObjectType,
+  ChangeDataType, DetailedChange, isField, isInstanceElement, ElemID, Value, ObjectType, isType,
   PrimitiveType, isObjectType, isPrimitiveType, isEqualElements, isEqualValues, isRemovalChange,
 } from '@salto-io/adapter-api'
 import { setPath } from './utils'
@@ -129,9 +129,9 @@ export const detailedCompare = (
     return [{ action: 'modify', data: { before, after }, id: after.elemID }]
   }
 
-  if (isInstanceElement(before) && isInstanceElement(after)) {
-    return getValuesChanges(after.elemID, before.value, after.value)
-  }
+  const valueChanges = isInstanceElement(before) && isInstanceElement(after)
+    ? getValuesChanges(after.elemID, before.value, after.value)
+    : []
 
   // A special case to handle changes in annotationType.
   const annotationTypeChanges = getAnnotationTypeChanges(
@@ -141,14 +141,14 @@ export const detailedCompare = (
   )
 
   const annotationChanges = getValuesChanges(
-    after.elemID.isTopLevel() ? after.elemID.createNestedID('attr') : after.elemID,
+    isType(after) ? after.elemID.createNestedID('attr') : after.elemID,
     before.annotations, after.annotations
   )
 
   const fieldChanges = createFieldChanges && isObjectType(before) && isObjectType(after)
     ? getFieldsChanges(before, after)
     : []
-  return [...annotationTypeChanges, ...annotationChanges, ...fieldChanges]
+  return [...annotationTypeChanges, ...annotationChanges, ...fieldChanges, ...valueChanges]
 }
 
 export const applyDetailedChanges = (

--- a/packages/adapter-utils/test/compare.test.ts
+++ b/packages/adapter-utils/test/compare.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ObjectType, ElemID, InstanceElement, DetailedChange, PrimitiveType, BuiltinTypes, PrimitiveTypes, Field } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, InstanceElement, DetailedChange, PrimitiveType, BuiltinTypes, PrimitiveTypes, Field, INSTANCE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { detailedCompare, applyDetailedChanges } from '../src/compare'
 
 describe('detailedCompare', () => {
@@ -32,6 +32,11 @@ describe('detailedCompare', () => {
       {
         before: 'Before',
         modify: 'Before',
+      },
+      undefined,
+      {
+        [INSTANCE_ANNOTATIONS.HIDDEN]: true,
+        [INSTANCE_ANNOTATIONS.SERVICE_URL]: 'before',
       }
     )
     const after = new InstanceElement(
@@ -40,6 +45,11 @@ describe('detailedCompare', () => {
       {
         after: 'Before',
         modify: 'After',
+      },
+      undefined,
+      {
+        [INSTANCE_ANNOTATIONS.SERVICE_URL]: 'after',
+        [INSTANCE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [],
       }
     )
     const changes = detailedCompare(before, after)
@@ -54,6 +64,21 @@ describe('detailedCompare', () => {
     it('should create modify changes for values that were only present both instances', () => {
       expect(hasChange(changes, 'modify', before.elemID.createNestedID('modify')))
         .toBeTruthy()
+    })
+    it('should create add changes for new annotation values', () => {
+      expect(
+        hasChange(changes, 'add', after.elemID.createNestedID(INSTANCE_ANNOTATIONS.GENERATED_DEPENDENCIES))
+      ).toBeTruthy()
+    })
+    it('should create modify changes for changed annotation values', () => {
+      expect(
+        hasChange(changes, 'modify', after.elemID.createNestedID(INSTANCE_ANNOTATIONS.SERVICE_URL))
+      ).toBeTruthy()
+    })
+    it('should create remove changes for removed annotation values', () => {
+      expect(
+        hasChange(changes, 'remove', before.elemID.createNestedID(INSTANCE_ANNOTATIONS.HIDDEN))
+      ).toBeTruthy()
     })
   })
 


### PR DESCRIPTION
This reverts commit 6bd84123dc7eca52ce4a4b86a326d659a7e0f808
Re-applying changes from #1823 and #1805

---
_Release Notes_: 
Salesforce adapter:
* Fixed issue where _generated_dependencies would not be updated to reflect the correct dependencies of ApexClasses and Flows when they change
