### PR TITLE
fixed salesforce deprecated config convertion

### DIFF
--- a/packages/salesforce-adapter/src/deprecated_config.ts
+++ b/packages/salesforce-adapter/src/deprecated_config.ts
@@ -122,15 +122,22 @@ const convertDeprecatedMetadataParams = (
 }
 
 const convertDeprecatedDataConf = (conf: DataManagementConfig): DataManagementConfig => ({
-  ...conf,
+  ..._.pickBy({
+    ...conf,
+    excludeObjects: conf?.excludeObjects?.map(convertDeprecatedRegex),
+    allowReferenceTo: conf?.allowReferenceTo?.map(convertDeprecatedRegex),
+  }, values.isDefined),
   includeObjects: conf.includeObjects.map(convertDeprecatedRegex),
-  excludeObjects: conf?.excludeObjects?.map(convertDeprecatedRegex),
-  allowReferenceTo: conf?.allowReferenceTo?.map(convertDeprecatedRegex),
   saltoIDSettings: {
-    ...conf.saltoIDSettings,
-    overrides: conf.saltoIDSettings.overrides?.map(
-      override => ({ ...override, objectsRegex: convertDeprecatedRegex(override.objectsRegex) })
-    ),
+    ..._.pickBy({
+      ...conf.saltoIDSettings,
+      overrides:
+        conf.saltoIDSettings.overrides?.map(override => ({
+          ...override,
+          objectsRegex: convertDeprecatedRegex(override.objectsRegex),
+        })),
+    }, values.isDefined),
+    defaultIdFields: conf.saltoIDSettings.defaultIdFields,
   },
 })
 

--- a/packages/salesforce-adapter/test/deprecated_config.test.ts
+++ b/packages/salesforce-adapter/test/deprecated_config.test.ts
@@ -98,6 +98,50 @@ describe('deprecated config', () => {
       expect(config?.message).toBe(DEPRECATED_OPTIONS_MESSAGE)
     })
 
+    it('dataManagement without all the properties should be converted to fetch.data', () => {
+      const configWithOldOptions = {
+        fetch: {
+          metadata: {
+            exclude: [
+              { metadataType: 'Type1' },
+            ],
+          },
+        },
+        dataManagement: {
+          includeObjects: ['aaa', '^eee', 'hhh\\.*'],
+          saltoIDSettings: {
+            defaultIdFields: ['Name'],
+          },
+        },
+      }
+
+      const updatedConfig = {
+        fetch: {
+          metadata: {
+            exclude: [
+              { metadataType: 'Type1' },
+            ],
+          },
+          data: {
+            includeObjects: ['.*aaa.*', 'eee.*', '.*hhh\\.*.*'],
+            saltoIDSettings: {
+              defaultIdFields: ['Name'],
+            },
+          },
+        },
+      }
+
+      const config = updateDeprecatedConfiguration(new InstanceElement(
+        ElemID.CONFIG_NAME,
+        configType,
+        configWithOldOptions
+      ))
+      // _.isEqual is used instead of '.toEqual' because '.toEqual'
+      // will return true of objects like {a: undefined} and {}
+      expect(_.isEqual(config?.config.value, updatedConfig)).toBeTruthy()
+      expect(config?.message).toBe(DEPRECATED_OPTIONS_MESSAGE)
+    })
+
     it('metadataTypesSkippedList should be converted to fetch.metadata.exclude', () => {
       const configWithOldOptions = _.cloneDeep(currentConfig)
       configWithOldOptions.metadataTypesSkippedList = ['a', 'b']


### PR DESCRIPTION
Fixed a bug in the conversion between the old salesforce configuration to the new where an undefined was written inside `data` in an attribute that was not filled in the old configuration

---
_Release Notes_: 
None