### PR TITLE
SALTO-1129: improved move-to-envs/move-to-common/clone messages

### DIFF
--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import os from 'os'
 // TODO: This import breaks the abstraction of CliOutput as it communicate directly with console
 import * as inquirer from 'inquirer'
 import {
@@ -94,6 +95,61 @@ export const shouldContinueInCaseOfWarnings = async (numWarnings: number,
   }
   return shouldContinue
 }
+
+const runElementsOperationMessages = async (
+  elemIds: readonly ElemID[],
+  { stdout }: CliOutput,
+  nothingToDoMessage: string,
+  informationMessage: string,
+  questionMessage: string,
+  startMessage: string,
+  force: boolean
+): Promise<boolean> => {
+  if (elemIds.length === 0) {
+    stdout.write(`${nothingToDoMessage}${os.EOL}`)
+    return false
+  }
+  stdout.write(`${informationMessage}${os.EOL}`)
+
+  const shouldStart = force || await getUserBooleanInput(questionMessage)
+  if (shouldStart) {
+    stdout.write(`${startMessage}${os.EOL}`)
+  }
+
+  return shouldStart
+}
+
+export const shouldMoveElements = async (
+  to: string,
+  elemIds: readonly ElemID[],
+  output: CliOutput,
+  force: boolean,
+): Promise<boolean> =>
+  runElementsOperationMessages(
+    elemIds,
+    output,
+    Prompts.NO_ELEMENTS_MESSAGE,
+    Prompts.MOVE_MESSAGE(to, elemIds.map(id => id.getFullName())),
+    Prompts.SHOULD_MOVE_QUESTION(to),
+    Prompts.MOVE_START(to),
+    force,
+  )
+
+export const shouldCloneElements = async (
+  targetEnvs: string[],
+  elemIds: readonly ElemID[],
+  output: CliOutput,
+  force: boolean,
+): Promise<boolean> =>
+  runElementsOperationMessages(
+    elemIds,
+    output,
+    Prompts.NO_ELEMENTS_MESSAGE,
+    Prompts.CLONE_MESSAGE(elemIds.map(id => id.getFullName())),
+    Prompts.SHOULD_CLONE_QUESTION,
+    Prompts.CLONE_TO_ENV_START(targetEnvs),
+    force,
+  )
 
 export const shouldAbortWorkspaceInCaseOfValidationError = async (numErrors: number):
   Promise<boolean> => getUserBooleanInput(formatShouldAbortWithValidationError(numErrors))

--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import os from 'os'
 // TODO: This import breaks the abstraction of CliOutput as it communicate directly with console
 import * as inquirer from 'inquirer'
 import {
@@ -95,61 +94,6 @@ export const shouldContinueInCaseOfWarnings = async (numWarnings: number,
   }
   return shouldContinue
 }
-
-const runElementsOperationMessages = async (
-  elemIds: readonly ElemID[],
-  { stdout }: CliOutput,
-  nothingToDoMessage: string,
-  informationMessage: string,
-  questionMessage: string,
-  startMessage: string,
-  force: boolean
-): Promise<boolean> => {
-  if (elemIds.length === 0) {
-    stdout.write(`${nothingToDoMessage}${os.EOL}`)
-    return false
-  }
-  stdout.write(`${informationMessage}${os.EOL}`)
-
-  const shouldStart = force || await getUserBooleanInput(questionMessage)
-  if (shouldStart) {
-    stdout.write(`${startMessage}${os.EOL}`)
-  }
-
-  return shouldStart
-}
-
-export const shouldMoveElements = async (
-  to: string,
-  elemIds: readonly ElemID[],
-  output: CliOutput,
-  force: boolean,
-): Promise<boolean> =>
-  runElementsOperationMessages(
-    elemIds,
-    output,
-    Prompts.NO_ELEMENTS_MESSAGE,
-    Prompts.MOVE_MESSAGE(to, elemIds.map(id => id.getFullName())),
-    Prompts.SHOULD_MOVE_QUESTION(to),
-    Prompts.MOVE_START(to),
-    force,
-  )
-
-export const shouldCloneElements = async (
-  targetEnvs: string[],
-  elemIds: readonly ElemID[],
-  output: CliOutput,
-  force: boolean,
-): Promise<boolean> =>
-  runElementsOperationMessages(
-    elemIds,
-    output,
-    Prompts.NO_ELEMENTS_MESSAGE,
-    Prompts.CLONE_MESSAGE(elemIds.map(id => id.getFullName())),
-    Prompts.SHOULD_CLONE_QUESTION,
-    Prompts.CLONE_TO_ENV_START(targetEnvs),
-    force,
-  )
 
 export const shouldAbortWorkspaceInCaseOfValidationError = async (numErrors: number):
   Promise<boolean> => getUserBooleanInput(formatShouldAbortWithValidationError(numErrors))

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -248,11 +248,13 @@ ${Prompts.SERVICE_ADD_HELP}`
     `The following configuration elements will be moved to ${to}:
 ${Prompts.LIST_IDS(ids)}
 
+
 `
 
   public static readonly MOVE_START = (
     to: string,
-  ): string => `Moving the specified elements to ${to}.`
+  ): string => `Moving the specified elements to ${to}.
+`
 
   private static readonly SHOULD_RUN_ELEMENTS_OPERATION = (operation: string): string =>
     `Would you like to complete the ${operation} operation?`
@@ -261,7 +263,8 @@ ${Prompts.LIST_IDS(ids)}
     Prompts.SHOULD_RUN_ELEMENTS_OPERATION(`move to ${to}`)
 
   public static readonly NO_ELEMENTS_MESSAGE = `Did not find any configuration elements that matches your criteria.
-Nothing to do.`
+Nothing to do.
+`
 
   public static readonly MOVE_FAILED = (
     error: string
@@ -275,13 +278,15 @@ Nothing to do.`
     targetEnvs: string[] = []
   ): string => `Cloning the specified elements to ${
     targetEnvs.length > 0 ? targetEnvs.join(', ') : 'all environments'
-  }.`
+  }.
+`
 
   public static readonly CLONE_MESSAGE = (
     ids: readonly string[],
   ): string =>
     `The following configuration elements will be cloned:
 ${Prompts.LIST_IDS(ids)}
+
 
 `
 

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -15,6 +15,7 @@
 */
 import chalk from 'chalk'
 import moment from 'moment'
+import os from 'os'
 
 export default class Prompts {
   public static readonly SHOULD_EXECUTE_PLAN = 'Do you want to perform these actions?'
@@ -235,9 +236,32 @@ ${Prompts.SERVICE_ADD_HELP}`
     ? `Unknown target environment: ${unknownEnvs[0]}`
     : `Unknown target environments: ${unknownEnvs?.join(' ')}`)
 
+  private static readonly LIST_IDS = (
+    ids: readonly string[],
+  ): string =>
+    [...ids].sort().map(id => `  - ${id}`).join(os.EOL)
+
+  public static readonly MOVE_MESSAGE = (
+    to: string,
+    ids: readonly string[],
+  ): string =>
+    `The following configuration elements will be moved to ${to}:
+${Prompts.LIST_IDS(ids)}
+
+`
+
   public static readonly MOVE_START = (
     to: string,
   ): string => `Moving the specified elements to ${to}.`
+
+  private static readonly SHOULD_RUN_ELEMENTS_OPERATION = (operation: string): string =>
+    `Would you like to complete the ${operation} operation?`
+
+  public static readonly SHOULD_MOVE_QUESTION = (to: string): string =>
+    Prompts.SHOULD_RUN_ELEMENTS_OPERATION(`move to ${to}`)
+
+  public static readonly NO_ELEMENTS_MESSAGE = `Did not find any configuration elements that matches your criteria.
+Nothing to do.`
 
   public static readonly MOVE_FAILED = (
     error: string
@@ -252,6 +276,16 @@ ${Prompts.SERVICE_ADD_HELP}`
   ): string => `Cloning the specified elements to ${
     targetEnvs.length > 0 ? targetEnvs.join(', ') : 'all environments'
   }.`
+
+  public static readonly CLONE_MESSAGE = (
+    ids: readonly string[],
+  ): string =>
+    `The following configuration elements will be cloned:
+${Prompts.LIST_IDS(ids)}
+
+`
+
+  public static readonly SHOULD_CLONE_QUESTION = Prompts.SHOULD_RUN_ELEMENTS_OPERATION('clone')
 
   public static readonly LIST_UNRESOLVED_START = (env: string): string => `Looking for unresolved references in ${env}`
   public static readonly LIST_UNRESOLVED_NONE = (env: string): string => `All references in ${env} were resolved successfully!`


### PR DESCRIPTION
Provided the elements to be moved/cloned in the message to the user in the operations: move-to-envs move-to-common and clone.
Images of the new messages can be found in https://salto-io.atlassian.net/browse/SALTO-1129.

---
_Release Notes_: 
CLI:
move-to-env/common and clone will now print the moved/clone elements and ask for confirmation from the user.
