### PR TITLE
SALTO-1189: added log for invalid elements ids

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -297,7 +297,7 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
       .groupBy(error => error.constructor.name)
       .entries()
       .forEach(([errorType, errorsGroup]) => {
-        log.error(`Invalid elements, error type: ${errorType}, element IDs: ${errorsGroup.map(e => e.elemID.getFullName())}`)
+        log.error(`Invalid elements, error type: ${errorType}, element IDs: ${errorsGroup.map(e => e.elemID.getFullName()).join(', ')}`)
       })
 
     return new Errors({

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -288,10 +288,22 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
   const errors = async (validate = true): Promise<Errors> => {
     const resolvedElements = await elements()
     const errorsFromSource = await naclFilesSource.getErrors()
+
+    const validationErrors = validate
+      ? validateElements(Object.values(resolvedElements.elements))
+      : []
+
+    _(validationErrors)
+      .groupBy(error => error.constructor.name)
+      .entries()
+      .forEach(([errorType, errorsGroup]) => {
+        log.error(`Invalid elements, error type: ${errorType}, element IDs: ${errorsGroup.map(e => e.elemID.getFullName())}`)
+      })
+
     return new Errors({
       ...errorsFromSource,
       merge: [...errorsFromSource.merge, ...resolvedElements.mergeErrors],
-      validation: validate ? validateElements(Object.values(resolvedElements.elements)) : [],
+      validation: validationErrors,
     })
   }
 

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -194,6 +194,17 @@ type multi.loc { b = 1 }`,
 
   'error.nacl': 'invalid syntax }}',
 
+  'reference_error.nacl': `
+type some.type {
+  string a {
+  }
+}
+
+some.type instance {
+  a = some.type.instance.notExists
+}
+`,
+
   'dup.nacl': `
 type salesforce.lead {
   string base_field {}
@@ -205,7 +216,7 @@ type salesforce.lead {
 }
 
 export const mockDirStore = (
-  exclude: string[] = ['error.nacl', 'dup.nacl'],
+  exclude: string[] = ['error.nacl', 'dup.nacl', 'reference_error.nacl'],
   empty = false,
   files?: Record<string, string>,
 ):

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -264,7 +264,7 @@ describe('workspace', () => {
       expect(await workspace.hasErrors()).toBeFalsy()
     })
     it('should contain parse errors', async () => {
-      const erroredWorkspace = await createWorkspace(mockDirStore(['dup.nacl']))
+      const erroredWorkspace = await createWorkspace(mockDirStore(['dup.nacl', 'reference_error.nacl']))
 
       const errors = await erroredWorkspace.errors()
       expect(errors.hasErrors()).toBeTruthy()
@@ -279,8 +279,23 @@ describe('workspace', () => {
       expect(workspaceErrors.length).toBeGreaterThanOrEqual(1)
       expect(workspaceErrors[0].sourceFragments).toHaveLength(1)
     })
+    it('should contain validation errors', async () => {
+      const erroredWorkspace = await createWorkspace(mockDirStore(['dup.nacl', 'error.nacl']))
+
+      const errors = await erroredWorkspace.errors()
+      expect(errors.hasErrors()).toBeTruthy()
+      expect(errors.strings()).toEqual(['unresolved reference some.type.instance.notExists'])
+      expect(errors.validation[0].message).toBe('Error validating "some.type.instance.instance.a": unresolved reference some.type.instance.notExists')
+
+      expect(await erroredWorkspace.hasErrors()).toBeTruthy()
+      const workspaceErrors = await Promise.all(
+        wu(errors.all()).map(error => erroredWorkspace.transformError(error))
+      )
+      expect(workspaceErrors.length).toBeGreaterThanOrEqual(1)
+      expect(workspaceErrors[0].sourceFragments).toHaveLength(1)
+    })
     it('should contain merge errors', async () => {
-      const erroredWorkspace = await createWorkspace(mockDirStore(['error.nacl']))
+      const erroredWorkspace = await createWorkspace(mockDirStore(['error.nacl', 'reference_error.nacl']))
 
       const errors = await erroredWorkspace.errors()
       expect(errors.hasErrors()).toBeTruthy()


### PR DESCRIPTION
Added log with elements ids that a validation error was thrown for.

The new logs in a workspace with a lot of errors:
<img width="1792" alt="Screen Shot 2021-02-15 at 16 52 35" src="https://user-images.githubusercontent.com/6839369/107961231-4787b200-6fae-11eb-8b36-0acfef24e30a.png">

The last one is `UnresolvedReferenceValidationError`

---
_Release Notes_: 
None