### PR TITLE
SALTO-1186: createDiffChanges correctly for field annotations

### DIFF
--- a/packages/core/src/core/diff.ts
+++ b/packages/core/src/core/diff.ts
@@ -49,6 +49,8 @@ const filterElementsByRelevance = (elements: Element[], relevantIds: ElemID[],
       transformFunc: filterRelevantParts(
         topLevelIdToRelevantIds[elem.elemID.getFullName()], selectorsToVerify
       ),
+      runOnFields: true,
+      strict: false,
     })
   })
 }

--- a/packages/core/test/core/diff.test.ts
+++ b/packages/core/test/core/diff.test.ts
@@ -231,7 +231,7 @@ describe('diff', () => {
           .sort()).toEqual([nestedID, simpleId].sort())
       })
 
-      it('includes field inner elements when the field is selected', async () => {
+      it('includes field inner annotations when the field is selected', async () => {
         const newSinglePathObjMerged = singlePathObjMerged.clone() as ObjectType
         newSinglePathObjMerged.fields.simple.annotations.description = 'new description'
         const simpleFieldId = newSinglePathObjMerged.elemID.createNestedID('field', 'simple')

--- a/packages/core/test/core/diff.test.ts
+++ b/packages/core/test/core/diff.test.ts
@@ -40,6 +40,9 @@ describe('diff', () => {
     fields: {
       simple: {
         type: BuiltinTypes.STRING,
+        annotations: {
+          description: 'description',
+        },
       },
       nested: {
         type: nestedType,
@@ -226,6 +229,20 @@ describe('diff', () => {
         expect(changes).toHaveLength(2)
         expect(changes.map(change => change.id.getFullName())
           .sort()).toEqual([nestedID, simpleId].sort())
+      })
+
+      it('includes field inner elements when the field is selected', async () => {
+        const newSinglePathObjMerged = singlePathObjMerged.clone() as ObjectType
+        newSinglePathObjMerged.fields.simple.annotations.description = 'new description'
+        const simpleFieldId = newSinglePathObjMerged.elemID.createNestedID('field', 'simple')
+        const selectors = [
+          createElementSelector(simpleFieldId.getFullName()),
+        ]
+        const changes = await createDiffChanges(
+          [newSinglePathObjMerged], [singlePathObjMerged], selectors
+        )
+        expect(changes.map(change => change.id.getFullName()))
+          .toEqual([simpleFieldId.createNestedID('description').getFullName()])
       })
     })
   })


### PR DESCRIPTION
https://salto-io.atlassian.net/browse/SALTO-1186

_Release Notes_: 
Core: Include field's annotations matches in restore & fetch commands when using field element ID as the element selector.
