### PR TITLE
SALTO-1147, SALTO-1148 - Switch axios mock library, avoid shortening elem id, add helper script for mocking http responses

### DIFF
--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -44,13 +44,13 @@
   "devDependencies": {
     "@types/jest": "^26.0.20",
     "@types/lodash": "^4.14.133",
-    "@types/moxios": "^0.4.10",
     "@types/node": "^12.7.1",
     "@types/shelljs": "^0.7.8",
     "@types/supertest": "^2.0.4",
     "@types/wu": "^2.1.40",
     "@typescript-eslint/eslint-plugin": "2.31.0",
     "@typescript-eslint/parser": "2.31.0",
+    "axios-mock-adapter": "^1.19.0",
     "eslint": "^6.2.2",
     "eslint-config-airbnb": "18.0.1",
     "eslint-plugin-header": "^3.0.0",
@@ -62,7 +62,6 @@
     "jest": "^26.6.3",
     "jest-circus": "^26.6.3",
     "jest-junit": "^12.0.0",
-    "moxios": "^0.4.0",
     "tsc-watch": "^2.2.1",
     "typescript": "3.9.3"
   }

--- a/packages/adapter-utils/scripts/client/mock_replies.py
+++ b/packages/adapter-utils/scripts/client/mock_replies.py
@@ -1,0 +1,32 @@
+#                      Copyright 2021 Salto Labs Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+
+def to_mock_details(logpath):
+  with open(logpath) as logfile:
+    return [l[l.find(': ') + 2:].strip() for l in logfile.readlines() if 'Full HTTP response' in l]
+
+def main():
+  if (len(sys.argv) != 3):
+    print(f'Usage: {sys.argv[0]} <input log file> <output jsonl file>')
+    print(f'\tExample: {sys.argv[0]} log.txt mocks.jsonl')
+    return
+  (logpath, mockpath) = sys.argv[1:]
+  with open(mockpath, 'w') as mockfile:
+    response_details = to_mock_details(logpath)
+    mockfile.writelines([f'{l}\n' for l in response_details])
+
+if __name__ == '__main__':
+  main()

--- a/packages/adapter-utils/src/client/http_connection.ts
+++ b/packages/adapter-utils/src/client/http_connection.ts
@@ -30,7 +30,6 @@ export type ResponseValue = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type APIConnection<T = any> = {
   // based on https://github.com/axios/axios/blob/f472e5da5fe76c72db703d6a0f5190e4ad31e642/index.d.ts#L140
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   get: (url: string, config?: { params: Record<string, unknown> }) => Promise<{
     data: T
     status: number
@@ -95,12 +94,7 @@ export const validateCredentials = async <TCredentials>(
   return accountId
 }
 
-export const axiosConnection = <TCredentials>({
-  retryOptions,
-  authParamsFunc,
-  baseURLFunc,
-  credValidateFunc,
-}: {
+type AxiosConnectionParams<TCredentials> = {
   retryOptions: RetryOptions
   authParamsFunc: (creds: TCredentials) => {
     auth?: AxiosBasicCredentials
@@ -108,7 +102,14 @@ export const axiosConnection = <TCredentials>({
   }
   baseURLFunc: (creds: TCredentials) => string
   credValidateFunc: (creds: TCredentials, conn: APIConnection) => Promise<AccountId>
-}): Connection<TCredentials> => {
+}
+
+export const axiosConnection = <TCredentials>({
+  retryOptions,
+  authParamsFunc,
+  baseURLFunc,
+  credValidateFunc,
+}: AxiosConnectionParams<TCredentials>): Connection<TCredentials> => {
   const login = async (
     creds: TCredentials,
   ): Promise<AuthenticatedAPIConnection> => {

--- a/packages/adapter-utils/src/client/pagination.ts
+++ b/packages/adapter-utils/src/client/pagination.ts
@@ -94,7 +94,9 @@ export const getWithPageOffsetPagination: GetAllItemsFunc = async function *getW
       Object.keys(params).length > 0 ? { params } : undefined
     )
 
-    log.debug(`Full HTTP response for ${url} ${safeJsonStringify(params)}: ${safeJsonStringify(response.data)}`)
+    log.debug('Full HTTP response for %s: %s', url, safeJsonStringify({
+      url, params, response: response.data,
+    }))
 
     if (response.status !== 200) {
       log.error(`error getting result for ${url}: %s %o %o`, response.status, response.statusText, response.data)
@@ -161,7 +163,9 @@ export const getWithCursorPagination: GetAllItemsFunc = async function *getWithC
       Object.keys(params).length > 0 ? { params } : undefined
     )
 
-    log.debug(`Full HTTP response for ${url} ${safeJsonStringify(params)}: ${safeJsonStringify(response.data)}`)
+    log.debug('Full HTTP response for %s: %s', url, safeJsonStringify({
+      url, params, response: response.data,
+    }))
 
     if (response.status !== 200 || response.data.success === false) {
       log.error(`error getting result for ${url}: %s %o %o`, response.status, response.statusText, response.data)

--- a/packages/adapter-utils/src/elements/ducktype/index.ts
+++ b/packages/adapter-utils/src/elements/ducktype/index.ts
@@ -17,4 +17,4 @@ export { findNestedField, returnFullEntry, FindNestedFieldFunc } from './field_f
 export { toInstance } from './instance_elements'
 export { createAdapterApiConfigType, createUserFetchConfigType, validateFetchConfig, ElementTranslationConfig, AdapterApiConfig, EndpointConfig, RequestConfig, UserFetchConfig } from './endpoint_config'
 export { getAllElements, getTypeAndInstances, simpleGetArgs } from './transformer'
-export { generateType } from './type_elements'
+export { generateType, toNestedTypeName } from './type_elements'

--- a/packages/adapter-utils/src/elements/ducktype/instance_elements.ts
+++ b/packages/adapter-utils/src/elements/ducktype/instance_elements.ts
@@ -55,7 +55,7 @@ export const toInstance = ({
 }): InstanceElement | undefined => {
   const name = entry[nameField] ?? defaultName
   const path = ((pathField && _.isString(entry[pathField]))
-    ? entry[pathField].slice(0, 100)
+    ? entry[pathField]
     : undefined)
   const entryData = fieldsToOmit !== undefined
     ? _.omit(entry, fieldsToOmit)
@@ -69,7 +69,7 @@ export const toInstance = ({
     nameSuffix
       ? `${name}${ID_SEPARATOR}${nameSuffix}`
       : name
-  ).slice(0, 100))
+  ))
   return new InstanceElement(
     naclName,
     type,
@@ -84,7 +84,7 @@ export const toInstance = ({
       adapterName,
       RECORDS_PATH,
       pathNaclCase(type.elemID.name),
-      path ? pathNaclCase(naclCase(path)) : pathNaclCase(naclName),
+      (path ? pathNaclCase(naclCase(path)) : pathNaclCase(naclName)).slice(0, 100),
     ],
   )
 }

--- a/packages/adapter-utils/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-utils/src/elements/ducktype/transformer.ts
@@ -124,7 +124,7 @@ export const getTypeAndInstances = async ({
           type: nestedFieldDetails.type,
           nameField: nameField ?? defaultNameField,
           pathField: pathField ?? defaultPathField,
-          defaultName: `unindexed_${index}_${nesteIndex}`, // TODO improve
+          defaultName: `unnamed_${index}_${nesteIndex}`, // TODO improve
           fieldsToOmit,
           hasDynamicFields,
         })
@@ -138,7 +138,7 @@ export const getTypeAndInstances = async ({
       type,
       nameField: nameField ?? defaultNameField,
       pathField: pathField ?? defaultPathField,
-      defaultName: `unindexed_${index}`, // TODO improve
+      defaultName: `unnamed_${index}`, // TODO improve
       // we omit the pagination fields only from the top level and not from inner ones
       fieldsToOmit: [...(topLevelFieldsToOmit ?? []), ...(fieldsToOmit ?? [])],
       hasDynamicFields,

--- a/packages/adapter-utils/test/client/http_client.test.ts
+++ b/packages/adapter-utils/test/client/http_client.test.ts
@@ -40,7 +40,7 @@ const { toArrayAsync } = collections.asynciterable
 describe('client_http_client', () => {
   let mockAxiosAdapter: MockAdapter
   beforeEach(() => {
-    mockAxiosAdapter = new MockAdapter(axios, { delayResponse: 20, onNoMatch: 'throwException' })
+    mockAxiosAdapter = new MockAdapter(axios, { delayResponse: 1, onNoMatch: 'throwException' })
   })
 
   afterEach(() => {

--- a/packages/adapter-utils/test/client/http_client.test.ts
+++ b/packages/adapter-utils/test/client/http_client.test.ts
@@ -28,8 +28,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
 import { collections } from '@salto-io/lowerdash'
-import moxios from 'moxios'
 import { ClientRateLimitConfig } from '../../src/client/config'
 import { AdapterHTTPClient, ClientOpts, ConnectionCreator, GetAllItemsFunc } from '../../src/client'
 import { createConnection, Credentials } from './common'
@@ -37,12 +38,13 @@ import { createConnection, Credentials } from './common'
 const { toArrayAsync } = collections.asynciterable
 
 describe('client_http_client', () => {
+  let mockAxiosAdapter: MockAdapter
   beforeEach(() => {
-    moxios.install()
+    mockAxiosAdapter = new MockAdapter(axios, { delayResponse: 20, onNoMatch: 'throwException' })
   })
 
   afterEach(() => {
-    moxios.uninstall()
+    mockAxiosAdapter.restore()
   })
 
   describe('get', () => {
@@ -78,23 +80,14 @@ describe('client_http_client', () => {
       expect(mockCreateConnection).not.toHaveBeenCalled()
       const client = new MyCustomClient({ credentials: { username: 'user', password: 'password' } })
       expect(mockCreateConnection).toHaveBeenCalledTimes(1)
-      const getRes = client.get({ url: '/ep' })
 
-      // should not call getPage until auth succeeds
-      expect(getPage).toHaveBeenCalledTimes(0)
-
-      moxios.withMock(() => {
-        moxios.wait(async () => {
-          const req = moxios.requests.mostRecent()
-          await req.respondWith({
-            status: 200,
-            response: {
-              accountId: 'ACCOUNT_ID',
-            },
-          })
-        })
+      mockAxiosAdapter.onGet('/users/me').reply(200, {
+        accountId: 'ACCOUNT_ID',
       })
 
+      const getRes = client.get({ url: '/ep' })
+      // should not call getPage until auth succeeds
+      expect(getPage).toHaveBeenCalledTimes(0)
       await toArrayAsync(await getRes)
       await toArrayAsync(await client.get({ url: '/ep2', paginationField: 'page', queryParams: { a: 'AAA' } }))
       expect(getPage).toHaveBeenCalledTimes(2)

--- a/packages/adapter-utils/test/client/http_connection.test.ts
+++ b/packages/adapter-utils/test/client/http_connection.test.ts
@@ -36,7 +36,7 @@ import { createConnection } from './common'
 describe('client_http_connection', () => {
   let mockAxiosAdapter: MockAdapter
   beforeEach(() => {
-    mockAxiosAdapter = new MockAdapter(axios, { delayResponse: 20, onNoMatch: 'throwException' })
+    mockAxiosAdapter = new MockAdapter(axios, { delayResponse: 1, onNoMatch: 'throwException' })
   })
 
   afterEach(() => {

--- a/packages/adapter-utils/test/client/http_connection.test.ts
+++ b/packages/adapter-utils/test/client/http_connection.test.ts
@@ -28,38 +28,39 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import moxios from 'moxios'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
 import { validateCredentials } from '../../src/client'
 import { createConnection } from './common'
 
 describe('client_http_connection', () => {
+  let mockAxiosAdapter: MockAdapter
   beforeEach(() => {
-    moxios.install()
+    mockAxiosAdapter = new MockAdapter(axios, { delayResponse: 20, onNoMatch: 'throwException' })
   })
 
   afterEach(() => {
-    moxios.uninstall()
+    mockAxiosAdapter.restore()
   })
 
   describe('validateCredentials with axiosConnection', async () => {
     it('should login', async () => {
-      const validateRes = validateCredentials({ username: 'user123', password: 'pass' }, { createConnection })
-      moxios.withMock(() => {
-        moxios.wait(async () => {
-          const req = moxios.requests.mostRecent()
-          await req.respondWith({
-            status: 200,
-            response: {
-              accountId: 'ACCOUNT_ID',
-            },
-          })
+      mockAxiosAdapter.onGet(
+        '/users/me',
+        undefined,
+        expect.objectContaining({
+          customheader1: 'user123',
         })
+      ).reply(200, {
+        accountId: 'ACCOUNT_ID',
       })
+      const validateRes = validateCredentials({ username: 'user123', password: 'pass' }, { createConnection })
       expect(await validateRes).toEqual('ACCOUNT_ID:user123')
-      const req = moxios.requests.mostRecent()
+      expect(mockAxiosAdapter.history.get.length).toBe(1)
+      const req = mockAxiosAdapter.history.get[0]
       expect(req.url).toEqual('/users/me')
-      expect(req.headers.Authorization).toContain('Basic ')
-      expect(req.headers.customheader1).toEqual('user123')
+      expect(req.auth).toEqual({ username: 'user123', password: 'pass' })
+      // already verified the customheader1 header in the onGet header matcher
     })
   })
 })

--- a/packages/adapter-utils/test/elements/ducktype/transformer.test.ts
+++ b/packages/adapter-utils/test/elements/ducktype/transformer.test.ts
@@ -150,7 +150,7 @@ describe('ducktype_transformer', () => {
         type: res[0],
         nameField: 'name',
         pathField: 'also_name',
-        defaultName: 'unindexed_0',
+        defaultName: 'unnamed_0',
         fieldsToOmit: [],
       })
       expect(instanceElements.toInstance).toHaveBeenCalledWith({
@@ -159,7 +159,7 @@ describe('ducktype_transformer', () => {
         type: res[0],
         nameField: 'name',
         pathField: 'also_name',
-        defaultName: 'unindexed_1',
+        defaultName: 'unnamed_1',
         fieldsToOmit: [],
       })
     })
@@ -204,7 +204,7 @@ describe('ducktype_transformer', () => {
         type: res[0],
         nameField: 'name',
         pathField: 'also_name',
-        defaultName: 'unindexed_0',
+        defaultName: 'unnamed_0',
         fieldsToOmit: ['missing'],
       })
       expect(instanceElements.toInstance).toHaveBeenCalledWith({
@@ -213,7 +213,7 @@ describe('ducktype_transformer', () => {
         type: res[0],
         nameField: 'name',
         pathField: 'also_name',
-        defaultName: 'unindexed_1',
+        defaultName: 'unnamed_1',
         fieldsToOmit: ['missing'],
       })
     })
@@ -263,7 +263,7 @@ describe('ducktype_transformer', () => {
         type: res[1],
         nameField: 'name',
         pathField: 'also_name',
-        defaultName: 'unindexed_0_0',
+        defaultName: 'unnamed_0_0',
         fieldsToOmit: undefined,
       })
       expect(instanceElements.toInstance).toHaveBeenCalledWith({
@@ -272,7 +272,7 @@ describe('ducktype_transformer', () => {
         type: res[1],
         nameField: 'name',
         pathField: 'also_name',
-        defaultName: 'unindexed_1_0',
+        defaultName: 'unnamed_1_0',
         fieldsToOmit: undefined,
       })
     })

--- a/packages/adapter-utils/test/elements/ducktype/type_elements.test.ts
+++ b/packages/adapter-utils/test/elements/ducktype/type_elements.test.ts
@@ -30,7 +30,7 @@
 */
 import { ObjectType, Values, ElemID, BuiltinTypes, MapType, ListType } from '@salto-io/adapter-api'
 // eslint-disable-next-line
-import { generateType } from '../../../src/elements/ducktype'
+import { generateType, toNestedTypeName } from '../../../src/elements/ducktype'
 import { TYPES_PATH, SUBTYPES_PATH } from '../../../src/elements'
 
 /* eslint-disable @typescript-eslint/camelcase */
@@ -339,6 +339,12 @@ describe('ducktype_type_elements', () => {
       }))).toBeTruthy()
       expect(nestedTypes).toHaveLength(0)
       expect(type.path).toEqual([ADAPTER_NAME, TYPES_PATH, SUBTYPES_PATH, 'parent_type', 'subtypeName'])
+    })
+  })
+
+  describe('toNestedTypeName', () => {
+    it('should concatenate the parent and child types', () => {
+      expect(toNestedTypeName('aaa', 'bbb')).toEqual('aaa__bbb')
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1964,13 +1964,6 @@
   resolved "https://registry.yarnpkg.com/@types/moo/-/moo-0.5.3.tgz#d034ae641728c473d367e7b7afd991123b8bdecb"
   integrity sha512-PJJ/jvb5Gor8DWvXN3e75njfQyYNRz0PaFSZ3br9GfHM9N2FxvuJ/E/ytcQePJOLzHlvgFSsIJIvfUMUxWTbnA==
 
-"@types/moxios@^0.4.10":
-  version "0.4.10"
-  resolved "https://registry.yarnpkg.com/@types/moxios/-/moxios-0.4.10.tgz#0762de3157714f8078a3c79ba65dcec4da701bfe"
-  integrity sha512-OGXB0kvKJT4KAdy4OzdGkBhNJ3f1x3FsqUq6elUBLcaBsVMy09hErlyhq2+zwEwcNbv1DGmksASW06XRISnxUQ==
-  dependencies:
-    axios "^0.21.1"
-
 "@types/nearley@^2.11.0":
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/@types/nearley/-/nearley-2.11.1.tgz#6ac3f57c00ca28071a1774ec72d2e45750f21420"
@@ -2948,6 +2941,14 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+
+axios-mock-adapter@^1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz#9d72e321a6c5418e1eff067aa99761a86c5188a4"
+  integrity sha512-D+0U4LNPr7WroiBDvWilzTMYPYTuZlbo6BI8YHZtj7wYQS8NkARlP9KBt8IWWHTQJ0q/8oZ0ClPBtKCCkx8cQg==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    is-buffer "^2.0.3"
 
 axios-retry@^3.1.9:
   version "3.1.9"
@@ -5177,7 +5178,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -6462,6 +6463,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-callable@^1.1.4, is-callable@^1.1.5, is-callable@^1.2.2:
   version "1.2.2"
@@ -8242,11 +8248,6 @@ move-concurrently@^1.0.1:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.3"
-
-moxios@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/moxios/-/moxios-0.4.0.tgz#fc0da2c65477d725ca6b9679d58370ed0c52f53b"
-  integrity sha1-/A2ixlR31yXKa5Z51YNw7QxS9Ts=
 
 ms@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Leftovers from https://github.com/salto-io/salto/pull/1811 and helper utils for Workato.
Extracted from https://github.com/salto-io/salto/pull/1812.

* Avoid shortening elem ids
* Switched to a better mocking library for Axios
* Adjusted the debug logs and added a script to convert them into initial mocks (which can then be modified manually). See the Workato PR for a sample usage ([here](https://github.com/salto-io/salto/pull/1812/files#diff-fec06cb19d512b6003757e93f2477a8cc53b5e509c299bdf6b50ba76c6f510ccR47)).


---
_Release Notes_: 
None
