### PR TITLE
SAAS-1477: Support logging errors specific information in log tags

### DIFF
--- a/packages/logging/jest.config.js
+++ b/packages/logging/jest.config.js
@@ -26,7 +26,7 @@ module.exports = deepMerge(
     ],
     coverageThreshold: {
       global: {
-        branches: 100,
+        branches: 98.18,
         functions: 100,
         lines: 100,
         statements: 100,

--- a/packages/logging/jest.config.js
+++ b/packages/logging/jest.config.js
@@ -26,7 +26,7 @@ module.exports = deepMerge(
     ],
     coverageThreshold: {
       global: {
-        branches: 98.18,
+        branches: 100,
         functions: 100,
         lines: 100,
         statements: 100,

--- a/packages/logging/src/internal/log-tags.ts
+++ b/packages/logging/src/internal/log-tags.ts
@@ -37,6 +37,8 @@ export const formatPrimitiveLogTagValue = (value: unknown): string => {
   return ''
 }
 
+export const isErrorType = (value: unknown): value is Error =>
+  value instanceof Error
 
 const formatKeyValue = (key: string, value: string): string =>
   `${key}=${value}`
@@ -52,6 +54,11 @@ export const formatLogTags = (logTags: Record<string, unknown>, baseKeys: string
     .map(([logTagKey, logTagValue]) => {
       if (isPrimitiveType(logTagValue)) {
         return formatKeyValue(logTagKey, formatPrimitiveLogTagValue(logTagValue))
+      }
+      if (isErrorType(logTagValue)) {
+        return formatObjectLogTag(
+          { error: logTagValue, stack: logTagValue.stack, message: logTagValue.message }
+        )
       }
       if (typeof logTagValue === 'object') {
         return formatObjectLogTag({ [logTagKey]: logTagValue })

--- a/packages/logging/src/internal/pino.ts
+++ b/packages/logging/src/internal/pino.ts
@@ -168,6 +168,13 @@ const formatJsonLog = (object: FormatterBaseInput): Record<string, unknown> => {
         Object.assign(formattedExcessArgs, { [key]: formatJsonStringValue(value) })
         return
       }
+      if (value instanceof Error) {
+        Object.assign(formattedExcessArgs,
+          { [key]: { ...value as {},
+            stack: formatJsonStringValue(value.stack ?? ''),
+            message: formatJsonStringValue(value.message ?? '') } })
+        return
+      }
       Object.assign(formattedExcessArgs, { [key]: value })
     })
   return { ...logJson, ...formattedExcessArgs }

--- a/packages/logging/src/internal/pino.ts
+++ b/packages/logging/src/internal/pino.ts
@@ -169,10 +169,10 @@ const formatJsonLog = (object: FormatterBaseInput): Record<string, unknown> => {
         return
       }
       if (value instanceof Error) {
-        Object.assign(formattedExcessArgs,
-          { [key]: { ...value as {},
-            stack: formatJsonStringValue(value.stack ?? ''),
-            message: formatJsonStringValue(value.message ?? '') } })
+        Object.assign(formattedExcessArgs, { [key]: Object.fromEntries(
+          Object.entries(Object.getOwnPropertyDescriptors(value))
+            .map(([k, v]) => [k, v.value])
+        ) })
         return
       }
       Object.assign(formattedExcessArgs, { [key]: value })

--- a/packages/logging/test/internal/log-tags.test.ts
+++ b/packages/logging/test/internal/log-tags.test.ts
@@ -39,5 +39,11 @@ describe('logTags', () => {
     it('should return empty string for function value', () => {
       expect(formatLogTags({ some: undefined }, [])).toEqual('')
     })
+    it('should print error stack-trace and message', () => {
+      const tagValue = formatLogTags({ error: new Error('something bad') }, [])
+      expect(tagValue).toContain('stack')
+      expect(tagValue).toContain('.ts')
+      expect(tagValue).toContain('something bad')
+    })
   })
 })

--- a/packages/logging/test/internal/pino_logger.test.ts
+++ b/packages/logging/test/internal/pino_logger.test.ts
@@ -685,6 +685,47 @@ describe('pino based logger', () => {
         })
       })
     })
+
+    describe('logging errors in tags', () => {
+      beforeEach(() => {
+        logger = createLogger()
+        logger.error('hello world', { error })
+      })
+
+      afterEach(() => repo.end())
+
+      it('should print error stacktrace, message, and error', () => {
+        const contents = consoleStream.contents()
+        expect(contents).toContain('hello world')
+        expect(contents).toContain('.ts')
+        expect(contents).toContain('stack')
+        expect(contents).toContain('testing 123')
+      })
+    })
+    describe('logging errors in tags in json format', () => {
+      beforeEach(() => {
+        initialConfig.format = 'json'
+        logger = createLogger()
+        logger.error('hello world', { error })
+        const [line1] = consoleStream.contents().split('\n')
+        jsonLine = JSON.parse(line1)
+      })
+
+      it('should print error stacktrace, message, and error', () => {
+        console.info('got')
+        console.info(jsonLine)
+        expect(jsonLine).toMatchObject({
+          time: expect.stringMatching(TIMESTAMP_REGEX),
+          level: 'error',
+          message: 'hello world',
+          error: {
+            stack: error.stack,
+            customProp1: 'customVal1',
+            customProp2: { aNumber: 42 },
+          },
+        })
+      })
+    })
   })
   describe('JSON format', () => {
     beforeEach(async () => {

--- a/packages/logging/test/internal/pino_logger.test.ts
+++ b/packages/logging/test/internal/pino_logger.test.ts
@@ -712,14 +712,12 @@ describe('pino based logger', () => {
       })
 
       it('should print error stacktrace, message, and error', () => {
-        console.info('got')
-        console.info(jsonLine)
         expect(jsonLine).toMatchObject({
-          time: expect.stringMatching(TIMESTAMP_REGEX),
           level: 'error',
           message: 'hello world',
           error: {
             stack: error.stack,
+            message: 'testing 123',
             customProp1: 'customVal1',
             customProp2: { aNumber: 42 },
           },


### PR DESCRIPTION
This PR adds the functionality of logging error stack-trace and message for errors given as logTagValues.

---

_Release Notes_: 
This should not affect the CLI users.