### PR TITLE
Fix race condition in CLI teardown

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -63,10 +63,9 @@ const main = async (): Promise<CliExitCode> => {
     })
     return ret
   } finally {
-    await Promise.all([
-      telemetry.stop(EVENTS_FLUSH_WAIT_TIME),
-      logger.end(),
-    ])
+    // Telemetry emits a log when stopping so it must be stopped before the logger
+    await telemetry.stop(EVENTS_FLUSH_WAIT_TIME)
+    await logger.end()
   }
 }
 


### PR DESCRIPTION
stopping telemetry and the logger in a Promise.all creates a race condition
because telemetry tries to emit a log when it stops

---
_Release Notes_: 
CLI:
- Fixed possible crash at the end of CLI commands when telemetry is enabled
