### PR TITLE
Remove reliance on custom object path to determine other element paths

### DIFF
--- a/packages/salesforce-adapter/src/filters/layouts.ts
+++ b/packages/salesforce-adapter/src/filters/layouts.ts
@@ -26,6 +26,7 @@ import {
   addObjectParentReference, generateApiNameToCustomObject,
 } from './utils'
 import { SALESFORCE, LAYOUT_TYPE_ID_METADATA_TYPE, WEBLINK_METADATA_TYPE } from '../constants'
+import { getObjectDirectoryPath } from './custom_objects'
 
 const log = logger(module)
 
@@ -45,14 +46,11 @@ const layoutObjAndName = (layout: InstanceElement): [string, string] => {
 
 const fixLayoutPath = (
   layout: InstanceElement,
-  { path: objectPath }: ObjectType,
+  customObject: ObjectType,
   layoutName: string,
 ): void => {
-  if (objectPath === undefined) {
-    return
-  }
   layout.path = [
-    ...objectPath.slice(0, -1),
+    ...getObjectDirectoryPath(customObject),
     layout.elemID.typeName,
     pathNaclCase(naclCase(layoutName)),
   ]


### PR DESCRIPTION
As preparation for partial fetch (where we can get elements that do not have a path)
Changing the implementation of places that set element paths to not rely on custom object
paths but instead apply the same logic to determine the path of the custom object as if
it was new

---

Tested (manually) by cleaning a workspace, fetching again, and checking that none of the files moved.

---
_Release Notes_: 
None
