### PR TITLE
SALTO-1191: Add support for Territory2 custom fields

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -62,6 +62,7 @@ import replaceFieldValuesFilter from './filters/replace_instance_field_values'
 import valueToStaticFileFilter from './filters/value_to_static_file'
 import convertMapsFilter from './filters/convert_maps'
 import elementsUrlFilter from './filters/elements_url'
+import territoryFilter from './filters/territory'
 import { ConfigChangeSuggestion, FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges } from './config_change'
 import { FilterCreator, Filter, filtersRunner } from './filter'
@@ -107,6 +108,7 @@ export const DEFAULT_FILTERS = [
   staticResourceFileExtFilter,
   xmlAttributesFilter,
   profilePathsFilter,
+  territoryFilter,
   elementsUrlFilter,
   // The following filters should remain last in order to make sure they fix all elements
   convertListsFilter,

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -311,6 +311,8 @@ export const WORKFLOW_TASK_METADATA_TYPE = 'WorkflowTask'
 export const WEBLINK_METADATA_TYPE = 'WebLink'
 export const BUSINESS_HOURS_METADATA_TYPE = 'BusinessHoursSettings'
 export const SETTINGS_METADATA_TYPE = 'Settings'
+export const TERRITORY2_TYPE = 'Territory2'
+export const TERRITORY2_MODEL_TYPE = 'Territory2Model'
 
 // Retrieve constants
 export const RETRIEVE_LOAD_OF_METADATA_ERROR_REGEX = /Load of metadata from db failed for metadata of type:(?<type>\w+) and file name:(?<instance>\w+).$/

--- a/packages/salesforce-adapter/src/filters/hardcoded_lists.json
+++ b/packages/salesforce-adapter/src/filters/hardcoded_lists.json
@@ -176,6 +176,8 @@
   "salesforce.SharingRules.field.sharingTerritoryRules",
   "salesforce.StandardValueSet.field.standardValue",
   "salesforce.SummaryLayout.field.summaryLayoutItems",
+  "salesforce.Territory2Metadata.field.ruleAssociations",
+  "salesforce.Territory2Rule.field.ruleItems",
   "salesforce.UiFormulaRule.field.criteria",
   "salesforce.ValueSettings.field.controllingFieldValue",
   "salesforce.Workflow.field.alerts",

--- a/packages/salesforce-adapter/src/filters/territory.ts
+++ b/packages/salesforce-adapter/src/filters/territory.ts
@@ -1,0 +1,49 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../filter'
+import { isInstanceOfType } from './utils'
+import { isMetadataObjectType, metadataType } from '../transformers/transformer'
+import { TERRITORY2_TYPE, TERRITORY2_MODEL_TYPE } from '../constants'
+
+const log = logger(module)
+
+const removeCustomFieldsFromType = (elements: Element[], typeName: string): void => {
+  const type = elements
+    .filter(isMetadataObjectType)
+    .find(elem => metadataType(elem) === typeName)
+  if (type === undefined) {
+    log.debug('Type %s not found', typeName)
+    return
+  }
+  delete type.fields.customFields
+
+  const instances = elements.filter(isInstanceOfType(typeName))
+  instances.forEach(inst => {
+    delete inst.value.customFields
+  })
+}
+
+const filterCreator: FilterCreator = () => ({
+  onFetch: async elements => {
+    // Remove custom field definitions from territory and territory model
+    removeCustomFieldsFromType(elements, TERRITORY2_TYPE)
+    removeCustomFieldsFromType(elements, TERRITORY2_MODEL_TYPE)
+  },
+})
+
+export default filterCreator

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -180,6 +180,8 @@ export const METADATA_TYPES_TO_RENAME: Map<string, string> = new Map([
   ['FlexiPage', 'LightningPage'],
   ['FlexiPageRegion', 'LightningPageRegion'],
   ['FlexiPageTemplateInstance', 'LightningPageTemplateInstance'],
+  ['Territory2', 'Territory2Metadata'],
+  ['Territory2Model', 'Territory2ModelMetadata'],
 ])
 
 export class Types {
@@ -737,7 +739,9 @@ export class Types {
   }
 
   public static getElemId(name: string, customObject: boolean, serviceIds?: ServiceIds): ElemID {
-    const updatedName = METADATA_TYPES_TO_RENAME.get(name) ?? name
+    const updatedName = customObject
+      ? name
+      : METADATA_TYPES_TO_RENAME.get(name) ?? name
     return (customObject && this.getElemIdFunc && serviceIds)
       ? this.getElemIdFunc(SALESFORCE, serviceIds, naclCase(updatedName))
       : new ElemID(SALESFORCE, naclCase(updatedName))

--- a/packages/salesforce-adapter/test/filters/territory.test.ts
+++ b/packages/salesforce-adapter/test/filters/territory.test.ts
@@ -1,0 +1,85 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, BuiltinTypes } from '@salto-io/adapter-api'
+import { FilterWith } from '../../src/filter'
+import filterCreator from '../../src/filters/territory'
+import mockClient from '../client'
+import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
+import { createInstanceElement, MetadataInstanceElement } from '../../src/transformers/transformer'
+import { SALESFORCE, TERRITORY2_TYPE } from '../../src/constants'
+
+const createMetadataTypeElement = (
+  typeName: string,
+  params: Partial<ConstructorParameters<typeof ObjectType>[0]>
+): ObjectType => new ObjectType({
+  ...params,
+  annotations: {
+    ...params.annotations,
+    metadataType: typeName,
+  },
+  elemID: new ElemID(SALESFORCE, typeName),
+})
+
+describe('territory filter', () => {
+  let filter: FilterWith<'onFetch'>
+  beforeEach(() => {
+    filter = filterCreator({
+      client: mockClient().client,
+      config: { fetchProfile: buildFetchProfile({}) },
+    }) as typeof filter
+  })
+  describe('onFetch', () => {
+    let type: ObjectType
+    let instance: MetadataInstanceElement
+    beforeEach(async () => {
+      type = createMetadataTypeElement(
+        TERRITORY2_TYPE,
+        {
+          fields: {
+            customFields: { type: new ObjectType({ elemID: new ElemID(SALESFORCE, 'FieldValue') }) },
+            description: { type: BuiltinTypes.STRING },
+          },
+        }
+      )
+      instance = createInstanceElement(
+        {
+          fullName: 'TerModel.Territory',
+          description: 'Desc',
+          customFields: [
+            { name: 'f__c', value: { 'attr_xsi:type': 'xsd:boolean', '#text': 'false' } },
+          ],
+        },
+        type,
+      )
+      await filter.onFetch([type, instance])
+    })
+    it('should remove custom fields from instance', () => {
+      expect(instance.value).not.toHaveProperty('customFields')
+    })
+    it('should keep other values on instance', () => {
+      expect(instance.value).toHaveProperty('description', 'Desc')
+    })
+    it('should remove custom fields from type fields', () => {
+      expect(type.fields).not.toHaveProperty('customFields')
+    })
+    it('should keep other fields on type', () => {
+      expect(type.fields).toHaveProperty(
+        'description',
+        expect.objectContaining({ type: BuiltinTypes.STRING })
+      )
+    })
+  })
+})


### PR DESCRIPTION
Territory2 and Territory2Model support custom fields by exposing a custom object
with the same name as the metadata type.
This changes the salto ID of the metadata types so it does not conflict with
the custom objects so that we are able to fetch the custom objects as well and
we remove the custom fields definitions on the metadata instances to avoid duplication


---
_Release Notes_: 
Salesforce adapter:
- Added support for custom fields on Territory2 and Territory2Model types
