### PR TITLE
Clone path when cloning object types

### DIFF
--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -327,6 +327,7 @@ export class ObjectType extends Element {
       annotationTypes: clonedAnnotationTypes,
       annotations: clonedAnnotations,
       isSettings,
+      path: this.path !== undefined ? [...this.path] : undefined,
     })
 
     res.annotate(additionalAnnotations)

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -104,6 +104,23 @@ describe('Test elements.ts', () => {
       expect(isEqualElements(ot, otDiff)).toBeFalsy()
     })
 
+    it('should use the same path when cloning object types', () => {
+      const obj = new ObjectType({
+        elemID: otID,
+        fields: {
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          num_field: { type: primNum },
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          str_field: { type: primStr },
+        },
+        annotationTypes: {},
+        annotations: {},
+        path: ['a', 'b', 'c', 'd'],
+      })
+      const newObj = obj.clone()
+      expect(newObj.path).toEqual(['a', 'b', 'c', 'd'])
+    })
+
     it('should identify equal fields', () => {
       expect(isEqualElements(strField, _.cloneDeep(strField))).toBeTruthy()
     })


### PR DESCRIPTION
Without this, cloned objects default to `unsorted.nacl`

---

_Release Notes_: 
None
