### PR TITLE
increase files read and dump concurrency

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -46,8 +46,8 @@ const log = logger(module)
 export type RoutingMode = 'isolated' | 'default' | 'align' | 'override'
 
 export const FILE_EXTENSION = '.nacl'
-const PARSE_CONCURRENCY = 20
-const DUMP_CONCURRENCY = 20
+const PARSE_CONCURRENCY = 100
+const DUMP_CONCURRENCY = 100
 // TODO: this should moved into cache implemenation
 const CACHE_READ_CONCURRENCY = 100
 


### PR DESCRIPTION
increase PARSE_CONCURRENCY and DUMP_CONCURRENCY from 20 to 100

---

a similar change to what @noamhammer done in PR: https://github.com/salto-io/salto/pull/1845

---
_Release Notes_: 
improve bulk element clone and move performance

