### PR TITLE
Remove unused manual type - OrganizationSettingsDetail

### DIFF
--- a/packages/salesforce-adapter/src/transformers/salesforce_types.ts
+++ b/packages/salesforce-adapter/src/transformers/salesforce_types.ts
@@ -220,17 +220,6 @@ export const allMissingSubTypes = [
     path: [...subTypesPath, 'Holidays'],
   }),
   new ObjectType({
-    elemID: new ElemID(SALESFORCE, 'OrganizationSettingsDetail'),
-    fields: {
-      settingName: { type: BuiltinTypes.STRING },
-      settingValue: { type: BuiltinTypes.STRING },
-    },
-    annotations: {
-      [METADATA_TYPE]: 'OrganizationSettingsDetail',
-    },
-    path: [...subTypesPath, 'OrganizationSettingsDetail'],
-  }),
-  new ObjectType({
     // taken from https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_configuration_tags
     elemID: new ElemID(SALESFORCE, 'TargetConfigs'),
     fields: {


### PR DESCRIPTION
Removing a subtype of OrgPreferenceSettings that was removed in a previous commit

---

Related to the removal of OrgPreferenceSettings in #1854 ([here](https://github.com/salto-io/salto/pull/1854/files#diff-f9e535c160d8b2ec686efb2ac45ae7129677f9fd56275c0b477e8af7dfa412b7L2008))

---
_Release Notes_: 
None
