### PR TITLE
SALTO-1202: added 'fetchAllCustomSettings' option

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -101,6 +101,7 @@ salesforce {
         ]
       }
     }
+    fetchAllCustomSettings = false
   }
 }
 ```
@@ -119,6 +120,7 @@ salesforce {
 | ------------------------------------------------------------| -------------------------------------------------| -----------
 | [metadata](#metadata-configuration-options)                 | Fetch all metdata                                | Specified the metadata fetch
 | [data](#data-management-configuration-options) | {} (do not manage data)       | Data management configuration object names will not be fetched in case they are matched in includeObjects
+| fetchAllCustomSettings                                      | true                                             | Whether to fetch all the custom settings instances. When false, it is still possible to choose specific custom settings instances via the `data` option
 
 ## Metadata configuration options
 

--- a/packages/salesforce-adapter/src/config_change.ts
+++ b/packages/salesforce-adapter/src/config_change.ts
@@ -139,6 +139,7 @@ export const getConfigFromConfigChanges = (
       configType,
       _.pickBy({
         fetch: _.pickBy({
+          ...(currentConfig.fetch ?? {}),
           metadata: {
             ...currentConfig.fetch?.metadata,
             exclude: [

--- a/packages/salesforce-adapter/src/deprecated_config.ts
+++ b/packages/salesforce-adapter/src/deprecated_config.ts
@@ -154,7 +154,11 @@ const convertDeprecatedFetchParameters = (
     ? convertDeprecatedDataConf(deprecatedFetchParameters.dataManagement)
     : fetchParameters?.data
 
-  const updatedFetchParameters = _.pickBy({ metadata, data }, values.isDefined)
+  const updatedFetchParameters = _.pickBy({
+    ...(fetchParameters ?? {}),
+    metadata,
+    data,
+  }, values.isDefined)
   return _.isEmpty(updatedFetchParameters) ? undefined : updatedFetchParameters
 }
 

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -22,14 +22,17 @@ import { buildMetadataQuery, MetadataQuery, validateMetadataParams } from './met
 export type FetchProfile = {
   readonly metadataQuery: MetadataQuery
   readonly dataManagement?: DataManagement
+  readonly shouldFetchAllCustomSettings: () => boolean
 }
 
 export const buildFetchProfile = ({
   metadata = {},
   data,
+  fetchAllCustomSettings,
 }: FetchParameters): FetchProfile => ({
   metadataQuery: buildMetadataQuery(metadata),
   dataManagement: data && buildDataManagement(data),
+  shouldFetchAllCustomSettings: () => fetchAllCustomSettings ?? true,
 })
 
 export const validateFetchParameters = (

--- a/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
+++ b/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
@@ -34,8 +34,12 @@ const logInvalidCustomSettings = (invalidCustomSettings: CustomObjectFetchSettin
     (log.debug(`Did not fetch instances for Custom Setting - ${apiName(settings.objectType)} cause ${settings.invalidIdFields} do not exist or are not queryable`)))
 )
 
-const filterCreator: FilterCreator = ({ client }) => ({
+const filterCreator: FilterCreator = ({ client, config }) => ({
   onFetch: async (elements: Element[]): Promise<ConfigChangeSuggestion[]> => {
+    if (!config.fetchProfile.shouldFetchAllCustomSettings()) {
+      return []
+    }
+
     const customSettingsObjects = elements
       .filter(isObjectType)
       .filter(isListCustomSettingsObject)

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -36,6 +36,7 @@ export const DATA_CONFIGURATION = 'data'
 export const METADATA_TYPES_SKIPPED_LIST = 'metadataTypesSkippedList'
 export const DATA_MANAGEMENT = 'dataManagement'
 export const INSTANCES_REGEX_SKIPPED_LIST = 'instancesRegexSkippedList'
+export const SHOULD_FETCH_ALL_CUSTOM_SETTINGS = 'fetchAllCustomSettings'
 
 
 export type MetadataInstance = {
@@ -54,6 +55,7 @@ export type MetadataParams = {
 export type FetchParameters = {
   metadata?: MetadataParams
   data?: DataManagementConfig
+  fetchAllCustomSettings?: boolean
 }
 
 export type DeprecatedMetadataParams = {
@@ -366,6 +368,7 @@ const fetchConfigType = new ObjectType({
   fields: {
     [METADATA_CONFIG]: { type: metadataConfigType },
     [DATA_CONFIGURATION]: { type: dataManagementType },
+    [SHOULD_FETCH_ALL_CUSTOM_SETTINGS]: { type: BuiltinTypes.BOOLEAN },
   },
 })
 
@@ -401,6 +404,7 @@ export const configType = new ObjectType({
               },
             ],
           },
+          [SHOULD_FETCH_ALL_CUSTOM_SETTINGS]: false,
         },
       },
     },

--- a/packages/salesforce-adapter/test/config_change.test.ts
+++ b/packages/salesforce-adapter/test/config_change.test.ts
@@ -36,6 +36,7 @@ describe('Config Changes', () => {
           defaultIdFields: ['Name'],
         },
       },
+      fetchAllCustomSettings: true,
     },
   }
   const cloneOfCurrentConfig = { ...currentConfig }

--- a/packages/salesforce-adapter/test/deprecated_config.test.ts
+++ b/packages/salesforce-adapter/test/deprecated_config.test.ts
@@ -37,6 +37,7 @@ describe('deprecated config', () => {
           defaultIdFields: ['Name'],
         },
       },
+      fetchAllCustomSettings: true,
     },
   }
   describe('convert from old options to new options', () => {

--- a/packages/salesforce-adapter/test/filters/custom_settings_filter.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_settings_filter.test.ts
@@ -36,7 +36,6 @@ const customSettingsWithNoNameField = new ObjectType({
   },
 })
 
-/* eslint-disable @typescript-eslint/camelcase */
 describe('Custom settings filter', () => {
   let connection: Connection
   let client: SalesforceClient
@@ -110,7 +109,7 @@ describe('Custom settings filter', () => {
       expect(noNameObject).toEqual(customSettingsWithNoNameField)
     })
 
-    it('Should add two instances for the valid object and no isntances for noName one', () => {
+    it('Should add two instances for the valid object and no instances for noName one', () => {
       const validObjectInstances = elements
         .filter(elm => isInstanceElement(elm)
           && elm.type.elemID.isEqual(customSettingsObject.elemID))
@@ -119,6 +118,50 @@ describe('Custom settings filter', () => {
         .filter(elm => isInstanceElement(elm)
           && elm.type.elemID.isEqual(customSettingsWithNoNameField.elemID))
       expect(noNameObjectInstances).toHaveLength(0)
+    })
+  })
+
+  describe('fetchAllCustomSettings', () => {
+    const customSettingsObject = createCustomSettingsObject('configurationobj', LIST_CUSTOM_SETTINGS_TYPE)
+    let elements: Element[]
+    beforeEach(() => {
+      elements = [customSettingsObject]
+    })
+
+    it('Should not add instances if "fetchAllCustomSettings" is false', async () => {
+      filter = filterCreator({
+        client,
+        config: {
+          fetchProfile: buildFetchProfile({ fetchAllCustomSettings: false }),
+        },
+      }) as FilterType
+      await filter.onFetch(elements)
+      expect(elements.filter(elm => isInstanceElement(elm)
+        && elm.type.elemID.isEqual(customSettingsObject.elemID))).toHaveLength(0)
+    })
+
+    it('Should not add instances if "fetchAllCustomSettings" is true', async () => {
+      filter = filterCreator({
+        client,
+        config: {
+          fetchProfile: buildFetchProfile({ fetchAllCustomSettings: true }),
+        },
+      }) as FilterType
+      await filter.onFetch(elements)
+      expect(elements.filter(elm => isInstanceElement(elm)
+        && elm.type.elemID.isEqual(customSettingsObject.elemID))).toHaveLength(2)
+    })
+
+    it('Should not add instances if "fetchAllCustomSettings" is undefined', async () => {
+      filter = filterCreator({
+        client,
+        config: {
+          fetchProfile: buildFetchProfile({}),
+        },
+      }) as FilterType
+      await filter.onFetch(elements)
+      expect(elements.filter(elm => isInstanceElement(elm)
+        && elm.type.elemID.isEqual(customSettingsObject.elemID))).toHaveLength(2)
     })
   })
 


### PR DESCRIPTION
This PR is for not fetching all the custom settings instances by default in new workspaces.
I added a `fetchAllCustomSettings` option that, when undefined, is treated as true, and when creating a new workspace, it is created with a false value.

---
_Release Notes_: 
Salesforce Adapter:
Added `fetchAllCustomSettings` option to pick whether to bring all the custom settings instances. In new workspaces, it will be created with a default of `false`.