### PR TITLE
Avoid query on profile info when not fetching profiles

### DIFF
--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -16,7 +16,7 @@
 
 import _ from 'lodash'
 import {
-  Element, ObjectType, isContainerType, MapType, ListType, InstanceElement, isInstanceElement,
+  Element, ObjectType, isContainerType, MapType, ListType, InstanceElement,
   Values, isAdditionOrModificationChange, isInstanceChange, getChangeElement, Change, isMapType,
   isListType,
 } from '@salto-io/adapter-api'
@@ -26,6 +26,7 @@ import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import { API_NAME_SEPARATOR, PROFILE_METADATA_TYPE, BUSINESS_HOURS_METADATA_TYPE } from '../constants'
 import { metadataType } from '../transformers/transformer'
+import { isInstanceOfType } from './utils'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -307,14 +308,6 @@ export const getInstanceChanges = (
     .filter(change => metadataType(getChangeElement(change)) === targetMetadataType)
 )
 
-export const findInstancesToConvert = (
-  elements: Element[],
-  targetMetadataType: string,
-): InstanceElement[] => {
-  const instances = elements.filter(isInstanceElement)
-  return instances.filter(e => metadataType(e) === targetMetadataType)
-}
-
 /**
  * Convert certain instances' fields into maps, so that they are easier to view,
  * could be referenced, and can be split across multiple files.
@@ -326,7 +319,7 @@ const filter: FilterCreator = ({ config }) => ({
         return
       }
 
-      const instancesToConvert = findInstancesToConvert(elements, targetMetadataType)
+      const instancesToConvert = elements.filter(isInstanceOfType(targetMetadataType))
       if (instancesToConvert.length === 0) {
         return
       }

--- a/packages/salesforce-adapter/src/filters/profile_paths.ts
+++ b/packages/salesforce-adapter/src/filters/profile_paths.ts
@@ -19,8 +19,7 @@ import { collections } from '@salto-io/lowerdash'
 import { FilterCreator, FilterWith } from '../filter'
 import { apiName } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
-import { findInstancesToConvert } from './convert_maps'
-import { getInternalId } from './utils'
+import { getInternalId, isInstanceOfType } from './utils'
 import { PROFILE_METADATA_TYPE } from '../constants'
 
 const { toArrayAsync } = collections.asynciterable
@@ -59,9 +58,11 @@ const replacePath = (
  */
 const filterCreator: FilterCreator = ({ client }): FilterWith<'onFetch'> => ({
   onFetch: async (elements: Element[]) => {
-    const profileInternalIdToName = await generateProfileInternalIdToName(client)
-    const profiles = findInstancesToConvert(elements, PROFILE_METADATA_TYPE)
-    profiles.forEach(inst => replacePath(inst, profileInternalIdToName))
+    const profiles = elements.filter(isInstanceOfType(PROFILE_METADATA_TYPE))
+    if (profiles.length > 0) {
+      const profileInternalIdToName = await generateProfileInternalIdToName(client)
+      profiles.forEach(inst => replacePath(inst, profileInternalIdToName))
+    }
   },
 })
 

--- a/packages/salesforce-adapter/test/filters/profile_paths.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_paths.test.ts
@@ -46,6 +46,11 @@ describe('profile paths filter', () => {
     }))
   })
 
+  it('should not run query when we do not fetch profiles', async () => {
+    await filter.onFetch([])
+    expect(connection.query).not.toHaveBeenCalled()
+  })
+
   it('should replace profile instance path', async () => {
     instance.value[INSTANCE_FULL_NAME_FIELD] = 'Admin'
     instance.value[INTERNAL_ID_FIELD] = 'AdminInternalId'


### PR DESCRIPTION

---
_Release Notes_: 
Salesforce adapter:
- Removed redundant call to SF API when not fetching profiles 
