### PR TITLE
Add option of validating existence of element id [SALTO-1203]

### DIFF
--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -163,9 +163,11 @@ const isElementPossiblyParentOfSearchedElement = (
 
 export const selectElementIdsByTraversal = (
   selectors: ElementSelector[], elements: ElementIDToValue[],
-  compact = false
+  compact = false,
+  validateDeterminedSelectors = false,
 ): ElemID[] => {
-  const [wildcardSelectors, determinedSelectors] = _.partition(selectors, selector => selector.origin.includes('*'))
+  const [wildcardSelectors, determinedSelectors] = validateDeterminedSelectors ? [selectors, []]
+    : _.partition(selectors, selector => selector.origin.includes('*'))
   const determinedIds = determinedSelectors.map(selector => selector.origin)
   const ids = new Set(determinedIds)
   if (wildcardSelectors.length === 0) {

--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -166,14 +166,14 @@ export const selectElementIdsByTraversal = (
   compact = false,
   validateDeterminedSelectors = false,
 ): ElemID[] => {
-  const [wildcardSelectors, determinedSelectors] = validateDeterminedSelectors ? [selectors, []]
+  const [selectorsToDetermine, determinedSelectors] = validateDeterminedSelectors ? [selectors, []]
     : _.partition(selectors, selector => selector.origin.includes('*'))
   const determinedIds = determinedSelectors.map(selector => selector.origin)
   const ids = new Set(determinedIds)
-  if (wildcardSelectors.length === 0) {
+  if (selectorsToDetermine.length === 0) {
     return [...ids].map(id => ElemID.fromFullName(id))
   }
-  const [topLevelSelectors, subElementSelectors] = _.partition(wildcardSelectors,
+  const [topLevelSelectors, subElementSelectors] = _.partition(selectorsToDetermine,
     isTopLevelSelector)
   if (topLevelSelectors.length !== 0) {
     const { elements: topLevelElements } = selectElementsBySelectors(elements,
@@ -202,7 +202,7 @@ export const selectElementIdsByTraversal = (
         return undefined
       }
     }
-    const stillRelevantSelectors = wildcardSelectors.filter(selector => selector
+    const stillRelevantSelectors = selectorsToDetermine.filter(selector => selector
       .origin.split(ElemID.NAMESPACE_SEPARATOR).length > testId.getFullNameParts().length)
     if (stillRelevantSelectors.length === 0) {
       return undefined

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -74,7 +74,7 @@ type MultiEnvSource = Omit<NaclFilesSource, 'getAll'> & {
   getAll: (env?: string) => Promise<Element[]>
   promote: (ids: ElemID[]) => Promise<void>
   getElementIdsBySelectors: (selectors: ElementSelector[],
-    commonOnly?: boolean) => Promise<ElemID[]>
+    commonOnly?: boolean, validateDeterminedSelectors?: boolean) => Promise<ElemID[]>
   demote: (ids: ElemID[]) => Promise<void>
   demoteAll: () => Promise<void>
   copyTo: (ids: ElemID[], targetEnvs?: string[]) => Promise<void>
@@ -234,9 +234,9 @@ const buildMultiEnvSource = (
     (await source.getAll()).map(elem => ({ elemID: elem.elemID, element: elem }))
 
   const getElementIdsBySelectors = async (selectors: ElementSelector[],
-    commonOnly = false): Promise<ElemID[]> =>
+    commonOnly = false, validateDeterminedSelectors = false): Promise<ElemID[]> =>
     selectElementIdsByTraversal(selectors, await getElementsFromSource(commonOnly
-      ? commonSource() : primarySource()))
+      ? commonSource() : primarySource()), false, validateDeterminedSelectors)
 
   const promote = async (ids: ElemID[]): Promise<void> => {
     const routedChanges = await routePromote(

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -368,7 +368,8 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
     getSourceRanges: (elemID: ElemID) => naclFilesSource.getSourceRanges(elemID),
     listNaclFiles: () => naclFilesSource.listNaclFiles(),
     getElementIdsBySelectors: async (selectors: ElementSelector[],
-      commonOnly = false) => naclFilesSource.getElementIdsBySelectors(selectors, commonOnly),
+      commonOnly = false, validateElementIdsExist = false) => naclFilesSource
+      .getElementIdsBySelectors(selectors, commonOnly, validateElementIdsExist),
     getElementReferencedFiles: id => naclFilesSource.getElementReferencedFiles(id),
     getElementNaclFiles: id => naclFilesSource.getElementNaclFiles(id),
     getTotalSize: () => naclFilesSource.getTotalSize(),

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -322,4 +322,28 @@ describe('select elements recursively', () => {
       }))))
     expect(elementIds).toEqual([ElemID.fromFullName('mockAdapter.test.instance.mockInstance.bool')])
   })
+  it('should just return element id if validateDeterminedSelectors is false', async () => {
+    const selectors = createElementSelectors([
+      'mockAdapter.test.instance.mockInstance.thispropertydoesntexist',
+    ]).validSelectors
+    const elementIds = (await selectElementIdsByTraversal(selectors,
+      [mockInstance, mockType].map(element => ({
+        elemID: element.elemID,
+        element,
+      }))))
+    expect(elementIds).toEqual([ElemID
+      .fromFullName('mockAdapter.test.instance.mockInstance.thispropertydoesntexist')])
+  })
+  it('should not return non-existant element id if validateDeterminedSelectors is true', async () => {
+    const selectors = createElementSelectors([
+      'mockAdapter.test.instance.mockInstance.thispropertydoesntexist',
+      'mockAdapter.test.field.strMap',
+    ]).validSelectors
+    const elementIds = (await selectElementIdsByTraversal(selectors,
+      [mockInstance, mockType].map(element => ({
+        elemID: element.elemID,
+        element,
+      })), false, true))
+    expect(elementIds).toEqual([ElemID.fromFullName('mockAdapter.test.field.strMap')])
+  })
 })


### PR DESCRIPTION
selectElementsByIdsTraversal will now have an optional parameter that makes sure that specified element ids exist.

---

Solving:
https://salto-io.atlassian.net/browse/SALTO-1203

---
_Release Notes_: 
None