### PR TITLE
SALTO-1198: Netsuite adapter now uses the changes detection function

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -20,6 +20,7 @@ import {
 import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
 import { resolveValues } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 import NetsuiteClient from './client/client'
 import {
   createInstanceElement, getLookUpName, toCustomizationInfo,
@@ -27,10 +28,8 @@ import {
 import {
   customTypes, getAllTypes, fileCabinetTypes,
 } from './types'
-import {
-  TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST, DEPLOY_REFERENCED_ELEMENTS, INTEGRATION, FETCH_TARGET,
-  SKIP_LIST,
-} from './constants'
+import { TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST, DEPLOY_REFERENCED_ELEMENTS,
+  INTEGRATION, FETCH_TARGET, SKIP_LIST } from './constants'
 import replaceInstanceReferencesFilter from './filters/instance_references'
 import convertLists from './filters/convert_lists'
 import consistentValues from './filters/consistent_values'
@@ -39,12 +38,18 @@ import {
   getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS,
 } from './config'
 import { getAllReferencedInstances, getRequiredReferencedInstances } from './reference_dependencies'
-import { andQuery, buildNetsuiteQuery, NetsuiteQueryParameters, notQuery } from './query'
+import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery } from './query'
+import { SuiteAppClient } from './client/suiteapp_client/suiteapp_client'
+import { createServerTimeElements, getLastServerTime } from './server_time'
+import { getChangedObjects } from './changes_detector/changes_detector'
 
 const { makeArray } = collections.array
 
+const log = logger(module)
+
 export interface NetsuiteAdapterParams {
   client: NetsuiteClient
+  suiteAppClient?: SuiteAppClient
   elementsSource: ReadOnlyElementsSource
   // Filters to support special cases upon fetch
   filtersCreators?: FilterCreator[]
@@ -72,9 +77,11 @@ export default class NetsuiteAdapter implements AdapterOperations {
   private getElemIdFunc?: ElemIdGetter
   private readonly fetchTarget?: NetsuiteQueryParameters
   private readonly skipList?: NetsuiteQueryParameters
+  private readonly suiteAppClient?: SuiteAppClient
 
   public constructor({
     client,
+    suiteAppClient,
     elementsSource,
     filtersCreators = [
       convertLists,
@@ -93,6 +100,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     config,
   }: NetsuiteAdapterParams) {
     this.client = client
+    this.suiteAppClient = suiteAppClient
     this.elementsSource = elementsSource
     this.filtersCreators = filtersCreators
     this.typesToSkip = typesToSkip.concat(makeArray(config[TYPES_TO_SKIP]))
@@ -115,11 +123,19 @@ export default class NetsuiteAdapter implements AdapterOperations {
       filePaths: this.filePathRegexSkipList.map(reg => `.*${reg}.*`),
     })
 
-    const fetchQuery = [
+    let fetchQuery = [
       this.fetchTarget && buildNetsuiteQuery(this.fetchTarget),
       this.skipList && notQuery(buildNetsuiteQuery(this.skipList)),
       notQuery(deprecatedSkipList),
     ].filter(values.isDefined).reduce(andQuery)
+
+
+    const { serverTimeElements, changedObjectsQuery } = await this.runSuiteAppOperations(fetchQuery)
+    fetchQuery = changedObjectsQuery !== undefined
+      ? andQuery(changedObjectsQuery, fetchQuery)
+      : fetchQuery
+
+    const isPartial = this.fetchTarget !== undefined || changedObjectsQuery !== undefined
 
     const getCustomObjectsResult = this.client.getCustomObjects(
       Object.keys(customTypes),
@@ -144,9 +160,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
         ?? fileCabinetTypes[customizationInfo.typeName]
       return type ? createInstanceElement(customizationInfo, type, this.getElemIdFunc) : undefined
     }).filter(isInstanceElement)
-    const elements = [...getAllTypes(), ...instances]
-
-    const isPartial = this.fetchTarget !== undefined
+    const elements = [...getAllTypes(), ...instances, ...serverTimeElements]
 
     progressReporter.reportProgress({ message: 'Finished fetching instances. Running filters for additional information' })
     await this.runFiltersOnFetch(elements, this.elementsSource, isPartial)
@@ -157,6 +171,38 @@ export default class NetsuiteAdapter implements AdapterOperations {
       return { elements, isPartial }
     }
     return { elements, updatedConfig, isPartial }
+  }
+
+  private async runSuiteAppOperations(fetchQuery: NetsuiteQuery):
+    Promise<{ serverTimeElements: Element[]; changedObjectsQuery?: NetsuiteQuery }> {
+    if (this.suiteAppClient === undefined) {
+      log.debug('SuiteApp not configured, skipping SuiteApp operations')
+      return { serverTimeElements: [] }
+    }
+
+    const sysInfo = await this.suiteAppClient.getSystemInformation()
+    if (sysInfo === undefined) {
+      log.debug('Failed to get sysInfo, skipping SuiteApp operations')
+      return { serverTimeElements: [] }
+    }
+
+    const serverTimeElements = this.fetchTarget === undefined
+      ? createServerTimeElements(sysInfo.time)
+      : []
+
+    const lastFetchTime = await getLastServerTime(this.elementsSource)
+    if (lastFetchTime === undefined) {
+      log.debug('Failed to get last fetch time')
+      return { serverTimeElements }
+    }
+
+    const changedObjectsQuery = await getChangedObjects(
+      this.suiteAppClient,
+      fetchQuery,
+      { start: lastFetchTime, end: sysInfo.time }
+    )
+
+    return { serverTimeElements, changedObjectsQuery }
   }
 
   private getAllRequiredReferencedInstances(

--- a/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
@@ -23,7 +23,7 @@ import scriptDetector from './changes_detectors/script'
 import roleDetector from './changes_detectors/role'
 import workflowDetector from './changes_detectors/workflow'
 import savedSearchDetector from './changes_detectors/savedsearch'
-import { formatSavedSearchDate } from './formats'
+import { formatSavedSearchDateRange } from './formats'
 import { ChangedType, DateRange } from './types'
 
 const log = logger(module)
@@ -38,6 +38,8 @@ export const DETECTORS = [
   savedSearchDetector,
 ]
 
+const SUPPORTED_TYPES = new Set(DETECTORS.map(detector => detector.getTypes()).flat())
+
 const getChangedInternalIds = async (client: SuiteAppClient, dateRange: DateRange):
 Promise<Set<number> | undefined> => {
   // Note that the internal id is NOT unique cross types and different instances
@@ -47,7 +49,7 @@ Promise<Set<number> | undefined> => {
   const results = await client.runSavedSearchQuery({
     type: 'systemnote',
     filters: [
-      ['date', 'within', formatSavedSearchDate(dateRange.start), formatSavedSearchDate(dateRange.end)],
+      ['date', 'within', ...formatSavedSearchDateRange(dateRange)],
     ],
     columns: ['recordid'],
   })
@@ -118,10 +120,15 @@ export const getChangedObjects = async (
   const types = new Set(changedTypes.map(type => type.name))
 
   log.debug('Finished to look for changed objects')
+  log.debug(`${scriptIds.size} script ids changes were detected`)
+  log.debug(`${types.size} types changes were detected`)
+  log.debug(`${paths.size} paths changes were detected`)
 
   return {
     isTypeMatch: () => true,
-    isObjectMatch: objectID => scriptIds.has(objectID.scriptId) || types.has(objectID.type),
+    isObjectMatch: objectID => !SUPPORTED_TYPES.has(objectID.type)
+      || scriptIds.has(objectID.scriptId)
+      || types.has(objectID.type),
     isFileMatch: filePath => paths.has(filePath),
   }
 }

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
@@ -15,17 +15,19 @@
 */
 import { logger } from '@salto-io/logging'
 import { SuiteAppClient } from '../../client/suiteapp_client/suiteapp_client'
-import { formatSuiteQLDate } from '../formats'
+import { formatSuiteQLDateRange } from '../formats'
 import { ChangedObject, DateRange, TypeChangesDetector } from '../types'
 
 const log = logger(module)
 
 const getChanges = async (type: string, client: SuiteAppClient, dateRange: DateRange):
   Promise<ChangedObject[]> => {
+  const [startDate, endDate] = formatSuiteQLDateRange(dateRange)
+
   const results = await client.runSuiteQL(`
       SELECT scriptid
       FROM ${type}
-      WHERE lastmodifieddate BETWEEN '${formatSuiteQLDate(dateRange.start)}' AND '${formatSuiteQLDate(dateRange.end)}'
+      WHERE lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
     `)
 
   if (results === undefined) {

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/file_cabinet.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/file_cabinet.ts
@@ -15,25 +15,26 @@
 */
 import path from 'path'
 import { logger } from '@salto-io/logging'
-import { formatSuiteQLDate } from '../formats'
+import { formatSuiteQLDateRange } from '../formats'
 import { FileCabinetChangesDetector } from '../types'
 
 const log = logger(module)
 
 
 export const getChangedFiles: FileCabinetChangesDetector = async (client, dateRange) => {
+  const [startDate, endDate] = formatSuiteQLDateRange(dateRange)
+
   const results = await client.runSuiteQL(`
     SELECT mediaitemfolder.appfolder, file.name, file.id
     FROM file
     JOIN mediaitemfolder ON mediaitemfolder.id = file.folder
-    WHERE file.lastmodifieddate BETWEEN '${formatSuiteQLDate(dateRange.start)}' AND '${formatSuiteQLDate(dateRange.end)}'
+    WHERE file.lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
   `)
 
   if (results === undefined) {
     log.warn('file changes query failed')
     return []
   }
-
   return results
     .filter((res): res is { name: string; appfolder: string; id: string } => {
       if ([res.appfolder, res.name, res.id].some(val => typeof val !== 'string')) {
@@ -50,10 +51,12 @@ export const getChangedFiles: FileCabinetChangesDetector = async (client, dateRa
 }
 
 export const getChangedFolders: FileCabinetChangesDetector = async (client, dateRange) => {
+  const [startDate, endDate] = formatSuiteQLDateRange(dateRange)
+
   const results = await client.runSuiteQL(`
     SELECT appfolder, id
     FROM mediaitemfolder
-    WHERE lastmodifieddate BETWEEN '${formatSuiteQLDate(dateRange.start)}' AND '${formatSuiteQLDate(dateRange.end)}'
+    WHERE lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
   `)
 
   if (results === undefined) {

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/savedsearch.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/savedsearch.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
-import { formatSavedSearchDate } from '../formats'
+import { formatSavedSearchDateRange } from '../formats'
 import { TypeChangesDetector } from '../types'
 
 const log = logger(module)
@@ -24,7 +24,7 @@ const changesDetector: TypeChangesDetector = {
     const results = await client.runSavedSearchQuery({
       type: 'savedsearch',
       columns: ['id'],
-      filters: [['datemodified', 'within', formatSavedSearchDate(dateRange.start), formatSavedSearchDate(dateRange.end)]],
+      filters: [['datemodified', 'within', ...formatSavedSearchDateRange(dateRange)]],
     })
 
     if (results === undefined) {

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/workflow.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/workflow.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
-import { formatSavedSearchDate } from '../formats'
+import { formatSavedSearchDateRange } from '../formats'
 import { TypeChangesDetector } from '../types'
 
 const log = logger(module)
@@ -26,7 +26,7 @@ const changesDetector: TypeChangesDetector = {
       filters: [
         ['recordtype', 'is', '-129'],
         'and',
-        ['date', 'within', formatSavedSearchDate(dateRange.start), formatSavedSearchDate(dateRange.end)],
+        ['date', 'within', ...formatSavedSearchDateRange(dateRange)],
       ],
       columns: ['recordid'],
     })

--- a/packages/netsuite-adapter/src/changes_detector/formats.ts
+++ b/packages/netsuite-adapter/src/changes_detector/formats.ts
@@ -13,10 +13,24 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { DateRange } from './types'
+
 export const formatSuiteQLDate = (date: Date): string => `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}`
 
 export const formatSavedSearchDate = (date: Date): string => {
   const hour = date.getUTCHours() > 12 ? date.getUTCHours() - 12 : date.getUTCHours()
   const dayTime = date.getUTCHours() >= 12 ? 'pm' : 'am'
   return `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()} ${hour}:${date.getUTCMinutes()} ${dayTime}`
+}
+
+export const formatSuiteQLDateRange = (dateRange: DateRange): [string, string] => {
+  const endDate = new Date(dateRange.end)
+  endDate.setDate(endDate.getDate() + 1)
+  return [formatSuiteQLDate(dateRange.start), formatSuiteQLDate(endDate)]
+}
+
+export const formatSavedSearchDateRange = (dateRange: DateRange): [string, string] => {
+  const endDate = new Date(dateRange.end)
+  endDate.setMinutes(endDate.getMinutes() + 1)
+  return [formatSavedSearchDate(dateRange.start), formatSavedSearchDate(endDate)]
 }

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -93,7 +93,7 @@ export class SuiteAppClient {
     try {
       const results = await this.sendRestletRequest('sysInfo')
 
-      if (!this.ajv.validate<{ time: string; appVersion: number[] }>(
+      if (!this.ajv.validate<{ time: number; appVersion: number[] }>(
         SYSTEM_INFORMATION_SCHEME,
         results
       )) {

--- a/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
@@ -100,7 +100,7 @@ export type SavedSearchQuery = {
 export const SYSTEM_INFORMATION_SCHEME = {
   type: 'object',
   properties: {
-    time: { type: 'string' },
+    time: { type: 'number' },
     appVersion: {
       type: 'array',
       items: { type: 'number' },

--- a/packages/netsuite-adapter/src/server_time.ts
+++ b/packages/netsuite-adapter/src/server_time.ts
@@ -1,0 +1,68 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, Element, ElemID, BuiltinTypes, CORE_ANNOTATIONS, InstanceElement, ReadOnlyElementsSource, isInstanceElement } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { NETSUITE, RECORDS_PATH, TYPES_PATH } from './constants'
+
+const log = logger(module)
+
+// The random suffix is to avoid collisions with netsuite types
+export const SERVER_TIME_TYPE_NAME = 'server_time5a2ca8777a7743c3814ec83e3c4f0147'
+
+
+export const createServerTimeElements = (time: Date): Element[] => {
+  log.debug(`Creating server time elements with time: ${time.toJSON()}`)
+  const type = new ObjectType({
+    elemID: new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME),
+    isSettings: true,
+    fields: {
+      serverTime: { type: BuiltinTypes.STRING },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.HIDDEN]: true,
+    },
+    path: [NETSUITE, TYPES_PATH, SERVER_TIME_TYPE_NAME],
+  })
+
+  const instance = new InstanceElement(
+    ElemID.CONFIG_NAME,
+    type,
+    { serverTime: time.toJSON() },
+    [NETSUITE, RECORDS_PATH, SERVER_TIME_TYPE_NAME],
+    { [CORE_ANNOTATIONS.HIDDEN]: true },
+  )
+
+  return [type, instance]
+}
+
+export const getLastServerTime = async (elementsSource: ReadOnlyElementsSource):
+  Promise<Date | undefined> => {
+  log.debug('Getting server time')
+  const serverTimeElement = await elementsSource.get(new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME, 'instance', ElemID.CONFIG_NAME))
+
+  if (!isInstanceElement(serverTimeElement)) {
+    log.info('Server time not found in elements source')
+    return undefined
+  }
+
+  if (serverTimeElement.value.serverTime === undefined) {
+    log.info('serverTime value does not exists in server time instance')
+    return undefined
+  }
+
+  log.info(`Server time is ${serverTimeElement.value.serverTime}`)
+  return new Date(serverTimeElement.value.serverTime)
+}

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -16,6 +16,7 @@
 
 import {
   ElemID, InstanceElement, StaticFile, ChangeDataType, DeployResult, getChangeElement, FetchOptions,
+  ObjectType,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
@@ -25,7 +26,7 @@ import { customTypes, fileCabinetTypes, getAllTypes } from '../src/types'
 import {
   ENTITY_CUSTOM_FIELD, SCRIPT_ID, SAVED_SEARCH, FILE, FOLDER, PATH, TRANSACTION_FORM, TYPES_TO_SKIP,
   FILE_PATHS_REGEX_SKIP_LIST, FETCH_ALL_TYPES_AT_ONCE, DEPLOY_REFERENCED_ELEMENTS,
-  FETCH_TYPE_TIMEOUT_IN_MINUTES, INTEGRATION, CLIENT_CONFIG, FETCH_TARGET,
+  FETCH_TYPE_TIMEOUT_IN_MINUTES, INTEGRATION, CLIENT_CONFIG, FETCH_TARGET, NETSUITE,
 } from '../src/constants'
 import { createInstanceElement, toCustomizationInfo } from '../src/transformer'
 import {
@@ -35,6 +36,9 @@ import { FilterCreator } from '../src/filter'
 import { configType, getConfigFromConfigChanges } from '../src/config'
 import { mockGetElemIdFunc, MockInterface } from './utils'
 import * as referenceDependenciesModule from '../src/reference_dependencies'
+import { SuiteAppClient } from '../src/client/suiteapp_client/suiteapp_client'
+import { SERVER_TIME_TYPE_NAME } from '../src/server_time'
+import * as changesDetector from '../src/changes_detector/changes_detector'
 
 jest.mock('../src/config', () => ({
   ...jest.requireActual<{}>('../src/config'),
@@ -45,6 +49,8 @@ const getAllReferencedInstancesMock = referenceDependenciesModule
   .getAllReferencedInstances as jest.Mock
 getAllReferencedInstancesMock
   .mockImplementation((sourceInstances: ReadonlyArray<InstanceElement>) => sourceInstances)
+
+jest.mock('../src/changes_detector/changes_detector')
 
 const getRequiredReferencedInstancesMock = referenceDependenciesModule
   .getRequiredReferencedInstances as jest.Mock
@@ -467,6 +473,139 @@ describe('Adapter', () => {
       await adapterAdd(instance)
       expect(getRequiredReferencedInstancesMock).toHaveBeenCalledTimes(1)
       expect(getAllReferencedInstancesMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('SuiteAppClient', () => {
+    const getSystemInformationMock = jest.fn().mockResolvedValue({
+      time: new Date(1000),
+      appVersion: [0, 1, 0],
+    })
+    let adapter: NetsuiteAdapter
+
+    const elementsSource = buildElementsSourceFromElements([])
+    const getElementMock = jest.spyOn(elementsSource, 'get')
+    const getChangedObjectsMock = jest.spyOn(changesDetector, 'getChangedObjects')
+
+    beforeEach(() => {
+      getElementMock.mockReset()
+
+      getChangedObjectsMock.mockReset()
+      getChangedObjectsMock.mockResolvedValue({
+        isTypeMatch: () => true,
+        isObjectMatch: objectID => objectID.scriptId.startsWith('aa'),
+        isFileMatch: () => true,
+      })
+
+      getSystemInformationMock.mockReset()
+      getSystemInformationMock.mockResolvedValue({
+        time: new Date(1000),
+        appVersion: [0, 1, 0],
+      })
+
+      const suiteAppClient = {
+        getSystemInformation: getSystemInformationMock,
+      } as unknown as SuiteAppClient
+
+      adapter = new NetsuiteAdapter({
+        client,
+        suiteAppClient,
+        elementsSource,
+        filtersCreators: [firstDummyFilter, secondDummyFilter],
+        config,
+        getElemIdFunc: mockGetElemIdFunc,
+      })
+    })
+
+    it('should not create serverTime elements when getSystemInformation returns undefined', async () => {
+      getSystemInformationMock.mockResolvedValue(undefined)
+
+      const { elements } = await adapter.fetch(mockFetchOpts)
+      expect(elements.filter(
+        e => e.elemID.getFullName().includes(SERVER_TIME_TYPE_NAME)
+      )).toHaveLength(0)
+    })
+
+    it('should not create serverTime elements when fetchTarget parameter was passed', async () => {
+      const suiteAppClient = {
+        getSystemInformation: getSystemInformationMock,
+      } as unknown as SuiteAppClient
+
+      adapter = new NetsuiteAdapter({
+        client,
+        suiteAppClient,
+        elementsSource,
+        filtersCreators: [firstDummyFilter, secondDummyFilter],
+        config: {
+          ...config,
+          [FETCH_TARGET]: {
+            types: {},
+            filePaths: [],
+          },
+        },
+        getElemIdFunc: mockGetElemIdFunc,
+      })
+
+      const { elements } = await adapter.fetch(mockFetchOpts)
+      expect(elements.filter(
+        e => e.elemID.getFullName().includes(SERVER_TIME_TYPE_NAME)
+      )).toHaveLength(0)
+    })
+    it('should create the serverTime elements when getSystemInformation returns the time', async () => {
+      const { elements } = await adapter.fetch(mockFetchOpts)
+      expect(elements.filter(
+        e => e.elemID.getFullName().includes(SERVER_TIME_TYPE_NAME)
+      )).toHaveLength(2)
+
+      const serverTimeInstance = elements.find(
+        e => e.elemID.isEqual(new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME, 'instance', ElemID.CONFIG_NAME))
+      )
+      expect((serverTimeInstance as InstanceElement)?.value?.serverTime)
+        .toEqual(new Date(1000).toJSON())
+    })
+
+    describe('getChangedObjects', () => {
+      beforeEach(() => {
+        getElementMock.mockResolvedValue(new InstanceElement(
+          ElemID.CONFIG_NAME,
+          new ObjectType({ elemID: new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME) }),
+          {
+            serverTime: '1970-01-01T00:00:00.500Z',
+          }
+        ))
+      })
+      it('should call getChangedObjectsMock with the right date range', async () => {
+        await adapter.fetch(mockFetchOpts)
+        expect(getElementMock).toHaveBeenCalledWith(new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME, 'instance', ElemID.CONFIG_NAME))
+        expect(getChangedObjectsMock).toHaveBeenCalledWith(
+          expect.any(Object),
+          expect.any(Object),
+          {
+            start: new Date('1970-01-01T00:00:00.500Z'),
+            end: new Date(1000),
+          },
+        )
+      })
+
+      it('should pass the received query to the client', async () => {
+        const getCustomObjectsMock = jest.spyOn(client, 'getCustomObjects')
+        await adapter.fetch(mockFetchOpts)
+
+        const passedQuery = getCustomObjectsMock.mock.calls[0][1]
+        expect(passedQuery.isObjectMatch({ scriptId: 'aaaa', type: '' })).toBeTruthy()
+        expect(passedQuery.isObjectMatch({ scriptId: 'bbbb', type: '' })).toBeFalsy()
+      })
+
+      it('should not call getChangedObjectsMock if server time instance is invalid', async () => {
+        getElementMock.mockResolvedValue(new InstanceElement(
+          ElemID.CONFIG_NAME,
+          new ObjectType({ elemID: new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME) }),
+          {}
+        ))
+        await adapter.fetch(mockFetchOpts)
+        expect(getElementMock).toHaveBeenCalledWith(new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME, 'instance', ElemID.CONFIG_NAME))
+        expect(getChangedObjectsMock).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
@@ -78,10 +78,11 @@ describe('changes_detector', () => {
     expect(changedObjectsQuery.isFileMatch('/path/to')).toBeTruthy()
     expect(changedObjectsQuery.isFileMatch('/path/to/notExists')).toBeFalsy()
 
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'a' })).toBeTruthy()
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'b' })).toBeTruthy()
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'c' })).toBeFalsy()
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'd' })).toBeFalsy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'a' })).toBeTruthy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'b' })).toBeTruthy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'c' })).toBeFalsy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'd' })).toBeFalsy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'notSupported', scriptId: 'd' })).toBeTruthy()
 
     expect(changedObjectsQuery.isObjectMatch({ type: 'customrecordtype', scriptId: 'anything' })).toBeTruthy()
     expect(changedObjectsQuery.isTypeMatch('anything')).toBeTruthy()
@@ -99,10 +100,11 @@ describe('changes_detector', () => {
     expect(changedObjectsQuery.isFileMatch('/path/to')).toBeTruthy()
     expect(changedObjectsQuery.isFileMatch('/path/to/notExists')).toBeFalsy()
 
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'a' })).toBeTruthy()
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'b' })).toBeTruthy()
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'c' })).toBeTruthy()
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'd' })).toBeFalsy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'a' })).toBeTruthy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'b' })).toBeTruthy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'c' })).toBeTruthy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'd' })).toBeFalsy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'notSupported', scriptId: 'd' })).toBeTruthy()
 
     expect(changedObjectsQuery.isObjectMatch({ type: 'customrecordtype', scriptId: 'anything' })).toBeTruthy()
   })

--- a/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
@@ -45,7 +45,7 @@ describe('custom_field', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
       SELECT scriptid
       FROM customfield
-      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/22/2021'
+      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
     `)
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
@@ -45,7 +45,7 @@ describe('custom_list', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
       SELECT scriptid
       FROM customlist
-      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/22/2021'
+      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
     `)
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
@@ -45,7 +45,7 @@ describe('custom_record_type', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
       SELECT scriptid
       FROM customrecordtype
-      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/22/2021'
+      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
     `)
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/file_cabinet.test.ts
@@ -46,7 +46,7 @@ describe('file_cabinet', () => {
     SELECT mediaitemfolder.appfolder, file.name, file.id
     FROM file
     JOIN mediaitemfolder ON mediaitemfolder.id = file.folder
-    WHERE file.lastmodifieddate BETWEEN '1/11/2021' AND '2/22/2021'
+    WHERE file.lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
   `)
       })
     })
@@ -102,7 +102,7 @@ describe('file_cabinet', () => {
         expect(runSuiteQLMock).toHaveBeenCalledWith(`
     SELECT appfolder, id
     FROM mediaitemfolder
-    WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/22/2021'
+    WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
   `)
       })
     })

--- a/packages/netsuite-adapter/test/changes_detector/role.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/role.test.ts
@@ -89,7 +89,7 @@ describe('role', () => {
       SELECT role.scriptid, role.id
       FROM role
       JOIN systemnote ON systemnote.recordid = role.id
-      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/22/2021' AND systemnote.recordtypeid = -118
+      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/23/2021' AND systemnote.recordtypeid = -118
     `)
 
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, `
@@ -100,7 +100,7 @@ describe('role', () => {
       expect(runSavedSearchQueryMock).toHaveBeenCalledWith({
         type: 'role',
         columns: ['internalid'],
-        filters: [['permchangedate', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:55 pm']],
+        filters: [['permchangedate', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:56 pm']],
       })
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/savedsearch.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/savedsearch.test.ts
@@ -45,7 +45,7 @@ describe('savedsearch', () => {
       expect(runSavedSearchQueryMock).toHaveBeenCalledWith({
         type: 'savedsearch',
         columns: ['id'],
-        filters: [['datemodified', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:55 pm']],
+        filters: [['datemodified', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:56 pm']],
       })
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/script.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/script.test.ts
@@ -88,7 +88,7 @@ describe('script', () => {
       SELECT script.scriptid, script.id
       FROM script
       JOIN systemnote ON systemnote.recordid = script.id
-      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/22/2021' AND systemnote.recordtypeid = -417
+      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/23/2021' AND systemnote.recordtypeid = -417
     `)
 
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, `
@@ -96,13 +96,13 @@ describe('script', () => {
       FROM scriptdeployment 
       JOIN systemnote ON systemnote.recordid = scriptdeployment.primarykey
       JOIN script ON scriptdeployment.script = script.id
-      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/22/2021' AND systemnote.recordtypeid = -418
+      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/23/2021' AND systemnote.recordtypeid = -418
     `)
 
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(3, `
       SELECT internalid
       FROM customfield
-      WHERE fieldtype = 'SCRIPT' AND lastmodifieddate BETWEEN '1/11/2021' AND '2/22/2021'
+      WHERE fieldtype = 'SCRIPT' AND lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
     `)
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/workflow.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/workflow.test.ts
@@ -47,7 +47,7 @@ describe('workflow', () => {
           filters: [
             ['recordtype', 'is', '-129'],
             'and',
-            ['date', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:55 am'],
+            ['date', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:56 am'],
           ],
           columns: ['recordid'],
         })

--- a/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
@@ -256,14 +256,14 @@ describe('SuiteAppClient', () => {
           status: 'success',
           results: {
             appVersion: [0, 1, 2],
-            time: '2021-02-22T18:55:17.949Z',
+            time: 1000,
           },
         },
       })
 
       const results = await client.getSystemInformation()
 
-      expect(results).toEqual({ appVersion: [0, 1, 2], time: new Date('2021-02-22T18:55:17.949Z') })
+      expect(results).toEqual({ appVersion: [0, 1, 2], time: new Date(1000) })
       expect(postMock).toHaveBeenCalledWith(
         'https://account-id.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=customscript_salto_restlet&deploy=customdeploy_salto_restlet',
         {


### PR DESCRIPTION
This PR makes the Netsuite adapter use the changes detection mechanism when the suiteAppClient is available.

In this PR, I save a global last fetch time if `fetchTarget` was not passed. In future PR, I will improve it the have a different time for each element so we will be able to update the time also if `fetchTarget` was passed.

Also, while developing this, some integration errors came up:
 - In suiteQL and saved search, doing between time A to time B includes A and does not include B (I thought it does include B).
 - I changed the SuiteApp to return the time as a GMT epoch time and not a string. 
 Both are fixed in this PR.

Since we never pass a SuiteAppClient to the adapter, this PR does not affect the user.

---
_Release Notes_: 
None