### PR TITLE
Lowerdash - multi index builder

### DIFF
--- a/packages/lowerdash/src/index.ts
+++ b/packages/lowerdash/src/index.ts
@@ -14,31 +14,33 @@
 * limitations under the License.
 */
 import * as collections from './collections'
-import * as promises from './promises'
-import * as types from './types'
 import * as decorators from './decorators'
+import * as functions from './functions'
+import * as hash from './hash'
+import * as multiIndex from './multi_index'
+import * as promises from './promises'
+import * as regex from './regex'
+import * as retry from './retry'
+import * as stack from './stack'
 import * as streams from './streams'
 import * as strings from './strings'
-import * as functions from './functions'
-import * as retry from './retry'
+import * as types from './types'
 import * as validators from './validators'
-import * as stack from './stack'
-import * as hash from './hash'
 import * as values from './values'
-import * as regex from './regex'
 
 export {
   collections,
-  promises,
-  types,
   decorators,
+  functions,
+  hash,
+  multiIndex,
+  promises,
+  regex,
+  retry,
+  stack,
   streams,
   strings,
-  functions,
-  retry,
+  types,
   validators,
-  stack,
-  hash,
   values,
-  regex,
 }

--- a/packages/lowerdash/src/multi_index.ts
+++ b/packages/lowerdash/src/multi_index.ts
@@ -1,0 +1,107 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { forEachAsync } from './collections/asynciterable'
+import { TypeGuard, Predicate } from './types'
+
+
+// The '0' key is used to "nudge" typescript to infer a tuple type instead of an array
+type TupleType<T> = T[] & { '0': T }
+type KeyType = TupleType<string>
+
+export type Index<Key extends KeyType, T> = {
+  get: (...key: Key) => T | undefined
+}
+
+type IndexFunction<
+  InputType = unknown,
+  FilteredType extends InputType = InputType,
+  ResultValueType = InputType,
+  Key extends KeyType = KeyType,
+  IndexName extends string = string,
+> = {
+  name: IndexName
+  filter?: TypeGuard<InputType, FilteredType> | Predicate<InputType>
+  key: (item: FilteredType) => Key
+  map?: (item: FilteredType) => ResultValueType
+}
+
+type MultiIndexBuilder<T, Result extends object = never> = {
+  addIndex: <Name extends string, Key extends KeyType, U extends T = T, V = T>(
+    f: IndexFunction<T, U, V, Key, Name>
+  ) => MultiIndexBuilder<T, Result & { [k in Name]: Index<Key, V> }>
+
+  process: (iter: AsyncIterable<T>) => Promise<Result>
+}
+
+export const buildMultiIndex = <T, Result extends object = {}>(): MultiIndexBuilder<T, Result> => {
+  const indexDefinitions: IndexFunction[] = []
+
+  const processItem = (item: T, index: Record<string, unknown>): void => {
+    indexDefinitions
+      .filter(indexDef => indexDef.filter === undefined || indexDef.filter(item))
+      .forEach(indexDef => {
+        const keyParts = indexDef.key(item)
+        if (keyParts.some(part => part === undefined)) {
+          // If key function type is correct this will never happen but just in case it does...
+          return
+        }
+        const value = indexDef.map === undefined ? item : indexDef.map(item)
+        _.set(index, [indexDef.name, ...keyParts], value)
+      })
+  }
+  const toMultiIndex = (index: Record<string, unknown>): Result => (
+    Object.fromEntries(
+      indexDefinitions.map(indexDef => ([
+        indexDef.name,
+        { get: (...key: string[]): unknown => _.get(index, [indexDef.name, ...key]) },
+      ]))
+    ) as Result
+  )
+  const indexBuilder: MultiIndexBuilder<T, Result> = {
+    addIndex: <U extends T, V, Key extends KeyType, Name extends string>(
+      func: IndexFunction<T, U, V, Key, Name>
+    ) => {
+      // Note - the cast to unknown is needed because we cannot maintain a consistent type
+      // for all index functions (we treat each one separately).
+      // This is not fully safe, but with the current implementation in "processItem" it works
+      // because we make sure to put the result of each function in the correct key as it is
+      // defined in the new result type
+      indexDefinitions.push(func as unknown as IndexFunction)
+      // Add the new index to the result type
+      return indexBuilder as MultiIndexBuilder<T, Result & { [k in Name]: Index<Key, V> }>
+    },
+    process: async iter => {
+      const index = {}
+      await forEachAsync(iter, item => processItem(item, index))
+      return toMultiIndex(index)
+    },
+  }
+  return indexBuilder
+}
+
+type KeyByAsyncParams<Key extends KeyType, T, U extends T, V> = {
+  iter: AsyncIterable<T>
+} & Omit<IndexFunction<T, U, V, Key>, 'name'>
+
+export const keyByAsync = async <Key extends KeyType, T, U extends T, V>(
+  { iter, key, map, filter }: KeyByAsyncParams<Key, T, U, V>
+): Promise<Index<Key, V>> => {
+  const { idx } = await buildMultiIndex<T>()
+    .addIndex({ name: 'idx', filter, map, key })
+    .process(iter)
+  return idx
+}

--- a/packages/lowerdash/src/multi_index.ts
+++ b/packages/lowerdash/src/multi_index.ts
@@ -29,28 +29,51 @@ export type Index<Key extends KeyType, T> = {
 type IndexFunction<
   InputType = unknown,
   FilteredType extends InputType = InputType,
-  ResultValueType = InputType,
+  ResultType = InputType,
   Key extends KeyType = KeyType,
   IndexName extends string = string,
 > = {
   name: IndexName
   filter?: TypeGuard<InputType, FilteredType> | Predicate<InputType>
   key: (item: FilteredType) => Key
-  map?: (item: FilteredType) => ResultValueType
+  map?: (item: FilteredType) => ResultType
 }
 
-type MultiIndexBuilder<T, Result extends object = never> = {
-  addIndex: <Name extends string, Key extends KeyType, U extends T = T, V = T>(
-    f: IndexFunction<T, U, V, Key, Name>
-  ) => MultiIndexBuilder<T, Result & { [k in Name]: Index<Key, V> }>
+type MultiIndexBuilder<InputType, Result extends object = {}> = {
+  addIndex: <
+    IndexName extends string,
+    Key extends KeyType,
+    FilteredType extends InputType = InputType,
+    ResultType = InputType
+  >(
+    f: IndexFunction<InputType, FilteredType, ResultType, Key, IndexName>
+  ) => MultiIndexBuilder<InputType, Result & { [name in IndexName]: Index<Key, ResultType> }>
 
-  process: (iter: AsyncIterable<T>) => Promise<Result>
+  process: (iter: AsyncIterable<InputType>) => Promise<Result>
 }
 
-export const buildMultiIndex = <T, Result extends object = {}>(): MultiIndexBuilder<T, Result> => {
+/**
+ * Index the specified items by one or more index definitions with a single iteration over the input
+ *
+ * Usage example:
+ *   const { even, odd } = await buildMultiIndex<number>()
+ *     .addIndex({
+ *       name: 'even',
+ *       filter: item => item % 2 === 0,
+ *       key: item => [item.toString()],
+ *     })
+ *     .addIndex({
+ *       name: 'odd',
+ *       filter: item => item % 2 === 1,
+ *       key: item => [item.toString()],
+ *     })
+ *     .process(items)
+ */
+export const buildMultiIndex = <InputType, Result extends object = {}>(
+): MultiIndexBuilder<InputType, Result> => {
   const indexDefinitions: IndexFunction[] = []
 
-  const processItem = (item: T, index: Record<string, unknown>): void => {
+  const processItem = (item: InputType, index: Record<string, unknown>): void => {
     indexDefinitions
       .filter(indexDef => indexDef.filter === undefined || indexDef.filter(item))
       .forEach(indexDef => {
@@ -67,22 +90,32 @@ export const buildMultiIndex = <T, Result extends object = {}>(): MultiIndexBuil
     Object.fromEntries(
       indexDefinitions.map(indexDef => ([
         indexDef.name,
-        { get: (...key: string[]): unknown => _.get(index, [indexDef.name, ...key]) },
+        { get: (...keyParts: string[]): unknown => _.get(index, [indexDef.name, ...keyParts]) },
       ]))
     ) as Result
   )
-  const indexBuilder: MultiIndexBuilder<T, Result> = {
-    addIndex: <U extends T, V, Key extends KeyType, Name extends string>(
-      func: IndexFunction<T, U, V, Key, Name>
+  const indexBuilder: MultiIndexBuilder<InputType, Result> = {
+    addIndex: <
+      FilteredType extends InputType,
+      ResultType,
+      Key extends KeyType,
+      IndexName extends string
+    >(
+      func: IndexFunction<InputType, FilteredType, ResultType, Key, IndexName>
     ) => {
-      // Note - the cast to unknown is needed because we cannot maintain a consistent type
-      // for all index functions (we treat each one separately).
-      // This is not fully safe, but with the current implementation in "processItem" it works
-      // because we make sure to put the result of each function in the correct key as it is
-      // defined in the new result type
+      // Note - the cast to unknown is needed because we store all index definition in one array.
+      // The type of that array has to be more general than the type of each index.
+      // This is not fully safe, but with the current implementation it works because we make sure
+      // to put the result of each function in the correct key as it is defined in the result type.
+      // The assumption made by both "processItem" and "toMultiIndex" is that the values in
+      // indexDefinitions match the result type - this is not guaranteed by typescript because we
+      // lose the type information here, but it is correct because at this point we make sure that
+      // the type added to Result matches the type of the index function we add here.
       indexDefinitions.push(func as unknown as IndexFunction)
       // Add the new index to the result type
-      return indexBuilder as MultiIndexBuilder<T, Result & { [k in Name]: Index<Key, V> }>
+      return indexBuilder as (
+        MultiIndexBuilder<InputType, Result & { [name in IndexName]: Index<Key, ResultType> }>
+      )
     },
     process: async iter => {
       const index = {}
@@ -93,14 +126,24 @@ export const buildMultiIndex = <T, Result extends object = {}>(): MultiIndexBuil
   return indexBuilder
 }
 
-type KeyByAsyncParams<Key extends KeyType, T, U extends T, V> = {
-  iter: AsyncIterable<T>
-} & Omit<IndexFunction<T, U, V, Key>, 'name'>
+type KeyByAsyncParams<
+  Key extends KeyType,
+  InputType,
+  FilteredType extends InputType,
+  ResultType
+> = {
+  iter: AsyncIterable<InputType>
+} & Omit<IndexFunction<InputType, FilteredType, ResultType, Key>, 'name'>
 
-export const keyByAsync = async <Key extends KeyType, T, U extends T, V>(
-  { iter, key, map, filter }: KeyByAsyncParams<Key, T, U, V>
-): Promise<Index<Key, V>> => {
-  const { idx } = await buildMultiIndex<T>()
+export const keyByAsync = async <
+  Key extends KeyType,
+  InputType,
+  FilteredType extends InputType,
+  ResultType
+>(
+  { iter, key, map, filter }: KeyByAsyncParams<Key, InputType, FilteredType, ResultType>
+): Promise<Index<Key, ResultType>> => {
+  const { idx } = await buildMultiIndex<InputType>()
     .addIndex({ name: 'idx', filter, map, key })
     .process(iter)
   return idx

--- a/packages/lowerdash/src/types.ts
+++ b/packages/lowerdash/src/types.ts
@@ -39,6 +39,9 @@ export type ValueOf<T> = T[keyof T]
 // makes specific fields required
 export type PickyRequired<T, K extends keyof T> = T & Required<Pick<T, K>>
 
+export type TypeGuard<T, S extends T> = (item: T) => item is S
+export type Predicate<T> = (item: T) => boolean
+
 /*
 
 --- Bean ---

--- a/packages/lowerdash/test/multi_index.test.ts
+++ b/packages/lowerdash/test/multi_index.test.ts
@@ -1,0 +1,107 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { buildMultiIndex, keyByAsync, Index } from '../src/multi_index'
+import { toAsyncIterable } from '../src/collections/asynciterable'
+
+export const mockFunction = <T extends (...args: never[]) => unknown>(): jest.MockedFunction<T> => (
+  jest.fn() as unknown as jest.MockedFunction<T>
+)
+
+describe('multi index', () => {
+  let items: AsyncIterable<number>
+  beforeEach(() => {
+    items = toAsyncIterable([1, 2, 3, 4])
+  })
+
+  describe('keyByAsync', () => {
+    let result: Index<[string, string], number>
+    let mapFunc: jest.MockedFunction<(n: number) => number>
+    beforeEach(async () => {
+      mapFunc = mockFunction<typeof mapFunc>().mockImplementation(item => item + 1)
+      result = await keyByAsync({
+        iter: items,
+        filter: item => item % 2 === 0,
+        key: item => [item.toString(), (item + 1).toString()],
+        map: mapFunc,
+      })
+    })
+    it('should filter items according to filter func', () => {
+      expect(mapFunc).not.toHaveBeenCalledWith(1)
+      expect(mapFunc).toHaveBeenCalledWith(2)
+      expect(mapFunc).not.toHaveBeenCalledWith(3)
+      expect(mapFunc).toHaveBeenCalledWith(4)
+    })
+    it('should return index according to key function and map function result', () => {
+      expect(result.get('2', '3')).toEqual(3)
+      expect(result.get('4', '5')).toEqual(5)
+      expect(result.get('1', '2')).toBeUndefined()
+    })
+  })
+
+  describe('buildMultiIndex', () => {
+    // Defining builder as const to avoid having to define its type explicitly
+    const builder = buildMultiIndex<number>()
+      .addIndex({
+        name: 'even',
+        filter: item => item % 2 === 0,
+        key: item => [item.toString()],
+        map: item => item + 1,
+      })
+      .addIndex({
+        name: 'odd',
+        filter: item => item % 2 === 1,
+        key: item => [item.toString()],
+      })
+      .addIndex({
+        name: 'all',
+        key: item => (
+          item === 10 ? ['all', undefined as unknown as string] : ['all', item.toString()]
+        ),
+      })
+
+    it('should build multiple indices in one iteration', async () => {
+      const { even, odd, all } = await builder.process(items)
+      expect(even.get('2')).toEqual(3)
+      expect(even.get('4')).toEqual(5)
+      expect(even.get('1')).toBeUndefined()
+
+      expect(odd.get('1')).toEqual(1)
+      expect(odd.get('3')).toEqual(3)
+      expect(odd.get('2')).toBeUndefined()
+
+      expect(all.get('all', '1')).toEqual(1)
+      expect(all.get('all', '2')).toEqual(2)
+      expect(all.get('all', '3')).toEqual(3)
+      expect(all.get('all', '4')).toEqual(4)
+    })
+    it('should be able to process different iterables with the same builder', async () => {
+      const { even, odd, all } = await builder.process(toAsyncIterable([5, 6]))
+      expect(even.get('6')).toEqual(7)
+      expect(even.get('5')).toBeUndefined()
+
+      expect(odd.get('5')).toEqual(5)
+      expect(odd.get('6')).toBeUndefined()
+
+      expect(all.get('all', '5')).toEqual(5)
+      expect(all.get('all', '6')).toEqual(6)
+    })
+    it('should omit values where the key function returns undefined', async () => {
+      const { all } = await builder.process(toAsyncIterable([9, 10]))
+      expect(all.get('all', '9')).toEqual(9)
+      expect(all.get('all', '10')).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
- Added multi index implementation for building multiple indices from a single
iteration over an async iterable
- Added short type definitions for TypeGuard and Predicate
- Sorted package index file

---
_Release Notes_: 
None
