### PR TITLE
Avoids listing files and instances if not necessary

### DIFF
--- a/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
@@ -123,5 +123,6 @@ export const getChangedObjects = async (
     isTypeMatch: () => true,
     isObjectMatch: objectID => scriptIds.has(objectID.scriptId) || types.has(objectID.type),
     isFileMatch: filePath => paths.has(filePath),
+    areSomeFilesMatch: () => paths.size !== 0,
   }
 }

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -372,6 +372,10 @@ export default class NetsuiteClient {
   @NetsuiteClient.logDecorator
   async getCustomObjects(typeNames: string[], query: NetsuiteQuery):
     Promise<GetCustomObjectsResult> {
+    if (typeNames.every(type => !query.isTypeMatch(type))) {
+      return { elements: [], failedToFetchAllAtOnce: false }
+    }
+
     const { executor, projectName, authId } = await this.initProject()
     const { failedToFetchAllAtOnce } = await this.importObjects(executor, typeNames, query)
     const objectsDirPath = NetsuiteClient.getObjectsDirPath(projectName)
@@ -566,6 +570,12 @@ export default class NetsuiteClient {
   @NetsuiteClient.logDecorator
   async importFileCabinetContent(query: NetsuiteQuery):
     Promise<ImportFileCabinetResult> {
+    if (!query.areSomeFilesMatch()) {
+      return {
+        elements: [],
+        failedPaths: [],
+      }
+    }
     const transformFiles = (filePaths: string[], fileAttrsPaths: string[],
       fileCabinetDirPath: string): Promise<FileCustomizationInfo[]> => {
       const filePathToAttrsPath = _.fromPairs(

--- a/packages/netsuite-adapter/src/query.ts
+++ b/packages/netsuite-adapter/src/query.ts
@@ -33,6 +33,7 @@ export type NetsuiteQuery = {
   isTypeMatch: (typeName: string) => boolean
   isObjectMatch: (objectID: ObjectID) => boolean
   isFileMatch: (filePath: string) => boolean
+  areSomeFilesMatch: () => boolean
 }
 
 export const validateParameters = ({ types = {}, filePaths = [] }:
@@ -71,6 +72,7 @@ export const buildNetsuiteQuery = (
     },
     isFileMatch: filePath =>
       parameters.filePaths.some(reg => new RegExp(`^${reg}$`).test(filePath)),
+    areSomeFilesMatch: () => parameters.filePaths.length !== 0,
   }
 }
 
@@ -81,10 +83,12 @@ export const andQuery = (firstQuery: NetsuiteQuery, secondQuery: NetsuiteQuery):
     firstQuery.isObjectMatch(objectID) && secondQuery.isObjectMatch(objectID),
   isFileMatch: filePath =>
     firstQuery.isFileMatch(filePath) && secondQuery.isFileMatch(filePath),
+  areSomeFilesMatch: () => firstQuery.areSomeFilesMatch() && secondQuery.areSomeFilesMatch(),
 })
 
 export const notQuery = (query: NetsuiteQuery): NetsuiteQuery => ({
   isTypeMatch: () => true,
   isObjectMatch: objectID => !query.isObjectMatch(objectID),
   isFileMatch: filePath => !query.isFileMatch(filePath),
+  areSomeFilesMatch: () => true,
 })

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -555,6 +555,16 @@ describe('netsuite client', () => {
         }),
       }))
     })
+
+    it('should do nothing of no files are matched', async () => {
+      const { elements, failedToFetchAllAtOnce } = await mockClient()
+        .getCustomObjects(typeNames, buildNetsuiteQuery({
+          types: {},
+        }))
+      expect(elements).toHaveLength(0)
+      expect(failedToFetchAllAtOnce).toBeFalsy()
+      expect(mockExecuteAction).not.toHaveBeenCalledWith()
+    })
   })
 
   describe('importFileCabinetContent', () => {
@@ -786,6 +796,16 @@ describe('netsuite client', () => {
       expect(mockExecuteAction).toHaveBeenNthCalledWith(4, listFilesCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(5, listFilesCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(6, deleteAuthIdCommandMatcher)
+    })
+
+    it('should do nothing of no files are matched', async () => {
+      const { elements, failedPaths } = await client.importFileCabinetContent(buildNetsuiteQuery({
+        filePaths: [],
+      }))
+
+      expect(elements).toHaveLength(0)
+      expect(failedPaths).toHaveLength(0)
+      expect(mockExecuteAction).not.toHaveBeenCalled()
     })
 
     it('should return only loaded files', async () => {

--- a/packages/netsuite-adapter/test/query.test.ts
+++ b/packages/netsuite-adapter/test/query.test.ts
@@ -60,6 +60,23 @@ describe('NetsuiteQuery', () => {
           expect(query.isObjectMatch({ scriptId: 'cccccc', type: 'addressForm' })).toBeFalsy()
         })
       })
+
+      describe('areSomeFilesMatch', () => {
+        it('when has files match should return true', () => {
+          expect(query.areSomeFilesMatch()).toBeTruthy()
+        })
+
+        it('when does not` has files match should return false', () => {
+          const q = buildNetsuiteQuery({
+            types: {
+              addressForm: ['aaa.*', 'bbb.*'],
+              advancedpdftemplate: ['ccc.*', 'ddd.*'],
+            },
+            filePaths: [],
+          })
+          expect(q.areSomeFilesMatch()).toBeFalsy()
+        })
+      })
     })
   })
 
@@ -146,6 +163,10 @@ describe('NetsuiteQuery', () => {
       expect(bothQuery.isObjectMatch({ scriptId: 'aaacccc', type: 'addressForm' })).toBeTruthy()
       expect(bothQuery.isObjectMatch({ scriptId: 'aaa', type: 'addressForm' })).toBeFalsy()
       expect(bothQuery.isObjectMatch({ scriptId: 'aaa', type: 'advancedpdftemplate' })).toBeFalsy()
+    })
+
+    it('should return whether both queries has some files match', () => {
+      expect(bothQuery.areSomeFilesMatch()).toBeTruthy()
     })
   })
 


### PR DESCRIPTION
Avoid listing files and instances if there is not going to be anything that matches them.

---
_Release Notes_: 
Netsuite Adapter:
Optimization to `fetchTarget` when no files/instances are matched to the value passed in `fetchTarget`.