### PR TITLE
SALTO-1209: Add fallback element source for readonly element source util

### DIFF
--- a/packages/adapter-utils/src/element_source.ts
+++ b/packages/adapter-utils/src/element_source.ts
@@ -21,7 +21,7 @@ export const buildElementsSourceFromElements = (
   fallbackSource?: ReadOnlyElementsSource
 ): ReadOnlyElementsSource => {
   const elementsMap = _.keyBy(elements, e => e.elemID.getFullName())
-  const elementsInThisSource = new Set(Object.keys(elementsMap))
+  const isIDInElementsMap = (id: ElemID): boolean => id.getFullName() in elementsMap
 
   async function *getIds(): AsyncIterable<ElemID> {
     for (const element of elements) {
@@ -31,7 +31,7 @@ export const buildElementsSourceFromElements = (
       return
     }
     for await (const elemID of await fallbackSource.list()) {
-      if (!elementsInThisSource.has(elemID.getFullName())) {
+      if (!isIDInElementsMap(elemID)) {
         yield elemID
       }
     }
@@ -45,7 +45,7 @@ export const buildElementsSourceFromElements = (
       return
     }
     for await (const element of await fallbackSource.getAll()) {
-      if (!elementsInThisSource.has(element.elemID.getFullName())) {
+      if (!isIDInElementsMap(element.elemID)) {
         yield element
       }
     }
@@ -55,6 +55,6 @@ export const buildElementsSourceFromElements = (
     getAll: async () => getElements(),
     get: async id => elementsMap[id.getFullName()] ?? fallbackSource?.get(id),
     list: async () => getIds(),
-    has: async id => id.getFullName() in elementsMap || (fallbackSource?.has(id) ?? false),
+    has: async id => isIDInElementsMap(id) || (fallbackSource?.has(id) ?? false),
   }
 }

--- a/packages/adapter-utils/test/element_source.test.ts
+++ b/packages/adapter-utils/test/element_source.test.ts
@@ -13,52 +13,111 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
-import { ElemID, ObjectType } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { ElemID, ObjectType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { buildElementsSourceFromElements } from '../src/element_source'
 
+const { toArrayAsync } = collections.asynciterable
+
 describe('buildElementsSourceFromElements', () => {
-  const elements = [
-    new ObjectType({ elemID: new ElemID('adapter', 'type1') }),
-    new ObjectType({ elemID: new ElemID('adapter', 'type2') }),
-  ]
+  describe('when built from elements', () => {
+    const elements = [
+      new ObjectType({ elemID: new ElemID('adapter', 'type1') }),
+      new ObjectType({ elemID: new ElemID('adapter', 'type2') }),
+    ]
+    const elementsSource = buildElementsSourceFromElements(elements)
 
-  const elementsSource = buildElementsSourceFromElements(elements)
+    describe('getAll', () => {
+      it('should return all the elements', async () => {
+        const receivedElements = await toArrayAsync(await elementsSource.getAll())
+        expect(receivedElements).toEqual(elements)
+      })
+    })
 
-  describe('getAll', () => {
-    it('should return all the elements', async () => {
-      const recievedElements = await collections.asynciterable
-        .toArrayAsync(await elementsSource.getAll())
-      expect(recievedElements).toEqual(elements)
+    describe('get', () => {
+      it('should return element if exists', async () => {
+        expect(await elementsSource.get(new ElemID('adapter', 'type1'))).toBe(elements[0])
+      })
+
+      it('should return undefined if not exists', async () => {
+        expect(await elementsSource.get(new ElemID('adapter', 'type3'))).toBeUndefined()
+      })
+    })
+
+    describe('list', () => {
+      it('should return all the elements ids', async () => {
+        const receivedElementsIds = await collections.asynciterable
+          .toArrayAsync(await elementsSource.list())
+        expect(receivedElementsIds).toEqual(elements.map(e => e.elemID))
+      })
+    })
+
+    describe('has', () => {
+      it('should return true if element id exists', async () => {
+        expect(await elementsSource.has(new ElemID('adapter', 'type1'))).toBeTruthy()
+      })
+
+      it('should return false if element id does not exist', async () => {
+        expect(await elementsSource.has(new ElemID('adapter', 'type3'))).toBeFalsy()
+      })
     })
   })
 
-  describe('get', () => {
-    it('should return element if exists', async () => {
-      expect(await elementsSource.get(new ElemID('adapter', 'type1'))).toBe(elements[0])
+  describe('with fallback element source', () => {
+    let fallbackSource: ReadOnlyElementsSource
+    let elementSource: ReadOnlyElementsSource
+    beforeEach(() => {
+      fallbackSource = buildElementsSourceFromElements([
+        new ObjectType({
+          elemID: new ElemID('adapter', 'type1'),
+          annotations: { fallback: true },
+        }),
+        new ObjectType({
+          elemID: new ElemID('adapter', 'type3'),
+        }),
+      ])
+      elementSource = buildElementsSourceFromElements(
+        [
+          new ObjectType({
+            elemID: new ElemID('adapter', 'type1'),
+            annotations: { fallback: false },
+          }),
+          new ObjectType({
+            elemID: new ElemID('adapter', 'type2'),
+          }),
+        ],
+        fallbackSource,
+      )
     })
-
-    it('should return undefined if not exists', async () => {
-      expect(await elementsSource.get(new ElemID('adapter', 'type3'))).toBeUndefined()
+    it('should combine elements from both sources in list', async () => {
+      const allIds = await toArrayAsync(await elementSource.list())
+      expect(allIds).toContainEqual(new ElemID('adapter', 'type1'))
+      expect(allIds).toContainEqual(new ElemID('adapter', 'type2'))
+      expect(allIds).toContainEqual(new ElemID('adapter', 'type3'))
+      expect(allIds).toHaveLength(3)
     })
-  })
-
-  describe('list', () => {
-    it('should return all the elements ids', async () => {
-      const recievedElementsIds = await collections.asynciterable
-        .toArrayAsync(await elementsSource.list())
-      expect(recievedElementsIds).toEqual(elements.map(e => e.elemID))
+    it('should return element from element list over fallback source in get', async () => {
+      const elem = await elementSource.get(new ElemID('adapter', 'type1'))
+      expect(elem).toBeDefined()
+      expect(elem?.annotations.fallback).toEqual(false)
     })
-  })
-
-  describe('has', () => {
-    it('should return true if element id exists', async () => {
-      expect(await elementsSource.has(new ElemID('adapter', 'type1'))).toBeTruthy()
+    it('should return elements from element list over fallback source in getAll', async () => {
+      const elements = await toArrayAsync(await elementSource.getAll())
+      expect(elements).toHaveLength(3)
+      const elementsByName = _.keyBy(elements, elem => elem.elemID.typeName)
+      expect(elementsByName).toHaveProperty('type1')
+      expect(elementsByName.type1.annotations.fallback).toEqual(false)
     })
-
-    it('should return false if element id does not exist', async () => {
-      expect(await elementsSource.has(new ElemID('adapter', 'type3'))).toBeFalsy()
+    it('should contain elements that exist only in elements list', async () => {
+      await expect(elementSource.has(new ElemID('adapter', 'type2'))).resolves.toEqual(true)
+    })
+    it('should contain elements that exist only in fallback source', async () => {
+      await expect(elementSource.has(new ElemID('adapter', 'type3'))).resolves.toEqual(true)
+    })
+    it('should not contain elements that do not exist', async () => {
+      await expect(elementSource.get(new ElemID('adapter', 'none'))).resolves.toBeUndefined()
+      await expect(elementSource.has(new ElemID('adapter', 'none'))).resolves.toEqual(false)
     })
   })
 })


### PR DESCRIPTION

---

This will be needed for the salesforce partial fetch feature where we want some of the elements to come from the current fetch but we also want the rest of the workspace elements to "exist" through the read only elements source that core provides

---
_Release Notes_: 
None
