### PR TITLE
move deploy change validator to adapter-components

### DIFF
--- a/packages/adapter-components/src/change_validators.ts
+++ b/packages/adapter-components/src/change_validators.ts
@@ -13,8 +13,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export * as client from './src/client'
-export * as config from './src/config'
-export * as elements from './src/elements'
-export * as changeValidators from './src/change_validators'
-export * as filterUtils from './src/filter_utils'
+import { ChangeValidator, getChangeElement } from '@salto-io/adapter-api'
+
+export const deployNotSupportedValidator: ChangeValidator = async changes => (
+  changes.map(change => ({
+    elemID: getChangeElement(change).elemID,
+    severity: 'Error',
+    message: 'Deploy is not supported.',
+    detailedMessage: 'Deploy is not supported.',
+  }))
+)

--- a/packages/adapter-components/test/change_validators.test.ts
+++ b/packages/adapter-components/test/change_validators.test.ts
@@ -1,0 +1,46 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID } from '@salto-io/adapter-api'
+import { createChangeValidator } from '@salto-io/adapter-utils'
+import { deployNotSupportedValidator } from '../src/change_validators'
+
+describe('change validator creator', () => {
+  describe('deployNotSupportedValidator', () => {
+    it('should not fail if there are no deploy changes', async () => {
+      expect(await createChangeValidator([deployNotSupportedValidator])([])).toEqual([])
+    })
+
+    it('should fail each change individually', async () => {
+      expect(await createChangeValidator([deployNotSupportedValidator])([
+        toChange({ after: new ObjectType({ elemID: new ElemID('myAdapter', 'obj') }) }),
+        toChange({ before: new ObjectType({ elemID: new ElemID('myAdapter', 'obj2') }) }),
+      ])).toEqual([
+        {
+          elemID: new ElemID('myAdapter', 'obj'),
+          severity: 'Error',
+          message: 'Deploy is not supported.',
+          detailedMessage: 'Deploy is not supported.',
+        },
+        {
+          elemID: new ElemID('myAdapter', 'obj2'),
+          severity: 'Error',
+          message: 'Deploy is not supported.',
+          detailedMessage: 'Deploy is not supported.',
+        },
+      ])
+    })
+  })
+})

--- a/packages/workato-adapter/src/change_validator.ts
+++ b/packages/workato-adapter/src/change_validator.ts
@@ -13,18 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeElement } from '@salto-io/adapter-api'
+import { ChangeValidator } from '@salto-io/adapter-api'
 import { createChangeValidator } from '@salto-io/adapter-utils'
+import { changeValidators } from '@salto-io/adapter-components'
 
-const deployNotSupportedValidator: ChangeValidator = async changes => (
-  changes.map(change => ({
-    elemID: getChangeElement(change).elemID,
-    severity: 'Error',
-    message: 'Deploy is not supported.',
-    detailedMessage: 'Deploy is not supported.',
-  }))
-)
+const { deployNotSupportedValidator } = changeValidators
 
-const changeValidators: ChangeValidator[] = [deployNotSupportedValidator]
+const validators: ChangeValidator[] = [deployNotSupportedValidator]
 
-export default createChangeValidator(changeValidators)
+export default createChangeValidator(validators)


### PR DESCRIPTION
Make the simple-adapter deploy change validator reusable for all simple adapters.

---

_Release Notes_: 
None
