### PR TITLE
Netsuite: Add instances that failed to import due to an unexpected SDF error to skipList

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -135,6 +135,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     const {
       elements: customObjects,
       failedToFetchAllAtOnce,
+      failedTypeToInstances,
     } = await getCustomObjectsResult
     progressReporter.reportProgress({ message: 'Finished fetching instances. Running filters for additional information' })
 
@@ -150,8 +151,9 @@ export default class NetsuiteAdapter implements AdapterOperations {
 
     progressReporter.reportProgress({ message: 'Finished fetching instances. Running filters for additional information' })
     await this.runFiltersOnFetch(elements, this.elementsSource, isPartial)
-    const updatedConfig = getConfigFromConfigChanges(failedToFetchAllAtOnce, failedFilePaths,
-      this.userConfig)
+    const updatedConfig = getConfigFromConfigChanges(
+      failedToFetchAllAtOnce, failedFilePaths, failedTypeToInstances, this.userConfig
+    )
 
     if (_.isUndefined(updatedConfig)) {
       return { elements, isPartial }

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -38,11 +38,17 @@ import {
   DEFAULT_FETCH_ALL_TYPES_AT_ONCE, DEFAULT_FETCH_TYPE_TIMEOUT_IN_MINUTES,
   DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST, DEFAULT_CONCURRENCY, SdfClientConfig,
 } from '../config'
-import { NetsuiteQuery, ObjectID } from '../query'
+import { NetsuiteQuery, NetsuiteQueryParameters, ObjectID } from '../query'
 import { SdfCredentials } from './credentials'
-import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, GetCustomObjectsResult, ImportFileCabinetResult, TemplateCustomTypeInfo } from './types'
+import {
+  CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo,
+  GetCustomObjectsResult, ImportFileCabinetResult, ImportObjectsResult, TemplateCustomTypeInfo,
+} from './types'
 import { ATTRIBUTE_PREFIX, CDATA_TAG_NAME } from './constants'
-import { isCustomTypeInfo, isFileCustomizationInfo, isFolderCustomizationInfo, isTemplateCustomTypeInfo } from './utils'
+import {
+  isCustomTypeInfo, isFileCustomizationInfo, isFolderCustomizationInfo, isTemplateCustomTypeInfo,
+  mergeTypeToInstances,
+} from './utils'
 
 const { makeArray } = collections.array
 const { withLimitedConcurrency } = promises.array
@@ -327,11 +333,13 @@ export default class SdfClient {
   async getCustomObjects(typeNames: string[], query: NetsuiteQuery):
     Promise<GetCustomObjectsResult> {
     if (typeNames.every(type => !query.isTypeMatch(type))) {
-      return { elements: [], failedToFetchAllAtOnce: false }
+      return { elements: [], failedToFetchAllAtOnce: false, failedTypeToInstances: {} }
     }
 
     const { executor, projectName, authId } = await this.initProject()
-    const { failedToFetchAllAtOnce } = await this.importObjects(executor, typeNames, query)
+    const { failedToFetchAllAtOnce, failedTypeToInstances } = await this.importObjects(
+      executor, typeNames, query
+    )
     const objectsDirPath = SdfClient.getObjectsDirPath(projectName)
     const filenames = await readDir(objectsDirPath)
     const scriptIdToFiles = _.groupBy(filenames, filename => filename.split(FILE_SEPARATOR)[0])
@@ -349,48 +357,55 @@ export default class SdfClient {
       })
     )
     await this.projectCleanup(projectName, authId)
-    return { elements, failedToFetchAllAtOnce }
+    return { elements, failedToFetchAllAtOnce, failedTypeToInstances }
   }
 
   private async importObjects(
     executor: CommandActionExecutor,
     typeNames: string[],
     query: NetsuiteQuery
-  ): Promise<{ failedToFetchAllAtOnce: boolean }> {
-    const importAllAtOnce = async (): Promise<boolean> => {
+  ): Promise<{ failedToFetchAllAtOnce: boolean; failedTypeToInstances: NetsuiteQueryParameters['types'] }> {
+    const importAllAtOnce = async (): Promise<NetsuiteQueryParameters['types'] | undefined> => {
       log.debug('Fetching all custom objects at once')
       try {
         // When fetchAllAtOnce we use the below heuristic in order to define a proper timeout,
         // instead of adding another configuration value
-        await this.runImportObjectsCommand(executor, ALL, ALL, this.fetchTypeTimeoutInMinutes * 4)
-        return true
+        return await this.runImportObjectsCommand(
+          executor, ALL, ALL, this.fetchTypeTimeoutInMinutes * 4
+        )
       } catch (e) {
         log.warn('Attempt to fetch all custom objects has failed')
         log.warn(e)
-        return false
+        return undefined
       }
     }
 
-    if (this.fetchAllTypesAtOnce && await importAllAtOnce()) {
-      return { failedToFetchAllAtOnce: false }
+    if (this.fetchAllTypesAtOnce) {
+      const failedTypeToInstances = await importAllAtOnce()
+      if (failedTypeToInstances !== undefined) {
+        return { failedToFetchAllAtOnce: false, failedTypeToInstances }
+      }
     }
-    await this.importObjectsInChunks(executor, typeNames, query)
-    return { failedToFetchAllAtOnce: this.fetchAllTypesAtOnce }
+    const failedTypeToInstances = await this.importObjectsInChunks(executor, typeNames, query)
+    return { failedToFetchAllAtOnce: this.fetchAllTypesAtOnce, failedTypeToInstances }
   }
 
   private async importObjectsInChunks(
     executor: CommandActionExecutor,
     typeNames: string[],
     query: NetsuiteQuery
-  ): Promise<void> {
+  ): Promise<NetsuiteQueryParameters['types']> {
     const importObjectsChunk = async (
       { type, ids, index, total }: ObjectsChunk, retry = true
-    ): Promise<void> => {
+    ): Promise<NetsuiteQueryParameters['types']> => {
       try {
         log.debug('Starting to fetch chunk %d/%d with %d objects of type: %s', index, total, ids.length, type)
-        await this.runImportObjectsCommand(executor, type, ids.join(' '),
-          this.fetchTypeTimeoutInMinutes)
-        log.debug('Fetched chunk %d/%d with %d objects of type: %s', index, total, ids.length, type)
+        const failedTypeToInstances = await this.runImportObjectsCommand(
+          executor, type, ids.join(' '), this.fetchTypeTimeoutInMinutes
+        )
+        log.debug('Fetched chunk %d/%d with %d objects of type: %s. failedTypeToInstances: %o',
+          index, total, ids.length, type, failedTypeToInstances)
+        return failedTypeToInstances
       } catch (e) {
         log.warn('Failed to fetch chunk %d/%d with %d objects of type: %s', index, total, ids.length, type)
         log.warn(e)
@@ -399,15 +414,15 @@ export default class SdfClient {
         }
         if (ids.length === 1) {
           log.debug('Retrying to fetch chunk %d/%d with a single object of type: %s', index, total, type)
-          await importObjectsChunk({ type, ids, index, total }, false)
-          return
+          return importObjectsChunk({ type, ids, index, total }, false)
         }
         log.debug('Retrying to fetch chunk %d/%d with %d objects of type: %s with smaller chunks', index, total, ids.length, type)
         const middle = (ids.length + 1) / 2
-        await Promise.all([
+        const results = await Promise.all([
           importObjectsChunk({ type, ids: ids.slice(0, middle), index, total }),
           importObjectsChunk({ type, ids: ids.slice(middle, ids.length), index, total }),
         ])
+        return mergeTypeToInstances(...results)
       }
     }
 
@@ -433,10 +448,11 @@ export default class SdfClient {
     ).flatten(true).toArray()
 
     log.debug('Fetching custom objects by types in chunks')
-    await withLimitedConcurrency( // limit the number of open promises
+    const results = await withLimitedConcurrency( // limit the number of open promises
       idsChunks.map(idsChunk => () => importObjectsChunk(idsChunk)),
       this.sdfConcurrencyLimit
     )
+    return mergeTypeToInstances(...results)
   }
 
   private async runImportObjectsCommand(
@@ -444,8 +460,8 @@ export default class SdfClient {
     type: string,
     scriptIds: string,
     timeoutInMinutes: number,
-  ): Promise<ActionResult> {
-    return this.executeProjectAction(
+  ): Promise<NetsuiteQueryParameters['types']> {
+    const actionResult = await this.executeProjectAction(
       COMMANDS.IMPORT_OBJECTS,
       {
         destinationfolder: `${FILE_CABINET_PATH_SEPARATOR}${OBJECTS_DIR}`,
@@ -457,6 +473,16 @@ export default class SdfClient {
       executor,
       timeoutInMinutes
     )
+    const importResult = actionResult.data as ImportObjectsResult
+    const failedTypeToInstances = new collections.map.DefaultMap<string, string[]>(() => [])
+
+    importResult.failedImports.forEach(failedImport => {
+      if (failedImport.customObject.result.message.includes('unexpected error')) {
+        log.debug('Failed to fetch (%s) instance due to SDF unexpected error: (%s)', failedImport.customObject.type, failedImport.customObject.id)
+        failedTypeToInstances.get(failedImport.customObject.type).push(failedImport.customObject.id)
+      }
+    })
+    return Object.fromEntries(failedTypeToInstances.entries())
   }
 
   async listInstances(

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { Values } from '@salto-io/adapter-api'
+import { NetsuiteQueryParameters } from '../query'
 
 export interface CustomizationInfo {
   typeName: string
@@ -41,9 +42,26 @@ export interface FolderCustomizationInfo extends CustomizationInfo {
 export type GetCustomObjectsResult = {
   elements: CustomTypeInfo[]
   failedToFetchAllAtOnce: boolean
+  failedTypeToInstances: NetsuiteQueryParameters['types']
 }
 
 export type ImportFileCabinetResult = {
   elements: (FileCustomizationInfo | FolderCustomizationInfo)[]
-  failedPaths: string[]
+  failedPaths: NetsuiteQueryParameters['filePaths']
+}
+
+export type ImportObjectsResult = {
+  errorImports: unknown
+  successfulImports: unknown
+  failedImports: {
+    customObject: {
+      id: string
+      type: string
+      result: {
+        code: 'FAILED'
+        message: string
+      }
+    }
+    referencedFileImportResult: unknown
+  }[]
 }

--- a/packages/netsuite-adapter/src/client/utils.ts
+++ b/packages/netsuite-adapter/src/client/utils.ts
@@ -39,7 +39,7 @@ export const mergeTypeToInstances = (
   _.mergeWith(
     {},
     ...typeToInstances,
-    (objValue: string[], srcValue: string[]) => (
+    (objValue: string[] | undefined, srcValue: string[]) => (
       objValue ? [...objValue, ...srcValue] : srcValue
     )
   )

--- a/packages/netsuite-adapter/src/client/utils.ts
+++ b/packages/netsuite-adapter/src/client/utils.ts
@@ -13,8 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { FILE, FOLDER } from '../constants'
 import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, TemplateCustomTypeInfo } from './types'
+import { NetsuiteQueryParameters } from '../query'
 
 export const isCustomTypeInfo = (customizationInfo: CustomizationInfo):
   customizationInfo is CustomTypeInfo => 'scriptId' in customizationInfo
@@ -30,3 +32,14 @@ export const isFileCustomizationInfo = (customizationInfo: CustomizationInfo):
 export const isFolderCustomizationInfo = (customizationInfo: CustomizationInfo):
   customizationInfo is FolderCustomizationInfo =>
   customizationInfo.typeName === FOLDER
+
+export const mergeTypeToInstances = (
+  ...typeToInstances: NetsuiteQueryParameters['types'][]
+): NetsuiteQueryParameters['types'] =>
+  _.mergeWith(
+    {},
+    ...typeToInstances,
+    (objValue: string[], srcValue: string[]) => (
+      objValue ? [...objValue, ...srcValue] : srcValue
+    )
+  )

--- a/packages/netsuite-adapter/test/utils.ts
+++ b/packages/netsuite-adapter/test/utils.ts
@@ -26,3 +26,7 @@ export type MockInterface<T extends {}> = {
     ? MockFunction<T[k]>
     : MockInterface<T[k]>
 }
+
+export const mockFunction = <T extends (...args: never[]) => unknown>(): MockFunction<T> => (
+  jest.fn()
+)


### PR DESCRIPTION
When we run SDF importObjects command we have few types of failures we encountered.
1. An error is thrown
2. In the response it's written that a certain object has failed to be imported due to "_You cannot download the XML file for this object because it is locked_."
3. In the response it's written that a certain object has failed to be imported due to "_An unexpected error has occurred_"

When #.1 happens we fail the fetch.
When #.2 happens we ignore it and it appears in the logs

This PR handles #.3 by adding the failing instances to the types skipList.
We decided to go with this approach as these failures are almost consistent. We saw in few customers' accounts that the same 10-70 instances fail to be imported due to that error message.
We also saw once in a while that a certain instance has failed to be imported due to that reason and in the next fetch it succeeded.

When a certain instance has this error it means that its XML is not downloadable also via the UI.
The purpose of adding it to the skipList is to let the user know that there are instances that we failed to import and s/he has to fix the issue, which probably indicates on a misconfigured element in NetSuite, in NetSuite UI.

---
**_Release Notes_:** 
NetSuite Adapter: Suggest adding instances to the types' skipList in case Salto fails to fetch them due to an unexpected error in SDF which indicates on a misconfigured element.
