### PR TITLE
SALTO-1198: Netsuite Adapter uses the changes detection mechanism

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -41,6 +41,7 @@ import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, n
 import { createServerTimeElements, getLastServerTime } from './server_time'
 import { getChangedObjects } from './changes_detector/changes_detector'
 import NetsuiteClient from './client/client'
+import { createDateRange } from './changes_detector/date_range'
 
 const { makeArray } = collections.array
 
@@ -130,7 +131,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       ? andQuery(changedObjectsQuery, fetchQuery)
       : fetchQuery
 
-    const isPartial = this.fetchTarget !== undefined || changedObjectsQuery !== undefined
+    const isPartial = this.fetchTarget !== undefined
 
     const getCustomObjectsResult = this.client.getCustomObjects(
       Object.keys(customTypes),
@@ -172,7 +173,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     Promise<{ serverTimeElements: Element[]; changedObjectsQuery?: NetsuiteQuery }> {
     const sysInfo = await this.client.getSystemInformation()
     if (sysInfo === undefined) {
-      log.debug('Failed to get sysInfo, skipping SuiteApp operations')
+      log.warn('Failed to get sysInfo, skipping SuiteApp operations')
       return { serverTimeElements: [] }
     }
 
@@ -189,7 +190,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     const changedObjectsQuery = await getChangedObjects(
       this.client,
       fetchQuery,
-      { start: lastFetchTime, end: sysInfo.time }
+      createDateRange(lastFetchTime, sysInfo.time)
     )
 
     return { serverTimeElements: [], changedObjectsQuery }

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -20,16 +20,15 @@ import {
 import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
 import { resolveValues } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 import {
   createInstanceElement, getLookUpName, toCustomizationInfo,
 } from './transformer'
 import {
   customTypes, getAllTypes, fileCabinetTypes,
 } from './types'
-import {
-  TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST, DEPLOY_REFERENCED_ELEMENTS, INTEGRATION, FETCH_TARGET,
-  SKIP_LIST,
-} from './constants'
+import { TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST, DEPLOY_REFERENCED_ELEMENTS,
+  INTEGRATION, FETCH_TARGET, SKIP_LIST } from './constants'
 import replaceInstanceReferencesFilter from './filters/instance_references'
 import convertLists from './filters/convert_lists'
 import consistentValues from './filters/consistent_values'
@@ -38,10 +37,14 @@ import {
   getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS,
 } from './config'
 import { getAllReferencedInstances, getRequiredReferencedInstances } from './reference_dependencies'
-import { andQuery, buildNetsuiteQuery, NetsuiteQueryParameters, notQuery } from './query'
+import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery } from './query'
+import { createServerTimeElements, getLastServerTime } from './server_time'
+import { getChangedObjects } from './changes_detector/changes_detector'
 import NetsuiteClient from './client/client'
 
 const { makeArray } = collections.array
+
+const log = logger(module)
 
 export interface NetsuiteAdapterParams {
   client: NetsuiteClient
@@ -115,11 +118,19 @@ export default class NetsuiteAdapter implements AdapterOperations {
       filePaths: this.filePathRegexSkipList.map(reg => `.*${reg}.*`),
     })
 
-    const fetchQuery = [
+    let fetchQuery = [
       this.fetchTarget && buildNetsuiteQuery(this.fetchTarget),
       this.skipList && notQuery(buildNetsuiteQuery(this.skipList)),
       notQuery(deprecatedSkipList),
     ].filter(values.isDefined).reduce(andQuery)
+
+
+    const { serverTimeElements, changedObjectsQuery } = await this.runSuiteAppOperations(fetchQuery)
+    fetchQuery = changedObjectsQuery !== undefined
+      ? andQuery(changedObjectsQuery, fetchQuery)
+      : fetchQuery
+
+    const isPartial = this.fetchTarget !== undefined || changedObjectsQuery !== undefined
 
     const getCustomObjectsResult = this.client.getCustomObjects(
       Object.keys(customTypes),
@@ -144,9 +155,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
         ?? fileCabinetTypes[customizationInfo.typeName]
       return type ? createInstanceElement(customizationInfo, type, this.getElemIdFunc) : undefined
     }).filter(isInstanceElement)
-    const elements = [...getAllTypes(), ...instances]
-
-    const isPartial = this.fetchTarget !== undefined
+    const elements = [...getAllTypes(), ...instances, ...serverTimeElements]
 
     progressReporter.reportProgress({ message: 'Finished fetching instances. Running filters for additional information' })
     await this.runFiltersOnFetch(elements, this.elementsSource, isPartial)
@@ -157,6 +166,33 @@ export default class NetsuiteAdapter implements AdapterOperations {
       return { elements, isPartial }
     }
     return { elements, updatedConfig, isPartial }
+  }
+
+  private async runSuiteAppOperations(fetchQuery: NetsuiteQuery):
+    Promise<{ serverTimeElements: Element[]; changedObjectsQuery?: NetsuiteQuery }> {
+    const sysInfo = await this.client.getSystemInformation()
+    if (sysInfo === undefined) {
+      log.debug('Failed to get sysInfo, skipping SuiteApp operations')
+      return { serverTimeElements: [] }
+    }
+
+    if (this.fetchTarget === undefined) {
+      return { serverTimeElements: createServerTimeElements(sysInfo.time) }
+    }
+
+    const lastFetchTime = await getLastServerTime(this.elementsSource)
+    if (lastFetchTime === undefined) {
+      log.debug('Failed to get last fetch time')
+      return { serverTimeElements: [] }
+    }
+
+    const changedObjectsQuery = await getChangedObjects(
+      this.client,
+      fetchQuery,
+      { start: lastFetchTime, end: sysInfo.time }
+    )
+
+    return { serverTimeElements: [], changedObjectsQuery }
   }
 
   private getAllRequiredReferencedInstances(

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -133,7 +133,8 @@ const netsuiteConfigFromConfig = (config: Readonly<InstanceElement> | undefined)
 
 const netsuiteCredentialsFromCredentials = (credentials: Readonly<InstanceElement>): Credentials =>
   ({
-    accountId: credentials.value.accountId,
+    // accountId must be uppercased as described in https://github.com/oracle/netsuite-suitecloud-sdk/issues/140
+    accountId: credentials.value.accountId.toUpperCase().replace('-', '_'),
     tokenId: credentials.value.tokenId,
     tokenSecret: credentials.value.tokenSecret,
     suiteAppTokenId: credentials.value.suiteAppTokenId === '' ? undefined : credentials.value.suiteAppTokenId,

--- a/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
@@ -22,7 +22,6 @@ import scriptDetector from './changes_detectors/script'
 import roleDetector from './changes_detectors/role'
 import workflowDetector from './changes_detectors/workflow'
 import savedSearchDetector from './changes_detectors/savedsearch'
-import { formatSavedSearchDateRange } from './formats'
 import { ChangedType, DateRange } from './types'
 import NetsuiteClient from '../client/client'
 
@@ -38,7 +37,7 @@ export const DETECTORS = [
   savedSearchDetector,
 ]
 
-const SUPPORTED_TYPES = new Set(DETECTORS.map(detector => detector.getTypes()).flat())
+const SUPPORTED_TYPES = new Set(DETECTORS.flatMap(detector => detector.getTypes()))
 
 const getChangedInternalIds = async (client: NetsuiteClient, dateRange: DateRange):
 Promise<Set<number> | undefined> => {
@@ -49,7 +48,7 @@ Promise<Set<number> | undefined> => {
   const results = await client.runSavedSearchQuery({
     type: 'systemnote',
     filters: [
-      ['date', 'within', ...formatSavedSearchDateRange(dateRange)],
+      ['date', 'within', ...dateRange.toSavedSearchRange()],
     ],
     columns: ['recordid'],
   })

--- a/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
@@ -22,7 +22,7 @@ import scriptDetector from './changes_detectors/script'
 import roleDetector from './changes_detectors/role'
 import workflowDetector from './changes_detectors/workflow'
 import savedSearchDetector from './changes_detectors/savedsearch'
-import { formatSavedSearchDate } from './formats'
+import { formatSavedSearchDateRange } from './formats'
 import { ChangedType, DateRange } from './types'
 import NetsuiteClient from '../client/client'
 
@@ -38,6 +38,8 @@ export const DETECTORS = [
   savedSearchDetector,
 ]
 
+const SUPPORTED_TYPES = new Set(DETECTORS.map(detector => detector.getTypes()).flat())
+
 const getChangedInternalIds = async (client: NetsuiteClient, dateRange: DateRange):
 Promise<Set<number> | undefined> => {
   // Note that the internal id is NOT unique cross types and different instances
@@ -47,7 +49,7 @@ Promise<Set<number> | undefined> => {
   const results = await client.runSavedSearchQuery({
     type: 'systemnote',
     filters: [
-      ['date', 'within', formatSavedSearchDate(dateRange.start), formatSavedSearchDate(dateRange.end)],
+      ['date', 'within', ...formatSavedSearchDateRange(dateRange)],
     ],
     columns: ['recordid'],
   })
@@ -118,10 +120,15 @@ export const getChangedObjects = async (
   const types = new Set(changedTypes.map(type => type.name))
 
   log.debug('Finished to look for changed objects')
+  log.debug(`${scriptIds.size} script ids changes were detected`)
+  log.debug(`${types.size} types changes were detected`)
+  log.debug(`${paths.size} paths changes were detected`)
 
   return {
     isTypeMatch: () => true,
-    isObjectMatch: objectID => scriptIds.has(objectID.scriptId) || types.has(objectID.type),
+    isObjectMatch: objectID => !SUPPORTED_TYPES.has(objectID.type)
+      || scriptIds.has(objectID.scriptId)
+      || types.has(objectID.type),
     isFileMatch: filePath => paths.has(filePath),
     areSomeFilesMatch: () => paths.size !== 0,
   }

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
-import { formatSuiteQLDateRange } from '../formats'
 import NetsuiteClient from '../../client/client'
 import { ChangedObject, DateRange, TypeChangesDetector } from '../types'
 
@@ -22,7 +21,7 @@ const log = logger(module)
 
 const getChanges = async (type: string, client: NetsuiteClient, dateRange: DateRange):
   Promise<ChangedObject[]> => {
-  const [startDate, endDate] = formatSuiteQLDateRange(dateRange)
+  const [startDate, endDate] = dateRange.toSuiteQLRange()
 
   const results = await client.runSuiteQL(`
       SELECT scriptid

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
@@ -14,18 +14,20 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
+import { formatSuiteQLDateRange } from '../formats'
 import NetsuiteClient from '../../client/client'
-import { formatSuiteQLDate } from '../formats'
 import { ChangedObject, DateRange, TypeChangesDetector } from '../types'
 
 const log = logger(module)
 
 const getChanges = async (type: string, client: NetsuiteClient, dateRange: DateRange):
   Promise<ChangedObject[]> => {
+  const [startDate, endDate] = formatSuiteQLDateRange(dateRange)
+
   const results = await client.runSuiteQL(`
       SELECT scriptid
       FROM ${type}
-      WHERE lastmodifieddate BETWEEN '${formatSuiteQLDate(dateRange.start)}' AND '${formatSuiteQLDate(dateRange.end)}'
+      WHERE lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
     `)
 
   if (results === undefined) {

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/file_cabinet.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/file_cabinet.ts
@@ -15,25 +15,26 @@
 */
 import path from 'path'
 import { logger } from '@salto-io/logging'
-import { formatSuiteQLDate } from '../formats'
+import { formatSuiteQLDateRange } from '../formats'
 import { FileCabinetChangesDetector } from '../types'
 
 const log = logger(module)
 
 
 export const getChangedFiles: FileCabinetChangesDetector = async (client, dateRange) => {
+  const [startDate, endDate] = formatSuiteQLDateRange(dateRange)
+
   const results = await client.runSuiteQL(`
     SELECT mediaitemfolder.appfolder, file.name, file.id
     FROM file
     JOIN mediaitemfolder ON mediaitemfolder.id = file.folder
-    WHERE file.lastmodifieddate BETWEEN '${formatSuiteQLDate(dateRange.start)}' AND '${formatSuiteQLDate(dateRange.end)}'
+    WHERE file.lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
   `)
 
   if (results === undefined) {
     log.warn('file changes query failed')
     return []
   }
-
   return results
     .filter((res): res is { name: string; appfolder: string; id: string } => {
       if ([res.appfolder, res.name, res.id].some(val => typeof val !== 'string')) {
@@ -50,10 +51,12 @@ export const getChangedFiles: FileCabinetChangesDetector = async (client, dateRa
 }
 
 export const getChangedFolders: FileCabinetChangesDetector = async (client, dateRange) => {
+  const [startDate, endDate] = formatSuiteQLDateRange(dateRange)
+
   const results = await client.runSuiteQL(`
     SELECT appfolder, id
     FROM mediaitemfolder
-    WHERE lastmodifieddate BETWEEN '${formatSuiteQLDate(dateRange.start)}' AND '${formatSuiteQLDate(dateRange.end)}'
+    WHERE lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
   `)
 
   if (results === undefined) {

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/file_cabinet.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/file_cabinet.ts
@@ -15,14 +15,13 @@
 */
 import path from 'path'
 import { logger } from '@salto-io/logging'
-import { formatSuiteQLDateRange } from '../formats'
 import { FileCabinetChangesDetector } from '../types'
 
 const log = logger(module)
 
 
 export const getChangedFiles: FileCabinetChangesDetector = async (client, dateRange) => {
-  const [startDate, endDate] = formatSuiteQLDateRange(dateRange)
+  const [startDate, endDate] = dateRange.toSuiteQLRange()
 
   const results = await client.runSuiteQL(`
     SELECT mediaitemfolder.appfolder, file.name, file.id
@@ -51,7 +50,7 @@ export const getChangedFiles: FileCabinetChangesDetector = async (client, dateRa
 }
 
 export const getChangedFolders: FileCabinetChangesDetector = async (client, dateRange) => {
-  const [startDate, endDate] = formatSuiteQLDateRange(dateRange)
+  const [startDate, endDate] = dateRange.toSuiteQLRange()
 
   const results = await client.runSuiteQL(`
     SELECT appfolder, id

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/role.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/role.ts
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
-import { formatSavedSearchDateRange, formatSuiteQLDateRange } from '../formats'
 import { ChangedObject, TypeChangesDetector } from '../types'
 
 const log = logger(module)
@@ -78,7 +77,7 @@ const parsePermissionRolesChanges = (
 
 const changesDetector: TypeChangesDetector = {
   getChanges: async (client, dateRange) => {
-    const [startDate, endDate] = formatSuiteQLDateRange(dateRange)
+    const [startDate, endDate] = dateRange.toSuiteQLRange()
 
     const rolesChangesPromise = client.runSuiteQL(`
       SELECT role.scriptid, role.id
@@ -90,7 +89,7 @@ const changesDetector: TypeChangesDetector = {
     const permissionChangesPromise = client.runSavedSearchQuery({
       type: 'role',
       columns: ['internalid'],
-      filters: [['permchangedate', 'within', ...formatSavedSearchDateRange(dateRange)]],
+      filters: [['permchangedate', 'within', ...dateRange.toSavedSearchRange()]],
     })
 
     const allRolesPromise = client.runSuiteQL(`

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/savedsearch.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/savedsearch.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
-import { formatSavedSearchDate } from '../formats'
+import { formatSavedSearchDateRange } from '../formats'
 import { TypeChangesDetector } from '../types'
 
 const log = logger(module)
@@ -24,7 +24,7 @@ const changesDetector: TypeChangesDetector = {
     const results = await client.runSavedSearchQuery({
       type: 'savedsearch',
       columns: ['id'],
-      filters: [['datemodified', 'within', formatSavedSearchDate(dateRange.start), formatSavedSearchDate(dateRange.end)]],
+      filters: [['datemodified', 'within', ...formatSavedSearchDateRange(dateRange)]],
     })
 
     if (results === undefined) {

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/savedsearch.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/savedsearch.ts
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
-import { formatSavedSearchDateRange } from '../formats'
 import { TypeChangesDetector } from '../types'
 
 const log = logger(module)
@@ -24,7 +23,7 @@ const changesDetector: TypeChangesDetector = {
     const results = await client.runSavedSearchQuery({
       type: 'savedsearch',
       columns: ['id'],
-      filters: [['datemodified', 'within', ...formatSavedSearchDateRange(dateRange)]],
+      filters: [['datemodified', 'within', ...dateRange.toSavedSearchRange()]],
     })
 
     if (results === undefined) {

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/script.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/script.ts
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
-import { formatSuiteQLDateRange } from '../formats'
 import { ChangedObject, TypeChangesDetector } from '../types'
 
 const log = logger(module)
@@ -73,7 +72,7 @@ const hasFieldChanges = (changes?: Record<string, unknown>[]): boolean => {
 
 const changesDetector: TypeChangesDetector = {
   getChanges: async (client, dateRange) => {
-    const [startDate, endDate] = formatSuiteQLDateRange(dateRange)
+    const [startDate, endDate] = dateRange.toSuiteQLRange()
 
     const scriptChangesPromise = client.runSuiteQL(`
       SELECT script.scriptid, script.id

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/workflow.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/workflow.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
-import { formatSavedSearchDate } from '../formats'
+import { formatSavedSearchDateRange } from '../formats'
 import { TypeChangesDetector } from '../types'
 
 const log = logger(module)
@@ -26,7 +26,7 @@ const changesDetector: TypeChangesDetector = {
       filters: [
         ['recordtype', 'is', '-129'],
         'and',
-        ['date', 'within', formatSavedSearchDate(dateRange.start), formatSavedSearchDate(dateRange.end)],
+        ['date', 'within', ...formatSavedSearchDateRange(dateRange)],
       ],
       columns: ['recordid'],
     })

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/workflow.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/workflow.ts
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
-import { formatSavedSearchDateRange } from '../formats'
 import { TypeChangesDetector } from '../types'
 
 const log = logger(module)
@@ -26,7 +25,7 @@ const changesDetector: TypeChangesDetector = {
       filters: [
         ['recordtype', 'is', '-129'],
         'and',
-        ['date', 'within', ...formatSavedSearchDateRange(dateRange)],
+        ['date', 'within', ...dateRange.toSavedSearchRange()],
       ],
       columns: ['recordid'],
     })

--- a/packages/netsuite-adapter/src/changes_detector/date_range.ts
+++ b/packages/netsuite-adapter/src/changes_detector/date_range.ts
@@ -15,22 +15,26 @@
 */
 import { DateRange } from './types'
 
-export const formatSuiteQLDate = (date: Date): string => `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}`
+const formatSuiteQLDate = (date: Date): string => `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}`
 
-export const formatSavedSearchDate = (date: Date): string => {
+const formatSavedSearchDate = (date: Date): string => {
   const hour = date.getUTCHours() > 12 ? date.getUTCHours() - 12 : date.getUTCHours()
   const dayTime = date.getUTCHours() >= 12 ? 'pm' : 'am'
   return `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()} ${hour}:${date.getUTCMinutes()} ${dayTime}`
 }
 
-export const formatSuiteQLDateRange = (dateRange: DateRange): [string, string] => {
-  const endDate = new Date(dateRange.end)
-  endDate.setDate(endDate.getDate() + 1)
-  return [formatSuiteQLDate(dateRange.start), formatSuiteQLDate(endDate)]
-}
 
-export const formatSavedSearchDateRange = (dateRange: DateRange): [string, string] => {
-  const endDate = new Date(dateRange.end)
-  endDate.setMinutes(endDate.getMinutes() + 1)
-  return [formatSavedSearchDate(dateRange.start), formatSavedSearchDate(endDate)]
-}
+export const createDateRange = (start: Date, end: Date): DateRange => ({
+  start,
+  end,
+  toSuiteQLRange: () => {
+    const endDate = new Date(end)
+    endDate.setDate(endDate.getDate() + 1)
+    return [formatSuiteQLDate(start), formatSuiteQLDate(endDate)]
+  },
+  toSavedSearchRange: () => {
+    const endDate = new Date(end)
+    endDate.setMinutes(endDate.getMinutes() + 1)
+    return [formatSavedSearchDate(start), formatSavedSearchDate(endDate)]
+  },
+})

--- a/packages/netsuite-adapter/src/changes_detector/formats.ts
+++ b/packages/netsuite-adapter/src/changes_detector/formats.ts
@@ -13,10 +13,24 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { DateRange } from './types'
+
 export const formatSuiteQLDate = (date: Date): string => `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}`
 
 export const formatSavedSearchDate = (date: Date): string => {
   const hour = date.getUTCHours() > 12 ? date.getUTCHours() - 12 : date.getUTCHours()
   const dayTime = date.getUTCHours() >= 12 ? 'pm' : 'am'
   return `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()} ${hour}:${date.getUTCMinutes()} ${dayTime}`
+}
+
+export const formatSuiteQLDateRange = (dateRange: DateRange): [string, string] => {
+  const endDate = new Date(dateRange.end)
+  endDate.setDate(endDate.getDate() + 1)
+  return [formatSuiteQLDate(dateRange.start), formatSuiteQLDate(endDate)]
+}
+
+export const formatSavedSearchDateRange = (dateRange: DateRange): [string, string] => {
+  const endDate = new Date(dateRange.end)
+  endDate.setMinutes(endDate.getMinutes() + 1)
+  return [formatSavedSearchDate(dateRange.start), formatSavedSearchDate(endDate)]
 }

--- a/packages/netsuite-adapter/src/changes_detector/types.ts
+++ b/packages/netsuite-adapter/src/changes_detector/types.ts
@@ -31,6 +31,8 @@ export type Change = ChangedType | ChangedObject
 export type DateRange = {
   start: Date
   end: Date
+  toSuiteQLRange: () => [string, string]
+  toSavedSearchRange: () => [string, string]
 }
 
 export type TypeChangesDetector = {

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -15,12 +15,15 @@
 */
 
 import { AccountId } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
 import { NetsuiteQuery } from '../query'
 import { Credentials } from './credentials'
 import SdfClient from './sdf_client'
 import SuiteAppClient from './suiteapp_client/suiteapp_client'
-import { SavedSearchQuery } from './suiteapp_client/types'
+import { SavedSearchQuery, SystemInformation } from './suiteapp_client/types'
 import { CustomizationInfo, GetCustomObjectsResult, ImportFileCabinetResult } from './types'
+
+const log = logger(module)
 
 export default class NetsuiteClient {
   private sdfClient: SdfClient
@@ -29,6 +32,11 @@ export default class NetsuiteClient {
   constructor(sdfClient: SdfClient, suiteAppClient?: SuiteAppClient) {
     this.sdfClient = sdfClient
     this.suiteAppClient = suiteAppClient
+    if (this.suiteAppClient === undefined) {
+      log.debug('Salto SuiteApp not configured')
+    } else {
+      log.debug('Salto SuiteApp configured')
+    }
   }
 
   static async validateCredentials(credentials: Credentials): Promise<AccountId> {
@@ -75,5 +83,9 @@ export default class NetsuiteClient {
   public async runSavedSearchQuery(query: SavedSearchQuery):
     Promise<Record<string, unknown>[] | undefined> {
     return this.suiteAppClient?.runSavedSearchQuery(query)
+  }
+
+  public async getSystemInformation(): Promise<SystemInformation | undefined> {
+    return this.suiteAppClient?.getSystemInformation()
   }
 }

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -126,7 +126,6 @@ export const convertToFolderCustomizationInfo = (xmlContent: string, path: strin
     { path }
   )
 
-
 export const convertToXmlContent = (customizationInfo: CustomizationInfo): string =>
   // eslint-disable-next-line new-cap
   new xmlParser.j2xParser({
@@ -173,11 +172,7 @@ export default class SdfClient {
     credentials,
     config,
   }: SdfClientOpts) {
-    this.credentials = {
-      ...credentials,
-      // accountId must be uppercased as decribed in https://github.com/oracle/netsuite-suitecloud-sdk/issues/140
-      accountId: credentials.accountId.toUpperCase().replace('-', '_'),
-    }
+    this.credentials = credentials
     this.fetchAllTypesAtOnce = config?.fetchAllTypesAtOnce ?? DEFAULT_FETCH_ALL_TYPES_AT_ONCE
     this.fetchTypeTimeoutInMinutes = config?.fetchTypeTimeoutInMinutes
       ?? DEFAULT_FETCH_TYPE_TIMEOUT_IN_MINUTES

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -45,7 +45,7 @@ export default class SuiteAppClient {
   constructor(params: SuiteAppClientParameters) {
     this.credentials = params.credentials
     this.callsLimiter = new Bottleneck({
-      concurrencyLimit: params.config?.suiteAppConcurrencyLimit ?? DEFAULT_CONCURRENCY,
+      maxConcurrent: params.config?.suiteAppConcurrencyLimit ?? DEFAULT_CONCURRENCY,
     })
 
     const accountIdUrl = params.credentials.accountId.replace('_', '-')
@@ -97,7 +97,7 @@ export default class SuiteAppClient {
     try {
       const results = await this.sendRestletRequest('sysInfo')
 
-      if (!this.ajv.validate<{ time: string; appVersion: number[] }>(
+      if (!this.ajv.validate<{ time: number; appVersion: number[] }>(
         SYSTEM_INFORMATION_SCHEME,
         results
       )) {

--- a/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
@@ -100,7 +100,7 @@ export type SavedSearchQuery = {
 export const SYSTEM_INFORMATION_SCHEME = {
   type: 'object',
   properties: {
-    time: { type: 'string' },
+    time: { type: 'number' },
     appVersion: {
       type: 'array',
       items: { type: 'number' },

--- a/packages/netsuite-adapter/src/query.ts
+++ b/packages/netsuite-adapter/src/query.ts
@@ -87,7 +87,7 @@ export const andQuery = (firstQuery: NetsuiteQuery, secondQuery: NetsuiteQuery):
 })
 
 export const notQuery = (query: NetsuiteQuery): NetsuiteQuery => ({
-  isTypeMatch: () => true,
+  isTypeMatch: typeName => !query.isTypeMatch(typeName),
   isObjectMatch: objectID => !query.isObjectMatch(objectID),
   isFileMatch: filePath => !query.isFileMatch(filePath),
   areSomeFilesMatch: () => true,

--- a/packages/netsuite-adapter/src/server_time.ts
+++ b/packages/netsuite-adapter/src/server_time.ts
@@ -1,0 +1,68 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, Element, ElemID, BuiltinTypes, CORE_ANNOTATIONS, InstanceElement, ReadOnlyElementsSource, isInstanceElement } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { NETSUITE, RECORDS_PATH, TYPES_PATH } from './constants'
+
+const log = logger(module)
+
+// The random suffix is to avoid collisions with netsuite types
+export const SERVER_TIME_TYPE_NAME = 'server_time5a2ca8777a7743c3814ec83e3c4f0147'
+
+
+export const createServerTimeElements = (time: Date): Element[] => {
+  log.debug(`Creating server time elements with time: ${time.toJSON()}`)
+  const type = new ObjectType({
+    elemID: new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME),
+    isSettings: true,
+    fields: {
+      serverTime: { type: BuiltinTypes.STRING },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.HIDDEN]: true,
+    },
+    path: [NETSUITE, TYPES_PATH, SERVER_TIME_TYPE_NAME],
+  })
+
+  const instance = new InstanceElement(
+    ElemID.CONFIG_NAME,
+    type,
+    { serverTime: time.toJSON() },
+    [NETSUITE, RECORDS_PATH, SERVER_TIME_TYPE_NAME],
+    { [CORE_ANNOTATIONS.HIDDEN]: true },
+  )
+
+  return [type, instance]
+}
+
+export const getLastServerTime = async (elementsSource: ReadOnlyElementsSource):
+  Promise<Date | undefined> => {
+  log.debug('Getting server time')
+  const serverTimeElement = await elementsSource.get(new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME, 'instance', ElemID.CONFIG_NAME))
+
+  if (!isInstanceElement(serverTimeElement)) {
+    log.info('Server time not found in elements source')
+    return undefined
+  }
+
+  if (serverTimeElement.value.serverTime === undefined) {
+    log.info('serverTime value does not exists in server time instance')
+    return undefined
+  }
+
+  log.info(`Server time is ${serverTimeElement.value.serverTime}`)
+  return new Date(serverTimeElement.value.serverTime)
+}

--- a/packages/netsuite-adapter/src/server_time.ts
+++ b/packages/netsuite-adapter/src/server_time.ts
@@ -15,12 +15,11 @@
 */
 import { ObjectType, Element, ElemID, BuiltinTypes, CORE_ANNOTATIONS, InstanceElement, ReadOnlyElementsSource, isInstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { NETSUITE, RECORDS_PATH, TYPES_PATH } from './constants'
+import { NETSUITE } from './constants'
 
 const log = logger(module)
 
-// The random suffix is to avoid collisions with netsuite types
-export const SERVER_TIME_TYPE_NAME = 'server_time5a2ca8777a7743c3814ec83e3c4f0147'
+export const SERVER_TIME_TYPE_NAME = 'server_time'
 
 
 export const createServerTimeElements = (time: Date): Element[] => {
@@ -34,14 +33,13 @@ export const createServerTimeElements = (time: Date): Element[] => {
     annotations: {
       [CORE_ANNOTATIONS.HIDDEN]: true,
     },
-    path: [NETSUITE, TYPES_PATH, SERVER_TIME_TYPE_NAME],
   })
 
   const instance = new InstanceElement(
     ElemID.CONFIG_NAME,
     type,
     { serverTime: time.toJSON() },
-    [NETSUITE, RECORDS_PATH, SERVER_TIME_TYPE_NAME],
+    undefined,
     { [CORE_ANNOTATIONS.HIDDEN]: true },
   )
 
@@ -54,15 +52,16 @@ export const getLastServerTime = async (elementsSource: ReadOnlyElementsSource):
   const serverTimeElement = await elementsSource.get(new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME, 'instance', ElemID.CONFIG_NAME))
 
   if (!isInstanceElement(serverTimeElement)) {
-    log.info('Server time not found in elements source')
+    log.warn('Server time not found in elements source')
     return undefined
   }
 
-  if (serverTimeElement.value.serverTime === undefined) {
-    log.info('serverTime value does not exists in server time instance')
+  const { serverTime } = serverTimeElement.value
+  if (serverTime === undefined) {
+    log.warn('serverTime value does not exists in server time instance')
     return undefined
   }
 
-  log.info(`Server time is ${serverTimeElement.value.serverTime}`)
-  return new Date(serverTimeElement.value.serverTime)
+  log.info(`Last server time is ${serverTime}`)
+  return new Date(serverTime)
 }

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -600,10 +600,10 @@ describe('Adapter', () => {
         expect(getChangedObjectsMock).toHaveBeenCalledWith(
           expect.any(Object),
           expect.any(Object),
-          {
+          expect.objectContaining({
             start: new Date('1970-01-01T00:00:00.500Z'),
             end: new Date(1000),
-          },
+          }),
         )
       })
 

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -16,6 +16,7 @@
 
 import {
   ElemID, InstanceElement, StaticFile, ChangeDataType, DeployResult, getChangeElement, FetchOptions,
+  ObjectType,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
@@ -25,7 +26,7 @@ import { customTypes, fileCabinetTypes, getAllTypes } from '../src/types'
 import {
   ENTITY_CUSTOM_FIELD, SCRIPT_ID, SAVED_SEARCH, FILE, FOLDER, PATH, TRANSACTION_FORM, TYPES_TO_SKIP,
   FILE_PATHS_REGEX_SKIP_LIST, FETCH_ALL_TYPES_AT_ONCE, DEPLOY_REFERENCED_ELEMENTS,
-  FETCH_TYPE_TIMEOUT_IN_MINUTES, INTEGRATION, CLIENT_CONFIG, FETCH_TARGET,
+  FETCH_TYPE_TIMEOUT_IN_MINUTES, INTEGRATION, CLIENT_CONFIG, FETCH_TARGET, NETSUITE,
 } from '../src/constants'
 import { createInstanceElement, toCustomizationInfo } from '../src/transformer'
 import { convertToCustomTypeInfo } from '../src/client/sdf_client'
@@ -33,6 +34,9 @@ import { FilterCreator } from '../src/filter'
 import { configType, getConfigFromConfigChanges } from '../src/config'
 import { mockGetElemIdFunc, MockInterface } from './utils'
 import * as referenceDependenciesModule from '../src/reference_dependencies'
+import SuiteAppClient from '../src/client/suiteapp_client/suiteapp_client'
+import { SERVER_TIME_TYPE_NAME } from '../src/server_time'
+import * as changesDetector from '../src/changes_detector/changes_detector'
 import NetsuiteClient from '../src/client/client'
 import { FileCustomizationInfo, FolderCustomizationInfo } from '../src/client/types'
 
@@ -45,6 +49,8 @@ const getAllReferencedInstancesMock = referenceDependenciesModule
   .getAllReferencedInstances as jest.Mock
 getAllReferencedInstancesMock
   .mockImplementation((sourceInstances: ReadonlyArray<InstanceElement>) => sourceInstances)
+
+jest.mock('../src/changes_detector/changes_detector')
 
 const getRequiredReferencedInstancesMock = referenceDependenciesModule
   .getRequiredReferencedInstances as jest.Mock
@@ -134,7 +140,7 @@ describe('Adapter', () => {
       const typesToSkip = [SAVED_SEARCH, TRANSACTION_FORM, INTEGRATION]
       expect(_.pull(Object.keys(customTypes), ...typesToSkip).every(customObjectsQuery.isTypeMatch))
         .toBeTruthy()
-      expect(typesToSkip.every(customObjectsQuery.isTypeMatch)).toBeTruthy()
+      expect(typesToSkip.some(customObjectsQuery.isTypeMatch)).toBeFalsy()
 
       const fileCabinetQuery = (client.importFileCabinetContent as jest.Mock).mock.calls[0][0]
       expect(fileCabinetQuery.isFileMatch('Some/File/Regex')).toBeFalsy()
@@ -179,12 +185,12 @@ describe('Adapter', () => {
         expect(isPartial).toBeTruthy()
       })
 
-      it('should match the types that match fetchTarget and skipList', async () => {
+      it('should match the types that match fetchTarget and not in typesToSkip', async () => {
         await adapter.fetch(mockFetchOpts)
 
         const customObjectsQuery = (client.getCustomObjects as jest.Mock).mock.calls[0][1]
         expect(customObjectsQuery.isTypeMatch('addressForm')).toBeTruthy()
-        expect(_.pull(Object.keys(customTypes), 'addressForm', SAVED_SEARCH, TRANSACTION_FORM).some(customObjectsQuery.isTypeMatch)).toBeFalsy()
+        expect(_.pull(Object.keys(customTypes), 'addressForm').some(customObjectsQuery.isTypeMatch)).toBeFalsy()
         expect(customObjectsQuery.isTypeMatch(INTEGRATION)).toBeFalsy()
       })
 
@@ -231,11 +237,11 @@ describe('Adapter', () => {
       expect(onFetchMock).toHaveBeenNthCalledWith(2, 2)
     })
 
-    it('should call getCustomObjects with query that matches types that match the types in skipList', async () => {
+    it('should call getCustomObjects with query that only matches types that are not in typesToSkip', async () => {
       await netsuiteAdapter.fetch(mockFetchOpts)
       const query = (client.getCustomObjects as jest.Mock).mock.calls[0][1]
       expect(query.isTypeMatch(ENTITY_CUSTOM_FIELD)).toBeTruthy()
-      expect(query.isTypeMatch(SAVED_SEARCH)).toBeTruthy()
+      expect(query.isTypeMatch(SAVED_SEARCH)).toBeFalsy()
     })
 
     it('should return only the elements when having no config changes', async () => {
@@ -467,6 +473,159 @@ describe('Adapter', () => {
       await adapterAdd(instance)
       expect(getRequiredReferencedInstancesMock).toHaveBeenCalledTimes(1)
       expect(getAllReferencedInstancesMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('SuiteAppClient', () => {
+    const getSystemInformationMock = jest.fn().mockResolvedValue({
+      time: new Date(1000),
+      appVersion: [0, 1, 0],
+    })
+    let adapter: NetsuiteAdapter
+
+    const elementsSource = buildElementsSourceFromElements([])
+    const getElementMock = jest.spyOn(elementsSource, 'get')
+    const getChangedObjectsMock = jest.spyOn(changesDetector, 'getChangedObjects')
+
+    beforeEach(() => {
+      getElementMock.mockReset()
+
+      getChangedObjectsMock.mockReset()
+      getChangedObjectsMock.mockResolvedValue({
+        isTypeMatch: () => true,
+        isObjectMatch: objectID => objectID.scriptId.startsWith('aa'),
+        isFileMatch: () => true,
+        areSomeFilesMatch: () => true,
+      })
+
+      getSystemInformationMock.mockReset()
+      getSystemInformationMock.mockResolvedValue({
+        time: new Date(1000),
+        appVersion: [0, 1, 0],
+      })
+
+      const suiteAppClient = {
+        getSystemInformation: getSystemInformationMock,
+      } as unknown as SuiteAppClient
+
+      adapter = new NetsuiteAdapter({
+        client: new NetsuiteClient(client, suiteAppClient),
+        elementsSource,
+        filtersCreators: [firstDummyFilter, secondDummyFilter],
+        config,
+        getElemIdFunc: mockGetElemIdFunc,
+      })
+    })
+
+    it('should not create serverTime elements when getSystemInformation returns undefined', async () => {
+      getSystemInformationMock.mockResolvedValue(undefined)
+
+      const { elements } = await adapter.fetch(mockFetchOpts)
+      expect(elements.filter(
+        e => e.elemID.getFullName().includes(SERVER_TIME_TYPE_NAME)
+      )).toHaveLength(0)
+    })
+
+    it('should not create serverTime elements when fetchTarget parameter was passed', async () => {
+      const suiteAppClient = {
+        getSystemInformation: getSystemInformationMock,
+      } as unknown as SuiteAppClient
+
+      adapter = new NetsuiteAdapter({
+        client: new NetsuiteClient(client, suiteAppClient),
+        elementsSource,
+        filtersCreators: [firstDummyFilter, secondDummyFilter],
+        config: {
+          ...config,
+          [FETCH_TARGET]: {
+            types: {},
+            filePaths: [],
+          },
+        },
+        getElemIdFunc: mockGetElemIdFunc,
+      })
+
+      const { elements } = await adapter.fetch(mockFetchOpts)
+      expect(elements.filter(
+        e => e.elemID.getFullName().includes(SERVER_TIME_TYPE_NAME)
+      )).toHaveLength(0)
+    })
+    it('should create the serverTime elements when getSystemInformation returns the time', async () => {
+      const { elements } = await adapter.fetch(mockFetchOpts)
+      expect(elements.filter(
+        e => e.elemID.getFullName().includes(SERVER_TIME_TYPE_NAME)
+      )).toHaveLength(2)
+
+      const serverTimeInstance = elements.find(
+        e => e.elemID.isEqual(new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME, 'instance', ElemID.CONFIG_NAME))
+      )
+      expect((serverTimeInstance as InstanceElement)?.value?.serverTime)
+        .toEqual(new Date(1000).toJSON())
+      expect(getChangedObjectsMock).not.toHaveBeenCalled()
+    })
+
+    describe('getChangedObjects', () => {
+      beforeEach(() => {
+        getElementMock.mockResolvedValue(new InstanceElement(
+          ElemID.CONFIG_NAME,
+          new ObjectType({ elemID: new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME) }),
+          {
+            serverTime: '1970-01-01T00:00:00.500Z',
+          }
+        ))
+
+        const suiteAppClient = {
+          getSystemInformation: getSystemInformationMock,
+        } as unknown as SuiteAppClient
+
+        adapter = new NetsuiteAdapter({
+          client: new NetsuiteClient(client, suiteAppClient),
+          elementsSource,
+          filtersCreators: [firstDummyFilter, secondDummyFilter],
+          config: {
+            ...config,
+            [FETCH_TARGET]: {
+              types: {
+                workflow: ['.*'],
+              },
+              filePaths: [],
+            },
+          },
+          getElemIdFunc: mockGetElemIdFunc,
+        })
+      })
+      it('should call getChangedObjects with the right date range', async () => {
+        await adapter.fetch(mockFetchOpts)
+        expect(getElementMock).toHaveBeenCalledWith(new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME, 'instance', ElemID.CONFIG_NAME))
+        expect(getChangedObjectsMock).toHaveBeenCalledWith(
+          expect.any(Object),
+          expect.any(Object),
+          {
+            start: new Date('1970-01-01T00:00:00.500Z'),
+            end: new Date(1000),
+          },
+        )
+      })
+
+      it('should pass the received query to the client', async () => {
+        const getCustomObjectsMock = jest.spyOn(client, 'getCustomObjects')
+        await adapter.fetch(mockFetchOpts)
+
+        const passedQuery = getCustomObjectsMock.mock.calls[0][1]
+        expect(passedQuery.isObjectMatch({ scriptId: 'aaaa', type: 'workflow' })).toBeTruthy()
+        expect(passedQuery.isObjectMatch({ scriptId: 'bbbb', type: 'workflow' })).toBeFalsy()
+      })
+
+      it('should not call getChangedObjectsMock if server time instance is invalid', async () => {
+        getElementMock.mockResolvedValue(new InstanceElement(
+          ElemID.CONFIG_NAME,
+          new ObjectType({ elemID: new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME) }),
+          {}
+        ))
+        await adapter.fetch(mockFetchOpts)
+        expect(getElementMock).toHaveBeenCalledWith(new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME, 'instance', ElemID.CONFIG_NAME))
+        expect(getChangedObjectsMock).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -48,7 +48,7 @@ describe('NetsuiteAdapter creator', () => {
     ElemID.CONFIG_NAME,
     adapter.authenticationMethods.basic.credentialsType,
     {
-      accountId: 'foo',
+      accountId: 'foo-a',
       tokenId: 'bar',
       tokenSecret: 'secret',
       suiteAppTokenId: '',
@@ -91,7 +91,7 @@ describe('NetsuiteAdapter creator', () => {
     it('should call validateCredentials with the correct credentials', async () => {
       await adapter.validateCredentials(credentials)
       expect(netsuiteValidateMock).toHaveBeenCalledWith(expect.objectContaining({
-        accountId: 'foo',
+        accountId: 'FOO_A',
         tokenId: 'bar',
         tokenSecret: 'secret',
       }))
@@ -110,13 +110,13 @@ describe('NetsuiteAdapter creator', () => {
 
       await adapter.validateCredentials(cred)
       expect(netsuiteValidateMock).toHaveBeenCalledWith(expect.objectContaining({
-        accountId: 'foo',
+        accountId: 'FOO_A',
         tokenId: 'bar',
         tokenSecret: 'secret',
       }))
 
       expect(suiteAppClientValidateMock).toHaveBeenCalledWith({
-        accountId: 'foo',
+        accountId: 'FOO_A',
         suiteAppTokenId: 'aaa',
         suiteAppTokenSecret: 'bbb',
       })
@@ -159,7 +159,7 @@ describe('NetsuiteAdapter creator', () => {
       })
       expect(SdfClient).toHaveBeenCalledWith({
         credentials: {
-          accountId: 'foo',
+          accountId: 'FOO_A',
           tokenId: 'bar',
           tokenSecret: 'secret',
           suiteAppTokenId: undefined,
@@ -195,7 +195,7 @@ describe('NetsuiteAdapter creator', () => {
       })
       expect(SuiteAppClient).toHaveBeenCalledWith({
         credentials: {
-          accountId: 'foo',
+          accountId: 'FOO_A',
           suiteAppTokenId: 'aaa',
           suiteAppTokenSecret: 'bbb',
         },
@@ -225,7 +225,7 @@ describe('NetsuiteAdapter creator', () => {
       })
       expect(SuiteAppClient).toHaveBeenCalledWith({
         credentials: {
-          accountId: 'foo',
+          accountId: 'FOO_A',
           suiteAppTokenId: 'aaa',
           suiteAppTokenSecret: 'bbb',
         },

--- a/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
@@ -22,6 +22,7 @@ import scriptDetector from '../../src/changes_detector/changes_detectors/script'
 import { getChangedObjects } from '../../src/changes_detector/changes_detector'
 import NetsuiteClient from '../../src/client/client'
 import mockSdfClient from '../client/sdf_client'
+import { createDateRange } from '../../src/changes_detector/date_range'
 
 describe('changes_detector', () => {
   const query = {
@@ -64,7 +65,7 @@ describe('changes_detector', () => {
     await getChangedObjects(
       client,
       query,
-      { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+      createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
     )
     expect(getCustomRecordTypeChangesMock).toHaveBeenCalled()
     expect(getScriptChangesMock).not.toHaveBeenCalled()
@@ -74,7 +75,7 @@ describe('changes_detector', () => {
     const changedObjectsQuery = await getChangedObjects(
       client,
       query,
-      { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+      createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
     )
     expect(changedObjectsQuery.isFileMatch('/path/to/file')).toBeTruthy()
     expect(changedObjectsQuery.isFileMatch('/path/to/file2')).toBeFalsy()
@@ -96,7 +97,7 @@ describe('changes_detector', () => {
     const changedObjectsQuery = await getChangedObjects(
       client,
       query,
-      { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+      createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
     )
     expect(changedObjectsQuery.isFileMatch('/path/to/file')).toBeTruthy()
     expect(changedObjectsQuery.isFileMatch('/path/to/file2')).toBeTruthy()

--- a/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
@@ -81,10 +81,11 @@ describe('changes_detector', () => {
     expect(changedObjectsQuery.isFileMatch('/path/to')).toBeTruthy()
     expect(changedObjectsQuery.isFileMatch('/path/to/notExists')).toBeFalsy()
 
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'a' })).toBeTruthy()
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'b' })).toBeTruthy()
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'c' })).toBeFalsy()
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'd' })).toBeFalsy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'a' })).toBeTruthy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'b' })).toBeTruthy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'c' })).toBeFalsy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'd' })).toBeFalsy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'notSupported', scriptId: 'd' })).toBeTruthy()
 
     expect(changedObjectsQuery.isObjectMatch({ type: 'customrecordtype', scriptId: 'anything' })).toBeTruthy()
     expect(changedObjectsQuery.isTypeMatch('anything')).toBeTruthy()
@@ -102,10 +103,11 @@ describe('changes_detector', () => {
     expect(changedObjectsQuery.isFileMatch('/path/to')).toBeTruthy()
     expect(changedObjectsQuery.isFileMatch('/path/to/notExists')).toBeFalsy()
 
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'a' })).toBeTruthy()
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'b' })).toBeTruthy()
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'c' })).toBeTruthy()
-    expect(changedObjectsQuery.isObjectMatch({ type: '', scriptId: 'd' })).toBeFalsy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'a' })).toBeTruthy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'b' })).toBeTruthy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'c' })).toBeTruthy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'd' })).toBeFalsy()
+    expect(changedObjectsQuery.isObjectMatch({ type: 'notSupported', scriptId: 'd' })).toBeTruthy()
 
     expect(changedObjectsQuery.isObjectMatch({ type: 'customrecordtype', scriptId: 'anything' })).toBeTruthy()
   })

--- a/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
@@ -47,7 +47,7 @@ describe('custom_field', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
       SELECT scriptid
       FROM customfield
-      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/22/2021'
+      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
     `)
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
@@ -18,6 +18,7 @@ import { customFieldDetector as detector } from '../../src/changes_detector/chan
 import { Change } from '../../src/changes_detector/types'
 import NetsuiteClient from '../../src/client/client'
 import mockSdfClient from '../client/sdf_client'
+import { createDateRange } from '../../src/changes_detector/date_range'
 
 describe('custom_field', () => {
   const runSuiteQLMock = jest.fn()
@@ -33,7 +34,7 @@ describe('custom_field', () => {
       runSuiteQLMock.mockResolvedValue([{ scriptid: 'a' }, { scriptid: 'b' }])
       results = await detector.getChanges(
         client,
-        { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+        createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
       )
     })
     it('should return the changes', () => {
@@ -59,7 +60,7 @@ describe('custom_field', () => {
       runSuiteQLMock.mockResolvedValue([{ scriptid: 'a' }, { scriptid: 'b' }, { qqq: 'b' }, { scriptid: {} }])
       results = await detector.getChanges(
         client,
-        { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+        createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
       )
     })
     it('should return the changes without the invalid results', () => {
@@ -72,7 +73,7 @@ describe('custom_field', () => {
   it('return nothing when query fails', async () => {
     runSuiteQLMock.mockResolvedValue(undefined)
     expect(
-      await detector.getChanges(client, { start: new Date(), end: new Date() })
+      await detector.getChanges(client, createDateRange(new Date(), new Date()))
     ).toHaveLength(0)
   })
 })

--- a/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
@@ -48,7 +48,7 @@ describe('custom_list', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
       SELECT scriptid
       FROM customlist
-      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/22/2021'
+      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
     `)
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
@@ -18,6 +18,7 @@ import { customListDetector as detector } from '../../src/changes_detector/chang
 import { Change } from '../../src/changes_detector/types'
 import mockSdfClient from '../client/sdf_client'
 import NetsuiteClient from '../../src/client/client'
+import { createDateRange } from '../../src/changes_detector/date_range'
 
 describe('custom_list', () => {
   const runSuiteQLMock = jest.fn()
@@ -34,7 +35,7 @@ describe('custom_list', () => {
       runSuiteQLMock.mockResolvedValue([{ scriptid: 'a' }, { scriptid: 'b' }])
       results = await detector.getChanges(
         client,
-        { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+        createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
       )
     })
     it('should return the changes', () => {
@@ -60,7 +61,7 @@ describe('custom_list', () => {
       runSuiteQLMock.mockResolvedValue([{ scriptid: 'a' }, { scriptid: 'b' }, { qqq: 'b' }, { scriptid: {} }])
       results = await detector.getChanges(
         client,
-        { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+        createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
       )
     })
     it('should return the changes without the invalid results', () => {
@@ -73,7 +74,7 @@ describe('custom_list', () => {
   it('return nothing when query fails', async () => {
     runSuiteQLMock.mockResolvedValue(undefined)
     expect(
-      await detector.getChanges(client, { start: new Date(), end: new Date() })
+      await detector.getChanges(client, createDateRange(new Date(), new Date()))
     ).toHaveLength(0)
   })
 })

--- a/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
@@ -18,6 +18,7 @@ import { customRecordTypeDetector as detector } from '../../src/changes_detector
 import { Change } from '../../src/changes_detector/types'
 import mockSdfClient from '../client/sdf_client'
 import NetsuiteClient from '../../src/client/client'
+import { createDateRange } from '../../src/changes_detector/date_range'
 
 describe('custom_record_type', () => {
   const runSuiteQLMock = jest.fn()
@@ -34,7 +35,7 @@ describe('custom_record_type', () => {
       runSuiteQLMock.mockResolvedValue([{ scriptid: 'a' }, { scriptid: 'b' }])
       results = await detector.getChanges(
         client,
-        { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+        createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
       )
     })
     it('should return the changes', () => {
@@ -60,7 +61,7 @@ describe('custom_record_type', () => {
       runSuiteQLMock.mockResolvedValue([{ scriptid: 'a' }, { scriptid: 'b' }, { qqq: 'b' }, { scriptid: {} }])
       results = await detector.getChanges(
         client,
-        { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+        createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
       )
     })
     it('should return the changes without the invalid results', () => {
@@ -73,7 +74,7 @@ describe('custom_record_type', () => {
   it('return nothing when query fails', async () => {
     runSuiteQLMock.mockResolvedValue(undefined)
     expect(
-      await detector.getChanges(client, { start: new Date(), end: new Date() })
+      await detector.getChanges(client, createDateRange(new Date(), new Date()))
     ).toHaveLength(0)
   })
 })

--- a/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
@@ -48,7 +48,7 @@ describe('custom_record_type', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
       SELECT scriptid
       FROM customrecordtype
-      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/22/2021'
+      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
     `)
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/file_cabinet.test.ts
@@ -18,6 +18,7 @@ import { getChangedFiles, getChangedFolders } from '../../src/changes_detector/c
 import { Change } from '../../src/changes_detector/types'
 import mockSdfClient from '../client/sdf_client'
 import NetsuiteClient from '../../src/client/client'
+import { createDateRange } from '../../src/changes_detector/date_range'
 
 describe('file_cabinet', () => {
   const runSuiteQLMock = jest.fn()
@@ -34,7 +35,7 @@ describe('file_cabinet', () => {
         runSuiteQLMock.mockResolvedValue([{ appfolder: 'a : b', name: 'c', id: '1' }, { appfolder: 'd : e', name: 'f', id: '2' }])
         results = await getChangedFiles(
           client,
-          { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+          createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
         )
       })
       it('should return the changes', () => {
@@ -65,7 +66,7 @@ describe('file_cabinet', () => {
         ])
         results = await getChangedFiles(
           client,
-          { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+          createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
         )
       })
       it('should return the changes', () => {
@@ -78,7 +79,7 @@ describe('file_cabinet', () => {
     it('return nothing when query fails', async () => {
       runSuiteQLMock.mockResolvedValue(undefined)
       expect(
-        await getChangedFiles(client, { start: new Date(), end: new Date() })
+        await getChangedFiles(client, createDateRange(new Date(), new Date()))
       ).toHaveLength(0)
     })
   })
@@ -91,7 +92,7 @@ describe('file_cabinet', () => {
         runSuiteQLMock.mockResolvedValue([{ appfolder: 'a : b', id: '1' }, { appfolder: 'd : e', id: '2' }])
         results = await getChangedFolders(
           client,
-          { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+          createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z')),
         )
       })
       it('should return the changes', () => {
@@ -121,7 +122,7 @@ describe('file_cabinet', () => {
         ])
         results = await getChangedFolders(
           client,
-          { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+          createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
         )
       })
       it('should return the changes', () => {
@@ -134,7 +135,7 @@ describe('file_cabinet', () => {
     it('return nothing when query fails', async () => {
       runSuiteQLMock.mockResolvedValue(undefined)
       expect(
-        await getChangedFolders(client, { start: new Date(), end: new Date() })
+        await getChangedFolders(client, createDateRange(new Date(), new Date()))
       ).toHaveLength(0)
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/file_cabinet.test.ts
@@ -49,7 +49,7 @@ describe('file_cabinet', () => {
     SELECT mediaitemfolder.appfolder, file.name, file.id
     FROM file
     JOIN mediaitemfolder ON mediaitemfolder.id = file.folder
-    WHERE file.lastmodifieddate BETWEEN '1/11/2021' AND '2/22/2021'
+    WHERE file.lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
   `)
       })
     })
@@ -105,7 +105,7 @@ describe('file_cabinet', () => {
         expect(runSuiteQLMock).toHaveBeenCalledWith(`
     SELECT appfolder, id
     FROM mediaitemfolder
-    WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/22/2021'
+    WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
   `)
       })
     })

--- a/packages/netsuite-adapter/test/changes_detector/role.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/role.test.ts
@@ -92,7 +92,7 @@ describe('role', () => {
       SELECT role.scriptid, role.id
       FROM role
       JOIN systemnote ON systemnote.recordid = role.id
-      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/22/2021' AND systemnote.recordtypeid = -118
+      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/23/2021' AND systemnote.recordtypeid = -118
     `)
 
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, `
@@ -103,7 +103,7 @@ describe('role', () => {
       expect(runSavedSearchQueryMock).toHaveBeenCalledWith({
         type: 'role',
         columns: ['internalid'],
-        filters: [['permchangedate', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:55 pm']],
+        filters: [['permchangedate', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:56 pm']],
       })
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/role.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/role.test.ts
@@ -18,6 +18,7 @@ import detector from '../../src/changes_detector/changes_detectors/role'
 import { Change } from '../../src/changes_detector/types'
 import mockSdfClient from '../client/sdf_client'
 import NetsuiteClient from '../../src/client/client'
+import { createDateRange } from '../../src/changes_detector/date_range'
 
 describe('role', () => {
   const runSuiteQLMock = jest.fn()
@@ -45,7 +46,7 @@ describe('role', () => {
     runSavedSearchQueryMock.mockResolvedValue(undefined)
     expect(await detector.getChanges(
       client,
-      { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+      createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
     )).toEqual([
       { type: 'object', externalId: 'a', internalId: 1 },
       { type: 'object', externalId: 'b', internalId: 2 },
@@ -76,7 +77,7 @@ describe('role', () => {
 
       results = await detector.getChanges(
         client,
-        { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+        createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
       )
     })
     it('should return the changes', () => {
@@ -111,7 +112,7 @@ describe('role', () => {
   it('return nothing when roles query fails', async () => {
     runSuiteQLMock.mockResolvedValue(undefined)
     expect(
-      await detector.getChanges(client, { start: new Date(), end: new Date() })
+      await detector.getChanges(client, createDateRange(new Date(), new Date()))
     ).toHaveLength(0)
   })
 })

--- a/packages/netsuite-adapter/test/changes_detector/savedsearch.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/savedsearch.test.ts
@@ -49,7 +49,7 @@ describe('savedsearch', () => {
       expect(runSavedSearchQueryMock).toHaveBeenCalledWith({
         type: 'savedsearch',
         columns: ['id'],
-        filters: [['datemodified', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:55 pm']],
+        filters: [['datemodified', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:56 pm']],
       })
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/savedsearch.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/savedsearch.test.ts
@@ -18,6 +18,7 @@ import detector from '../../src/changes_detector/changes_detectors/savedsearch'
 import { Change } from '../../src/changes_detector/types'
 import NetsuiteClient from '../../src/client/client'
 import mockSdfClient from '../client/sdf_client'
+import { createDateRange } from '../../src/changes_detector/date_range'
 
 describe('savedsearch', () => {
   const runSavedSearchQueryMock = jest.fn()
@@ -35,7 +36,7 @@ describe('savedsearch', () => {
       runSavedSearchQueryMock.mockResolvedValue([{ id: 'a' }, { id: 'b' }, { invalid: 0 }])
       results = await detector.getChanges(
         client,
-        { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+        createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
       )
     })
     it('should return the changes', () => {
@@ -57,7 +58,7 @@ describe('savedsearch', () => {
   it('return nothing when query fails', async () => {
     runSavedSearchQueryMock.mockResolvedValue(undefined)
     expect(
-      await detector.getChanges(client, { start: new Date(), end: new Date() })
+      await detector.getChanges(client, createDateRange(new Date(), new Date()))
     ).toHaveLength(0)
   })
 })

--- a/packages/netsuite-adapter/test/changes_detector/script.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/script.test.ts
@@ -92,7 +92,7 @@ describe('script', () => {
       SELECT script.scriptid, script.id
       FROM script
       JOIN systemnote ON systemnote.recordid = script.id
-      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/22/2021' AND systemnote.recordtypeid = -417
+      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/23/2021' AND systemnote.recordtypeid = -417
     `)
 
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, `
@@ -100,13 +100,13 @@ describe('script', () => {
       FROM scriptdeployment 
       JOIN systemnote ON systemnote.recordid = scriptdeployment.primarykey
       JOIN script ON scriptdeployment.script = script.id
-      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/22/2021' AND systemnote.recordtypeid = -418
+      WHERE systemnote.date BETWEEN '1/11/2021' AND '2/23/2021' AND systemnote.recordtypeid = -418
     `)
 
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(3, `
       SELECT internalid
       FROM customfield
-      WHERE fieldtype = 'SCRIPT' AND lastmodifieddate BETWEEN '1/11/2021' AND '2/22/2021'
+      WHERE fieldtype = 'SCRIPT' AND lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
     `)
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/script.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/script.test.ts
@@ -18,6 +18,7 @@ import detector, { SCRIPT_TYPES } from '../../src/changes_detector/changes_detec
 import { Change } from '../../src/changes_detector/types'
 import NetsuiteClient from '../../src/client/client'
 import mockSdfClient from '../client/sdf_client'
+import { createDateRange } from '../../src/changes_detector/date_range'
 
 describe('script', () => {
   const runSuiteQLMock = jest.fn()
@@ -45,7 +46,7 @@ describe('script', () => {
 
       results = await detector.getChanges(
         client,
-        { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+        createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
       )
     })
     it('should return the changes', () => {
@@ -75,7 +76,7 @@ describe('script', () => {
 
       results = await detector.getChanges(
         client,
-        { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+        createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
       )
     })
     it('should return the changes', () => {
@@ -114,7 +115,7 @@ describe('script', () => {
   it('return nothing when roles query fails', async () => {
     runSuiteQLMock.mockResolvedValue(undefined)
     expect(
-      await detector.getChanges(client, { start: new Date(), end: new Date() })
+      await detector.getChanges(client, createDateRange(new Date(), new Date()))
     ).toHaveLength(0)
   })
 })

--- a/packages/netsuite-adapter/test/changes_detector/workflow.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/workflow.test.ts
@@ -18,6 +18,7 @@ import detector from '../../src/changes_detector/changes_detectors/workflow'
 import { Change } from '../../src/changes_detector/types'
 import NetsuiteClient from '../../src/client/client'
 import mockSdfClient from '../client/sdf_client'
+import { createDateRange } from '../../src/changes_detector/date_range'
 
 describe('workflow', () => {
   const runSavedSearchQueryMock = jest.fn()
@@ -36,7 +37,7 @@ describe('workflow', () => {
         runSavedSearchQueryMock.mockResolvedValue([{ recordid: 'a' }])
         results = await detector.getChanges(
           client,
-          { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T06:55:17.949Z') }
+          createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T06:55:17.949Z'))
         )
       })
       it('should return the type', () => {
@@ -65,7 +66,7 @@ describe('workflow', () => {
         runSavedSearchQueryMock.mockResolvedValue([])
         results = await detector.getChanges(
           client,
-          { start: new Date('2021-01-11T18:55:17.949Z'), end: new Date('2021-02-22T18:55:17.949Z') }
+          createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z'))
         )
       })
       it('should return nothing', () => {
@@ -77,7 +78,7 @@ describe('workflow', () => {
   it('return nothing when query fails', async () => {
     runSavedSearchQueryMock.mockResolvedValue(undefined)
     expect(
-      await detector.getChanges(client, { start: new Date(), end: new Date() })
+      await detector.getChanges(client, createDateRange(new Date(), new Date()))
     ).toHaveLength(0)
   })
 })

--- a/packages/netsuite-adapter/test/changes_detector/workflow.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/workflow.test.ts
@@ -51,7 +51,7 @@ describe('workflow', () => {
           filters: [
             ['recordtype', 'is', '-129'],
             'and',
-            ['date', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:55 am'],
+            ['date', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:56 am'],
           ],
           columns: ['recordid'],
         })

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -18,10 +18,7 @@ import { readFile, readDir, writeFile, mkdirp, rm } from '@salto-io/file'
 import osPath from 'path'
 import { buildNetsuiteQuery, notQuery } from '../../src/query'
 import mockClient, { DUMMY_CREDENTIALS } from './sdf_client'
-import SdfClient, {
-  ATTRIBUTES_FILE_SUFFIX, ATTRIBUTES_FOLDER_NAME, COMMANDS,
-  fileCabinetTopLevelFolders, FOLDER_ATTRIBUTES_FILE_SUFFIX,
-} from '../../src/client/sdf_client'
+import SdfClient, { ATTRIBUTES_FILE_SUFFIX, ATTRIBUTES_FOLDER_NAME, COMMANDS, fileCabinetTopLevelFolders, FOLDER_ATTRIBUTES_FILE_SUFFIX } from '../../src/client/sdf_client'
 import {
   FILE_CABINET_PATH_SEPARATOR,
 } from '../../src/constants'
@@ -146,13 +143,12 @@ jest.mock('@salto-io/suitecloud-cli', () => ({
 }), { virtual: true })
 
 describe('netsuite client', () => {
-  const transformedAccountId = 'TSTDRV123456_SB'
   const createProjectCommandMatcher = expect
     .objectContaining({ commandName: COMMANDS.CREATE_PROJECT })
   const saveTokenCommandMatcher = expect.objectContaining({
     commandName: COMMANDS.SETUP_ACCOUNT,
     arguments: expect.objectContaining({
-      account: transformedAccountId,
+      account: DUMMY_CREDENTIALS.accountId,
       tokenid: DUMMY_CREDENTIALS.tokenId,
       tokensecret: DUMMY_CREDENTIALS.tokenSecret,
       authid: expect.anything(),
@@ -213,7 +209,7 @@ describe('netsuite client', () => {
       const accountId = await SdfClient.validateCredentials(DUMMY_CREDENTIALS)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
-      expect(accountId).toEqual(transformedAccountId)
+      expect(accountId).toEqual(DUMMY_CREDENTIALS.accountId)
     })
   })
 

--- a/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
@@ -254,14 +254,14 @@ describe('SuiteAppClient', () => {
           status: 'success',
           results: {
             appVersion: [0, 1, 2],
-            time: '2021-02-22T18:55:17.949Z',
+            time: 1000,
           },
         },
       })
 
       const results = await client.getSystemInformation()
 
-      expect(results).toEqual({ appVersion: [0, 1, 2], time: new Date('2021-02-22T18:55:17.949Z') })
+      expect(results).toEqual({ appVersion: [0, 1, 2], time: new Date(1000) })
       expect(postMock).toHaveBeenCalledWith(
         'https://account-id.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=customscript_salto_restlet&deploy=customdeploy_salto_restlet',
         {

--- a/packages/netsuite-adapter/test/query.test.ts
+++ b/packages/netsuite-adapter/test/query.test.ts
@@ -179,8 +179,8 @@ describe('NetsuiteQuery', () => {
     })
     const inverseQuery = notQuery(query)
 
-    it('should match all types', () => {
-      expect(inverseQuery.isTypeMatch('addressForm')).toBeTruthy()
+    it('should match only types that do not match the original query', () => {
+      expect(inverseQuery.isTypeMatch('addressForm')).toBeFalsy()
       expect(inverseQuery.isTypeMatch('advancedpdftemplate')).toBeTruthy()
     })
 

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -24,9 +24,7 @@ import {
   EMAIL_TEMPLATE, NETSUITE, RECORDS_PATH, FILE, FILE_CABINET_PATH, FOLDER, PATH, WORKFLOW,
 } from '../src/constants'
 import { customTypes, fileCabinetTypes } from '../src/types'
-import {
-  convertToCustomTypeInfo, convertToXmlContent,
-} from '../src/client/sdf_client'
+import { convertToCustomTypeInfo, convertToXmlContent } from '../src/client/sdf_client'
 import { CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, TemplateCustomTypeInfo } from '../src/client/types'
 import { isFileCustomizationInfo, isFolderCustomizationInfo } from '../src/client/utils'
 


### PR DESCRIPTION
This PR makes the Netsuite adapter use the changes detection mechanism when the suiteAppClient is available.

In this PR, I save a global last fetch time if `fetchTarget` was not passed. In future PR, I will improve it the have a different time for each element so we will be able to update the time also if `fetchTarget` was passed.

Also, while developing this, some integration errors came up:
 - In suiteQL and saved search, doing between time A to time B includes A and does not include B (I thought it does include B).
 - I changed the SuiteApp to return the time as a GMT epoch time and not a string. 
 Both are fixed in this PR.

Since we never pass a SuiteAppClient to the adapter, this PR does not affect the user.

---
_Release Notes_: 
None