### PR TITLE
Netsuite: reduce the default fetch timeout per type's chunk

### DIFF
--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -13,8 +13,8 @@ netsuite {
   deployReferencedElements = false
   client = {
     fetchAllTypesAtOnce = false
-    fetchTypeTimeoutInMinutes = 20
-    maxItemsInImportObjectsRequest = 30
+    fetchTypeTimeoutInMinutes = 4
+    maxItemsInImportObjectsRequest = 40
     sdfConcurrencyLimit = 4
   }
 }
@@ -33,8 +33,8 @@ netsuite {
 | Name                           | Default when undefined  | Description
 | -------------------------------| ------------------------| -----------
 | fetchAllTypesAtOnce            | false                   | Attempt to fetch all configuration elements in a single SDF API call
-| fetchTypeTimeoutInMinutes      | 20                      | The max number of minutes a single type's fetch can run
-| maxItemsInImportObjectsRequest | 30                      | Limits the max number of requested items a single import-objects request
+| fetchTypeTimeoutInMinutes      | 4                       | The max number of minutes a single type's chunk fetch can run
+| maxItemsInImportObjectsRequest | 40                      | Limits the max number of requested items a single import-objects request
 | sdfConcurrencyLimit            | 4                       | Limits the max number of concurrent SDF API calls. The number should not exceed the concurrency limit enforced by the upstream service.
 
 ### Skip list configuration options

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -32,7 +32,7 @@ const { makeArray } = collections.array
 // in small Netsuite accounts the concurrency limit per integration can be between 1-4
 export const DEFAULT_CONCURRENCY = 4
 export const DEFAULT_FETCH_ALL_TYPES_AT_ONCE = false
-export const DEFAULT_FETCH_TYPE_TIMEOUT_IN_MINUTES = 8
+export const DEFAULT_FETCH_TYPE_TIMEOUT_IN_MINUTES = 4
 export const DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST = 40
 export const DEFAULT_DEPLOY_REFERENCED_ELEMENTS = false
 


### PR DESCRIPTION
After noticing that when we reach the timeout we waste a precious time and the retry on smaller chunks makes it work faster, I decided to reduce the `fetchTypeTimeoutInMinutes` default to 4 minutes as the longest chunk fetch that I saw that eventually succeeded to fetch, took around 3 minutes.

---
_Release Notes_: 
NetSuite Adapter: reduce the default fetchTypeTimeoutInMinutes config value to 4 to avoid waiting too long for a response from SDF
