### PR TITLE
Omit extended schemas from workato elements (applies to recipe code)

### DIFF
--- a/packages/workato-adapter/src/config.ts
+++ b/packages/workato-adapter/src/config.ts
@@ -25,6 +25,8 @@ export const DEFAULT_ID_FIELDS = ['name']
 export const FIELDS_TO_OMIT: configUtils.FieldToOmitType[] = [
   { fieldName: 'created_at', fieldType: 'string' },
   { fieldName: 'updated_at', fieldType: 'string' },
+  { fieldName: 'extended_input_schema' },
+  { fieldName: 'extended_output_schema' },
 ]
 
 export const CLIENT_CONFIG = 'client'

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -226,10 +226,6 @@ describe('adapter', () => {
             since_offset: '-3600',
           },
           // eslint-disable-next-line @typescript-eslint/camelcase
-          extended_output_schema: expect.anything(),
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          extended_input_schema: expect.anything(),
-          // eslint-disable-next-line @typescript-eslint/camelcase
           visible_config_fields: [
             'sobject_name',
             'since_offset',


### PR DESCRIPTION
The extended schemas can be very long, and at least for now we get the data we need from other fields.
Note that the fields are only omitted in the default configuration - they can be added back if needed without requiring a new release.
