### PR TITLE
SALTO-1205 - Add postFetch step

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -50,9 +50,15 @@ export type DeployOptions = {
   changeGroup: ChangeGroup
 }
 
+export type PostFetchOptions = {
+  localElements: Element[]
+  elementsByAdapter: Record<string, ReadonlyArray<Readonly<Element>>>
+}
+
 export type AdapterOperations = {
   fetch: (opts: FetchOptions) => Promise<FetchResult>
   deploy: (opts: DeployOptions) => Promise<DeployResult>
+  postFetch?: (opts: PostFetchOptions) => Promise<boolean>
 }
 
 export type AdapterOperationName = keyof AdapterOperations

--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -51,14 +51,14 @@ export type DeployOptions = {
 }
 
 export type PostFetchOptions = {
-  localElements: Element[]
-  elementsByAdapter: Record<string, ReadonlyArray<Readonly<Element>>>
+  currentAdapterElements: Element[]
+  elementsByAdapter: Readonly<Record<string, ReadonlyArray<Readonly<Element>>>>
 }
 
 export type AdapterOperations = {
   fetch: (opts: FetchOptions) => Promise<FetchResult>
   deploy: (opts: DeployOptions) => Promise<DeployResult>
-  postFetch?: (opts: PostFetchOptions) => Promise<boolean>
+  postFetch?: (opts: PostFetchOptions) => Promise<{ changed: boolean }>
 }
 
 export type AdapterOperationName = keyof AdapterOperations

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -102,11 +102,13 @@ export const createAdapterApiConfigType = ({
 
 export const createUserFetchConfigType = (
   adapter: string,
+  additionalFields?: Record<string, FieldDefinition>,
 ): ObjectType => (
   new ObjectType({
     elemID: new ElemID(adapter, 'userFetchConfig'),
     fields: {
       includeTypes: { type: new ListType(BuiltinTypes.STRING) },
+      ...additionalFields,
     },
   })
 )

--- a/packages/adapter-components/test/filter_utils.test.ts
+++ b/packages/adapter-components/test/filter_utils.test.ts
@@ -89,10 +89,13 @@ describe('filter utils', () => {
       expect(mockOnFetch2).toHaveBeenCalled()
       expect(mockOnFetch3).toHaveBeenCalled()
     })
-    it('should call onPostFetch for all nested filters in order', async () => {
+    it('should call onPostFetch for all nested filters', async () => {
       const p = makeResolvablePromise(3)
       const runner = filtersRunner({ get: jest.fn() }, { configVal: '123 ', promise: p.promise }, filters)
-      const onPostFetchRes = runner.onPostFetch({ elementsByAdapter: {}, localElements: [] })
+      const onPostFetchRes = runner.onPostFetch({
+        elementsByAdapter: {},
+        currentAdapterElements: [],
+      })
       await new Promise(resolve => setTimeout(resolve, 2))
       expect(mockOnPostFetch2).not.toHaveBeenCalled()
       expect(mockOnPostFetch3).not.toHaveBeenCalled()

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -205,7 +205,6 @@ export const fetch: FetchFunc = async (
   const [filteredStateElements, stateElementsNotCoveredByFetch] = partitionElementsByServices(
     stateElements, fetchServices
   )
-  const workspaceElementsByAdapter = _.groupBy(await workspace.elements(), e => e.elemID.adapter)
   const adaptersCreatorConfigs = await getAdaptersCreatorConfigs(
     fetchServices,
     await workspace.servicesCredentials(services),
@@ -226,8 +225,9 @@ export const fetch: FetchFunc = async (
       changes, elements, mergeErrors, configChanges, adapterNameToConfigMessage, unmergedElements,
     } = await fetchChanges(
       adapters,
-      workspaceElementsByAdapter,
+      filterElementsByServices(await workspace.elements(), fetchServices),
       filteredStateElements,
+      stateElementsNotCoveredByFetch,
       currentConfigs,
       progressEmitter,
     )

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -205,6 +205,7 @@ export const fetch: FetchFunc = async (
   const [filteredStateElements, stateElementsNotCoveredByFetch] = partitionElementsByServices(
     stateElements, fetchServices
   )
+  const workspaceElementsByAdapter = _.groupBy(await workspace.elements(), e => e.elemID.adapter)
   const adaptersCreatorConfigs = await getAdaptersCreatorConfigs(
     fetchServices,
     await workspace.servicesCredentials(services),
@@ -225,7 +226,7 @@ export const fetch: FetchFunc = async (
       changes, elements, mergeErrors, configChanges, adapterNameToConfigMessage, unmergedElements,
     } = await fetchChanges(
       adapters,
-      filterElementsByServices(await workspace.elements(), fetchServices),
+      workspaceElementsByAdapter,
       filteredStateElements,
       currentConfigs,
       progressEmitter,

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -116,7 +116,8 @@ describe('fetch', () => {
       it('should fail', async () => {
         const fetchChangesResult = await fetchChanges(
           mockAdapters,
-          { dummy: [] },
+          [],
+          [],
           [],
           [],
         )
@@ -131,7 +132,8 @@ describe('fetch', () => {
           )
           const fetchChangesResult = await fetchChanges(
             mockAdapters,
-            { dummy: [newTypeBaseModified, typeWithField] },
+            [newTypeBaseModified, typeWithField],
+            [],
             [],
             [],
           )
@@ -144,8 +146,9 @@ describe('fetch', () => {
           )
           const fetchChangesResult = await fetchChanges(
             mockAdapters,
-            { dummy: [] },
+            [],
             [newTypeBase, typeWithField],
+            [],
             [],
           )
           expect(fetchChangesResult.elements).toEqual([newTypeBaseModified, typeWithField])
@@ -158,7 +161,8 @@ describe('fetch', () => {
           )
           const fetchChangesResult = await fetchChanges(
             mockAdapters,
-            { dummy: [newTypeBaseModified, typeWithField] },
+            [newTypeBaseModified, typeWithField],
+            [],
             [],
             [],
           )
@@ -173,8 +177,9 @@ describe('fetch', () => {
           )
           const fetchChangesResult = await fetchChanges(
             mockAdapters,
-            { dummy: [] },
+            [],
             [newTypeBase, typeWithField],
+            [],
             [],
           )
           expect(fetchChangesResult.elements).toEqual([newTypeBaseModified])
@@ -214,8 +219,9 @@ describe('fetch', () => {
         )
         const fetchChangesResult = await fetchChanges(
           mockAdapters,
-          { dummy: [beforeElement, workspaceReferencedElement] },
+          [beforeElement, workspaceReferencedElement],
           [beforeElement, stateReferencedElement],
+          [],
           [],
         )
 
@@ -252,10 +258,11 @@ describe('fetch', () => {
         it('should ignore deletions only for adapter with partial results', async () => {
           const fetchChangesResult = await fetchChanges(
             adapters,
-            {
-              dummy1: [new ObjectType({ elemID: new ElemID('dummy1', 'type') })],
-              dummy2: [new ObjectType({ elemID: new ElemID('dummy2', 'type') })],
-            },
+            [
+              new ObjectType({ elemID: new ElemID('dummy1', 'type') }),
+              new ObjectType({ elemID: new ElemID('dummy2', 'type') }),
+            ],
+            [],
             [],
             [],
           )
@@ -303,7 +310,7 @@ describe('fetch', () => {
       })
       it('should return config change plan when there is no current config', async () => {
         const fetchChangesResult = await fetchChanges(
-          mockAdapters, { dummy: [] }, [], [],
+          mockAdapters, [], [], [], [],
         )
         verifyPlan(
           fetchChangesResult.configChanges,
@@ -315,7 +322,8 @@ describe('fetch', () => {
       it('should return config change plan when there is current config', async () => {
         const fetchChangesResult = await fetchChanges(
           mockAdapters,
-          { dummy: [] },
+          [],
+          [],
           [],
           [currentInstanceConfig],
         )
@@ -328,7 +336,7 @@ describe('fetch', () => {
 
       it('should return empty plan when there is no change', async () => {
         const fetchChangesResult = await fetchChanges(
-          mockAdapters, { dummy: [] }, [], [configInstance],
+          mockAdapters, [], [], [], [configInstance],
         )
         expect([...fetchChangesResult.configChanges.itemsByEvalOrder()]).toHaveLength(0)
       })
@@ -352,7 +360,7 @@ describe('fetch', () => {
               mockAdapters.dummy.fetch.mockResolvedValueOnce(
                 Promise.resolve({ elements: [dupTypeBase, dupTypeBase2] })
               )
-              await fetchChanges(mockAdapters, { dummy: [] }, [dupTypeBase], [])
+              await fetchChanges(mockAdapters, [], [], [dupTypeBase], [])
               expect(false).toBeTruthy()
             } catch (e) {
               expect(e.message).toMatch(/.*duplicate annotation.*/)
@@ -373,7 +381,7 @@ describe('fetch', () => {
               { elements: [dupInstance, validInstance, dupTypeBase, dupTypeBase2, typeWithField] }
             )
           )
-          fetchChangesResult = await fetchChanges(mockAdapters, { dummy: [] }, [], [])
+          fetchChangesResult = await fetchChanges(mockAdapters, [], [], [], [])
         })
         it('should return errors', async () => {
           expect(fetchChangesResult.mergeErrors).toHaveLength(1)
@@ -403,8 +411,9 @@ describe('fetch', () => {
 
         const result = await fetchChanges(
           mockAdapters,
-          { dummy: [newTypeMerged, hiddenInstance] },
           [newTypeMerged, hiddenInstance],
+          [newTypeMerged, hiddenInstance],
+          [],
           [],
         )
         elements = result.elements
@@ -436,8 +445,9 @@ describe('fetch', () => {
 
         const result = await fetchChanges(
           mockAdapters,
-          { dummy: [typeWithField, hiddenInstance] },
           [typeWithField, hiddenInstance],
+          [typeWithField, hiddenInstance],
+          [],
           [],
         )
         changes = [...result.changes]
@@ -469,7 +479,8 @@ describe('fetch', () => {
           )
           const result = await fetchChanges(
             mockAdapters,
-            { dummy: [] },
+            [],
+            [],
             [],
             [],
             progressEmitter
@@ -490,7 +501,8 @@ describe('fetch', () => {
           })
           const result = await fetchChanges(
             mockAdapters,
-            { dummy: [] },
+            [],
+            [],
             [],
             [],
             progressEmitter
@@ -513,7 +525,8 @@ describe('fetch', () => {
         )
         const result = await fetchChanges(
           mockAdapters,
-          { dummy: [] },
+          [],
+          [],
           [],
           [],
         )
@@ -542,8 +555,9 @@ describe('fetch', () => {
             )
             const result = await fetchChanges(
               mockAdapters,
-              { dummy: [newTypeBaseWPath] },
               [newTypeBaseWPath],
+              [newTypeBaseWPath],
+              [],
               [],
             )
             changes = [...result.changes]
@@ -578,8 +592,9 @@ describe('fetch', () => {
             )
             const result = await fetchChanges(
               mockAdapters,
-              { dummy: [newTypeA] },
               [newTypeA],
+              [newTypeA],
+              [],
               [],
             )
             changes = [...result.changes]
@@ -602,8 +617,9 @@ describe('fetch', () => {
           )
           const result = await fetchChanges(
             mockAdapters,
-            { dummy: [typeWithFieldChange] },
+            [typeWithFieldChange],
             [typeWithField],
+            [],
             [],
           )
           changes = [...result.changes]
@@ -620,8 +636,9 @@ describe('fetch', () => {
           )
           const result = await fetchChanges(
             mockAdapters,
-            { dummy: [typeWithFieldConflict] },
+            [typeWithFieldConflict],
             [typeWithField],
+            [],
             [],
           )
           changes = [...result.changes]
@@ -638,8 +655,9 @@ describe('fetch', () => {
           )
           const result = await fetchChanges(
             mockAdapters,
-            { dummy: [] },
+            [],
             [typeWithField],
+            [],
             [],
           )
           changes = [...result.changes]
@@ -805,7 +823,8 @@ describe('fetch', () => {
         )
         const result = await fetchChanges(
           mockAdapters,
-          { dummy: [] },
+          [],
+          [],
           [],
           [],
         )
@@ -831,7 +850,8 @@ describe('fetch', () => {
         )
         await fetchChanges(
           mockAdapters,
-          { dummy: [] },
+          [],
+          [],
           [],
           [],
         )
@@ -849,14 +869,15 @@ describe('fetch', () => {
       },
     }
     describe('fetch is partial', () => {
-      it('should call postFetch with the workspace elements and service elements combined in elementsByAdapter, but only the fetched elements in currentAdapterElements', async () => {
+      it('should call postFetch with the state and service elements combined in elementsByAdapter, but only the fetched elements in currentAdapterElements', async () => {
         mockAdapters.dummy.fetch.mockResolvedValueOnce(
           { elements: [newTypeBaseModified], isPartial: true },
         )
         const fetchChangesResult = await fetchChanges(
           mockAdapters,
-          { dummy: [typeWithField] },
+          [typeWithField],
           [newTypeBase, typeWithField],
+          [],
           [],
         )
         expect(fetchChangesResult.elements).toEqual([newTypeBaseModified, typeWithField])
@@ -880,8 +901,9 @@ describe('fetch', () => {
         )
         const fetchChangesResult = await fetchChanges(
           mockAdapters,
-          { dummy: [] },
+          [],
           [newTypeBase, typeWithField],
+          [],
           [],
         )
         expect(fetchChangesResult.elements).toEqual([newTypeBaseModified])
@@ -928,11 +950,8 @@ describe('fetch', () => {
       it('should call postFetch for all relevant adapters when all are fetched', async () => {
         await fetchChanges(
           adapters,
-          {
-            dummy1: [dummy1],
-            dummy2: [dummy2],
-            dummy3: [dummy3],
-          },
+          [],
+          [dummy1, dummy2, dummy3],
           [],
           [],
         )
@@ -956,14 +975,32 @@ describe('fetch', () => {
       it('should call postFetch only for fetched adapters (with postFetch defined) when not all are fetched', async () => {
         await fetchChanges(
           _.pick(adapters, ['dummy1', 'dummy2']),
-          {
-            dummy1: [dummy1],
-            dummy2: [dummy2],
-            dummy3: [dummy3],
-          },
           [],
+          [dummy1, dummy2],
+          [dummy3],
           [],
         )
+        expect(adapters.dummy2.postFetch).toHaveBeenCalledWith({
+          currentAdapterElements: expect.arrayContaining([dummy2Type1]),
+          elementsByAdapter: {
+            // dummy1 is partial so it also includes elements from the workspace
+            dummy1: expect.arrayContaining([dummy1Type1, dummy1]),
+            dummy2: expect.arrayContaining([dummy2Type1]),
+            // dummy3 was not fetched so it includes only elements from the workspace
+            dummy3: expect.arrayContaining([dummy3]),
+          },
+        })
+        expect(adapters.dummy3.postFetch).not.toHaveBeenCalled()
+      })
+      it('should not fail on errors', async () => {
+        adapters.dummy2.postFetch.mockImplementationOnce(() => { throw new Error(' failure') })
+        await expect(fetchChanges(
+          _.pick(adapters, ['dummy1', 'dummy2']),
+          [],
+          [dummy1, dummy2],
+          [dummy3],
+          [],
+        )).resolves.not.toThrow()
         expect(adapters.dummy2.postFetch).toHaveBeenCalledWith({
           currentAdapterElements: expect.arrayContaining([dummy2Type1]),
           elementsByAdapter: {

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -360,7 +360,7 @@ describe('fetch', () => {
               mockAdapters.dummy.fetch.mockResolvedValueOnce(
                 Promise.resolve({ elements: [dupTypeBase, dupTypeBase2] })
               )
-              await fetchChanges(mockAdapters, [], [], [dupTypeBase], [])
+              await fetchChanges(mockAdapters, [], [dupTypeBase], [], [])
               expect(false).toBeTruthy()
             } catch (e) {
               expect(e.message).toMatch(/.*duplicate annotation.*/)

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { EventEmitter } from 'pietile-eventemitter'
 import {
   ElemID, Field, BuiltinTypes, ObjectType, getChangeElement, AdapterOperations, Element,
@@ -115,7 +116,7 @@ describe('fetch', () => {
       it('should fail', async () => {
         const fetchChangesResult = await fetchChanges(
           mockAdapters,
-          [],
+          { dummy: [] },
           [],
           [],
         )
@@ -130,7 +131,7 @@ describe('fetch', () => {
           )
           const fetchChangesResult = await fetchChanges(
             mockAdapters,
-            [newTypeBaseModified, typeWithField],
+            { dummy: [newTypeBaseModified, typeWithField] },
             [],
             [],
           )
@@ -143,7 +144,7 @@ describe('fetch', () => {
           )
           const fetchChangesResult = await fetchChanges(
             mockAdapters,
-            [],
+            { dummy: [] },
             [newTypeBase, typeWithField],
             [],
           )
@@ -157,7 +158,7 @@ describe('fetch', () => {
           )
           const fetchChangesResult = await fetchChanges(
             mockAdapters,
-            [newTypeBaseModified, typeWithField],
+            { dummy: [newTypeBaseModified, typeWithField] },
             [],
             [],
           )
@@ -166,13 +167,13 @@ describe('fetch', () => {
           expect(resultChanges[0].change.action).toBe('remove')
         })
 
-        it('should return the only the service elements', async () => {
+        it('should return only the service elements', async () => {
           mockAdapters.dummy.fetch.mockResolvedValueOnce(
             { elements: [newTypeBaseModified], isPartial: false },
           )
           const fetchChangesResult = await fetchChanges(
             mockAdapters,
-            [],
+            { dummy: [] },
             [newTypeBase, typeWithField],
             [],
           )
@@ -213,7 +214,7 @@ describe('fetch', () => {
         )
         const fetchChangesResult = await fetchChanges(
           mockAdapters,
-          [beforeElement, workspaceReferencedElement],
+          { dummy: [beforeElement, workspaceReferencedElement] },
           [beforeElement, stateReferencedElement],
           [],
         )
@@ -251,10 +252,10 @@ describe('fetch', () => {
         it('should ignore deletions only for adapter with partial results', async () => {
           const fetchChangesResult = await fetchChanges(
             adapters,
-            [
-              new ObjectType({ elemID: new ElemID('dummy1', 'type') }),
-              new ObjectType({ elemID: new ElemID('dummy2', 'type') }),
-            ],
+            {
+              dummy1: [new ObjectType({ elemID: new ElemID('dummy1', 'type') })],
+              dummy2: [new ObjectType({ elemID: new ElemID('dummy2', 'type') })],
+            },
             [],
             [],
           )
@@ -302,7 +303,7 @@ describe('fetch', () => {
       })
       it('should return config change plan when there is no current config', async () => {
         const fetchChangesResult = await fetchChanges(
-          mockAdapters, [], [], [],
+          mockAdapters, { dummy: [] }, [], [],
         )
         verifyPlan(
           fetchChangesResult.configChanges,
@@ -314,7 +315,7 @@ describe('fetch', () => {
       it('should return config change plan when there is current config', async () => {
         const fetchChangesResult = await fetchChanges(
           mockAdapters,
-          [],
+          { dummy: [] },
           [],
           [currentInstanceConfig],
         )
@@ -327,7 +328,7 @@ describe('fetch', () => {
 
       it('should return empty plan when there is no change', async () => {
         const fetchChangesResult = await fetchChanges(
-          mockAdapters, [], [], [configInstance],
+          mockAdapters, { dummy: [] }, [], [configInstance],
         )
         expect([...fetchChangesResult.configChanges.itemsByEvalOrder()]).toHaveLength(0)
       })
@@ -351,7 +352,7 @@ describe('fetch', () => {
               mockAdapters.dummy.fetch.mockResolvedValueOnce(
                 Promise.resolve({ elements: [dupTypeBase, dupTypeBase2] })
               )
-              await fetchChanges(mockAdapters, [], [dupTypeBase], [])
+              await fetchChanges(mockAdapters, { dummy: [] }, [dupTypeBase], [])
               expect(false).toBeTruthy()
             } catch (e) {
               expect(e.message).toMatch(/.*duplicate annotation.*/)
@@ -372,7 +373,7 @@ describe('fetch', () => {
               { elements: [dupInstance, validInstance, dupTypeBase, dupTypeBase2, typeWithField] }
             )
           )
-          fetchChangesResult = await fetchChanges(mockAdapters, [], [], [])
+          fetchChangesResult = await fetchChanges(mockAdapters, { dummy: [] }, [], [])
         })
         it('should return errors', async () => {
           expect(fetchChangesResult.mergeErrors).toHaveLength(1)
@@ -402,7 +403,7 @@ describe('fetch', () => {
 
         const result = await fetchChanges(
           mockAdapters,
-          [newTypeMerged, hiddenInstance],
+          { dummy: [newTypeMerged, hiddenInstance] },
           [newTypeMerged, hiddenInstance],
           [],
         )
@@ -435,7 +436,7 @@ describe('fetch', () => {
 
         const result = await fetchChanges(
           mockAdapters,
-          [typeWithField, hiddenInstance],
+          { dummy: [typeWithField, hiddenInstance] },
           [typeWithField, hiddenInstance],
           [],
         )
@@ -468,7 +469,7 @@ describe('fetch', () => {
           )
           const result = await fetchChanges(
             mockAdapters,
-            [],
+            { dummy: [] },
             [],
             [],
             progressEmitter
@@ -489,7 +490,7 @@ describe('fetch', () => {
           })
           const result = await fetchChanges(
             mockAdapters,
-            [],
+            { dummy: [] },
             [],
             [],
             progressEmitter
@@ -512,7 +513,7 @@ describe('fetch', () => {
         )
         const result = await fetchChanges(
           mockAdapters,
-          [],
+          { dummy: [] },
           [],
           [],
         )
@@ -541,7 +542,7 @@ describe('fetch', () => {
             )
             const result = await fetchChanges(
               mockAdapters,
-              [newTypeBaseWPath],
+              { dummy: [newTypeBaseWPath] },
               [newTypeBaseWPath],
               [],
             )
@@ -577,7 +578,7 @@ describe('fetch', () => {
             )
             const result = await fetchChanges(
               mockAdapters,
-              [newTypeA],
+              { dummy: [newTypeA] },
               [newTypeA],
               [],
             )
@@ -601,7 +602,7 @@ describe('fetch', () => {
           )
           const result = await fetchChanges(
             mockAdapters,
-            [typeWithFieldChange],
+            { dummy: [typeWithFieldChange] },
             [typeWithField],
             [],
           )
@@ -619,7 +620,7 @@ describe('fetch', () => {
           )
           const result = await fetchChanges(
             mockAdapters,
-            [typeWithFieldConflict],
+            { dummy: [typeWithFieldConflict] },
             [typeWithField],
             [],
           )
@@ -637,7 +638,7 @@ describe('fetch', () => {
           )
           const result = await fetchChanges(
             mockAdapters,
-            [],
+            { dummy: [] },
             [typeWithField],
             [],
           )
@@ -804,7 +805,7 @@ describe('fetch', () => {
         )
         const result = await fetchChanges(
           mockAdapters,
-          [],
+          { dummy: [] },
           [],
           [],
         )
@@ -830,11 +831,150 @@ describe('fetch', () => {
         )
         await fetchChanges(
           mockAdapters,
-          [],
+          { dummy: [] },
           [],
           [],
         )
         expect(utils.applyInstancesDefaults).toHaveBeenCalledWith([hiddenInstance])
+      })
+    })
+  })
+
+  describe('fetchChanges with postFetch', () => {
+    const mockAdapters = {
+      dummy: {
+        fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [] }),
+        deploy: mockFunction<AdapterOperations['deploy']>(),
+        postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue(true),
+      },
+    }
+    describe('fetch is partial', () => {
+      it('should call postFetch with the workspace elements and service elements combined in elementsByAdapter, but only the fetched elements in localElements', async () => {
+        mockAdapters.dummy.fetch.mockResolvedValueOnce(
+          { elements: [newTypeBaseModified], isPartial: true },
+        )
+        const fetchChangesResult = await fetchChanges(
+          mockAdapters,
+          { dummy: [typeWithField] },
+          [newTypeBase, typeWithField],
+          [],
+        )
+        expect(fetchChangesResult.elements).toEqual([newTypeBaseModified, typeWithField])
+        expect(mockAdapters.dummy.postFetch).toHaveBeenCalledWith({
+          localElements: expect.arrayContaining([
+            newTypeBaseModified,
+          ]),
+          elementsByAdapter: {
+            dummy: expect.arrayContaining([
+              newTypeBaseModified,
+              typeWithField,
+            ]),
+          },
+        })
+      })
+    })
+    describe('fetch is not partial', () => {
+      it('should call postFetch with only the service elements', async () => {
+        mockAdapters.dummy.fetch.mockResolvedValueOnce(
+          { elements: [newTypeBaseModified], isPartial: false },
+        )
+        const fetchChangesResult = await fetchChanges(
+          mockAdapters,
+          { dummy: [] },
+          [newTypeBase, typeWithField],
+          [],
+        )
+        expect(fetchChangesResult.elements).toEqual([newTypeBaseModified])
+        expect(mockAdapters.dummy.postFetch).toHaveBeenCalledWith({
+          localElements: expect.arrayContaining([
+            newTypeBaseModified,
+          ]),
+          elementsByAdapter: {
+            dummy: expect.arrayContaining([
+              newTypeBaseModified,
+            ]),
+          },
+        })
+      })
+    })
+
+    describe('multiple adapters', () => {
+      const dummy1 = new ObjectType({ elemID: new ElemID('dummy1', 'type') })
+      const dummy2 = new ObjectType({ elemID: new ElemID('dummy2', 'type') })
+      const dummy3 = new ObjectType({ elemID: new ElemID('dummy3', 'type') })
+      const dummy1Type1 = new ObjectType({ elemID: new ElemID('dummy1', 'd1t1'), fields: {} })
+      const dummy2Type1 = new ObjectType({ elemID: new ElemID('dummy2', 'd2t1'), fields: {} })
+      const dummy3Type1 = new ObjectType({ elemID: new ElemID('dummy3', 'd3t1'), fields: {} })
+      const adapters = {
+        dummy1: {
+          fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [dummy1Type1], isPartial: true }),
+          deploy: mockFunction<AdapterOperations['deploy']>(),
+        },
+        dummy2: {
+          fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [dummy2Type1], isPartial: false }),
+          deploy: mockFunction<AdapterOperations['deploy']>(),
+          postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue(true),
+        },
+        dummy3: {
+          fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [dummy3Type1], isPartial: false }),
+          deploy: mockFunction<AdapterOperations['deploy']>(),
+          postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue(true),
+        },
+      }
+      beforeEach(() => {
+        jest.clearAllMocks()
+      })
+
+      it('should call postFetch for all relevant adapters when all are fetched', async () => {
+        await fetchChanges(
+          adapters,
+          {
+            dummy1: [dummy1],
+            dummy2: [dummy2],
+            dummy3: [dummy3],
+          },
+          [],
+          [],
+        )
+        expect(adapters.dummy2.postFetch).toHaveBeenCalledWith({
+          localElements: expect.arrayContaining([dummy2Type1]),
+          elementsByAdapter: {
+            dummy1: expect.arrayContaining([dummy1, dummy1Type1]),
+            dummy2: expect.arrayContaining([dummy2Type1]),
+            dummy3: expect.arrayContaining([dummy3Type1]),
+          },
+        })
+        expect(adapters.dummy3.postFetch).toHaveBeenCalledWith({
+          localElements: expect.arrayContaining([dummy3Type1]),
+          elementsByAdapter: {
+            dummy1: expect.arrayContaining([dummy1Type1, dummy1]),
+            dummy2: expect.arrayContaining([dummy2Type1]),
+            dummy3: expect.arrayContaining([dummy3Type1]),
+          },
+        })
+      })
+      it('should call postFetch only for fetched adapters (with postFetch defined) when not all are fetched', async () => {
+        await fetchChanges(
+          _.pick(adapters, ['dummy1', 'dummy2']),
+          {
+            dummy1: [dummy1],
+            dummy2: [dummy2],
+            dummy3: [dummy3],
+          },
+          [],
+          [],
+        )
+        expect(adapters.dummy2.postFetch).toHaveBeenCalledWith({
+          localElements: expect.arrayContaining([dummy2Type1]),
+          elementsByAdapter: {
+            // dummy1 is partial so it also includes elements from the workspace
+            dummy1: expect.arrayContaining([dummy1Type1, dummy1]),
+            dummy2: expect.arrayContaining([dummy2Type1]),
+            // dummy3 was not fetched so it includes only elements from the workspace
+            dummy3: expect.arrayContaining([dummy3]),
+          },
+        })
+        expect(adapters.dummy3.postFetch).not.toHaveBeenCalled()
       })
     })
   })

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -845,11 +845,11 @@ describe('fetch', () => {
       dummy: {
         fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [] }),
         deploy: mockFunction<AdapterOperations['deploy']>(),
-        postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue(true),
+        postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue({ changed: true }),
       },
     }
     describe('fetch is partial', () => {
-      it('should call postFetch with the workspace elements and service elements combined in elementsByAdapter, but only the fetched elements in localElements', async () => {
+      it('should call postFetch with the workspace elements and service elements combined in elementsByAdapter, but only the fetched elements in currentAdapterElements', async () => {
         mockAdapters.dummy.fetch.mockResolvedValueOnce(
           { elements: [newTypeBaseModified], isPartial: true },
         )
@@ -861,7 +861,7 @@ describe('fetch', () => {
         )
         expect(fetchChangesResult.elements).toEqual([newTypeBaseModified, typeWithField])
         expect(mockAdapters.dummy.postFetch).toHaveBeenCalledWith({
-          localElements: expect.arrayContaining([
+          currentAdapterElements: expect.arrayContaining([
             newTypeBaseModified,
           ]),
           elementsByAdapter: {
@@ -886,7 +886,7 @@ describe('fetch', () => {
         )
         expect(fetchChangesResult.elements).toEqual([newTypeBaseModified])
         expect(mockAdapters.dummy.postFetch).toHaveBeenCalledWith({
-          localElements: expect.arrayContaining([
+          currentAdapterElements: expect.arrayContaining([
             newTypeBaseModified,
           ]),
           elementsByAdapter: {
@@ -913,12 +913,12 @@ describe('fetch', () => {
         dummy2: {
           fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [dummy2Type1], isPartial: false }),
           deploy: mockFunction<AdapterOperations['deploy']>(),
-          postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue(true),
+          postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue({ changed: true }),
         },
         dummy3: {
           fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [dummy3Type1], isPartial: false }),
           deploy: mockFunction<AdapterOperations['deploy']>(),
-          postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue(true),
+          postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue({ changed: true }),
         },
       }
       beforeEach(() => {
@@ -937,7 +937,7 @@ describe('fetch', () => {
           [],
         )
         expect(adapters.dummy2.postFetch).toHaveBeenCalledWith({
-          localElements: expect.arrayContaining([dummy2Type1]),
+          currentAdapterElements: expect.arrayContaining([dummy2Type1]),
           elementsByAdapter: {
             dummy1: expect.arrayContaining([dummy1, dummy1Type1]),
             dummy2: expect.arrayContaining([dummy2Type1]),
@@ -945,7 +945,7 @@ describe('fetch', () => {
           },
         })
         expect(adapters.dummy3.postFetch).toHaveBeenCalledWith({
-          localElements: expect.arrayContaining([dummy3Type1]),
+          currentAdapterElements: expect.arrayContaining([dummy3Type1]),
           elementsByAdapter: {
             dummy1: expect.arrayContaining([dummy1Type1, dummy1]),
             dummy2: expect.arrayContaining([dummy2Type1]),
@@ -965,7 +965,7 @@ describe('fetch', () => {
           [],
         )
         expect(adapters.dummy2.postFetch).toHaveBeenCalledWith({
-          localElements: expect.arrayContaining([dummy2Type1]),
+          currentAdapterElements: expect.arrayContaining([dummy2Type1]),
           elementsByAdapter: {
             // dummy1 is partial so it also includes elements from the workspace
             dummy1: expect.arrayContaining([dummy1Type1, dummy1]),


### PR DESCRIPTION
Allow adapters to make adjustments based on fetch results from other adapters.
This currently needs to run within `fetch` before we calculate the changes, because otherwise we may get unwanted changes because core cannot compare reference expressions and plain values.
Also added support for the `postFetch` filter operation in `adapter-components` (the first usage will be in workato which is using it).

---
_Release Notes_: 
Add post-fetch step to allow adapters to define references to elements from other adapters
