### PR TITLE
SALTO-1205 - Workato cross-service references

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -229,15 +229,16 @@ type UpdatedConfig = {
   message: string
 }
 
-type AadpterOperationsWithPostFetch = types.PickyRequired<AdapterOperations, 'postFetch'>
-const isAadpterOperationsWithPostFetch = (
+type AdapterOperationsWithPostFetch = types.PickyRequired<AdapterOperations, 'postFetch'>
+
+const isAdapterOperationsWithPostFetch = (
   v: AdapterOperations
-): v is AadpterOperationsWithPostFetch => (
+): v is AdapterOperationsWithPostFetch => (
   v.postFetch !== undefined
 )
 
 const runPostFetch = async (
-  adapters: Record<string, AadpterOperationsWithPostFetch>,
+  adapters: Record<string, AdapterOperationsWithPostFetch>,
   serviceElements: Element[],
   stateElementsByAdapter: Record<string, ReadonlyArray<Element>>,
   partiallyFetchedAdapters: Set<string>,
@@ -324,7 +325,7 @@ const fetchAndProcessMergeErrors = async (
 
     log.debug(`fetched ${serviceElements.length} elements from adapters`)
 
-    const adaptersWithPostFetch = _.pickBy(adapters, isAadpterOperationsWithPostFetch)
+    const adaptersWithPostFetch = _.pickBy(adapters, isAdapterOperationsWithPostFetch)
     if (!_.isEmpty(adaptersWithPostFetch)) {
       try {
         const stateElementsByAdapter = _.groupBy(

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -50,7 +50,7 @@ import { defaultMissingFields } from './missing_fields'
 const { makeArray } = collections.array
 const { isDefined } = lowerDashValues
 
-export const metadataType = (element: Element): string => {
+export const metadataType = (element: Readonly<Element>): string => {
   if (isInstanceElement(element)) {
     return metadataType(element.type)
   }
@@ -61,7 +61,7 @@ export const metadataType = (element: Element): string => {
   return element.annotations[METADATA_TYPE] || 'unknown'
 }
 
-export const isCustomObject = (element: Element): element is ObjectType => (
+export const isCustomObject = (element: Readonly<Element>): element is ObjectType => (
   isObjectType(element)
   && metadataType(element) === CUSTOM_OBJECT
   // The last part is so we can tell the difference between a custom object
@@ -77,26 +77,26 @@ export const isFieldOfCustomObject = (field: Field): boolean =>
 // for instances of Lead, but it will not be true for Lead itself when it is still an instance
 // (before the custom objects filter turns it into a type).
 // To filter for instances like the Lead definition, use isInstanceOfType(CUSTOM_OBJECT) instead
-export const isInstanceOfCustomObject = (element: Element): element is InstanceElement =>
+export const isInstanceOfCustomObject = (element: Readonly<Element>): element is InstanceElement =>
   isInstanceElement(element) && isCustomObject(element.type)
 
 export const isCustom = (fullName: string): boolean =>
   fullName.endsWith(SALESFORCE_CUSTOM_SUFFIX)
 
-export const isCustomSettings = (instance: InstanceElement): boolean =>
+export const isCustomSettings = (instance: Readonly<InstanceElement>): boolean =>
   instance.value[CUSTOM_SETTINGS_TYPE]
 
-export const isCustomSettingsObject = (obj: Element): boolean =>
+export const isCustomSettingsObject = (obj: Readonly<Element>): boolean =>
   obj.annotations[CUSTOM_SETTINGS_TYPE]
 
-export const defaultApiName = (element: Element): string => {
+export const defaultApiName = (element: Readonly<Element>): string => {
   const { name } = element.elemID
   return isCustom(name) || isInstanceElement(element)
     ? name
     : `${name}${SALESFORCE_CUSTOM_SUFFIX}`
 }
 
-const fullApiName = (elem: Element): string => {
+const fullApiName = (elem: Readonly<Element>): string => {
   if (isInstanceElement(elem)) {
     return isCustomObject(elem.type)
       ? elem.value[CUSTOM_OBJECT_ID_FIELD] : elem.value[INSTANCE_FULL_NAME_FIELD]
@@ -108,7 +108,7 @@ export const relativeApiName = (name: string): string => (
   _.last(name.split(API_NAME_SEPARATOR)) as string
 )
 
-export const apiName = (elem: Element, relative = false): string => {
+export const apiName = (elem: Readonly<Element>, relative = false): string => {
   const name = fullApiName(elem)
   return name && relative ? relativeApiName(name) : name
 }

--- a/packages/workato-adapter/config_doc.md
+++ b/packages/workato-adapter/config_doc.md
@@ -24,6 +24,10 @@ workato {
       "recipes",
       "roles",
     ]
+    serviceConnectionNames = {
+      salesforce = "Salesforce sandbox 1 connection"
+      netsuite = "Netsuite sbx"
+    }
   }
 }
 ```
@@ -71,3 +75,4 @@ workato {
 |                                             |   "recipes",             |
 |                                             |   "roles",               |
 |                                             |  ]                       |
+| serviceConnectionNames                      |                          | Mapping from adapter name to workato connection name, which is used for resolving the relevant elements into references across multiple adapters in the same environment. Currently salesforce and netsuite are supported

--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  FetchResult, AdapterOperations, DeployResult, Element,
+  FetchResult, AdapterOperations, DeployResult, Element, PostFetchOptions,
 } from '@salto-io/adapter-api'
 import { elements as elementUtils } from '@salto-io/adapter-components'
 import { logDuration } from '@salto-io/adapter-utils'
@@ -24,6 +24,7 @@ import { FilterCreator, Filter, filtersRunner } from './filter'
 import { WorkatoConfig } from './config'
 import extractFieldsFilter from './filters/extract_fields'
 import fieldReferencesFilter from './filters/field_references'
+import recipeCrossServiceReferencesFilter from './filters/cross_service/recipe_references'
 import { WORKATO } from './constants'
 
 const log = logger(module)
@@ -34,6 +35,7 @@ const {
 export const DEFAULT_FILTERS = [
   extractFieldsFilter,
   fieldReferencesFilter,
+  recipeCrossServiceReferencesFilter,
 ]
 
 export interface WorkatoAdapterParams {
@@ -89,6 +91,12 @@ export default class WorkatoAdapter implements AdapterOperations {
     log.debug('going to run filters on %d fetched elements', elements.length)
     await this.filtersRunner.onFetch(elements)
     return { elements }
+  }
+
+  @logDuration('updating cross-service references')
+  async postFetch(args: PostFetchOptions): Promise<{ changed: boolean }> {
+    const changed = await this.filtersRunner.onPostFetch(args)
+    return { changed }
   }
 
   /**

--- a/packages/workato-adapter/src/adapter_creator.ts
+++ b/packages/workato-adapter/src/adapter_creator.ts
@@ -15,10 +15,7 @@
 */
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import {
-  InstanceElement, Adapter, AdapterOperations, AdapterOperationsContext,
-} from '@salto-io/adapter-api'
-import { types } from '@salto-io/lowerdash'
+import { InstanceElement, Adapter } from '@salto-io/adapter-api'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
 import WorkatoAdapter from './adapter'
 import { Credentials, usernameTokenCredentialsType } from './auth'
@@ -68,9 +65,7 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
   return adapterConfig
 }
 
-export const adapter: Omit<Adapter, 'operations'> & {
-  operations: (context: AdapterOperationsContext) => types.PickyRequired<AdapterOperations, 'postFetch'>
-} = {
+export const adapter: Adapter = {
   operations: context => {
     const config = adapterConfigFromConfig(context.config)
     const credentials = credentialsFromConfig(context.credentials)

--- a/packages/workato-adapter/src/constants.ts
+++ b/packages/workato-adapter/src/constants.ts
@@ -14,3 +14,9 @@
 * limitations under the License.
 */
 export const WORKATO = 'workato'
+
+// services supporting cross-service reference - mapping from salto name to workato name
+export const CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS: Record<string, string> = {
+  salesforce: 'salesforce',
+  netsuite: 'netsuite',
+}

--- a/packages/workato-adapter/src/filters/cross_service/element_indexes.ts
+++ b/packages/workato-adapter/src/filters/cross_service/element_indexes.ts
@@ -1,0 +1,88 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { Element, isInstanceElement, InstanceElement } from '@salto-io/adapter-api'
+
+type ElemLookupMapping = Record<string, Record<string, Readonly<Element>[]>>
+
+export type SalesforceIndex = ElemLookupMapping
+export type NetsuiteIndex = ElemLookupMapping
+
+// salesforce indexes
+
+const API_NAME = 'apiName'
+export const METADATA_TYPE = 'metadataType'
+
+const metadataType: (elem: Readonly<Element>) => string | undefined = elem => (
+  elem.annotations[METADATA_TYPE]
+)
+
+const apiName: (elem: Readonly<Element>) => string | undefined = elem => (
+  elem.annotations[API_NAME] ?? metadataType(elem)
+)
+
+export const indexSalesforceByMetadataTypeAndApiName = (
+  salesforceElements: ReadonlyArray<Readonly<Element>>,
+): SalesforceIndex => {
+  // needed in order to handle element fragments in custom objects
+  const elementsById = _.groupBy(salesforceElements, e => e.elemID.getFullName())
+
+  const mapApiNameToElem = (elements: Readonly<Element>[]): Record<string, Readonly<Element>[]> => (
+    _.mapValues(
+      _.keyBy(
+        elements.filter(e => apiName(e) !== undefined),
+        elem => apiName(elem) as string,
+      ),
+      e => elementsById[e.elemID.getFullName()],
+    )
+  )
+
+  const groupByMetadataTypeAndApiName = (
+    elements: ReadonlyArray<Readonly<Element>>
+  ): ElemLookupMapping => (
+    _.mapValues(
+      _.groupBy(
+        elements.filter(e => metadataType(e) !== undefined),
+        metadataType
+      ),
+      mapApiNameToElem
+    )
+  )
+
+  return groupByMetadataTypeAndApiName(salesforceElements)
+}
+
+// netsuite index
+
+export const indexNetsuiteByTypeAndScriptId = (
+  elements: ReadonlyArray<Readonly<Element>>
+): NetsuiteIndex => {
+  const byType = _.groupBy(
+    elements.filter(isInstanceElement),
+    e => e.type.elemID.name,
+  )
+
+  const toScriptId = (inst: Readonly<InstanceElement>): string | undefined => inst.value.scriptid
+
+  return _.mapValues(
+    byType,
+    // TODO check if guaranteed to be unique
+    groupedElements => _.groupBy(
+      groupedElements.filter(e => toScriptId(e) !== undefined),
+      e => toScriptId(e) as string
+    )
+  )
+}

--- a/packages/workato-adapter/src/filters/cross_service/element_indexes.ts
+++ b/packages/workato-adapter/src/filters/cross_service/element_indexes.ts
@@ -14,12 +14,10 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Element, isInstanceElement, InstanceElement } from '@salto-io/adapter-api'
+import { Element, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 
-type ElemLookupMapping = Record<string, Record<string, Readonly<Element>[]>>
-
-export type SalesforceIndex = ElemLookupMapping
-export type NetsuiteIndex = ElemLookupMapping
+export type SalesforceIndex = Record<string, Record<string, Readonly<Element>[]>>
+export type NetsuiteIndex = Record<string, Readonly<Element>>
 
 // salesforce indexes
 
@@ -52,7 +50,7 @@ export const indexSalesforceByMetadataTypeAndApiName = (
 
   const groupByMetadataTypeAndApiName = (
     elements: ReadonlyArray<Readonly<Element>>
-  ): ElemLookupMapping => (
+  ): SalesforceIndex => (
     _.mapValues(
       _.groupBy(
         elements.filter(e => metadataType(e) !== undefined),
@@ -70,19 +68,9 @@ export const indexSalesforceByMetadataTypeAndApiName = (
 export const indexNetsuiteByTypeAndScriptId = (
   elements: ReadonlyArray<Readonly<Element>>
 ): NetsuiteIndex => {
-  const byType = _.groupBy(
-    elements.filter(isInstanceElement),
-    e => e.type.elemID.name,
-  )
-
   const toScriptId = (inst: Readonly<InstanceElement>): string | undefined => inst.value.scriptid
-
-  return _.mapValues(
-    byType,
-    // TODO check if guaranteed to be unique
-    groupedElements => _.groupBy(
-      groupedElements.filter(e => toScriptId(e) !== undefined),
-      e => toScriptId(e) as string
-    )
+  return _.keyBy(
+    elements.filter(isInstanceElement).filter(e => toScriptId(e) !== undefined),
+    e => toScriptId(e) as string,
   )
 }

--- a/packages/workato-adapter/src/filters/cross_service/recipe_block_types.ts
+++ b/packages/workato-adapter/src/filters/cross_service/recipe_block_types.ts
@@ -1,0 +1,72 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS } from '../../constants'
+
+type RefListItem = {
+  label: string
+  value: string
+}
+
+export type SalesforceBlock = {
+  provider: 'salesforce'
+  dynamicPickListSelection: {
+    sobject_name: string
+    field_list?: RefListItem[]
+    table_list?: RefListItem[]
+  }
+  input: {
+    sobject_name: string
+  }
+}
+export type NetsuiteBlock = {
+  provider: 'netsuite'
+  dynamicPickListSelection: {
+    netsuite_object: string
+    custom_list?: RefListItem[]
+  }
+  input?: {
+    netsuite_object: string
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isListItem = (value: any): value is RefListItem => (
+  _.isObjectLike(value) && _.isString(value.label) && _.isString(value.value)
+)
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isSalesforceBlock = (value: any): value is SalesforceBlock => (
+  _.isObjectLike(value)
+  && value.provider === CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS.salesforce
+  && _.isObjectLike(value.dynamicPickListSelection)
+  && _.isString(value.dynamicPickListSelection.sobject_name)
+  && (value.dynamicPickListSelection.table_list ?? []).every(isListItem)
+  && (value.dynamicPickListSelection.field_list ?? []).every(isListItem)
+  && _.isObjectLike(value.input)
+  && _.isString(value.input.sobject_name)
+)
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isNetsuiteBlock = (value: any): value is NetsuiteBlock => (
+  _.isObjectLike(value)
+  && value.provider === CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS.netsuite
+  && _.isObjectLike(value.dynamicPickListSelection)
+  && _.isString(value.dynamicPickListSelection.netsuite_object)
+  && (value.dynamicPickListSelection.custom_list ?? []).every(isListItem)
+  && _.isObjectLike(value.input)
+  && _.isString(value.input.netsuite_object)
+)

--- a/packages/workato-adapter/src/filters/cross_service/recipe_references.ts
+++ b/packages/workato-adapter/src/filters/cross_service/recipe_references.ts
@@ -1,0 +1,429 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  Element, isInstanceElement, InstanceElement, ElemID, isReferenceExpression, ReferenceExpression,
+  PostFetchOptions, isObjectType, ObjectType, Field,
+} from '@salto-io/adapter-api'
+import { elements as elementUtils } from '@salto-io/adapter-components'
+import { transformElement, TransformFunc, safeJsonStringify, setPath, extendGeneratedDependencies } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { values as lowerdashValues } from '@salto-io/lowerdash'
+import { FilterCreator } from '../../filter'
+import { FETCH_CONFIG } from '../../config'
+import { CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS } from '../../constants'
+import { indexSalesforceByMetadataTypeAndApiName, indexNetsuiteByTypeAndScriptId, NetsuiteIndex, SalesforceIndex } from './element_indexes'
+
+const log = logger(module)
+const { isDefined } = lowerdashValues
+const { toNestedTypeName } = elementUtils.ducktype
+
+type MappedReference = {
+  srcPath: ElemID | undefined
+  ref: ReferenceExpression
+}
+
+type RefListItem = {
+  label: string
+  value: string
+}
+
+type SalesforceBlock = {
+  provider: 'salesforce'
+  dynamicPickListSelection: {
+    sobject_name: string
+    field_list?: RefListItem[]
+    table_list?: RefListItem[]
+  }
+  input: {
+    sobject_name: string
+  }
+}
+type NetsuiteBlock = {
+  provider: 'netsuite'
+  dynamicPickListSelection: {
+    netsuite_object: string
+    custom_list?: RefListItem[]
+  }
+  input?: {
+    netsuite_object: string
+  }
+}
+
+type ReferenceFinder<T extends SalesforceBlock | NetsuiteBlock> = (
+  value: T,
+  path: ElemID,
+) => MappedReference[]
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isListItem = (value: any): value is RefListItem => (
+  _.isObjectLike(value) && _.isString(value.label) && _.isString(value.value)
+)
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isSalesforceBlock = (value: any): value is SalesforceBlock => (
+  _.isObjectLike(value)
+  && value.provider === CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS.salesforce
+  && _.isObjectLike(value.dynamicPickListSelection)
+  && _.isString(value.dynamicPickListSelection.sobject_name)
+  && (value.dynamicPickListSelection.table_list ?? []).every(isListItem)
+  && (value.dynamicPickListSelection.field_list ?? []).every(isListItem)
+  && _.isObjectLike(value.input)
+  && _.isString(value.input.sobject_name)
+)
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isNetsuiteBlock = (value: any): value is NetsuiteBlock => (
+  _.isObjectLike(value)
+  && value.provider === CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS.netsuite
+  && _.isObjectLike(value.dynamicPickListSelection)
+  && _.isString(value.dynamicPickListSelection.netsuite_object)
+  && (value.dynamicPickListSelection.custom_list ?? []).every(isListItem)
+  && _.isObjectLike(value.input)
+  && _.isString(value.input.netsuite_object)
+)
+
+const addReferencesForService = <T extends SalesforceBlock | NetsuiteBlock>(
+  inst: InstanceElement,
+  addReferences: ReferenceFinder<T>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  typeGuard: (value: any) => value is T,
+): boolean => {
+  const dependencyMapping: MappedReference[] = []
+
+  const findReferences: TransformFunc = ({ value, path }) => {
+    if (typeGuard(value)) {
+      dependencyMapping.push(...addReferences(
+        value,
+        path ?? inst.elemID,
+      ))
+    }
+    return value
+  }
+
+  // used for traversal, the transform result is ignored
+  transformElement({
+    element: inst,
+    transformFunc: findReferences,
+  })
+  if (dependencyMapping.length > 0) {
+    log.info('found the following references: %s', safeJsonStringify(dependencyMapping.map(dep => [dep.srcPath?.getFullName(), dep.ref.elemId.getFullName()])))
+    dependencyMapping.forEach(({ srcPath, ref }) => {
+      if (srcPath !== undefined) {
+        setPath(inst, srcPath, ref)
+      }
+    })
+    extendGeneratedDependencies(inst, dependencyMapping.map(dep => dep.ref))
+    return true
+  }
+  return false
+}
+
+const SALESFORCE_LABEL_ANNOTATION = 'label'
+
+const addSalesforceRecipeReferences = (
+  inst: InstanceElement,
+  indexedElements: SalesforceIndex,
+): boolean => {
+  const getObjectDetails = (objectName: string): {
+    id: ElemID
+    fields: Record<string, Readonly<Field>>
+    label?: string
+   } | undefined => {
+    const refObjectFragments = (
+      indexedElements.CustomObject?.[objectName] ?? indexedElements[objectName]?.[objectName]
+    )
+    if (refObjectFragments !== undefined && refObjectFragments.every(isObjectType)) {
+      const fields: Record<string, Field> = _.assign(
+        {},
+        ...(refObjectFragments as ObjectType[]).map(fragment => fragment.fields),
+      )
+      const label = refObjectFragments.map(
+        ref => ref.annotations[SALESFORCE_LABEL_ANNOTATION]
+      ).find(_.isString)
+      return {
+        id: refObjectFragments[0].elemID,
+        fields,
+        label,
+      }
+    }
+    return undefined
+  }
+
+  const referenceFinder: ReferenceFinder<SalesforceBlock> = (blockValue, path) => {
+    const { dynamicPickListSelection, input } = blockValue
+    const objectDetails = getObjectDetails(input.sobject_name)
+    if (objectDetails === undefined) {
+      return []
+    }
+
+    const references: MappedReference[] = [{
+      srcPath: path.createNestedID('input', 'sobject_name'),
+      ref: new ReferenceExpression(objectDetails.id),
+    }]
+
+    const inputFieldNames = Object.keys(_.omit(input, 'sobject_name'))
+    inputFieldNames.forEach(fieldName => {
+      if (objectDetails.fields[fieldName] !== undefined) {
+        references.push(
+          {
+            // no srcPath because we can't override the field keys in the current format
+            srcPath: undefined,
+            ref: new ReferenceExpression(objectDetails.fields[fieldName].elemID),
+          },
+        )
+      }
+    })
+
+    // dynamicPickListSelection uses the label, not the api name
+    if (dynamicPickListSelection.sobject_name === objectDetails.label) {
+      references.push({
+        srcPath: path.createNestedID('dynamicPickListSelection', 'sobject_name'),
+        ref: new ReferenceExpression(objectDetails.id),
+      })
+
+      if (dynamicPickListSelection.field_list !== undefined) {
+        const potentialFields: string[] = (dynamicPickListSelection.field_list).map(
+          (f: { value: string }) => f.value
+        )
+        potentialFields.forEach((fieldName, idx) => {
+          if (objectDetails.fields[fieldName] !== undefined) {
+            references.push(
+              {
+                srcPath: path.createNestedID('dynamicPickListSelection', 'field_list', String(idx)),
+                ref: new ReferenceExpression(objectDetails.fields[fieldName].elemID),
+              },
+            )
+          }
+        })
+      }
+      if (dynamicPickListSelection.table_list !== undefined) {
+        const potentialReferencedTypes: string[] = (dynamicPickListSelection.table_list).map(
+          (f: { value: string }) => f.value
+        )
+        potentialReferencedTypes.forEach((typeName, idx) => {
+          const refObjectDetails = getObjectDetails(typeName)
+          if (refObjectDetails !== undefined) {
+            references.push(
+              {
+                srcPath: path.createNestedID('dynamicPickListSelection', 'table_list', String(idx)),
+                ref: new ReferenceExpression(refObjectDetails.id),
+              },
+            )
+          }
+        })
+      }
+    }
+    return references
+  }
+
+  return addReferencesForService<SalesforceBlock>(inst, referenceFinder, isSalesforceBlock)
+}
+
+const addNetsuiteRecipeReferences = (
+  inst: InstanceElement,
+  indexedElements: NetsuiteIndex,
+): boolean => {
+  const referenceFinder: ReferenceFinder<NetsuiteBlock> = (blockValue, path) => {
+    const references: MappedReference[] = []
+
+    const { dynamicPickListSelection, input } = blockValue
+
+    const netsuiteObject = input?.netsuite_object
+    if (netsuiteObject !== undefined) {
+      if (_.isString(netsuiteObject) && netsuiteObject.split('@@').length === 2) {
+        const customRecordId = _.last(netsuiteObject.toLowerCase().split('@@'))
+        if (customRecordId !== undefined) {
+          // TODO check if need to extend to more types besides customrecordtype
+          const referencedInstanceFragments = indexedElements.customrecordtype?.[customRecordId]
+          if (!_.isEmpty(referencedInstanceFragments)) {
+            references.push({
+              srcPath: path.createNestedID('input', 'netsuite_object'),
+              ref: new ReferenceExpression(referencedInstanceFragments[0].elemID),
+            })
+          }
+        }
+      }
+    }
+
+    (dynamicPickListSelection.custom_list ?? []).forEach(({ value }, idx) => {
+      if (_.isString(value) && value.split('@').length === 2) {
+        const [type, name] = value.toLowerCase().split('@')
+        const referencedInstanceFragments = indexedElements[type]?.[name]
+        if (!_.isEmpty(referencedInstanceFragments)) {
+          references.push({
+            srcPath: path.createNestedID('dynamicPickListSelection', 'custom_list', String(idx)),
+            ref: new ReferenceExpression(referencedInstanceFragments[0].elemID),
+          })
+        }
+      }
+    })
+    return references
+  }
+
+  return addReferencesForService<NetsuiteBlock>(inst, referenceFinder, isNetsuiteBlock)
+}
+
+const toKey = (first: string, second: string): string => `${first}:${second}`
+
+const getServiceConnectionIDs = (
+  serviceConnectionNames: Record<string, string>,
+  connectionInstances: InstanceElement[],
+): Record<string, ElemID> => {
+  const supportedAdapters = Object.values(CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS)
+  const unsupportedServiceNames = Object.keys(serviceConnectionNames).filter(
+    name => !supportedAdapters.includes(name)
+  )
+  if (unsupportedServiceNames.length > 0) {
+    log.error('the following services are not supported, and will be ignored: %s', unsupportedServiceNames)
+  }
+
+  const connections = new Set(connectionInstances.map(
+    inst => toKey(inst.value.application, inst.value.name)
+  ))
+  const missingConnections = Object.entries(serviceConnectionNames).filter(
+    ([adapterName, connectionName]) => !connections.has(toKey(adapterName, connectionName))
+  )
+  if (missingConnections.length > 0) {
+    log.error('the following services do not have any workato connections in the fetch results: %s', missingConnections)
+  }
+
+  const serviceConnectionIDs = _.pickBy(
+    _.mapValues(
+      _.pickBy(
+        serviceConnectionNames,
+        (_connectionName, adapterName) => supportedAdapters.includes(adapterName)
+      ),
+      (connectionName, serviceName) => _.first(connectionInstances
+        .filter(inst => inst.value.name === connectionName)
+        .filter(inst =>
+          inst.value.application === CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS[serviceName])
+        .map(inst => inst.elemID))
+    ),
+    isDefined,
+  )
+  const unresolvedConnectionNames = (
+    Object.entries(serviceConnectionNames)
+      .filter(([serviceName]) => serviceConnectionNames[serviceName] === undefined)
+  )
+  if (unresolvedConnectionNames.length > 0) {
+    log.error('the following connection names could not be resolved: %s', safeJsonStringify(unresolvedConnectionNames))
+  }
+
+  return serviceConnectionIDs
+}
+
+/**
+ * Return the code parts of recipes that use the specified connection.
+ * (at most one connection for each connector can be used in each recipe using standard connectors)
+ */
+const filterRelevantRecipeCodes = (
+  connectionID: ElemID,
+  recipeInstances: InstanceElement[],
+  recipeCodeInstances: Record<string, InstanceElement>,
+): InstanceElement[] => {
+  const relevantRecipes = (
+    recipeInstances
+      .filter(recipe => isReferenceExpression(recipe.value.code))
+      .filter(recipe => Array.isArray(recipe.value.config) && recipe.value.config.some(
+        connectionConfig => (
+          _.isObjectLike(connectionConfig)
+          && isReferenceExpression(connectionConfig.account_id)
+          && connectionID.isEqual(connectionConfig.account_id.elemId)
+        )
+      ))
+  )
+  return relevantRecipes.map(
+    recipe => recipeCodeInstances[recipe.value.code.elemId.getFullName()]
+  )
+}
+
+const addReferencesForConnectionRecipes = (
+  relevantRecipeCodes: InstanceElement[],
+  serviceName: string,
+  serviceElements: ReadonlyArray<Readonly<Element>>,
+): boolean => {
+  if (serviceName === CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS.salesforce) {
+    const index = indexSalesforceByMetadataTypeAndApiName(
+      serviceElements ?? []
+    )
+    const res = relevantRecipeCodes.map(
+      inst => addSalesforceRecipeReferences(inst, index)
+    )
+    return res.some(t => t)
+  }
+  if (serviceName === CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS.netsuite) {
+    const index = indexNetsuiteByTypeAndScriptId(
+      serviceElements ?? []
+    )
+    const res = relevantRecipeCodes.map(
+      inst => addNetsuiteRecipeReferences(inst, index)
+    )
+    return res.some(t => t)
+  }
+
+  log.debug('unsupported service name %s, not resolving recipe references', serviceName)
+  return false
+}
+
+/**
+ * Find references from recipe code blocks to other adapters in the workspace.
+ */
+const filter: FilterCreator = ({ config }) => ({
+  onPostFetch: async ({
+    currentAdapterElements,
+    elementsByAdapter,
+  }: PostFetchOptions): Promise<boolean> => {
+    const { serviceConnectionNames } = config[FETCH_CONFIG]
+    if (serviceConnectionNames === undefined || _.isEmpty(serviceConnectionNames)) {
+      return false
+    }
+
+    const serviceConnections = getServiceConnectionIDs(
+      serviceConnectionNames,
+      currentAdapterElements
+        .filter(isInstanceElement)
+        .filter(inst => inst.type.elemID.name === 'connection'),
+    )
+    const recipeInstances = (
+      currentAdapterElements
+        .filter(isInstanceElement)
+        .filter(inst => inst.type.elemID.name === 'recipe')
+    )
+    const recipeCodeInstancesByElemID = _.keyBy(
+      currentAdapterElements
+        .filter(isInstanceElement)
+        .filter(inst => inst.type.elemID.name === toNestedTypeName('recipe', 'code')),
+      inst => inst.elemID.getFullName()
+    )
+
+    const updateResults = Object.entries(serviceConnections).map(([serviceName, connectionID]) => {
+      const relevantRecipeCodes = filterRelevantRecipeCodes(
+        connectionID,
+        recipeInstances,
+        recipeCodeInstancesByElemID,
+      )
+      return addReferencesForConnectionRecipes(
+        relevantRecipeCodes,
+        serviceName,
+        elementsByAdapter[serviceName],
+      )
+    })
+    return updateResults.some(t => t)
+  },
+})
+
+export default filter

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -16,8 +16,9 @@
 import _ from 'lodash'
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
-import { InstanceElement, isObjectType, isInstanceElement, ReferenceExpression, ObjectType, ElemID, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { InstanceElement, isObjectType, isInstanceElement, ReferenceExpression, ObjectType, ElemID, CORE_ANNOTATIONS, AdapterOperations } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { types } from '@salto-io/lowerdash'
 import mockReplies from './mock_replies.json'
 import { adapter } from '../src/adapter_creator'
 import { usernameTokenCredentialsType } from '../src/auth'
@@ -315,12 +316,13 @@ describe('adapter', () => {
             }
           ),
           elementsSource: buildElementsSourceFromElements([]),
-        })
+        }) as types.PickyRequired<AdapterOperations, 'postFetch'>
 
         const fetchResult = await adapterOperations.fetch({
           progressReporter: { reportProgress: () => null },
         })
         const currentAdapterElements = fetchResult.elements
+        expect(adapterOperations.postFetch).toBeDefined()
         const postFetchRes = await adapterOperations.postFetch({
           currentAdapterElements,
           elementsByAdapter: {

--- a/packages/workato-adapter/test/adapter_creator.test.ts
+++ b/packages/workato-adapter/test/adapter_creator.test.ts
@@ -84,7 +84,7 @@ describe('adapter creator', () => {
     })).toBeInstanceOf(WorkatoAdapter)
   })
 
-  it('should throw error on invalid configuration', () => {
+  it('should throw error on inconsistent configuration between fetch and apiDefinitions', () => {
     expect(() => adapter.operations({
       credentials: new InstanceElement(WORKATO,
         adapter.authenticationMethods.basic.credentialsType),
@@ -111,6 +111,36 @@ describe('adapter creator', () => {
       ),
       elementsSource: buildElementsSourceFromElements([]),
     })).toThrow(new Error('Invalid type names in fetch: a,b'))
+  })
+
+  it('should throw error on invalid serviceConnectionNames configuration', () => {
+    expect(() => adapter.operations({
+      credentials: new InstanceElement(WORKATO,
+        adapter.authenticationMethods.basic.credentialsType),
+      config: new InstanceElement(
+        WORKATO,
+        adapter.configType as ObjectType,
+        {
+          fetch: {
+            includeTypes: [],
+            serviceConnectionNames: {
+              salesforce: 'abc',
+              unsupportedName: 'def',
+            },
+          },
+          apiDefinitions: {
+            types: {
+              c: {
+                request: {
+                  url: '/c',
+                },
+              },
+            },
+          },
+        },
+      ),
+      elementsSource: buildElementsSourceFromElements([]),
+    })).toThrow(new Error('Unsupported service names in fetch: unsupportedName. The supported services are: salesforce,netsuite'))
   })
 
   it('should validate credentials using createConnection', async () => {

--- a/packages/workato-adapter/test/filters/recipe_references.test.ts
+++ b/packages/workato-adapter/test/filters/recipe_references.test.ts
@@ -1,0 +1,769 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, BuiltinTypes, ListType, CORE_ANNOTATIONS, isReferenceExpression } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import filterCreator from '../../src/filters/cross_service/recipe_references'
+import WorkatoClient from '../../src/client/client'
+import { DEFAULT_TYPES, DEFAULT_ID_FIELDS } from '../../src/config'
+import { WORKATO } from '../../src/constants'
+
+/* eslint-disable @typescript-eslint/camelcase */
+
+describe('Recipe references filter', () => {
+  let client: WorkatoClient
+  type FilterType = filterUtils.FilterWith<'onPostFetch'>
+  let filter: FilterType
+
+  beforeAll(() => {
+    client = new WorkatoClient({
+      credentials: { username: 'a', token: 'b' },
+    })
+    filter = filterCreator({
+      client,
+      config: {
+        fetch: {
+          includeTypes: ['connection', 'recipe'],
+          serviceConnectionNames: {
+            salesforce: 'salesforce sandbox 1',
+            netsuite: 'netsuite sbx 123',
+            ignoreThis: 'abc',
+          },
+        },
+        apiDefinitions: {
+          typeDefaults: {
+            transformation: {
+              idFields: DEFAULT_ID_FIELDS,
+            },
+          },
+          types: DEFAULT_TYPES,
+        },
+      },
+    }) as FilterType
+  })
+
+  const generateCurrentAdapterElements = (
+  ): Element[] => {
+    const connectionType = new ObjectType({
+      elemID: new ElemID(WORKATO, 'connection'),
+      fields: {
+        id: { type: BuiltinTypes.NUMBER },
+        application: { type: BuiltinTypes.STRING },
+        name: { type: BuiltinTypes.STRING },
+      },
+    })
+
+    const sfSandbox1 = new InstanceElement(
+      'salesforce_sandbox_1',
+      connectionType,
+      {
+        id: 1234,
+        application: 'salesforce',
+        name: 'salesforce sandbox 1',
+      }
+    )
+    const anotherSfSandbox = new InstanceElement(
+      'another_salesforce_sandbox',
+      connectionType,
+      {
+        id: 1235,
+        application: 'salesforce',
+        name: 'another salesforce sandbox',
+      }
+    )
+    const netsuiteSandbox123 = new InstanceElement(
+      'netsuite_sbx_123',
+      connectionType,
+      {
+        id: 1236,
+        application: 'netsuite',
+        name: 'netsuite sbx 123',
+      }
+    )
+
+    const labelValueType = new ObjectType({
+      elemID: new ElemID(WORKATO, 'labelValue'),
+      fields: {
+        label: { type: BuiltinTypes.STRING },
+        value: { type: BuiltinTypes.STRING },
+      },
+    })
+
+    const dynamicPickListSelectionType = new ObjectType({
+      elemID: new ElemID(WORKATO, 'recipe__code__dynamicPickListSelection'),
+      fields: {
+        sobject_name: { type: BuiltinTypes.STRING },
+        netsuite_object: { type: BuiltinTypes.STRING },
+        topic_id: { type: BuiltinTypes.STRING },
+        table_list: { type: new ListType(labelValueType) },
+        field_list: { type: new ListType(labelValueType) },
+      },
+    })
+
+    const inputType = new ObjectType({
+      elemID: new ElemID(WORKATO, 'recipe__code__input'),
+      fields: {
+        sobject_name: { type: BuiltinTypes.STRING },
+        netsuite_object: { type: BuiltinTypes.STRING },
+        topic_id: { type: BuiltinTypes.STRING },
+        table_list: { type: new ListType(labelValueType) },
+        field_list: { type: new ListType(labelValueType) },
+      },
+    })
+
+    // imitate 3-level recursive type generation until we fix it
+
+    const nestedBlockTypeInner = new ObjectType({
+      elemID: new ElemID(WORKATO, 'recipe__code__block__block__block'),
+      fields: {
+        provider: { type: BuiltinTypes.STRING },
+        name: { type: BuiltinTypes.STRING },
+        dynamicPickListSelection: { type: dynamicPickListSelectionType },
+        input: { type: inputType },
+      },
+    })
+
+    const nestedBlockType = new ObjectType({
+      elemID: new ElemID(WORKATO, 'recipe__code__block__block'),
+      fields: {
+        provider: { type: BuiltinTypes.STRING },
+        name: { type: BuiltinTypes.STRING },
+        dynamicPickListSelection: { type: dynamicPickListSelectionType },
+        input: { type: inputType },
+        block: { type: new ListType(nestedBlockTypeInner) },
+      },
+    })
+
+    const blockType = new ObjectType({
+      elemID: new ElemID(WORKATO, 'recipe__code__block'),
+      fields: {
+        provider: { type: BuiltinTypes.STRING },
+        name: { type: BuiltinTypes.STRING },
+        dynamicPickListSelection: { type: dynamicPickListSelectionType },
+        input: { type: inputType },
+        block: { type: new ListType(nestedBlockType) },
+      },
+    })
+
+    const codeType = new ObjectType({
+      elemID: new ElemID(WORKATO, 'recipe__code'),
+      fields: {
+        provider: { type: BuiltinTypes.STRING },
+        name: { type: BuiltinTypes.STRING },
+        dynamicPickListSelection: { type: dynamicPickListSelectionType },
+        input: { type: inputType },
+        block: { type: new ListType(blockType) },
+      },
+    })
+
+    const recipeConfigType = new ObjectType({
+      elemID: new ElemID(WORKATO, 'recipe__config'),
+      fields: {
+        name: { type: BuiltinTypes.STRING },
+        provider: { type: BuiltinTypes.STRING },
+        account_id: { type: BuiltinTypes.NUMBER },
+        keyword: { type: BuiltinTypes.STRING },
+      },
+    })
+
+    const recipeType = new ObjectType({
+      elemID: new ElemID(WORKATO, 'recipe'),
+      fields: {
+        code: { type: codeType },
+        config: { type: recipeConfigType },
+        applications: { type: new ListType(BuiltinTypes.STRING) },
+        trigger_application: { type: BuiltinTypes.STRING },
+        action_applications: { type: new ListType(BuiltinTypes.STRING) },
+      },
+    })
+
+    const sharedRecipeCode = {
+      provider: 'salesforce',
+      name: 'updated_custom_object',
+      dynamicPickListSelection: {
+        sobject_name: 'Opportunity',
+        field_list: [
+          {
+            label: 'Opportunity ID',
+            value: 'Id',
+          },
+          {
+            label: 'Account ID',
+            value: 'AccountId',
+          },
+          {
+            label: 'Name',
+            value: 'Name',
+          },
+          {
+            label: 'Custom field',
+            value: 'Custom__c',
+          },
+        ],
+        table_list: [
+          {
+            label: 'Price Book',
+            value: 'Pricebook2',
+          },
+          {
+            label: 'Owner',
+            value: 'User',
+          },
+          {
+            label: 'Account',
+            value: 'Account',
+          },
+        ],
+      },
+      input: {
+        sobject_name: 'Opportunity',
+      },
+      block: [
+        {
+          provider: 'netsuite',
+          name: 'add_object',
+          dynamicPickListSelection: {
+            netsuite_object: 'custom record type label',
+            custom_list: [
+              { value: 'othercustomfield@custrecord2', label: 'something' },
+            ],
+          },
+          input: {
+            netsuite_object: 'custom record type label@@customrecord16',
+          },
+          block: [
+            {
+              provider: 'salesforce',
+              name: 'updated_custom_object',
+              dynamicPickListSelection: {
+                sobject_name: 'My Custom',
+              },
+              input: {
+                sobject_name: 'MyCustom__c',
+                customField__c: 'something',
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    const recipe1code = new InstanceElement('recipe1_code', codeType, _.cloneDeep(sharedRecipeCode))
+    const recipe1 = new InstanceElement('recipe1', recipeType, {
+      config: [
+        {
+          keyword: 'application',
+          name: 'salesforce',
+          provider: 'salesforce',
+          account_id: new ReferenceExpression(sfSandbox1.elemID),
+        },
+        {
+          keyword: 'application',
+          name: 'rest',
+          provider: 'rest',
+        },
+        {
+          keyword: 'application',
+          name: 'netsuite',
+          provider: 'netsuite',
+          account_id: new ReferenceExpression(netsuiteSandbox123.elemID),
+        },
+      ],
+      code: new ReferenceExpression(recipe1code.elemID),
+    })
+
+    const recipe2WrongConnectionCode = new InstanceElement('recipe2_code', codeType, _.cloneDeep(sharedRecipeCode))
+    const recipe2WrongConnection = new InstanceElement('recipe2', recipeType, {
+      config: [
+        {
+          keyword: 'application',
+          name: 'salesforce',
+          provider: 'salesforce',
+          account_id: new ReferenceExpression(anotherSfSandbox.elemID),
+        },
+        {
+          keyword: 'application',
+          name: 'rest',
+          provider: 'rest',
+        },
+      ],
+      code: new ReferenceExpression(recipe2WrongConnectionCode.elemID),
+    })
+
+    const recipe3OnlyNetsuiteCode = new InstanceElement('recipe3_code', codeType, _.cloneDeep(sharedRecipeCode))
+    const recipe3OnlyNetsuite = new InstanceElement('recipe3', recipeType, {
+      config: [
+        {
+          keyword: 'application',
+          name: 'salesforce',
+          provider: 'salesforce',
+          account_id: new ReferenceExpression(anotherSfSandbox.elemID),
+        },
+        {
+          keyword: 'application',
+          name: 'rest',
+          provider: 'rest',
+        },
+        {
+          keyword: 'application',
+          name: 'netsuite',
+          provider: 'netsuite',
+          account_id: new ReferenceExpression(netsuiteSandbox123.elemID),
+        },
+      ],
+      code: new ReferenceExpression(recipe3OnlyNetsuiteCode.elemID),
+    })
+    const recipe4UnknownSalesforceSobjectCode = new InstanceElement('recipe4_code', codeType, {
+      provider: 'salesforce',
+      name: 'updated_custom_object',
+      dynamicPickListSelection: {
+        sobject_name: 'Unknown',
+        field_list: [
+          {
+            label: 'Opportunity ID',
+            value: 'Id',
+          },
+          {
+            label: 'Account ID',
+            value: 'AccountId',
+          },
+          {
+            label: 'Name',
+            value: 'Name',
+          },
+          {
+            label: 'Custom field',
+            value: 'Custom__c',
+          },
+        ],
+        table_list: [
+          {
+            label: 'Price Book',
+            value: 'Pricebook2',
+          },
+          {
+            label: 'Owner',
+            value: 'User',
+          },
+          {
+            label: 'Account',
+            value: 'Account',
+          },
+        ],
+      },
+      input: {
+        sobject_name: 'Unknown',
+      },
+    })
+    const recipe4UnknownSalesforceSobject = new InstanceElement('recipe4', recipeType, {
+      config: [
+        {
+          keyword: 'application',
+          name: 'salesforce',
+          provider: 'salesforce',
+          account_id: new ReferenceExpression(anotherSfSandbox.elemID),
+        },
+      ],
+      code: new ReferenceExpression(recipe4UnknownSalesforceSobjectCode.elemID),
+    })
+    return [
+      connectionType,
+      sfSandbox1,
+      anotherSfSandbox,
+      netsuiteSandbox123,
+      labelValueType,
+      dynamicPickListSelectionType,
+      inputType,
+      nestedBlockTypeInner,
+      nestedBlockType,
+      blockType,
+      codeType,
+      recipeConfigType,
+      recipeType,
+      recipe1,
+      recipe1code,
+      recipe2WrongConnection,
+      recipe2WrongConnectionCode,
+      recipe3OnlyNetsuite,
+      recipe3OnlyNetsuiteCode,
+      recipe4UnknownSalesforceSobject,
+      recipe4UnknownSalesforceSobjectCode,
+    ]
+  }
+
+  const generateSalesforceElements = (): Element[] => {
+    const opportunity = new ObjectType({
+      elemID: new ElemID('salesforce', 'Opportunity'),
+      fields: {
+        Id: {
+          type: BuiltinTypes.STRING,
+          annotations: {
+            apiName: 'Opportunity.Id',
+          },
+        },
+        Custom__c: {
+          type: BuiltinTypes.STRING,
+          annotations: {
+            apiName: 'Opportunity.Custom__c',
+          },
+        },
+        Name: {
+          type: BuiltinTypes.STRING,
+          annotations: {
+            apiName: 'Opportunity.Name',
+          },
+        },
+      },
+      annotations: {
+        metadataType: 'CustomObject',
+        apiName: 'Opportunity',
+        label: 'Opportunity',
+      },
+    })
+    const user = new ObjectType({
+      elemID: new ElemID('salesforce', 'User'),
+      fields: {},
+      annotations: {
+        metadataType: 'CustomObject',
+        apiName: 'User',
+      },
+    })
+    const myCustom = new ObjectType({
+      elemID: new ElemID('salesforce', 'MyCustom__c'),
+      fields: {
+        customField__c: { type: BuiltinTypes.NUMBER },
+      },
+      annotations: {
+        metadataType: 'CustomObject',
+        apiName: 'MyCustom__c',
+        label: 'My Custom',
+      },
+    })
+
+    return [opportunity, user, myCustom]
+  }
+  const generateNetsuiteElements = (): Element[] => {
+    const customRecordType = new ObjectType({
+      elemID: new ElemID('netsuite', 'customrecordtype'),
+      fields: {},
+    })
+    const myCustomRecord = new InstanceElement(
+      'customrecord16',
+      customRecordType,
+      {
+        scriptid: 'customrecord16',
+        recordname: 'my custom record',
+      }
+    )
+
+    const otherCustomFieldType = new ObjectType({
+      elemID: new ElemID('netsuite', 'othercustomfield'),
+      fields: {},
+    })
+    const otherCustomFieldInst = new InstanceElement(
+      'custrecord2',
+      otherCustomFieldType,
+      {
+        scriptid: 'custrecord2',
+        recordname: 'something',
+      }
+    )
+
+    return [customRecordType, myCustomRecord, otherCustomFieldType, otherCustomFieldInst]
+  }
+
+  describe('on post-fetch', () => {
+    let currentAdapterElements: Element[]
+    let salesforceElements: Element[]
+    let netsuiteElements: Element[]
+    let res: boolean
+
+    beforeAll(async () => {
+      currentAdapterElements = generateCurrentAdapterElements()
+      salesforceElements = generateSalesforceElements()
+      netsuiteElements = generateNetsuiteElements()
+      res = await filter.onPostFetch({
+        currentAdapterElements,
+        elementsByAdapter: {
+          salesforce: salesforceElements,
+          netsuite: netsuiteElements,
+        },
+      })
+    })
+
+    describe('recipe1', () => {
+      it('should show all resolved references in the _generated_dependencies annotation, in alphabetical order', () => {
+        const recipeCode = currentAdapterElements.find(e => e.elemID.getFullName() === 'workato.recipe__code.instance.recipe1_code')
+        expect(recipeCode).toBeDefined()
+        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(9)
+        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].every(
+          isReferenceExpression
+        )).toBeTruthy()
+        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
+          (ref: ReferenceExpression) => ref.elemId.getFullName()
+        )).toEqual([
+          'netsuite.customrecordtype.instance.customrecord16',
+          'netsuite.othercustomfield.instance.custrecord2',
+          'salesforce.MyCustom__c',
+          'salesforce.MyCustom__c.field.customField__c',
+          'salesforce.Opportunity',
+          'salesforce.Opportunity.field.Custom__c',
+          'salesforce.Opportunity.field.Id',
+          'salesforce.Opportunity.field.Name',
+          'salesforce.User',
+        ])
+      })
+
+      it('should resolve references in-place where possible', () => {
+        const recipeCode = currentAdapterElements.find(
+          e => e.elemID.getFullName() === 'workato.recipe__code.instance.recipe1_code'
+        ) as InstanceElement
+        expect(recipeCode).toBeInstanceOf(InstanceElement)
+        expect(recipeCode.value.input.sobject_name).toBeInstanceOf(
+          ReferenceExpression
+        )
+        expect(recipeCode.value.input.sobject_name.elemId.getFullName()).toEqual('salesforce.Opportunity')
+        expect(recipeCode.value.dynamicPickListSelection.sobject_name).toBeInstanceOf(
+          ReferenceExpression
+        )
+        expect(recipeCode.value.dynamicPickListSelection.sobject_name.elemId.getFullName()).toEqual('salesforce.Opportunity')
+        expect(recipeCode.value.dynamicPickListSelection.field_list).toHaveLength(4)
+        // some, but not all, references are resolved
+        expect(
+          recipeCode.value.dynamicPickListSelection.field_list.every(isReferenceExpression)
+        ).toBeFalsy()
+        expect(
+          recipeCode.value.dynamicPickListSelection.field_list.some(isReferenceExpression)
+        ).toBeTruthy()
+        expect(recipeCode.value.dynamicPickListSelection.field_list[0].elemId.getFullName()).toEqual('salesforce.Opportunity.field.Id')
+        expect(recipeCode.value.dynamicPickListSelection.field_list[1]).toEqual({ label: 'Account ID', value: 'AccountId' })
+        expect(recipeCode.value.dynamicPickListSelection.field_list[2].elemId.getFullName()).toEqual('salesforce.Opportunity.field.Name')
+        expect(recipeCode.value.dynamicPickListSelection.field_list[3].elemId.getFullName()).toEqual('salesforce.Opportunity.field.Custom__c')
+        expect(recipeCode.value.dynamicPickListSelection.table_list).toHaveLength(3)
+        // some, but not all, references are resolved
+        expect(
+          recipeCode.value.dynamicPickListSelection.table_list.every(isReferenceExpression)
+        ).toBeFalsy()
+        expect(
+          recipeCode.value.dynamicPickListSelection.table_list.some(isReferenceExpression)
+        ).toBeTruthy()
+        expect(recipeCode.value.dynamicPickListSelection.table_list[0]).toEqual({ label: 'Price Book', value: 'Pricebook2' })
+        expect(recipeCode.value.dynamicPickListSelection.table_list[1].elemId.getFullName()).toEqual('salesforce.User')
+        expect(recipeCode.value.dynamicPickListSelection.table_list[2]).toEqual({ label: 'Account', value: 'Account' })
+      })
+      it('should resolve references in-place in nested blocks', () => {
+        const recipeCode = currentAdapterElements.find(
+          e => e.elemID.getFullName() === 'workato.recipe__code.instance.recipe1_code'
+        ) as InstanceElement
+        expect(recipeCode).toBeInstanceOf(InstanceElement)
+        const block1 = recipeCode.value.block[0]
+        expect(block1.input.netsuite_object).toBeInstanceOf(
+          ReferenceExpression
+        )
+        expect(block1.input.netsuite_object.elemId.getFullName()).toEqual('netsuite.customrecordtype.instance.customrecord16')
+        const block2 = block1.block[0]
+        expect(block2.input.sobject_name).toBeInstanceOf(
+          ReferenceExpression
+        )
+        expect(block2.input.sobject_name.elemId.getFullName()).toEqual('salesforce.MyCustom__c')
+      })
+    })
+
+    describe('recipe2WrongConnection', () => {
+      it('should not have any _generated_dependencies', () => {
+        const recipeCode = currentAdapterElements.find(e => e.elemID.getFullName() === 'workato.recipe__code.instance.recipe2_code')
+        expect(recipeCode).toBeDefined()
+        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
+      })
+
+      it('should be identical to the original generated element', () => {
+        const recipeCode = currentAdapterElements.find(
+          e => e.elemID.getFullName() === 'workato.recipe__code.instance.recipe2_code'
+        ) as InstanceElement
+        const origRecipeCode = generateCurrentAdapterElements().find(
+          e => e.elemID.getFullName() === 'workato.recipe__code.instance.recipe2_code'
+        ) as InstanceElement
+        expect(origRecipeCode.isEqual(recipeCode)).toBeTruthy()
+      })
+    })
+
+    describe('recipe3OnlyNetsuite', () => {
+      it('should show all netsuite resolved references in the _generated_dependencies annotation', () => {
+        const recipeCode = currentAdapterElements.find(e => e.elemID.getFullName() === 'workato.recipe__code.instance.recipe3_code')
+        expect(recipeCode).toBeDefined()
+        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(2)
+        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].every(
+          isReferenceExpression
+        )).toBeTruthy()
+        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
+          (ref: ReferenceExpression) => ref.elemId.getFullName()
+        )).toEqual([
+          'netsuite.customrecordtype.instance.customrecord16',
+          'netsuite.othercustomfield.instance.custrecord2',
+        ])
+      })
+
+      it('should not resolve any salesforce references in-place', () => {
+        const recipeCode = currentAdapterElements.find(
+          e => e.elemID.getFullName() === 'workato.recipe__code.instance.recipe3_code'
+        ) as InstanceElement
+        expect(recipeCode).toBeInstanceOf(InstanceElement)
+        expect(recipeCode.value.input.sobject_name).toEqual('Opportunity')
+        expect(recipeCode.value.dynamicPickListSelection.sobject_name).toEqual('Opportunity')
+        expect(recipeCode.value.dynamicPickListSelection.field_list).toHaveLength(4)
+        expect(
+          recipeCode.value.dynamicPickListSelection.field_list.some(isReferenceExpression)
+        ).toBeFalsy()
+        expect(
+          recipeCode.value.dynamicPickListSelection.table_list.some(isReferenceExpression)
+        ).toBeFalsy()
+        const block2 = recipeCode.value.block[0].block[0]
+        expect(block2.input.sobject_name).toEqual('MyCustom__c')
+      })
+      it('should resolve references in-place in nested nestuite block', () => {
+        const recipeCode = currentAdapterElements.find(
+          e => e.elemID.getFullName() === 'workato.recipe__code.instance.recipe3_code'
+        ) as InstanceElement
+        expect(recipeCode).toBeInstanceOf(InstanceElement)
+        const block1 = recipeCode.value.block[0]
+        expect(block1.input.netsuite_object).toBeInstanceOf(
+          ReferenceExpression
+        )
+        expect(block1.input.netsuite_object.elemId.getFullName()).toEqual('netsuite.customrecordtype.instance.customrecord16')
+      })
+    })
+
+    describe('recipe4UnknownSalesforceSobject', () => {
+      it('should not have any _generated_dependencies', () => {
+        const recipeCode = currentAdapterElements.find(e => e.elemID.getFullName() === 'workato.recipe__code.instance.recipe4_code')
+        expect(recipeCode).toBeDefined()
+        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
+      })
+
+      it('should not resolve any references in-place', () => {
+        const recipeCode = currentAdapterElements.find(
+          e => e.elemID.getFullName() === 'workato.recipe__code.instance.recipe4_code'
+        ) as InstanceElement
+        expect(recipeCode).toBeInstanceOf(InstanceElement)
+        expect(recipeCode.value.input.sobject_name).toEqual('Unknown')
+        expect(recipeCode.value.dynamicPickListSelection.sobject_name).toEqual('Unknown')
+        expect(recipeCode.value.dynamicPickListSelection.field_list).toHaveLength(4)
+        expect(
+          recipeCode.value.dynamicPickListSelection.field_list.some(isReferenceExpression)
+        ).toBeFalsy()
+        expect(
+          recipeCode.value.dynamicPickListSelection.table_list.some(isReferenceExpression)
+        ).toBeFalsy()
+      })
+    })
+
+    it('should return true if any element was changed', () => {
+      expect(res).toBeTruthy()
+    })
+    it('should return false if no elements were modified', async () => {
+      const elements = generateCurrentAdapterElements()
+      expect(await filter.onPostFetch({
+        currentAdapterElements: elements,
+        elementsByAdapter: {
+          salesforce: [],
+          netsuite: [],
+        },
+      })).toBeFalsy()
+    })
+
+    it('should do nothing if serviceConnectionNames is missing', async () => {
+      const elements = generateCurrentAdapterElements()
+
+      const otherFilter = filterCreator({
+        client,
+        config: {
+          fetch: {
+            includeTypes: ['connection', 'recipe'],
+          },
+          apiDefinitions: {
+            typeDefaults: {
+              transformation: {
+                idFields: DEFAULT_ID_FIELDS,
+              },
+            },
+            types: DEFAULT_TYPES,
+          },
+        },
+      }) as FilterType
+
+      expect(await otherFilter.onPostFetch({
+        currentAdapterElements: elements,
+        elementsByAdapter: {
+          salesforce: [],
+          netsuite: [],
+        },
+      })).toBeFalsy()
+      expect(
+        elements.filter(e => e.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] !== undefined)
+      ).toHaveLength(0)
+    })
+
+    it('should handle unresolved connection names gracefully', async () => {
+      const elements = generateCurrentAdapterElements()
+
+      const otherFilter = filterCreator({
+        client,
+        config: {
+          fetch: {
+            includeTypes: ['connection', 'recipe'],
+            serviceConnectionNames: {
+              salesforce: 'salesforce sandbox 1 unresolved',
+              netsuite: 'netsuite sbx 123',
+              ignoreThis: 'abc',
+            },
+          },
+          apiDefinitions: {
+            typeDefaults: {
+              transformation: {
+                idFields: DEFAULT_ID_FIELDS,
+              },
+            },
+            types: DEFAULT_TYPES,
+          },
+        },
+      }) as FilterType
+
+      // should still resolve the netsuite references
+      expect(await otherFilter.onPostFetch({
+        currentAdapterElements: elements,
+        elementsByAdapter: {
+          salesforce: generateSalesforceElements(),
+          netsuite: generateNetsuiteElements(),
+        },
+      })).toBeTruthy()
+      expect(
+        elements.filter(e => e.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] !== undefined)
+      ).toHaveLength(2)
+      expect(
+        elements
+          .flatMap(e => e.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] ?? [])
+          .map(e => e.elemId.getFullName())
+      ).toEqual([
+        'netsuite.customrecordtype.instance.customrecord16',
+        'netsuite.othercustomfield.instance.custrecord2',
+        'netsuite.customrecordtype.instance.customrecord16',
+        'netsuite.othercustomfield.instance.custrecord2',
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Find references to salesforce/netsuite that are contained inside workato recipes.
Each recipe is linked to at most one salesforce and one netsuite account (through the standard connectors), and we only look at recipes with the configured connections (the config is not multienv-friendly yet - see SALTO-1213).

For now, we add _all_ references we find under the `_generated_dependencies` annotation, and also replace in-place where possible. This will be improved later.

This includes some but not all references - will extend in subsequent PRs.

---
_Release Notes_: 
Add cross-service references from Workato recipes to Salesforce and Nestuite.
