### PR TITLE
Add util function for extending generated dependencies

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -796,3 +796,19 @@ export const getAllReferencedIds = (element: Element, onlyAnnotations = false): 
 export const getParents = (instance: Element): Array<Value> => (
   collections.array.makeArray(instance.annotations[CORE_ANNOTATIONS.PARENT])
 )
+
+export const extendGeneratedDependencies = (
+  elem: Element,
+  newDependencies: ReferenceExpression[],
+): void => {
+  elem.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] = _.sortedUniqBy(
+    _.sortBy(
+      [
+        ...collections.array.makeArray(elem.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]),
+        ...newDependencies,
+      ],
+      ref => ref.elemId.getFullName(),
+    ),
+    ref => ref.elemId.getFullName(),
+  )
+}

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -29,7 +29,7 @@ import {
   findInstances, flattenElementStr, valuesDeepSome, filterByID, setPath, ResolveValuesFunc,
   flatValues, mapKeysRecursive, createDefaultInstanceFromType, applyInstancesDefaults,
   restoreChangeElement, RestoreValuesFunc, getAllReferencedIds, applyFunctionToChangeData,
-  transformElement, toObjectType, getParents,
+  transformElement, toObjectType, getParents, extendGeneratedDependencies,
 } from '../src/utils'
 import { mockFunction, MockFunction } from './common'
 
@@ -1951,6 +1951,153 @@ describe('Test utils.ts', () => {
       it('should return an empty array', () => {
         expect(result).toEqual([])
       })
+    })
+  })
+
+  describe('extendGeneratedDependencies', () => {
+    it('should create the _generated_dependencies annotation if it does not exist', () => {
+      const type = new ObjectType({
+        elemID: mockElem,
+        annotationTypes: {
+          testAnno: mockStrType,
+        },
+        annotations: {
+          testAnno: 'TEST ANNO',
+        },
+        fields: {
+          f1: { type: BuiltinTypes.STRING },
+        },
+      })
+      const inst = new InstanceElement('something', mockType, {})
+
+      const refs = [new ReferenceExpression(new ElemID('adapter', 'type123'))]
+
+      extendGeneratedDependencies(type, refs)
+      expect(type.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(type.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(refs)
+
+      extendGeneratedDependencies(inst, refs)
+      expect(inst.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(inst.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(refs)
+
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
+      extendGeneratedDependencies(type.fields.f1, refs)
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(refs)
+    })
+    it('should extend the _generated_dependencies annotation if it already exists', () => {
+      const oldRefs = [
+        new ReferenceExpression(new ElemID('adapter', 'type123')),
+      ]
+      const type = new ObjectType({
+        elemID: mockElem,
+        annotationTypes: {
+          testAnno: mockStrType,
+        },
+        annotations: {
+          testAnno: 'TEST ANNO',
+          [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [...oldRefs],
+        },
+        fields: {
+          f1: {
+            type: BuiltinTypes.STRING,
+            annotations: { [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [...oldRefs] },
+          },
+        },
+      })
+      const inst = new InstanceElement(
+        'something',
+        mockType,
+        {},
+        undefined,
+        { [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [...oldRefs] },
+      )
+
+      const newRefs = [new ReferenceExpression(new ElemID('adapter', 'type456'))]
+
+      extendGeneratedDependencies(type, newRefs)
+      expect(type.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(type.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(
+        [...oldRefs, ...newRefs]
+      )
+
+      extendGeneratedDependencies(inst, newRefs)
+      expect(inst.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(inst.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(
+        [...oldRefs, ...newRefs]
+      )
+
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      extendGeneratedDependencies(type.fields.f1, newRefs)
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(
+        [...oldRefs, ...newRefs]
+      )
+    })
+    it('should keep annotations sorted by elem id and avoid duplicates', () => {
+      const oldRefs = [
+        new ReferenceExpression(new ElemID('adapter', 'type123')),
+        new ReferenceExpression(new ElemID('adapter', 'type456')),
+      ]
+      const type = new ObjectType({
+        elemID: mockElem,
+        annotationTypes: {
+          testAnno: mockStrType,
+        },
+        annotations: {
+          testAnno: 'TEST ANNO',
+          [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [...oldRefs],
+        },
+        fields: {
+          f1: {
+            type: BuiltinTypes.STRING,
+            annotations: { [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [...oldRefs] },
+          },
+        },
+      })
+      const inst = new InstanceElement(
+        'something',
+        mockType,
+        {},
+        undefined,
+        { [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [...oldRefs] },
+      )
+
+      const newRefs = [
+        new ReferenceExpression(new ElemID('adapter', 'type456', 'instance', 'inst456')),
+        new ReferenceExpression(new ElemID('adapter', 'type123')),
+        new ReferenceExpression(new ElemID('adapter', 'aaa')),
+      ]
+
+      extendGeneratedDependencies(type, newRefs)
+      expect(type.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
+        (e: ReferenceExpression) => e.elemId.getFullName()
+      )).toEqual([
+        'adapter.aaa',
+        'adapter.type123',
+        'adapter.type456',
+        'adapter.type456.instance.inst456',
+      ])
+
+      extendGeneratedDependencies(inst, newRefs)
+      expect(inst.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
+        (e: ReferenceExpression) => e.elemId.getFullName()
+      )).toEqual([
+        'adapter.aaa',
+        'adapter.type123',
+        'adapter.type456',
+        'adapter.type456.instance.inst456',
+      ])
+
+      extendGeneratedDependencies(type.fields.f1, newRefs)
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
+        (e: ReferenceExpression) => e.elemId.getFullName()
+      )).toEqual([
+        'adapter.aaa',
+        'adapter.type123',
+        'adapter.type456',
+        'adapter.type456.instance.inst456',
+      ])
     })
   })
 })

--- a/packages/salesforce-adapter/src/filters/extra_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/extra_dependencies.ts
@@ -15,11 +15,11 @@
 */
 import _ from 'lodash'
 import {
-  Element, isObjectType, CORE_ANNOTATIONS, ReferenceExpression, ElementMap, ElemID,
+  Element, isObjectType, ReferenceExpression, ElementMap, ElemID,
 } from '@salto-io/adapter-api'
 import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
-import { getAllReferencedIds } from '@salto-io/adapter-utils'
+import { getAllReferencedIds, extendGeneratedDependencies } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
 import { metadataType, apiName, isCustomObject } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
@@ -136,13 +136,7 @@ const addGeneratedDependencies = (elem: Element, refElemIDs: ElemID[]): void => 
     .map(elemId => new ReferenceExpression(elemId))
 
   if (newDependencies.length !== 0) {
-    elem.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] = _.sortBy(
-      [
-        ...collections.array.makeArray(elem.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]),
-        ...newDependencies,
-      ],
-      ref => ref.elemId.getFullName(),
-    )
+    extendGeneratedDependencies(elem, newDependencies)
   }
 }
 


### PR DESCRIPTION
The `_generated_depenedencies` annotation's values should be sorted and unique - adding a util function for that so it doesn't need be be re-implemented every time (split from https://github.com/salto-io/salto/pull/1900).

---
_Release Notes_: 
None
