### PR TITLE
Change suitetcloud mock to be non-virtual

### DIFF
--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -140,7 +140,7 @@ jest.mock('@salto-io/suitecloud-cli', () => ({
   CommandActionExecutor: jest.fn().mockImplementation(() => ({
     executeAction: mockExecuteAction,
   })),
-}), { virtual: true })
+}))
 
 describe('netsuite client', () => {
   const createProjectCommandMatcher = expect


### PR DESCRIPTION
Doesn't seem like we need the mock to be virtual anymore since suitecloud is a normal dependency
Changing because the virtual mock didn't always work and it would causes unit tests to fail

---

@omrilit - I am not sure why this was virtual or what the virtual thing really does, but the netsuite unit tests would fail from time to time and it seemed like it was because the mock didn't work correctly, I assume this was the reason because it is the only place where we use a different type of mock....

---
_Release Notes_: 
None
