### PR TITLE
fixed merge errors when update contain only hidden changes

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -269,7 +269,7 @@ export const loadWorkspace = async (
 
     const mergeData = await getAfterElements({
       src1Changes: workspaceChanges,
-      src1: stateToBuild.merged,
+      src1: await naclFilesSource.getElementsSource(),
       src2Changes: await completeStateOnlyChanges(stateOnlyChanges),
       src2: mapReadOnlyElementsSource(
         state(),


### PR DESCRIPTION
_Fix merge error on fetch with only hidden changes_

---

_The element source used to complete changes which only present in the state only changes was wrong (used the merge source instead of the nacl file source) which created the duplications._
