### PR TITLE
Fix config overrides for default adapter config

### DIFF
--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -304,7 +304,7 @@ export const mockWorkspace = ({
     currentEnv: mockFunction<Workspace['currentEnv']>().mockReturnValue(envs[0]),
     services: mockFunction<Workspace['services']>().mockReturnValue(services),
     servicesCredentials: mockFunction<Workspace['servicesCredentials']>().mockResolvedValue({}),
-    servicesConfig: mockFunction<Workspace['servicesConfig']>().mockResolvedValue({}),
+    serviceConfig: mockFunction<Workspace['serviceConfig']>().mockResolvedValue(undefined),
     isEmpty: mockFunction<Workspace['isEmpty']>().mockResolvedValue(false),
     hasElementsInServices: mockFunction<Workspace['hasElementsInServices']>().mockResolvedValue(true),
     hasElementsInEnv: mockFunction<Workspace['hasElementsInEnv']>().mockResolvedValue(false),

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -124,7 +124,7 @@ export const deploy = async (
   const adapters = await getAdapters(
     services,
     await workspace.servicesCredentials(services),
-    await workspace.servicesConfig(services),
+    workspace.serviceConfig.bind(workspace),
     buildElementsSourceFromElements(workspaceElements)
   )
 
@@ -208,7 +208,7 @@ export const fetch: FetchFunc = async (
   const adaptersCreatorConfigs = await getAdaptersCreatorConfigs(
     fetchServices,
     await workspace.servicesCredentials(services),
-    await workspace.servicesConfig(services),
+    workspace.serviceConfig.bind(workspace),
     buildElementsSourceFromElements(stateElements),
     createElemIdGetter(filteredStateElements)
   )
@@ -340,7 +340,7 @@ export const addAdapter = async (
   const adapter = getAdapterCreator(adapterName)
   await workspace.addService(adapterName)
 
-  if (_.isUndefined((await workspace.servicesConfig([adapterName]))[adapterName])) {
+  if (_.isUndefined(await workspace.serviceConfig(adapterName))) {
     const defaultConfig = getDefaultAdapterConfig(adapterName)
     if (!_.isUndefined(defaultConfig)) {
       await workspace.updateServiceConfig(adapterName, defaultConfig)

--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -90,37 +90,41 @@ const filterElementsSourceAdapter = (
   has: async id => (id.adapter === adapter ? elementsSource.has(id) : false),
 })
 
+type AdapterConfigGetter = (
+  adapter: string, defaultValue?: InstanceElement
+) => Promise<InstanceElement | undefined>
+
 export const getAdaptersCreatorConfigs = async (
   adapters: ReadonlyArray<string>,
   credentials: Readonly<Record<string, InstanceElement>>,
-  config: Readonly<Record<string, InstanceElement>>,
+  getConfig: AdapterConfigGetter,
   workspaceElementsSource: ReadOnlyElementsSource,
   elemIdGetter?: ElemIdGetter,
 ): Promise<Record<string, AdapterOperationsContext>> => (
-  _.fromPairs(await Promise.all(adapters.map(
-    async adapter => {
-      const adapterConfig = config[adapter]
-      return ([adapter, {
+  Object.fromEntries(await Promise.all(adapters.map(
+    async adapter => [
+      adapter,
+      {
         credentials: credentials[adapter],
-        config: adapterConfig ?? getDefaultAdapterConfig(adapter),
+        config: await getConfig(adapter, getDefaultAdapterConfig(adapter)),
         elementsSource: filterElementsSourceAdapter(workspaceElementsSource, adapter),
         getElemIdFunc: elemIdGetter,
-      }])
-    }
+      },
+    ]
   )))
 )
 
 export const getAdapters = async (
   adapters: ReadonlyArray<string>,
   credentials: Readonly<Record<string, InstanceElement>>,
-  config: Readonly<Record<string, InstanceElement>>,
+  getConfig: AdapterConfigGetter,
   workspaceElementsSource: ReadOnlyElementsSource,
   elemIdGetter?: ElemIdGetter,
 ): Promise<Record<string, AdapterOperations>> =>
   initAdapters(await getAdaptersCreatorConfigs(
     adapters,
     credentials,
-    config,
+    getConfig,
     workspaceElementsSource,
     elemIdGetter
   ))

--- a/packages/core/src/local-workspace/workspace_config.ts
+++ b/packages/core/src/local-workspace/workspace_config.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import path from 'path'
 import { workspaceConfigSource as wcs,
   WorkspaceConfig, configSource } from '@salto-io/workspace'
-import { InstanceElement, DetailedChange } from '@salto-io/adapter-api'
+import { DetailedChange } from '@salto-io/adapter-api'
 import { localDirectoryStore } from './dir_store'
 import { getSaltoHome, CONFIG_DIR_NAME } from '../app_config'
 import { WORKSPACE_CONFIG_NAME, ENVS_CONFIG_NAME, EnvsConfig,
@@ -80,10 +80,11 @@ export const workspaceConfigSource = async (
       await repoCs.set(WORKSPACE_CONFIG_NAME, workspaceMetadata)
       await localCs.set(USER_CONFIG_NAME, userData)
     },
-    getAdapter: (adapter: string): Promise<InstanceElement | undefined> =>
-      repoCs.get(path.join(ADAPTERS_CONFIG_NAME, adapter)),
-    setAdapter: async (adapter: string, config: Readonly<InstanceElement>): Promise<void> =>
+    getAdapter: (adapter, defaultValue) => (
+      repoCs.get(path.join(ADAPTERS_CONFIG_NAME, adapter), defaultValue)
+    ),
+    setAdapter: (adapter, config) => (
       repoCs.set(path.join(ADAPTERS_CONFIG_NAME, adapter), config)
-    ,
+    ),
   }
 }

--- a/packages/core/test/common/workspace.ts
+++ b/packages/core/test/common/workspace.ts
@@ -91,7 +91,7 @@ export const mockWorkspace = ({
       [mockService]: mockConfigInstance,
       [emptyMockService]: mockEmptyConfigInstance,
     }),
-    servicesConfig: jest.fn().mockResolvedValue({}),
+    serviceConfig: jest.fn().mockResolvedValue(undefined),
     getWorkspaceErrors: jest.fn().mockResolvedValue([]),
     addService: jest.fn(),
     updateServiceCredentials: jest.fn(),

--- a/packages/core/test/core/adapters/adapters.test.ts
+++ b/packages/core/test/core/adapters/adapters.test.ts
@@ -73,7 +73,7 @@ describe('adapters.ts', () => {
       const result = await getAdaptersCreatorConfigs(
         [serviceName],
         { [sfConfig.elemID.adapter]: sfConfig },
-        {},
+        async () => undefined,
         buildElementsSourceFromElements([])
       )
       expect(result[serviceName]).toEqual(
@@ -90,7 +90,7 @@ describe('adapters.ts', () => {
       const result = await getAdaptersCreatorConfigs(
         [serviceName],
         { [sfConfig.elemID.adapter]: sfConfig },
-        { [sfConfig.elemID.adapter]: sfConfig },
+        async name => (name === sfConfig.elemID.adapter ? sfConfig : undefined),
         buildElementsSourceFromElements([]),
       )
       expect(result[serviceName]).toEqual(
@@ -108,7 +108,7 @@ describe('adapters.ts', () => {
       const result = await getAdaptersCreatorConfigs(
         [serviceName],
         { [sfConfig.elemID.adapter]: sfConfig },
-        { [sfConfig.elemID.adapter]: sfConfig },
+        async name => (name === sfConfig.elemID.adapter ? sfConfig : undefined),
         buildElementsSourceFromElements([
           new ObjectType({ elemID: new ElemID(serviceName, 'type1') }),
           new ObjectType({ elemID: new ElemID('dummy', 'type2') }),

--- a/packages/workspace/src/workspace/config_source.ts
+++ b/packages/workspace/src/workspace/config_source.ts
@@ -25,7 +25,7 @@ import { DirectoryStore } from './dir_store'
 const log = logger(module)
 
 export interface ConfigSource {
-  get(name: string): Promise<InstanceElement | undefined>
+  get(name: string, defaultValue?: InstanceElement): Promise<InstanceElement | undefined>
   set(name: string, config: Readonly<InstanceElement>): Promise<void>
   delete(name: string): Promise<void>
   rename(name: string, newName: string): Promise<void>
@@ -99,8 +99,8 @@ export const configSource = (
   }
 
   return {
-    get: async (name: string): Promise<InstanceElement | undefined> => {
-      const conf = await getConfigWithoutOverrides(name)
+    get: async (name, defaultValue) => {
+      const conf = await getConfigWithoutOverrides(name) ?? defaultValue
       if (conf === undefined) {
         return undefined
       }

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -87,8 +87,8 @@ export type Workspace = {
   services: () => ReadonlyArray<string>
   servicesCredentials: (names?: ReadonlyArray<string>) =>
     Promise<Readonly<Record<string, InstanceElement>>>
-  servicesConfig: (names?: ReadonlyArray<string>) =>
-    Promise<Readonly<Record<string, InstanceElement>>>
+  serviceConfig: (name: string, defaultValue?: InstanceElement) =>
+    Promise<InstanceElement | undefined>
 
   isEmpty(naclFilesOnly?: boolean): Promise<boolean>
   hasElementsInServices(serviceNames: string[]): Promise<boolean>
@@ -329,14 +329,7 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
     servicesCredentials: async (names?: ReadonlyArray<string>) => _.fromPairs(await Promise.all(
       pickServices(names).map(async service => [service, await credentials.get(credsPath(service))])
     )),
-    servicesConfig: async (names?: ReadonlyArray<string>) => _.fromPairs(await Promise.all(
-      pickServices(names).map(
-        async service => [
-          service,
-          (await config.getAdapter(service)),
-        ]
-      )
-    )),
+    serviceConfig: (name, defaultValue) => config.getAdapter(name, defaultValue),
     isEmpty: async (naclFilesOnly = false): Promise<boolean> => {
       const isNaclFilesSourceEmpty = !naclFilesSource || await naclFilesSource.isEmpty()
       return isNaclFilesSourceEmpty && (naclFilesOnly || _.isEmpty(await state().getAll()))

--- a/packages/workspace/src/workspace/workspace_config_source.ts
+++ b/packages/workspace/src/workspace/workspace_config_source.ts
@@ -16,9 +16,9 @@
 import { InstanceElement } from '@salto-io/adapter-api'
 import { WorkspaceConfig } from './config/workspace_config_types'
 
-// Seperating adapter config to allow for lazy adapter loading.
+// Separating adapter config to allow for lazy adapter loading.
 export type AdapterConfigSource = {
-  getAdapter(adapter: string): Promise<InstanceElement | undefined>
+  getAdapter(adapter: string, defaultValue?: InstanceElement): Promise<InstanceElement | undefined>
   setAdapter(adapter: string, config: Readonly<InstanceElement>): Promise<void>
 }
 

--- a/packages/workspace/test/workspace/config_source.test.ts
+++ b/packages/workspace/test/workspace/config_source.test.ts
@@ -30,6 +30,7 @@ describe('configSource', () => {
     const overrides: DetailedChange[] = [
       createConfigOverride('valid', ['val'], 2),
       createConfigOverride('valid', ['new'], { a: true }),
+      createConfigOverride('default', ['new'], 'new'),
     ]
     dirStore = mockDirStore(
       undefined,
@@ -90,6 +91,33 @@ describe('configSource', () => {
     })
     it('should fail if the config file has parse errors', async () => {
       await expect(source.get('error')).rejects.toThrow()
+    })
+    describe('with default value', () => {
+      let defaultValue: InstanceElement
+      beforeEach(() => {
+        defaultValue = new InstanceElement('default', new ObjectType({ elemID: new ElemID('test') }))
+      })
+      describe('with valid config', () => {
+        let inst: InstanceElement
+        beforeEach(async () => {
+          inst = await source.get('valid', defaultValue) as InstanceElement
+        })
+        it('should return the valid config', async () => {
+          expect(inst.value).toMatchObject({
+            other: 3,
+          })
+        })
+      })
+      describe('with empty file', () => {
+        let inst: InstanceElement
+        beforeEach(async () => {
+          inst = await source.get('noSuchFile', defaultValue) as InstanceElement
+        })
+        it('should return default value', () => {
+          expect(inst).toBeInstanceOf(InstanceElement)
+          expect(inst).toEqual(defaultValue)
+        })
+      })
     })
   })
   describe('set', () => {


### PR DESCRIPTION
Before this change config overrides would not be applied to adapter configuration
if the configuration file did not exist.

---
_Release Notes_: 
CLI:
- Fix bug where config overrides (-C) for adapter configuration would not work when adapter config file did not exist
