### PR TITLE
Turn generated dependencies from string to unknown to avoid validation warnings on cross-service references

### DIFF
--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -91,7 +91,7 @@ export const BuiltinTypes = {
 export const InstanceAnnotationTypes: TypeMap = {
   [INSTANCE_ANNOTATIONS.DEPENDS_ON]: new ListType(StandardBuiltinTypes.STRING),
   [INSTANCE_ANNOTATIONS.PARENT]: new ListType(StandardBuiltinTypes.STRING),
-  [INSTANCE_ANNOTATIONS.GENERATED_DEPENDENCIES]: new ListType(StandardBuiltinTypes.STRING),
+  [INSTANCE_ANNOTATIONS.GENERATED_DEPENDENCIES]: new ListType(StandardBuiltinTypes.UNKNOWN),
   [INSTANCE_ANNOTATIONS.HIDDEN]: StandardBuiltinTypes.BOOLEAN,
   [INSTANCE_ANNOTATIONS.SERVICE_URL]: BuiltinTypes.HIDDEN_STRING,
 }


### PR DESCRIPTION
With `_generated_dependencies` defined as a string, we sometimes get validation warnings (`Error validating "workato.recipe__code.instance.<some_id>._generated_dependencies.1": Invalid value type for string`). Generated dependencies can point to any element / element path, so I think there's no reason to define them specifically as strings.

---
_Release Notes_: 
None (the new references that get these warnings were not released yet)
