### PR TITLE
SALTO-1198: changed to not list paths when receiving them from changes detection

### DIFF
--- a/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
@@ -115,12 +115,17 @@ const getChangedIds = (
     .map(([id]) => id)
     .value())
 
+export type GetChangedObjectsResults = {
+  query: NetsuiteQuery
+  paths: string[]
+}
+
 export const getChangedObjects = async (
   client: NetsuiteClient,
   query: NetsuiteQuery,
   dateRange: DateRange,
   elementsSourceIndex: LazyElementsSourceIndex,
-): Promise<NetsuiteQuery> => {
+): Promise<GetChangedObjectsResults> => {
   log.debug('Starting to look for changed objects')
 
   const instancesChangesPromise = Promise.all(
@@ -167,11 +172,14 @@ export const getChangedObjects = async (
   log.debug(`${paths.size} paths changes were detected`)
 
   return {
-    isTypeMatch: () => scriptIds.size !== 0,
-    isObjectMatch: objectID => !SUPPORTED_TYPES.has(objectID.type)
-      || scriptIds.has(objectID.scriptId)
-      || types.has(objectID.type),
-    isFileMatch: filePath => paths.has(filePath),
-    areSomeFilesMatch: () => paths.size !== 0,
+    query: {
+      isTypeMatch: () => scriptIds.size !== 0,
+      isObjectMatch: objectID => !SUPPORTED_TYPES.has(objectID.type)
+        || scriptIds.has(objectID.scriptId)
+        || types.has(objectID.type),
+      isFileMatch: filePath => paths.has(filePath),
+      areSomeFilesMatch: () => paths.size !== 0,
+    },
+    paths: Array.from(paths),
   }
 }

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -66,9 +66,9 @@ export default class NetsuiteClient {
     return this.sdfClient.getCustomObjects(typeNames, query)
   }
 
-  async importFileCabinetContent(query: NetsuiteQuery):
+  async importFileCabinetContent(query: NetsuiteQuery, paths?: string[]):
     Promise<ImportFileCabinetResult> {
-    return this.sdfClient.importFileCabinetContent(query)
+    return this.sdfClient.importFileCabinetContent(query, paths)
   }
 
   async deploy(customizationInfos: CustomizationInfo[]): Promise<void> {

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -541,7 +541,7 @@ export default class SdfClient {
   }
 
   @SdfClient.logDecorator
-  async importFileCabinetContent(query: NetsuiteQuery):
+  async importFileCabinetContent(query: NetsuiteQuery, paths?: string[]):
     Promise<ImportFileCabinetResult> {
     if (!query.areSomeFilesMatch()) {
       return {
@@ -581,8 +581,12 @@ export default class SdfClient {
       }))
 
     const project = await this.initProject()
-    const listFilesResults = await this.listFilePaths(project.executor)
-    const filePathsToImport = listFilesResults.listedPaths
+
+    const { listedPaths, failedPaths } = paths !== undefined
+      ? { listedPaths: paths, failedPaths: [] }
+      : await this.listFilePaths(project.executor)
+
+    const filePathsToImport = listedPaths
       .filter(path => query.isFileMatch(path))
     const importFilesResult = await this.importFiles(filePathsToImport, project.executor)
     // folder attributes file is returned multiple times
@@ -600,7 +604,7 @@ export default class SdfClient {
     await this.projectCleanup(project.projectName, project.authId)
     return {
       elements,
-      failedPaths: listFilesResults.failedPaths,
+      failedPaths,
     }
   }
 

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -518,10 +518,13 @@ describe('Adapter', () => {
 
       getChangedObjectsMock.mockReset()
       getChangedObjectsMock.mockResolvedValue({
-        isTypeMatch: () => true,
-        isObjectMatch: objectID => objectID.scriptId.startsWith('aa'),
-        isFileMatch: () => true,
-        areSomeFilesMatch: () => true,
+        query: {
+          isTypeMatch: () => true,
+          isObjectMatch: objectID => objectID.scriptId.startsWith('aa'),
+          isFileMatch: () => true,
+          areSomeFilesMatch: () => true,
+        },
+        paths: [],
       })
 
       getSystemInformationMock.mockReset()

--- a/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
@@ -86,18 +86,19 @@ describe('changes_detector', () => {
   })
 
   it('should use the system note results to filter the changes', async () => {
-    const changedObjectsQuery = await getChangedObjects(
+    const { query: changedObjectsQuery, paths } = (await getChangedObjects(
       client,
       query,
       createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z')),
       elementsSourceIndex,
-    )
+    ))
     expect(changedObjectsQuery.isFileMatch('/Templates/path/to/file')).toBeTruthy()
     expect(changedObjectsQuery.isFileMatch('/Templates/path/to/file2')).toBeFalsy()
     expect(changedObjectsQuery.isFileMatch('/Templates/path/to')).toBeTruthy()
     expect(changedObjectsQuery.isFileMatch('/Templates/path/to/notExists')).toBeFalsy()
     expect(changedObjectsQuery.isFileMatch('/other/path/to/file')).toBeFalsy()
 
+    expect(paths).toEqual(['/Templates/path/to/file', '/Templates/path/to'])
 
     expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'a' })).toBeTruthy()
     expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'b' })).toBeTruthy()
@@ -113,12 +114,12 @@ describe('changes_detector', () => {
 
   it('should return all the results of system note query failed', async () => {
     runSavedSearchQueryMock.mockResolvedValue(undefined)
-    const changedObjectsQuery = await getChangedObjects(
+    const changedObjectsQuery = (await getChangedObjects(
       client,
       query,
       createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z')),
       elementsSourceIndex,
-    )
+    )).query
     expect(changedObjectsQuery.isFileMatch('/Templates/path/to/file')).toBeTruthy()
     expect(changedObjectsQuery.isFileMatch('/Templates/path/to/file2')).toBeTruthy()
     expect(changedObjectsQuery.isFileMatch('/Templates/path/to')).toBeTruthy()
@@ -140,12 +141,12 @@ describe('changes_detector', () => {
       a: { lastFetchTime: new Date('2022-02-22T18:55:17.949Z') },
       b: { lastFetchTime: new Date('2022-02-22T18:55:17.949Z') },
     })
-    const changedObjectsQuery = await getChangedObjects(
+    const changedObjectsQuery = (await getChangedObjects(
       client,
       query,
       createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z')),
       elementsSourceIndex,
-    )
+    )).query
 
     expect(changedObjectsQuery.isFileMatch('/Templates/path/to/file')).toBeFalsy()
     expect(changedObjectsQuery.isFileMatch('/Templates/path/to')).toBeTruthy()
@@ -156,12 +157,12 @@ describe('changes_detector', () => {
   it('areSomeFilesMatch return false when no file changes were detected', async () => {
     getChangedFilesMock.mockResolvedValue([])
     getChangesFoldersMock.mockResolvedValue([])
-    const changedObjectsQuery = await getChangedObjects(
+    const changedObjectsQuery = (await getChangedObjects(
       client,
       query,
       createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z')),
       elementsSourceIndex,
-    )
+    )).query
     expect(changedObjectsQuery.areSomeFilesMatch()).toBeFalsy()
   })
 
@@ -169,12 +170,12 @@ describe('changes_detector', () => {
     runSavedSearchQueryMock.mockResolvedValue([
       { recordid: '1', date: 'invalid' },
     ])
-    const changedObjectsQuery = await getChangedObjects(
+    const changedObjectsQuery = (await getChangedObjects(
       client,
       query,
       createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z')),
       elementsSourceIndex,
-    )
+    )).query
     expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'a' })).toBeTruthy()
     expect(changedObjectsQuery.isFileMatch('/Templates/path/to/file')).toBeFalsy()
   })
@@ -187,12 +188,12 @@ describe('changes_detector', () => {
     getCustomRecordTypeChangesMock.mockResolvedValue([
       { type: 'object', externalId: 'B', time: undefined },
     ])
-    const changedObjectsQuery = await getChangedObjects(
+    const changedObjectsQuery = (await getChangedObjects(
       client,
       query,
       createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z')),
       elementsSourceIndex,
-    )
+    )).query
     expect(changedObjectsQuery.isObjectMatch({ type: 'workflow', scriptId: 'b' })).toBeTruthy()
   })
 })


### PR DESCRIPTION
Changed to not list file when using changes detection and use the paths returned from the changes detection instead.

---
_Release Notes_: 
None