### PR TITLE
SALTO-1090: changes to notify about the number syntactic instead of the semantic changes

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -212,12 +212,12 @@ export const action: WorkspaceCommandAction<DeployArgs> = async ({
   let cliExitCode = result.success ? CliExitCode.Success : CliExitCode.AppError
   if (!_.isUndefined(result.changes)) {
     const changes = [...result.changes]
-    if (!await updateWorkspace({
+    if (!(await updateWorkspace({
       workspace,
       output,
       changes,
       force,
-    })) {
+    })).success) {
       cliExitCode = CliExitCode.AppError
     }
   }

--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -24,7 +24,7 @@ import { logger } from '@salto-io/logging'
 import { progressOutputer, outputLine, errorOutputLine } from '../outputer'
 import { WorkspaceCommandAction, createWorkspaceCommand } from '../command_builder'
 import { CliOutput, CliExitCode, CliTelemetry } from '../types'
-import { formatChangesSummary, formatMergeErrors, formatFatalFetchError, formatFetchHeader, formatFetchFinish, formatStateChanges, formatStateRecencies, formatAppliedChanges } from '../formatter'
+import { formatMergeErrors, formatFatalFetchError, formatFetchHeader, formatFetchFinish, formatStateChanges, formatStateRecencies, formatAppliedChanges } from '../formatter'
 import { getApprovedChanges as cliGetApprovedChanges, shouldUpdateConfig as cliShouldUpdateConfig, getChangeToAlignAction } from '../callbacks'
 import { getWorkspaceTelemetryTags, updateStateOnly, applyChangesToWorkspace, isValidWorkspaceForCommand } from '../workspace/workspace'
 import Prompts from '../prompts'
@@ -97,8 +97,8 @@ export const fetchCommand = async (
     Prompts.FETCH_CALC_DIFF_FAIL,
     output
   ))
-  fetchProgress.on('workspaceWillBeUpdated', (progress: StepEmitter, changes: number, approved: number) => {
-    log.debug(formatChangesSummary(changes, approved))
+  fetchProgress.on('workspaceWillBeUpdated', (progress: StepEmitter, _changes: number, approved: number) => {
+    log.debug(`Applying ${approved} semantic changes to the local workspace`)
 
     progressOutputer(
       Prompts.APPLYING_CHANGES,

--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -20,7 +20,7 @@ import { logger } from '@salto-io/logging'
 import { CommandConfig, LocalChange, restore, Tags } from '@salto-io/core'
 import { CliOutput, CliExitCode, CliTelemetry } from '../types'
 import { errorOutputLine, outputLine } from '../outputer'
-import { header, formatDetailedChanges, formatInvalidFilters, formatStepStart, formatRestoreFinish, formatStepCompleted, formatStepFailed, formatStateRecencies, formatAppliedChanges, formatChangesSummary } from '../formatter'
+import { header, formatDetailedChanges, formatInvalidFilters, formatStepStart, formatRestoreFinish, formatStepCompleted, formatStepFailed, formatStateRecencies, formatAppliedChanges } from '../formatter'
 import Prompts from '../prompts'
 import { getWorkspaceTelemetryTags, updateWorkspace, isValidWorkspaceForCommand } from '../workspace/workspace'
 import { getApprovedChanges } from '../callbacks'
@@ -71,7 +71,7 @@ const applyLocalChangesToWorkspace = async (
     : await getApprovedChanges(changes, interactive)
 
   cliTelemetry.changesToApply(changesToApply.length, workspaceTags)
-  log.debug(formatChangesSummary(changes.length, changesToApply.length))
+  log.debug(`Applying ${changesToApply.length} semantic changes to the local workspace`)
 
   outputLine(EOL, output)
   outputLine(

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -409,10 +409,14 @@ export const formatChangesSummary = (changes: number, approved: number): string 
   if (changes === 0) {
     return Prompts.FETCH_NO_CHANGES
   }
-  if (approved === 0) {
-    return Prompts.FETCH_NOTHING_TO_UPDATE
-  }
   return Prompts.FETCH_CHANGES_TO_APPLY(approved)
+}
+
+export const formatAppliedChanges = (appliedChanges: number): string => {
+  if (appliedChanges === 0) {
+    return Prompts.FETCH_NO_CHANGES
+  }
+  return Prompts.FETCH_CHANGES_APPLIED(appliedChanges)
 }
 
 export const formatConfigFieldInput = (fieldName: string, message: string): string =>

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -405,13 +405,6 @@ export const formatFetchChangeForApproval = (
   ].join('\n')
 }
 
-export const formatChangesSummary = (changes: number, approved: number): string => {
-  if (changes === 0) {
-    return Prompts.FETCH_NO_CHANGES
-  }
-  return Prompts.FETCH_CHANGES_TO_APPLY(approved)
-}
-
 export const formatAppliedChanges = (appliedChanges: number): string => {
   if (appliedChanges === 0) {
     return Prompts.FETCH_NO_CHANGES

--- a/packages/cli/src/outputer.ts
+++ b/packages/cli/src/outputer.ts
@@ -29,17 +29,17 @@ export const errorOutputLine = (text: string, output: CliOutput): void => {
   output.stderr.write(`${text}\n`)
   log.debug(text)
 }
-export const progressOutputer = (
+export const progressOutputer = <T>(
   startText: string,
-  successText: string,
+  successCallback: (params: T) => string,
   defaultErrorText: string,
   output: CliOutput
-) => (progress: StepEmitter) => {
-  outputLine(EOL, output)
-  outputLine(formatStepStart(startText), output)
-  progress.on('completed', () => outputLine(formatStepCompleted(successText), output))
-  progress.on('failed', (errorText?: string) => {
-    outputLine(formatStepFailed(errorText ?? defaultErrorText), output)
+) => (progress: StepEmitter<T>) => {
     outputLine(EOL, output)
-  })
-}
+    outputLine(formatStepStart(startText), output)
+    progress.on('completed', (params: T) => outputLine(formatStepCompleted(successCallback(params)), output))
+    progress.on('failed', (errorText?: string) => {
+      outputLine(formatStepFailed(errorText ?? defaultErrorText), output)
+      outputLine(EOL, output)
+    })
+  }

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -91,8 +91,6 @@ The steps are: I. Fetching configs, II. Calculating difference and III. Applying
   public static readonly FETCH_SHOULD_APPROVE_CHANGE = 'Would you like to update your workspace with this change?'
   public static readonly FETCH_CHANGE_REJECTED = 'The change will not be applied to your workspace'
   public static readonly FETCH_NO_CHANGES = 'No changes found, workspace is up to date'
-  public static readonly FETCH_NOTHING_TO_UPDATE = 'No changes chosen, Leaving workspace unchanged'
-  public static readonly FETCH_CHANGES_TO_APPLY = (numChanges: number): string => `Applying ${numChanges} semantic changes to the local workspace`
   public static readonly FETCH_CONFLICTING_CHANGE = 'This change conflicts with the following pending change from your workspace:'
   public static readonly FETCH_MERGE_ERRORS = 'These errors occurred as part of the fetch:'
   public static readonly FETCH_FATAL_MERGE_ERROR_PREFIX = 'Error occurred during fetch, cause:\n'

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -85,7 +85,6 @@ The steps are: I. Fetching configs, II. Calculating difference and III. Applying
   public static readonly FETCH_CALC_DIFF_START = 'Calculating the difference between local and remote'
   public static readonly FETCH_CALC_DIFF_FINISH = 'Finished calculating the difference between local and remote'
   public static readonly FETCH_CALC_DIFF_FAIL = 'Calculating diff failed!'
-  public static readonly FETCH_UPDATE_WORKSPACE_SUCCESS = 'Applied changes'
   public static readonly FETCH_SUCCESS_FINISHED = 'Done! Your workspace is now updated with the latest changes.'
   public static readonly FETCH_UPDATE_WORKSPACE_FAIL = 'Failed to apply changes to your local workspace'
   public static readonly FETCH_CHANGE_HEADER = (changeIdx: number, totalChanges: number): string => `Change ${changeIdx} of ${totalChanges}:`
@@ -93,10 +92,12 @@ The steps are: I. Fetching configs, II. Calculating difference and III. Applying
   public static readonly FETCH_CHANGE_REJECTED = 'The change will not be applied to your workspace'
   public static readonly FETCH_NO_CHANGES = 'No changes found, workspace is up to date'
   public static readonly FETCH_NOTHING_TO_UPDATE = 'No changes chosen, Leaving workspace unchanged'
-  public static readonly FETCH_CHANGES_TO_APPLY = (numChanges: number): string => `Applying ${numChanges} changes to the local workspace`
+  public static readonly FETCH_CHANGES_TO_APPLY = (numChanges: number): string => `Applying ${numChanges} semantic changes to the local workspace`
   public static readonly FETCH_CONFLICTING_CHANGE = 'This change conflicts with the following pending change from your workspace:'
   public static readonly FETCH_MERGE_ERRORS = 'These errors occurred as part of the fetch:'
   public static readonly FETCH_FATAL_MERGE_ERROR_PREFIX = 'Error occurred during fetch, cause:\n'
+  public static readonly FETCH_CHANGES_APPLIED = (appliedChanges: number): string => `${appliedChanges} changes were applied to the local workspace`
+  public static readonly APPLYING_CHANGES = 'Applying changes'
 
   public static readonly LOADING_WORKSPACE = 'Loading workspace...'
   public static readonly FINISHED_LOADING = 'Finished loading workspace'

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -180,6 +180,7 @@ describe('deploy command', () => {
         workspace.errors.mockResolvedValueOnce(
           mocks.mockErrors([{ severity: 'Error', message: '' }])
         )
+        return 0
       })
       mockGetUserBooleanInput.mockReturnValue(true)
     })

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -482,6 +482,7 @@ describe('fetch command', () => {
                 workspace.errors.mockResolvedValue(
                   mocks.mockErrors([{ severity: 'Error', message: 'BLA Error' }])
                 )
+                return 0
               })
 
               const res = await fetchCommand({
@@ -510,6 +511,7 @@ describe('fetch command', () => {
                 workspace.errors.mockResolvedValue(
                   mocks.mockErrors([{ severity: 'Warning', message: 'BLA Error' }])
                 )
+                return 0
               })
 
               const res = await fetchCommand({

--- a/packages/cli/test/commands/restore.test.ts
+++ b/packages/cli/test/commands/restore.test.ts
@@ -88,6 +88,8 @@ describe('restore command', () => {
     let workspace: Workspace
     beforeEach(async () => {
       workspace = mocks.mockWorkspace({})
+      jest.spyOn(workspace, 'updateNaclFiles').mockResolvedValue(2)
+
       result = await action({
         ...cliCommandArgs,
         input: {
@@ -121,7 +123,7 @@ describe('restore command', () => {
 
     it('should print deployment to console', () => {
       expect(output.stdout.content).toContain('Finished calculating the difference')
-      expect(output.stdout.content).toContain('Applying 2 changes to the local workspace')
+      expect(output.stdout.content).toContain('2 changes were applied to the local workspace')
       expect(output.stdout.content).toContain('Done!')
     })
   })
@@ -207,6 +209,7 @@ describe('restore command', () => {
       workspace.errors.mockResolvedValue(
         mocks.mockErrors([{ severity: 'Error', message: 'some error ' }])
       )
+      return 0
     })
     const result = await action({
       ...cliCommandArgs,

--- a/packages/cli/test/workspace/workspace.test.ts
+++ b/packages/cli/test/workspace/workspace.test.ts
@@ -130,7 +130,7 @@ describe('workspace', () => {
         output: cliOutput,
         changes: dummyChanges.map(change => ({ change, serviceChange: change })),
       })
-      expect(result).toBe(false)
+      expect(result.success).toBe(false)
       expect(mockWs.updateNaclFiles).toHaveBeenCalledWith(dummyChanges, 'default')
       expect(mockWs.flush).toHaveBeenCalledTimes(1)
     })

--- a/packages/core/src/core/deploy.ts
+++ b/packages/core/src/core/deploy.ts
@@ -46,8 +46,8 @@ export class DeployError extends Error {
 
 export type ItemStatus = 'started' | 'finished' | 'error' | 'cancelled'
 
-export type StepEvents = {
-  completed: () => void
+export type StepEvents<T = void> = {
+  completed: (params: T) => void
   failed: (errorText?: string) => void
 }
 

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -56,13 +56,17 @@ export const toAddFetchChange = (elem: Element): FetchChange => {
 }
 
 
-export class StepEmitter extends EventEmitter<StepEvents> {}
+export class StepEmitter<T = void> extends EventEmitter<StepEvents<T>> {}
 
 export type FetchProgressEvents = {
   adaptersDidInitialize: () => void
   changesWillBeFetched: (stepProgress: StepEmitter, adapterNames: string[]) => void
   diffWillBeCalculated: (stepProgress: StepEmitter) => void
-  workspaceWillBeUpdated: (stepProgress: StepEmitter, changes: number, approved: number) => void
+  workspaceWillBeUpdated: (
+    stepProgress: StepEmitter<number>,
+    changes: number,
+    approved: number
+  ) => void
   stateWillBeUpdated: (stepProgress: StepEmitter, changes: number) => void
   adapterFetch: (adapterName: string, phase: string) => void
 } & AdapterEvents

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -100,7 +100,7 @@ export type Workspace = {
   transformToWorkspaceError<T extends SaltoElementError>(saltoElemErr: T):
     Promise<Readonly<WorkspaceError<T>>>
   transformError: (error: SaltoError) => Promise<WorkspaceError<SaltoError>>
-  updateNaclFiles: (changes: DetailedChange[], mode?: RoutingMode) => Promise<void>
+  updateNaclFiles: (changes: DetailedChange[], mode?: RoutingMode) => Promise<number>
   listNaclFiles: () => Promise<string[]>
   getTotalSize: () => Promise<number>
   getNaclFile: (filename: string) => Promise<NaclFile | undefined>
@@ -214,12 +214,13 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
   const updateNaclFiles = async (
     changes: DetailedChange[],
     mode?: RoutingMode
-  ): Promise<void> => {
+  ): Promise<number> => {
     const changesAfterHiddenRemoved = await handleHiddenChanges(
       changes, state(), naclFilesSource.getAll,
     )
     const elementChanges = await naclFilesSource.updateNaclFiles(changesAfterHiddenRemoved, mode)
     workspaceState = buildWorkspaceState({ changes: elementChanges })
+    return elementChanges.length
   }
 
   const updateStateAndReturnChanges = async (elementChanges: Change[]):


### PR DESCRIPTION
Changed the CLI message in fetch and restore the show the number of syntactic changes in the NaCl files instead of the number of semantic changes.

---
_Release Notes_: 
CLI:
Improvement to the CLI messages in fetch and restore.