### PR TITLE
SALTO-1198: changed log level

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -206,7 +206,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     }> {
     const sysInfo = await this.client.getSystemInformation()
     if (sysInfo === undefined) {
-      log.warn('Failed to get sysInfo, skipping SuiteApp operations')
+      log.debug('Did not get sysInfo, skipping SuiteApp operations')
       return {}
     }
 


### PR DESCRIPTION
I changed the log of "Failed to get sysInfo" from a warning to debug because it always happens if the SuiteApp is not configured, and I think it might be confusing. If there was a real error with getting the sysInfo, another log will be written.

---
_Release Notes_: 
None