### PR TITLE
SALTO-1198: fixed bugs in changes detection

### DIFF
--- a/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
@@ -17,7 +17,8 @@ import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { NetsuiteQuery } from '../query'
 import { getChangedFiles, getChangedFolders } from './changes_detectors/file_cabinet'
-import { customRecordTypeDetector, customFieldDetector, customListDetector } from './changes_detectors/custom_type'
+import { customFieldDetector, customListDetector } from './changes_detectors/custom_type'
+import customRecordTypeDetector from './changes_detectors/custom_record_type'
 import scriptDetector from './changes_detectors/script'
 import roleDetector from './changes_detectors/role'
 import workflowDetector from './changes_detectors/workflow'
@@ -175,7 +176,7 @@ export const getChangedObjects = async (
   log.debug(`${folderPaths.length} folder paths changes were detected`)
 
   return {
-    isTypeMatch: () => scriptIds.size !== 0,
+    isTypeMatch: () => scriptIds.size !== 0 || types.size !== 0,
     isObjectMatch: objectID => !SUPPORTED_TYPES.has(objectID.type)
       || scriptIds.has(objectID.scriptId)
       || types.has(objectID.type),

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_record_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_record_type.ts
@@ -1,0 +1,71 @@
+
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { logger } from '@salto-io/logging'
+import { convertSuiteQLStringToDate } from '../date_formats'
+import { ChangedObject, TypeChangesDetector } from '../types'
+
+const log = logger(module)
+
+const changesDetector: TypeChangesDetector = {
+  getChanges: async (client, dateRange) => {
+    const [startDate, endDate] = dateRange.toSuiteQLRange()
+
+    const results = await client.runSuiteQL(`
+        SELECT scriptid, lastmodifieddate
+        FROM customrecordtype
+        WHERE lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
+      `)
+
+    if (results === undefined) {
+      log.warn('customrecordtype changes query failed')
+      return []
+    }
+
+    const changes: ChangedObject[] = results
+      .filter((res): res is { scriptid: string; lastmodifieddate: string } => {
+        if ([res.scriptid, res.lastmodifieddate].some(val => typeof val !== 'string')) {
+          log.warn('Got invalid result from customrecordtype query, %o', res)
+          return false
+        }
+        return true
+      })
+      .map(res => ({
+        type: 'object',
+        externalId: res.scriptid,
+        time: convertSuiteQLStringToDate(res.lastmodifieddate),
+      }))
+
+    // the script ids of the custom segments that are returned from the SDF
+    // are returned without the 'customrecord_' prefix.
+    const changesForCustomSegments: ChangedObject[] = changes.map(change => ({
+      type: 'object',
+      externalId: change.externalId.slice('customrecord_'.length),
+      time: change.time,
+    }))
+
+    return [
+      ...changes,
+      ...changesForCustomSegments,
+    ]
+  },
+  getTypes: () => ([
+    'customrecordtype',
+    'customsegment',
+  ]),
+}
+
+export default changesDetector

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
@@ -50,11 +50,6 @@ const getChanges = async (type: string, client: NetsuiteClient, dateRange: DateR
     }))
 }
 
-export const customRecordTypeDetector: TypeChangesDetector = {
-  getChanges: async (client, dateRange) => getChanges('customrecordtype', client, dateRange),
-  getTypes: () => (['customrecordtype', 'customsegement']),
-}
-
 export const customListDetector: TypeChangesDetector = {
   getChanges: async (client, dateRange) => getChanges('customlist', client, dateRange),
   getTypes: () => (['customlist']),

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/role.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/role.ts
@@ -95,7 +95,7 @@ const changesDetector: TypeChangesDetector = {
 
     const permissionChangesPromise = client.runSavedSearchQuery({
       type: 'role',
-      columns: ['internalid'],
+      columns: ['internalid', 'permchangedate'],
       filters: [['permchangedate', 'within', ...dateRange.toSavedSearchRange()]],
     })
 

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/savedsearch.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/savedsearch.ts
@@ -23,7 +23,7 @@ const changesDetector: TypeChangesDetector = {
   getChanges: async (client, dateRange) => {
     const results = await client.runSavedSearchQuery({
       type: 'savedsearch',
-      columns: ['id'],
+      columns: ['id', 'datemodified'],
       filters: [['datemodified', 'within', ...dateRange.toSavedSearchRange()]],
     })
 

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/script.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/script.ts
@@ -82,7 +82,7 @@ const changesDetector: TypeChangesDetector = {
     `)
 
     const scriptDeploymentChangesPromise = client.runSuiteQL(`
-      SELECT script.scriptid, script.id
+      SELECT script.scriptid, scriptdeployment.primarykey AS id
       FROM scriptdeployment 
       JOIN systemnote ON systemnote.recordid = scriptdeployment.primarykey
       JOIN script ON scriptdeployment.script = script.id

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/workflow.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/workflow.ts
@@ -27,7 +27,7 @@ const changesDetector: TypeChangesDetector = {
         'and',
         ['date', 'within', ...dateRange.toSavedSearchRange()],
       ],
-      columns: ['internalid'],
+      columns: ['recordid'],
     })
 
     if (results === undefined) {

--- a/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
@@ -17,7 +17,7 @@
 import SuiteAppClient from '../../src/client/suiteapp_client/suiteapp_client'
 import { NetsuiteQuery } from '../../src/query'
 import * as fileCabinetDetector from '../../src/changes_detector/changes_detectors/file_cabinet'
-import { customRecordTypeDetector } from '../../src/changes_detector/changes_detectors/custom_type'
+import customRecordTypeDetector from '../../src/changes_detector/changes_detectors/custom_record_type'
 import scriptDetector from '../../src/changes_detector/changes_detectors/script'
 import { getChangedObjects } from '../../src/changes_detector/changes_detector'
 import NetsuiteClient from '../../src/client/client'

--- a/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import SuiteAppClient from '../../src/client/suiteapp_client/suiteapp_client'
-import { customRecordTypeDetector as detector } from '../../src/changes_detector/changes_detectors/custom_type'
+import detector from '../../src/changes_detector/changes_detectors/custom_record_type'
 import { Change } from '../../src/changes_detector/types'
 import mockSdfClient from '../client/sdf_client'
 import NetsuiteClient from '../../src/client/client'
@@ -33,8 +33,8 @@ describe('custom_record_type', () => {
     beforeEach(async () => {
       runSuiteQLMock.mockReset()
       runSuiteQLMock.mockResolvedValue([
-        { scriptid: 'a', lastmodifieddate: '03/15/2021' },
-        { scriptid: 'b', lastmodifieddate: '03/16/2021' },
+        { scriptid: 'customrecord_a', lastmodifieddate: '03/15/2021' },
+        { scriptid: 'customrecord_b', lastmodifieddate: '03/16/2021' },
       ])
       results = await detector.getChanges(
         client,
@@ -43,6 +43,8 @@ describe('custom_record_type', () => {
     })
     it('should return the changes', () => {
       expect(results).toEqual([
+        { type: 'object', externalId: 'customrecord_a', time: new Date('2021-03-16T00:00:00.000Z') },
+        { type: 'object', externalId: 'customrecord_b', time: new Date('2021-03-17T00:00:00.000Z') },
         { type: 'object', externalId: 'a', time: new Date('2021-03-16T00:00:00.000Z') },
         { type: 'object', externalId: 'b', time: new Date('2021-03-17T00:00:00.000Z') },
       ])
@@ -50,10 +52,10 @@ describe('custom_record_type', () => {
 
     it('should make the right query', () => {
       expect(runSuiteQLMock).toHaveBeenCalledWith(`
-      SELECT scriptid, lastmodifieddate
-      FROM customrecordtype
-      WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
-    `)
+        SELECT scriptid, lastmodifieddate
+        FROM customrecordtype
+        WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
+      `)
     })
   })
 
@@ -62,8 +64,8 @@ describe('custom_record_type', () => {
     beforeEach(async () => {
       runSuiteQLMock.mockReset()
       runSuiteQLMock.mockResolvedValue([
-        { scriptid: 'a', lastmodifieddate: '03/15/2021' },
-        { scriptid: 'b', lastmodifieddate: '03/16/2021' },
+        { scriptid: 'customrecord_a', lastmodifieddate: '03/15/2021' },
+        { scriptid: 'customrecord_b', lastmodifieddate: '03/16/2021' },
         { qqq: 'b' },
         { scriptid: {} },
       ])
@@ -74,6 +76,8 @@ describe('custom_record_type', () => {
     })
     it('should return the changes without the invalid results', () => {
       expect(results).toEqual([
+        { type: 'object', externalId: 'customrecord_a', time: new Date('2021-03-16T00:00:00.000Z') },
+        { type: 'object', externalId: 'customrecord_b', time: new Date('2021-03-17T00:00:00.000Z') },
         { type: 'object', externalId: 'a', time: new Date('2021-03-16T00:00:00.000Z') },
         { type: 'object', externalId: 'b', time: new Date('2021-03-17T00:00:00.000Z') },
       ])

--- a/packages/netsuite-adapter/test/changes_detector/role.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/role.test.ts
@@ -103,7 +103,7 @@ describe('role', () => {
 
       expect(runSavedSearchQueryMock).toHaveBeenCalledWith({
         type: 'role',
-        columns: ['internalid'],
+        columns: ['internalid', 'permchangedate'],
         filters: [['permchangedate', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:56 pm']],
       })
     })

--- a/packages/netsuite-adapter/test/changes_detector/savedsearch.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/savedsearch.test.ts
@@ -52,7 +52,7 @@ describe('savedsearch', () => {
     it('should make the right query', () => {
       expect(runSavedSearchQueryMock).toHaveBeenCalledWith({
         type: 'savedsearch',
-        columns: ['id'],
+        columns: ['id', 'datemodified'],
         filters: [['datemodified', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:56 pm']],
       })
     })

--- a/packages/netsuite-adapter/test/changes_detector/script.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/script.test.ts
@@ -99,7 +99,7 @@ describe('script', () => {
     `)
 
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, `
-      SELECT script.scriptid, script.id
+      SELECT script.scriptid, scriptdeployment.primarykey AS id
       FROM scriptdeployment 
       JOIN systemnote ON systemnote.recordid = scriptdeployment.primarykey
       JOIN script ON scriptdeployment.script = script.id

--- a/packages/netsuite-adapter/test/changes_detector/workflow.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/workflow.test.ts
@@ -54,7 +54,7 @@ describe('workflow', () => {
             'and',
             ['date', 'within', '1/11/2021 6:55 pm', '2/22/2021 6:56 am'],
           ],
-          columns: ['internalid'],
+          columns: ['recordid'],
         })
       })
     })


### PR DESCRIPTION
Fixed the following bugs:
- isTypeMatch should also check if there are types changes
- customsegments (which are returned from the customrecordtype query) are returned without the `customrecord_` prefix
- role and savedsearch has missing fields
- the script deployment query returns the id of the script instead of the id of the deployment.

---
_Release Notes_: 
None