### PR TITLE
Removed test that relied on internal node implementation

### DIFF
--- a/packages/logging/test/internal/pino_logger.test.ts
+++ b/packages/logging/test/internal/pino_logger.test.ts
@@ -785,7 +785,6 @@ describe('pino based logger', () => {
           'foo',
           { inlineTag1: 'inlineTag1', inlineTag2: 'inlineTag2', inlineTag3: 'so many tags' },
           { extra: 'should be in log' },
-          () => 'shouldn\'t be in log '
         );
         [line] = consoleStream.contents().split(EOL)
         jsonLine = JSON.parse(line)
@@ -797,7 +796,6 @@ describe('pino based logger', () => {
           inlineTag2: 'inlineTag2',
           inlineTag3: 'so many tags',
           extra: 'should be in log',
-          arg2: '[Function]',
         })
       })
 


### PR DESCRIPTION

---

Test would fail on newer versions of node.js because the string representation of anonymous functions can be different

---
_Release Notes_: 
None
