### PR TITLE
SALTO-1198: exposed changes detection to the user

### DIFF
--- a/packages/netsuite-adapter/specific-cli-options.md
+++ b/packages/netsuite-adapter/specific-cli-options.md
@@ -36,3 +36,17 @@ salto fetch -C 'netsuite.fetchTarget.filePaths=["/path/to/dir/.*\.js"]'
 ```bash
 salto fetch -C 'netsuite.fetchTarget.types.emailtemplate=[".*"]' -C 'netsuite.fetchTarget.types.entryForm=[".*"]'
 ```
+
+## Changes Detection
+When using `fetchTarget`, given the Salto SuiteApp credentials, Salto will attempt to detect the elements that were changed in the service and fetch only them.
+
+| Name                           |  Description
+| -------------------------------| ------------------------| -----------
+| netsuite.useChangesDetection | Whether to fetch only changed elements when using `fetchTarget`
+
+### Examples
+Disable changes detection
+
+```bash
+salto fetch -C 'netsuite.fetchTarget.types.addressForm=[".*"]' -C 'netsuite.useChangesDetection=false'
+```

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -50,17 +50,16 @@ export const defaultCredentialsType = new ObjectType({
   fields: {
     accountId: {
       type: BuiltinTypes.STRING,
-      // annotations: { message: 'Account ID' },
+      annotations: { message: 'Account ID' },
     },
     tokenId: {
       type: BuiltinTypes.STRING,
-      // annotations: { message: 'SDF Token ID' },
+      annotations: { message: 'SDF Token ID' },
     },
     tokenSecret: {
       type: BuiltinTypes.STRING,
-      // annotations: { message: 'SDF Token Secret' },
+      annotations: { message: 'SDF Token Secret' },
     },
-    /**
     suiteAppTokenId: {
       type: BuiltinTypes.STRING,
       annotations: {
@@ -73,7 +72,6 @@ export const defaultCredentialsType = new ObjectType({
         message: 'Salto SuiteApp Token Secret (empty if Salto SuiteApp is not installed)',
       },
     },
-     */
   },
   annotationTypes: {},
   annotations: {},


### PR DESCRIPTION
Exposed the credentials for the SuiteApp to the user and documented the changes detection related option.

---
_Release Notes_: 
Netsuite:
Salto can now integrate with a dedicated Salto SuiteApp (contact Salto to install the SuiteApp). Given the required credentials to the SuiteApp integration, Salto will use the SuiteApp to detect changes in elements in the service and fetch only the changed element when using `fetchTarget` (not supported for all element types).