### PR TITLE
Skip adding fullName to custom object instances

### DIFF
--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -90,9 +90,9 @@ export const addMetadataType = (elem: ObjectType, metadataTypeValue = CUSTOM_OBJ
 }
 
 export const addDefaults = (element: ChangeDataType): void => {
-  const addInstanceDefaults = (elem: InstanceElement): void => {
-    if (elem.value[INSTANCE_FULL_NAME_FIELD] === undefined) {
-      elem.value[INSTANCE_FULL_NAME_FIELD] = defaultApiName(elem)
+  const addInstanceDefaults = (inst: InstanceElement): void => {
+    if (inst.value[INSTANCE_FULL_NAME_FIELD] === undefined && !isCustomObject(inst.type)) {
+      inst.value[INSTANCE_FULL_NAME_FIELD] = defaultApiName(inst)
     }
   }
 

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -19,6 +19,7 @@ import { SALESFORCE, LABEL, API_NAME, CUSTOM_FIELD, INSTANCE_FULL_NAME_FIELD, ME
 import { Types } from '../../src/transformers/transformer'
 import { CustomObject } from '../../src/client/types'
 import { mockTypes } from '../mock_elements'
+import { createCustomObjectType } from '../utils'
 
 describe('addDefaults', () => {
   describe('when called with instance', () => {
@@ -29,6 +30,17 @@ describe('addDefaults', () => {
     })
     it('should add api name', () => {
       expect(instance.value).toHaveProperty(INSTANCE_FULL_NAME_FIELD, 'test')
+    })
+  })
+  describe('when called with custom object instance', () => {
+    let instance: InstanceElement
+    beforeEach(() => {
+      const customObj = createCustomObjectType('test', {})
+      instance = new InstanceElement('test', customObj)
+      addDefaults(instance)
+    })
+    it('should not add api name', () => {
+      expect(instance.value).not.toHaveProperty(INSTANCE_FULL_NAME_FIELD)
     })
   })
   describe('when called with field', () => {


### PR DESCRIPTION
Custom object instances get their ID generated by the service
We should not add a default fullName in our code


---
_Release Notes_: 
Salesforce adapter
- Fixed bug where data instances deployed from salto would get an extra "fullName" value in the nacl
