### PR TITLE
Fix lowerdsah TreeMap get/set for inherited properties

### DIFF
--- a/packages/lowerdash/.vscode/launch.json
+++ b/packages/lowerdash/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "lowerdash Debug Jest Tests",
+            "cwd": "${workspaceFolder}",
+            "args": [
+                "${workspaceRoot}/node_modules/.bin/jest",
+                "--runInBand",
+                "--config",
+                "${workspaceRoot}/jest.config.js"
+            ],
+            "outFiles": [],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+        },
+    ]
+}

--- a/packages/lowerdash/src/collections/tree_map.ts
+++ b/packages/lowerdash/src/collections/tree_map.ts
@@ -39,10 +39,10 @@ export class TreeMap<T> implements Map<string, T[]> {
       return data
     }
     const [key, ...restOfPath] = path
-    if (data.children[key] === undefined && createIfMissing) {
+    if (!Object.prototype.hasOwnProperty.call(data.children, key) && createIfMissing) {
       data.children[key] = { children: {}, value: [] }
     }
-    if (data.children[key]) {
+    if (Object.prototype.hasOwnProperty.call(data.children, key)) {
       return TreeMap.getFromPath(data.children[key], restOfPath, createIfMissing, returnPartial)
     }
     return returnPartial ? data : undefined

--- a/packages/lowerdash/test/collections/tree_map.test.ts
+++ b/packages/lowerdash/test/collections/tree_map.test.ts
@@ -34,7 +34,7 @@ describe('tree map', () => {
     expect(sourceMap.size).toEqual(5)
   })
 
-  it('should set non exsiting coplex key', () => {
+  it('should set non existing complex key', () => {
     const sourceMap = new TreeMap([], separator)
     const value = ['new_value']
     const key = 'a|b|c'
@@ -42,6 +42,16 @@ describe('tree map', () => {
     expect(sourceMap.get(key)).toEqual(value)
   })
 
+  it('should set non existing complex key even if it is an inherited property', () => {
+    const sourceMap = new TreeMap([], separator)
+    const value = ['new_value']
+    const key = 'toString'
+    expect(Object.keys(_.get(sourceMap, 'data.children'))).toEqual([])
+    expect(sourceMap.get(key)).toBeUndefined()
+    sourceMap.set(key, value)
+    expect(Object.keys(_.get(sourceMap, 'data.children'))).toEqual(['toString'])
+    expect(sourceMap.get(key)).toEqual(value)
+  })
   it('should return proper has value', () => {
     const sourceMap = new TreeMap([], separator)
     const value = ['new_value']

--- a/packages/lowerdash/test/collections/tree_map.test.ts
+++ b/packages/lowerdash/test/collections/tree_map.test.ts
@@ -45,11 +45,9 @@ describe('tree map', () => {
   it('should set non existing complex key even if it is an inherited property', () => {
     const sourceMap = new TreeMap([], separator)
     const value = ['new_value']
-    const key = 'toString'
-    expect(Object.keys(_.get(sourceMap, 'data.children'))).toEqual([])
+    const key = 'a|toString|b'
     expect(sourceMap.get(key)).toBeUndefined()
     sourceMap.set(key, value)
-    expect(Object.keys(_.get(sourceMap, 'data.children'))).toEqual(['toString'])
     expect(sourceMap.get(key)).toEqual(value)
   })
   it('should return proper has value', () => {


### PR DESCRIPTION
In some cases we check for the existence of nested values by just reading them from the object - for object methods this will never return `undefined`, so the logic is incorrect and we may erroneously return the builtin functions / modify these shared properties in unintended ways.
Ran into this while trying out a swagger that has a nested field named `toString` - when this happens it crashes the fetch operation on  
```
error cli/cli Caught exception: TypeError: Cannot read property 'push' of undefined
TypeError: Cannot read property 'push' of undefined
    at TreeMap.push (/Users/neta/code/salto/packages/lowerdash/src/collections/tree_map.ts:104:24)
...
```

Fixed the two relevant places in the flow that broke - there may be additional places that are impacted by this, these are the ones I found so far.

Also added the vscode config for lowerdash because it was missing.

---
_Release Notes_: 
None
