### PR TITLE
SALTO-1163: Change validator for multiple default values

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -22,6 +22,7 @@ import unknownFieldValidator from './change_validators/unknown_field'
 import customFieldTypeValidator from './change_validators/custom_field_type'
 import standardFieldLabelValidator from './change_validators/standard_field_label'
 import profileMapKeysValidator from './change_validators/profile_map_keys'
+import multipleDefaultsValidator from './change_validators/multiple_deafults'
 
 const changeValidators: ChangeValidator[] = [
   packageValidator,
@@ -31,6 +32,7 @@ const changeValidators: ChangeValidator[] = [
   customFieldTypeValidator,
   standardFieldLabelValidator,
   profileMapKeysValidator,
+  multipleDefaultsValidator,
 ]
 
 export default createChangeValidator(changeValidators)

--- a/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
+++ b/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
@@ -101,16 +101,10 @@ const changeValidator: ChangeValidator = async changes => {
     .flatMap(getInstancesMultipleDefaultsErrors)
 
   // special treatment for picklist & multipicklist valueSets
-  const picklistChangesErrors = [...changes
+  const picklistChangesErrors = changes
     .filter(isAdditionOrModificationChange)
     .filter(isFieldChange)
-    .map(getChangeElement),
-  // ...changes
-  //   .filter(isAdditionChange)
-  //   .filter(isObjectTypeChange)
-  //   .map(getChangeElement)
-  //   .flatMap(change => Object.values(change.fields)),
-  ]
+    .map(getChangeElement)
     .filter(isFieldOfCustomObject)
     .filter(field => values.isDefined(field.annotations.valueSet))
     .flatMap(getPicklistMultipleDefaultsErrors)

--- a/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
+++ b/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
@@ -19,6 +19,7 @@ import {
   isInstanceChange, Field, InstanceElement,
   Element, isFieldChange, isListType, TypeElement, isMapType, Value, isReferenceExpression,
 } from '@salto-io/adapter-api'
+import { values } from '@salto-io/lowerdash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { LABEL } from '../constants'
@@ -100,7 +101,7 @@ const changeValidator: ChangeValidator = async changes => {
     .filter(isFieldChange)
     .map(getChangeElement)
     .filter(isFieldOfCustomObject)
-    .filter(field => field.annotations.valueSet !== undefined)
+    .filter(field => values.isDefined(field.annotations.valueSet))
     .flatMap(getPicklistMultipleDefaultsErrors)
 
   return [...instanceChangesErrors, ...picklistChangesErrors]

--- a/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
+++ b/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
@@ -1,0 +1,85 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeError, getChangeElement, ChangeValidator, isAdditionOrModificationChange,
+  isInstanceChange, Field, InstanceElement, isContainerType, ContainerType, ObjectType,
+} from '@salto-io/adapter-api'
+import { TransformFunc, transformValues } from '@salto-io/adapter-utils'
+import { apiName, metadataType } from '../transformers/transformer'
+import { FieldReferenceDefinition, generateReferenceResolverFinder } from '../transformers/reference_mapping'
+
+
+const fieldSelectMapping: FieldReferenceDefinition[] = [
+  {
+    src: { field: 'default', parentTypes: ['ProfileApplicationVisibility', 'ProfileRecordTypeVisibility', 'StandardValue'] },
+  },
+]
+
+const createChangeError = (parentType: ObjectType, instance: InstanceElement): ChangeError =>
+  ({
+    elemID: instance.elemID,
+    severity: 'Warning',
+    message: `There cannot be more than one 'default' field set to 'true' in instance: ${apiName(instance)} of type: ${metadataType(instance)}.`,
+    detailedMessage: `There is more than one 'default' field set to 'true' in instance: ${apiName(instance)} of type: ${metadataType(instance)}. Field type: ${metadataType(parentType)}.`,
+  })
+
+const isDefaultField = (field: Field): boolean => {
+  const resolverFinder = generateReferenceResolverFinder(fieldSelectMapping)
+  return resolverFinder(field).length > 0
+}
+
+const getMultipleDefaultsErrors = (after: InstanceElement): ChangeError[] => {
+  const defaultValues: boolean[] = []
+  const errors: ChangeError[] = []
+  // TODO: name of transform func
+  // TODO: design of transform func
+  const transformFunc: TransformFunc = ({ value, field }) => {
+    if (field !== undefined && isDefaultField(field) && value) {
+      if (defaultValues.length === 0) {
+        defaultValues.push(value)
+      } else if (errors.length === 0) {
+        errors.push(createChangeError(field.parent, after))
+      }
+    }
+    return value
+  }
+
+  Object.entries(after.value)
+    .filter(([fieldName]) => isContainerType(after.type.fields[fieldName]?.type))
+    .forEach(([fieldName, fieldValues]) => {
+      const fieldType = after.type.fields[fieldName].type as ContainerType
+      transformValues({
+        values: fieldValues,
+        type: fieldType,
+        transformFunc,
+        strict: false,
+      })
+    })
+  return errors
+}
+
+/**
+   * It is forbidden to set more than 'default' field as 'true' for some types.
+   */
+const changeValidator: ChangeValidator = async changes => (
+  changes
+    .filter(isAdditionOrModificationChange)
+    .filter(isInstanceChange)
+    .map(getChangeElement)
+    .flatMap(getMultipleDefaultsErrors)
+)
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
+++ b/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
@@ -61,7 +61,7 @@ const createChangeError = (field: Field, contexts: string[], instanceName?: stri
   elemID: field.elemID,
   severity: 'Warning',
   message: `There cannot be more than one 'default' field set to 'true'. Field name: ${field.name} in${instanceName ? ` instance: ${instanceName}` : ''} type ${field.parent.elemID.name}.`,
-  detailedMessage: `There cannot be more than one 'default' field set to 'true'. Field name: ${field.name} in${instanceName ? ` instance: ${instanceName}` : ''} type ${field.parent.elemID.name}. The 'default = true' are where the ${fieldNameToInnerContextField[field.name] ?? LABEL}s are: ${contexts}`,
+  detailedMessage: `There cannot be more than one 'default' ${field.name} in${instanceName ? ` instance: ${instanceName}` : ''} type ${field.parent.elemID.name}. The following ${fieldNameToInnerContextField[field.name] ?? LABEL}s are set to default: ${contexts}`,
 })
 
 const getPicklistMultipleDefaultsErrors = (field: FieldWithValueSet): ChangeError[] => {

--- a/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
+++ b/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
@@ -86,7 +86,7 @@ const getInstancesMultipleDefaultsErrors = (after: InstanceElement): ChangeError
 }
 
 /**
- * It is forbidden to set more than 'default' field as 'true' for some types.
+ * It is forbidden to set more than one 'default' field as 'true' for some types.
  */
 const changeValidator: ChangeValidator = async changes => {
   const instanceChangesErrors = changes

--- a/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
+++ b/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
@@ -18,7 +18,6 @@ import {
   ChangeError, getChangeElement, ChangeValidator, isAdditionOrModificationChange,
   isInstanceChange, Field, InstanceElement,
   isFieldChange, isListType, TypeElement, isMapType, Value, isReferenceExpression,
-  // isAdditionChange, isObjectTypeChange,
 } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -150,7 +150,6 @@ export const BUSINESS_OWNER_GROUP = 'businessOwnerGroup'
 export const BUSINESS_STATUS = 'businessStatus'
 export const SECURITY_CLASSIFICATION = 'securityClassification'
 export const COMPLIANCE_GROUP = 'complianceGroup'
-export const VALUE_SET = 'valueSet'
 
 export const FIELD_ANNOTATIONS = {
   UNIQUE: 'unique',
@@ -178,7 +177,7 @@ export const FIELD_ANNOTATIONS = {
   SUMMARY_FOREIGN_KEY: 'summaryForeignKey',
   SUMMARY_OPERATION: 'summaryOperation',
   RESTRICTED: 'restricted',
-  VALUE_SET,
+  VALUE_SET: 'valueSet',
   DEFAULT_VALUE: 'defaultValue',
   FORMULA_TREAT_BLANKS_AS: 'formulaTreatBlanksAs',
   CREATABLE: 'createable',

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -150,6 +150,7 @@ export const BUSINESS_OWNER_GROUP = 'businessOwnerGroup'
 export const BUSINESS_STATUS = 'businessStatus'
 export const SECURITY_CLASSIFICATION = 'securityClassification'
 export const COMPLIANCE_GROUP = 'complianceGroup'
+export const VALUE_SET = 'valueSet'
 
 export const FIELD_ANNOTATIONS = {
   UNIQUE: 'unique',
@@ -177,7 +178,7 @@ export const FIELD_ANNOTATIONS = {
   SUMMARY_FOREIGN_KEY: 'summaryForeignKey',
   SUMMARY_OPERATION: 'summaryOperation',
   RESTRICTED: 'restricted',
-  VALUE_SET: 'valueSet',
+  VALUE_SET,
   DEFAULT_VALUE: 'defaultValue',
   FORMULA_TREAT_BLANKS_AS: 'formulaTreatBlanksAs',
   CREATABLE: 'createable',

--- a/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
@@ -17,11 +17,11 @@ import {
   ChangeError, ElemID, Field, InstanceElement, ListType, ObjectType, toChange,
   BuiltinTypes, MapType,
 } from '@salto-io/adapter-api'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { createInstanceElement, Types } from '../../src/transformers/transformer'
 import multipleDefaultsValidator from '../../src/change_validators/multiple_deafults'
 import { createField } from '../utils'
 import { API_NAME, CUSTOM_OBJECT, METADATA_TYPE, SALESFORCE } from '../../src/constants'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
 
 
 describe('multiple defaults change validator', () => {

--- a/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
@@ -1,0 +1,372 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeError, ElemID, Field, InstanceElement, ListType, ObjectType, toChange,
+  BuiltinTypes, MapType,
+} from '@salto-io/adapter-api'
+import { createInstanceElement, Types } from '../../src/transformers/transformer'
+import multipleDefaultsValidator from '../../src/change_validators/multiple_deafults'
+import { createField } from '../utils'
+import { API_NAME, CUSTOM_OBJECT, METADATA_TYPE, SALESFORCE } from '../../src/constants'
+
+
+describe('multiple defaults change validator', () => {
+  const runChangeValidatorOnUpdate = (before: Field | InstanceElement,
+    after: Field | InstanceElement):
+      Promise<ReadonlyArray<ChangeError>> =>
+    multipleDefaultsValidator([toChange({ before, after })])
+
+  describe('in custom fields', () => {
+    let obj: ObjectType
+    beforeEach(() => {
+      obj = new ObjectType({
+        elemID: new ElemID('salesforce', 'obj'),
+        annotations: {
+          [METADATA_TYPE]: CUSTOM_OBJECT,
+          [API_NAME]: 'obj',
+        },
+      })
+    })
+
+    const createAfterField = (beforeField: Field): Field => {
+      const afterField = beforeField.clone()
+      afterField.annotations.valueSet[1].default = true
+      return afterField
+    }
+
+    describe('picklist', () => {
+      it('should have warning for a picklist field', async () => {
+        const beforeField = createField(obj, Types.primitiveDataTypes.Picklist, 'PicklistField', {
+          valueSet: [{
+            fullName: 'Gold',
+            default: true,
+            label: 'Gold',
+          },
+          {
+            fullName: 'Silver',
+            default: false,
+            label: 'Silver',
+          },
+          ],
+        })
+        const afterField = createAfterField(beforeField)
+        const changeErrors = await runChangeValidatorOnUpdate(beforeField, afterField)
+        expect(changeErrors).toHaveLength(1)
+        const [changeError] = changeErrors
+        expect(changeError.elemID).toEqual(beforeField.elemID)
+        expect(changeError.severity).toEqual('Warning')
+      })
+      it('should not have error for <= 1 default values in picklist', async () => {
+        const beforeField = createField(obj, Types.primitiveDataTypes.Picklist, 'PicklistField', {
+          valueSet: [{
+            fullName: 'Gold',
+            default: false,
+            label: 'Gold',
+          },
+          {
+            fullName: 'Silver',
+            default: false,
+            label: 'Silver',
+          },
+          ],
+        })
+        const afterField = createAfterField(beforeField)
+        const changeErrors = await runChangeValidatorOnUpdate(beforeField, afterField)
+        expect(changeErrors).toHaveLength(0)
+      })
+    })
+
+    describe('multi-select picklist', () => {
+      it('should have warning for a MultiselectPicklist field', async () => {
+        const beforeField = createField(obj, Types.primitiveDataTypes.MultiselectPicklist, 'PicklistField', {
+          valueSet: [{
+            fullName: 'Gold',
+            default: true,
+            label: 'Gold',
+          },
+          {
+            fullName: 'Silver',
+            default: false,
+            label: 'Silver',
+          },
+          ],
+        })
+        const afterField = createAfterField(beforeField)
+        const changeErrors = await runChangeValidatorOnUpdate(beforeField, afterField)
+        expect(changeErrors).toHaveLength(1)
+        const [changeError] = changeErrors
+        expect(changeError.elemID).toEqual(beforeField.elemID)
+        expect(changeError.severity).toEqual('Warning')
+      })
+      it('should not have error for <= 1 default values in picklist', async () => {
+        const beforeField = createField(obj, Types.primitiveDataTypes.MultiselectPicklist, 'PicklistField', {
+          valueSet: [{
+            fullName: 'Gold',
+            default: false,
+            label: 'Gold',
+          },
+          {
+            fullName: 'Silver',
+            default: false,
+            label: 'Silver',
+          },
+          ],
+        })
+        const afterField = createAfterField(beforeField)
+        const changeErrors = await runChangeValidatorOnUpdate(beforeField, afterField)
+        expect(changeErrors).toHaveLength(0)
+      })
+    })
+  })
+  describe('In metadata instances', () => {
+    describe('GlobalValueSet', () => {
+      let type: ObjectType
+      beforeEach(() => {
+        type = new ObjectType({ elemID: new ElemID(SALESFORCE, 'GlobalValueSet'),
+          fields: { customValue: { type: new ListType(new ObjectType({
+            elemID: new ElemID(SALESFORCE, 'CustomValue'),
+            fields: {
+              fullName: { type: BuiltinTypes.STRING },
+              default: { type: BuiltinTypes.BOOLEAN },
+              label: { type: BuiltinTypes.STRING },
+            },
+            annotations: {
+              [METADATA_TYPE]: 'CustomValue',
+            },
+          })) } } })
+      })
+
+      const createAfterInstance = (beforeInstance: InstanceElement): InstanceElement => {
+        const afterInstance = beforeInstance.clone()
+        afterInstance.value.customValue[1].default = true
+        return afterInstance
+      }
+
+      it('should have warning for a GlobalValueSet instance', async () => {
+        const beforeInstance = createInstanceElement({ fullName: 'globalValueSetIntance',
+          customValue: [
+            {
+              fullName: 'lolo',
+              default: true,
+              label: 'lolo',
+            },
+            {
+              fullName: 'lala',
+              default: false,
+              label: 'lala',
+            },
+          ] }, type)
+        const afterInstance = createAfterInstance(beforeInstance)
+        const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
+        expect(changeErrors).toHaveLength(1)
+        const [changeError] = changeErrors
+        expect(changeError.elemID).toEqual(afterInstance.elemID)
+        expect(changeError.severity).toEqual('Warning')
+      })
+      it('should not have error for <= 1 default values GlobalValueSet', async () => {
+        const beforeInstance = createInstanceElement({ fullName: 'globalValueSetIntance',
+          customValue: [
+            {
+              fullName: 'lolo',
+              default: false,
+              label: 'lolo',
+            },
+            {
+              fullName: 'lala',
+              default: false,
+              label: 'lala',
+            },
+          ] }, type)
+        const afterInstance = createAfterInstance(beforeInstance)
+        const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
+        expect(changeErrors).toHaveLength(0)
+      })
+    })
+
+    describe('Profile', () => {
+      let type: ObjectType
+      beforeEach(() => {
+        type = new ObjectType({
+          elemID: new ElemID(SALESFORCE, 'Profile'),
+          fields: {
+            applicationVisibilities: { type: new MapType(new ObjectType({
+              elemID: new ElemID(SALESFORCE, 'ProfileApplicationVisibility'),
+              fields: { default: { type: BuiltinTypes.BOOLEAN } },
+              annotations: {
+                [METADATA_TYPE]: 'ProfileApplicationVisibility',
+              },
+            })) },
+            recordTypeVisibilities: { type: new MapType(new MapType(new ObjectType({
+              elemID: new ElemID(SALESFORCE, 'ProfileRecordTypeVisibility'),
+              fields: { default: { type: BuiltinTypes.BOOLEAN } },
+              annotations: {
+                [METADATA_TYPE]: 'ProfileRecordTypeVisibility',
+              },
+            }))) },
+          },
+          annotations: {
+            [METADATA_TYPE]: 'Profile',
+          },
+        })
+      })
+
+      describe('ProfileApplicationVisibility', () => {
+        const createAfterInstance = (beforeInstance: InstanceElement): InstanceElement => {
+          const afterInstance = beforeInstance.clone()
+          afterInstance.value.applicationVisibilities.app.default = true
+          return afterInstance
+        }
+
+        it('should have warning for ProfileApplicationVisibility', async () => {
+          const beforeInstance = createInstanceElement({
+            fullName: 'ProfileInstance',
+            applicationVisibilities: {
+              app: {
+                default: false,
+              },
+              anotherApp: {
+                default: true,
+              },
+            },
+          }, type)
+
+          const afterInstance = createAfterInstance(beforeInstance)
+          const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
+          expect(changeErrors).toHaveLength(1)
+          const [changeError] = changeErrors
+          expect(changeError.elemID).toEqual(afterInstance.elemID)
+          expect(changeError.severity).toEqual('Warning')
+        })
+
+        it('should not have error for <= 1 default values in ProfileApplicationVisibility', async () => {
+          const beforeInstance = createInstanceElement({
+            fullName: 'ProfileInstance',
+            applicationVisibilities: {
+              app: {
+                default: false,
+              },
+              anotherApp: {
+                default: false,
+              },
+            },
+          }, type)
+
+          const afterInstance = createAfterInstance(beforeInstance)
+          const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
+          expect(changeErrors).toHaveLength(0)
+        })
+      })
+
+      describe('ProfileRecordTypeVisibility', () => {
+        const createAfterInstance = (beforeInstance: InstanceElement): InstanceElement => {
+          const afterInstance = beforeInstance.clone()
+          afterInstance.value.recordTypeVisibilities.test1.testRecordType1.default = true
+          return afterInstance
+        }
+        it('should have error for ProfileRecordTypeVisibility', async () => {
+          const beforeInstance = createInstanceElement({
+            fullName: 'ProfileInstance',
+            recordTypeVisibilities: {
+              test1: {
+                testRecordType1: {
+                  default: false,
+                },
+              },
+              test2: {
+                testRecordType2: {
+                  default: true,
+                },
+              },
+
+            },
+          }, type)
+
+          const afterInstance = createAfterInstance(beforeInstance)
+          const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
+          expect(changeErrors).toHaveLength(1)
+          const [changeError] = changeErrors
+          expect(changeError.elemID).toEqual(afterInstance.elemID)
+          expect(changeError.severity).toEqual('Warning')
+        })
+
+        it('should not have error for <= 1 default values in ProfileRecordTypeVisibility', async () => {
+          const beforeInstance = createInstanceElement({
+            fullName: 'ProfileInstance',
+            recordTypeVisibilities: {
+              test1: {
+                testRecordType1: {
+                  default: false,
+                },
+              },
+              test2: {
+                testRecordType2: {
+                  default: false,
+                },
+              },
+
+            },
+          }, type)
+
+          const afterInstance = createAfterInstance(beforeInstance)
+          const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
+          expect(changeErrors).toHaveLength(0)
+        })
+      })
+
+      describe('several warnings in one instance', () => {
+        const createAfterInstance = (beforeInstance: InstanceElement): InstanceElement => {
+          const afterInstance = beforeInstance.clone()
+          afterInstance.value.recordTypeVisibilities.test1.testRecordType1.default = true
+          afterInstance.value.applicationVisibilities.app.default = true
+          return afterInstance
+        }
+        it('should have 2 errors', async () => {
+          const beforeInstance = createInstanceElement({
+            fullName: 'ProfileInstance',
+            recordTypeVisibilities: {
+              test1: {
+                testRecordType1: {
+                  default: false,
+                },
+              },
+              test2: {
+                testRecordType2: {
+                  default: true,
+                },
+              },
+            },
+            applicationVisibilities: {
+              app: {
+                default: false,
+              },
+              anotherApp: {
+                default: true,
+              },
+            },
+          }, type)
+
+          const afterInstance = createAfterInstance(beforeInstance)
+          const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
+          expect(changeErrors).toHaveLength(2)
+          changeErrors.forEach(error => {
+            expect(error.elemID).toEqual(afterInstance.elemID)
+            expect(error.severity).toEqual('Warning')
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Added a change validator to check for places where several `default` fields are set to `true` (only one is allowed) in specific lists/maps, and in picklists / multi-picklists.


_Release Notes_: 
Attempt to deploy instances with a field of one of those metadata types: `'ProfileApplicationVisibility', 'ProfileRecordTypeVisibility', 'StandardValue', 'CustomValue'`, or in a valueSet of a picklist/MultiselectPicklist, where `default = true` in more than one entry, will raise a warning since it is not allowed by SF.