### PR TITLE
postFetch flow remove the uneeded elements filtering and saving in me…

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -214,7 +214,6 @@ export const fetch: FetchFunc = async (
       adapters,
       await workspace.elements(),
       workspace.state(),
-      stateElementsNotCoveredByFetch,
       currentConfigs,
       progressEmitter,
     )

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -227,11 +227,15 @@ const isAdapterOperationsWithPostFetch = (
 const runPostFetch = async (
   adapters: Record<string, AdapterOperationsWithPostFetch>,
   serviceElements: Element[],
-  stateElementsByAdapter: Record<string, ReadonlyArray<Element>>,
+  stateElements: elementSource.ElementsSource,
   partiallyFetchedAdapters: Set<string>,
 ): Promise<void> => {
   const serviceElementsByAdapter = _.groupBy(serviceElements, e => e.elemID.adapter)
-
+  // TODO: We should keep using ElementsSource at this stage
+  const stateElementsByAdapter = _.groupBy(
+    await awu(await stateElements.getAll()).toArray(),
+    e => e.elemID.adapter,
+  )
   const getAdapterElements = (adapterName: string): ReadonlyArray<Element> => {
     if (!partiallyFetchedAdapters.has(adapterName)) {
       return serviceElementsByAdapter[adapterName] ?? stateElementsByAdapter[adapterName]
@@ -247,7 +251,6 @@ const runPostFetch = async (
       ...missingElements,
     ]
   }
-
   const elementsByAdapter = Object.fromEntries(
     [...new Set([
       ...Object.keys(stateElementsByAdapter),
@@ -267,8 +270,7 @@ const runPostFetch = async (
 
 const fetchAndProcessMergeErrors = async (
   adapters: Record<string, AdapterOperations>,
-  filteredStateElements: elementSource.ElementsSource,
-  otherStateElements: ReadonlyArray<Element>,
+  stateElements: elementSource.ElementsSource,
   getChangesEmitter: StepEmitter,
   progressEmitter?: EventEmitter<FetchProgressEvents>
 ):
@@ -315,16 +317,11 @@ const fetchAndProcessMergeErrors = async (
     const adaptersWithPostFetch = _.pickBy(adapters, isAdapterOperationsWithPostFetch)
     if (!_.isEmpty(adaptersWithPostFetch)) {
       try {
-        const stateElementsByAdapter = _.groupBy(
-          // TODO: Fix this in the next iteration
-          [...await awu(await filteredStateElements.getAll()).toArray(), ...otherStateElements],
-          e => e.elemID.adapter,
-        )
         // update elements based on fetch results from other services
         await runPostFetch(
           adaptersWithPostFetch,
           serviceElements,
-          stateElementsByAdapter,
+          stateElements,
           partiallyFetchedAdapters,
         )
         log.debug('ran post-fetch in the following adapters: %s', Object.keys(adaptersWithPostFetch))
@@ -349,7 +346,7 @@ const fetchAndProcessMergeErrors = async (
     const processErrorsResult = await processMergeErrors(
       applyInstancesDefaults(elements.values()),
       mergeErrorsArr,
-      filteredStateElements,
+      stateElements,
     )
 
     const droppedElements = new Set(
@@ -434,7 +431,6 @@ export const fetchChanges = async (
   adapters: Record<string, AdapterOperations>,
   workspaceElements: elementSource.ElementsSource,
   stateElements: elementSource.ElementsSource,
-  otherStateElements: ReadonlyArray<Element>,
   currentConfigs: InstanceElement[],
   progressEmitter?: EventEmitter<FetchProgressEvents>
 ): Promise<FetchChangesResult> => {
@@ -448,7 +444,6 @@ export const fetchChanges = async (
   } = await fetchAndProcessMergeErrors(
     adapters,
     stateElements,
-    otherStateElements,
     getChangesEmitter,
     progressEmitter
   )
@@ -466,10 +461,9 @@ export const fetchChanges = async (
     getChangesEmitter.emit('completed')
     progressEmitter.emit('diffWillBeCalculated', calculateDiffEmitter)
   }
-
-  const isFirstFetch = await awu(await workspaceElements.getAll())
-    .concat(await stateElements.getAll())
-    .filter(e => !e.elemID.isConfig())
+  const isFirstFetch = await awu(await workspaceElements.list())
+    .concat(await stateElements.list())
+    .filter(e => !e.isConfig())
     .isEmpty()
   const changes = isFirstFetch
     ? serviceElements.map(toAddFetchChange)
@@ -479,7 +473,7 @@ export const fetchChanges = async (
       // When we init a new env, state will be empty. We fallback to the workspace
       // elements since they should be considered a part of the env and the diff
       // should be calculated with them in mind.
-      await awu(await stateElements.getAll()).isEmpty() ? workspaceElements : stateElements,
+      await awu(await stateElements.list()).isEmpty() ? workspaceElements : stateElements,
       workspaceElements,
       partiallyFetchedAdapters
     )

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -133,7 +133,6 @@ describe('fetch', () => {
           createElementSource([]),
           createElementSource([]),
           [],
-          [],
         )
         expect(fetchChangesResult.mergeErrors).toHaveLength(1)
       })
@@ -149,7 +148,6 @@ describe('fetch', () => {
             createInMemoryElementSource([newTypeBaseModified, typeWithField]),
             createInMemoryElementSource([]),
             [],
-            [],
           )
           expect(Array.from(fetchChangesResult.changes).length).toBe(0)
         })
@@ -162,7 +160,6 @@ describe('fetch', () => {
             mockAdapters,
             createInMemoryElementSource([]),
             createInMemoryElementSource([newTypeBase, typeWithField]),
-            [],
             [],
           )
           expect(fetchChangesResult.elements).toEqual([newTypeBaseModified, typeWithField])
@@ -178,7 +175,6 @@ describe('fetch', () => {
             createInMemoryElementSource([newTypeBaseModified, typeWithField]),
             createInMemoryElementSource([]),
             [],
-            [],
           )
           const resultChanges = Array.from(fetchChangesResult.changes)
           expect(resultChanges.length).toBe(1)
@@ -193,7 +189,6 @@ describe('fetch', () => {
             mockAdapters,
             createInMemoryElementSource([]),
             createInMemoryElementSource([newTypeBase, typeWithField]),
-            [],
             [],
           )
           expect(fetchChangesResult.elements).toEqual([newTypeBaseModified])
@@ -236,7 +231,6 @@ describe('fetch', () => {
           createInMemoryElementSource([beforeElement, workspaceReferencedElement]),
           createInMemoryElementSource([beforeElement, stateReferencedElement]),
           [],
-          [],
         )
 
         const resultChanges = Array.from(fetchChangesResult.changes)
@@ -277,7 +271,6 @@ describe('fetch', () => {
               new ObjectType({ elemID: new ElemID('dummy2', 'type') }),
             ]),
             createInMemoryElementSource([]),
-            [],
             [],
           )
           const resultChanges = Array.from(fetchChangesResult.changes)
@@ -334,7 +327,6 @@ describe('fetch', () => {
           createElementSource([]),
           createElementSource([]),
           [],
-          [],
         )
         verifyPlan(
           fetchChangesResult.configChanges,
@@ -351,7 +343,6 @@ describe('fetch', () => {
           mockAdapters,
           createElementSource([]),
           createElementSource([]),
-          [],
           [currentInstanceConfig],
         )
         verifyPlan(
@@ -369,7 +360,6 @@ describe('fetch', () => {
           mockAdapters,
           createElementSource([]),
           createElementSource([]),
-          [],
           [configInstance],
         )
         expect([...fetchChangesResult.configChanges.itemsByEvalOrder()]).toHaveLength(0)
@@ -398,7 +388,6 @@ describe('fetch', () => {
                 mockAdapters,
                 createElementSource([]),
                 createElementSource([dupTypeBase]),
-                [],
                 []
               )
               expect(false).toBeTruthy()
@@ -425,7 +414,6 @@ describe('fetch', () => {
             mockAdapters,
             createElementSource([]),
             createElementSource([]),
-            [],
             [],
           )
         })
@@ -460,7 +448,6 @@ describe('fetch', () => {
           createElementSource([newTypeMerged, hiddenInstance]),
           createElementSource([newTypeMerged, hiddenInstance]),
           [],
-          [],
         )
         elements = result.elements
         changes = [...result.changes]
@@ -493,7 +480,6 @@ describe('fetch', () => {
           mockAdapters,
           createElementSource([typeWithField, hiddenInstance]),
           createElementSource([typeWithField, hiddenInstance]),
-          [],
           [],
         )
         changes = [...result.changes]
@@ -528,7 +514,6 @@ describe('fetch', () => {
             elementSource.createInMemoryElementSource([]),
             elementSource.createInMemoryElementSource([]),
             [],
-            [],
             progressEmitter
           )
           changes = [...result.changes]
@@ -549,7 +534,6 @@ describe('fetch', () => {
             mockAdapters,
             elementSource.createInMemoryElementSource([]),
             elementSource.createInMemoryElementSource([]),
-            [],
             [],
             progressEmitter
           )
@@ -573,7 +557,6 @@ describe('fetch', () => {
           mockAdapters,
           createElementSource([]),
           createElementSource([]),
-          [],
           [],
         )
         changes = [...result.changes]
@@ -603,7 +586,6 @@ describe('fetch', () => {
               mockAdapters,
               createElementSource([newTypeBaseWPath]),
               createElementSource([newTypeBaseWPath]),
-              [],
               [],
             )
             changes = [...result.changes]
@@ -641,7 +623,6 @@ describe('fetch', () => {
               createElementSource([newTypeA]),
               createElementSource([newTypeA]),
               [],
-              [],
             )
             changes = [...result.changes]
           })
@@ -666,7 +647,6 @@ describe('fetch', () => {
             createElementSource([typeWithFieldChange]),
             createElementSource([typeWithField]),
             [],
-            [],
           )
           changes = [...result.changes]
         })
@@ -685,7 +665,6 @@ describe('fetch', () => {
             createElementSource([typeWithFieldConflict]),
             createElementSource([typeWithField]),
             [],
-            [],
           )
           changes = [...result.changes]
         })
@@ -703,7 +682,6 @@ describe('fetch', () => {
             mockAdapters,
             createElementSource([]),
             createElementSource([typeWithField]),
-            [],
             [],
           )
           changes = [...result.changes]
@@ -897,7 +875,6 @@ describe('fetch', () => {
           createElementSource([]),
           createElementSource([]),
           [],
-          [],
         )
         changes = [...result.changes]
       })
@@ -930,7 +907,6 @@ describe('fetch', () => {
           createElementSource([]),
           createElementSource([]),
           [],
-          [],
         )
         expect(await awu(instancesPassed).toArray()).toEqual([hiddenInstance])
       })
@@ -954,7 +930,6 @@ describe('fetch', () => {
           mockAdapters,
           createElementSource([typeWithField]),
           createElementSource([newTypeBase, typeWithField]),
-          [],
           [],
         )
         expect(fetchChangesResult.elements).toEqual([newTypeBaseModified, typeWithField])
@@ -980,7 +955,6 @@ describe('fetch', () => {
           mockAdapters,
           createElementSource([]),
           createElementSource([newTypeBase, typeWithField]),
-          [],
           [],
         )
         expect(fetchChangesResult.elements).toEqual([newTypeBaseModified])
@@ -1030,7 +1004,6 @@ describe('fetch', () => {
           createElementSource([]),
           createElementSource([dummy1, dummy2, dummy3]),
           [],
-          [],
         )
         expect(adapters.dummy2.postFetch).toHaveBeenCalledWith({
           currentAdapterElements: expect.arrayContaining([dummy2Type1]),
@@ -1053,8 +1026,7 @@ describe('fetch', () => {
         await fetchChanges(
           _.pick(adapters, ['dummy1', 'dummy2']),
           createElementSource([]),
-          createElementSource([dummy1, dummy2]),
-          [dummy3],
+          createElementSource([dummy1, dummy2, dummy3]),
           [],
         )
         expect(adapters.dummy2.postFetch).toHaveBeenCalledWith({
@@ -1074,8 +1046,7 @@ describe('fetch', () => {
         await expect(fetchChanges(
           _.pick(adapters, ['dummy1', 'dummy2']),
           createElementSource([]),
-          createElementSource([dummy1, dummy2]),
-          [dummy3],
+          createElementSource([dummy1, dummy2, dummy3]),
           [],
         )).resolves.not.toThrow()
         expect(adapters.dummy2.postFetch).toHaveBeenCalledWith({


### PR DESCRIPTION
…mory when no postFetch is ran

** We will need to do another iteration on this to actually use ElementSource properly and not do getAll inside runPostFetch in the future

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_
