### PR TITLE
SALTO-1240 - Avoid converting ReferenceExpression to regular object when searching for hidden values

### DIFF
--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -19,7 +19,7 @@ import { logger } from '@salto-io/logging'
 import {
   CORE_ANNOTATIONS, Element, isInstanceElement, isType, TypeElement, getField, DetailedChange,
   isRemovalChange, ElemID, isObjectType, ObjectType, Values, isRemovalOrModificationChange,
-  isAdditionOrModificationChange, isElement, isField,
+  isAdditionOrModificationChange, isElement, isField, isReferenceExpression,
 } from '@salto-io/adapter-api'
 import { transformElement, TransformFunc, transformValues, applyFunctionToChangeData, elementAnnotationTypes } from '@salto-io/adapter-utils'
 import { mergeElements, MergeResult } from '../merger'
@@ -427,6 +427,10 @@ const filterOutHiddenChanges = async (
       if (isHiddenField(changeType, changePath, isInstanceElement(baseElem))) {
         // The change is inside a hidden field value, omit the change
         return undefined
+      }
+
+      if (isReferenceExpression(change.data.after)) {
+        return change
       }
 
       const fieldType = changeType && getField(changeType, changePath)?.type

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ObjectType, ElemID, BuiltinTypes, PrimitiveType, PrimitiveTypes, isObjectType, InstanceElement, isInstanceElement, CORE_ANNOTATIONS, DetailedChange, getChangeElement, Element, INSTANCE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, BuiltinTypes, PrimitiveType, PrimitiveTypes, isObjectType, InstanceElement, isInstanceElement, CORE_ANNOTATIONS, DetailedChange, getChangeElement, Element, INSTANCE_ANNOTATIONS, ReferenceExpression } from '@salto-io/adapter-api'
 import { MergeResult } from '../../src/merger'
 import { handleHiddenChanges, mergeWithHidden } from '../../src/workspace/hidden_values'
 import { mockState } from '../common/state'
@@ -231,6 +231,73 @@ describe('handleHiddenChanges', () => {
       )
 
       expect(result.length).toBe(0)
+    })
+  })
+
+  describe('reference expression', () => {
+    let instance: InstanceElement
+    beforeEach(() => {
+      instance = new InstanceElement(
+        'instance',
+        new ObjectType({
+          elemID: new ElemID('test', 'type'),
+          fields: {
+            val: { type: BuiltinTypes.STRING },
+            ref: { type: BuiltinTypes.STRING },
+          },
+        }),
+        { val: 'asd' },
+      )
+    })
+
+    describe('when adding a reference expression', () => {
+      let result: DetailedChange[]
+      let filteredValue: unknown
+      beforeEach(async () => {
+        const change: DetailedChange = {
+          id: instance.elemID.createNestedID('ref'),
+          action: 'add',
+          data: {
+            after: new ReferenceExpression(new ElemID('a', 'b')),
+          },
+        }
+
+        result = await handleHiddenChanges(
+          [change],
+          mockState(),
+          mockFunction<() => Promise<Element[]>>().mockResolvedValue([])
+        )
+        expect(result).toHaveLength(1)
+        filteredValue = getChangeElement(result[0])
+      })
+      it('should keep the reference expression as-is', () => {
+        expect(filteredValue).toBeInstanceOf(ReferenceExpression)
+      })
+    })
+    describe('when converting a value to a reference expression', () => {
+      let result: DetailedChange[]
+      let filteredValue: unknown
+      beforeEach(async () => {
+        const change: DetailedChange = {
+          id: instance.elemID.createNestedID('val'),
+          action: 'modify',
+          data: {
+            before: 'asd',
+            after: new ReferenceExpression(new ElemID('a', 'b')),
+          },
+        }
+
+        result = await handleHiddenChanges(
+          [change],
+          mockState(),
+          mockFunction<() => Promise<Element[]>>().mockResolvedValue([])
+        )
+        expect(result).toHaveLength(1)
+        filteredValue = getChangeElement(result[0])
+      })
+      it('should keep the updated value as a reference expression', () => {
+        expect(filteredValue).toBeInstanceOf(ReferenceExpression)
+      })
     })
   })
 })


### PR DESCRIPTION
If the change element is a reference expression, do not run it through `transformValues` to avoid converting it to a reference expression. 
(see the ticket for details about the alternative solution of handling this in `transformValues` - it can be done and may cover more cases, but may change some existing assumptions).

---

The serializer has special handling for expressions that converts them into paths, and it relies on the change element being an instance of a reference expression / template ([here](https://github.com/salto-io/salto/blob/master/packages/workspace/src/parser/internal/dump.ts#L141)) - so it's important not to change that.
It may be worth also coverting template expressions - but as these cannot be returned directly from fetch, I'm not sure they can go through this flow.

---

_Release Notes_: 
Fix potential corruption in nacl files when changing only reference expressions
