### PR TITLE
SALTO-1240: Avoid replacing classes with plain objects in transform

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -194,6 +194,9 @@ export const transformValues = (
   const fieldMapper = fieldMapperGenerator(type, values)
 
   const newVal = isTopLevel ? transformFunc({ value: values, path: pathID }) : values
+  if (!_.isPlainObject(newVal)) {
+    return newVal
+  }
   const result = _(newVal)
     .mapValues((value, key) => transformValue(value, pathID?.createNestedID(key), fieldMapper(key)))
     .omitBy(_.isUndefined)

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -21,6 +21,7 @@ import {
   Element, isReferenceExpression, isPrimitiveValue, CORE_ANNOTATIONS, FieldMap, AdditionChange,
   RemovalChange, ModificationChange, isInstanceElement, isObjectType, MapType, isMapType,
   ContainerType,
+  VariableExpression,
 } from '@salto-io/adapter-api'
 import { AdditionDiff, RemovalDiff, ModificationDiff } from '@salto-io/dag'
 import {
@@ -444,7 +445,6 @@ describe('Test utils.ts', () => {
         })
       })
 
-
       describe('when called with type map', () => {
         let origValue: Values
         let typeMap: TypeMap
@@ -512,6 +512,36 @@ describe('Test utils.ts', () => {
         })
         it('should keep all defined fields values', () => {
           expect(origValue).toMatchObject(resp)
+        })
+      })
+
+      describe('when called with value as top level', () => {
+        let refResult: Values | undefined
+        let staticFileResult: Values | undefined
+        let varResult: Values | undefined
+        beforeEach(() => {
+          refResult = transformValues({
+            values: new ReferenceExpression(mockInstance.elemID),
+            type: mockType,
+            transformFunc,
+          })
+          staticFileResult = transformValues({
+            values: new StaticFile({ content: Buffer.from('asd'), filepath: 'a' }),
+            type: mockType,
+            transformFunc,
+          })
+          varResult = transformValues({
+            values: new VariableExpression(
+              new ElemID(ElemID.VARIABLES_NAMESPACE, 'myVar', 'var')
+            ),
+            type: mockType,
+            transformFunc,
+          })
+        })
+        it('should keep the value type', () => {
+          expect(refResult).toBeInstanceOf(ReferenceExpression)
+          expect(staticFileResult).toBeInstanceOf(StaticFile)
+          expect(varResult).toBeInstanceOf(VariableExpression)
         })
       })
     })

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -490,22 +490,6 @@ describe('Transformer', () => {
       expect(xmlContent).toEqual(removeLineBreaks(XML_TEMPLATES.WITH_SCRIPT_ID))
     })
 
-    it('should ignore list field with incompatible type', () => {
-      instance.value.roleaccesses = {
-        roleaccess: 'not a list',
-      }
-      const customizationInfo = toCustomizationInfo(instance)
-      const xmlContent = convertToXmlContent(customizationInfo)
-      expect(xmlContent).toEqual(removeLineBreaks(XML_TEMPLATES.WITH_SCRIPT_ID))
-    })
-
-    it('should ignore object field with incompatible type', () => {
-      instance.value.roleaccesses = ['not an object']
-      const customizationInfo = toCustomizationInfo(instance)
-      const xmlContent = convertToXmlContent(customizationInfo)
-      expect(xmlContent).toEqual(removeLineBreaks(XML_TEMPLATES.WITH_SCRIPT_ID))
-    })
-
     it('should encode to html chars', () => {
       instance.value.label = 'Golf & Co’Co element​Name' // There is ZeroWidthSpace char between element and Name
       const customizationInfo = toCustomizationInfo(instance)


### PR DESCRIPTION


---

Alternative to #1956 that handles cases for other non-plain objects as well (static file, variables and such)

---
_Release Notes_: 
- Fix potential corruption in nacl files when changing only reference expressions
