### PR TITLE
SALTO-1234: moved deploy modifiers to adapter operations

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -55,10 +55,18 @@ export type PostFetchOptions = {
   elementsByAdapter: Readonly<Record<string, ReadonlyArray<Readonly<Element>>>>
 }
 
+
+export type DeployModifiers = {
+  changeValidator?: ChangeValidator
+  dependencyChanger?: DependencyChanger
+  getChangeGroupIds?: ChangeGroupIdFunction
+}
+
 export type AdapterOperations = {
   fetch: (opts: FetchOptions) => Promise<FetchResult>
   deploy: (opts: DeployOptions) => Promise<DeployResult>
   postFetch?: (opts: PostFetchOptions) => Promise<{ changed: boolean }>
+  deployModifiers?: DeployModifiers
 }
 
 export type AdapterOperationName = keyof AdapterOperations
@@ -89,11 +97,6 @@ export type Adapter = {
   validateCredentials: (config: Readonly<InstanceElement>) => Promise<AccountId>
   authenticationMethods: AdapterAuthentication
   configType?: ObjectType
-  deployModifiers?: {
-    changeValidator?: ChangeValidator
-    dependencyChanger?: DependencyChanger
-    getChangeGroupIds?: ChangeGroupIdFunction
-  }
   install?: () => Promise<AdapterInstallResult>
 }
 

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -97,12 +97,18 @@ export const preview = async (
   services = workspace.services(),
 ): Promise<Plan> => {
   const stateElements = await workspace.state().getAll()
+  const adapters = await getAdapters(
+    services,
+    await workspace.servicesCredentials(services),
+    workspace.serviceConfig.bind(workspace),
+    buildElementsSourceFromElements(await workspace.elements())
+  )
   return getPlan({
     before: filterElementsByServices(stateElements, services),
     after: filterElementsByServices(await workspace.elements(), services),
-    changeValidators: getAdapterChangeValidators(),
-    dependencyChangers: defaultDependencyChangers.concat(getAdapterDependencyChangers()),
-    customGroupIdFunctions: getAdapterChangeGroupIdFunctions(),
+    changeValidators: getAdapterChangeValidators(adapters),
+    dependencyChangers: defaultDependencyChangers.concat(getAdapterDependencyChangers(adapters)),
+    customGroupIdFunctions: getAdapterChangeGroupIdFunctions(adapters),
   })
 }
 

--- a/packages/core/src/core/adapters/change_validators.ts
+++ b/packages/core/src/core/adapters/change_validators.ts
@@ -15,11 +15,12 @@
 */
 import _ from 'lodash'
 import { values } from '@salto-io/lowerdash'
-import { ChangeValidator } from '@salto-io/adapter-api'
-import adapterCreators from './creators'
+import { AdapterOperations, ChangeValidator } from '@salto-io/adapter-api'
 
-export const getAdapterChangeValidators = (): Record<string, ChangeValidator> =>
-  _(adapterCreators)
+export const getAdapterChangeValidators = (
+  adapters: Record<string, AdapterOperations>
+): Record<string, ChangeValidator> =>
+  _(adapters)
     .mapValues(adapter => adapter.deployModifiers?.changeValidator)
     .pickBy(values.isDefined)
     .value()

--- a/packages/core/src/core/adapters/custom_group_key.ts
+++ b/packages/core/src/core/adapters/custom_group_key.ts
@@ -15,11 +15,12 @@
 */
 import _ from 'lodash'
 import { values } from '@salto-io/lowerdash'
-import { ChangeGroupIdFunction } from '@salto-io/adapter-api'
-import adapterCreators from './creators'
+import { AdapterOperations, ChangeGroupIdFunction } from '@salto-io/adapter-api'
 
-export const getAdapterChangeGroupIdFunctions = (): Record<string, ChangeGroupIdFunction> =>
-  _(adapterCreators)
+export const getAdapterChangeGroupIdFunctions = (
+  adapters: Record<string, AdapterOperations>
+): Record<string, ChangeGroupIdFunction> =>
+  _(adapters)
     .mapValues(adapter => adapter.deployModifiers?.getChangeGroupIds)
     .pickBy(values.isDefined)
     .value()

--- a/packages/core/src/core/adapters/dependency_changers.ts
+++ b/packages/core/src/core/adapters/dependency_changers.ts
@@ -16,8 +16,7 @@
 import wu from 'wu'
 import _ from 'lodash'
 import { values } from '@salto-io/lowerdash'
-import { DependencyChanger, getChangeElement, Adapter } from '@salto-io/adapter-api'
-import adapterCreators from './creators'
+import { DependencyChanger, getChangeElement, AdapterOperations } from '@salto-io/adapter-api'
 
 type AdapterDependencyChanger = (name: string, changer: DependencyChanger) => DependencyChanger
 const adapterDependencyChanger: AdapterDependencyChanger = (name, changer) => (changes, deps) => {
@@ -34,9 +33,9 @@ const adapterDependencyChanger: AdapterDependencyChanger = (name, changer) => (c
 }
 
 export const getAdapterDependencyChangers = (
-  creators: Record<string, Adapter> = adapterCreators,
+  adapters: Record<string, AdapterOperations>
 ): ReadonlyArray<DependencyChanger> => (
-  _(creators)
+  _(adapters)
     .mapValues(({ deployModifiers }) => deployModifiers?.dependencyChanger)
     .pickBy(values.isDefined)
     .mapValues((changer, name) => adapterDependencyChanger(name, changer))

--- a/packages/core/test/core/adapters/dependency_changers.test.ts
+++ b/packages/core/test/core/adapters/dependency_changers.test.ts
@@ -13,29 +13,22 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Adapter, ObjectType, ElemID, DependencyChanger, dependencyChange,
+import { ObjectType, ElemID, DependencyChanger, dependencyChange,
   DependencyChange, ChangeEntry, AdapterOperations, toChange } from '@salto-io/adapter-api'
 import { getAdapterDependencyChangers } from '../../../src/core/adapters'
 import { mockFunction } from '../../common/helpers'
 
 describe('getAdapterDependencyChangers', () => {
-  const mockAdapter = (dependencyChanger?: DependencyChanger): Adapter => ({
-    authenticationMethods: { basic: {
-      credentialsType: new ObjectType({ elemID: new ElemID('test') }),
-    } },
-    configType: new ObjectType({ elemID: new ElemID('test') }),
-    operations: mockFunction<Adapter['operations']>().mockReturnValue({
-      fetch: mockFunction<AdapterOperations['fetch']>(),
-      deploy: mockFunction<AdapterOperations['deploy']>(),
-    }),
-    validateCredentials: mockFunction<Adapter['validateCredentials']>(),
+  const mockAdapter = (dependencyChanger?: DependencyChanger): AdapterOperations => ({
+    fetch: mockFunction<AdapterOperations['fetch']>(),
+    deploy: mockFunction<AdapterOperations['deploy']>(),
     deployModifiers: {
       dependencyChanger,
     },
   })
 
   const mockDepChanges = [dependencyChange('add', 1, 2)]
-  const mockCreators: Record<string, Adapter> = {
+  const mockCreators: Record<string, AdapterOperations> = {
     withDepChanger: mockAdapter(
       mockFunction<DependencyChanger>().mockResolvedValue(mockDepChanges)
     ),

--- a/packages/hubspot-adapter/src/adapter.ts
+++ b/packages/hubspot-adapter/src/adapter.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import {
   Element, InstanceElement, ObjectType, FetchResult, AdapterOperations,
-  DeployOptions, DeployResult,
+  DeployOptions, DeployResult, DeployModifiers,
 } from '@salto-io/adapter-api'
 import {
   restoreValues, deployInstance, resolveValues,
@@ -33,6 +33,8 @@ import { FilterCreator } from './filter'
 import formFieldFilter from './filters/form_field'
 import useridentifierFilter from './filters/useridentifier'
 import instanceTransformFilter from './filters/instance_transform'
+import changeValidator from './change_validator'
+
 
 const validateFormGuid = (
   before: InstanceElement,
@@ -173,5 +175,12 @@ export default class HubspotAdapter implements AdapterOperations {
       (prevRes, filter) => prevRes.then(() => filter.onFetch(elements)),
       Promise.resolve(),
     )
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public get deployModifiers(): DeployModifiers {
+    return {
+      changeValidator,
+    }
   }
 }

--- a/packages/hubspot-adapter/src/adapter_creator.ts
+++ b/packages/hubspot-adapter/src/adapter_creator.ts
@@ -18,7 +18,6 @@ import {
 } from '@salto-io/adapter-api'
 import HubspotClient, { Credentials } from './client/client'
 import HubspotAdapter from './adapter'
-import changeValidator from './change_validator'
 
 const configID = new ElemID('hubspot')
 
@@ -47,8 +46,5 @@ export const adapter: Adapter = {
     basic: {
       credentialsType: defaultCredentialsType,
     },
-  },
-  deployModifiers: {
-    changeValidator,
   },
 }

--- a/packages/marketo-adapter/src/adapter.ts
+++ b/packages/marketo-adapter/src/adapter.ts
@@ -19,7 +19,7 @@ import {
   DeployOptions,
   DeployResult,
   Element, ObjectType, Change,
-  ChangeDataType, isObjectType, isField, FieldMap, Values,
+  ChangeDataType, isObjectType, isField, FieldMap, Values, DeployModifiers,
 } from '@salto-io/adapter-api'
 import MarketoClient from './client/client'
 import {
@@ -36,6 +36,7 @@ import {
   UPDATE_ONLY,
   API_NAME, STATE, APPROVED_STATE,
 } from './constants'
+import changeValidator from './change_validator'
 
 
 export interface MarketoAdapterParams {
@@ -239,6 +240,13 @@ export default class MarketoAdapter implements AdapterOperations {
   private async approveCustomObjectIfNeeded(annotations: Values): Promise<void> {
     if (annotations[STATE] === APPROVED_STATE) {
       await this.client.approveCustomObject(annotations[API_NAME])
+    }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public get deployModifiers(): DeployModifiers {
+    return {
+      changeValidator,
     }
   }
 }

--- a/packages/marketo-adapter/src/adapter_creator.ts
+++ b/packages/marketo-adapter/src/adapter_creator.ts
@@ -18,7 +18,6 @@ import {
 } from '@salto-io/adapter-api'
 import MarketoClient from './client/client'
 import MarketoAdapter from './adapter'
-import changeValidator from './change_validator'
 import { Credentials } from './client/types'
 
 const configID = new ElemID('marketo')
@@ -54,8 +53,5 @@ export const adapter: Adapter = {
     basic: {
       credentialsType,
     },
-  },
-  deployModifiers: {
-    changeValidator,
   },
 }

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -16,7 +16,7 @@
 import {
   FetchResult, isInstanceElement, AdapterOperations, DeployResult, DeployOptions,
   ElemIdGetter, Element, getChangeElement, InstanceElement, ReadOnlyElementsSource,
-  FetchOptions, Field, BuiltinTypes, CORE_ANNOTATIONS,
+  FetchOptions, Field, BuiltinTypes, CORE_ANNOTATIONS, DeployModifiers,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
@@ -46,6 +46,8 @@ import NetsuiteClient from './client/client'
 import { createDateRange } from './changes_detector/date_formats'
 import { createElementsSourceIndex } from './elements_source_index/elements_source_index'
 import { LazyElementsSourceIndex } from './elements_source_index/types'
+import changeValidator from './change_validator'
+import { getChangeGroupIds } from './group_changes'
 
 const { makeArray } = collections.array
 
@@ -275,5 +277,13 @@ export default class NetsuiteAdapter implements AdapterOperations {
         filter.onFetch({ elements, elementsSourceIndex, isPartial })),
       Promise.resolve(),
     )
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public get deployModifiers(): DeployModifiers {
+    return {
+      changeValidator,
+      getChangeGroupIds,
+    }
   }
 }

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -21,8 +21,6 @@ import { collections, regex } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { SdkDownloadService } from '@salto-io/suitecloud-cli'
-import changeValidator from './change_validator'
-import { getChangeGroupIds } from './group_changes'
 import NetsuiteAdapter from './adapter'
 import { configType, NetsuiteConfig } from './config'
 import {
@@ -177,10 +175,6 @@ export const adapter: Adapter = {
     },
   },
   configType,
-  deployModifiers: {
-    changeValidator,
-    getChangeGroupIds,
-  },
   install: async (): Promise<AdapterInstallResult> => {
     try {
       return await SdkDownloadService.download()

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -17,6 +17,7 @@ import {
   TypeElement, ObjectType, InstanceElement, isAdditionChange, getChangeElement,
   ElemIdGetter, FetchResult, AdapterOperations, DeployResult, FetchOptions, DeployOptions,
   ReadOnlyElementsSource,
+  DeployModifiers,
 } from '@salto-io/adapter-api'
 import { logDuration, resolveChangeElement, restoreChangeElement } from '@salto-io/adapter-utils'
 import { MetadataObject } from 'jsforce'
@@ -71,6 +72,8 @@ import { isCustomObjectInstanceChanges, deployCustomObjectInstancesGroup } from 
 import { getLookUpName } from './transformers/reference_mapping'
 import { deployMetadata, NestedMetadataTypeInfo } from './metadata_deploy'
 import { FetchProfile, buildFetchProfile } from './fetch_profile/fetch_profile'
+import changeValidator from './change_validator'
+import { getChangeGroupIds } from './group_changes'
 
 const log = logger(module)
 
@@ -475,6 +478,14 @@ export default class SalesforceAdapter implements AdapterOperations {
     return {
       elements: instances.elements,
       configChanges: [...instances.configChanges, ...configChanges],
+    }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public get deployModifiers(): DeployModifiers {
+    return {
+      changeValidator,
+      getChangeGroupIds,
     }
   }
 }

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -17,7 +17,6 @@ import {
   TypeElement, ObjectType, InstanceElement, isAdditionChange, getChangeElement,
   ElemIdGetter, FetchResult, AdapterOperations, DeployResult, FetchOptions, DeployOptions,
   ReadOnlyElementsSource,
-  DeployModifiers,
 } from '@salto-io/adapter-api'
 import { logDuration, resolveChangeElement, restoreChangeElement } from '@salto-io/adapter-utils'
 import { MetadataObject } from 'jsforce'
@@ -72,8 +71,6 @@ import { isCustomObjectInstanceChanges, deployCustomObjectInstancesGroup } from 
 import { getLookUpName } from './transformers/reference_mapping'
 import { deployMetadata, NestedMetadataTypeInfo } from './metadata_deploy'
 import { FetchProfile, buildFetchProfile } from './fetch_profile/fetch_profile'
-import changeValidator from './change_validator'
-import { getChangeGroupIds } from './group_changes'
 
 const log = logger(module)
 
@@ -478,14 +475,6 @@ export default class SalesforceAdapter implements AdapterOperations {
     return {
       elements: instances.elements,
       configChanges: [...instances.configChanges, ...configChanges],
-    }
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  public get deployModifiers(): DeployModifiers {
-    return {
-      changeValidator,
-      getChangeGroupIds,
     }
   }
 }

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -19,8 +19,6 @@ import {
   Values,
 } from '@salto-io/adapter-api'
 import SalesforceClient, { validateCredentials } from './client/client'
-import changeValidator from './change_validator'
-import { getChangeGroupIds } from './group_changes'
 import SalesforceAdapter from './adapter'
 import { configType, usernamePasswordCredentialsType, oauthRequestParameters,
   isAccessTokenConfig, SalesforceConfig, accessTokenCredentialsType,
@@ -132,6 +130,7 @@ export const adapter: Adapter = {
       },
 
       deploy: salesforceAdapter.deploy.bind(salesforceAdapter),
+      deployModifiers: salesforceAdapter.deployModifiers,
     }
   },
   validateCredentials: async config => validateCredentials(credentialsFromConfig(config)),
@@ -151,8 +150,4 @@ export const adapter: Adapter = {
     },
   },
   configType,
-  deployModifiers: {
-    changeValidator,
-    getChangeGroupIds,
-  },
 }

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -28,6 +28,8 @@ import { validateFetchParameters } from './fetch_profile/fetch_profile'
 import { ConfigValidationError } from './config_validation'
 import { updateDeprecatedConfiguration } from './deprecated_config'
 import { ConfigChange } from './config_change'
+import changeValidator from './change_validator'
+import { getChangeGroupIds } from './group_changes'
 
 const log = logger(module)
 
@@ -130,7 +132,10 @@ export const adapter: Adapter = {
       },
 
       deploy: salesforceAdapter.deploy.bind(salesforceAdapter),
-      deployModifiers: salesforceAdapter.deployModifiers,
+      deployModifiers: {
+        changeValidator,
+        getChangeGroupIds,
+      },
     }
   },
   validateCredentials: async config => validateCredentials(credentialsFromConfig(config)),

--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  FetchResult, AdapterOperations, DeployResult, Element, PostFetchOptions,
+  FetchResult, AdapterOperations, DeployResult, Element, PostFetchOptions, DeployModifiers,
 } from '@salto-io/adapter-api'
 import { elements as elementUtils } from '@salto-io/adapter-components'
 import { logDuration } from '@salto-io/adapter-utils'
@@ -26,6 +26,7 @@ import extractFieldsFilter from './filters/extract_fields'
 import fieldReferencesFilter from './filters/field_references'
 import recipeCrossServiceReferencesFilter from './filters/cross_service/recipe_references'
 import { WORKATO } from './constants'
+import changeValidator from './change_validator'
 
 const log = logger(module)
 const {
@@ -106,5 +107,12 @@ export default class WorkatoAdapter implements AdapterOperations {
   // eslint-disable-next-line class-methods-use-this
   async deploy(): Promise<DeployResult> {
     throw new Error('Not implemented.')
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public get deployModifiers(): DeployModifiers {
+    return {
+      changeValidator,
+    }
   }
 }

--- a/packages/workato-adapter/src/adapter_creator.ts
+++ b/packages/workato-adapter/src/adapter_creator.ts
@@ -19,7 +19,6 @@ import { InstanceElement, Adapter } from '@salto-io/adapter-api'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
 import WorkatoAdapter from './adapter'
 import { Credentials, usernameTokenCredentialsType } from './auth'
-import changeValidator from './change_validator'
 import {
   configType, WorkatoConfig, CLIENT_CONFIG, FETCH_CONFIG, DEFAULT_TYPES, DEFAULT_ID_FIELDS,
   FIELDS_TO_OMIT,
@@ -89,7 +88,4 @@ export const adapter: Adapter = {
     },
   },
   configType,
-  deployModifiers: {
-    changeValidator,
-  },
 }


### PR DESCRIPTION
Moved the deploy modifiers methods to be part of the `AdapterOperations` so we will have access to the `adapterContext` inside of these methods.

This is needed for the feature of deploying the file cabinet elements using the SuiteApp. In `getChangeGroupIds`, if the SuiteApp credentials were passed, I want to split the changed elements to a group of elements to deploy via SDF and a group of elements to deploy via the SuiteApp. If the SuiteApp credentials were not passed, I want to group all the changes under SDF. This change is needed to do so.

---
_Release Notes_: 
None