### PR TITLE
SALTO-1244 - Keep trailing whitespace in multiline strings

### DIFF
--- a/packages/workspace/src/parser/internal/native/consumers/values.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/values.ts
@@ -90,8 +90,8 @@ const createTemplateExpressions = (
 
 const trimToken = (token: Required<Token>): Required<Token> => ({
   ...token,
-  text: trimEnd(token.text),
-  value: trimEnd(token.value),
+  text: trimEnd(token.text, '\r\n'),
+  value: trimEnd(token.value, '\r\n'),
 })
 
 const createStringValue = (

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -175,9 +175,14 @@ each([true, false]).describe('Salto parser', (useLegacyParser: boolean) => {
         Give me some 
         OK?
         '''
+        withTrailingNewline = '''
+        This has 
+        a trailing line with spaces
+  
+        '''
         withQuotes = '''
           "I can see Russia from my house!"
-        '''
+'''
       }
 
       type salesforce.stringAttr {
@@ -624,9 +629,13 @@ each([true, false]).describe('Salto parser', (useLegacyParser: boolean) => {
         expect(multilineObject.annotations).toHaveProperty('data')
         expect(multilineObject.annotations.data).toEqual('        This\n        is\n        Multiline')
       })
-      it('should preserve end of line spaces', () => {
+      it('should preserve end of line spaces without inserting a newline', () => {
         expect(multilineObject.annotations).toHaveProperty('withSpaces')
         expect(multilineObject.annotations.withSpaces).toEqual('        Give me some \n        OK?')
+      })
+      it('should preserve end of line spaces on new line', () => {
+        expect(multilineObject.annotations).toHaveProperty('withTrailingNewline')
+        expect(multilineObject.annotations.withTrailingNewline).toEqual('        This has \n        a trailing line with spaces\n  ')
       })
       it('should handle qoutation marks inside the multiline string', () => {
         expect(multilineObject.annotations).toHaveProperty('withQuotes')


### PR DESCRIPTION
Trimming trailing whitespace can result in incorrect items in the deploy plan - for example for this nacl:
```
dummy.x y {
  a = '''

      Something
   
  Something else  
    
'''
}
```
We would get this from `deploy -dp`:
```
| dummy.x.instance.y:
  M a: "\n      Something\n   \n  Something else  \n    " => "\n      Something\n   \n  Something else  \n"
```
(because the whitespace is omitted when parsing but still exists in the state).

---
_Release Notes_: 
Fix bug that could add unneeded deploy items for multi-line strings ending in whitespace.
