### PR TITLE
SALTO-1242 - Add dedicated command for re-generating the cache

### DIFF
--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -635,7 +635,9 @@ export const formatInvalidElementCommand = (command: string): string => [
   emptyLine(),
 ].join('\n')
 
-export const formatCleanWorkspace = (cleanArgs: WorkspaceComponents): string => {
+export const formatCleanWorkspace = (
+  cleanArgs: WorkspaceComponents & { regenerateCache: boolean }
+): string => {
   const componentsToClean = Object.entries(cleanArgs)
     .filter(([_comp, shouldClean]) => shouldClean)
     .map(([comp]) => _.startCase(comp).toLowerCase())

--- a/packages/cli/test/commands/clean.test.ts
+++ b/packages/cli/test/commands/clean.test.ts
@@ -88,7 +88,7 @@ describe('clean command', () => {
         ...cliCommandArgs,
         input: {
           force: false,
-          nacl: false,
+          nacl: true,
           state: false,
           cache: false,
           staticResources: false,
@@ -120,12 +120,12 @@ describe('clean command', () => {
       expect(output.stderr.content.search('Cannot clear static resources without clearing the state, cache and nacls')).toBeGreaterThanOrEqual(0)
     })
 
-    it('should fail if combining regenerating the cache with other clean operations', async () => {
+    it('should fail if attempting to regenerate and clean the cache at the same time', async () => {
       expect(await action({
         ...cliCommandArgs,
         input: {
           force: false,
-          nacl: true,
+          nacl: false,
           state: false,
           cache: true,
           staticResources: false,
@@ -136,7 +136,7 @@ describe('clean command', () => {
         workspace: mocks.mockWorkspace({}),
       })).toBe(CliExitCode.UserInputError)
       expect(callbacks.getUserBooleanInput).not.toHaveBeenCalled()
-      expect(output.stderr.content.search('Cannot re-generate the cache and clear parts of the workspace in the same operation')).toBeGreaterThanOrEqual(0)
+      expect(output.stderr.content.search('Cannot re-generate and clear the cache in the same operation')).toBeGreaterThanOrEqual(0)
     })
     it('should prompt user and continue if yes', async () => {
       const workspace = mocks.mockWorkspace({})
@@ -167,7 +167,7 @@ describe('clean command', () => {
       expect(output.stdout.content.search('Starting to clean')).toBeGreaterThan(0)
       expect(output.stdout.content.search('Finished cleaning')).toBeGreaterThan(0)
     })
-    it('should prompt user and continue if yes (regenerate-cache), cleaning the cache', async () => {
+    it('should prompt user and continue if yes (regenerate-cache)', async () => {
       const workspace = mocks.mockWorkspace({})
       expect(await action({
         ...cliCommandArgs,

--- a/packages/cli/test/commands/clean.test.ts
+++ b/packages/cli/test/commands/clean.test.ts
@@ -54,6 +54,7 @@ describe('clean command', () => {
           staticResources: false,
           credentials: false,
           serviceConfig: false,
+          regenerateCache: false,
         },
         workspace: mocks.mockWorkspace({}),
       })).toBe(CliExitCode.UserInputError)
@@ -74,13 +75,32 @@ describe('clean command', () => {
           staticResources: true,
           credentials: true,
           serviceConfig: true,
+          regenerateCache: false,
         },
         workspace: mocks.mockWorkspace({}),
       })).toBe(CliExitCode.Success)
       expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith('Do you want to perform these actions?')
       expect(output.stdout.content.search('Canceling...')).toBeGreaterThan(0)
     })
-
+    it('should prompt user and exit if no (regenerate-cache)', async () => {
+      jest.spyOn(callbacks, 'getUserBooleanInput').mockImplementationOnce(() => Promise.resolve(false))
+      expect(await action({
+        ...cliCommandArgs,
+        input: {
+          force: false,
+          nacl: false,
+          state: false,
+          cache: false,
+          staticResources: false,
+          credentials: false,
+          serviceConfig: false,
+          regenerateCache: true,
+        },
+        workspace: mocks.mockWorkspace({}),
+      })).toBe(CliExitCode.Success)
+      expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith('Do you want to perform these actions?')
+      expect(output.stdout.content.search('Canceling...')).toBeGreaterThan(0)
+    })
     it('should fail if trying to clean static resources without all dependent components', async () => {
       expect(await action({
         ...cliCommandArgs,
@@ -92,6 +112,7 @@ describe('clean command', () => {
           staticResources: true,
           credentials: true,
           serviceConfig: true,
+          regenerateCache: false,
         },
         workspace: mocks.mockWorkspace({}),
       })).toBe(CliExitCode.UserInputError)
@@ -99,6 +120,24 @@ describe('clean command', () => {
       expect(output.stderr.content.search('Cannot clear static resources without clearing the state, cache and nacls')).toBeGreaterThanOrEqual(0)
     })
 
+    it('should fail if combining regenerating the cache with other clean operations', async () => {
+      expect(await action({
+        ...cliCommandArgs,
+        input: {
+          force: false,
+          nacl: true,
+          state: false,
+          cache: true,
+          staticResources: false,
+          credentials: false,
+          serviceConfig: false,
+          regenerateCache: true,
+        },
+        workspace: mocks.mockWorkspace({}),
+      })).toBe(CliExitCode.UserInputError)
+      expect(callbacks.getUserBooleanInput).not.toHaveBeenCalled()
+      expect(output.stderr.content.search('Cannot re-generate the cache and clear parts of the workspace in the same operation')).toBeGreaterThanOrEqual(0)
+    })
     it('should prompt user and continue if yes', async () => {
       const workspace = mocks.mockWorkspace({})
       expect(await action({
@@ -111,6 +150,7 @@ describe('clean command', () => {
           staticResources: true,
           credentials: true,
           serviceConfig: true,
+          regenerateCache: false,
         },
         workspace,
       })).toBe(CliExitCode.Success)
@@ -127,7 +167,38 @@ describe('clean command', () => {
       expect(output.stdout.content.search('Starting to clean')).toBeGreaterThan(0)
       expect(output.stdout.content.search('Finished cleaning')).toBeGreaterThan(0)
     })
+    it('should prompt user and continue if yes (regenerate-cache), cleaning the cache', async () => {
+      const workspace = mocks.mockWorkspace({})
+      expect(await action({
+        ...cliCommandArgs,
+        input: {
+          force: false,
+          nacl: false,
+          state: false,
+          cache: false,
+          staticResources: false,
+          credentials: false,
+          serviceConfig: false,
+          regenerateCache: true,
+        },
+        workspace,
+      })).toBe(CliExitCode.Success)
+      expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith('Do you want to perform these actions?')
+      expect(core.cleanWorkspace).toHaveBeenCalledWith(workspace, {
+        nacl: false,
+        state: false,
+        cache: true,
+        staticResources: false,
+        credentials: false,
+        serviceConfig: false,
+      })
+      expect(workspace.errors).toHaveBeenCalledTimes(1)
+      // expecting 1 because there is no call from the mocked cleanWorkspace
+      expect(workspace.flush).toHaveBeenCalledTimes(1)
 
+      expect(output.stdout.content.search('Starting to clean')).toBeGreaterThan(0)
+      expect(output.stdout.content.search('Finished cleaning')).toBeGreaterThan(0)
+    })
     it('should exit cleanly on error', async () => {
       jest.spyOn(core, 'cleanWorkspace').mockImplementationOnce(
         () => { throw new Error('something bad happened') }
@@ -142,6 +213,7 @@ describe('clean command', () => {
           staticResources: true,
           credentials: true,
           serviceConfig: true,
+          regenerateCache: false,
         },
         workspace: mocks.mockWorkspace({}),
       })).toBe(CliExitCode.AppError)
@@ -167,6 +239,7 @@ describe('clean command', () => {
           staticResources: true,
           credentials: true,
           serviceConfig: true,
+          regenerateCache: false,
         },
         workspace,
       })).toBe(CliExitCode.Success)


### PR DESCRIPTION
Add option to recompute the nacl file cache separately from deploy/fetch, based on @roironn 's suggestion. 
This can be useful for speeding up the VSCode extension on slow machines, allowing it to run quicker reference lookups without requiring heavy blocking computations.

This is added initially as an additional flag under the `clean` command - we may want to revisit this later. 
This can be combined with any other `clean` flag except for cleaning the cache.

---
_Release Notes_: 
Add option to re-generate the file cache as part of the `salto clean` command
