### PR TITLE
SALTO-1234: added parent to file cabinet instances

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -33,6 +33,7 @@ import { TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST, DEPLOY_REFERENCED_ELEMENTS,
 import replaceInstanceReferencesFilter from './filters/instance_references'
 import convertLists from './filters/convert_lists'
 import consistentValues from './filters/consistent_values'
+import addParentFolder from './filters/add_parent_folder'
 import { FilterCreator } from './filter'
 import {
   getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS,
@@ -88,6 +89,8 @@ export default class NetsuiteAdapter implements AdapterOperations {
     client,
     elementsSource,
     filtersCreators = [
+      // addParentFolder must run before replaceInstanceReferencesFilter
+      addParentFolder,
       convertLists,
       consistentValues,
       replaceInstanceReferencesFilter,

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -18,14 +18,14 @@ import { createChangeValidator } from '@salto-io/adapter-utils'
 import removeCustomizationValidator from './change_validators/remove_customization'
 import removeListItemValidator from './change_validators/remove_list_item'
 import instanceChangesValidator from './change_validators/instance_changes'
-import serviceIdsChangesValidator from './change_validators/service_ids_changes'
+import immutableChangesValidator from './change_validators/immutable_changes'
 import { validateDependsOnInvalidElement } from './change_validators/dependencies'
 
 
 const changeValidators: ChangeValidator[] = [
   removeCustomizationValidator,
   instanceChangesValidator,
-  serviceIdsChangesValidator,
+  immutableChangesValidator,
   removeListItemValidator,
 ]
 

--- a/packages/netsuite-adapter/src/filters/add_parent_folder.ts
+++ b/packages/netsuite-adapter/src/filters/add_parent_folder.ts
@@ -1,0 +1,31 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
+import path from 'path'
+import { isFileCabinetType } from '../types'
+import { FilterCreator } from '../filter'
+
+const filterCreator: FilterCreator = () => ({
+  onFetch: async ({ elements }) => {
+    elements
+      .filter(isInstanceElement)
+      .filter(e => isFileCabinetType(e.type))
+      .filter(e => path.dirname(e.value.path) !== '/')
+      .forEach(e => { e.annotations[CORE_ANNOTATIONS.PARENT] = `[${path.dirname(e.value.path)}]` })
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/instance_references.ts
+++ b/packages/netsuite-adapter/src/filters/instance_references.ts
@@ -15,6 +15,7 @@
 */
 import {
   Element, isInstanceElement, Values, ObjectType, ElemID, ReferenceExpression, InstanceElement,
+  InstanceAnnotationTypes, TypeMap,
 } from '@salto-io/adapter-api'
 import {
   transformElement,
@@ -94,7 +95,7 @@ const generateServiceIdToElemID = (elements: Element[]): Record<string, ElemID> 
 
 const replaceReferenceValues = (
   values: Values,
-  refElement: ObjectType,
+  refElement: ObjectType| TypeMap,
   fetchedElementsServiceIdToElemID: Record<string, ElemID>,
   elementsSourceServiceIdToElemID: Record<string, ElemID>,
 ): Values => {
@@ -158,7 +159,7 @@ const filterCreator: FilterCreator = () => ({
 
       instance.annotations = replaceReferenceValues(
         instance.annotations,
-        instance.type,
+        InstanceAnnotationTypes,
         fetchedElemenentsServiceIdToElemID,
         elementsSourceServiceIdToElemID
       )

--- a/packages/netsuite-adapter/src/filters/instance_references.ts
+++ b/packages/netsuite-adapter/src/filters/instance_references.ts
@@ -155,6 +155,13 @@ const filterCreator: FilterCreator = () => ({
         fetchedElemenentsServiceIdToElemID,
         elementsSourceServiceIdToElemID
       )
+
+      instance.annotations = replaceReferenceValues(
+        instance.annotations,
+        instance.type,
+        fetchedElemenentsServiceIdToElemID,
+        elementsSourceServiceIdToElemID
+      )
     })
   },
 })

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -228,6 +228,7 @@ export const toCustomizationInfo = (instance: InstanceElement): CustomizationInf
   if (isFileCabinetType(instance.type)) {
     const path = values[PATH].split(FILE_CABINET_PATH_SEPARATOR).slice(1)
     delete values[PATH]
+    delete values.parent
     if (instance.type.elemID.isEqual(fileCabinetTypes[FILE].elemID)) {
       const contentFieldName = (fileContentField as Field).name
       const fileContent = values[contentFieldName]

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -228,7 +228,6 @@ export const toCustomizationInfo = (instance: InstanceElement): CustomizationInf
   if (isFileCabinetType(instance.type)) {
     const path = values[PATH].split(FILE_CABINET_PATH_SEPARATOR).slice(1)
     delete values[PATH]
-    delete values.parent
     if (instance.type.elemID.isEqual(fileCabinetTypes[FILE].elemID)) {
       const contentFieldName = (fileContentField as Field).name
       const fileContent = values[contentFieldName]

--- a/packages/netsuite-adapter/test/change_validators/immutable_changes.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/immutable_changes.test.ts
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, toChange } from '@salto-io/adapter-api'
-import serviceIdsChangesValidator from '../../src/change_validators/service_ids_changes'
+import { CORE_ANNOTATIONS, InstanceElement, toChange } from '@salto-io/adapter-api'
+import immutableChangesValidator from '../../src/change_validators/immutable_changes'
 import { customTypes, fileCabinetTypes } from '../../src/types'
 import { ENTITY_CUSTOM_FIELD, FILE, PATH, SCRIPT_ID } from '../../src/constants'
 
@@ -27,7 +27,7 @@ describe('customization type change validator', () => {
       })
     const after = entityCustomFieldInstance.clone()
     after.value[SCRIPT_ID] = 'modified'
-    const changeErrors = await serviceIdsChangesValidator(
+    const changeErrors = await immutableChangesValidator(
       [toChange({ before: entityCustomFieldInstance, after })]
     )
     expect(changeErrors).toHaveLength(1)
@@ -41,7 +41,21 @@ describe('customization type change validator', () => {
     })
     const after = fileInstance.clone()
     after.value[PATH] = 'Templates/modified.html'
-    const changeErrors = await serviceIdsChangesValidator(
+    const changeErrors = await immutableChangesValidator(
+      [toChange({ before: fileInstance, after })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].elemID).toEqual(fileInstance.elemID)
+  })
+
+  it('should have change error if file cabinet type parent has been modified', async () => {
+    const fileInstance = new InstanceElement('fileInstance', fileCabinetTypes[FILE], {}, undefined, {
+      parent: 'Templates/content',
+    })
+    const after = fileInstance.clone()
+    after.annotations[CORE_ANNOTATIONS.PARENT] = 'Templates/modified'
+    const changeErrors = await immutableChangesValidator(
       [toChange({ before: fileInstance, after })]
     )
     expect(changeErrors).toHaveLength(1)
@@ -57,7 +71,7 @@ describe('customization type change validator', () => {
       })
     const after = entityCustomFieldInstance.clone()
     after.value.label = 'modified'
-    const changeErrors = await serviceIdsChangesValidator(
+    const changeErrors = await immutableChangesValidator(
       [toChange({ before: entityCustomFieldInstance, after })]
     )
     expect(changeErrors).toHaveLength(0)
@@ -70,7 +84,7 @@ describe('customization type change validator', () => {
     })
     const after = fileInstance.clone()
     after.value.content = 'modified'
-    const changeErrors = await serviceIdsChangesValidator(
+    const changeErrors = await immutableChangesValidator(
       [toChange({ before: fileInstance, after })]
     )
     expect(changeErrors).toHaveLength(0)

--- a/packages/netsuite-adapter/test/filters/add_parent_folder.test.ts
+++ b/packages/netsuite-adapter/test/filters/add_parent_folder.test.ts
@@ -1,0 +1,50 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, InstanceElement } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/add_parent_folder'
+import { fileCabinetTypes } from '../../src/types'
+import { PATH, FILE } from '../../src/constants'
+import { OnFetchParameters } from '../../src/filter'
+
+describe('add_parent_folder filter', () => {
+  let instance: InstanceElement
+  let onFetchParameters: OnFetchParameters
+  beforeEach(() => {
+    instance = new InstanceElement(
+      'someFile',
+      fileCabinetTypes[FILE],
+      {}
+    )
+
+    onFetchParameters = {
+      elements: [instance],
+      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      isPartial: false,
+    }
+  })
+
+  it('should add parent field to file', async () => {
+    instance.value[PATH] = '/aa/bb/cc.txt'
+    await filterCreator().onFetch(onFetchParameters)
+    expect(instance.annotations[CORE_ANNOTATIONS.PARENT]).toEqual('[/aa/bb]')
+  })
+
+  it('should not add parent if file is top level', async () => {
+    instance.value[PATH] = '/aa'
+    await filterCreator().onFetch(onFetchParameters)
+    expect(instance.annotations[CORE_ANNOTATIONS.PARENT]).toBeUndefined()
+  })
+})

--- a/packages/netsuite-adapter/test/filters/instance_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/instance_references.test.ts
@@ -81,6 +81,11 @@ describe('instance_references filter', () => {
           refToNonExistingPath: '[/Templates/non.existing]',
           refToInstanceInElementSourcePath: '[/Templates/instanceInElementsSource]',
         },
+        undefined,
+        {
+          refToFilePath: '[/Templates/file.name]',
+          refToScriptId: '[scriptid=top_level]',
+        }
       )
     })
 
@@ -103,6 +108,19 @@ describe('instance_references filter', () => {
       })
 
       expect(instanceWithRefs.value.refToScriptId)
+        .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID(SCRIPT_ID)))
+    })
+
+    it('should replace annotations references', async () => {
+      await filterCreator().onFetch({
+        elements: [fileInstance, workflowInstance, instanceWithRefs],
+        elementsSourceIndex,
+        isPartial: false,
+      })
+
+      expect(instanceWithRefs.annotations.refToFilePath)
+        .toEqual(new ReferenceExpression(fileInstance.elemID.createNestedID(PATH)))
+      expect(instanceWithRefs.annotations.refToScriptId)
         .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID(SCRIPT_ID)))
     })
 


### PR DESCRIPTION
Added 'parent' field to the file cabinet instances

---
_Release Notes_: 
Netsuite Adapter:
Instances of the file cabinet will now have a 'parent' field that will reference the parent folder of the instance.