### PR TITLE
SALTO-1152 - Netsuite: return consistent values when SDF is inconsistent #2

### DIFF
--- a/packages/netsuite-adapter/scripts/types_generator.py
+++ b/packages/netsuite-adapter/scripts/types_generator.py
@@ -519,6 +519,7 @@ inner_types_to_export = {
     'suitelet_scriptdeployments',
     'usereventscript_scriptdeployments',
     'workflowactionscript_scriptdeployments',
+    'customrecordtype_permissions_permission',
 }
 
 should_not_be_required = {

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -44,6 +44,7 @@ export const FOLDER = 'folder'
 // Fields
 export const SCRIPT_ID = 'scriptid'
 export const PATH = 'path'
+export const PERMITTED_ROLE = 'permittedrole'
 export const RECORD_TYPE = 'recordType'
 export const LAST_FETCH_TIME = '_lastfetchtime'
 

--- a/packages/netsuite-adapter/src/filters/consistent_values.ts
+++ b/packages/netsuite-adapter/src/filters/consistent_values.ts
@@ -13,47 +13,105 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, isInstanceElement, Value } from '@salto-io/adapter-api'
+/* eslint-disable @typescript-eslint/camelcase */
+import { Field, InstanceElement, isInstanceElement, Value } from '@salto-io/adapter-api'
+import { TransformFunc, transformValues } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
-import { ENTRY_FORM, TRANSACTION_FORM, RECORD_TYPE } from '../constants'
+import {
+  CUSTOM_RECORD_TYPE, ENTRY_FORM, TRANSACTION_FORM, PERMITTED_ROLE, RECORD_TYPE,
+} from '../constants'
+import { customrecordtype_permissions_permission } from '../types/custom_types/customrecordtype'
+import { entryForm } from '../types/custom_types/entryForm'
+import { transactionForm } from '../types/custom_types/transactionForm'
 
 type InconsistentFieldMapping = {
-  field: string
+  field: Field
   inconsistentValues: Value[]
   consistentValue: Value
 }
 
-const entryFormRecordType = {
-  field: RECORD_TYPE,
+const customRecordTypeApClerkPermittedRole = {
+  field: customrecordtype_permissions_permission.fields[PERMITTED_ROLE],
+  inconsistentValues: ['CUSTOMROLEAP_CLERK', 'AP_CLERK'],
+  consistentValue: 'AP_CLERK',
+}
+
+const customRecordTypeCeoHandsOffPermittedRole = {
+  field: customrecordtype_permissions_permission.fields[PERMITTED_ROLE],
+  inconsistentValues: ['CUSTOMROLEATHENA_NS_VIEW_ALL', 'CEO_HANDS_OFF'],
+  consistentValue: 'CEO_HANDS_OFF',
+}
+
+const entryFormDiscountItemRecordType = {
+  field: entryForm.fields[RECORD_TYPE],
   inconsistentValues: ['DISCOUNTITEM', 'MARKUPITEM'],
   consistentValue: 'DISCOUNTITEM',
 }
 
+const entryFormItemGroupRecordType = {
+  field: entryForm.fields[RECORD_TYPE],
+  inconsistentValues: ['ASSEMBLYITEM', 'KITITEM', 'ITEMGROUP'],
+  consistentValue: 'ITEMGROUP',
+}
+
+const entryFormJobRecordType = {
+  field: entryForm.fields[RECORD_TYPE],
+  inconsistentValues: ['MFGPROJECT', 'JOB'],
+  consistentValue: 'JOB',
+}
+
+const entryFormServiceItemRecordType = {
+  field: entryForm.fields[RECORD_TYPE],
+  inconsistentValues: ['OTHERCHARGEPURCHASEITEM', 'OTHERCHARGERESALEITEM', 'NONINVENTORYSALEITEM', 'SERVICEPURCHASEITEM', 'GIFTCERTIFICATEITEM', 'DOWNLOADITEM', 'SERVICERESALEITEM', 'OTHERCHARGEITEM', 'SERVICEITEM', 'NONINVENTORYPURCHASEITEM', 'OTHERCHARGESALEITEM', 'NONINVENTORYRESALEITEM', 'SERVICESALEITEM'],
+  consistentValue: 'SERVICEITEM',
+}
+
 const transactionFormRecordType = {
-  field: RECORD_TYPE,
+  field: transactionForm.fields[RECORD_TYPE],
   inconsistentValues: ['JOURNALENTRY', 'INTERCOMPANYJOURNALENTRY', 'ADVINTERCOMPANYJOURNALENTRY', 'STATISTICALJOURNALENTRY'],
   consistentValue: 'JOURNALENTRY',
 }
 
-const typeToFieldsMapping: Record<string, InconsistentFieldMapping[]> = {
-  [ENTRY_FORM]: [entryFormRecordType],
+const typeToFieldMappings: Record<string, InconsistentFieldMapping[]> = {
+  [CUSTOM_RECORD_TYPE]: [
+    customRecordTypeApClerkPermittedRole,
+    customRecordTypeCeoHandsOffPermittedRole,
+  ],
+  [ENTRY_FORM]: [
+    entryFormDiscountItemRecordType,
+    entryFormItemGroupRecordType,
+    entryFormJobRecordType,
+    entryFormServiceItemRecordType,
+  ],
   [TRANSACTION_FORM]: [transactionFormRecordType],
 }
 
 const setConsistentValues = (instance: InstanceElement): void => {
-  const fieldsMappings = typeToFieldsMapping[instance.type.elemID.name]
-  if (!fieldsMappings) return
-  fieldsMappings.forEach(fieldMapping => {
-    if (fieldMapping.inconsistentValues.includes(instance.value[fieldMapping.field])) {
-      instance.value[fieldMapping.field] = fieldMapping.consistentValue
+  const transformFunc = (
+    fieldMappings: InconsistentFieldMapping[]
+  ): TransformFunc => ({ value, field }) => {
+    const matchingFieldMapping = fieldMappings.find(fieldMapping =>
+      field && fieldMapping.field.isEqual(field) && fieldMapping.inconsistentValues.includes(value))
+    if (matchingFieldMapping) {
+      return matchingFieldMapping.consistentValue
     }
-  })
+    return value
+  }
+
+  const fieldMappings = typeToFieldMappings[instance.type.elemID.name]
+  if (!fieldMappings) return
+  instance.value = transformValues({
+    values: instance.value,
+    type: instance.type,
+    transformFunc: transformFunc(fieldMappings),
+    strict: false,
+  }) ?? instance.value
 }
 
 const filterCreator: FilterCreator = () => ({
   /**
    * Upon fetch, set fields that are randomly returned with different values but have the same
-   * meaning to have a consistent equivalent  value so there won't be irrelevant changes upon fetch
+   * meaning to have a consistent equivalent value so there won't be irrelevant changes upon fetch
    * even if nothing hasn't really changed in the service.
    *
    * @param elements the already fetched elements

--- a/packages/netsuite-adapter/src/types/custom_types/customrecordtype.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/customrecordtype.ts
@@ -489,7 +489,7 @@ customrecordtypeInnerTypes.push(customrecordtype_links)
 
 const customrecordtype_permissions_permissionElemID = new ElemID(constants.NETSUITE, 'customrecordtype_permissions_permission')
 
-const customrecordtype_permissions_permission = new ObjectType({
+export const customrecordtype_permissions_permission = new ObjectType({
   elemID: customrecordtype_permissions_permissionElemID,
   annotations: {
   },


### PR DESCRIPTION
_Release Notes_: 
Netsuite Adapter:
Return consistent recordType value for entryForms and permittedRole for customRecordTypes