### PR TITLE
SALTO-1234: dependencies will now be created for references to inner attributes

### DIFF
--- a/packages/core/test/core/plan/dependency.test.ts
+++ b/packages/core/test/core/plan/dependency.test.ts
@@ -277,6 +277,7 @@ describe('dependency changers', () => {
             type: BuiltinTypes.STRING,
             annotations: { fieldRef: new ReferenceExpression(fieldRefType.elemID) },
           },
+          someField: { type: BuiltinTypes.STRING },
         },
         annotations: { annoRef: new ReferenceExpression(testAnnoType.elemID) },
         annotationTypes: { annoRef: testAnnoType },
@@ -284,14 +285,16 @@ describe('dependency changers', () => {
       testParent = new InstanceElement(
         'parent',
         testType,
-        {},
+        {
+          someField: 'someValue',
+        },
       )
       testInstance = new InstanceElement(
         'test',
         testType,
         { ref: new ReferenceExpression(testTypeId) },
         undefined,
-        { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(testParent.elemID)] }
+        { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(testParent.elemID.createNestedID('someField'))] }
       )
     })
 
@@ -351,8 +354,10 @@ describe('dependency changers', () => {
         ])
         dependencyChanges = [...await addReferencesDependency(inputChanges, new Map())]
       })
-      it('should not add dependency', () => {
-        expect(dependencyChanges).toHaveLength(0)
+      it('should add dependency', () => {
+        expect(dependencyChanges).toEqual([
+          { action: 'add', dependency: { source: 1, target: 0 } },
+        ])
       })
     })
     describe('when reference source is a type', () => {

--- a/packages/core/test/core/plan/dependency.test.ts
+++ b/packages/core/test/core/plan/dependency.test.ts
@@ -277,7 +277,6 @@ describe('dependency changers', () => {
             type: BuiltinTypes.STRING,
             annotations: { fieldRef: new ReferenceExpression(fieldRefType.elemID) },
           },
-          someField: { type: BuiltinTypes.STRING },
         },
         annotations: { annoRef: new ReferenceExpression(testAnnoType.elemID) },
         annotationTypes: { annoRef: testAnnoType },
@@ -285,16 +284,13 @@ describe('dependency changers', () => {
       testParent = new InstanceElement(
         'parent',
         testType,
-        {
-          someField: 'someValue',
-        },
       )
       testInstance = new InstanceElement(
         'test',
         testType,
         { ref: new ReferenceExpression(testTypeId) },
         undefined,
-        { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(testParent.elemID.createNestedID('someField'))] }
+        { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(testParent.elemID)] }
       )
     })
 
@@ -354,7 +350,7 @@ describe('dependency changers', () => {
         ])
         dependencyChanges = [...await addReferencesDependency(inputChanges, new Map())]
       })
-      it('should add dependency', () => {
+      it('should add dependency to the element that contains the target', () => {
         expect(dependencyChanges).toEqual([
           { action: 'add', dependency: { source: 1, target: 0 } },
         ])


### PR DESCRIPTION
Changed `addReferencesDependency` to add dependencies also for references to none-elements targets (values, annotations, etc..)
This is needed for Netsuite, where all the references are to the ids of specific values of instance elements and not the ids of the instance elements.

---
_Release Notes_: 
None