### PR TITLE
SALTO-1234: support deploying the entire Netsuite file cabinet

### DIFF
--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -27,7 +27,7 @@ import { SavedSearchQuery, SystemInformation } from './suiteapp_client/types'
 import { GetCustomObjectsResult, ImportFileCabinetResult } from './types'
 import { getAllReferencedInstances, getRequiredReferencedInstances } from '../reference_dependencies'
 import { getLookUpName, toCustomizationInfo } from '../transformer'
-import { SDF_GROUPS, SUITEAPP_CREATING_FILES_GROUP_ID } from '../group_changes'
+import { SDF_CHANGE_GROUP_ID, SUITEAPP_CREATING_FILES_GROUP_ID } from '../group_changes'
 
 const log = logger(module)
 
@@ -122,7 +122,7 @@ export default class NetsuiteClient {
       change is Change<InstanceElement> =>
       isInstanceElement(getChangeElement(change)))
 
-    if (SDF_GROUPS.includes(changeGroup.groupID)) {
+    if (SDF_CHANGE_GROUP_ID === changeGroup.groupID) {
       return this.sdfDeploy(instancesChanges, deployReferencedElements)
     }
 

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -105,10 +105,8 @@ export default class NetsuiteClient {
     ).map(instance => resolveValues(instance, getLookUpName))
       .map(toCustomizationInfo)
 
-    const sdfDeployPromise = this.sdfClient.deploy(customizationInfos)
-
     try {
-      await sdfDeployPromise
+      await this.sdfClient.deploy(customizationInfos)
       return { errors: [], appliedChanges: changes }
     } catch (e) {
       return { errors: [e], appliedChanges: [] }
@@ -128,7 +126,7 @@ export default class NetsuiteClient {
 
     return this.suiteAppClient !== undefined
       ? suiteAppFileCabinet.deploy(this.suiteAppClient, instancesChanges, changeGroup.groupID === SUITEAPP_CREATING_FILES_GROUP_ID ? 'add' : 'update')
-      : { errors: [], appliedChanges: [] }
+      : { errors: [new Error(`Salto SuiteApp is not configured and therefore changes group "${changeGroup.groupID}" cannot be deployed`)], appliedChanges: [] }
   }
 
   public async runSuiteQL(query: string):

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { AccountId, Change, ChangeGroup, DeployResult, getChangeElement, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { AccountId, Change, ChangeGroup, DeployResult, getChangeElement, InstanceElement, isInstanceChange } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { decorators } from '@salto-io/lowerdash'
 import { resolveValues } from '@salto-io/adapter-utils'
@@ -116,9 +116,7 @@ export default class NetsuiteClient {
   @NetsuiteClient.logDecorator
   async deploy(changeGroup: ChangeGroup, deployReferencedElements: boolean):
     Promise<DeployResult> {
-    const instancesChanges = changeGroup.changes.filter((change):
-      change is Change<InstanceElement> =>
-      isInstanceElement(getChangeElement(change)))
+    const instancesChanges = changeGroup.changes.filter(isInstanceChange)
 
     if (SDF_CHANGE_GROUP_ID === changeGroup.groupID) {
       return this.sdfDeploy(instancesChanges, deployReferencedElements)

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -27,7 +27,7 @@ import { SavedSearchQuery, SystemInformation } from './suiteapp_client/types'
 import { GetCustomObjectsResult, ImportFileCabinetResult } from './types'
 import { getAllReferencedInstances, getRequiredReferencedInstances } from '../reference_dependencies'
 import { getLookUpName, toCustomizationInfo } from '../transformer'
-import { SDF_GROUPS, SUITEAPP_CREATING_FILES } from '../group_changes'
+import { SDF_GROUPS, SUITEAPP_CREATING_FILES_GROUP_ID } from '../group_changes'
 
 const log = logger(module)
 
@@ -127,7 +127,7 @@ export default class NetsuiteClient {
     }
 
     return this.suiteAppClient !== undefined
-      ? suiteAppFileCabinet.deploy(this.suiteAppClient, instancesChanges, changeGroup.groupID === SUITEAPP_CREATING_FILES ? 'add' : 'update')
+      ? suiteAppFileCabinet.deploy(this.suiteAppClient, instancesChanges, changeGroup.groupID === SUITEAPP_CREATING_FILES_GROUP_ID ? 'add' : 'update')
       : { errors: [], appliedChanges: [] }
   }
 

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/schemas.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/schemas.ts
@@ -1,0 +1,990 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// The schemas here were generated automatically using https://github.com/YousefED/typescript-json-schema
+
+export const GET_RESULTS_SCHEMA = {
+  anyOf: [
+    {
+      properties: {
+        'soapenv:Envelope': {
+          properties: {
+            'soapenv:Body': {
+              properties: {
+                getResponse: {
+                  properties: {
+                    'platformMsgs:readResponse': {
+                      properties: {
+                        'platformCore:status': {
+                          properties: {
+                            _attributes: {
+                              properties: {
+                                isSuccess: {
+                                  enum: [
+                                    'true',
+                                  ],
+                                  type: 'string',
+                                },
+                              },
+                              required: [
+                                'isSuccess',
+                              ],
+                              type: 'object',
+                            },
+                          },
+                          required: [
+                            '_attributes',
+                          ],
+                          type: 'object',
+                        },
+                        'platformMsgs:record': {
+                          properties: {
+                            'docFileCab:content': {
+                              properties: {
+                                _text: {
+                                  type: 'string',
+                                },
+                              },
+                              type: 'object',
+                            },
+                          },
+                          required: [
+                            'docFileCab:content',
+                          ],
+                          type: 'object',
+                        },
+                      },
+                      required: [
+                        'platformCore:status',
+                        'platformMsgs:record',
+                      ],
+                      type: 'object',
+                    },
+                  },
+                  required: [
+                    'platformMsgs:readResponse',
+                  ],
+                  type: 'object',
+                },
+              },
+              required: [
+                'getResponse',
+              ],
+              type: 'object',
+            },
+          },
+          required: [
+            'soapenv:Body',
+          ],
+          type: 'object',
+        },
+      },
+      required: [
+        'soapenv:Envelope',
+      ],
+      type: 'object',
+    },
+    {
+      properties: {
+        'soapenv:Envelope': {
+          properties: {
+            'soapenv:Body': {
+              properties: {
+                getResponse: {
+                  properties: {
+                    'platformMsgs:readResponse': {
+                      properties: {
+                        'platformCore:status': {
+                          properties: {
+                            _attributes: {
+                              properties: {
+                                isSuccess: {
+                                  enum: [
+                                    'false',
+                                  ],
+                                  type: 'string',
+                                },
+                              },
+                              required: [
+                                'isSuccess',
+                              ],
+                              type: 'object',
+                            },
+                            'platformCore:statusDetail': {
+                              properties: {
+                                'platformCore:code': {
+                                  properties: {
+                                    _text: {
+                                      type: 'string',
+                                    },
+                                  },
+                                  required: [
+                                    '_text',
+                                  ],
+                                  type: 'object',
+                                },
+                                'platformCore:message': {
+                                  properties: {
+                                    _text: {
+                                      type: 'string',
+                                    },
+                                  },
+                                  required: [
+                                    '_text',
+                                  ],
+                                  type: 'object',
+                                },
+                              },
+                              required: [
+                                'platformCore:code',
+                                'platformCore:message',
+                              ],
+                              type: 'object',
+                            },
+                          },
+                          required: [
+                            '_attributes',
+                            'platformCore:statusDetail',
+                          ],
+                          type: 'object',
+                        },
+                      },
+                      required: [
+                        'platformCore:status',
+                      ],
+                      type: 'object',
+                    },
+                  },
+                  required: [
+                    'platformMsgs:readResponse',
+                  ],
+                  type: 'object',
+                },
+              },
+              required: [
+                'getResponse',
+              ],
+              type: 'object',
+            },
+          },
+          required: [
+            'soapenv:Body',
+          ],
+          type: 'object',
+        },
+      },
+      required: [
+        'soapenv:Envelope',
+      ],
+      type: 'object',
+    },
+  ],
+}
+
+export const UPDATE_LIST_SCHEMA = {
+  anyOf: [
+    {
+      properties: {
+        'soapenv:Envelope': {
+          properties: {
+            'soapenv:Body': {
+              properties: {
+                updateListResponse: {
+                  properties: {
+                    writeResponseList: {
+                      properties: {
+                        'platformCore:status': {
+                          properties: {
+                            _attributes: {
+                              properties: {
+                                isSuccess: {
+                                  enum: [
+                                    'true',
+                                  ],
+                                  type: 'string',
+                                },
+                              },
+                              required: [
+                                'isSuccess',
+                              ],
+                              type: 'object',
+                            },
+                          },
+                          required: [
+                            '_attributes',
+                          ],
+                          type: 'object',
+                        },
+                        writeResponse: {
+                          anyOf: [
+                            {
+                              properties: {
+                                baseRef: {
+                                  properties: {
+                                    _attributes: {
+                                      properties: {
+                                        internalId: {
+                                          type: 'string',
+                                        },
+                                      },
+                                      required: [
+                                        'internalId',
+                                      ],
+                                      type: 'object',
+                                    },
+                                  },
+                                  required: [
+                                    '_attributes',
+                                  ],
+                                  type: 'object',
+                                },
+                                'platformCore:status': {
+                                  properties: {
+                                    _attributes: {
+                                      properties: {
+                                        isSuccess: {
+                                          enum: [
+                                            'true',
+                                          ],
+                                          type: 'string',
+                                        },
+                                      },
+                                      required: [
+                                        'isSuccess',
+                                      ],
+                                      type: 'object',
+                                    },
+                                  },
+                                  required: [
+                                    '_attributes',
+                                  ],
+                                  type: 'object',
+                                },
+                              },
+                              required: [
+                                'baseRef',
+                                'platformCore:status',
+                              ],
+                              type: 'object',
+                            },
+                            {
+                              properties: {
+                                'platformCore:status': {
+                                  properties: {
+                                    _attributes: {
+                                      properties: {
+                                        isSuccess: {
+                                          enum: [
+                                            'false',
+                                          ],
+                                          type: 'string',
+                                        },
+                                      },
+                                      required: [
+                                        'isSuccess',
+                                      ],
+                                      type: 'object',
+                                    },
+                                    'platformCore:statusDetail': {
+                                      properties: {
+                                        'platformCore:code': {
+                                          properties: {
+                                            _text: {
+                                              type: 'string',
+                                            },
+                                          },
+                                          required: [
+                                            '_text',
+                                          ],
+                                          type: 'object',
+                                        },
+                                        'platformCore:message': {
+                                          properties: {
+                                            _text: {
+                                              type: 'string',
+                                            },
+                                          },
+                                          required: [
+                                            '_text',
+                                          ],
+                                          type: 'object',
+                                        },
+                                      },
+                                      required: [
+                                        'platformCore:code',
+                                        'platformCore:message',
+                                      ],
+                                      type: 'object',
+                                    },
+                                  },
+                                  required: [
+                                    '_attributes',
+                                    'platformCore:statusDetail',
+                                  ],
+                                  type: 'object',
+                                },
+                              },
+                              required: [
+                                'platformCore:status',
+                              ],
+                              type: 'object',
+                            },
+                            {
+                              items: {
+                                anyOf: [
+                                  {
+                                    properties: {
+                                      baseRef: {
+                                        properties: {
+                                          _attributes: {
+                                            properties: {
+                                              internalId: {
+                                                type: 'string',
+                                              },
+                                            },
+                                            required: [
+                                              'internalId',
+                                            ],
+                                            type: 'object',
+                                          },
+                                        },
+                                        required: [
+                                          '_attributes',
+                                        ],
+                                        type: 'object',
+                                      },
+                                      'platformCore:status': {
+                                        properties: {
+                                          _attributes: {
+                                            properties: {
+                                              isSuccess: {
+                                                enum: [
+                                                  'true',
+                                                ],
+                                                type: 'string',
+                                              },
+                                            },
+                                            required: [
+                                              'isSuccess',
+                                            ],
+                                            type: 'object',
+                                          },
+                                        },
+                                        required: [
+                                          '_attributes',
+                                        ],
+                                        type: 'object',
+                                      },
+                                    },
+                                    required: [
+                                      'baseRef',
+                                      'platformCore:status',
+                                    ],
+                                    type: 'object',
+                                  },
+                                  {
+                                    properties: {
+                                      'platformCore:status': {
+                                        properties: {
+                                          _attributes: {
+                                            properties: {
+                                              isSuccess: {
+                                                enum: [
+                                                  'false',
+                                                ],
+                                                type: 'string',
+                                              },
+                                            },
+                                            required: [
+                                              'isSuccess',
+                                            ],
+                                            type: 'object',
+                                          },
+                                          'platformCore:statusDetail': {
+                                            properties: {
+                                              'platformCore:code': {
+                                                properties: {
+                                                  _text: {
+                                                    type: 'string',
+                                                  },
+                                                },
+                                                required: [
+                                                  '_text',
+                                                ],
+                                                type: 'object',
+                                              },
+                                              'platformCore:message': {
+                                                properties: {
+                                                  _text: {
+                                                    type: 'string',
+                                                  },
+                                                },
+                                                required: [
+                                                  '_text',
+                                                ],
+                                                type: 'object',
+                                              },
+                                            },
+                                            required: [
+                                              'platformCore:code',
+                                              'platformCore:message',
+                                            ],
+                                            type: 'object',
+                                          },
+                                        },
+                                        required: [
+                                          '_attributes',
+                                          'platformCore:statusDetail',
+                                        ],
+                                        type: 'object',
+                                      },
+                                    },
+                                    required: [
+                                      'platformCore:status',
+                                    ],
+                                    type: 'object',
+                                  },
+                                ],
+                              },
+                              type: 'array',
+                            },
+                          ],
+                        },
+                      },
+                      required: [
+                        'platformCore:status',
+                        'writeResponse',
+                      ],
+                      type: 'object',
+                    },
+                  },
+                  required: [
+                    'writeResponseList',
+                  ],
+                  type: 'object',
+                },
+              },
+              required: [
+                'updateListResponse',
+              ],
+              type: 'object',
+            },
+          },
+          required: [
+            'soapenv:Body',
+          ],
+          type: 'object',
+        },
+      },
+      required: [
+        'soapenv:Envelope',
+      ],
+      type: 'object',
+    },
+    {
+      properties: {
+        'soapenv:Envelope': {
+          properties: {
+            'soapenv:Body': {
+              properties: {
+                updateListResponse: {
+                  properties: {
+                    writeResponseList: {
+                      properties: {
+                        'platformCore:status': {
+                          properties: {
+                            _attributes: {
+                              properties: {
+                                isSuccess: {
+                                  enum: [
+                                    'false',
+                                  ],
+                                  type: 'string',
+                                },
+                              },
+                              required: [
+                                'isSuccess',
+                              ],
+                              type: 'object',
+                            },
+                            'platformCore:statusDetail': {
+                              properties: {
+                                'platformCore:code': {
+                                  properties: {
+                                    _text: {
+                                      type: 'string',
+                                    },
+                                  },
+                                  required: [
+                                    '_text',
+                                  ],
+                                  type: 'object',
+                                },
+                                'platformCore:message': {
+                                  properties: {
+                                    _text: {
+                                      type: 'string',
+                                    },
+                                  },
+                                  required: [
+                                    '_text',
+                                  ],
+                                  type: 'object',
+                                },
+                              },
+                              required: [
+                                'platformCore:code',
+                                'platformCore:message',
+                              ],
+                              type: 'object',
+                            },
+                          },
+                          required: [
+                            '_attributes',
+                            'platformCore:statusDetail',
+                          ],
+                          type: 'object',
+                        },
+                      },
+                      required: [
+                        'platformCore:status',
+                      ],
+                      type: 'object',
+                    },
+                  },
+                  required: [
+                    'writeResponseList',
+                  ],
+                  type: 'object',
+                },
+              },
+              required: [
+                'updateListResponse',
+              ],
+              type: 'object',
+            },
+          },
+          required: [
+            'soapenv:Body',
+          ],
+          type: 'object',
+        },
+      },
+      required: [
+        'soapenv:Envelope',
+      ],
+      type: 'object',
+    },
+  ],
+}
+
+export const ADD_LIST_SCHEMA = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  anyOf: [
+    {
+      properties: {
+        'soapenv:Envelope': {
+          properties: {
+            'soapenv:Body': {
+              properties: {
+                addListResponse: {
+                  properties: {
+                    writeResponseList: {
+                      properties: {
+                        'platformCore:status': {
+                          properties: {
+                            _attributes: {
+                              properties: {
+                                isSuccess: {
+                                  enum: [
+                                    'true',
+                                  ],
+                                  type: 'string',
+                                },
+                              },
+                              required: [
+                                'isSuccess',
+                              ],
+                              type: 'object',
+                            },
+                          },
+                          required: [
+                            '_attributes',
+                          ],
+                          type: 'object',
+                        },
+                        writeResponse: {
+                          anyOf: [
+                            {
+                              properties: {
+                                baseRef: {
+                                  properties: {
+                                    _attributes: {
+                                      properties: {
+                                        internalId: {
+                                          type: 'string',
+                                        },
+                                      },
+                                      required: [
+                                        'internalId',
+                                      ],
+                                      type: 'object',
+                                    },
+                                  },
+                                  required: [
+                                    '_attributes',
+                                  ],
+                                  type: 'object',
+                                },
+                                'platformCore:status': {
+                                  properties: {
+                                    _attributes: {
+                                      properties: {
+                                        isSuccess: {
+                                          enum: [
+                                            'true',
+                                          ],
+                                          type: 'string',
+                                        },
+                                      },
+                                      required: [
+                                        'isSuccess',
+                                      ],
+                                      type: 'object',
+                                    },
+                                  },
+                                  required: [
+                                    '_attributes',
+                                  ],
+                                  type: 'object',
+                                },
+                              },
+                              required: [
+                                'baseRef',
+                                'platformCore:status',
+                              ],
+                              type: 'object',
+                            },
+                            {
+                              properties: {
+                                'platformCore:status': {
+                                  properties: {
+                                    _attributes: {
+                                      properties: {
+                                        isSuccess: {
+                                          enum: [
+                                            'false',
+                                          ],
+                                          type: 'string',
+                                        },
+                                      },
+                                      required: [
+                                        'isSuccess',
+                                      ],
+                                      type: 'object',
+                                    },
+                                    'platformCore:statusDetail': {
+                                      properties: {
+                                        'platformCore:code': {
+                                          properties: {
+                                            _text: {
+                                              type: 'string',
+                                            },
+                                          },
+                                          required: [
+                                            '_text',
+                                          ],
+                                          type: 'object',
+                                        },
+                                        'platformCore:message': {
+                                          properties: {
+                                            _text: {
+                                              type: 'string',
+                                            },
+                                          },
+                                          required: [
+                                            '_text',
+                                          ],
+                                          type: 'object',
+                                        },
+                                      },
+                                      required: [
+                                        'platformCore:code',
+                                        'platformCore:message',
+                                      ],
+                                      type: 'object',
+                                    },
+                                  },
+                                  required: [
+                                    '_attributes',
+                                    'platformCore:statusDetail',
+                                  ],
+                                  type: 'object',
+                                },
+                              },
+                              required: [
+                                'platformCore:status',
+                              ],
+                              type: 'object',
+                            },
+                            {
+                              items: {
+                                anyOf: [
+                                  {
+                                    properties: {
+                                      baseRef: {
+                                        properties: {
+                                          _attributes: {
+                                            properties: {
+                                              internalId: {
+                                                type: 'string',
+                                              },
+                                            },
+                                            required: [
+                                              'internalId',
+                                            ],
+                                            type: 'object',
+                                          },
+                                        },
+                                        required: [
+                                          '_attributes',
+                                        ],
+                                        type: 'object',
+                                      },
+                                      'platformCore:status': {
+                                        properties: {
+                                          _attributes: {
+                                            properties: {
+                                              isSuccess: {
+                                                enum: [
+                                                  'true',
+                                                ],
+                                                type: 'string',
+                                              },
+                                            },
+                                            required: [
+                                              'isSuccess',
+                                            ],
+                                            type: 'object',
+                                          },
+                                        },
+                                        required: [
+                                          '_attributes',
+                                        ],
+                                        type: 'object',
+                                      },
+                                    },
+                                    required: [
+                                      'baseRef',
+                                      'platformCore:status',
+                                    ],
+                                    type: 'object',
+                                  },
+                                  {
+                                    properties: {
+                                      'platformCore:status': {
+                                        properties: {
+                                          _attributes: {
+                                            properties: {
+                                              isSuccess: {
+                                                enum: [
+                                                  'false',
+                                                ],
+                                                type: 'string',
+                                              },
+                                            },
+                                            required: [
+                                              'isSuccess',
+                                            ],
+                                            type: 'object',
+                                          },
+                                          'platformCore:statusDetail': {
+                                            properties: {
+                                              'platformCore:code': {
+                                                properties: {
+                                                  _text: {
+                                                    type: 'string',
+                                                  },
+                                                },
+                                                required: [
+                                                  '_text',
+                                                ],
+                                                type: 'object',
+                                              },
+                                              'platformCore:message': {
+                                                properties: {
+                                                  _text: {
+                                                    type: 'string',
+                                                  },
+                                                },
+                                                required: [
+                                                  '_text',
+                                                ],
+                                                type: 'object',
+                                              },
+                                            },
+                                            required: [
+                                              'platformCore:code',
+                                              'platformCore:message',
+                                            ],
+                                            type: 'object',
+                                          },
+                                        },
+                                        required: [
+                                          '_attributes',
+                                          'platformCore:statusDetail',
+                                        ],
+                                        type: 'object',
+                                      },
+                                    },
+                                    required: [
+                                      'platformCore:status',
+                                    ],
+                                    type: 'object',
+                                  },
+                                ],
+                              },
+                              type: 'array',
+                            },
+                          ],
+                        },
+                      },
+                      required: [
+                        'platformCore:status',
+                        'writeResponse',
+                      ],
+                      type: 'object',
+                    },
+                  },
+                  required: [
+                    'writeResponseList',
+                  ],
+                  type: 'object',
+                },
+              },
+              required: [
+                'addListResponse',
+              ],
+              type: 'object',
+            },
+          },
+          required: [
+            'soapenv:Body',
+          ],
+          type: 'object',
+        },
+      },
+      required: [
+        'soapenv:Envelope',
+      ],
+      type: 'object',
+    },
+    {
+      properties: {
+        'soapenv:Envelope': {
+          properties: {
+            'soapenv:Body': {
+              properties: {
+                addListResponse: {
+                  properties: {
+                    writeResponseList: {
+                      properties: {
+                        'platformCore:status': {
+                          properties: {
+                            _attributes: {
+                              properties: {
+                                isSuccess: {
+                                  enum: [
+                                    'false',
+                                  ],
+                                  type: 'string',
+                                },
+                              },
+                              required: [
+                                'isSuccess',
+                              ],
+                              type: 'object',
+                            },
+                            'platformCore:statusDetail': {
+                              properties: {
+                                'platformCore:code': {
+                                  properties: {
+                                    _text: {
+                                      type: 'string',
+                                    },
+                                  },
+                                  required: [
+                                    '_text',
+                                  ],
+                                  type: 'object',
+                                },
+                                'platformCore:message': {
+                                  properties: {
+                                    _text: {
+                                      type: 'string',
+                                    },
+                                  },
+                                  required: [
+                                    '_text',
+                                  ],
+                                  type: 'object',
+                                },
+                              },
+                              required: [
+                                'platformCore:code',
+                                'platformCore:message',
+                              ],
+                              type: 'object',
+                            },
+                          },
+                          required: [
+                            '_attributes',
+                            'platformCore:statusDetail',
+                          ],
+                          type: 'object',
+                        },
+                      },
+                      required: [
+                        'platformCore:status',
+                      ],
+                      type: 'object',
+                    },
+                  },
+                  required: [
+                    'writeResponseList',
+                  ],
+                  type: 'object',
+                },
+              },
+              required: [
+                'addListResponse',
+              ],
+              type: 'object',
+            },
+          },
+          required: [
+            'soapenv:Body',
+          ],
+          type: 'object',
+        },
+      },
+      required: [
+        'soapenv:Envelope',
+      ],
+      type: 'object',
+    },
+  ],
+}

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -13,6 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+/* eslint-disable no-underscore-dangle */
+
 import { logger } from '@salto-io/logging'
 import Ajv from 'ajv'
 import axios from 'axios'
@@ -68,16 +70,13 @@ export default class SoapClient {
 
     if (!isGetSuccess(response)) {
       const result = response['soapenv:Envelope']['soapenv:Body'].getResponse['platformMsgs:readResponse']
-      // eslint-disable-next-line no-underscore-dangle
       const code = result['platformCore:status']['platformCore:statusDetail']['platformCore:code']._text
-      // eslint-disable-next-line no-underscore-dangle
       const message = result['platformCore:status']['platformCore:statusDetail']['platformCore:message']._text
 
       log.error(`Failed to read file with id ${id}: error code: ${code}, error message: ${message}`)
       throw new ReadFileError(`Failed to read file with id ${id}: error code: ${code}, error message: ${message}`)
     }
 
-    // eslint-disable-next-line no-underscore-dangle
     const b64content = response['soapenv:Envelope']['soapenv:Body'].getResponse['platformMsgs:readResponse']['platformMsgs:record']['docFileCab:content']._text
     return b64content !== undefined ? Buffer.from(b64content, 'base64') : Buffer.from('')
   }
@@ -190,9 +189,7 @@ export default class SoapClient {
 
     if (!isAddListSuccess(response)) {
       const details = response['soapenv:Envelope']['soapenv:Body'].addListResponse.writeResponseList['platformCore:status']['platformCore:statusDetail']
-      // eslint-disable-next-line no-underscore-dangle
       const code = details['platformCore:code']._text
-      // eslint-disable-next-line no-underscore-dangle
       const message = details['platformCore:message']._text
 
       log.error(`Failed to addList: error code: ${code}, error message: ${message}`)
@@ -202,15 +199,12 @@ export default class SoapClient {
     return collections.array.makeArray(response['soapenv:Envelope']['soapenv:Body'].addListResponse.writeResponseList.writeResponse).map((writeResponse, index) => {
       if (!isWriteResponseSuccess(writeResponse)) {
         const details = writeResponse['platformCore:status']['platformCore:statusDetail']
-        // eslint-disable-next-line no-underscore-dangle
         const code = details['platformCore:code']._text
-        // eslint-disable-next-line no-underscore-dangle
         const message = details['platformCore:message']._text
 
         log.error(`SOAP api call to add file cabinet instance ${fileCabinetInstances[index].path} failed. error code: ${code}, error message: ${message}`)
         return new Error(`SOAP api call to add file cabinet instance ${fileCabinetInstances[index].path} failed. error code: ${code}, error message: ${message}`)
       }
-      // eslint-disable-next-line no-underscore-dangle
       return parseInt(writeResponse.baseRef._attributes.internalId, 10)
     })
   }
@@ -235,9 +229,7 @@ export default class SoapClient {
 
     if (!isUpdateListSuccess(response)) {
       const details = response['soapenv:Envelope']['soapenv:Body'].updateListResponse.writeResponseList['platformCore:status']['platformCore:statusDetail']
-      // eslint-disable-next-line no-underscore-dangle
       const code = details['platformCore:code']._text
-      // eslint-disable-next-line no-underscore-dangle
       const message = details['platformCore:message']._text
 
       log.error(`Failed to updateList: error code: ${code}, error message: ${message}`)
@@ -247,15 +239,12 @@ export default class SoapClient {
     return collections.array.makeArray(response['soapenv:Envelope']['soapenv:Body'].updateListResponse.writeResponseList.writeResponse).map((writeResponse, index) => {
       if (!isWriteResponseSuccess(writeResponse)) {
         const details = writeResponse['platformCore:status']['platformCore:statusDetail']
-        // eslint-disable-next-line no-underscore-dangle
         const code = details['platformCore:code']._text
-        // eslint-disable-next-line no-underscore-dangle
         const message = details['platformCore:message']._text
 
         log.error(`SOAP api call to update file cabinet instance ${fileCabinetInstances[index].path} failed. error code: ${code}, error message: ${message}`)
         return Error(`SOAP api call to update file cabinet instance ${fileCabinetInstances[index].path} failed. error code: ${code}, error message: ${message}`)
       }
-      // eslint-disable-next-line no-underscore-dangle
       return parseInt(writeResponse.baseRef._attributes.internalId, 10)
     })
   }

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -152,11 +152,8 @@ export default class SoapClient {
       'q1:isInactive': {
         _text: folder.isInactive,
       },
-      'q1:isOnline': {
-        _text: folder.isOnline,
-      },
-      'q1:hideInBundle': {
-        _text: folder.hideInBundle,
+      'q1:isPrivate': {
+        _text: folder.isPrivate,
       },
       ...parentEntry,
     }

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/types.ts
@@ -13,16 +13,32 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+type StatusSuccess = {
+  _attributes: {
+    isSuccess: 'true'
+  }
+}
+
+type StatusError = {
+  _attributes: {
+    isSuccess: 'false'
+  }
+  'platformCore:statusDetail': {
+    'platformCore:code': {
+      _text: string
+    }
+    'platformCore:message': {
+      _text: string
+    }
+  }
+}
+
 export type GetSuccess = {
   'soapenv:Envelope': {
     'soapenv:Body': {
       getResponse: {
         'platformMsgs:readResponse': {
-          'platformCore:status': {
-            _attributes: {
-              isSuccess: 'true'
-            }
-          }
+          'platformCore:status': StatusSuccess
           'platformMsgs:record': {
             'docFileCab:content': {
               _text?: string
@@ -39,19 +55,7 @@ export type GetError = {
     'soapenv:Body': {
       getResponse: {
         'platformMsgs:readResponse': {
-          'platformCore:status': {
-            _attributes: {
-              isSuccess: 'false'
-            }
-            'platformCore:statusDetail': {
-              'platformCore:code': {
-                _text: string
-              }
-              'platformCore:message': {
-                _text: string
-              }
-            }
-          }
+          'platformCore:status': StatusError
         }
       }
     }
@@ -64,180 +68,85 @@ export const isGetSuccess = (result: GetResult): result is GetSuccess =>
   // eslint-disable-next-line no-underscore-dangle
   result['soapenv:Envelope']['soapenv:Body'].getResponse['platformMsgs:readResponse']['platformCore:status']._attributes.isSuccess === 'true'
 
-export const GET_RESULTS_SCHEMA = {
-  anyOf: [
-    {
-      properties: {
-        'soapenv:Envelope': {
-          properties: {
-            'soapenv:Body': {
-              properties: {
-                getResponse: {
-                  properties: {
-                    'platformMsgs:readResponse': {
-                      properties: {
-                        'platformCore:status': {
-                          properties: {
-                            _attributes: {
-                              properties: {
-                                isSuccess: {
-                                  enum: [
-                                    'true',
-                                  ],
-                                  type: 'string',
-                                },
-                              },
-                              required: [
-                                'isSuccess',
-                              ],
-                              type: 'object',
-                            },
-                          },
-                          required: [
-                            '_attributes',
-                          ],
-                          type: 'object',
-                        },
-                        'platformMsgs:record': {
-                          properties: {
-                            'docFileCab:content': {
-                              properties: {
-                                _text: {
-                                  type: 'string',
-                                },
-                              },
-                              type: 'object',
-                            },
-                          },
-                          required: [
-                            'docFileCab:content',
-                          ],
-                          type: 'object',
-                        },
-                      },
-                      required: [
-                        'platformCore:status',
-                        'platformMsgs:record',
-                      ],
-                      type: 'object',
-                    },
-                  },
-                  required: [
-                    'platformMsgs:readResponse',
-                  ],
-                  type: 'object',
-                },
-              },
-              required: [
-                'getResponse',
-              ],
-              type: 'object',
-            },
-          },
-          required: [
-            'soapenv:Body',
-          ],
-          type: 'object',
-        },
-      },
-      required: [
-        'soapenv:Envelope',
-      ],
-      type: 'object',
-    },
-    {
-      properties: {
-        'soapenv:Envelope': {
-          properties: {
-            'soapenv:Body': {
-              properties: {
-                getResponse: {
-                  properties: {
-                    'platformMsgs:readResponse': {
-                      properties: {
-                        'platformCore:status': {
-                          properties: {
-                            _attributes: {
-                              properties: {
-                                isSuccess: {
-                                  enum: [
-                                    'false',
-                                  ],
-                                  type: 'string',
-                                },
-                              },
-                              required: [
-                                'isSuccess',
-                              ],
-                              type: 'object',
-                            },
-                            'platformCore:statusDetail': {
-                              properties: {
-                                'platformCore:code': {
-                                  properties: {
-                                    _text: {
-                                      type: 'string',
-                                    },
-                                  },
-                                  required: [
-                                    '_text',
-                                  ],
-                                  type: 'object',
-                                },
-                                'platformCore:message': {
-                                  properties: {
-                                    _text: {
-                                      type: 'string',
-                                    },
-                                  },
-                                  required: [
-                                    '_text',
-                                  ],
-                                  type: 'object',
-                                },
-                              },
-                              required: [
-                                'platformCore:code',
-                                'platformCore:message',
-                              ],
-                              type: 'object',
-                            },
-                          },
-                          required: [
-                            '_attributes',
-                            'platformCore:statusDetail',
-                          ],
-                          type: 'object',
-                        },
-                      },
-                      required: [
-                        'platformCore:status',
-                      ],
-                      type: 'object',
-                    },
-                  },
-                  required: [
-                    'platformMsgs:readResponse',
-                  ],
-                  type: 'object',
-                },
-              },
-              required: [
-                'getResponse',
-              ],
-              type: 'object',
-            },
-          },
-          required: [
-            'soapenv:Body',
-          ],
-          type: 'object',
-        },
-      },
-      required: [
-        'soapenv:Envelope',
-      ],
-      type: 'object',
-    },
-  ],
+export type WriteResponseSuccess = {
+  'platformCore:status': StatusSuccess
+  baseRef: {
+    _attributes: {
+      internalId: string
+    }
+  }
 }
+
+export type WriteResponseError = {
+  'platformCore:status': StatusError
+}
+
+export type WriteResponse = WriteResponseSuccess | WriteResponseError
+
+export const isWriteResponseSuccess = (result: WriteResponse): result is WriteResponseSuccess =>
+  // eslint-disable-next-line no-underscore-dangle
+  result['platformCore:status']._attributes.isSuccess === 'true'
+
+
+export type UpdateListSuccess = {
+  'soapenv:Envelope': {
+    'soapenv:Body': {
+      updateListResponse: {
+        writeResponseList: {
+          'platformCore:status': StatusSuccess
+          writeResponse: WriteResponse[] | WriteResponse
+        }
+      }
+    }
+  }
+}
+
+export type UpdateListError = {
+  'soapenv:Envelope': {
+    'soapenv:Body': {
+      updateListResponse: {
+        writeResponseList: {
+          'platformCore:status': StatusError
+        }
+      }
+    }
+  }
+}
+
+export type UpdateListResults = UpdateListError | UpdateListSuccess
+
+export const isUpdateListSuccess = (result: UpdateListResults): result is UpdateListSuccess =>
+  // eslint-disable-next-line no-underscore-dangle
+  result['soapenv:Envelope']['soapenv:Body'].updateListResponse.writeResponseList['platformCore:status']._attributes.isSuccess === 'true'
+
+
+export type AddListSuccess = {
+  'soapenv:Envelope': {
+    'soapenv:Body': {
+      addListResponse: {
+        writeResponseList: {
+          'platformCore:status': StatusSuccess
+          writeResponse: WriteResponse[] | WriteResponse
+        }
+      }
+    }
+  }
+}
+
+export type AddListError = {
+  'soapenv:Envelope': {
+    'soapenv:Body': {
+      addListResponse: {
+        writeResponseList: {
+          'platformCore:status': StatusError
+        }
+      }
+    }
+  }
+}
+
+export type AddListResults = AddListError | AddListSuccess
+
+export const isAddListSuccess = (result: AddListResults): result is AddListSuccess =>
+  // eslint-disable-next-line no-underscore-dangle
+  result['soapenv:Envelope']['soapenv:Body'].addListResponse.writeResponseList['platformCore:status']._attributes.isSuccess === 'true'

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -21,10 +21,11 @@ import Ajv from 'ajv'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
-import { CallsLimiter, FILES_READ_SCHEMA, HttpMethod, isError, ReadResults, RestletOperation,
-  RestletResults, RESTLET_RESULTS_SCHEMA, SavedSearchQuery, SavedSearchResults,
-  SAVED_SEARCH_RESULTS_SCHEMA, SuiteAppClientParameters, SuiteQLResults, SUITE_QL_RESULTS_SCHEMA,
-  SystemInformation, SYSTEM_INFORMATION_SCHEME } from './types'
+import { CallsLimiter, ExistingFileCabinetInstanceDetails, FileCabinetInstanceDetails,
+  FILES_READ_SCHEMA, HttpMethod, isError, ReadResults, RestletOperation, RestletResults,
+  RESTLET_RESULTS_SCHEMA, SavedSearchQuery, SavedSearchResults, SAVED_SEARCH_RESULTS_SCHEMA,
+  SuiteAppClientParameters, SuiteQLResults, SUITE_QL_RESULTS_SCHEMA, SystemInformation,
+  SYSTEM_INFORMATION_SCHEME } from './types'
 import { SuiteAppCredentials } from '../credentials'
 import { DEFAULT_CONCURRENCY } from '../../config'
 import { CONSUMER_KEY, CONSUMER_SECRET } from './constants'
@@ -268,5 +269,15 @@ export default class SuiteAppClient {
     } catch (e) {
       return e
     }
+  }
+
+  public async updateFileCabinet(fileCabinetInstances:
+    ExistingFileCabinetInstanceDetails[]): Promise<(number | Error)[]> {
+    return this.soapClient.updateFileCabinet(fileCabinetInstances)
+  }
+
+  public async addFileCabinetInstances(fileCabinetInstances:
+    (FileCabinetInstanceDetails)[]): Promise<(number | Error)[]> {
+    return this.soapClient.addFileCabinetInstances(fileCabinetInstances)
   }
 }

--- a/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
@@ -203,8 +203,7 @@ export type FolderDetails = {
   parent?: number
   bundleable: boolean
   isInactive: boolean
-  isOnline: boolean
-  hideInBundle: boolean
+  isPrivate: boolean
   description: string
 }
 

--- a/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
@@ -182,3 +182,32 @@ export type ReadResults = (ReadSuccess | ReadFailure)[]
 export type RestletOperation = 'search' | 'sysInfo' | 'readFile'
 
 export type CallsLimiter = <T>(fn: () => Promise<T>) => Promise<T>
+
+export type FileDetails = {
+  type: 'file'
+  path: string
+  id?: number
+  folder: number
+  bundleable: boolean
+  isInactive: boolean
+  isOnline: boolean
+  hideInBundle: boolean
+  content: Buffer
+  description: string
+}
+
+export type FolderDetails = {
+  type: 'folder'
+  path: string
+  id?: number
+  parent?: number
+  bundleable: boolean
+  isInactive: boolean
+  isOnline: boolean
+  hideInBundle: boolean
+  description: string
+}
+
+export type FileCabinetInstanceDetails = FileDetails | FolderDetails
+
+export type ExistingFileCabinetInstanceDetails = FileCabinetInstanceDetails & { id: number }

--- a/packages/netsuite-adapter/src/group_changes.ts
+++ b/packages/netsuite-adapter/src/group_changes.ts
@@ -20,14 +20,24 @@ import {
 } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
 import * as suiteAppFileCabinet from './suiteapp_file_cabinet'
-import { customTypes, fileCabinetTypes, isFileCabinetType } from './types'
+import { customTypes, fileCabinetTypes, isFileCabinetInstance } from './types'
 
 export const SDF_CHANGE_GROUP_ID = 'SDF'
+export const RECORDS_CHANGE_GROUP_ID = 'Records'
+export const SDF_FILE_CABINET_CHANGE_GROUP_ID = 'SDF - File Cabinet'
+export const SUITEAPP_CREATING_FILES_GROUP_ID = 'Salto SuiteApp - File Cabinet - Creating Files'
+export const SUITEAPP_UPDATING_FILES_GROUP_ID = 'Salto SuiteApp - File Cabinet - Updating Files'
 
-export const SDF_GROUPS = [SDF_CHANGE_GROUP_ID, 'Records', 'SDF - File Cabinet']
+export const SDF_GROUPS = [
+  SDF_CHANGE_GROUP_ID,
+  RECORDS_CHANGE_GROUP_ID,
+  SDF_FILE_CABINET_CHANGE_GROUP_ID,
+]
 
-export const SUITEAPP_CREATING_FILES = 'Salto SuiteApp - File Cabinet - Creating Files'
-export const SUITEAPP_GROUPS = [SUITEAPP_CREATING_FILES, 'Salto SuiteApp - File Cabinet - Updating Files']
+export const SUITEAPP_GROUPS = [
+  SUITEAPP_CREATING_FILES_GROUP_ID,
+  SUITEAPP_UPDATING_FILES_GROUP_ID,
+]
 
 const getChangeGroupIdsWithoutSuiteApp: ChangeGroupIdFunction = async changes => {
   const isSdfChange = (change: Change): boolean => {
@@ -52,32 +62,29 @@ const getChangeGroupIdsWithSuiteApp: ChangeGroupIdFunction = async changes => {
 
   const isSuiteAppFileCabinetModification = (change: Change): boolean => {
     const changeElement = getChangeElement(change)
-    return isInstanceElement(changeElement)
-    && isFileCabinetType(changeElement.type)
+    return isFileCabinetInstance(changeElement)
     && suiteAppFileCabinet.isChangeDeployable(change)
     && isModificationChange(change)
   }
 
   const isSuiteAppFileCabinetAddition = (change: Change): boolean => {
     const changeElement = getChangeElement(change)
-    return isInstanceElement(changeElement)
-    && isFileCabinetType(changeElement.type)
+    return isFileCabinetInstance(changeElement)
     && suiteAppFileCabinet.isChangeDeployable(change)
     && isAdditionChange(change)
   }
 
   const isSdfFileCabinetChange = (change: Change): boolean => {
     const changeElement = getChangeElement(change)
-    return isInstanceElement(changeElement)
-    && isFileCabinetType(changeElement.type)
+    return isFileCabinetInstance(changeElement)
     && !suiteAppFileCabinet.isChangeDeployable(change)
   }
 
   const conditionsToGroups = [
-    { condition: isRecordChange, group: 'Records' },
-    { condition: isSuiteAppFileCabinetAddition, group: SUITEAPP_CREATING_FILES },
-    { condition: isSuiteAppFileCabinetModification, group: 'Salto SuiteApp - File Cabinet - Updating Files' },
-    { condition: isSdfFileCabinetChange, group: 'SDF - File Cabinet' },
+    { condition: isRecordChange, group: RECORDS_CHANGE_GROUP_ID },
+    { condition: isSuiteAppFileCabinetAddition, group: SUITEAPP_CREATING_FILES_GROUP_ID },
+    { condition: isSuiteAppFileCabinetModification, group: SUITEAPP_UPDATING_FILES_GROUP_ID },
+    { condition: isSdfFileCabinetChange, group: SDF_FILE_CABINET_CHANGE_GROUP_ID },
   ]
 
   return new Map(

--- a/packages/netsuite-adapter/src/group_changes.ts
+++ b/packages/netsuite-adapter/src/group_changes.ts
@@ -23,16 +23,8 @@ import * as suiteAppFileCabinet from './suiteapp_file_cabinet'
 import { customTypes, fileCabinetTypes, isFileCabinetInstance } from './types'
 
 export const SDF_CHANGE_GROUP_ID = 'SDF'
-export const RECORDS_CHANGE_GROUP_ID = 'Records'
-export const SDF_FILE_CABINET_CHANGE_GROUP_ID = 'SDF - File Cabinet'
 export const SUITEAPP_CREATING_FILES_GROUP_ID = 'Salto SuiteApp - File Cabinet - Creating Files'
 export const SUITEAPP_UPDATING_FILES_GROUP_ID = 'Salto SuiteApp - File Cabinet - Updating Files'
-
-export const SDF_GROUPS = [
-  SDF_CHANGE_GROUP_ID,
-  RECORDS_CHANGE_GROUP_ID,
-  SDF_FILE_CABINET_CHANGE_GROUP_ID,
-]
 
 export const SUITEAPP_GROUPS = [
   SUITEAPP_CREATING_FILES_GROUP_ID,
@@ -54,12 +46,6 @@ const getChangeGroupIdsWithoutSuiteApp: ChangeGroupIdFunction = async changes =>
 }
 
 const getChangeGroupIdsWithSuiteApp: ChangeGroupIdFunction = async changes => {
-  const isRecordChange = (change: Change): boolean => {
-    const changeElement = getChangeElement(change)
-    return isInstanceElement(changeElement)
-    && Object.keys(customTypes).includes(changeElement.elemID.typeName)
-  }
-
   const isSuiteAppFileCabinetModification = (change: Change): boolean => {
     const changeElement = getChangeElement(change)
     return isFileCabinetInstance(changeElement)
@@ -74,17 +60,17 @@ const getChangeGroupIdsWithSuiteApp: ChangeGroupIdFunction = async changes => {
     && isAdditionChange(change)
   }
 
-  const isSdfFileCabinetChange = (change: Change): boolean => {
+  const isSdfChange = (change: Change): boolean => {
     const changeElement = getChangeElement(change)
-    return isFileCabinetInstance(changeElement)
-    && !suiteAppFileCabinet.isChangeDeployable(change)
+    return Object.keys(customTypes).includes(changeElement.elemID.typeName)
+      || (isFileCabinetInstance(changeElement)
+        && !suiteAppFileCabinet.isChangeDeployable(change))
   }
 
   const conditionsToGroups = [
-    { condition: isRecordChange, group: RECORDS_CHANGE_GROUP_ID },
     { condition: isSuiteAppFileCabinetAddition, group: SUITEAPP_CREATING_FILES_GROUP_ID },
     { condition: isSuiteAppFileCabinetModification, group: SUITEAPP_UPDATING_FILES_GROUP_ID },
-    { condition: isSdfFileCabinetChange, group: SDF_FILE_CABINET_CHANGE_GROUP_ID },
+    { condition: isSdfChange, group: SDF_CHANGE_GROUP_ID },
   ]
 
   return new Map(

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -275,9 +275,9 @@ const convertToFileCabinetDetails = (
       path: instance.value.path,
       folder: pathToId[dirname],
       bundleable: instance.value.bundleable ?? false,
-      isInactive: instance.value.isInactive ?? false,
-      isOnline: instance.value.isOnline ?? false,
-      hideInBundle: instance.value.hideInBundle ?? false,
+      isInactive: instance.value.isinactive ?? false,
+      isOnline: instance.value.availablewithoutlogin ?? false,
+      hideInBundle: instance.value.hideinbundle ?? false,
       content: getContent(instance.value.content),
       description: instance.value.description ?? '',
     }
@@ -286,9 +286,8 @@ const convertToFileCabinetDetails = (
       path: instance.value.path,
       parent: dirname !== '/' ? pathToId[dirname] : undefined,
       bundleable: instance.value.bundleable ?? false,
-      isInactive: instance.value.isInactive ?? false,
-      isOnline: instance.value.isOnline ?? false,
-      hideInBundle: instance.value.hideInBundle ?? false,
+      isInactive: instance.value.isinactive ?? false,
+      isPrivate: instance.value.isprivate ?? false,
       description: instance.value.description ?? '',
     }
 }
@@ -429,7 +428,7 @@ export const isChangeDeployable = (
   // SuiteApp can't modify files bigger than 10mb
   if (isAdditionOrModificationChange(change)
     && isFileInstance(changedElement)
-    && getContent(changedElement.value.content).length > MAX_DEPLOYABLE_FILE_SIZE) {
+    && getContent(changedElement.value.content).toString('base64').length > MAX_DEPLOYABLE_FILE_SIZE) {
     return false
   }
 

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ObjectType, TypeElement } from '@salto-io/adapter-api'
+import { Element, InstanceElement, isInstanceElement, ObjectType, TypeElement } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { file, folder } from './types/file_cabinet_types'
 import { addressForm, addressFormInnerTypes } from './types/custom_types/addressForm'
@@ -213,6 +213,9 @@ export const isCustomType = (type: ObjectType): boolean =>
 
 export const isFileCabinetType = (type: ObjectType): boolean =>
   !_.isUndefined(fileCabinetTypes[type.elemID.name])
+
+export const isFileCabinetInstance = (element: Element): element is InstanceElement =>
+  isInstanceElement(element) && isFileCabinetType(element.type)
 
 export const getAllTypes = (): TypeElement[] => [
   ...Object.values(customTypes),

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -217,6 +217,10 @@ export const isFileCabinetType = (type: ObjectType): boolean =>
 export const isFileCabinetInstance = (element: Element): element is InstanceElement =>
   isInstanceElement(element) && isFileCabinetType(element.type)
 
+export const isFileInstance = (element: Element): boolean =>
+  isInstanceElement(element) && element.type.elemID.name === 'file'
+
+
 export const getAllTypes = (): TypeElement[] => [
   ...Object.values(customTypes),
   ...innerCustomTypes,

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -41,6 +41,7 @@ import * as changesDetector from '../src/changes_detector/changes_detector'
 import SuiteAppClient from '../src/client/suiteapp_client/suiteapp_client'
 import { SERVER_TIME_TYPE_NAME } from '../src/server_time'
 import * as suiteAppFileCabinet from '../src/suiteapp_file_cabinet'
+import { SDF_CHANGE_GROUP_ID } from '../src/group_changes'
 
 jest.mock('../src/config', () => ({
   ...jest.requireActual<{}>('../src/config'),
@@ -342,7 +343,7 @@ describe('Adapter', () => {
 
     const adapterAdd = (after: ChangeDataType): Promise<DeployResult> => netsuiteAdapter.deploy({
       changeGroup: {
-        groupID: after.elemID.getFullName(),
+        groupID: SDF_CHANGE_GROUP_ID,
         changes: [{ action: 'add', data: { after } }],
       },
     })
@@ -382,7 +383,7 @@ describe('Adapter', () => {
       it('should support deploying multiple changes at once', async () => {
         const result = await netsuiteAdapter.deploy({
           changeGroup: {
-            groupID: 'some group id',
+            groupID: SDF_CHANGE_GROUP_ID,
             changes: [
               { action: 'add', data: { after: fileInstance } },
               { action: 'add', data: { after: folderInstance } },
@@ -401,7 +402,7 @@ describe('Adapter', () => {
         client.deploy = jest.fn().mockRejectedValue(clientError)
         const result = await netsuiteAdapter.deploy({
           changeGroup: {
-            groupID: 'some group id',
+            groupID: SDF_CHANGE_GROUP_ID,
             changes: [
               { action: 'add', data: { after: fileInstance } },
               { action: 'add', data: { after: folderInstance } },
@@ -422,7 +423,7 @@ describe('Adapter', () => {
         before: ChangeDataType, after: ChangeDataType
       ): Promise<DeployResult> => netsuiteAdapter.deploy({
         changeGroup: {
-          groupID: after.elemID.getFullName(),
+          groupID: SDF_CHANGE_GROUP_ID,
           changes: [{ action: 'modify', data: { before, after } }],
         },
       })
@@ -494,7 +495,7 @@ describe('Adapter', () => {
 
       await netsuiteAdapterWithDeployReferencedElements.deploy({
         changeGroup: {
-          groupID: instance.elemID.getFullName(),
+          groupID: SDF_CHANGE_GROUP_ID,
           changes: [{ action: 'add', data: { after: instance } }],
         },
       })

--- a/packages/netsuite-adapter/test/change_validators/file_changes.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/file_changes.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, toChange } from '@salto-io/adapter-api'
+import { InstanceElement, StaticFile, toChange } from '@salto-io/adapter-api'
 import { customtransactiontype } from '../../src/types/custom_types/customtransactiontype'
 import fileValidator from '../../src/change_validators/file_changes'
 import { file } from '../../src/types/file_cabinet_types'
@@ -27,7 +27,7 @@ describe('file changes validator', () => {
       file,
       {
         path: '/Templates/valid',
-        content: { content: BigBuffer },
+        content: new StaticFile({ filepath: 'somePath', content: BigBuffer }),
       },
     )
 
@@ -37,7 +37,7 @@ describe('file changes validator', () => {
       {
         path: '/Templates/valid',
         description: 'aaa',
-        content: { content: BigBuffer },
+        content: new StaticFile({ filepath: 'somePath', content: BigBuffer }),
       },
     )
 
@@ -47,7 +47,7 @@ describe('file changes validator', () => {
       {
         path: '/Templates/valid2',
         generateurltimestamp: false,
-        content: { content: Buffer.from('aaa') },
+        content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
       },
     )
 
@@ -57,7 +57,7 @@ describe('file changes validator', () => {
       {
         path: '/Templates/valid2',
         generateurltimestamp: true,
-        content: { content: Buffer.from('aaa') },
+        content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
       },
     )
 
@@ -66,7 +66,7 @@ describe('file changes validator', () => {
       file,
       {
         path: '/Images/valid3',
-        content: { content: Buffer.from('aaa') },
+        content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
       },
     )
 
@@ -76,7 +76,7 @@ describe('file changes validator', () => {
       {
         path: '/Images/valid3',
         description: 'aaa',
-        content: { content: Buffer.from('aaa') },
+        content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
       },
     )
 
@@ -100,7 +100,7 @@ describe('file changes validator', () => {
       {
         path: '/Images/valid5',
         generateurltimestamp: false,
-        content: { content: Buffer.from('aaa') },
+        content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
       },
     )
 
@@ -123,7 +123,7 @@ describe('file changes validator', () => {
       file,
       {
         path: '/Templates/valid1',
-        content: { content: BigBuffer },
+        content: new StaticFile({ filepath: 'somePath', content: BigBuffer }),
       },
     )
 
@@ -133,7 +133,7 @@ describe('file changes validator', () => {
       {
         path: '/Images/invalid1',
         description: 'aaa',
-        content: { content: BigBuffer },
+        content: new StaticFile({ filepath: 'somePath', content: BigBuffer }),
       },
     )
 
@@ -143,7 +143,7 @@ describe('file changes validator', () => {
       {
         path: '/Images/invalid2',
         generateurltimestamp: false,
-        content: { content: Buffer.from('aaa') },
+        content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
       },
     )
 
@@ -153,7 +153,7 @@ describe('file changes validator', () => {
       {
         path: '/Images/invalid2',
         generateurltimestamp: true,
-        content: { content: Buffer.from('aaa') },
+        content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
       },
     )
 
@@ -163,7 +163,7 @@ describe('file changes validator', () => {
       {
         path: '/Images/invalid3',
         generateurltimestamp: true,
-        content: { content: Buffer.from('aaa') },
+        content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
       },
     )
 

--- a/packages/netsuite-adapter/test/change_validators/file_changes.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/file_changes.test.ts
@@ -14,49 +14,167 @@
 * limitations under the License.
 */
 import { InstanceElement, toChange } from '@salto-io/adapter-api'
+import { customtransactiontype } from '../../src/types/custom_types/customtransactiontype'
 import fileValidator from '../../src/change_validators/file_changes'
 import { file } from '../../src/types/file_cabinet_types'
 
 
 describe('file changes validator', () => {
-  it('should have change error if custom type SCRIPT_ID has been modified', async () => {
-    const validFileBefore = new InstanceElement(
+  it('should not return errors for valid changes', async () => {
+    const BigBuffer = Buffer.from('a'.repeat(1024 * 1024 * 11))
+    const validBigFileBefore = new InstanceElement(
       'valid',
       file,
-      { path: '/Templates/valid' },
+      {
+        path: '/Templates/valid',
+        content: { content: BigBuffer },
+      },
     )
 
-    const validFileAfter = new InstanceElement(
+    const validBigFileAfter = new InstanceElement(
       'valid',
       file,
       {
         path: '/Templates/valid',
         description: 'aaa',
+        content: { content: BigBuffer },
       },
     )
 
-    const invalidFileBefore = new InstanceElement(
-      'invalid',
-      file,
-      { path: '/OtherFolder/invalid' },
-    )
-
-    const invalidFileAfter = new InstanceElement(
-      'invalid',
+    const validTimestampChangeBefore = new InstanceElement(
+      'valid2',
       file,
       {
-        path: '/OtherFolder/invalid',
-        description: 'aaa',
+        path: '/Templates/valid2',
+        generateurltimestamp: false,
+        content: { content: Buffer.from('aaa') },
       },
     )
+
+    const validTimestampChangeAfter = new InstanceElement(
+      'valid2',
+      file,
+      {
+        path: '/Templates/valid2',
+        generateurltimestamp: true,
+        content: { content: Buffer.from('aaa') },
+      },
+    )
+
+    const validDifferentDirChangeBefore = new InstanceElement(
+      'valid3',
+      file,
+      {
+        path: '/Images/valid3',
+        content: { content: Buffer.from('aaa') },
+      },
+    )
+
+    const validDifferentDirChangeAfter = new InstanceElement(
+      'valid3',
+      file,
+      {
+        path: '/Images/valid3',
+        description: 'aaa',
+        content: { content: Buffer.from('aaa') },
+      },
+    )
+
+    const validNonFileChangeBefore = new InstanceElement(
+      'valid4',
+      customtransactiontype,
+      {},
+    )
+
+    const validNonFileChangeAfter = new InstanceElement(
+      'valid4',
+      customtransactiontype,
+      {
+        someField: 'val',
+      },
+    )
+
+    const validNewTimestampChange = new InstanceElement(
+      'valid5',
+      file,
+      {
+        path: '/Images/valid5',
+        generateurltimestamp: false,
+        content: { content: Buffer.from('aaa') },
+      },
+    )
+
     const changeErrors = await fileValidator(
       [
-        toChange({ before: validFileBefore, after: validFileAfter }),
-        toChange({ before: invalidFileBefore, after: invalidFileAfter }),
+        toChange({ before: validBigFileBefore, after: validBigFileAfter }),
+        toChange({ before: validTimestampChangeBefore, after: validTimestampChangeAfter }),
+        toChange({ before: validDifferentDirChangeBefore, after: validDifferentDirChangeAfter }),
+        toChange({ before: validNonFileChangeBefore, after: validNonFileChangeAfter }),
+        toChange({ after: validNewTimestampChange }),
       ]
     )
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0].severity).toEqual('Error')
-    expect(changeErrors[0].elemID).toEqual(invalidFileBefore.elemID)
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('should return errors for invalid changes', async () => {
+    const BigBuffer = Buffer.from('a'.repeat(1024 * 1024 * 11))
+    const invalidBigFileBefore = new InstanceElement(
+      'invalid1',
+      file,
+      {
+        path: '/Templates/valid1',
+        content: { content: BigBuffer },
+      },
+    )
+
+    const invalidBigFileAfter = new InstanceElement(
+      'invalid1',
+      file,
+      {
+        path: '/Images/invalid1',
+        description: 'aaa',
+        content: { content: BigBuffer },
+      },
+    )
+
+    const invalidTimestampChangeBefore = new InstanceElement(
+      'invalid2',
+      file,
+      {
+        path: '/Images/invalid2',
+        generateurltimestamp: false,
+        content: { content: Buffer.from('aaa') },
+      },
+    )
+
+    const invalidTimestampChangeAfter = new InstanceElement(
+      'invalid2',
+      file,
+      {
+        path: '/Images/invalid2',
+        generateurltimestamp: true,
+        content: { content: Buffer.from('aaa') },
+      },
+    )
+
+    const invalidNewTimestampChange = new InstanceElement(
+      'invalid3',
+      file,
+      {
+        path: '/Images/invalid3',
+        generateurltimestamp: true,
+        content: { content: Buffer.from('aaa') },
+      },
+    )
+
+    const changeErrors = await fileValidator(
+      [
+        toChange({ before: invalidBigFileBefore, after: invalidBigFileAfter }),
+        toChange({ before: invalidTimestampChangeBefore, after: invalidTimestampChangeAfter }),
+        toChange({ after: invalidNewTimestampChange }),
+
+      ]
+    )
+    expect(changeErrors).toHaveLength(3)
   })
 })

--- a/packages/netsuite-adapter/test/client/soap_client.test.ts
+++ b/packages/netsuite-adapter/test/client/soap_client.test.ts
@@ -87,8 +87,7 @@ describe('soap_client', () => {
           id: 62330,
           bundleable: true,
           isInactive: false,
-          isOnline: false,
-          hideInBundle: true,
+          isPrivate: false,
           description: 'desc',
         },
       ])).toEqual([
@@ -120,8 +119,7 @@ describe('soap_client', () => {
           id: 62330,
           bundleable: true,
           isInactive: false,
-          isOnline: false,
-          hideInBundle: true,
+          isPrivate: false,
           description: 'desc',
         },
       ])).rejects.toThrow('Failed to updateList: error code: SOME_ERROR, error message: SOME_ERROR')
@@ -150,8 +148,7 @@ describe('soap_client', () => {
           id: 62330,
           bundleable: true,
           isInactive: false,
-          isOnline: false,
-          hideInBundle: true,
+          isPrivate: false,
           description: 'desc',
         },
       ])).rejects.toThrow('Got invalid response from updateList request. Errors:')
@@ -181,8 +178,7 @@ describe('soap_client', () => {
           parent: -600,
           bundleable: true,
           isInactive: false,
-          isOnline: false,
-          hideInBundle: true,
+          isPrivate: false,
           description: 'desc',
         },
       ])).toEqual([
@@ -213,8 +209,7 @@ describe('soap_client', () => {
           parent: -600,
           bundleable: true,
           isInactive: false,
-          isOnline: false,
-          hideInBundle: true,
+          isPrivate: false,
           description: 'desc',
         },
       ])).rejects.toThrow('Failed to addList: error code: SOME_ERROR, error message: SOME_ERROR')
@@ -242,8 +237,7 @@ describe('soap_client', () => {
           parent: -600,
           bundleable: true,
           isInactive: false,
-          isOnline: false,
-          hideInBundle: true,
+          isPrivate: false,
           description: 'desc',
         },
       ])).rejects.toThrow('Got invalid response from addList request. Errors:')

--- a/packages/netsuite-adapter/test/client/soap_client.test.ts
+++ b/packages/netsuite-adapter/test/client/soap_client.test.ts
@@ -16,7 +16,7 @@
 import axios from 'axios'
 import { ReadFileError } from '../../src/client/suiteapp_client/errors'
 import SoapClient from '../../src/client/suiteapp_client/soap_client/soap_client'
-import { READ_FAILURE_RESPONSE, READ_INVALID_RESPONSE, READ_SUCCESS_RESPONSE, READ_SUCCESS_RESPONSE_NO_CONTENT } from './soap_responses'
+import { ADD_FILE_CABINET_ERROR_RESPONSE, ADD_FILE_CABINET_INVALID_RESPONSE, ADD_FILE_CABINET_SUCCESS_RESPONSE, READ_FAILURE_RESPONSE, READ_INVALID_RESPONSE, READ_SUCCESS_RESPONSE, READ_SUCCESS_RESPONSE_NO_CONTENT, UPDATE_FILE_CABINET_ERROR_RESPONSE, UPDATE_FILE_CABINET_INVALID_RESPONSE, UPDATE_FILE_CABINET_SUCCESS_RESPONSE } from './soap_responses'
 
 
 describe('soap_client', () => {
@@ -61,6 +61,192 @@ describe('soap_client', () => {
         data: READ_INVALID_RESPONSE,
       })
       await expect(client.readFile(1)).rejects.toThrow(Error)
+    })
+  })
+  describe('updateFileCabinet', () => {
+    it('should return the id is success and the error if fails', async () => {
+      postMock.mockResolvedValue({
+        data: UPDATE_FILE_CABINET_SUCCESS_RESPONSE,
+      })
+      expect(await client.updateFileCabinet([
+        {
+          type: 'file',
+          path: 'somePath',
+          id: 6233,
+          folder: -6,
+          bundleable: true,
+          isInactive: false,
+          isOnline: false,
+          hideInBundle: true,
+          content: Buffer.from('aaa'),
+          description: 'desc',
+        },
+        {
+          type: 'folder',
+          path: 'somePath2',
+          id: 62330,
+          bundleable: true,
+          isInactive: false,
+          isOnline: false,
+          hideInBundle: true,
+          description: 'desc',
+        },
+      ])).toEqual([
+        6233,
+        new Error('SOAP api call to update file cabinet instance somePath2 failed. error code: MEDIA_NOT_FOUND, error message: Media item not found 62330'),
+      ])
+    })
+
+    it('should throw an error if request fails', async () => {
+      postMock.mockResolvedValue({
+        data: UPDATE_FILE_CABINET_ERROR_RESPONSE,
+      })
+      await expect(client.updateFileCabinet([
+        {
+          type: 'file',
+          path: 'somePath',
+          id: 6233,
+          folder: -6,
+          bundleable: true,
+          isInactive: false,
+          isOnline: false,
+          hideInBundle: true,
+          content: Buffer.from('aaa'),
+          description: 'desc',
+        },
+        {
+          type: 'folder',
+          path: 'somePath2',
+          id: 62330,
+          bundleable: true,
+          isInactive: false,
+          isOnline: false,
+          hideInBundle: true,
+          description: 'desc',
+        },
+      ])).rejects.toThrow('Failed to updateList: error code: SOME_ERROR, error message: SOME_ERROR')
+    })
+
+    it('should throw an error if received invalid response', async () => {
+      postMock.mockResolvedValue({
+        data: UPDATE_FILE_CABINET_INVALID_RESPONSE,
+      })
+      await expect(client.updateFileCabinet([
+        {
+          type: 'file',
+          path: 'somePath',
+          id: 6233,
+          folder: -6,
+          bundleable: true,
+          isInactive: false,
+          isOnline: false,
+          hideInBundle: true,
+          content: Buffer.from('aaa'),
+          description: 'desc',
+        },
+        {
+          type: 'folder',
+          path: 'somePath2',
+          id: 62330,
+          bundleable: true,
+          isInactive: false,
+          isOnline: false,
+          hideInBundle: true,
+          description: 'desc',
+        },
+      ])).rejects.toThrow('Got invalid response from updateList request. Errors:')
+    })
+  })
+
+  describe('addFileCabinetInstances', () => {
+    it('should return the id is success and the error if fails', async () => {
+      postMock.mockResolvedValue({
+        data: ADD_FILE_CABINET_SUCCESS_RESPONSE,
+      })
+      expect(await client.addFileCabinetInstances([
+        {
+          type: 'file',
+          path: 'addedFile',
+          folder: -6,
+          bundleable: true,
+          isInactive: false,
+          isOnline: false,
+          hideInBundle: true,
+          content: Buffer.from('aaa'),
+          description: 'desc',
+        },
+        {
+          type: 'folder',
+          path: 'addedFile2',
+          parent: -600,
+          bundleable: true,
+          isInactive: false,
+          isOnline: false,
+          hideInBundle: true,
+          description: 'desc',
+        },
+      ])).toEqual([
+        6334,
+        new Error('SOAP api call to add file cabinet instance addedFile2 failed. error code: INVALID_KEY_OR_REF, error message: Invalid folder reference key -600.'),
+      ])
+    })
+
+    it('should throw an error if request fails', async () => {
+      postMock.mockResolvedValue({
+        data: ADD_FILE_CABINET_ERROR_RESPONSE,
+      })
+      await expect(client.addFileCabinetInstances([
+        {
+          type: 'file',
+          path: 'addedFile',
+          folder: -6,
+          bundleable: true,
+          isInactive: false,
+          isOnline: false,
+          hideInBundle: true,
+          content: Buffer.from('aaa'),
+          description: 'desc',
+        },
+        {
+          type: 'folder',
+          path: 'addedFile2',
+          parent: -600,
+          bundleable: true,
+          isInactive: false,
+          isOnline: false,
+          hideInBundle: true,
+          description: 'desc',
+        },
+      ])).rejects.toThrow('Failed to addList: error code: SOME_ERROR, error message: SOME_ERROR')
+    })
+
+    it('should throw an error if received invalid response', async () => {
+      postMock.mockResolvedValue({
+        data: ADD_FILE_CABINET_INVALID_RESPONSE,
+      })
+      await expect(client.addFileCabinetInstances([
+        {
+          type: 'file',
+          path: 'addedFile',
+          folder: -6,
+          bundleable: true,
+          isInactive: false,
+          isOnline: false,
+          hideInBundle: true,
+          content: Buffer.from('aaa'),
+          description: 'desc',
+        },
+        {
+          type: 'folder',
+          path: 'addedFile2',
+          parent: -600,
+          bundleable: true,
+          isInactive: false,
+          isOnline: false,
+          hideInBundle: true,
+          description: 'desc',
+        },
+      ])).rejects.toThrow('Got invalid response from addList request. Errors:')
     })
   })
 })

--- a/packages/netsuite-adapter/test/client/soap_responses.ts
+++ b/packages/netsuite-adapter/test/client/soap_responses.ts
@@ -157,3 +157,148 @@ export const READ_INVALID_RESPONSE = `<?xml version="1.0" encoding="UTF-8"?>
         </getResponse>
     </soapenv:Body>
 </soapenv:Envelope>`
+
+export const UPDATE_FILE_CABINET_SUCCESS_RESPONSE = `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Header>
+        <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2020_2.platform.webservices.netsuite.com">
+            <platformMsgs:nsId>WEBSERVICES_TSTDRV2259448_040420211679021275384972772_5a58ea</platformMsgs:nsId>
+        </platformMsgs:documentInfo>
+    </soapenv:Header>
+    <soapenv:Body>
+        <updateListResponse xmlns="">
+            <writeResponseList xmlns:platformMsgs="urn:messages_2020_2.platform.webservices.netsuite.com">
+                <platformCore:status isSuccess="true" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com"/>
+                <writeResponse>
+                    <platformCore:status isSuccess="true" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com">
+                        <platformCore:statusDetail>
+                            <platformCore:afterSubmitFailed>false</platformCore:afterSubmitFailed>
+                        </platformCore:statusDetail>
+                    </platformCore:status>
+                    <baseRef internalId="6233" type="file" xsi:type="platformCore:RecordRef" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com"/>
+                </writeResponse>
+                <writeResponse>
+                    <platformCore:status isSuccess="false" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com">
+                        <platformCore:statusDetail type="ERROR">
+                            <platformCore:code>MEDIA_NOT_FOUND</platformCore:code>
+                            <platformCore:message>Media item not found 62330</platformCore:message>
+                        </platformCore:statusDetail>
+                    </platformCore:status>
+                    <baseRef internalId="62330" type="file" xsi:type="platformCore:RecordRef" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com"/>
+                </writeResponse>
+            </writeResponseList>
+        </updateListResponse>
+    </soapenv:Body>
+</soapenv:Envelope>`
+
+export const UPDATE_FILE_CABINET_ERROR_RESPONSE = `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Header>
+        <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2020_2.platform.webservices.netsuite.com">
+            <platformMsgs:nsId>WEBSERVICES_TSTDRV2259448_040420211679021275384972772_5a58ea</platformMsgs:nsId>
+        </platformMsgs:documentInfo>
+    </soapenv:Header>
+    <soapenv:Body>
+        <updateListResponse xmlns="">
+            <writeResponseList xmlns:platformMsgs="urn:messages_2020_2.platform.webservices.netsuite.com">
+              <platformCore:status isSuccess="false" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com">
+                <platformCore:statusDetail type="ERROR">
+                  <platformCore:code>SOME_ERROR</platformCore:code>
+                  <platformCore:message>SOME_ERROR</platformCore:message>
+                </platformCore:statusDetail>
+              </platformCore:status>
+            </writeResponseList>
+        </updateListResponse>
+    </soapenv:Body>
+</soapenv:Envelope>`
+
+export const UPDATE_FILE_CABINET_INVALID_RESPONSE = `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Header>
+        <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2020_2.platform.webservices.netsuite.com">
+            <platformMsgs:nsId>WEBSERVICES_TSTDRV2259448_040420211679021275384972772_5a58ea</platformMsgs:nsId>
+        </platformMsgs:documentInfo>
+    </soapenv:Header>
+    <soapenv:Body>
+        <updateListResponse xmlns="">
+            <writeResponseList xmlns:platformMsgs="urn:messages_2020_2.platform.webservices.netsuite.com">
+                <platformCore:status isSuccess="true" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com"/>
+                <writeResponse>
+                    <platformCore:status isSuccess="false" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com">
+                    </platformCore:status>
+                    <baseRef internalId="62330" type="file" xsi:type="platformCore:RecordRef" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com"/>
+                </writeResponse>
+            </writeResponseList>
+        </updateListResponse>
+    </soapenv:Body>
+</soapenv:Envelope>`
+
+export const ADD_FILE_CABINET_SUCCESS_RESPONSE = `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Header>
+        <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2020_2.platform.webservices.netsuite.com">
+            <platformMsgs:nsId>WEBSERVICES_TSTDRV2259448_0404202116668635922013689574_7ac6b</platformMsgs:nsId>
+        </platformMsgs:documentInfo>
+    </soapenv:Header>
+    <soapenv:Body>
+        <addListResponse xmlns="urn:messages_2020_2.platform.webservices.netsuite.com">
+            <writeResponseList>
+                <platformCore:status isSuccess="true" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com"/>
+                <writeResponse>
+                    <platformCore:status isSuccess="true" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com">
+                        <platformCore:statusDetail>
+                            <platformCore:afterSubmitFailed>false</platformCore:afterSubmitFailed>
+                        </platformCore:statusDetail>
+                    </platformCore:status>
+                    <baseRef internalId="6334" type="file" xsi:type="platformCore:RecordRef" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com"/>
+                </writeResponse>
+                <writeResponse>
+                    <platformCore:status isSuccess="false" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com">
+                        <platformCore:statusDetail type="ERROR">
+                            <platformCore:code>INVALID_KEY_OR_REF</platformCore:code>
+                            <platformCore:message>Invalid folder reference key -600.</platformCore:message>
+                        </platformCore:statusDetail>
+                    </platformCore:status>
+                </writeResponse>
+            </writeResponseList>
+        </addListResponse>
+    </soapenv:Body>
+</soapenv:Envelope>`
+
+export const ADD_FILE_CABINET_ERROR_RESPONSE = `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Header>
+        <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2020_2.platform.webservices.netsuite.com">
+            <platformMsgs:nsId>WEBSERVICES_TSTDRV2259448_0404202116668635922013689574_7ac6b</platformMsgs:nsId>
+        </platformMsgs:documentInfo>
+    </soapenv:Header>
+    <soapenv:Body>
+        <addListResponse xmlns="urn:messages_2020_2.platform.webservices.netsuite.com">
+          <writeResponseList xmlns:platformMsgs="urn:messages_2020_2.platform.webservices.netsuite.com">
+            <platformCore:status isSuccess="false" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com">
+              <platformCore:statusDetail type="ERROR">
+                <platformCore:code>SOME_ERROR</platformCore:code>
+                <platformCore:message>SOME_ERROR</platformCore:message>
+              </platformCore:statusDetail>
+            </platformCore:status>
+          </writeResponseList>
+        </addListResponse>
+    </soapenv:Body>
+</soapenv:Envelope>`
+
+export const ADD_FILE_CABINET_INVALID_RESPONSE = `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Header>
+        <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2020_2.platform.webservices.netsuite.com">
+            <platformMsgs:nsId>WEBSERVICES_TSTDRV2259448_0404202116668635922013689574_7ac6b</platformMsgs:nsId>
+        </platformMsgs:documentInfo>
+    </soapenv:Header>
+    <soapenv:Body>
+        <addListResponse xmlns="urn:messages_2020_2.platform.webservices.netsuite.com">
+          <writeResponseList xmlns:platformMsgs="urn:messages_2020_2.platform.webservices.netsuite.com">
+            <platformCore:status isSuccess="false" xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com">
+            </platformCore:status>
+          </writeResponseList>
+        </addListResponse>
+    </soapenv:Body>
+</soapenv:Envelope>`

--- a/packages/netsuite-adapter/test/group_changes.test.ts
+++ b/packages/netsuite-adapter/test/group_changes.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeGroupId, ChangeId, ElemID, InstanceElement, ObjectType, toChange, Change } from '@salto-io/adapter-api'
+import { ChangeGroupId, ChangeId, ElemID, InstanceElement, ObjectType, toChange, Change, StaticFile } from '@salto-io/adapter-api'
 import { getChangeGroupIdsFunc, SDF_CHANGE_GROUP_ID } from '../src/group_changes'
 import { customTypes, fileCabinetTypes } from '../src/types'
 import { ENTITY_CUSTOM_FIELD, FILE, NETSUITE } from '../src/constants'
@@ -66,7 +66,7 @@ describe('Group Changes with Salto suiteApp', () => {
     fileCabinetTypes[FILE],
     {
       path: '/Images/file',
-      content: { content: Buffer.from('aaa') },
+      content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
     }
   )
 
@@ -75,7 +75,7 @@ describe('Group Changes with Salto suiteApp', () => {
     fileCabinetTypes[FILE],
     {
       path: '/Templates/file',
-      content: { content: Buffer.from('aaa') },
+      content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
     }
   )
 
@@ -84,7 +84,7 @@ describe('Group Changes with Salto suiteApp', () => {
     fileCabinetTypes[FILE],
     {
       path: '/Images/file3',
-      content: { content: Buffer.from('aaa') },
+      content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
     }
   )
 
@@ -94,7 +94,7 @@ describe('Group Changes with Salto suiteApp', () => {
     {
       path: '/Images/file3',
       description: 'aa',
-      content: { content: Buffer.from('aaa') },
+      content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
     }
   )
 
@@ -103,7 +103,7 @@ describe('Group Changes with Salto suiteApp', () => {
     fileCabinetTypes[FILE],
     {
       path: '/Templates/file',
-      content: { content: Buffer.from('a'.repeat(11 * 1024 * 1024)) },
+      content: new StaticFile({ filepath: 'somePath', content: Buffer.from('a'.repeat(11 * 1024 * 1024)) }),
     }
   )
   const sdfFileInstance2 = new InstanceElement(
@@ -112,7 +112,7 @@ describe('Group Changes with Salto suiteApp', () => {
     {
       path: '/Templates/file',
       generateurltimestamp: true,
-      content: { content: Buffer.from('aaa') },
+      content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
     }
   )
 

--- a/packages/netsuite-adapter/test/group_changes.test.ts
+++ b/packages/netsuite-adapter/test/group_changes.test.ts
@@ -14,11 +14,11 @@
 * limitations under the License.
 */
 import { ChangeGroupId, ChangeId, ElemID, InstanceElement, ObjectType, toChange, Change } from '@salto-io/adapter-api'
-import { getChangeGroupIds, SDF_CHANGE_GROUP_ID } from '../src/group_changes'
+import { getChangeGroupIdsFunc, SDF_CHANGE_GROUP_ID } from '../src/group_changes'
 import { customTypes, fileCabinetTypes } from '../src/types'
 import { ENTITY_CUSTOM_FIELD, FILE, NETSUITE } from '../src/constants'
 
-describe('Group Changes', () => {
+describe('Group Changes without Salto suiteApp', () => {
   const customFieldInstance = new InstanceElement('elementName',
     customTypes[ENTITY_CUSTOM_FIELD])
 
@@ -29,7 +29,7 @@ describe('Group Changes', () => {
   let changeGroupIds: Map<ChangeId, ChangeGroupId>
 
   beforeAll(async () => {
-    changeGroupIds = await getChangeGroupIds(new Map<string, Change>([
+    changeGroupIds = await getChangeGroupIdsFunc(false)(new Map<string, Change>([
       [fileInstance.elemID.getFullName(), toChange({ after: fileInstance })],
       [customFieldInstance.elemID.getFullName(), toChange({ after: customFieldInstance })],
       [nonSdfInstance.elemID.getFullName(), toChange({ after: nonSdfInstance })],
@@ -38,12 +38,127 @@ describe('Group Changes', () => {
   })
 
   it('should set correct group id for custom types instances', () => {
-    expect(changeGroupIds.get(fileInstance.elemID.getFullName())).toEqual(SDF_CHANGE_GROUP_ID)
+    expect(changeGroupIds.get(customFieldInstance.elemID.getFullName()))
+      .toEqual(SDF_CHANGE_GROUP_ID)
   })
 
   it('should set correct group id for file cabinet types instances', () => {
+    expect(changeGroupIds.get(fileInstance.elemID.getFullName())).toEqual(SDF_CHANGE_GROUP_ID)
+  })
+
+  it('should not set group id for non SDF types instances', () => {
+    expect(changeGroupIds.has(nonSdfInstance.elemID.getFullName())).toBe(false)
+  })
+
+  it('should not set group id for non SDF types', () => {
+    expect(changeGroupIds.has(dummyType.elemID.getFullName())).toBe(false)
+  })
+})
+
+describe('Group Changes with Salto suiteApp', () => {
+  const customFieldInstance = new InstanceElement('elementName',
+    customTypes[ENTITY_CUSTOM_FIELD])
+  const dummyType = new ObjectType({ elemID: new ElemID(NETSUITE, 'dummytype') })
+  const nonSdfInstance = new InstanceElement('nonSdfInstance', dummyType)
+
+  const suiteAppFileInstance1 = new InstanceElement(
+    'fileInstance',
+    fileCabinetTypes[FILE],
+    {
+      path: '/Images/file',
+      content: { content: Buffer.from('aaa') },
+    }
+  )
+
+  const suiteAppFileInstance2 = new InstanceElement(
+    'fileInstance2',
+    fileCabinetTypes[FILE],
+    {
+      path: '/Templates/file',
+      content: { content: Buffer.from('aaa') },
+    }
+  )
+
+  const suiteAppFileInstance3Before = new InstanceElement(
+    'fileInstance3',
+    fileCabinetTypes[FILE],
+    {
+      path: '/Images/file3',
+      content: { content: Buffer.from('aaa') },
+    }
+  )
+
+  const suiteAppFileInstance3After = new InstanceElement(
+    'fileInstance3',
+    fileCabinetTypes[FILE],
+    {
+      path: '/Images/file3',
+      description: 'aa',
+      content: { content: Buffer.from('aaa') },
+    }
+  )
+
+  const sdfFileInstance1 = new InstanceElement(
+    'fileInstance4',
+    fileCabinetTypes[FILE],
+    {
+      path: '/Templates/file',
+      content: { content: Buffer.from('a'.repeat(11 * 1024 * 1024)) },
+    }
+  )
+  const sdfFileInstance2 = new InstanceElement(
+    'fileInstance5',
+    fileCabinetTypes[FILE],
+    {
+      path: '/Templates/file',
+      generateurltimestamp: true,
+      content: { content: Buffer.from('aaa') },
+    }
+  )
+
+  let changeGroupIds: Map<ChangeId, ChangeGroupId>
+
+
+  beforeAll(async () => {
+    changeGroupIds = await getChangeGroupIdsFunc(true)(new Map<string, Change>([
+      [customFieldInstance.elemID.getFullName(), toChange({ after: customFieldInstance })],
+      [nonSdfInstance.elemID.getFullName(), toChange({ after: nonSdfInstance })],
+      [dummyType.elemID.getFullName(), toChange({ after: dummyType })],
+      [suiteAppFileInstance1.elemID.getFullName(), toChange({ after: suiteAppFileInstance1 })],
+      [suiteAppFileInstance2.elemID.getFullName(), toChange({ after: suiteAppFileInstance2 })],
+      [
+        suiteAppFileInstance3Before.elemID.getFullName(),
+        toChange({ before: suiteAppFileInstance3Before, after: suiteAppFileInstance3After }),
+      ],
+      [sdfFileInstance1.elemID.getFullName(), toChange({ after: sdfFileInstance1 })],
+      [sdfFileInstance2.elemID.getFullName(), toChange({ after: sdfFileInstance2 })],
+    ]))
+  })
+
+  it('should set correct group id for custom types instances', () => {
     expect(changeGroupIds.get(customFieldInstance.elemID.getFullName()))
-      .toEqual(SDF_CHANGE_GROUP_ID)
+      .toEqual('Records')
+  })
+
+  it('should set correct group id for new suiteApp file instances', () => {
+    expect(changeGroupIds.get(suiteAppFileInstance1.elemID.getFullName()))
+      .toEqual('Salto SuiteApp - File Cabinet - Creating Files')
+
+    expect(changeGroupIds.get(suiteAppFileInstance2.elemID.getFullName()))
+      .toEqual('Salto SuiteApp - File Cabinet - Creating Files')
+  })
+
+  it('should set correct group id for existing suiteApp file instances', () => {
+    expect(changeGroupIds.get(suiteAppFileInstance3Before.elemID.getFullName()))
+      .toEqual('Salto SuiteApp - File Cabinet - Updating Files')
+  })
+
+  it('should set correct group id for SDF file instances', () => {
+    expect(changeGroupIds.get(sdfFileInstance1.elemID.getFullName()))
+      .toEqual('SDF - File Cabinet')
+
+    expect(changeGroupIds.get(sdfFileInstance2.elemID.getFullName()))
+      .toEqual('SDF - File Cabinet')
   })
 
   it('should not set group id for non SDF types instances', () => {

--- a/packages/netsuite-adapter/test/group_changes.test.ts
+++ b/packages/netsuite-adapter/test/group_changes.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ChangeGroupId, ChangeId, ElemID, InstanceElement, ObjectType, toChange, Change, StaticFile } from '@salto-io/adapter-api'
-import { getChangeGroupIdsFunc, SDF_CHANGE_GROUP_ID } from '../src/group_changes'
+import { getChangeGroupIdsFunc, SDF_CHANGE_GROUP_ID, SUITEAPP_CREATING_FILES_GROUP_ID, SUITEAPP_UPDATING_FILES_GROUP_ID } from '../src/group_changes'
 import { customTypes, fileCabinetTypes } from '../src/types'
 import { ENTITY_CUSTOM_FIELD, FILE, NETSUITE } from '../src/constants'
 
@@ -137,28 +137,28 @@ describe('Group Changes with Salto suiteApp', () => {
 
   it('should set correct group id for custom types instances', () => {
     expect(changeGroupIds.get(customFieldInstance.elemID.getFullName()))
-      .toEqual('Records')
+      .toEqual(SDF_CHANGE_GROUP_ID)
   })
 
   it('should set correct group id for new suiteApp file instances', () => {
     expect(changeGroupIds.get(suiteAppFileInstance1.elemID.getFullName()))
-      .toEqual('Salto SuiteApp - File Cabinet - Creating Files')
+      .toEqual(SUITEAPP_CREATING_FILES_GROUP_ID)
 
     expect(changeGroupIds.get(suiteAppFileInstance2.elemID.getFullName()))
-      .toEqual('Salto SuiteApp - File Cabinet - Creating Files')
+      .toEqual(SUITEAPP_CREATING_FILES_GROUP_ID)
   })
 
   it('should set correct group id for existing suiteApp file instances', () => {
     expect(changeGroupIds.get(suiteAppFileInstance3Before.elemID.getFullName()))
-      .toEqual('Salto SuiteApp - File Cabinet - Updating Files')
+      .toEqual(SUITEAPP_UPDATING_FILES_GROUP_ID)
   })
 
   it('should set correct group id for SDF file instances', () => {
     expect(changeGroupIds.get(sdfFileInstance1.elemID.getFullName()))
-      .toEqual('SDF - File Cabinet')
+      .toEqual(SDF_CHANGE_GROUP_ID)
 
     expect(changeGroupIds.get(sdfFileInstance2.elemID.getFullName()))
-      .toEqual('SDF - File Cabinet')
+      .toEqual(SDF_CHANGE_GROUP_ID)
   })
 
   it('should not set group id for non SDF types instances', () => {

--- a/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, InstanceElement, toChange } from '@salto-io/adapter-api'
+import { Change, InstanceElement, StaticFile, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { NetsuiteQuery } from '../src/query'
 import SuiteAppClient from '../src/client/suiteapp_client/suiteapp_client'
@@ -353,7 +353,7 @@ describe('suiteapp_file_cabinet', () => {
           fileCabinetTypes[FILE],
           {
             path: '/Templates/invalid1',
-            content: { content: Buffer.from('a'.repeat(11 * 1024 * 1024)) },
+            content: new StaticFile({ filepath: 'somePath', content: Buffer.from('a'.repeat(11 * 1024 * 1024)) }),
           }
         ),
         new InstanceElement(
@@ -362,7 +362,7 @@ describe('suiteapp_file_cabinet', () => {
           {
             path: '/Templates/invalid2',
             generateurltimestamp: true,
-            content: { content: Buffer.from('aaa') },
+            content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
           }
         ),
         new InstanceElement(
@@ -371,6 +371,14 @@ describe('suiteapp_file_cabinet', () => {
           {}
         ),
         customtransactiontype,
+        new InstanceElement(
+          'invalid4',
+          fileCabinetTypes[FILE],
+          {
+            path: '/Templates/invalid1',
+            content: 'a'.repeat(11 * 1024 * 1024),
+          }
+        ),
       ]
 
       expect(
@@ -386,7 +394,7 @@ describe('suiteapp_file_cabinet', () => {
         fileCabinetTypes[FILE],
         {
           path: '/Templates/valid1',
-          content: { content: Buffer.from('aaa') },
+          content: new StaticFile({ filepath: 'somePath', content: Buffer.from('aaa') }),
         }
       )
 


### PR DESCRIPTION
Added support for deploying the entire file cabinet using the SuiteApp.

This PR includes:

- Adding the functionality of updating and creating files and folders through SOAP API.

- Using the new functionality to deploy the changes in the `suiteapp_file_cabinet`.

In case of additions, we need to deploy new folders before new files inside of those folders. To do so, we split the new changes into groups by the depth for the path of each file and deploy the groups in the order of their depths so a folder will always be deployed before the files inside it.

- Splitting the changes into the following groups:
    - "Records" - Changes of anything that is not the file cabinet using SDF
    - "Salto SuiteApp - File Cabinet - Creating Files" - Additions of new files and folders to the file cabinet to be deployed through the SuiteApp.
    - "Salto SuiteApp - File Cabinet - Updating Files" - Modifications to files and folders to the file cabinet to be deployed through the SuiteApp.
    - "SDF - File Cabinet" - Changes to files and folders to be deployed through SDF because we can't deploy them through the SuiteApp.
  
We can't deploy a file cabinet instance using the SuiteApp when: it's a file whose content is above 10 MB, or there is a change to the `generateurltimestamp` field.
 
- Change Validation that the file cabinet changes are deployable.

If we can't use both the SuiteApp and SDF (where the conditions above are applied and the file is not under SDF supported paths), then a change validator will raise an error.

---
_Release Notes_: 
Support deploying the entire file cabinet (and not just the folders '/SuiteScripts' '/Templates' '/Web Site Hosting Files') when Salto SuiteApp is configured.
