### PR TITLE
changed parent to reference the element itself

### DIFF
--- a/packages/netsuite-adapter/src/filters/instance_references.ts
+++ b/packages/netsuite-adapter/src/filters/instance_references.ts
@@ -15,7 +15,7 @@
 */
 import {
   Element, isInstanceElement, Values, ObjectType, ElemID, ReferenceExpression, InstanceElement,
-  InstanceAnnotationTypes, TypeMap,
+  InstanceAnnotationTypes, TypeMap, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import {
   transformElement,
@@ -99,7 +99,7 @@ const replaceReferenceValues = (
   fetchedElementsServiceIdToElemID: Record<string, ElemID>,
   elementsSourceServiceIdToElemID: Record<string, ElemID>,
 ): Values => {
-  const replacePrimitive: TransformFunc = ({ value }) => {
+  const replacePrimitive: TransformFunc = ({ field, value }) => {
     if (!_.isString(value)) {
       return value
     }
@@ -113,6 +113,12 @@ const replaceReferenceValues = (
     if (_.isUndefined(elemID)) {
       return value
     }
+
+
+    if (field?.name === CORE_ANNOTATIONS.PARENT) {
+      return new ReferenceExpression(elemID.createBaseID().parent)
+    }
+
     return new ReferenceExpression(elemID)
   }
 

--- a/packages/netsuite-adapter/test/filters/instance_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/instance_references.test.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import {
+  CORE_ANNOTATIONS,
   ElemID, InstanceElement, ObjectType, ReferenceExpression,
 } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/instance_references'
@@ -85,6 +86,7 @@ describe('instance_references filter', () => {
         {
           refToFilePath: '[/Templates/file.name]',
           refToScriptId: '[scriptid=top_level]',
+          [CORE_ANNOTATIONS.PARENT]: '[/Templates/file.name]',
         }
       )
     })
@@ -122,6 +124,17 @@ describe('instance_references filter', () => {
         .toEqual(new ReferenceExpression(fileInstance.elemID.createNestedID(PATH)))
       expect(instanceWithRefs.annotations.refToScriptId)
         .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID(SCRIPT_ID)))
+    })
+
+    it('parent should reference the element itself', async () => {
+      await filterCreator().onFetch({
+        elements: [fileInstance, workflowInstance, instanceWithRefs],
+        elementsSourceIndex,
+        isPartial: false,
+      })
+
+      expect(instanceWithRefs.annotations[CORE_ANNOTATIONS.PARENT])
+        .toEqual(new ReferenceExpression(fileInstance.elemID))
     })
 
     it('should replace scriptid with 1 nesting level references', async () => {


### PR DESCRIPTION
Following a conversion with @ori-moisis, it would be better if the `_parent` annotations in NetSuite file cabinet instances would reference the parent element itself and not its path.

---
_Release Notes_: 
None