### PR TITLE
changed parent to reference the element itself

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
@@ -20,7 +20,11 @@ import {
 import _ from 'lodash'
 import { isCustomType, isFileCabinetType } from '../types'
 
-const getReferenceValue = (val: unknown): unknown =>
+// In netsuite, a reference can be either a ReferenceExpression
+// or a string of the form [/some/path] or [scriptid=someid] if no reference was found.
+// In the case of ReferenceExpression, we would want to compare using the elemID,
+// otherwise we can use the string.
+const getReferenceIdentifier = (val: unknown): unknown =>
   (isReferenceExpression(val) ? val.elemId.getFullName() : val)
 
 const changeValidator: ChangeValidator = async changes => (
@@ -43,8 +47,8 @@ const changeValidator: ChangeValidator = async changes => (
 
       // parent annotations in file cabinet instances
       if (isFileCabinetType(after.type)
-        && getReferenceValue(before.annotations[CORE_ANNOTATIONS.PARENT])
-          !== getReferenceValue(after.annotations[CORE_ANNOTATIONS.PARENT])) {
+        && getReferenceIdentifier(before.annotations[CORE_ANNOTATIONS.PARENT])
+          !== getReferenceIdentifier(after.annotations[CORE_ANNOTATIONS.PARENT])) {
         modifiedImmutableFields.push(CORE_ANNOTATIONS.PARENT)
       }
       return modifiedImmutableFields.map(modifiedField => ({

--- a/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
@@ -17,6 +17,7 @@ import {
   BuiltinTypes, ChangeError, ChangeValidator, CORE_ANNOTATIONS, getChangeElement, InstanceElement,
   isInstanceChange, isModificationChange, isReferenceExpression,
 } from '@salto-io/adapter-api'
+import { getParents } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { isCustomType, isFileCabinetType } from '../types'
 
@@ -47,8 +48,10 @@ const changeValidator: ChangeValidator = async changes => (
 
       // parent annotations in file cabinet instances
       if (isFileCabinetType(after.type)
-        && getReferenceIdentifier(before.annotations[CORE_ANNOTATIONS.PARENT])
-          !== getReferenceIdentifier(after.annotations[CORE_ANNOTATIONS.PARENT])) {
+        && !_.isEqual(
+          getParents(before).map(getReferenceIdentifier),
+          getParents(after).map(getReferenceIdentifier),
+        )) {
         modifiedImmutableFields.push(CORE_ANNOTATIONS.PARENT)
       }
       return modifiedImmutableFields.map(modifiedField => ({

--- a/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
@@ -20,7 +20,8 @@ import {
 import _ from 'lodash'
 import { isCustomType, isFileCabinetType } from '../types'
 
-const getReferenceValue = (val: unknown): unknown => (isReferenceExpression(val) ? val.value : val)
+const getReferenceValue = (val: unknown): unknown =>
+  (isReferenceExpression(val) ? val.elemId.getFullName() : val)
 
 const changeValidator: ChangeValidator = async changes => (
   _.flatten(changes

--- a/packages/netsuite-adapter/src/filters/add_parent_folder.ts
+++ b/packages/netsuite-adapter/src/filters/add_parent_folder.ts
@@ -24,7 +24,7 @@ const filterCreator: FilterCreator = () => ({
       .filter(isInstanceElement)
       .filter(e => isFileCabinetType(e.type))
       .filter(e => path.dirname(e.value.path) !== '/')
-      .forEach(e => { e.annotations[CORE_ANNOTATIONS.PARENT] = `[${path.dirname(e.value.path)}]` })
+      .forEach(e => { e.annotations[CORE_ANNOTATIONS.PARENT] = [`[${path.dirname(e.value.path)}]`] })
   },
 })
 

--- a/packages/netsuite-adapter/src/filters/instance_references.ts
+++ b/packages/netsuite-adapter/src/filters/instance_references.ts
@@ -113,8 +113,7 @@ const replaceReferenceValues = (
       return value
     }
 
-
-    if (path?.isAttrID() && path?.name === CORE_ANNOTATIONS.PARENT) {
+    if (path?.isAttrID() && path.createParentID().name === CORE_ANNOTATIONS.PARENT) {
       return new ReferenceExpression(elemID.createBaseID().parent)
     }
 

--- a/packages/netsuite-adapter/src/filters/instance_references.ts
+++ b/packages/netsuite-adapter/src/filters/instance_references.ts
@@ -15,7 +15,7 @@
 */
 import {
   Element, isInstanceElement, Values, ObjectType, ElemID, ReferenceExpression, InstanceElement,
-  InstanceAnnotationTypes, TypeMap,
+  InstanceAnnotationTypes, TypeMap, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import {
   transformElement,
@@ -99,7 +99,7 @@ const replaceReferenceValues = (
   fetchedElementsServiceIdToElemID: Record<string, ElemID>,
   elementsSourceServiceIdToElemID: Record<string, ElemID>,
 ): Values => {
-  const replacePrimitive: TransformFunc = ({ value }) => {
+  const replacePrimitive: TransformFunc = ({ field, value }) => {
     if (!_.isString(value)) {
       return value
     }
@@ -113,6 +113,12 @@ const replaceReferenceValues = (
     if (_.isUndefined(elemID)) {
       return value
     }
+
+
+    if (field?.name === CORE_ANNOTATIONS.PARENT) {
+      return new ReferenceExpression(elemID.createBaseID().parent)
+    }
+
     return new ReferenceExpression(elemID)
   }
 

--- a/packages/netsuite-adapter/test/change_validators/immutable_changes.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/immutable_changes.test.ts
@@ -51,10 +51,10 @@ describe('customization type change validator', () => {
 
   it('should have change error if file cabinet type parent has been modified', async () => {
     const fileInstance = new InstanceElement('fileInstance', fileCabinetTypes[FILE], {}, undefined, {
-      [CORE_ANNOTATIONS.PARENT]: '[/Templates/content]',
+      [CORE_ANNOTATIONS.PARENT]: ['[/Templates/content]'],
     })
     const after = fileInstance.clone()
-    after.annotations[CORE_ANNOTATIONS.PARENT] = '[/Templates/modified]'
+    after.annotations[CORE_ANNOTATIONS.PARENT] = ['[/Templates/modified]']
     const changeErrors = await immutableChangesValidator(
       [toChange({ before: fileInstance, after })]
     )
@@ -87,10 +87,10 @@ describe('customization type change validator', () => {
       },
       undefined,
       {
-        [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(
+        [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(
           new ElemID('netsuite', 'someType', 'instance', 'someInstance'),
           new InstanceElement('someInstance', new ObjectType({ elemID: new ElemID('netsuite', 'someType') })),
-        ),
+        )],
       }
     )
     const after = fileInstance.clone()

--- a/packages/netsuite-adapter/test/change_validators/immutable_changes.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/immutable_changes.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, InstanceElement, toChange } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import immutableChangesValidator from '../../src/change_validators/immutable_changes'
 import { customTypes, fileCabinetTypes } from '../../src/types'
 import { ENTITY_CUSTOM_FIELD, FILE, PATH, SCRIPT_ID } from '../../src/constants'
@@ -51,10 +51,10 @@ describe('customization type change validator', () => {
 
   it('should have change error if file cabinet type parent has been modified', async () => {
     const fileInstance = new InstanceElement('fileInstance', fileCabinetTypes[FILE], {}, undefined, {
-      parent: 'Templates/content',
+      [CORE_ANNOTATIONS.PARENT]: '[/Templates/content]',
     })
     const after = fileInstance.clone()
-    after.annotations[CORE_ANNOTATIONS.PARENT] = 'Templates/modified'
+    after.annotations[CORE_ANNOTATIONS.PARENT] = '[/Templates/modified]'
     const changeErrors = await immutableChangesValidator(
       [toChange({ before: fileInstance, after })]
     )
@@ -78,10 +78,21 @@ describe('customization type change validator', () => {
   })
 
   it('should not have change error if file cabinet type regular field has been modified', async () => {
-    const fileInstance = new InstanceElement('fileInstance', fileCabinetTypes[FILE], {
-      [PATH]: 'Templates/content.html',
-      content: 'original',
-    })
+    const fileInstance = new InstanceElement(
+      'fileInstance',
+      fileCabinetTypes[FILE],
+      {
+        [PATH]: 'Templates/content.html',
+        content: 'original',
+      },
+      undefined,
+      {
+        [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(
+          new ElemID('netsuite', 'someType', 'instance', 'someInstance'),
+          new InstanceElement('someInstance', new ObjectType({ elemID: new ElemID('netsuite', 'someType') })),
+        ),
+      }
+    )
     const after = fileInstance.clone()
     after.value.content = 'modified'
     const changeErrors = await immutableChangesValidator(

--- a/packages/netsuite-adapter/test/filters/add_parent_folder.test.ts
+++ b/packages/netsuite-adapter/test/filters/add_parent_folder.test.ts
@@ -39,7 +39,7 @@ describe('add_parent_folder filter', () => {
   it('should add parent field to file', async () => {
     instance.value[PATH] = '/aa/bb/cc.txt'
     await filterCreator().onFetch(onFetchParameters)
-    expect(instance.annotations[CORE_ANNOTATIONS.PARENT]).toEqual('[/aa/bb]')
+    expect(instance.annotations[CORE_ANNOTATIONS.PARENT]).toEqual(['[/aa/bb]'])
   })
 
   it('should not add parent if file is top level', async () => {

--- a/packages/netsuite-adapter/test/filters/instance_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/instance_references.test.ts
@@ -86,7 +86,7 @@ describe('instance_references filter', () => {
         {
           refToFilePath: '[/Templates/file.name]',
           refToScriptId: '[scriptid=top_level]',
-          [CORE_ANNOTATIONS.PARENT]: '[/Templates/file.name]',
+          [CORE_ANNOTATIONS.PARENT]: ['[/Templates/file.name]'],
         }
       )
     })
@@ -134,7 +134,7 @@ describe('instance_references filter', () => {
       })
 
       expect(instanceWithRefs.annotations[CORE_ANNOTATIONS.PARENT])
-        .toEqual(new ReferenceExpression(fileInstance.elemID))
+        .toEqual([new ReferenceExpression(fileInstance.elemID)])
     })
 
     it('should replace scriptid with 1 nesting level references', async () => {

--- a/packages/netsuite-adapter/test/filters/instance_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/instance_references.test.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import {
+  CORE_ANNOTATIONS,
   ElemID, InstanceElement, ObjectType, ReferenceExpression,
 } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/instance_references'
@@ -85,6 +86,7 @@ describe('instance_references filter', () => {
         {
           refToFilePath: '[/Templates/file.name]',
           refToScriptId: '[scriptid=top_level]',
+          [CORE_ANNOTATIONS.PARENT]: '[/Templates/file.name]',
         }
       )
     })
@@ -122,6 +124,17 @@ describe('instance_references filter', () => {
         .toEqual(new ReferenceExpression(fileInstance.elemID.createNestedID(PATH)))
       expect(instanceWithRefs.annotations.refToScriptId)
         .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID(SCRIPT_ID)))
+    })
+
+    it('parent should reference the element itself', async () => {
+      await filterCreator().onFetch({
+        elements: [fileInstance, workflowInstance, instanceWithRefs],
+        elementsSourceIndex,
+        isPartial: false,
+      })
+
+      expect(instanceWithRefs.annotations[CORE_ANNOTATIONS.PARENT])
+        .toEqual(new ReferenceExpression(fileInstance.elemID))
     })
 
     it('should replace scriptid with 1 nesting level references', async () => {


### PR DESCRIPTION
Following a conversion with @ori-moisis, it would be better if the `_parent` annotations in NetSuite file cabinet instances would reference the parent element itself and not its path.

---
_Release Notes_: 
None