### PR TITLE
SALTO-1147 Support anyOf and oneOf in swagger adapter components

### DIFF
--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -16,18 +16,19 @@
 import _ from 'lodash'
 import { ObjectType, PrimitiveType, ElemID, BuiltinTypes, Field, MapType, ListType, TypeMap } from '@salto-io/adapter-api'
 import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
-import { values as lowerdashValues } from '@salto-io/lowerdash'
+import { types as lowerdashTypes, values as lowerdashValues } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { TYPES_PATH, SUBTYPES_PATH } from '../../constants'
 import { RequestableTypeSwaggerConfig, AdapterSwaggerApiConfig } from '../../../config/swagger'
 import {
-  getParsedDefs, isReferenceObject, toNormalizedRefName, ReferenceObject, SchemaObject,
+  getParsedDefs, isReferenceObject, toNormalizedRefName, SchemaObject,
   extractProperties, ADDITIONAL_PROPERTIES_FIELD, toPrimitiveType, toTypeName, SwaggerRefs,
   SchemaOrReference, SWAGGER_ARRAY, SWAGGER_OBJECT, isArraySchemaObject,
 } from './swagger_parser'
 import { fixTypes, defineAdditionalTypes } from './type_config_override'
 
 const { isDefined } = lowerdashValues
+const { isArrayOfType } = lowerdashTypes
 const log = logger(module)
 
 type TypeAdderType = (
@@ -35,10 +36,6 @@ type TypeAdderType = (
   origTypeName: string,
   endpointName?: string,
 ) => PrimitiveType | ObjectType
-
-const isReferenceObjectArray = (array: unknown[]): array is ReferenceObject[] => (
-  array.every(isReferenceObject)
-)
 
 /**
  * Helper function for creating type elements for the given swagger definitions.
@@ -136,7 +133,7 @@ const typeAdder = ({
       _.mapValues(allProperties, (fieldSchema, fieldName) => {
         const toNestedTypeName = ({ allOf, anyOf, oneOf }: SchemaObject): string => {
           const xOf = [allOf, anyOf, oneOf].filter(isDefined).flat()
-          if (xOf.length > 0 && isReferenceObjectArray(xOf)) {
+          if (xOf.length > 0 && isArrayOfType(xOf, isReferenceObject)) {
             if (xOf.length === 1) {
               return toNormalizedRefName(xOf[0])
             }

--- a/packages/adapter-components/src/elements/swagger/type_elements/swagger_parser.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/swagger_parser.ts
@@ -154,13 +154,6 @@ type HasXOf = {
   oneOf?: SchemaOrReference[]
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const xOfCompatible = (val: any): val is HasXOf => (
-  (val.allOf === undefined || Array.isArray(val.allOf))
-  && (val.anyOf === undefined || Array.isArray(val.anyOf))
-  && (val.oneOf === undefined || Array.isArray(val.oneOf))
-)
-
 /**
  * Extract the nested fields for the specified schema that are defined in its allOf nested schemas,
  * including additionalProperties.
@@ -176,7 +169,6 @@ export const extractProperties = (schemaDefObj: SchemaObject, refs: SwaggerRefs)
       xOf => [
         ...xOf,
         ...xOf
-          .filter(x => xOfCompatible(x) || isReferenceObject(x))
           .flatMap(nested => (isReferenceObject(nested) ? [nested] : recursiveXOf(nested))),
       ]
     )
@@ -201,7 +193,7 @@ export const extractProperties = (schemaDefObj: SchemaObject, refs: SwaggerRefs)
   const flattenXOfAdditionalProps = (schemaDef: SchemaObject): SchemaObject[] => (
     [
       schemaDef.additionalProperties,
-      ...(xOfCompatible(schemaDef) ? recursiveXOf(schemaDef) : []).flatMap(nested => (
+      ...recursiveXOf(schemaDef).flatMap(nested => (
         isReferenceObject(nested)
           ? flattenXOfAdditionalProps(refs.get(nested.$ref))
           : [

--- a/packages/adapter-components/test/elements/swagger/petstore_openapi.v3.json
+++ b/packages/adapter-components/test/elements/swagger/petstore_openapi.v3.json
@@ -926,6 +926,44 @@
         }
       }
     },
+    "/foodOrCategory": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FoodOrCategory"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/foodXorCategory": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FoodXorCategory"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/food/{foodId}": {
       "get": {
         "parameters": [
@@ -947,6 +985,33 @@
               "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/Food"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/location/{locationName}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "locationName",
+            "in": "path",
+            "description": "Name of location",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Location"
                 }
               }
             }
@@ -1031,6 +1096,26 @@
       },
       "FoodAndCategory": {
         "allOf": [
+          {
+            "$ref": "#/components/schemas/Food"
+          },
+          {
+            "$ref": "#/components/schemas/Category"
+          }
+        ]
+      },
+      "FoodOrCategory": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Food"
+          },
+          {
+            "$ref": "#/components/schemas/Category"
+          }
+        ]
+      },
+      "FoodXorCategory": {
+        "oneOf": [
           {
             "$ref": "#/components/schemas/Food"
           },
@@ -1186,6 +1271,41 @@
           },
           "message": {
             "type": "string"
+          }
+        }
+      },
+      "Address": {
+        "type": "object",
+        "properties": {
+          "city": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "street": {
+            "type": "string"
+          },
+          "zip": {
+            "type": "number"
+          }
+        }
+      },
+      "Location": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/Address"
+              }
+            ]
           }
         }
       }

--- a/packages/adapter-components/test/elements/swagger/petstore_openapi.v3.yaml
+++ b/packages/adapter-components/test/elements/swagger/petstore_openapi.v3.yaml
@@ -604,6 +604,28 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FoodAndCategory'
+  /foodOrCategory:
+    get:
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FoodOrCategory'
+  /foodXorCategory:
+    get:
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FoodXorCategory'
   /food/{foodId}:
     get:
       parameters:
@@ -621,6 +643,22 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/Food'
+  /location/{locationName}:
+    get:
+      parameters:
+      - name: locationName
+        in: path
+        description: Name of location
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Location'
 components:
   schemas:
     Order:
@@ -674,6 +712,14 @@ components:
             $ref: '#/components/schemas/Category'
     FoodAndCategory:
       allOf:
+      - $ref: '#/components/schemas/Food'
+      - $ref: '#/components/schemas/Category'
+    FoodOrCategory:
+      anyOf:
+      - $ref: '#/components/schemas/Food'
+      - $ref: '#/components/schemas/Category'
+    FoodXorCategory:
+      oneOf:
       - $ref: '#/components/schemas/Food'
       - $ref: '#/components/schemas/Category'
     User:
@@ -773,6 +819,27 @@ components:
           type: string
         message:
           type: string
+    Address:
+      type: object
+      properties:
+        city:
+          type: string
+        country:
+          type: string
+        street:
+          type: string
+        zip:
+          type: number
+    Location:
+      type: object
+      properties:
+        name:
+          type: string
+        address:
+          anyOf:
+            - type: string
+            - $ref: "#/components/schemas/Address"
+
   securitySchemes:
     petstore_auth:
       type: oauth2

--- a/packages/lowerdash/src/types.ts
+++ b/packages/lowerdash/src/types.ts
@@ -75,3 +75,10 @@ export class _Bean<T> {
 
 export type Bean<T> = _Bean<T> & T
 export const Bean = _Bean as new <T>(props: T) => Bean<T>
+
+export const isArrayOfType = <T>(
+  array: unknown[],
+  typeGuard: TypeGuard<unknown, T>,
+): array is T[] => (
+    array.every(typeGuard)
+  )

--- a/packages/lowerdash/test/types.test.ts
+++ b/packages/lowerdash/test/types.test.ts
@@ -13,9 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import {
-  AtLeastOne, RequiredMember, hasMember, filterHasMember, ValueOf,
-  Bean,
+  AtLeastOne, RequiredMember, hasMember, filterHasMember, ValueOf, Bean, isArrayOfType, TypeGuard,
 } from '../src/types'
 
 // Note: some of the tests here are compile-time, so the actual assertions may look weird.
@@ -104,6 +104,27 @@ describe('types', () => {
       const m = new MyBean({ p1: 'astring', p2: 12 })
       expect(m.p1).toBe('astring')
       expect(m.p2).toBe(12)
+    })
+  })
+
+  describe('isArrayOfType', () => {
+    type MyType = { a: string }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    type Guard = TypeGuard<unknown, MyType>
+
+    it('should return true if the type guard returns true for all items', () => {
+      const truthy: Guard = (_t: unknown): _t is MyType => true
+      expect(isArrayOfType([{ a: 'b' }, { c: 'd' }], truthy)).toBeTruthy()
+    })
+    it('should return false if the type guard returns false for any item', () => {
+      const falsy: Guard = (_t: unknown): _t is MyType => false
+      expect(isArrayOfType([{ a: 'b' }, { c: 'd' }], falsy)).toBeFalsy()
+      const actual: Guard = (t: unknown): t is MyType => _.isString(_.get(t, 'a'))
+      expect(isArrayOfType([{ a: 'b' }, { c: 'd' }], actual)).toBeFalsy()
+    })
+    it('should return true if the array is empty', () => {
+      const falsy: Guard = (_t: unknown): _t is MyType => false
+      expect(isArrayOfType([], falsy)).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
Add support for `anyOf` and `oneOf` in the swagger type generator - leftover from https://github.com/salto-io/salto/pull/1941 .

Note: This does not cover all functionality (in terms of validations) because of some limitations of our type system, see SALTO-1259 for a suggested extension.

---
_Release Notes_: 
None
