### PR TITLE
SALTO-1147 Separate pagination layer from client

### DIFF
--- a/packages/adapter-components/src/client/base.ts
+++ b/packages/adapter-components/src/client/base.ts
@@ -23,7 +23,7 @@ export abstract class AdapterClientBase<TRateLimitConfig extends ClientRateLimit
   protected isLoggedIn = false
   protected readonly config?: ClientBaseConfig<TRateLimitConfig>
   protected readonly rateLimiters: BottleneckBuckets<TRateLimitConfig>
-  protected getPageSize: number
+  protected getPageSizeInner: number
   protected apiClient?: APIConnection
   protected loginPromise?: Promise<APIConnection>
 
@@ -42,9 +42,13 @@ export abstract class AdapterClientBase<TRateLimitConfig extends ClientRateLimit
       _.defaults({}, config?.rateLimit, defaults.rateLimit),
       this.clientName,
     )
-    this.getPageSize = (
+    this.getPageSizeInner = (
       this.config?.pageSize?.get
       ?? defaults.pageSize.get
     )
+  }
+
+  getPageSize(): number {
+    return this.getPageSizeInner
   }
 }

--- a/packages/adapter-components/src/client/base.ts
+++ b/packages/adapter-components/src/client/base.ts
@@ -23,9 +23,9 @@ export abstract class AdapterClientBase<TRateLimitConfig extends ClientRateLimit
   protected isLoggedIn = false
   protected readonly config?: ClientBaseConfig<TRateLimitConfig>
   protected readonly rateLimiters: BottleneckBuckets<TRateLimitConfig>
-  protected getPageSizeInner: number
   protected apiClient?: APIConnection
   protected loginPromise?: Promise<APIConnection>
+  private getPageSizeInner: number
 
   constructor(
     clientName: string,

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -30,13 +30,16 @@ export type ResponseValue = {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type GetResponse<T = any> = {
+  data: T
+  status: number
+  statusText?: string
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type APIConnection<T = any> = {
   // based on https://github.com/axios/axios/blob/f472e5da5fe76c72db703d6a0f5190e4ad31e642/index.d.ts#L140
-  get: (url: string, config?: { params: Record<string, unknown> }) => Promise<{
-    data: T
-    status: number
-    statusText: string
-  }>
+  get: (url: string, config?: { params: Record<string, unknown> }) => Promise<GetResponse<T>>
 }
 
 type AuthenticatedAPIConnection = APIConnection & {

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -30,7 +30,7 @@ export type ResponseValue = {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type GetResponse<T = any> = {
+export type GetResponse<T> = {
   data: T
   status: number
   statusText?: string

--- a/packages/adapter-components/src/client/index.ts
+++ b/packages/adapter-components/src/client/index.ts
@@ -19,5 +19,5 @@ export { DEFAULT_RETRY_OPTS, RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS } from
 export { logDecorator, requiresLogin } from './decorators'
 export { AdapterHTTPClient, ClientOpts, HTTPClientInterface } from './http_client'
 export { APIConnection, ConnectionCreator, axiosConnection, createClientConnection, createRetryOptions, validateCredentials, UnauthorizedError, ResponseValue } from './http_connection'
-export { ClientGetParams, getWithCursorPagination, getWithPageOffsetPagination, traverseRequests, GetAllItemsFunc, PaginationFunc } from './pagination'
+export { createPaginator, getWithCursorPagination, getWithPageOffsetPagination, traverseRequests, ClientGetWithPaginationParams, PaginationFunc, Paginator, GetAllItemsFunc } from './pagination'
 export { createRateLimitersFromConfig, throttle, BottleneckBuckets } from './rate_limit'

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -18,7 +18,7 @@ import { Element, Values } from '@salto-io/adapter-api'
 import { naclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
-import { HTTPClientInterface } from '../../client'
+import { Paginator } from '../../client'
 import { generateType } from './type_elements'
 import { toInstance } from './instance_elements'
 import { TypeConfig } from '../../config'
@@ -39,7 +39,7 @@ const log = logger(module)
 export const getTypeAndInstances = async ({
   adapterName,
   typeName,
-  client,
+  paginator,
   nestedFieldFinder,
   computeGetArgs,
   typesConfig,
@@ -48,7 +48,7 @@ export const getTypeAndInstances = async ({
 }: {
   adapterName: string
   typeName: string
-  client: HTTPClientInterface
+  paginator: Paginator
   nestedFieldFinder: FindNestedFieldFunc
   computeGetArgs: ComputeGetArgsFunc
   typesConfig: Record<string, TypeDuckTypeConfig>
@@ -81,7 +81,7 @@ export const getTypeAndInstances = async ({
   const getEntries = async (): Promise<Values[]> => {
     const getArgs = computeGetArgs(requestWithDefaults, contextElements)
     return (await Promise.all(
-      getArgs.map(async args => (await toArrayAsync(await client.get(args))).flat())
+      getArgs.map(async args => (await toArrayAsync(await paginator(args))).flat())
     )).flat()
   }
 
@@ -140,7 +140,7 @@ export const getAllElements = async ({
   adapterName,
   includeTypes,
   types,
-  client,
+  paginator,
   nestedFieldFinder,
   computeGetArgs,
   typeDefaults,
@@ -148,7 +148,7 @@ export const getAllElements = async ({
   adapterName: string
   includeTypes: string[]
   types: Record<string, TypeConfig>
-  client: HTTPClientInterface
+  paginator: Paginator
   nestedFieldFinder: FindNestedFieldFunc
   computeGetArgs: ComputeGetArgsFunc
   typeDefaults: TypeDuckTypeDefaultsConfig
@@ -159,7 +159,7 @@ export const getAllElements = async ({
 
   const elementGenerationParams = {
     adapterName,
-    client,
+    paginator,
     nestedFieldFinder,
     computeGetArgs,
     typesConfig: types,

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -101,6 +101,10 @@ export const getTypeAndInstances = async ({
   // find the field and type containing the actual instances
   const nestedFieldDetails = nestedFieldFinder(type, fieldsToOmit, dataField)
 
+  if (nestedFieldDetails === undefined) {
+    log.debug(`storing full entries for ${type.elemID.name}`)
+  }
+
   const instances = naclEntries.flatMap((entry, index) => {
     if (nestedFieldDetails !== undefined) {
       return makeArray(entry[nestedFieldDetails.field.name]).map(
@@ -115,7 +119,6 @@ export const getTypeAndInstances = async ({
       ).filter(isDefined)
     }
 
-    log.info(`storing full entry for ${type.elemID.name}`)
     return toInstance({
       entry,
       type,

--- a/packages/adapter-components/src/elements/request_parameters.ts
+++ b/packages/adapter-components/src/elements/request_parameters.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { Element, Values, isInstanceElement } from '@salto-io/adapter-api'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { ClientGetParams } from '../client'
+import { ClientGetWithPaginationParams } from '../client'
 import { RequestConfig, ARG_PLACEHOLDER_MATCHER } from '../config/request'
 
 const log = logger(module)
@@ -25,7 +25,7 @@ const log = logger(module)
 export type ComputeGetArgsFunc = (
   request: RequestConfig,
   contextElements?: Record<string, Element[]>,
-) => ClientGetParams[]
+) => ClientGetWithPaginationParams[]
 
 /**
  * Convert an endpoint's request details into get argumets.

--- a/packages/adapter-components/src/filter_utils.ts
+++ b/packages/adapter-components/src/filter_utils.ts
@@ -15,6 +15,7 @@
 */
 import { Element, PostFetchOptions } from '@salto-io/adapter-api'
 import { types, promises } from '@salto-io/lowerdash'
+import { Paginator } from './client'
 
 export type Filter = Partial<{
   onFetch(elements: Element[]): Promise<void>
@@ -24,15 +25,16 @@ export type Filter = Partial<{
 export type FilterWith<M extends keyof Filter> = types.HasMember<Filter, M>
 
 export type FilterCreator<TClient, TContext> = (
-  opts: { client: TClient; config: TContext }
+  opts: { client: TClient; paginator: Paginator; config: TContext }
 ) => Filter
 
 export const filtersRunner = <TClient, TContext>(
   client: TClient,
+  paginator: Paginator,
   config: TContext,
   filterCreators: ReadonlyArray<FilterCreator<TClient, TContext>>,
 ): Required<Filter> => {
-  const allFilters = filterCreators.map(f => f({ client, config }))
+  const allFilters = filterCreators.map(f => f({ client, config, paginator }))
 
   const filtersWith = <M extends keyof Filter>(m: M): FilterWith<M>[] =>
     types.filterHasMember<Filter, M>(m, allFilters)

--- a/packages/adapter-components/test/filter_utils.test.ts
+++ b/packages/adapter-components/test/filter_utils.test.ts
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 import { filtersRunner, FilterCreator } from '../src/filter_utils'
-import { makeResolvablePromise } from './common'
+import { makeResolvablePromise, mockFunction } from './common'
+import { Paginator, HTTPClientInterface } from '../src/client'
 
 describe('filter utils', () => {
   describe('filtersRunner', () => {
@@ -64,7 +65,12 @@ describe('filter utils', () => {
 
     it('should call onFetch for all nested filters in order', async () => {
       const p = makeResolvablePromise(3)
-      const runner = filtersRunner({ get: jest.fn() }, { configVal: '123 ', promise: p.promise }, filters)
+      const runner = filtersRunner(
+        { get: mockFunction<HTTPClientInterface['getSinglePage']>() },
+        mockFunction<Paginator>(),
+        { configVal: '123 ', promise: p.promise },
+        filters,
+      )
       const onFetchRes = runner.onFetch([])
       await new Promise(resolve => setTimeout(resolve, 2))
       expect(mockOnFetch2).not.toHaveBeenCalled()
@@ -76,7 +82,12 @@ describe('filter utils', () => {
     })
     it('should call onPostFetch for all nested filters', async () => {
       const p = makeResolvablePromise(3)
-      const runner = filtersRunner({ get: jest.fn() }, { configVal: '123 ', promise: p.promise }, filters)
+      const runner = filtersRunner(
+        { get: mockFunction<HTTPClientInterface['getSinglePage']>() },
+        mockFunction<Paginator>(),
+        { configVal: '123 ', promise: p.promise },
+        filters,
+      )
       const onPostFetchRes = runner.onPostFetch({
         elementsByAdapter: {},
         currentAdapterElements: [],

--- a/packages/workato-adapter/src/client/client.ts
+++ b/packages/workato-adapter/src/client/client.ts
@@ -17,11 +17,8 @@ import { client as clientUtils } from '@salto-io/adapter-components'
 import { createConnection } from './connection'
 import { WORKATO } from '../constants'
 import { Credentials } from '../auth'
-import { getMinSinceIdPagination } from './pagination'
 
-const {
-  getWithPageOffsetPagination, DEFAULT_RETRY_OPTS, RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
-} = clientUtils
+const { DEFAULT_RETRY_OPTS, RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS } = clientUtils
 
 const DEFAULT_MAX_CONCURRENT_API_REQUESTS: Required<clientUtils.ClientRateLimitConfig> = {
   total: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
@@ -33,18 +30,6 @@ const DEFAULT_PAGE_SIZE: Required<clientUtils.ClientPageSizeConfig> = {
   get: 10,
 }
 
-export const paginate: clientUtils.GetAllItemsFunc = async function *paginate({
-  conn,
-  pageSize,
-  getParams,
-}) {
-  if (getParams?.paginationField === 'since_id') {
-    // special handling for endpoints that use descending ids, like the recipes endpoint
-    yield* getMinSinceIdPagination({ conn, pageSize, getParams })
-  } else {
-    yield* getWithPageOffsetPagination({ conn, pageSize, getParams })
-  }
-}
 export default class WorkatoClient extends clientUtils.AdapterHTTPClient<
   Credentials, clientUtils.ClientRateLimitConfig
 > {
@@ -62,6 +47,4 @@ export default class WorkatoClient extends clientUtils.AdapterHTTPClient<
       }
     )
   }
-
-  protected getAllItems = paginate
 }

--- a/packages/workato-adapter/src/client/pagination.ts
+++ b/packages/workato-adapter/src/client/pagination.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 
-const { traverseRequests } = clientUtils
+const { getWithPageOffsetPagination, traverseRequests } = clientUtils
 const log = logger(module)
 
 /**
@@ -52,4 +52,17 @@ export const getMinSinceIdPagination: clientUtils.GetAllItemsFunc = async functi
     }]
   }
   yield* traverseRequests(nextPage)(args)
+}
+
+export const paginate: clientUtils.GetAllItemsFunc = async function *paginate({
+  client,
+  pageSize,
+  getParams,
+}) {
+  if (getParams?.paginationField === 'since_id') {
+    // special handling for endpoints that use descending ids, like the recipes endpoint
+    yield* getMinSinceIdPagination({ client, pageSize, getParams })
+  } else {
+    yield* getWithPageOffsetPagination({ client, pageSize, getParams })
+  }
 }

--- a/packages/workato-adapter/test/filters/extract_fields.test.ts
+++ b/packages/workato-adapter/test/filters/extract_fields.test.ts
@@ -17,8 +17,9 @@ import {
   ObjectType, ElemID, InstanceElement, Element, BuiltinTypes, isInstanceElement,
   ReferenceExpression,
 } from '@salto-io/adapter-api'
-import { filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
 import WorkatoClient from '../../src/client/client'
+import { paginate } from '../../src/client/pagination'
 import filterCreator from '../../src/filters/extract_fields'
 import { DEFAULT_TYPES, DEFAULT_ID_FIELDS } from '../../src/config'
 import { WORKATO } from '../../src/constants'
@@ -82,6 +83,10 @@ describe('Extract fields filter', () => {
     })
     filter = filterCreator({
       client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFunc: paginate,
+      }),
       config: {
         fetch: {
           includeTypes: ['connection', 'recipe'],

--- a/packages/workato-adapter/test/filters/field_references.test.ts
+++ b/packages/workato-adapter/test/filters/field_references.test.ts
@@ -14,9 +14,10 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, BuiltinTypes, isInstanceElement, ListType } from '@salto-io/adapter-api'
-import { filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/field_references'
 import WorkatoClient from '../../src/client/client'
+import { paginate } from '../../src/client/pagination'
 import { DEFAULT_TYPES, DEFAULT_ID_FIELDS } from '../../src/config'
 import { WORKATO } from '../../src/constants'
 
@@ -32,6 +33,10 @@ describe('Field references filter', () => {
     })
     filter = filterCreator({
       client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFunc: paginate,
+      }),
       config: {
         fetch: {
           includeTypes: ['connection', 'recipe'],

--- a/packages/workato-adapter/test/filters/recipe_references.test.ts
+++ b/packages/workato-adapter/test/filters/recipe_references.test.ts
@@ -15,9 +15,10 @@
 */
 import _ from 'lodash'
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, BuiltinTypes, ListType, CORE_ANNOTATIONS, isReferenceExpression } from '@salto-io/adapter-api'
-import { filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/cross_service/recipe_references'
 import WorkatoClient from '../../src/client/client'
+import { paginate } from '../../src/client/pagination'
 import { DEFAULT_TYPES, DEFAULT_ID_FIELDS } from '../../src/config'
 import { WORKATO } from '../../src/constants'
 
@@ -34,6 +35,10 @@ describe('Recipe references filter', () => {
     })
     filter = filterCreator({
       client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFunc: paginate,
+      }),
       config: {
         fetch: {
           includeTypes: ['connection', 'recipe'],
@@ -725,6 +730,10 @@ describe('Recipe references filter', () => {
 
       const otherFilter = filterCreator({
         client,
+        paginator: clientUtils.createPaginator({
+          client,
+          paginationFunc: paginate,
+        }),
         config: {
           fetch: {
             includeTypes: ['connection', 'recipe'],
@@ -757,6 +766,10 @@ describe('Recipe references filter', () => {
 
       const otherFilter = filterCreator({
         client,
+        paginator: clientUtils.createPaginator({
+          client,
+          paginationFunc: paginate,
+        }),
         config: {
           fetch: {
             includeTypes: ['connection', 'recipe'],


### PR DESCRIPTION
Interface change in the lightweight adapter shared infra:
* The client will only have a simple `get` that covers one page
* The pagination function will be provided separately (but still use the client and its config)

---

Also adjusted workato (in this PR) and zuora (in its [branch](https://github.com/netama/salto/commit/228652b9a0f6ee3c022a257488fe76fb292f96da)) - similar changes will be required in the other in-progress adapters.

---

_Release Notes_: 
None
