### PR TITLE
SALTO-1150 Add OAuth access token reusable auth method

### DIFF
--- a/packages/adapter-components/package.json
+++ b/packages/adapter-components/package.json
@@ -38,7 +38,8 @@
     "axios": "^0.21.1",
     "axios-retry": "^3.1.9",
     "bottleneck": "^2.19.5",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "qs": "^6.10.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",

--- a/packages/adapter-components/src/auth/index.ts
+++ b/packages/adapter-components/src/auth/index.ts
@@ -13,9 +13,4 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export * as auth from './src/auth'
-export * as client from './src/client'
-export * as config from './src/config'
-export * as elements from './src/elements'
-export * as changeValidators from './src/change_validators'
-export * as filterUtils from './src/filter_utils'
+export { oauthClientCredentialsBearerToken, OAuthClientCredentialsArgs } from './oauth'

--- a/packages/adapter-components/src/auth/oauth.ts
+++ b/packages/adapter-components/src/auth/oauth.ts
@@ -1,0 +1,80 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import qs from 'qs'
+import axios from 'axios'
+import axiosRetry from 'axios-retry'
+import { logger } from '@salto-io/logging'
+import { RetryOptions } from '../client/http_connection'
+
+const log = logger(module)
+
+export type OAuthClientCredentialsArgs = {
+  clientId: string
+  clientSecret: string
+}
+
+const BEARER_TOKEN_TYPE = 'bearer'
+
+/**
+ * Authenticate using OAuth 2.0 with the client_credentials grant type.
+ *
+ * Can be extended to include a scope in the request when needed.
+ * Not yet handling refreshing on expiration (when added, it should be done in the connection).
+ */
+export const oauthClientCredentialsBearerToken = async ({
+  endpoint = '/oauth/token',
+  baseURL,
+  clientId,
+  clientSecret,
+  retryOptions,
+  additionalHeaders = {},
+}: OAuthClientCredentialsArgs & {
+  endpoint?: string
+  baseURL: string
+  retryOptions: RetryOptions
+  additionalHeaders?: Record<string, string>
+}): Promise<{ headers?: Record<string, unknown> }> => {
+  const httpClient = axios.create({
+    baseURL,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      ...additionalHeaders,
+    },
+  })
+  axiosRetry(httpClient, retryOptions)
+
+  const res = await httpClient.post(
+    endpoint,
+    qs.stringify({
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      client_id: clientId,
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      client_secret: clientSecret,
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      grant_type: 'client_credentials',
+    }),
+  )
+  const { token_type: tokenType, access_token: accessToken, expires_in: expiresIn } = res.data
+  log.debug('received access token: type %s, expires in %s', tokenType, expiresIn)
+  if (tokenType !== BEARER_TOKEN_TYPE) {
+    throw new Error(`Unsupported token type ${tokenType}`)
+  }
+  return {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  }
+}

--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { Connection, ConnectionCreator, createRetryOptions, createClientConnection, ResponseValue, GetResponse } from './http_connection'
+import { Connection, ConnectionCreator, createRetryOptions, createClientConnection, ResponseValue, Response } from './http_connection'
 import { AdapterClientBase } from './base'
 import { ClientRetryConfig, ClientRateLimitConfig, ClientPageSizeConfig, ClientBaseConfig } from './config'
 import { requiresLogin, logDecorator } from './decorators'
@@ -39,7 +39,7 @@ export type ClientGetParams = {
 }
 
 export interface HTTPClientInterface {
-  getSinglePage(params: ClientGetParams): Promise<GetResponse<ResponseValue | ResponseValue[]>>
+  getSinglePage(params: ClientGetParams): Promise<Response<ResponseValue | ResponseValue[]>>
 
   getPageSize(): number
 }
@@ -95,7 +95,7 @@ export abstract class AdapterHTTPClient<
   @requiresLogin()
   public async getSinglePage({
     url, queryParams,
-  }: ClientGetParams): Promise<GetResponse<ResponseValue | ResponseValue[]>> {
+  }: ClientGetParams): Promise<Response<ResponseValue | ResponseValue[]>> {
     if (this.apiClient === undefined) {
       // initialized by requiresLogin (through ensureLoggedIn in this case)
       throw new Error(`uninitialized ${this.clientName} client`)

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -37,10 +37,10 @@ export type Response<T> = {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type APIConnection<T = any> = {
+export type APIConnection<T = any, S = any> = {
   // based on https://github.com/axios/axios/blob/f472e5da5fe76c72db703d6a0f5190e4ad31e642/index.d.ts#L140
   get: (url: string, config?: { params: Record<string, unknown> }) => Promise<Response<T>>
-  post: (url: string, data: T, config?: { params: Record<string, unknown> }) => Promise<Response<T>>
+  post: (url: string, data: S, config?: { params: Record<string, unknown> }) => Promise<Response<T>>
 }
 
 type AuthenticatedAPIConnection = APIConnection & {

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -30,7 +30,7 @@ export type ResponseValue = {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type GetResponse<T> = {
+export type Response<T> = {
   data: T
   status: number
   statusText?: string
@@ -39,14 +39,15 @@ export type GetResponse<T> = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type APIConnection<T = any> = {
   // based on https://github.com/axios/axios/blob/f472e5da5fe76c72db703d6a0f5190e4ad31e642/index.d.ts#L140
-  get: (url: string, config?: { params: Record<string, unknown> }) => Promise<GetResponse<T>>
+  get: (url: string, config?: { params: Record<string, unknown> }) => Promise<Response<T>>
+  post: (url: string, data: T, config?: { params: Record<string, unknown> }) => Promise<Response<T>>
 }
 
 type AuthenticatedAPIConnection = APIConnection & {
   accountId: AccountId
 }
 
-type RetryOptions = {
+export type RetryOptions = {
   retries: number
   retryDelay?: (retryCount: number, error: AxiosError) => number
 }
@@ -101,10 +102,10 @@ export const validateCredentials = async <TCredentials>(
 
 type AxiosConnectionParams<TCredentials> = {
   retryOptions: RetryOptions
-  authParamsFunc: (creds: TCredentials) => {
+  authParamsFunc: (creds: TCredentials) => Promise<{
     auth?: AxiosBasicCredentials
     headers?: Record<string, unknown>
-  }
+  }>
   baseURLFunc: (creds: TCredentials) => string
   credValidateFunc: (creds: TCredentials, conn: APIConnection) => Promise<AccountId>
 }
@@ -120,7 +121,7 @@ export const axiosConnection = <TCredentials>({
   ): Promise<AuthenticatedAPIConnection> => {
     const httpClient = axios.create({
       baseURL: baseURLFunc(creds),
-      ...authParamsFunc(creds),
+      ...await authParamsFunc(creds),
     })
     axiosRetry(httpClient, retryOptions)
 

--- a/packages/adapter-components/test/auth/oauth.test.ts
+++ b/packages/adapter-components/test/auth/oauth.test.ts
@@ -1,0 +1,131 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { oauthClientCredentialsBearerToken } from '../../src/auth'
+
+describe('oauth', () => {
+  describe('oauthClientCredentialsBearerToken', () => {
+    let mockAxiosAdapter: MockAdapter
+    beforeEach(() => {
+      mockAxiosAdapter = new MockAdapter(axios, { delayResponse: 1, onNoMatch: 'throwException' })
+    })
+
+    afterEach(() => {
+      mockAxiosAdapter.restore()
+    })
+
+    it('should make the right request and return a header on success', async () => {
+      mockAxiosAdapter.onPost(
+        '/oauth/token',
+      ).reply(200, {
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        access_token: 'token123', expires_in: 3599, token_type: 'bearer', scope: 'abc def',
+      })
+
+      expect(await oauthClientCredentialsBearerToken({
+        baseURL: 'localhost',
+        clientId: 'client id',
+        clientSecret: 'secret',
+        retryOptions: { retries: 2 },
+      })).toEqual({ headers: { Authorization: 'Bearer token123' } })
+      expect(mockAxiosAdapter.history.post.length).toBe(1)
+      const req = mockAxiosAdapter.history.post[0]
+      expect(req.url).toEqual('/oauth/token')
+      expect(req.auth).toBeUndefined()
+      expect(req.data).toEqual('client_id=client%20id&client_secret=secret&grant_type=client_credentials')
+      expect(req.headers).toEqual({
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: expect.stringContaining('application/json'),
+      })
+    })
+    it('should throw error on failure', async () => {
+      mockAxiosAdapter.onPost(
+        '/oauth/token',
+      ).reply(400, {})
+
+      await expect(() => oauthClientCredentialsBearerToken({
+        baseURL: 'localhost',
+        clientId: 'client id',
+        clientSecret: 'secret',
+        retryOptions: { retries: 2 },
+      })).rejects.toThrow(new Error('Request failed with status code 400'))
+    })
+    it('should throw error on unexpected token type', async () => {
+      mockAxiosAdapter.onPost(
+        '/oauth/token',
+      ).reply(200, {
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        access_token: 'token123', expires_in: 3599, token_type: 'mac', scope: 'abc def',
+      })
+
+      await expect(() => oauthClientCredentialsBearerToken({
+        baseURL: 'localhost',
+        clientId: 'client id',
+        clientSecret: 'secret',
+        retryOptions: { retries: 2 },
+      })).rejects.toThrow(new Error('Unsupported token type mac'))
+    })
+    it('should retry on transient errors', async () => {
+      mockAxiosAdapter.onPost(
+        '/oauth/token',
+      ).reply(503).onPost(
+        '/oauth/token',
+      ).reply(200, {
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        access_token: 'token123', expires_in: 3599, token_type: 'bearer', scope: 'abc def',
+      })
+
+      expect(await oauthClientCredentialsBearerToken({
+        baseURL: 'localhost',
+        clientId: 'client id',
+        clientSecret: 'secret',
+        retryOptions: { retries: 2 },
+      })).toEqual({ headers: { Authorization: 'Bearer token123' } })
+    })
+    it('should support customizations', async () => {
+      mockAxiosAdapter.onPost(
+        '/custom_oauth_endpoint',
+      ).reply(200, {
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        access_token: 'token123', expires_in: 3599, token_type: 'bearer', scope: 'abc def',
+      })
+
+      expect(await oauthClientCredentialsBearerToken({
+        endpoint: '/custom_oauth_endpoint',
+        baseURL: 'localhost',
+        clientId: 'client id',
+        clientSecret: 'secret',
+        retryOptions: { retries: 2 },
+        additionalHeaders: {
+          aaa: 'bbb',
+          ccc: 'ddd',
+        },
+      })).toEqual({ headers: { Authorization: 'Bearer token123' } })
+      expect(mockAxiosAdapter.history.post.length).toBe(1)
+      const req = mockAxiosAdapter.history.post[0]
+      expect(req.url).toEqual('/custom_oauth_endpoint')
+      expect(req.auth).toBeUndefined()
+      expect(req.data).toEqual('client_id=client%20id&client_secret=secret&grant_type=client_credentials')
+      expect(req.headers).toEqual({
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: expect.stringContaining('application/json'),
+        aaa: 'bbb',
+        ccc: 'ddd',
+      })
+    })
+  })
+})

--- a/packages/adapter-components/test/client/common.ts
+++ b/packages/adapter-components/test/client/common.ts
@@ -31,7 +31,7 @@ export const validateCreds = async (
 export const createConnection: ConnectionCreator<Credentials> = retryOptions => (
   axiosConnection({
     retryOptions,
-    authParamsFunc: ({ username, password }: Credentials) => ({
+    authParamsFunc: async ({ username, password }: Credentials) => ({
       headers: {
         customheader1: username,
       },

--- a/packages/adapter-components/test/client/pagination.test.ts
+++ b/packages/adapter-components/test/client/pagination.test.ts
@@ -27,6 +27,7 @@ describe('client_pagination', () => {
     }
     beforeEach(() => {
       client.getSinglePage.mockReset()
+      client.getPageSize.mockReset()
     })
 
     it('should query a single page if paginationField is not specified', async () => {
@@ -241,6 +242,7 @@ describe('client_pagination', () => {
     }
     beforeEach(() => {
       client.getSinglePage.mockReset()
+      client.getPageSize.mockReset()
     })
 
     it('should query a single page if paginationField is not specified', async () => {

--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -145,7 +145,7 @@ export const getApprovedChanges = async (
 
 // TODO: SALTO-770 CLI should mask secret credentials based on adapter definition
 const isPasswordInputType = (fieldName: string): boolean =>
-  ['token', 'password', 'tokenId', 'tokenSecret', 'consumerKey', 'suiteAppTokenId', 'suiteAppTokenSecret'].includes(fieldName)
+  ['token', 'password', 'tokenId', 'tokenSecret', 'consumerKey', 'suiteAppTokenId', 'suiteAppTokenSecret', 'clientSecret'].includes(fieldName)
 
 export const getFieldInputType = (fieldType: TypeElement, fieldName: string): string => {
   if (!isPrimitiveType(fieldType) || fieldType.primitive === PrimitiveTypes.UNKNOWN) {

--- a/packages/workato-adapter/src/client/connection.ts
+++ b/packages/workato-adapter/src/client/connection.ts
@@ -31,7 +31,7 @@ export const validateCredentials = async (
 export const createConnection: clientUtils.ConnectionCreator<Credentials> = retryOptions => (
   clientUtils.axiosConnection({
     retryOptions,
-    authParamsFunc: ({ username, token }: Credentials) => ({
+    authParamsFunc: async ({ username, token }: Credentials) => ({
       headers: {
         'x-user-email': username,
         'x-user-token': token,

--- a/packages/workato-adapter/test/client/connection.test.ts
+++ b/packages/workato-adapter/test/client/connection.test.ts
@@ -34,6 +34,7 @@ describe('client connection', () => {
             ? ({ data: { id: 'id456' }, status: 200, statusText: 'OK' })
             : { data: {}, status: 200, statusText: 'OK' }
         )),
+      post: mockFunction<clientUtils.APIConnection['post']>(),
     }
     it('should always extract empty account id', async () => {
       expect(await validateCredentials({ username: 'user123', token: 'token456' }, mockConnection)).toEqual('')

--- a/packages/workato-adapter/test/client/pagination.test.ts
+++ b/packages/workato-adapter/test/client/pagination.test.ts
@@ -34,6 +34,7 @@ describe('client_pagination', () => {
     }
     beforeEach(() => {
       client.getSinglePage.mockReset()
+      client.getPageSize.mockReset()
     })
 
     it('should query a single page if paginationField is not specified', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5498,6 +5498,15 @@ get-intrinsic@^1.0.0:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
+get-intrinsic@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+
 get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
@@ -8536,7 +8545,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.7.0, object-inspect@^1.8.0:
+object-inspect@^1.7.0, object-inspect@^1.8.0, object-inspect@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
   integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
@@ -9325,6 +9334,13 @@ qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
+qs@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
+  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  dependencies:
+    side-channel "^1.0.4"
 
 qs@^6.9.4:
   version "6.9.4"
@@ -10142,6 +10158,15 @@ side-channel@^1.0.2:
   dependencies:
     es-abstract "^1.17.0-next.1"
     object-inspect "^1.7.0"
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"


### PR DESCRIPTION
Add OAuth `client_credentials` token auth method (only the functionality needed so far) in adapter-components.
This is initially intended for the Zuora adapter - see (temporary) usage [here](https://github.com/netama/salto/blob/feature/SALTO-1150-zuora-initial-with-infra/packages/zuora-billing-adapter/src/client/connection.ts#L42).

---

This has minor conflicts with https://github.com/salto-io/salto/pull/1990 in some tests - will be resolved once the first of them is merged.

---
_Release Notes_: 
None
