### PR TITLE
Fix issue with multi_env_source

### DIFF
--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -116,7 +116,7 @@ export const diffAction: WorkspaceCommandAction<EnvDiffArgs> = async ({
     actualServices,
     validSelectors,
   )
-  outputLine(formatEnvDiff(changes, detailedPlan, toEnv, fromEnv), output)
+  outputLine(await formatEnvDiff(changes, detailedPlan, toEnv, fromEnv), output)
   outputLine(formatStepCompleted(Prompts.DIFF_CALC_DIFF_FINISH(toEnv, fromEnv)), output)
   outputLine(EOL, output)
 

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -657,14 +657,14 @@ export const formatListUnresolvedMissing = (elemIDs: ElemID[]): string => [
   emptyLine(),
 ].join('\n')
 
-export const formatEnvDiff = (
+export const formatEnvDiff = async (
   changes: LocalChange[],
   detailed: boolean,
   toEnv: string,
   fromEnv: string
-): string => {
+): Promise<string> => {
   const changesStr = changes.length > 0
-    ? formatDetailedChanges([changes.map(change => change.change)], detailed)
+    ? await formatDetailedChanges([changes.map(change => change.change)], detailed)
     : 'No changes'
   return [
     emptyLine(),

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -134,10 +134,12 @@ const buildMultiEnvSource = (
     envChanges?: EnvsChanges
   }): Promise<{ state: MultiEnvState; changes: Change[] }> => {
     const primaryEnv = env ?? primarySourceName
-    const actualChanges = primaryEnv === primarySourceName
+    const isReadingFromPrimaryEnv = primaryEnv === primarySourceName
+
+    const actualChanges = isReadingFromPrimaryEnv
       ? envChanges
       : await mapValuesAsync(sources, src => src.load({ cachePrefix: primarySourceName }))
-    const current = state !== undefined
+    const current = (state !== undefined && isReadingFromPrimaryEnv)
       ? state
       : await buildState(env)
 

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -438,6 +438,15 @@ describe('multi env source', () => {
       expect(await source.get(inactiveElemID)).not.toBeDefined()
     })
   })
+  describe('getElementSource', async () => {
+    it('should return an element source according to env even if state is set', async () => {
+      const primarySource = await source.getElementsSource()
+      const primarySourceByEnvName = await source.getElementsSource(activePrefix)
+      const secondarySourceByEnvName = await source.getElementsSource(inactivePrefix)
+      expect(primarySource).toEqual(primarySourceByEnvName)
+      expect(primarySource).not.toEqual(secondarySourceByEnvName)
+    })
+  })
   describe('getAll', () => {
     it('should return all merged elements', async () => {
       const elements = await awu(await source.getAll()).toArray()


### PR DESCRIPTION
Fix an issue where MultiEnvSource would return the wrong thing when asked for a secondary env source.
Also fixed an issue where diff would print a promise instead of the desired string.
---

---
Diff should start working