### PR TITLE
SALTO-1147 Support hiding fields in simple-adapter configs

### DIFF
--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -17,4 +17,4 @@ export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, TypeDuckT
 export { createRequestConfigs, validateRequestConfig, RequestConfig } from './request'
 export { createAdapterApiConfigType, createUserFetchConfigType, AdapterApiConfig, UserFetchConfig, TypeConfig } from './shared'
 export { createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig } from './swagger'
-export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType } from './transformation'
+export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType } from './transformation'

--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -15,6 +15,6 @@
 */
 export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateFetchConfig as validateDuckTypeFetchConfig } from './ducktype'
 export { createRequestConfigs, validateRequestConfig, RequestConfig } from './request'
-export { createAdapterApiConfigType, createUserFetchConfigType, AdapterApiConfig, UserFetchConfig, TypeConfig } from './shared'
+export { createAdapterApiConfigType, createUserFetchConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig } from './shared'
 export { createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig } from './swagger'
 export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType } from './transformation'

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import {
   ElemID, ObjectType, BuiltinTypes, CORE_ANNOTATIONS, FieldDefinition, ListType, MapType,
 } from '@salto-io/adapter-api'
@@ -112,3 +113,17 @@ export const createUserFetchConfigType = (
     },
   })
 )
+
+export const getConfigWithDefault = <
+  T extends TransformationConfig | RequestConfig | undefined,
+  S extends TransformationDefaultConfig | RequestDefaultConfig
+>(
+    typeSpecificConfig: T,
+    defaultConfig: S,
+  ): T & S => (
+    _.defaults(
+      {},
+      typeSpecificConfig,
+      defaultConfig,
+    )
+  )

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -97,6 +97,8 @@ export const getTypeAndInstances = async ({
     name: typeName,
     entries: naclEntries,
     hasDynamicFields: hasDynamicFields === true,
+    transformationConfigByType,
+    transformationDefaultConfig,
   })
   // find the field and type containing the actual instances
   const nestedFieldDetails = nestedFieldFinder(type, fieldsToOmit, dataField)

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -21,7 +21,7 @@ import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
 import { Paginator } from '../../client'
 import { generateType } from './type_elements'
 import { toInstance } from './instance_elements'
-import { TypeConfig } from '../../config'
+import { TypeConfig, getConfigWithDefault } from '../../config'
 import { FindNestedFieldFunc } from '../field_finder'
 import { TypeDuckTypeDefaultsConfig, TypeDuckTypeConfig } from '../../config/ducktype'
 import { ComputeGetArgsFunc } from '../request_parameters'
@@ -68,7 +68,7 @@ export const getTypeAndInstances = async ({
 
   const {
     fieldsToOmit, hasDynamicFields, dataField,
-  } = _.defaults({}, transformation, typeDefaultConfig.transformation)
+  } = getConfigWithDefault(transformation, typeDefaultConfig.transformation)
 
   const transformationConfigByType = _.pickBy(
     _.mapValues(typesConfig, def => def.transformation),
@@ -76,7 +76,9 @@ export const getTypeAndInstances = async ({
   )
   const transformationDefaultConfig = typeDefaultConfig.transformation
 
-  const requestWithDefaults = _.defaults({}, request, typeDefaultConfig.request ?? {})
+  const requestWithDefaults = getConfigWithDefault(
+    request, typeDefaultConfig.request ?? {},
+  )
 
   const getEntries = async (): Promise<Values[]> => {
     const getArgs = computeGetArgs(requestWithDefaults, contextElements)

--- a/packages/adapter-components/src/elements/ducktype/type_elements.ts
+++ b/packages/adapter-components/src/elements/ducktype/type_elements.ts
@@ -19,7 +19,7 @@ import {
   FieldDefinition,
 } from '@salto-io/adapter-api'
 import { pathNaclCase, naclCase } from '@salto-io/adapter-utils'
-import { TransformationConfig, TransformationDefaultConfig } from '../../config/transformation'
+import { TransformationConfig, TransformationDefaultConfig, getConfigWithDefault } from '../../config'
 import { TYPES_PATH, SUBTYPES_PATH } from '../constants'
 import { hideFields } from '../type_elements'
 
@@ -199,9 +199,8 @@ export const generateType = ({
     )
 
   // mark fields as hidden based on config
-  const { fieldsToHide } = _.defaults(
-    {},
-    transformationConfigByType[naclName] ?? {},
+  const { fieldsToHide } = getConfigWithDefault(
+    transformationConfigByType[naclName],
     transformationDefaultConfig,
   )
 

--- a/packages/adapter-components/src/elements/ducktype/type_elements.ts
+++ b/packages/adapter-components/src/elements/ducktype/type_elements.ts
@@ -16,9 +16,12 @@
 import _ from 'lodash'
 import {
   ObjectType, ElemID, BuiltinTypes, Values, MapType, PrimitiveType, ListType, isObjectType,
+  FieldDefinition,
 } from '@salto-io/adapter-api'
 import { pathNaclCase, naclCase } from '@salto-io/adapter-utils'
+import { TransformationConfig, TransformationDefaultConfig } from '../../config/transformation'
 import { TYPES_PATH, SUBTYPES_PATH } from '../constants'
+import { hideFields } from '../type_elements'
 
 const ID_SEPARATOR = '__'
 
@@ -36,11 +39,21 @@ type NestedTypeWithNestedTypes = {
   nestedTypes: ObjectType[]
 }
 
-const generateNestedType = ({ adapterName, typeName, parentName, entries, hasDynamicFields }: {
+const generateNestedType = ({
+  adapterName,
+  typeName,
+  parentName,
+  entries,
+  transformationConfigByType,
+  transformationDefaultConfig,
+  hasDynamicFields,
+}: {
   adapterName: string
   typeName: string
   parentName: string
   entries: Values[]
+  transformationConfigByType: Record<string, TransformationConfig>
+  transformationDefaultConfig: TransformationDefaultConfig
   hasDynamicFields: boolean
 }): NestedTypeWithNestedTypes => {
   const validEntries = entries.filter(entry => entry !== undefined && entry !== null)
@@ -54,6 +67,8 @@ const generateNestedType = ({ adapterName, typeName, parentName, entries, hasDyn
         parentName,
         entries: validEntries.flat(),
         hasDynamicFields,
+        transformationConfigByType,
+        transformationDefaultConfig,
       })
       return {
         type: new ListType(nestedType.type),
@@ -70,6 +85,8 @@ const generateNestedType = ({ adapterName, typeName, parentName, entries, hasDyn
         name,
         entries: validEntries,
         hasDynamicFields,
+        transformationConfigByType,
+        transformationDefaultConfig,
         isSubType: true,
       })
     }
@@ -119,12 +136,16 @@ export const generateType = ({
   name,
   entries,
   hasDynamicFields,
+  transformationConfigByType,
+  transformationDefaultConfig,
   isSubType = false,
 }: {
   adapterName: string
   name: string
   entries: Values[]
   hasDynamicFields: boolean
+  transformationConfigByType: Record<string, TransformationConfig>
+  transformationDefaultConfig: TransformationDefaultConfig
   isSubType?: boolean
 }): ObjectTypeWithNestedTypes => {
   const naclName = naclCase(name)
@@ -145,7 +166,7 @@ export const generateType = ({
     return typeWithNested.type
   }
 
-  const fields = hasDynamicFields
+  const fields: Record<string, FieldDefinition> = hasDynamicFields
     ? {
       value: {
         type: new MapType(addNestedType(generateNestedType({
@@ -153,6 +174,8 @@ export const generateType = ({
           typeName: 'value',
           parentName: name,
           entries: entries.flatMap(Object.values).filter(entry => entry !== undefined),
+          transformationConfigByType,
+          transformationDefaultConfig,
           hasDynamicFields: false,
         }))),
       },
@@ -167,11 +190,24 @@ export const generateType = ({
               typeName: fieldName,
               parentName: name,
               entries: entries.map(entry => entry[fieldName]).filter(entry => entry !== undefined),
+              transformationConfigByType,
+              transformationDefaultConfig,
               hasDynamicFields: false,
             })),
           },
         ])
     )
+
+  // mark fields as hidden based on config
+  const { fieldsToHide } = _.defaults(
+    {},
+    transformationConfigByType[naclName] ?? {},
+    transformationDefaultConfig,
+  )
+
+  if (Array.isArray(fieldsToHide)) {
+    hideFields(fieldsToHide, fields, name)
+  }
 
   const type = new ObjectType({
     elemID: new ElemID(adapterName, naclName),

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -20,7 +20,7 @@ import {
 import { pathNaclCase, naclCase, transformValues, TransformFunc } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { RECORDS_PATH } from './constants'
-import { TransformationConfig, TransformationDefaultConfig } from '../config'
+import { TransformationConfig, TransformationDefaultConfig, getConfigWithDefault } from '../config'
 
 const log = logger(module)
 
@@ -75,11 +75,12 @@ export const toBasicInstance = ({
     strict: false,
   })
 
-  const adapterName = type.elemID.adapter
-  const transformationConfig = transformationConfigByType[type.elemID.name]
   const {
     idFields, fileNameFields,
-  } = _.defaults({}, transformationConfig, transformationDefaultConfig)
+  } = getConfigWithDefault(
+    transformationConfigByType[type.elemID.name],
+    transformationDefaultConfig,
+  )
 
   const nameParts = idFields.map(field => _.get(entry, field))
   if (nameParts.includes(undefined)) {
@@ -97,6 +98,7 @@ export const toBasicInstance = ({
   const naclName = naclCase(
     parent && nestName ? `${parent.elemID.name}${ID_SEPARATOR}${name}` : String(name)
   )
+  const adapterName = type.elemID.adapter
 
   return new InstanceElement(
     naclName,

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -26,7 +26,7 @@ import { InstanceCreationParams, toBasicInstance } from '../instance_elements'
 import { UnauthorizedError, Paginator } from '../../client'
 import {
   UserFetchConfig, TypeSwaggerDefaultConfig, TransformationConfig, TransformationDefaultConfig,
-  AdapterSwaggerApiConfig, TypeSwaggerConfig,
+  AdapterSwaggerApiConfig, TypeSwaggerConfig, getConfigWithDefault,
 } from '../../config'
 import { findDataField, FindNestedFieldFunc } from '../field_finder'
 import { computeGetArgs as defaultComputeGetArgs, ComputeGetArgsFunc } from '../request_parameters'
@@ -257,7 +257,7 @@ const getInstancesForType = async ({
 
   const {
     fieldsToOmit, dataField,
-  } = _.defaults({}, transformation, typeDefaultConfig.transformation)
+  } = getConfigWithDefault(transformation, typeDefaultConfig.transformation)
 
   try {
     const nestedFieldDetails = nestedFieldFinder(type, fieldsToOmit, dataField)

--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -252,6 +252,7 @@ export const generateTypes = async (
   {
     swagger,
     types,
+    typeDefaults,
   }: AdapterSwaggerApiConfig,
 ): Promise<{
   allTypes: TypeMap
@@ -290,7 +291,7 @@ export const generateTypes = async (
   if (swagger.additionalTypes !== undefined) {
     defineAdditionalTypes(adapterName, swagger.additionalTypes, definedTypes, types)
   }
-  fixTypes(definedTypes, types)
+  fixTypes(definedTypes, types, typeDefaults)
 
   return {
     allTypes: definedTypes,

--- a/packages/adapter-components/src/elements/swagger/type_elements/type_config_override.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/type_config_override.ts
@@ -13,9 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
 import { ObjectType, BuiltinTypes, MapType, ListType, TypeElement, isEqualElements, LIST_ID_PREFIX, GENERIC_ID_PREFIX, GENERIC_ID_SUFFIX, MAP_ID_PREFIX, ElemID } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
+import { getConfigWithDefault } from '../../../config/shared'
 import { TypeSwaggerConfig, AdditionalTypeConfig, TypeSwaggerDefaultConfig } from '../../../config/swagger'
 import { FieldTypeOverrideType, FieldToHideType, TransformationConfig } from '../../../config/transformation'
 import { toPrimitiveType } from './swagger_parser'
@@ -114,9 +114,8 @@ export const fixTypes = (
   }
 
   const getTypeTransformationConfig = (typeName: string): TransformationConfig => (
-    _.defaults(
-      {},
-      typeConfig[typeName]?.transformation ?? {},
+    getConfigWithDefault(
+      typeConfig[typeName]?.transformation,
       typeDefaultConfig.transformation,
     )
   )

--- a/packages/adapter-components/src/elements/swagger/type_elements/type_config_override.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/type_config_override.ts
@@ -13,11 +13,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { ObjectType, BuiltinTypes, MapType, ListType, TypeElement, isEqualElements, LIST_ID_PREFIX, GENERIC_ID_PREFIX, GENERIC_ID_SUFFIX, MAP_ID_PREFIX, ElemID } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { TypeSwaggerConfig, AdditionalTypeConfig } from '../../../config/swagger'
-import { FieldTypeOverrideType } from '../../../config/transformation'
+import { TypeSwaggerConfig, AdditionalTypeConfig, TypeSwaggerDefaultConfig } from '../../../config/swagger'
+import { FieldTypeOverrideType, FieldToHideType, TransformationConfig } from '../../../config/transformation'
 import { toPrimitiveType } from './swagger_parser'
+import { hideFields } from '../../type_elements'
 
 const log = logger(module)
 
@@ -87,12 +89,14 @@ export const defineAdditionalTypes = (
 }
 
 /**
- * Adjust the computed types to fix known inconsistencies between the swagger and the response data
- * that are listed in the configuration.
+ * Adjust the computed types based on the configuration in order to:
+ *  1. Fix known inconsistencies between the swagger and the response data
+ *  2. Hide field values that are known to be env-specific
  */
 export const fixTypes = (
   definedTypes: Record<string, ObjectType>,
-  typeConfig: Record<string, TypeSwaggerConfig>
+  typeConfig: Record<string, TypeSwaggerConfig>,
+  typeDefaultConfig: TypeSwaggerDefaultConfig,
 ): void => {
   const toTypeWithContainers = (typeName: string): TypeElement => {
     const containerDetails = getContainerForType(typeName)
@@ -109,26 +113,46 @@ export const fixTypes = (
     return type
   }
 
+  const getTypeTransformationConfig = (typeName: string): TransformationConfig => (
+    _.defaults(
+      {},
+      typeConfig[typeName]?.transformation ?? {},
+      typeDefaultConfig.transformation,
+    )
+  )
+
+  // fix field types
   Object.keys(typeConfig)
-    .filter(typeName => typeConfig[typeName].transformation?.fieldTypeOverrides !== undefined)
+    .filter(typeName => getTypeTransformationConfig(typeName).fieldTypeOverrides !== undefined)
     .forEach(typeName => {
       const type = definedTypes[typeName]
       if (type === undefined) {
-        log.error('type %s not found, cannot override its field types', typeName)
+        log.warn('type %s not found, cannot override its field types', typeName)
         return
       }
-      const fieldTypeOverrides = typeConfig[
+      const fieldTypeOverrides = getTypeTransformationConfig(
         typeName
-      ].transformation?.fieldTypeOverrides as FieldTypeOverrideType[]
+      ).fieldTypeOverrides as FieldTypeOverrideType[]
       fieldTypeOverrides.forEach(({ fieldName, fieldType }) => {
         const field = type.fields[fieldName]
         if (field === undefined) {
-          log.error('field %s.%s not found, cannot override its type', typeName, fieldName)
+          log.warn('field %s.%s not found, cannot override its type', typeName, fieldName)
           return
         }
         const newFieldType = toTypeWithContainers(fieldType)
-        log.info('Modifying field type for %s.%s from %s to %s', typeName, fieldName, field.type.elemID.name, newFieldType.elemID.name)
+        log.debug('Modifying field type for %s.%s from %s to %s', typeName, fieldName, field.type.elemID.name, newFieldType.elemID.name)
         field.type = newFieldType
       })
+    })
+
+  // hide env-specific fields
+  Object.entries(definedTypes)
+    .filter(([typeName]) => getTypeTransformationConfig(typeName).fieldsToHide !== undefined)
+    .forEach(([typeName, type]) => {
+      hideFields(
+        getTypeTransformationConfig(typeName).fieldsToHide as FieldToHideType[],
+        type.fields,
+        typeName,
+      )
     })
 }

--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -1,0 +1,45 @@
+
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { FieldDefinition, Field, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { FieldToHideType } from '../config/transformation'
+
+const log = logger(module)
+
+/**
+ * Annotate fields with _hidden_value=true if they match the specified configuration.
+ */
+export const hideFields = (
+  fieldsToHide: FieldToHideType[],
+  typeFields: Record<string, FieldDefinition | Field>,
+  typeName: string,
+): void => {
+  fieldsToHide.forEach(({ fieldName, fieldType }) => {
+    const field = typeFields[fieldName]
+    if (field === undefined) {
+      log.warn('field %s.%s not found, cannot hide it', typeName, fieldName)
+      return
+    }
+    if (fieldType === undefined || fieldType === field.type.elemID.name) {
+      log.debug('Hiding values for field %s.%s', typeName, fieldName)
+      field.annotations = {
+        ...(field.annotations ?? {}),
+        [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+      }
+    }
+  })
+}

--- a/packages/adapter-components/test/config/shared.test.ts
+++ b/packages/adapter-components/test/config/shared.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { createUserFetchConfigType } from '../../src/config'
+import { createUserFetchConfigType, getConfigWithDefault } from '../../src/config'
 
 describe('config_shared', () => {
   describe('createUserFetchConfigType', () => {
@@ -21,6 +21,28 @@ describe('config_shared', () => {
       const type = createUserFetchConfigType('myAdapter')
       expect(Object.keys(type.fields)).toHaveLength(1)
       expect(type.fields.includeTypes).toBeDefined()
+    })
+  })
+  describe('getConfigWithDefault', () => {
+    it('should return the config with defaults for adapter api when type-specific config is provided', () => {
+      expect(getConfigWithDefault(
+        { url: 'abc', queryParams: { a: 'specific' } },
+        { paginationField: 'page', queryParams: { b: 'default' } }
+      )).toEqual({ url: 'abc', queryParams: { a: 'specific' }, paginationField: 'page' })
+      expect(getConfigWithDefault(
+        { standaloneFields: [{ fieldName: 'specific' }] },
+        { idFields: ['a', 'b'], standaloneFields: [{ fieldName: 'default' }] },
+      )).toEqual({ idFields: ['a', 'b'], standaloneFields: [{ fieldName: 'specific' }] })
+    })
+    it('should return the config with defaults for adapter api  when type-specific config is missing', () => {
+      expect(getConfigWithDefault(
+        undefined,
+        { paginationField: 'page', queryParams: { b: 'default' } }
+      )).toEqual({ paginationField: 'page', queryParams: { b: 'default' } })
+      expect(getConfigWithDefault(
+        undefined,
+        { idFields: ['a', 'b'], standaloneFields: [{ fieldName: 'default' }] },
+      )).toEqual({ idFields: ['a', 'b'], standaloneFields: [{ fieldName: 'default' }] })
     })
   })
 })

--- a/packages/adapter-components/test/config/transformation.test.ts
+++ b/packages/adapter-components/test/config/transformation.test.ts
@@ -20,16 +20,14 @@ describe('config_transformation', () => {
   describe('createTransformationConfigTypes', () => {
     it('should return default config type when no custom fields were added', () => {
       const { transformation, transformationDefault } = createTransformationConfigTypes('myAdapter')
-      expect(Object.keys(transformation.fields)).toHaveLength(6)
-      expect(Object.keys(transformation.fields).sort()).toEqual(['dataField', 'fieldTypeOverrides', 'fieldsToOmit', 'fileNameFields', 'idFields', 'standaloneFields'])
+      expect(Object.keys(transformation.fields).sort()).toEqual(['dataField', 'fieldTypeOverrides', 'fieldsToHide', 'fieldsToOmit', 'fileNameFields', 'idFields', 'standaloneFields'])
       expect(transformation.fields.idFields.annotations[CORE_ANNOTATIONS.REQUIRED]).toBeUndefined()
       const idFieldsType = transformation.fields.idFields.type as ListType
       expect(idFieldsType).toBeInstanceOf(ListType)
       const idFieldsTypeInner = idFieldsType.innerType
       expect(idFieldsTypeInner).toEqual(BuiltinTypes.STRING)
 
-      expect(Object.keys(transformationDefault.fields)).toHaveLength(6)
-      expect(Object.keys(transformationDefault.fields).sort()).toEqual(['dataField', 'fieldTypeOverrides', 'fieldsToOmit', 'fileNameFields', 'idFields', 'standaloneFields'])
+      expect(Object.keys(transformationDefault.fields).sort()).toEqual(['dataField', 'fieldTypeOverrides', 'fieldsToHide', 'fieldsToOmit', 'fileNameFields', 'idFields', 'standaloneFields'])
       expect(transformationDefault.fields.idFields.annotations[CORE_ANNOTATIONS.REQUIRED]).toEqual(
         true
       )
@@ -44,11 +42,9 @@ describe('config_transformation', () => {
         'myAdapter',
         { a: { type: BuiltinTypes.STRING } },
       )
-      expect(Object.keys(transformation.fields)).toHaveLength(7)
-      expect(Object.keys(transformation.fields).sort()).toEqual(['a', 'dataField', 'fieldTypeOverrides', 'fieldsToOmit', 'fileNameFields', 'idFields', 'standaloneFields'])
+      expect(Object.keys(transformation.fields).sort()).toEqual(['a', 'dataField', 'fieldTypeOverrides', 'fieldsToHide', 'fieldsToOmit', 'fileNameFields', 'idFields', 'standaloneFields'])
       expect(transformation.fields.a.type).toEqual(BuiltinTypes.STRING)
-      expect(Object.keys(transformationDefault.fields)).toHaveLength(7)
-      expect(Object.keys(transformationDefault.fields).sort()).toEqual(['a', 'dataField', 'fieldTypeOverrides', 'fieldsToOmit', 'fileNameFields', 'idFields', 'standaloneFields'])
+      expect(Object.keys(transformationDefault.fields).sort()).toEqual(['a', 'dataField', 'fieldTypeOverrides', 'fieldsToHide', 'fieldsToOmit', 'fileNameFields', 'idFields', 'standaloneFields'])
       expect(transformationDefault.fields.a.type).toEqual(BuiltinTypes.STRING)
     })
   })
@@ -70,6 +66,10 @@ describe('config_transformation', () => {
               { fieldName: 'abc' },
               { fieldName: 'abd', fieldType: 'cef' },
             ],
+            fieldsToHide: [
+              { fieldName: 'abc' },
+              { fieldName: 'abd', fieldType: 'cef' },
+            ],
             standaloneFields: [
               { fieldName: 'abc' },
             ],
@@ -83,7 +83,7 @@ describe('config_transformation', () => {
         },
       )).not.toThrow()
     })
-    it('should fail if there are conflicts between field entries in the default config', () => {
+    it('should fail if there are conflicts between field entries in the default config (fieldsToOmit)', () => {
       expect(() => validateTransoformationConfig(
         'PATH',
         {
@@ -116,6 +116,40 @@ describe('config_transformation', () => {
           },
         },
       )).toThrow(new Error('Duplicate fieldsToOmit params found in PATH default config: abc'))
+    })
+    it('should fail if there are conflicts between field entries in the default config (fieldsToHide)', () => {
+      expect(() => validateTransoformationConfig(
+        'PATH',
+        {
+          idFields: ['a', 'b', 'c'],
+          fieldsToHide: [
+            { fieldName: 'abc', fieldType: 'something' },
+            { fieldName: 'abc', fieldType: 'something' },
+            { fieldName: 'abc' },
+          ],
+        },
+        {
+          t1: {
+            fieldTypeOverrides: [
+              { fieldName: 'abc', fieldType: 'def' },
+              { fieldName: 'abd', fieldType: 'cef' },
+            ],
+            fieldsToHide: [
+              { fieldName: 'abc' },
+              { fieldName: 'abd', fieldType: 'cef' },
+            ],
+            standaloneFields: [
+              { fieldName: 'abc' },
+            ],
+          },
+          t2: {
+            fieldTypeOverrides: [
+              { fieldName: 'abc', fieldType: 'def' },
+              { fieldName: 'abd', fieldType: 'cef' },
+            ],
+          },
+        },
+      )).toThrow(new Error('Duplicate fieldsToHide params found in PATH default config: abc'))
     })
     it('should fail if there are conflicts between field entries for specific types', () => {
       expect(() => validateTransoformationConfig(

--- a/packages/adapter-components/test/elements/ducktype/transformer.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/transformer.test.ts
@@ -102,6 +102,11 @@ describe('ducktype_transformer', () => {
         name: 'myType',
         entries: [{ name: 'bla1' }, { missing: 'something' }],
         hasDynamicFields: false,
+        transformationConfigByType: {},
+        transformationDefaultConfig: {
+          idFields: ['name'],
+          fileNameFields: ['also_name'],
+        },
       })
       expect(instanceElements.toInstance).toHaveBeenCalledTimes(2)
       expect(instanceElements.toInstance).toHaveBeenCalledWith({
@@ -166,6 +171,15 @@ describe('ducktype_transformer', () => {
         name: 'myType',
         entries: [{ name: 'bla1' }, { missing: 'something' }],
         hasDynamicFields: false,
+        transformationConfigByType: {
+          myType: {
+            fieldsToOmit: [{ fieldName: 'missing' }],
+          },
+        },
+        transformationDefaultConfig: {
+          idFields: ['name'],
+          fileNameFields: ['also_name'],
+        },
       })
       expect(instanceElements.toInstance).toHaveBeenCalledTimes(2)
       expect(instanceElements.toInstance).toHaveBeenCalledWith({
@@ -240,6 +254,11 @@ describe('ducktype_transformer', () => {
         name: 'myType',
         entries: [{ someNested: { name: 'bla1' } }, { someNested: [{ missing: 'something' }] }],
         hasDynamicFields: false,
+        transformationConfigByType: {},
+        transformationDefaultConfig: {
+          idFields: ['name'],
+          fileNameFields: ['also_name'],
+        },
       })
       expect(instanceElements.toInstance).toHaveBeenCalledTimes(2)
       expect(instanceElements.toInstance).toHaveBeenCalledWith({

--- a/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
@@ -31,6 +31,8 @@ describe('ducktype_type_elements', () => {
         entries,
         hasDynamicFields: false,
         isSubType: false,
+        transformationConfigByType: {},
+        transformationDefaultConfig: { idFields: [] },
       })
       expect(type.isEqual(new ObjectType({ elemID: new ElemID(ADAPTER_NAME, 'typeName'), fields: {} }))).toBeTruthy()
       expect(nestedTypes).toHaveLength(0)
@@ -89,6 +91,8 @@ describe('ducktype_type_elements', () => {
         entries,
         hasDynamicFields: false,
         isSubType: false,
+        transformationConfigByType: {},
+        transformationDefaultConfig: { idFields: [] },
       })
       expect(type.isEqual(new ObjectType({
         elemID: new ElemID(ADAPTER_NAME, 'typeName'),
@@ -135,6 +139,108 @@ describe('ducktype_type_elements', () => {
         },
       }))).toBeTruthy()
     })
+    it('should annotate fields marked as fieldsToHide with _hidden_value', () => {
+      const entries = [
+        {
+          id: 41619,
+          api_collection_id: 11815,
+          flow_id: 1381119,
+          flow_ids: [1381119, 1382229],
+          name: 'ab321',
+          method: 'GET',
+          url: 'https://some.url.com/a/bbb/user/{id}',
+          legacy_url: null,
+          base_path: '/a/bbb/user/{id}',
+          path: 'user/{id}',
+          active: false,
+          legacy: false,
+          created_at: '2020-12-21T16:08:03.762-08:00',
+          updated_at: '2020-12-21T16:08:03.762-08:00',
+        },
+        {
+          id: 54775,
+          api_collection_id: 22,
+          flow_id: 890,
+          flow_ids: [890, 980],
+          name: 'some other name',
+          field_with_complex_type: {
+            number: 53,
+            nested_type: {
+              val: 'agds',
+              another_val: 'dgadgasg',
+            },
+          },
+          field_with_complex_list_type: [{
+            number: 53,
+          }],
+        },
+        {
+          field_with_complex_type: {
+            number: 222,
+            nested_type: {
+              val: 'agds',
+              another_val: 7,
+              abc: 'abc',
+              unknown: null,
+            },
+          },
+        },
+      ]
+      const { type, nestedTypes } = generateType({
+        adapterName: ADAPTER_NAME,
+        name: 'typeName',
+        entries,
+        hasDynamicFields: false,
+        isSubType: false,
+        transformationConfigByType: {
+          typeName: {
+            fieldsToHide: [
+              { fieldName: 'flow_id', fieldType: 'number' },
+            ],
+          },
+          typeName__field_with_complex_type: {
+            fieldsToHide: [
+              { fieldName: 'number' },
+            ],
+          },
+        },
+        transformationDefaultConfig: { idFields: [] },
+      })
+      expect(type.isEqual(new ObjectType({
+        elemID: new ElemID(ADAPTER_NAME, 'typeName'),
+        fields: {
+          id: { type: BuiltinTypes.NUMBER },
+          api_collection_id: { type: BuiltinTypes.NUMBER },
+          flow_id: {
+            type: BuiltinTypes.NUMBER,
+            annotations: { _hidden_value: true },
+          },
+          flow_ids: { type: new ListType(BuiltinTypes.NUMBER) },
+          name: { type: BuiltinTypes.STRING },
+          method: { type: BuiltinTypes.STRING },
+          url: { type: BuiltinTypes.STRING },
+          legacy_url: { type: BuiltinTypes.UNKNOWN },
+          base_path: { type: BuiltinTypes.STRING },
+          path: { type: BuiltinTypes.STRING },
+          active: { type: BuiltinTypes.BOOLEAN },
+          legacy: { type: BuiltinTypes.BOOLEAN },
+          created_at: { type: BuiltinTypes.STRING },
+          updated_at: { type: BuiltinTypes.STRING },
+          field_with_complex_type: { type: nestedTypes[0] },
+          field_with_complex_list_type: { type: new ListType(nestedTypes[2]) },
+        },
+      }))).toBeTruthy()
+      expect(nestedTypes[0].isEqual(new ObjectType({
+        elemID: new ElemID(ADAPTER_NAME, 'typeName__field_with_complex_type'),
+        fields: {
+          number: {
+            type: BuiltinTypes.NUMBER,
+            annotations: { _hidden_value: true },
+          },
+          nested_type: { type: nestedTypes[1] },
+        },
+      }))).toBeTruthy()
+    })
     it('should ignore nulls when determining types for fields', () => {
       const entries = [
         {
@@ -170,6 +276,8 @@ describe('ducktype_type_elements', () => {
         entries,
         hasDynamicFields: false,
         isSubType: false,
+        transformationConfigByType: {},
+        transformationDefaultConfig: { idFields: [] },
       })
       expect(type.isEqual(new ObjectType({
         elemID: new ElemID(ADAPTER_NAME, 'typeName'),
@@ -210,6 +318,8 @@ describe('ducktype_type_elements', () => {
         entries,
         hasDynamicFields: true,
         isSubType: false,
+        transformationConfigByType: {},
+        transformationDefaultConfig: { idFields: [] },
       })
       expect(type.isEqual(new ObjectType({
         elemID: new ElemID(ADAPTER_NAME, 'typeName'),
@@ -242,6 +352,8 @@ describe('ducktype_type_elements', () => {
         entries,
         hasDynamicFields: true,
         isSubType: false,
+        transformationConfigByType: {},
+        transformationDefaultConfig: { idFields: [] },
       })
       expect(type.isEqual(new ObjectType({
         elemID: new ElemID(ADAPTER_NAME, 'typeName'),
@@ -284,6 +396,8 @@ describe('ducktype_type_elements', () => {
         entries,
         hasDynamicFields: true,
         isSubType: false,
+        transformationConfigByType: {},
+        transformationDefaultConfig: { idFields: [] },
       })
       expect(type.isEqual(new ObjectType({
         elemID: new ElemID(ADAPTER_NAME, 'typeName'),
@@ -301,6 +415,8 @@ describe('ducktype_type_elements', () => {
         entries,
         hasDynamicFields: false,
         isSubType: false,
+        transformationConfigByType: {},
+        transformationDefaultConfig: { idFields: [] },
       })
       expect(type.isEqual(new ObjectType({
         elemID: new ElemID(ADAPTER_NAME, 'typeName_requiring_naclcase@vu'),
@@ -317,6 +433,8 @@ describe('ducktype_type_elements', () => {
         entries,
         hasDynamicFields: false,
         isSubType: true,
+        transformationConfigByType: {},
+        transformationDefaultConfig: { idFields: [] },
       })
       expect(type.isEqual(new ObjectType({
         elemID: new ElemID(ADAPTER_NAME, 'parent_type__subtypeName'),

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -198,6 +198,9 @@ describe('swagger_type_elements', () => {
                     { fieldName: 'quantity', fieldType: 'map<Category>' },
                     { fieldName: 'newField', fieldType: 'map<Category>' },
                   ],
+                  fieldsToHide: [
+                    { fieldName: 'petId' },
+                  ],
                 },
               },
               NewType: {
@@ -250,6 +253,12 @@ describe('swagger_type_elements', () => {
         expect(order.fields.shipDate.type).toEqual(allTypes.Category)
         expect(order.fields.quantity.type).toBeInstanceOf(MapType)
         expect((order.fields.quantity.type as MapType).innerType).toEqual(allTypes.Category)
+      })
+      it('should annotate fields from fieldsToHide with _hidden_value=true', () => {
+        const order = allTypes.Order as ObjectType
+        expect(order).toBeInstanceOf(ObjectType)
+        // eslint-disable-next-line no-underscore-dangle
+        expect((order.fields.petId.annotations?._hidden_value)).toBeTruthy()
       })
       it('should not add fields that did not already exist', () => {
         const order = allTypes.Order as ObjectType

--- a/packages/adapter-components/test/elements/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/type_elements.test.ts
@@ -1,0 +1,89 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { FieldDefinition, BuiltinTypes, ObjectType, ElemID } from '@salto-io/adapter-api'
+import { hideFields } from '../../src/elements/type_elements'
+
+describe('type_elements', () => {
+  describe('hideFields', () => {
+    let myCustomType: ObjectType
+    let fields: Record<string, FieldDefinition>
+
+    beforeEach(() => {
+      myCustomType = new ObjectType({
+        elemID: new ElemID('adapter', 'myCustomType'),
+        fields: {
+          str: { type: BuiltinTypes.STRING },
+          num: { type: BuiltinTypes.NUMBER },
+        },
+      })
+      fields = {
+        str: { type: BuiltinTypes.STRING },
+        num: { type: BuiltinTypes.NUMBER },
+        custom: { type: myCustomType },
+      }
+    })
+    it('should hide values for fields matching the specification', () => {
+      hideFields([
+        { fieldName: 'str', fieldType: 'string' },
+      ], myCustomType.fields, 'bla')
+      // eslint-disable-next-line no-underscore-dangle
+      expect(myCustomType.fields.str.annotations._hidden_value).toBeTruthy()
+      expect(myCustomType.fields.num.annotations).toEqual({})
+
+      hideFields([
+        { fieldName: 'num' },
+        { fieldName: 'custom', fieldType: 'myCustomType' },
+      ], fields, 'bla')
+      // eslint-disable-next-line no-underscore-dangle
+      expect(fields.num.annotations?._hidden_value).toBeTruthy()
+      // eslint-disable-next-line no-underscore-dangle
+      expect(fields.custom.annotations?._hidden_value).toBeTruthy()
+      expect(fields.str.annotations).toBeUndefined()
+    })
+    it('should not hide values for fields that do not have the right type', () => {
+      hideFields([
+        { fieldName: 'str', fieldType: 'something' },
+      ], myCustomType.fields, 'bla')
+      expect(myCustomType.fields.str.annotations).toEqual({})
+      expect(myCustomType.fields.num.annotations).toEqual({})
+
+      hideFields([
+        { fieldName: 'num', fieldType: 'string' },
+        { fieldName: 'custom', fieldType: 'number' },
+      ], fields, 'bla')
+      expect(fields.str.annotations).toBeUndefined()
+      expect(fields.num.annotations).toBeUndefined()
+      expect(fields.custom.annotations).toBeUndefined()
+    })
+    it('should ignore fields that are not found', () => {
+      hideFields([
+        { fieldName: 'missing' },
+      ], myCustomType.fields, 'bla')
+      expect(Object.keys(myCustomType.fields)).toHaveLength(2)
+      expect(myCustomType.fields.str.annotations).toEqual({})
+      expect(myCustomType.fields.num.annotations).toEqual({})
+
+      hideFields([
+        { fieldName: 'missing' },
+      ], fields, 'bla')
+      expect(Object.keys(fields)).toHaveLength(3)
+      expect(fields.str.annotations).toBeUndefined()
+      expect(fields.num.annotations).toBeUndefined()
+      expect(fields.custom.annotations).toBeUndefined()
+    })
+  })
+})

--- a/packages/workato-adapter/src/filters/extract_fields.ts
+++ b/packages/workato-adapter/src/filters/extract_fields.ts
@@ -89,6 +89,8 @@ const addFieldTypeAndInstances = ({
     entries: instancesWithValues.map(inst => inst.value[fieldName]),
     hasDynamicFields: false,
     isSubType: true,
+    transformationConfigByType,
+    transformationDefaultConfig,
   })
   type.fields[fieldName].type = fieldType.type
   elements.push(fieldType.type, ...fieldType.nestedTypes)
@@ -151,7 +153,7 @@ const extractFields = ({
     instances.forEach(inst => convertStringToObject(inst, standaloneFields))
 
     // now extract the field data to its own type and instances, and replace the original
-    // value with a reference to the newly-generate instance
+    // value with a reference to the newly-generated instance
     standaloneFields.forEach(fieldDef => {
       newElements.push(...addFieldTypeAndInstances({
         typeName,


### PR DESCRIPTION
Add simple-adapter config option for hiding values for env-specific fields (`fieldsToHide`).
This is done by setting the `_hidden_value` annotation on the field to true.

Note that this needs to be used carefully, because it has the usual caveats of hidden values - mainly, hiding values nested inside lists can cause merge conflicts. This can be avoided by either completely omitting the field values (using `fieldsToOmit`), or making the array items standalone fields, so that the array becomes an array of references and but the elements that are merged are single elements.


---
_Release Notes_: 
None
