### PR TITLE
SALTO-1208: added support for go-to-service for file cabinet instnaces

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -79,13 +79,6 @@ describe('Netsuite adapter E2E with real account', () => {
     ['without SuiteApp', false],
     ['with SuiteApp', true],
   ]).describe('%s', (_text, withSuiteApp) => {
-    beforeAll(async () => {
-      const adapterAttr = realAdapter(
-        { credentials: credentialsLease.value, withSuiteApp },
-      )
-      adapter = adapterAttr.adapter
-    })
-
     let fetchResult: FetchResult
     let fetchedInstances: InstanceElement[]
 
@@ -208,6 +201,11 @@ describe('Netsuite adapter E2E with real account', () => {
 
       let deployResult: DeployResult
       beforeAll(async () => {
+        const adapterAttr = realAdapter(
+          { credentials: credentialsLease.value, withSuiteApp },
+        )
+        adapter = adapterAttr.adapter
+
         const idToGroup = (await adapter?.deployModifiers
           ?.getChangeGroupIds?.(changes)) as Map<ChangeId, ChangeGroupId>
         const changesGroups = _(changes)
@@ -258,6 +256,11 @@ describe('Netsuite adapter E2E with real account', () => {
 
     describe('Fetch after creation', () => {
       beforeAll(async () => {
+        const adapterAttr = realAdapter(
+          { credentials: credentialsLease.value, withSuiteApp },
+        )
+        adapter = adapterAttr.adapter
+
         const mockFetchOpts: MockInterface<FetchOptions> = {
           progressReporter: { reportProgress: jest.fn() },
         }

--- a/packages/netsuite-adapter/e2e_test/adapter.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.ts
@@ -18,7 +18,7 @@ import { logger } from '@salto-io/logging'
 import { creds, CredsLease } from '@salto-io/e2e-credentials-store'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import Bottleneck from 'bottleneck'
-import { Credentials } from '../src/client/credentials'
+import { Credentials, toCredentialsAccountId } from '../src/client/credentials'
 import SdfClient from '../src/client/sdf_client'
 import NetsuiteAdapter, { NetsuiteAdapterParams } from '../src/adapter'
 import { NetsuiteConfig } from '../src/config'
@@ -43,7 +43,7 @@ export const realAdapter = (
 ): { client: NetsuiteClient; adapter: NetsuiteAdapter } => {
   const netsuiteCredentials = {
     ...credentials,
-    accountId: credentials.accountId.toUpperCase().replace('-', '_'),
+    accountId: toCredentialsAccountId(credentials.accountId),
   }
   const globalLimiter = new Bottleneck({ maxConcurrent: 4 })
   const client = (adapterParams && adapterParams.client)

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -33,6 +33,7 @@ import replaceInstanceReferencesFilter from './filters/instance_references'
 import convertLists from './filters/convert_lists'
 import consistentValues from './filters/consistent_values'
 import addParentFolder from './filters/add_parent_folder'
+import serviceUrls from './filters/service_urls'
 import { FilterCreator } from './filter'
 import {
   getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS,
@@ -92,6 +93,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       convertLists,
       consistentValues,
       replaceInstanceReferencesFilter,
+      serviceUrls,
     ],
     typesToSkip = [
       INTEGRATION, // The imported xml has no values, especially no SCRIPT_ID, for standard
@@ -257,7 +259,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     // Fetch filters order is important so they should run one after the other
     return this.filtersCreators.map(filterCreator => filterCreator()).reduce(
       (prevRes, filter) => prevRes.then(() =>
-        filter.onFetch({ elements, elementsSourceIndex, isPartial })),
+        filter.onFetch({ elements, client: this.client, elementsSourceIndex, isPartial })),
       Promise.resolve(),
     )
   }

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -33,7 +33,7 @@ import {
   CONCURRENCY_LIMIT,
 } from './constants'
 import { validateParameters } from './query'
-import { Credentials } from './client/credentials'
+import { Credentials, toCredentialsAccountId } from './client/credentials'
 import SuiteAppClient from './client/suiteapp_client/suiteapp_client'
 import SdfClient from './client/sdf_client'
 import NetsuiteClient from './client/client'
@@ -134,8 +134,7 @@ const netsuiteConfigFromConfig = (config: Readonly<InstanceElement> | undefined)
 
 const netsuiteCredentialsFromCredentials = (credentials: Readonly<InstanceElement>): Credentials =>
   ({
-    // accountId must be uppercased as described in https://github.com/oracle/netsuite-suitecloud-sdk/issues/140
-    accountId: credentials.value.accountId.toUpperCase().replace('-', '_'),
+    accountId: toCredentialsAccountId(credentials.value.accountId),
     tokenId: credentials.value.tokenId,
     tokenSecret: credentials.value.tokenSecret,
     suiteAppTokenId: credentials.value.suiteAppTokenId === '' ? undefined : credentials.value.suiteAppTokenId,

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -19,7 +19,7 @@ import { logger } from '@salto-io/logging'
 import { decorators } from '@salto-io/lowerdash'
 import { resolveValues } from '@salto-io/adapter-utils'
 import { NetsuiteQuery } from '../query'
-import { Credentials } from './credentials'
+import { Credentials, toUrlAccountId } from './credentials'
 import SdfClient from './sdf_client'
 import SuiteAppClient from './suiteapp_client/suiteapp_client'
 import { createSuiteAppFileCabinetOperations, SuiteAppFileCabinetOperations, DeployType } from '../suiteapp_file_cabinet'
@@ -53,7 +53,7 @@ export default class NetsuiteClient {
       log.debug('Salto SuiteApp configured')
     }
 
-    this.url = new URL(`https://${this.sdfClient.getCredentials().accountId.replace('_', '-')}.app.netsuite.com`)
+    this.url = new URL(`https://${toUrlAccountId(this.sdfClient.getCredentials().accountId)}.app.netsuite.com`)
   }
 
   @NetsuiteClient.logDecorator

--- a/packages/netsuite-adapter/src/client/credentials.ts
+++ b/packages/netsuite-adapter/src/client/credentials.ts
@@ -26,3 +26,8 @@ export type SdfCredentials = {
 }
 
 export type Credentials = SdfCredentials & Partial<SuiteAppCredentials>
+
+export const toUrlAccountId = (accountId: string): string => accountId.toLowerCase().replace('_', '-')
+
+// accountId must be uppercased as described in https://github.com/oracle/netsuite-suitecloud-sdk/issues/140
+export const toCredentialsAccountId = (accountId: string): string => accountId.toUpperCase().replace('-', '_')

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -197,6 +197,10 @@ export default class SdfClient {
     return Promise.resolve(netsuiteClient.credentials.accountId)
   }
 
+  public getCredentials(): Readonly<SdfCredentials> {
+    return this.credentials
+  }
+
   private static initCommandActionExecutor(executionPath: string): CommandActionExecutor {
     return new CommandActionExecutor({
       executionPath,

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -22,7 +22,7 @@ import crypto from 'crypto'
 import xmlConvert from 'xml-js'
 import { collections } from '@salto-io/lowerdash'
 import path from 'path'
-import { SuiteAppCredentials } from '../../credentials'
+import { SuiteAppCredentials, toUrlAccountId } from '../../credentials'
 import { CONSUMER_KEY, CONSUMER_SECRET } from '../constants'
 import { ReadFileError } from '../errors'
 import { CallsLimiter, ExistingFileCabinetInstanceDetails, FileCabinetInstanceDetails, FileDetails, FolderDetails } from '../types'
@@ -40,7 +40,7 @@ export default class SoapClient {
   constructor(credentials: SuiteAppCredentials, callsLimiter: CallsLimiter) {
     this.credentials = credentials
     this.callsLimiter = callsLimiter
-    this.soapUrl = new URL(`https://${credentials.accountId.replace('_', '-')}.suitetalk.api.netsuite.com/services/NetSuitePort_2020_2`)
+    this.soapUrl = new URL(`https://${toUrlAccountId(credentials.accountId)}.suitetalk.api.netsuite.com/services/NetSuitePort_2020_2`)
     this.ajv = new Ajv({ allErrors: true, strict: false })
   }
 

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -26,7 +26,7 @@ import { CallsLimiter, ExistingFileCabinetInstanceDetails, FileCabinetInstanceDe
   RESTLET_RESULTS_SCHEMA, SavedSearchQuery, SavedSearchResults, SAVED_SEARCH_RESULTS_SCHEMA,
   SuiteAppClientParameters, SuiteQLResults, SUITE_QL_RESULTS_SCHEMA, SystemInformation,
   SYSTEM_INFORMATION_SCHEME } from './types'
-import { SuiteAppCredentials } from '../credentials'
+import { SuiteAppCredentials, toUrlAccountId } from '../credentials'
 import { DEFAULT_CONCURRENCY } from '../../config'
 import { CONSUMER_KEY, CONSUMER_SECRET } from './constants'
 import SoapClient from './soap_client/soap_client'
@@ -66,7 +66,7 @@ export default class SuiteAppClient {
     })
     this.callsLimiter = fn => params.globalLimiter.schedule(() => limiter.schedule(fn))
 
-    const accountIdUrl = params.credentials.accountId.replace('_', '-')
+    const accountIdUrl = toUrlAccountId(params.credentials.accountId)
     this.suiteQLUrl = new URL(`https://${accountIdUrl}.suitetalk.api.netsuite.com/services/rest/query/v1/suiteql`)
     this.restletUrl = new URL(`https://${accountIdUrl}.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=customscript_salto_restlet&deploy=customdeploy_salto_restlet`)
 

--- a/packages/netsuite-adapter/src/filters/service_urls.ts
+++ b/packages/netsuite-adapter/src/filters/service_urls.ts
@@ -13,21 +13,20 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element } from '@salto-io/adapter-api'
-import NetsuiteClient from './client/client'
-import { LazyElementsSourceIndex } from './elements_source_index/types'
+import { FilterCreator } from '../filter'
+import setFileCabinetUrls from '../service_url/file_cabinet'
 
-export type OnFetchParameters = {
-  elements: Element[]
-  client: NetsuiteClient
-  elementsSourceIndex: LazyElementsSourceIndex
-  isPartial: boolean
-}
+const SERVICE_URL_SETTERS = [
+  setFileCabinetUrls,
+]
 
-// Filter interface, filters will be activated upon adapter fetch operations.
-// The filter will be responsible for specific business logic.
-export type OnFetchFilter = {
-  onFetch(parameters: OnFetchParameters): Promise<void>
-}
+const filterCreator: FilterCreator = () => ({
+  onFetch: async ({ elements, client }) => {
+    if (!client.isSuiteAppConfigured()) {
+      return
+    }
+    await Promise.all(SERVICE_URL_SETTERS.map(setter => setter(elements, client)))
+  },
+})
 
-export type FilterCreator = () => OnFetchFilter
+export default filterCreator

--- a/packages/netsuite-adapter/src/service_url/file_cabinet.ts
+++ b/packages/netsuite-adapter/src/service_url/file_cabinet.ts
@@ -1,0 +1,46 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { CORE_ANNOTATIONS, InstanceElement } from '@salto-io/adapter-api'
+import { promises } from '@salto-io/lowerdash'
+import { ServiceUrlSetter } from './types'
+import { isFileCabinetInstance, isFileInstance } from '../types'
+import NetsuiteClient from '../client/client'
+
+const generateUrl = async (element: InstanceElement, client: NetsuiteClient):
+  Promise<string | undefined> => {
+  const id = await client.getPathInternalId(element.value.path)
+  if (id === undefined) {
+    return undefined
+  }
+
+  return isFileInstance(element)
+    ? `app/common/media/mediaitem.nl?id=${id}`
+    : `app/common/media/mediaitemfolder.nl?id=${id}`
+}
+
+const setServiceUrl: ServiceUrlSetter = async (elements, client) => {
+  const relevantElements = elements.filter(isFileCabinetInstance)
+
+  // We use series here and not Promise.all since getPathInternalId is not concurrency safe
+  // and there isn't much advantage in running it in parallel
+  await promises.array.series(relevantElements.map(element => async () => {
+    const url = await generateUrl(element, client)
+    element.annotations[CORE_ANNOTATIONS.SERVICE_URL] = url && new URL(url, client.url).href
+  }))
+}
+
+export default setServiceUrl

--- a/packages/netsuite-adapter/src/service_url/file_cabinet.ts
+++ b/packages/netsuite-adapter/src/service_url/file_cabinet.ts
@@ -39,7 +39,9 @@ const setServiceUrl: ServiceUrlSetter = async (elements, client) => {
   // and there isn't much advantage in running it in parallel
   await promises.array.series(relevantElements.map(element => async () => {
     const url = await generateUrl(element, client)
-    element.annotations[CORE_ANNOTATIONS.SERVICE_URL] = url && new URL(url, client.url).href
+    if (url !== undefined) {
+      element.annotations[CORE_ANNOTATIONS.SERVICE_URL] = new URL(url, client.url).href
+    }
   }))
 }
 

--- a/packages/netsuite-adapter/src/service_url/types.ts
+++ b/packages/netsuite-adapter/src/service_url/types.ts
@@ -13,21 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+
 import { Element } from '@salto-io/adapter-api'
-import NetsuiteClient from './client/client'
-import { LazyElementsSourceIndex } from './elements_source_index/types'
+import NetsuiteClient from '../client/client'
 
-export type OnFetchParameters = {
-  elements: Element[]
-  client: NetsuiteClient
-  elementsSourceIndex: LazyElementsSourceIndex
-  isPartial: boolean
-}
-
-// Filter interface, filters will be activated upon adapter fetch operations.
-// The filter will be responsible for specific business logic.
-export type OnFetchFilter = {
-  onFetch(parameters: OnFetchParameters): Promise<void>
-}
-
-export type FilterCreator = () => OnFetchFilter
+export type ServiceUrlSetter = (elements: Element[], client: NetsuiteClient) => Promise<void>

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -42,6 +42,7 @@ import SuiteAppClient from '../src/client/suiteapp_client/suiteapp_client'
 import { SERVER_TIME_TYPE_NAME } from '../src/server_time'
 import * as suiteAppFileCabinet from '../src/suiteapp_file_cabinet'
 import { SDF_CHANGE_GROUP_ID } from '../src/group_changes'
+import { SuiteAppFileCabinetOperations } from '../src/suiteapp_file_cabinet'
 
 jest.mock('../src/config', () => ({
   ...jest.requireActual<{}>('../src/config'),
@@ -81,6 +82,13 @@ describe('Adapter', () => {
       [FETCH_TYPE_TIMEOUT_IN_MINUTES]: 1,
     },
   }
+
+  const suiteAppImportFileCabinetMock = jest.fn()
+
+  jest.spyOn(suiteAppFileCabinet, 'createSuiteAppFileCabinetOperations').mockReturnValue({
+    importFileCabinet: suiteAppImportFileCabinetMock,
+  } as unknown as SuiteAppFileCabinetOperations)
+
   const netsuiteAdapter = new NetsuiteAdapter({
     client: new NetsuiteClient(client),
     elementsSource: buildElementsSourceFromElements([]),
@@ -92,8 +100,6 @@ describe('Adapter', () => {
   const mockFetchOpts: MockInterface<FetchOptions> = {
     progressReporter: { reportProgress: jest.fn() },
   }
-
-  const suiteAppImportFileCabinetMock = jest.spyOn(suiteAppFileCabinet, 'importFileCabinet')
 
   beforeEach(() => {
     jest.clearAllMocks()

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -31,6 +31,7 @@ import {
 } from '../src/constants'
 import { mockGetElemIdFunc } from './utils'
 import SuiteAppClient from '../src/client/suiteapp_client/suiteapp_client'
+import { SdfCredentials } from '../src/client/credentials'
 
 jest.mock('../src/client/sdf_client')
 jest.mock('../src/client/suiteapp_client/suiteapp_client')
@@ -83,6 +84,7 @@ describe('NetsuiteAdapter creator', () => {
   describe('validateCredentials', () => {
     const suiteAppClientValidateMock = jest.spyOn(SuiteAppClient, 'validateCredentials')
     const netsuiteValidateMock = jest.spyOn(SdfClient, 'validateCredentials')
+
     beforeEach(() => {
       jest.mock('@salto-io/suitecloud-cli', () => undefined, { virtual: true })
       suiteAppClientValidateMock.mockReset()
@@ -153,6 +155,7 @@ describe('NetsuiteAdapter creator', () => {
 
   describe('client creation', () => {
     it('should create the client correctly', () => {
+      jest.spyOn(SdfClient.prototype, 'getCredentials').mockReturnValue({ accountId: 'someId' } as SdfCredentials)
       adapter.operations({
         credentials,
         config,

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -1,0 +1,51 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import SuiteAppClient from '../../src/client/suiteapp_client/suiteapp_client'
+import SdfClient from '../../src/client/sdf_client'
+import * as suiteAppFileCabinet from '../../src/suiteapp_file_cabinet'
+import NetsuiteClient from '../../src/client/client'
+
+describe('NetsuiteClient', () => {
+  const sdfClient = {
+    getCredentials: () => ({ accountId: 'someId' }),
+  } as unknown as SdfClient
+
+  const suiteAppClient = {} as SuiteAppClient
+
+  const getPathToIdMapMock = jest.fn()
+  jest.spyOn(suiteAppFileCabinet, 'createSuiteAppFileCabinetOperations').mockReturnValue({
+    getPathToIdMap: getPathToIdMapMock,
+  } as unknown as suiteAppFileCabinet.SuiteAppFileCabinetOperations)
+
+  const client = new NetsuiteClient(sdfClient, suiteAppClient)
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('getPathInternalId', () => {
+    it('should return the right id', async () => {
+      getPathToIdMapMock.mockResolvedValue({ '/some/path': 1 })
+      expect(await client.getPathInternalId('/some/path')).toBe(1)
+      expect(await client.getPathInternalId('/some/path2')).toBeUndefined()
+    })
+
+    it('should return undefined when failed to get map', async () => {
+      getPathToIdMapMock.mockResolvedValue(undefined)
+      expect(await client.getPathInternalId('/some/path1')).toBeUndefined()
+    })
+  })
+})

--- a/packages/netsuite-adapter/test/filters/add_parent_folder.test.ts
+++ b/packages/netsuite-adapter/test/filters/add_parent_folder.test.ts
@@ -18,6 +18,7 @@ import filterCreator from '../../src/filters/add_parent_folder'
 import { fileCabinetTypes } from '../../src/types'
 import { PATH, FILE } from '../../src/constants'
 import { OnFetchParameters } from '../../src/filter'
+import NetsuiteClient from '../../src/client/client'
 
 describe('add_parent_folder filter', () => {
   let instance: InstanceElement
@@ -31,6 +32,7 @@ describe('add_parent_folder filter', () => {
 
     onFetchParameters = {
       elements: [instance],
+      client: {} as NetsuiteClient,
       elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
       isPartial: false,
     }

--- a/packages/netsuite-adapter/test/filters/consistent_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/consistent_values.test.ts
@@ -21,6 +21,7 @@ import {
   RECORD_TYPE,
 } from '../../src/constants'
 import { OnFetchParameters } from '../../src/filter'
+import NetsuiteClient from '../../src/client/client'
 
 describe('consistent_values filter', () => {
   const instanceName = 'instanceName'
@@ -50,6 +51,7 @@ describe('consistent_values filter', () => {
 
     onFetchParameters = {
       elements: [instance, instanceWithNestedInconsistentValue],
+      client: {} as NetsuiteClient,
       elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
       isPartial: false,
     }

--- a/packages/netsuite-adapter/test/filters/convert_lists.test.ts
+++ b/packages/netsuite-adapter/test/filters/convert_lists.test.ts
@@ -18,6 +18,7 @@ import { customTypes } from '../../src/types'
 import { DATASET, ENTITY_CUSTOM_FIELD, SAVED_CSV_IMPORT } from '../../src/constants'
 import filterCreator from '../../src/filters/convert_lists'
 import { OnFetchParameters } from '../../src/filter'
+import NetsuiteClient from '../../src/client/client'
 
 describe('convert_lists filter', () => {
   const instanceName = 'instanceName'
@@ -34,6 +35,7 @@ describe('convert_lists filter', () => {
       })
     onFetchParameters = {
       elements: [instance],
+      client: {} as NetsuiteClient,
       elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
       isPartial: false,
     }

--- a/packages/netsuite-adapter/test/filters/instance_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/instance_references.test.ts
@@ -20,6 +20,7 @@ import {
 import filterCreator from '../../src/filters/instance_references'
 import { customTypes, fileCabinetTypes } from '../../src/types'
 import { FILE, PATH, SCRIPT_ID, WORKFLOW } from '../../src/constants'
+import NetsuiteClient from '../../src/client/client'
 
 
 describe('instance_references filter', () => {
@@ -94,6 +95,7 @@ describe('instance_references filter', () => {
     it('should replace path references', async () => {
       await filterCreator().onFetch({
         elements: [fileInstance, workflowInstance, instanceWithRefs],
+        client: {} as NetsuiteClient,
         elementsSourceIndex,
         isPartial: false,
       })
@@ -105,6 +107,7 @@ describe('instance_references filter', () => {
     it('should replace scriptid references', async () => {
       await filterCreator().onFetch({
         elements: [fileInstance, workflowInstance, instanceWithRefs],
+        client: {} as NetsuiteClient,
         elementsSourceIndex,
         isPartial: false,
       })
@@ -116,6 +119,7 @@ describe('instance_references filter', () => {
     it('should replace annotations references', async () => {
       await filterCreator().onFetch({
         elements: [fileInstance, workflowInstance, instanceWithRefs],
+        client: {} as NetsuiteClient,
         elementsSourceIndex,
         isPartial: false,
       })
@@ -129,6 +133,7 @@ describe('instance_references filter', () => {
     it('parent should reference the element itself', async () => {
       await filterCreator().onFetch({
         elements: [fileInstance, workflowInstance, instanceWithRefs],
+        client: {} as NetsuiteClient,
         elementsSourceIndex,
         isPartial: false,
       })
@@ -140,6 +145,7 @@ describe('instance_references filter', () => {
     it('should replace scriptid with 1 nesting level references', async () => {
       await filterCreator().onFetch({
         elements: [fileInstance, workflowInstance, instanceWithRefs],
+        client: {} as NetsuiteClient,
         elementsSourceIndex,
         isPartial: false,
       })
@@ -151,6 +157,7 @@ describe('instance_references filter', () => {
     it('should replace scriptid with 2 nesting level references', async () => {
       await filterCreator().onFetch({
         elements: [fileInstance, workflowInstance, instanceWithRefs],
+        client: {} as NetsuiteClient,
         elementsSourceIndex,
         isPartial: false,
       })
@@ -162,6 +169,7 @@ describe('instance_references filter', () => {
     it('should replace inner scriptid references', async () => {
       await filterCreator().onFetch({
         elements: [fileInstance, workflowInstance, instanceWithRefs],
+        client: {} as NetsuiteClient,
         elementsSourceIndex,
         isPartial: false,
       })
@@ -174,6 +182,7 @@ describe('instance_references filter', () => {
     it('should not replace scriptid references for unresolved ref', async () => {
       await filterCreator().onFetch({
         elements: [fileInstance, workflowInstance, instanceWithRefs],
+        client: {} as NetsuiteClient,
         elementsSourceIndex,
         isPartial: false,
       })
@@ -185,6 +194,7 @@ describe('instance_references filter', () => {
     it('should not replace path references for unresolved ref', async () => {
       await filterCreator().onFetch({
         elements: [fileInstance, workflowInstance, instanceWithRefs],
+        client: {} as NetsuiteClient,
         elementsSourceIndex,
         isPartial: false,
       })
@@ -199,6 +209,7 @@ describe('instance_references filter', () => {
       })
       await filterCreator().onFetch({
         elements: [fileInstance, workflowInstance, instanceWithRefs],
+        client: {} as NetsuiteClient,
         elementsSourceIndex,
         isPartial: true,
       })
@@ -213,6 +224,7 @@ describe('instance_references filter', () => {
       })
       await filterCreator().onFetch({
         elements: [fileInstance, workflowInstance, instanceWithRefs],
+        client: {} as NetsuiteClient,
         elementsSourceIndex,
         isPartial: false,
       })

--- a/packages/netsuite-adapter/test/filters/service_urls.test.ts
+++ b/packages/netsuite-adapter/test/filters/service_urls.test.ts
@@ -1,0 +1,60 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, InstanceElement, Element } from '@salto-io/adapter-api'
+import { file } from '../../src/types/file_cabinet_types'
+import NetsuiteClient from '../../src/client/client'
+import serviceUrls from '../../src/filters/service_urls'
+
+describe('serviceUrls', () => {
+  const getPathInternalIdMock = jest.fn()
+  const isSuiteAppConfiguredMock = jest.fn()
+  const client = {
+    getPathInternalId: getPathInternalIdMock,
+    isSuiteAppConfigured: isSuiteAppConfiguredMock,
+    url: 'https://tstdrv2259448.app.netsuite.com',
+  } as unknown as NetsuiteClient
+
+  let elements: Element[]
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    getPathInternalIdMock.mockResolvedValue(1)
+    isSuiteAppConfiguredMock.mockReturnValue(true)
+    elements = [
+      new InstanceElement('A', file, { path: '/path/A' }),
+    ]
+  })
+
+  it('should set the right url', async () => {
+    await serviceUrls().onFetch({
+      elements,
+      client,
+      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      isPartial: false,
+    })
+    expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBe('https://tstdrv2259448.app.netsuite.com/app/common/media/mediaitem.nl?id=1')
+  })
+  it('should do nothing if Salto SuiteApp is not configured', async () => {
+    isSuiteAppConfiguredMock.mockReturnValue(false)
+    await serviceUrls().onFetch({
+      elements,
+      client,
+      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      isPartial: false,
+    })
+    expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+  })
+})

--- a/packages/netsuite-adapter/test/service_url/file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/service_url/file_cabinet.test.ts
@@ -1,0 +1,51 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, InstanceElement } from '@salto-io/adapter-api'
+import NetsuiteClient from '../../src/client/client'
+import setServiceUrl from '../../src/service_url/file_cabinet'
+import { file, folder } from '../../src/types/file_cabinet_types'
+
+
+describe('setFileCabinetUrls', () => {
+  const getPathInternalIdMock = jest.fn()
+  const client = {
+    getPathInternalId: getPathInternalIdMock,
+    url: 'https://tstdrv2259448.app.netsuite.com',
+  } as unknown as NetsuiteClient
+
+  const elements = [
+    new InstanceElement('A', file, { path: '/path/A' }),
+    new InstanceElement('B', folder, { path: '/path/B' }),
+    new InstanceElement('C', folder, { path: '/path/C' }),
+  ]
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    getPathInternalIdMock.mockResolvedValueOnce(1)
+    getPathInternalIdMock.mockResolvedValueOnce(2)
+  })
+
+  it('should set the right url', async () => {
+    await setServiceUrl(elements, client)
+    expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBe('https://tstdrv2259448.app.netsuite.com/app/common/media/mediaitem.nl?id=1')
+    expect(elements[1].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBe('https://tstdrv2259448.app.netsuite.com/app/common/media/mediaitemfolder.nl?id=2')
+  })
+
+  it('should not set url if not found interanl id', async () => {
+    await setServiceUrl(elements, client)
+    expect(elements[2].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Added support for "Go To Service" for file cabinet instances.

This PR includes: 
- Creating `service_urls` filter to add URLs to elements
- Changing the `suiteapp_file_cabinet` to a class (Salto style), so it can cache the queries results to avoid running the queries more than once
- Adding the URL to file and folder instances

---
_Release Notes_: 
Netsuite Adapter:
Added support for "Go To Service" for file cabinet instances