### PR TITLE
SAAS-1833: Fix addition routing for nested values

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -238,21 +238,21 @@ export const routeDefault = async (
   secondarySources: Record<string, NaclFilesSource>
 ): Promise<RoutedChanges> => {
   if (change.action === 'add') {
-    const topLevelID = change.id.createTopLevelParentID().parent
-    const commonTopLevelElement = await commonSource.get(topLevelID)
-    const envTopLevelElements = await Promise.all(
-      [primarySource, ...Object.values(secondarySources)].map(src => src.get(topLevelID))
+    const parentID = change.id.isTopLevel() ? change.id : change.id.createParentID()
+    const commonParent = await commonSource.get(parentID)
+    const envParents = await Promise.all(
+      [primarySource, ...Object.values(secondarySources)].map(src => src.get(parentID))
     )
-    const hasCommonTopLevel = commonTopLevelElement !== undefined
-    const hasEnvSpecificDefinition = _.some(envTopLevelElements, srcElem => srcElem !== undefined)
+    const hasCommonParent = commonParent !== undefined
+    const hasEnvSpecificParent = _.some(envParents, srcElem => srcElem !== undefined)
     // If we only have 1 env we will add the element to common UNLESS its parent already
     // has a part defined in the env
-    if (_.isEmpty(secondarySources) && !hasEnvSpecificDefinition) {
+    if (_.isEmpty(secondarySources) && !hasEnvSpecificParent) {
       return { commonSource: [change] }
     }
     // If the element parent is completely defined in common we will add new nested
     // additions to common
-    if (hasCommonTopLevel && !hasEnvSpecificDefinition) {
+    if (hasCommonParent && !hasEnvSpecificParent) {
       return { commonSource: [change] }
     }
     return { primarySource: [change] }

--- a/packages/workspace/test/workspace/multi_env/routers.test.ts
+++ b/packages/workspace/test/workspace/multi_env/routers.test.ts
@@ -236,11 +236,24 @@ describe('default fetch routing', () => {
     expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
   })
 
-  it('should route nested add changes to primary env when the containing element is only in common', async () => {
+  it('should route nested add changes to common when the containing element is only in common', async () => {
     const change: DetailedChange = {
       action: 'add',
       data: { after: 'value' },
       id: commonOnlyObject.elemID.createNestedID('attr', 'newAttr'),
+    }
+    const routedChanges = await routeChanges([change], envSource, commonSource, { sec: secEnv }, 'default')
+    expect(routedChanges.primarySource).toHaveLength(0)
+    expect(routedChanges.commonSource).toHaveLength(1)
+    expect(routedChanges.commonSource && routedChanges.commonSource[0]).toEqual(change)
+    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+  })
+
+  it('should route nested add changes to common when the direct parent is only in common', async () => {
+    const change: DetailedChange = {
+      action: 'add',
+      data: { after: 'value' },
+      id: commonObj.fields.commonField.elemID.createNestedID('label'),
     }
     const routedChanges = await routeChanges([change], envSource, commonSource, { sec: secEnv }, 'default')
     expect(routedChanges.primarySource).toHaveLength(0)


### PR DESCRIPTION
Fix issue where addition changes could be routed to a nacl source that did not contain
their parent, which caused invalid nacls to be written

---

When we update nacls with changes, addition changes assume they are either a top level element, or their parent exists (because if the parent did not exist, the change would have been adding the parent).
because of this bug in routing, it was possible to get to the nacl update code with an addition change that did not have a parent.
aligning the condition to match the condition in the nacl update code should make it work

---
_Release Notes_: 
Core
- Fixed bug that would cause invalid nacl files to be written on fetch in case new annotations or values were added to common elements in a multi-env workspace
