### PR TITLE
Swagger adapter-components - allow passing in pre-parsed swagger defs

### DIFF
--- a/packages/adapter-components/src/elements/swagger/index.ts
+++ b/packages/adapter-components/src/elements/swagger/index.ts
@@ -14,5 +14,5 @@
 * limitations under the License.
 */
 export { getAllInstances } from './instance_elements'
-export { generateTypes } from './type_elements/element_generator'
-export { toPrimitiveType, ADDITIONAL_PROPERTIES_FIELD } from './type_elements/swagger_parser'
+export { generateTypes, ParsedTypes } from './type_elements/element_generator'
+export { toPrimitiveType, ADDITIONAL_PROPERTIES_FIELD, SchemaObject, SchemasAndRefs, SchemaOrReference } from './type_elements/swagger_parser'

--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -23,7 +23,7 @@ import { RequestableTypeSwaggerConfig, AdapterSwaggerApiConfig } from '../../../
 import {
   getParsedDefs, isReferenceObject, toNormalizedRefName, SchemaObject,
   extractProperties, ADDITIONAL_PROPERTIES_FIELD, toPrimitiveType, toTypeName, SwaggerRefs,
-  SchemaOrReference, SWAGGER_ARRAY, SWAGGER_OBJECT, isArraySchemaObject,
+  SchemaOrReference, SWAGGER_ARRAY, SWAGGER_OBJECT, isArraySchemaObject, SchemasAndRefs,
 } from './swagger_parser'
 import { fixTypes, defineAdditionalTypes } from './type_config_override'
 
@@ -244,6 +244,11 @@ const typeAdder = ({
   return addType
 }
 
+export type ParsedTypes = {
+  allTypes: TypeMap
+  parsedConfigs: Record<string, RequestableTypeSwaggerConfig>
+}
+
 /**
  * Generate types for the given OpenAPI definitions.
  */
@@ -254,10 +259,8 @@ export const generateTypes = async (
     types,
     typeDefaults,
   }: AdapterSwaggerApiConfig,
-): Promise<{
-  allTypes: TypeMap
-  parsedConfigs: Record<string, RequestableTypeSwaggerConfig>
-}> => {
+  preParsedDefs?: SchemasAndRefs,
+): Promise<ParsedTypes> => {
   // TODO SALTO-1252 - persist swagger locally
 
   const toUpdatedResourceName = (
@@ -269,7 +272,7 @@ export const generateTypes = async (
   const definedTypes: Record<string, ObjectType> = {}
   const parsedConfigs: Record<string, RequestableTypeSwaggerConfig> = {}
 
-  const { schemas: getResponseSchemas, refs } = await getParsedDefs(swagger.url)
+  const { schemas: getResponseSchemas, refs } = preParsedDefs ?? await getParsedDefs(swagger.url)
 
   const addType = typeAdder({
     adapterName,

--- a/packages/adapter-components/src/elements/swagger/type_elements/swagger_parser.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/swagger_parser.ts
@@ -27,7 +27,7 @@ const log = logger(module)
 
 export type ReferenceObject = OpenAPIV2.ReferenceObject | OpenAPIV3.ReferenceObject
 export type SchemaObject = OpenAPIV2.SchemaObject | OpenAPIV3.SchemaObject | IJsonSchema
-export type SwaggerRefs = SwaggerParser.$Refs
+export type SwaggerRefs = Pick<SwaggerParser.$Refs, 'get'>
 
 export type SchemaOrReference = ReferenceObject | SchemaObject
 
@@ -66,7 +66,7 @@ export const toPrimitiveType = (val: string | string[] | undefined): PrimitiveTy
   if (types.length === 1) {
     return types[0]
   }
-  log.error('Found %d types for %s, falling back to unknown', types.length, val)
+  log.warn('Found %d types for %s, falling back to unknown', types.length, val)
   return BuiltinTypes.UNKNOWN
 }
 
@@ -104,11 +104,13 @@ const isV3 = (doc: OpenAPI.Document): doc is OpenAPIV3.Document => {
   return _.isString(version) && version.startsWith('3.')
 }
 
-export const getParsedDefs = async (swaggerPath: string):
-  Promise<{
+export type SchemasAndRefs = {
   schemas: Record<string, SchemaOrReference>
   refs: SwaggerRefs
-}> => {
+}
+
+export const getParsedDefs = async (swaggerPath: string):
+  Promise<SchemasAndRefs> => {
   const parser = new SwaggerParser()
   const parsedSwagger: OpenAPI.Document = await parser.bundle(swaggerPath)
 


### PR DESCRIPTION
Allow generating type elements based on pre-parsed swagger definitions.
Also exported the return type do avoid re-defining it in the adapters.

---

This will be used in the Zuora billing adapter to generate types for the settings endpoint, whose definitions are returned dynamically and not defined in the main swagger.

---
_Release Notes_: 
None
