### PR TITLE
Swagger adapter-components - support creating fields that did not exist based on config

### DIFF
--- a/packages/adapter-components/src/elements/swagger/type_elements/type_config_override.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/type_config_override.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ObjectType, BuiltinTypes, MapType, ListType, TypeElement, isEqualElements, LIST_ID_PREFIX, GENERIC_ID_PREFIX, GENERIC_ID_SUFFIX, MAP_ID_PREFIX, ElemID } from '@salto-io/adapter-api'
+import { ObjectType, BuiltinTypes, MapType, ListType, TypeElement, isEqualElements, LIST_ID_PREFIX, GENERIC_ID_PREFIX, GENERIC_ID_SUFFIX, MAP_ID_PREFIX, ElemID, Field } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { getConfigWithDefault } from '../../../config/shared'
 import { TypeSwaggerConfig, AdditionalTypeConfig, TypeSwaggerDefaultConfig } from '../../../config/swagger'
@@ -134,13 +134,14 @@ export const fixTypes = (
       ).fieldTypeOverrides as FieldTypeOverrideType[]
       fieldTypeOverrides.forEach(({ fieldName, fieldType }) => {
         const field = type.fields[fieldName]
-        if (field === undefined) {
-          log.warn('field %s.%s not found, cannot override its type', typeName, fieldName)
-          return
-        }
         const newFieldType = toTypeWithContainers(fieldType)
-        log.debug('Modifying field type for %s.%s from %s to %s', typeName, fieldName, field.type.elemID.name, newFieldType.elemID.name)
-        field.type = newFieldType
+        if (field === undefined) {
+          log.debug('Creating field type for %s.%s with type %s', typeName, fieldName, newFieldType.elemID.name)
+          type.fields[fieldName] = new Field(type, fieldName, newFieldType)
+        } else {
+          log.debug('Modifying field type for %s.%s from %s to %s', typeName, fieldName, field.type.elemID.name, newFieldType.elemID.name)
+          field.type = newFieldType
+        }
       })
     })
 

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -197,9 +197,11 @@ describe('swagger_type_elements', () => {
                     { fieldName: 'shipDate', fieldType: 'Category' },
                     { fieldName: 'quantity', fieldType: 'map<Category>' },
                     { fieldName: 'newField', fieldType: 'map<Category>' },
+                    { fieldName: 'newHiddenField', fieldType: 'Category' },
                   ],
                   fieldsToHide: [
                     { fieldName: 'petId' },
+                    { fieldName: 'newHiddenField' },
                   ],
                 },
               },
@@ -254,17 +256,23 @@ describe('swagger_type_elements', () => {
         expect(order.fields.quantity.type).toBeInstanceOf(MapType)
         expect((order.fields.quantity.type as MapType).innerType).toEqual(allTypes.Category)
       })
+      it('should add fields that did not already exist', () => {
+        const order = allTypes.Order as ObjectType
+        expect(order).toBeInstanceOf(ObjectType)
+        expect(order.fields.newField).toBeDefined()
+        expect(order.fields.newField.type).toBeInstanceOf(MapType)
+        expect((order.fields.newField.type as MapType).innerType).toEqual(allTypes.Category)
+        expect(order.fields.newHiddenField).toBeDefined()
+        expect(order.fields.newHiddenField.type).toEqual(allTypes.Category)
+      })
       it('should annotate fields from fieldsToHide with _hidden_value=true', () => {
         const order = allTypes.Order as ObjectType
         expect(order).toBeInstanceOf(ObjectType)
         // eslint-disable-next-line no-underscore-dangle
         expect((order.fields.petId.annotations?._hidden_value)).toBeTruthy()
+        expect((order.fields.newHiddenField.annotations?._hidden_value)).toBeTruthy()
       })
-      it('should not add fields that did not already exist', () => {
-        const order = allTypes.Order as ObjectType
-        expect(order).toBeInstanceOf(ObjectType)
-        expect(order.fields.newField).toBeUndefined()
-      })
+
       it('should not add types that did not already exist', () => {
         const order = allTypes.NewType as ObjectType
         expect(order).toBeUndefined()


### PR DESCRIPTION
Allow specifying field types even if the field did not exist in the original definition (instead of only overriding existing ones).

---

Will be useful in Zuora to extract a field that is nested under `additionalProperties` - but it can be useful in general for that purpose.

---
_Release Notes_: 
None
