### PR TITLE
fixed config suggestion ignored in salesforce

### DIFF
--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -109,7 +109,7 @@ In Addition, ${configFromFetch.message}`,
     return configWithoutDeprecated
   }
 
-  return undefined
+  return configFromFetch
 }
 
 export const adapter: Adapter = {

--- a/packages/salesforce-adapter/test/adapter.creator.test.ts
+++ b/packages/salesforce-adapter/test/adapter.creator.test.ts
@@ -643,6 +643,22 @@ In order to complete the fetch operation, Salto needs to stop managing these ite
       })
     })
 
+    describe('only fetchConfiguration is defined', () => {
+      const configChange = {
+        config,
+        message: `Salto failed to fetch some items from salesforce.
+
+In order to complete the fetch operation, Salto needs to stop managing these items by applying the following configuration change:`,
+      }
+      const updatedConfig = getConfigChange(
+        configChange,
+        undefined,
+      )
+      it('return configWithoutDeprecated', () => {
+        expect(updatedConfig).toBe(configChange)
+      })
+    })
+
     describe('both configFromFetch and configWithoutDeprecated are undefined', () => {
       const updatedConfig = getConfigChange(
         undefined,


### PR DESCRIPTION
Fixed a bug where in Salesforce the config suggestions would be ignored if the configuration would not have deprecated fields

---
_Release Notes_: 
Salesforce Adapater:
Fixed a bug where in some cases the config suggestion would be ignored