### PR TITLE
SALTO-1274: Limit salesforce query length

### DIFF
--- a/packages/core/src/core/deploy.ts
+++ b/packages/core/src/core/deploy.ts
@@ -84,6 +84,11 @@ export const deployActions = async (
         updatePlanElement(item, result.appliedChanges)
         await postDeployAction(result.appliedChanges)
         if (result.errors.length > 0) {
+          log.warn(
+            'Failed to deploy %s, errors: %s',
+            item.groupKey,
+            result.errors.map(err => err.stack ?? err.message).join('\n'),
+          )
           throw new Error(
             `Failed to deploy ${item.groupKey} with errors:\n${result.errors.join('\n')}`
           )

--- a/packages/core/src/core/deploy.ts
+++ b/packages/core/src/core/deploy.ts
@@ -87,7 +87,7 @@ export const deployActions = async (
           log.warn(
             'Failed to deploy %s, errors: %s',
             item.groupKey,
-            result.errors.map(err => err.stack ?? err.message).join('\n'),
+            result.errors.map(err => err.stack ?? err.message).join('\n\n'),
           )
           throw new Error(
             `Failed to deploy ${item.groupKey} with errors:\n${result.errors.join('\n')}`

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -281,7 +281,7 @@ export const DEFAULT_MAX_CONCURRENT_API_REQUESTS = {
 }
 export const DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST = 2500
 export const DEFAULT_USE_OLD_PROFILES = false
-export const MAX_IDS_PER_INSTANCES_QUERY = 500
+export const MAX_QUERY_LENGTH = 2000
 
 // Metadata types
 export const TOPICS_FOR_OBJECTS_METADATA_TYPE = 'TopicsForObjects'


### PR DESCRIPTION
Limit custom object instances query length in fetch and deploy to not exceed
the recommended salesforce URI length of 2000

---
_Release Notes_: 
Salesforce Adapter:
- Fix issue where fetching or deploying a large number of data records could fail with a "URI too long" error
