### PR TITLE
Fix clear only service config fails (SALTO-1272)

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -586,11 +586,11 @@ export const loadWorkspace = async (
       return loadWorkspace(config, credentials, envSources, remoteMapCreator)
     },
     clear: async (args: Omit<WorkspaceComponents, 'serviceConfig'>) => {
+      const currentWSState = await getWorkspaceState()
       if (args.cache || args.nacl || args.staticResources) {
         if (args.staticResources && !(args.state && args.cache && args.nacl)) {
           throw new Error('Cannot clear static resources without clearing the state, cache and nacls')
         }
-        const currentWSState = await getWorkspaceState()
         await currentWSState.merged.clear()
         await currentWSState.errors.clear()
         await currentWSState.validationErrors.clear()


### PR DESCRIPTION
Need to load the workspace regardless of clear params so it will be ready to be flushed. 