### PR TITLE
SALTO-1277: Set command timeout for all commands from SDF and bump SDF to 1.1.2-salto-6

### DIFF
--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -39,7 +39,7 @@ netsuite {
 | Name                           | Default when undefined  | Description
 | -------------------------------| ------------------------| -----------
 | fetchAllTypesAtOnce            | false                   | Attempt to fetch all configuration elements in a single SDF API call
-| fetchTypeTimeoutInMinutes      | 4                       | The max number of minutes a single type's chunk fetch can run
+| fetchTypeTimeoutInMinutes      | 4                       | The max number of minutes a single SDF command can run
 | maxItemsInImportObjectsRequest | 40                      | Limits the max number of requested items a single import-objects request
 | sdfConcurrencyLimit            | 4                       | Limits the max number of concurrent SDF API calls. The number should not exceed the concurrency limit enforced by the upstream service.
 

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -36,7 +36,7 @@
     "@salto-io/file": "0.2.10",
     "@salto-io/logging": "0.2.10",
     "@salto-io/lowerdash": "0.2.10",
-    "@salto-io/suitecloud-cli": "1.1.2-salto-5",
+    "@salto-io/suitecloud-cli": "1.1.2-salto-6",
     "ajv": "^7.1.1",
     "async-lock": "^1.2.4",
     "axios": "^0.21.1",

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -34,7 +34,7 @@ const { makeArray } = collections.array
 // in small Netsuite accounts the concurrency limit per integration can be between 1-4
 export const DEFAULT_CONCURRENCY = 4
 export const DEFAULT_FETCH_ALL_TYPES_AT_ONCE = false
-export const DEFAULT_FETCH_TYPE_TIMEOUT_IN_MINUTES = 4
+export const DEFAULT_COMMAND_TIMEOUT_IN_MINUTES = 4
 export const DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST = 40
 export const DEFAULT_DEPLOY_REFERENCED_ELEMENTS = false
 export const DEFAULT_USE_CHANGES_DETECTION = true
@@ -51,7 +51,7 @@ const clientConfigType = new ObjectType({
     [FETCH_TYPE_TIMEOUT_IN_MINUTES]: {
       type: BuiltinTypes.NUMBER,
       annotations: {
-        [CORE_ANNOTATIONS.DEFAULT]: DEFAULT_FETCH_TYPE_TIMEOUT_IN_MINUTES,
+        [CORE_ANNOTATIONS.DEFAULT]: DEFAULT_COMMAND_TIMEOUT_IN_MINUTES,
         [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
           min: 1,
         }),

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -51,6 +51,8 @@ const clientConfigType = new ObjectType({
     [FETCH_TYPE_TIMEOUT_IN_MINUTES]: {
       type: BuiltinTypes.NUMBER,
       annotations: {
+        // We set DEFAULT_COMMAND_TIMEOUT_IN_MINUTES to FETCH_TYPE_TIMEOUT_IN_MINUTES since we did
+        // not want to have a disrupting change to existing WSs with renaming this annotation.
         [CORE_ANNOTATIONS.DEFAULT]: DEFAULT_COMMAND_TIMEOUT_IN_MINUTES,
         [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
           min: 1,

--- a/packages/netsuite-adapter/types/suitecloud-cli.d.ts
+++ b/packages/netsuite-adapter/types/suitecloud-cli.d.ts
@@ -21,6 +21,10 @@ declare module '@salto-io/suitecloud-cli' {
     download(): Promise<AdapterInstallResult>
   }
 
+  interface SdkPropertiesI {
+    setCommandTimeout(commandTimeout: number): void
+  }
+
   export class CommandsMetadataService {
     constructor()
   }
@@ -58,4 +62,6 @@ declare module '@salto-io/suitecloud-cli' {
   }
 
   export const SdkDownloadService: SdkDownloadServiceI
+
+  export const SdkProperties: SdkPropertiesI
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1632,10 +1632,10 @@
     requirejs "2.3.6"
     xml2js "0.4.19"
 
-"@salto-io/suitecloud-cli@1.1.2-salto-5":
-  version "1.1.2-salto-5"
-  resolved "https://registry.yarnpkg.com/@salto-io/suitecloud-cli/-/suitecloud-cli-1.1.2-salto-5.tgz#6d5efc43122c95cadc264ac65d1f53e84aa23d5a"
-  integrity sha512-o1ApSpzFfCt3dOmiuAk2p1oOEyxbrfge9YPHe+Ljr74wmG+hIuJ1N8jt8eAP3IIhJCocJMtJrl1itnbnKwEfsA==
+"@salto-io/suitecloud-cli@1.1.2-salto-6":
+  version "1.1.2-salto-6"
+  resolved "https://registry.yarnpkg.com/@salto-io/suitecloud-cli/-/suitecloud-cli-1.1.2-salto-6.tgz#351ab1f2a87cb414f94fbebb87dd7669b7f45eef"
+  integrity sha512-6Lr0cOyydnHyxZD9imeRkeMB7lk1urClvG6Q4MzDHQsD5ZFboisVgxJVLCdLSRIDghhiJY5EKsA68u9LgBiNtg==
   dependencies:
     "@oracle/suitecloud-cli-localserver-command" "^1.1.1"
     "@salto-io/logging" "^0.2.8"


### PR DESCRIPTION
**This PR won't pass build until https://github.com/salto-io/netsuite-suitecloud-sdk/pull/26 is merged and published to npm.**

I chose not to rename `fetchTypeTimeoutInMinutes` to `commandTimeout` since I wanted to avoid another disrupting change to customers existing WSs, and especially SaaS customers until [Feature Suggestion: notify customers about upcoming changes in their configuration](https://salto-io.atlassian.net/browse/SAAS-1749) is implemented. If you think otherwise please LMK. FYI @tomermevorach 

_Release Notes_: 
Netsuite Adapter: Modify fetchTypeTimeoutInMinutes client property to enforce timeout for all SDF commands.
