### PR TITLE
Fix weightedChunks when first item is larger than size limit

### DIFF
--- a/packages/lowerdash/src/chunks.ts
+++ b/packages/lowerdash/src/chunks.ts
@@ -18,12 +18,12 @@ export const weightedChunks = <T>(
   size: number,
   weightFunc: (val: T) => number
 ): T[][] => {
-  const chunks: T[][] = [[]]
+  const chunks: T[][] = []
 
   values.reduce((chunkWeight, val) => {
     const valWeight = weightFunc(val)
 
-    if (valWeight + chunkWeight > size) {
+    if (valWeight + chunkWeight > size || chunks.length === 0) {
       chunks.push([val])
       return valWeight
     }

--- a/packages/lowerdash/test/chunks.test.ts
+++ b/packages/lowerdash/test/chunks.test.ts
@@ -16,8 +16,12 @@
 import { weightedChunks } from '../src/chunks'
 
 describe('weightedChunks', () => {
-  it('should split chunks correctly', () => {
+  it('should split chunks correctly when first chunk is smaller than max size', () => {
     const chunks = weightedChunks(['a', 'bb', 'cccc', 'dddddd', 'eeeeeeeeee'], 7, val => val.length)
     expect(chunks).toEqual([['a', 'bb', 'cccc'], ['dddddd'], ['eeeeeeeeee']])
+  })
+  it('should split chunks correctly when first chunk is larger than max size', () => {
+    const chunks = weightedChunks(['eeeeeeeeee', 'dddddd', 'cccc', 'bb', 'a'], 7, val => val.length)
+    expect(chunks).toEqual([['eeeeeeeeee'], ['dddddd'], ['cccc', 'bb', 'a']])
   })
 })


### PR DESCRIPTION
Fix for an edge-case bug found when reviewing https://github.com/salto-io/salto/pull/2016 - when the first item is larger than the max size, the first chunk is empty.

---
_Release Notes_: 
None
