### PR TITLE
SALTO-1279 - fix dummy adapter fixture error

### DIFF
--- a/packages/dummy-adapter/src/data/fixtures/partialInst2.nacl.mock
+++ b/packages/dummy-adapter/src/data/fixtures/partialInst2.nacl.mock
@@ -1,3 +1,3 @@
-dummy.Partial PartialInst {
+dummy.Partial2 PartialInst {
     numField = 2222
 }

--- a/packages/dummy-adapter/src/data/fixtures/partialObj2.nacl.mock
+++ b/packages/dummy-adapter/src/data/fixtures/partialObj2.nacl.mock
@@ -1,4 +1,4 @@
-type dummy.Partial {
+type dummy.Partial2 {
     annotations {
         number numAnno {
         }


### PR DESCRIPTION
Fix small error in defining fixtures for dummy adapter.
---

---
_Release Notes_: 
Fixed small error when defining fixtures for dummy adapter
