### PR TITLE
SALTO-1280 Support secondary connectors, formulas and related objects in workato cross-service references

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -65,7 +65,7 @@ export type DeployModifiers = {
 export type AdapterOperations = {
   fetch: (opts: FetchOptions) => Promise<FetchResult>
   deploy: (opts: DeployOptions) => Promise<DeployResult>
-  postFetch?: (opts: PostFetchOptions) => Promise<{ changed: boolean }>
+  postFetch?: (opts: PostFetchOptions) => Promise<void>
   deployModifiers?: DeployModifiers
 }
 

--- a/packages/adapter-components/src/filter_utils.ts
+++ b/packages/adapter-components/src/filter_utils.ts
@@ -19,7 +19,7 @@ import { Paginator } from './client'
 
 export type Filter = Partial<{
   onFetch(elements: Element[]): Promise<void>
-  onPostFetch(args: PostFetchOptions): Promise<boolean>
+  onPostFetch(args: PostFetchOptions): Promise<void>
 }>
 
 export type FilterWith<M extends keyof Filter> = types.HasMember<Filter, M>
@@ -46,10 +46,9 @@ export const filtersRunner = <TClient, TContext>(
       )
     },
     onPostFetch: async args => {
-      const results = await promises.array.series(
+      await promises.array.series(
         filtersWith('onPostFetch').map(filter => () => filter.onPostFetch(args))
       )
-      return results.some(res => res === true)
     },
   }
 }

--- a/packages/adapter-components/test/filter_utils.test.ts
+++ b/packages/adapter-components/test/filter_utils.test.ts
@@ -30,16 +30,14 @@ describe('filter utils', () => {
         await new Promise(resolve => setTimeout(resolve, 2))
       }
     )
-    const mockOnPostFetch2: () => Promise<boolean> = jest.fn().mockImplementation(
-      async (): Promise<boolean> => {
+    const mockOnPostFetch2: () => Promise<void> = jest.fn().mockImplementation(
+      async (): Promise<void> => {
         await new Promise(resolve => setTimeout(resolve, 2))
-        return true
       }
     )
-    const mockOnPostFetch3: () => Promise<boolean> = jest.fn().mockImplementation(
-      async (): Promise<boolean> => {
+    const mockOnPostFetch3: () => Promise<void> = jest.fn().mockImplementation(
+      async (): Promise<void> => {
         await new Promise(resolve => setTimeout(resolve, 2))
-        return false
       }
     )
     beforeAll(() => {

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -865,7 +865,7 @@ describe('fetch', () => {
       dummy: {
         fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [] }),
         deploy: mockFunction<AdapterOperations['deploy']>(),
-        postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue({ changed: true }),
+        postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue(),
       },
     }
     describe('fetch is partial', () => {
@@ -935,12 +935,12 @@ describe('fetch', () => {
         dummy2: {
           fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [dummy2Type1], isPartial: false }),
           deploy: mockFunction<AdapterOperations['deploy']>(),
-          postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue({ changed: true }),
+          postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue(),
         },
         dummy3: {
           fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [dummy3Type1], isPartial: false }),
           deploy: mockFunction<AdapterOperations['deploy']>(),
-          postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue({ changed: true }),
+          postFetch: mockFunction<Required<AdapterOperations>['postFetch']>().mockResolvedValue(),
         },
       }
       beforeEach(() => {

--- a/packages/lowerdash/src/strings.ts
+++ b/packages/lowerdash/src/strings.ts
@@ -27,3 +27,21 @@ export const insecureRandomString = (
 
 export const capitalizeFirstLetter = (str: string): string =>
   str.charAt(0).toUpperCase() + str.slice(1)
+
+/**
+ * Find all matches to the specified regular expression.
+ * This is a partial replacement for String.prototype.matchAll which
+ * is not currently available in node.
+ */
+export function *matchAll(str: string, matcher: RegExp): Iterable<RegExpExecArray> {
+  if (!matcher.global) {
+    throw new Error('matchAll only supports global regular expressions')
+  }
+  while (true) {
+    const match = matcher.exec(str)
+    if (match === null) {
+      break
+    }
+    yield match
+  }
+}

--- a/packages/lowerdash/test/strings.test.ts
+++ b/packages/lowerdash/test/strings.test.ts
@@ -87,4 +87,29 @@ describe('strings', () => {
       expect(strings.capitalizeFirstLetter('')).toEqual('')
     })
   })
+
+  describe('matchAll', () => {
+    it('should find all matches for a global regular expression', () => {
+      const unnamed = [...strings.matchAll('abcdacdbcd', /[ab](cd)/g)]
+      expect(unnamed).toHaveLength(3)
+      expect(unnamed[0][0]).toEqual('bcd')
+      expect(unnamed[0][1]).toEqual('cd')
+      expect(unnamed[0].groups).toBeUndefined()
+      expect(unnamed[1][0]).toEqual('acd')
+      expect(unnamed[1][1]).toEqual('cd')
+      const named = [...strings.matchAll('abcdacdbcd', /[ab](?<g1>cd)/g)]
+      expect(named).toHaveLength(3)
+      expect(named[0][0]).toEqual('bcd')
+      expect(named[0][1]).toEqual('cd')
+      expect(named[0].groups).toEqual({ g1: 'cd' })
+      expect(named[1][0]).toEqual('acd')
+      expect(named[1][1]).toEqual('cd')
+    })
+    it('should return empty when no matches were found', () => {
+      expect([...strings.matchAll('abcdbcdbcd', /[ab](cde)/g)]).toEqual([])
+    })
+    it('should throw for non-global regular expressions', () => {
+      expect(() => [...strings.matchAll('abcdacdbcd', /[ab](cd)/)]).toThrow(new Error('matchAll only supports global regular expressions'))
+    })
+  })
 })

--- a/packages/workato-adapter/config_doc.md
+++ b/packages/workato-adapter/config_doc.md
@@ -25,8 +25,13 @@ workato {
       "roles",
     ]
     serviceConnectionNames = {
-      salesforce = "Salesforce sandbox 1 connection"
-      netsuite = "Netsuite sbx"
+      salesforce = [
+        "Salesforce sandbox 1 primary connection",
+        "Salesforce sandbox 1 secondary connection",
+      ]
+      netsuite = [
+        "Netsuite sbx",
+      ]
     }
   }
 }
@@ -75,4 +80,4 @@ workato {
 |                                             |   "recipes",             |
 |                                             |   "roles",               |
 |                                             |  ]                       |
-| serviceConnectionNames                      |                          | Mapping from adapter name to workato connection name, which is used for resolving the relevant elements into references across multiple adapters in the same environment. Currently salesforce and netsuite are supported
+| serviceConnectionNames                      |                          | Mapping from adapter name to workato connection name(s), which is used for resolving the relevant elements into references across multiple adapters in the same environment. Currently salesforce and netsuite are supported

--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -102,9 +102,8 @@ export default class WorkatoAdapter implements AdapterOperations {
   }
 
   @logDuration('updating cross-service references')
-  async postFetch(args: PostFetchOptions): Promise<{ changed: boolean }> {
-    const changed = await this.filtersRunner.onPostFetch(args)
-    return { changed }
+  async postFetch(args: PostFetchOptions): Promise<void> {
+    await this.filtersRunner.onPostFetch(args)
   }
 
   /**

--- a/packages/workato-adapter/src/constants.ts
+++ b/packages/workato-adapter/src/constants.ts
@@ -15,8 +15,10 @@
 */
 export const WORKATO = 'workato'
 
-// services supporting cross-service reference - mapping from salto name to workato name
-export const CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS: Record<string, string> = {
-  salesforce: 'salesforce',
-  netsuite: 'netsuite',
+export const SALESFORCE = 'salesforce'
+export const NETSUITE = 'netsuite'
+
+export const CROSS_SERVICE_SUPPORTED_APPS = {
+  [SALESFORCE]: ['salesforce', 'salesforce_secondary'],
+  [NETSUITE]: ['netsuite', 'netsuite_secondary'],
 }

--- a/packages/workato-adapter/src/filters/cross_service/recipe_references.ts
+++ b/packages/workato-adapter/src/filters/cross_service/recipe_references.ts
@@ -36,7 +36,7 @@ type ConnectionDetails = {
   applicationName: string
 }
 
-const getServiceConnectionNames = (
+const getServiceConnectionDetails = (
   serviceConnectionConfig: Record<string, string[]>,
   connectionInstances: InstanceElement[],
 ): Record<string, Record<string, ConnectionDetails>> => {
@@ -133,7 +133,7 @@ const filter: FilterCreator = ({ config }) => ({
       return
     }
 
-    const serviceConnectionDetails = getServiceConnectionNames(
+    const serviceConnectionDetails = getServiceConnectionDetails(
       serviceConnectionNames,
       currentAdapterElements
         .filter(isInstanceElement)

--- a/packages/workato-adapter/src/filters/cross_service/recipe_references.ts
+++ b/packages/workato-adapter/src/filters/cross_service/recipe_references.ts
@@ -15,298 +15,63 @@
 */
 import _ from 'lodash'
 import {
-  Element, isInstanceElement, InstanceElement, ElemID, isReferenceExpression, ReferenceExpression,
-  PostFetchOptions, isObjectType, ObjectType, Field, Value,
+  Element, isInstanceElement, InstanceElement, ElemID, isReferenceExpression, PostFetchOptions,
 } from '@salto-io/adapter-api'
 import { elements as elementUtils } from '@salto-io/adapter-components'
-import { transformElement, TransformFunc, safeJsonStringify, setPath, extendGeneratedDependencies } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { values as lowerdashValues } from '@salto-io/lowerdash'
+import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../../filter'
 import { FETCH_CONFIG } from '../../config'
-import { CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS } from '../../constants'
-import { indexSalesforceByMetadataTypeAndApiName, indexNetsuiteByTypeAndScriptId, NetsuiteIndex, SalesforceIndex } from './element_indexes'
-import { isNetsuiteBlock, isSalesforceBlock, NetsuiteBlock, SalesforceBlock } from './recipe_block_types'
+import { SALESFORCE, NETSUITE } from '../../constants'
+import { indexSalesforceByMetadataTypeAndApiName, indexNetsuiteByTypeAndScriptId } from './element_indexes'
+import { addNetsuiteRecipeReferences } from './reference_finders/netsuite'
+import { addSalesforceRecipeReferences } from './reference_finders/salesforce'
 
 const log = logger(module)
-const { isDefined } = lowerdashValues
+const { makeArray } = collections.array
 const { toNestedTypeName } = elementUtils.ducktype
 
-type MappedReference = {
-  srcPath: ElemID | undefined
-  ref: ReferenceExpression
+type ConnectionDetails = {
+  id: ElemID
+  applicationName: string
 }
 
-type ReferenceFinder<T extends SalesforceBlock | NetsuiteBlock> = (
-  value: T,
-  path: ElemID,
-) => MappedReference[]
-
-type FormulaReferenceFinder = (
-  value: string,
-  path: ElemID,
-) => MappedReference[]
-
-const addReferencesForService = <T extends SalesforceBlock | NetsuiteBlock>(
-  inst: InstanceElement,
-  typeGuard: (value: Value) => value is T,
-  addReferences: ReferenceFinder<T>,
-  addFormulaReferences?: FormulaReferenceFinder,
-): boolean => {
-  const dependencyMapping: MappedReference[] = []
-
-  const findReferences: TransformFunc = ({ value, path }) => {
-    if (typeGuard(value)) {
-      dependencyMapping.push(...addReferences(
-        value,
-        path ?? inst.elemID,
-      ))
-    }
-    if (
-      addFormulaReferences !== undefined
-      && path !== undefined
-      && _.isString(value)
-    ) {
-      dependencyMapping.push(...addFormulaReferences(value, path))
-    }
-    return value
-  }
-
-  // used for traversal, the transform result is ignored
-  transformElement({
-    element: inst,
-    transformFunc: findReferences,
-    strict: false,
-  })
-  if (dependencyMapping.length === 0) {
-    return false
-  }
-  log.debug('found the following references: %s', safeJsonStringify(dependencyMapping.map(dep => [dep.srcPath?.getFullName(), dep.ref.elemId.getFullName()])))
-  dependencyMapping.forEach(({ srcPath, ref }) => {
-    if (srcPath !== undefined) {
-      setPath(inst, srcPath, ref)
-    }
-  })
-  extendGeneratedDependencies(inst, dependencyMapping.map(dep => dep.ref))
-  return true
-}
-
-const SALESFORCE_LABEL_ANNOTATION = 'label'
-
-const addSalesforceRecipeReferences = (
-  inst: InstanceElement,
-  indexedElements: SalesforceIndex,
-): boolean => {
-  const getObjectDetails = (objectName: string): {
-    id: ElemID
-    fields: Record<string, Readonly<Field>>
-    label?: string
-   } | undefined => {
-    const refObjectFragments = (
-      indexedElements.CustomObject?.[objectName] ?? indexedElements[objectName]?.[objectName]
-    )
-    if (refObjectFragments !== undefined && refObjectFragments.every(isObjectType)) {
-      const fields: Record<string, Field> = _.assign(
-        {},
-        ...(refObjectFragments as ObjectType[]).map(fragment => fragment.fields),
-      )
-      const label = refObjectFragments.map(
-        ref => ref.annotations[SALESFORCE_LABEL_ANNOTATION]
-      ).find(_.isString)
-      return {
-        id: refObjectFragments[0].elemID,
-        fields,
-        label,
-      }
-    }
-    return undefined
-  }
-
-  const referenceFinder: ReferenceFinder<SalesforceBlock> = (blockValue, path) => {
-    const { dynamicPickListSelection, input } = blockValue
-    const objectDetails = getObjectDetails(input.sobject_name)
-    if (objectDetails === undefined) {
-      return []
-    }
-
-    const references: MappedReference[] = [{
-      srcPath: path.createNestedID('input', 'sobject_name'),
-      ref: new ReferenceExpression(objectDetails.id),
-    }]
-
-    const inputFieldNames = Object.keys(_.omit(input, 'sobject_name'))
-    inputFieldNames.forEach(fieldName => {
-      if (objectDetails.fields[fieldName] !== undefined) {
-        references.push(
-          {
-            // no srcPath because we can't override the field keys in the current format
-            srcPath: undefined,
-            ref: new ReferenceExpression(objectDetails.fields[fieldName].elemID),
-          },
-        )
-      }
-    })
-
-    // dynamicPickListSelection uses the label, not the api name
-    if (dynamicPickListSelection.sobject_name === objectDetails.label) {
-      references.push({
-        srcPath: path.createNestedID('dynamicPickListSelection', 'sobject_name'),
-        ref: new ReferenceExpression(objectDetails.id),
-      })
-
-      if (dynamicPickListSelection.field_list !== undefined) {
-        const potentialFields: string[] = (dynamicPickListSelection.field_list).map(
-          (f: { value: string }) => f.value
-        )
-        potentialFields.forEach((fieldName, idx) => {
-          if (objectDetails.fields[fieldName] !== undefined) {
-            references.push(
-              {
-                srcPath: path.createNestedID('dynamicPickListSelection', 'field_list', String(idx)),
-                ref: new ReferenceExpression(objectDetails.fields[fieldName].elemID),
-              },
-            )
-          }
-        })
-      }
-      if (dynamicPickListSelection.table_list !== undefined) {
-        const potentialReferencedTypes: string[] = (dynamicPickListSelection.table_list).map(
-          (f: { value: string }) => f.value
-        )
-        potentialReferencedTypes.forEach((typeName, idx) => {
-          const refObjectDetails = getObjectDetails(typeName)
-          if (refObjectDetails !== undefined) {
-            references.push(
-              {
-                srcPath: path.createNestedID('dynamicPickListSelection', 'table_list', String(idx)),
-                ref: new ReferenceExpression(refObjectDetails.id),
-              },
-            )
-          }
-        })
-      }
-    }
-    return references
-  }
-
-  return addReferencesForService<SalesforceBlock>(inst, isSalesforceBlock, referenceFinder)
-}
-
-const addNetsuiteRecipeReferences = (
-  inst: InstanceElement,
-  indexedElements: NetsuiteIndex,
-): boolean => {
-  const referenceFinder: ReferenceFinder<NetsuiteBlock> = (blockValue, path) => {
-    const references: MappedReference[] = []
-
-    const { dynamicPickListSelection, input } = blockValue
-
-    const addPotentialReference = (value: unknown, separator: string, nestedPath: ElemID): void => {
-      if (_.isString(value) && value.split(separator).length === 2) {
-        const scriptId = _.last(value.toLowerCase().split(separator))
-        if (scriptId !== undefined) {
-          const referencedId = indexedElements[scriptId]
-          if (referencedId !== undefined) {
-            references.push({
-              srcPath: nestedPath,
-              ref: new ReferenceExpression(referencedId),
-            })
-          }
-        }
-      }
-    }
-
-    const netsuiteObject = input?.netsuite_object
-    if (netsuiteObject !== undefined) {
-      addPotentialReference(netsuiteObject, '@@', path.createNestedID('input', 'netsuite_object'))
-    }
-    (dynamicPickListSelection.custom_list ?? []).forEach(({ value }, idx) => {
-      addPotentialReference(
-        value,
-        '@',
-        path.createNestedID('dynamicPickListSelection', 'custom_list', String(idx)),
-      )
-    })
-    return references
-  }
-
-  const formulaReferenceFinder: FormulaReferenceFinder = value => {
-    function *fieldMatcher(): Iterable<string> {
-      // note: for netsuite standard fields / salesforce fields we'd need to parse the block's id
-      // and (optional) object type to know which object to look for the field under - but
-      // for custom fields we have the script id which is globally unique, so we can use it directly
-      const matcher = /#\{_\('data\.netsuite\.(?:\w+\.)+custom_fields\.f_?(?:[0-9]+_)*(?<field>\w*)'\)\}/g
-      while (true) {
-        const match = matcher.exec(value)?.groups?.field
-        if (match === undefined || match === null) {
-          break
-        }
-        yield match
-      }
-    }
-    const potentialFields = [...fieldMatcher()]
-    return potentialFields.map(fieldNameScriptId => {
-      const referencedId = indexedElements[fieldNameScriptId]
-      if (referencedId !== undefined) {
-        return {
-          srcPath: undefined,
-          ref: new ReferenceExpression(referencedId),
-        }
-      }
-      return undefined
-    }).filter(isDefined)
-  }
-
-  return addReferencesForService<NetsuiteBlock>(
-    inst,
-    isNetsuiteBlock,
-    referenceFinder,
-    formulaReferenceFinder,
-  )
-}
-
-const toKey = (first: string, second: string): string => `${first}:${second}`
-
-const getServiceConnectionIDs = (
-  serviceConnectionNames: Record<string, string>,
+const getServiceConnectionNames = (
+  serviceConnectionConfig: Record<string, string[]>,
   connectionInstances: InstanceElement[],
-): Record<string, ElemID> => {
-  const unsupportedServiceNames = Object.keys(serviceConnectionNames).filter(
-    name => !Object.keys(CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS).includes(name)
+): Record<string, Record<string, ConnectionDetails>> => {
+  const connectionInstanceDetails = Object.fromEntries(
+    connectionInstances
+      .filter(inst => _.isString(inst.value.name) && _.isString(inst.value.application))
+      .map(inst => [
+        inst.value.name as string,
+        ({ id: inst.elemID, applicationName: inst.value.application as string }),
+      ])
   )
-  if (unsupportedServiceNames.length > 0) {
-    log.error('the following services are not supported, and will be ignored: %s', unsupportedServiceNames)
-  }
 
-  const connections = new Set(connectionInstances.map(
-    inst => toKey(inst.value.application, inst.value.name)
-  ))
-  const missingConnections = Object.entries(serviceConnectionNames).filter(
-    ([adapterName, connectionName]) => !connections.has(
-      toKey(CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS[adapterName] ?? '', connectionName)
+  const connectionDetailsByService = _.mapValues(
+    serviceConnectionConfig,
+    connectionNames => Object.fromEntries(
+      // makeArray can eventually be removed - added for short-term backward compatibility with the
+      // old single-connection config format
+      makeArray(connectionNames)
+        .filter(name => connectionInstanceDetails[name] !== undefined)
+        .map(name => [name, connectionInstanceDetails[name]]),
     )
   )
-  if (missingConnections.length > 0) {
-    log.error('the following services do not have any workato connections in the fetch results: %s', missingConnections)
-  }
-
-  const serviceConnectionIDs = _.pickBy(
-    _.mapValues(
-      _.pickBy(
-        serviceConnectionNames,
-        (_connectionName, adapterName) =>
-          Object.values(CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS).includes(adapterName)
-      ),
-      (connectionName, serviceName) => _.first(connectionInstances
-        .filter(inst => inst.value.name === connectionName)
-        .filter(inst =>
-          inst.value.application === CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS[serviceName])
-        .map(inst => inst.elemID))
-    ),
-    isDefined,
+  const missingConnections = (
+    Object.entries(serviceConnectionConfig).flatMap(
+      ([serviceName, connectionNames]) => makeArray(connectionNames).filter(
+        name => connectionDetailsByService[serviceName][name] === undefined
+      )
+    )
   )
 
-  return serviceConnectionIDs
+  if (missingConnections.length > 0) {
+    log.error('The following workato connections could not be found: %s', missingConnections)
+  }
+
+  return connectionDetailsByService
 }
 
 /**
@@ -323,7 +88,7 @@ const filterRelevantRecipeCodes = (
       .filter(recipe => isReferenceExpression(recipe.value.code))
       .filter(recipe => Array.isArray(recipe.value.config) && recipe.value.config.some(
         connectionConfig => (
-          _.isObjectLike(connectionConfig)
+          _.isPlainObject(connectionConfig)
           && isReferenceExpression(connectionConfig.account_id)
           && connectionID.isEqual(connectionConfig.account_id.elemId)
         )
@@ -336,26 +101,23 @@ const filterRelevantRecipeCodes = (
 
 const addReferencesForConnectionRecipes = (
   relevantRecipeCodes: InstanceElement[],
+  appName: string,
   serviceName: string,
   serviceElements: ReadonlyArray<Readonly<Element>>,
-): boolean => {
-  if (serviceName === CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS.salesforce) {
+): void => {
+  if (serviceName === SALESFORCE) {
     const index = indexSalesforceByMetadataTypeAndApiName(serviceElements)
-    const res = relevantRecipeCodes.map(
-      inst => addSalesforceRecipeReferences(inst, index)
+    relevantRecipeCodes.forEach(
+      inst => addSalesforceRecipeReferences(inst, index, appName)
     )
-    return res.some(t => t)
+    return
   }
-  if (serviceName === CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS.netsuite) {
+  if (serviceName === NETSUITE) {
     const index = indexNetsuiteByTypeAndScriptId(serviceElements)
-    const res = relevantRecipeCodes.map(
-      inst => addNetsuiteRecipeReferences(inst, index)
+    relevantRecipeCodes.forEach(
+      inst => addNetsuiteRecipeReferences(inst, index, appName)
     )
-    return res.some(t => t)
   }
-
-  log.debug('unsupported service name %s, not resolving recipe references', serviceName)
-  return false
 }
 
 /**
@@ -365,13 +127,13 @@ const filter: FilterCreator = ({ config }) => ({
   onPostFetch: async ({
     currentAdapterElements,
     elementsByAdapter,
-  }: PostFetchOptions): Promise<boolean> => {
+  }: PostFetchOptions): Promise<void> => {
     const { serviceConnectionNames } = config[FETCH_CONFIG]
     if (serviceConnectionNames === undefined || _.isEmpty(serviceConnectionNames)) {
-      return false
+      return
     }
 
-    const serviceConnections = getServiceConnectionIDs(
+    const serviceConnectionDetails = getServiceConnectionNames(
       serviceConnectionNames,
       currentAdapterElements
         .filter(isInstanceElement)
@@ -389,19 +151,21 @@ const filter: FilterCreator = ({ config }) => ({
       inst => inst.elemID.getFullName()
     )
 
-    const updateResults = Object.entries(serviceConnections).map(([serviceName, connectionID]) => {
-      const relevantRecipeCodes = filterRelevantRecipeCodes(
-        connectionID,
-        recipeInstances,
-        recipeCodeInstancesByElemID,
-      )
-      return addReferencesForConnectionRecipes(
-        relevantRecipeCodes,
-        serviceName,
-        elementsByAdapter[serviceName] ?? [],
-      )
+    Object.entries(serviceConnectionDetails).forEach(([serviceName, connections]) => {
+      Object.values(connections).forEach(({ id, applicationName }) => {
+        const relevantRecipeCodes = filterRelevantRecipeCodes(
+          id,
+          recipeInstances,
+          recipeCodeInstancesByElemID,
+        )
+        addReferencesForConnectionRecipes(
+          relevantRecipeCodes,
+          applicationName,
+          serviceName,
+          elementsByAdapter[serviceName] ?? [],
+        )
+      })
     })
-    return updateResults.some(t => t)
   },
 })
 

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
@@ -24,6 +24,9 @@ import { addReferencesForService, FormulaReferenceFinder, MappedReference, Refer
 
 const { isDefined } = lowerdashValues
 
+const OBJECT_REFERENCE_SEEPARATOR = '@@'
+const FIELD_REFERENCE_SEPARATOR = '@'
+
 type NetsuiteFieldMatchGroup = { field: string }
 const isNetsuiteFieldMatchGroup = (val: Values): val is NetsuiteFieldMatchGroup => (
   _.isString(val.field)
@@ -42,15 +45,16 @@ export const addNetsuiteRecipeReferences = (
   inst: InstanceElement,
   indexedElements: NetsuiteIndex,
   appName: string,
-): boolean => {
+): void => {
   const referenceFinder: ReferenceFinder<NetsuiteBlock> = (blockValue, path) => {
     const references: MappedReference[] = []
 
     const { dynamicPickListSelection, input } = blockValue
 
     const addPotentialReference = (value: unknown, separator: string, nestedPath: ElemID): void => {
-      if (_.isString(value) && value.split(separator).length === 2) {
-        const scriptId = _.last(value.toLowerCase().split(separator))
+      const lowercaseSeparator = separator.toLowerCase()
+      if (_.isString(value) && value.split(lowercaseSeparator).length === 2) {
+        const scriptId = _.last(value.toLowerCase().split(lowercaseSeparator))
         if (scriptId !== undefined) {
           const referencedId = indexedElements[scriptId]
           if (referencedId !== undefined) {
@@ -65,12 +69,12 @@ export const addNetsuiteRecipeReferences = (
 
     const netsuiteObject = input?.netsuite_object
     if (netsuiteObject !== undefined) {
-      addPotentialReference(netsuiteObject, '@@', path.createNestedID('input', 'netsuite_object'))
+      addPotentialReference(netsuiteObject, OBJECT_REFERENCE_SEEPARATOR, path.createNestedID('input', 'netsuite_object'))
     }
     (dynamicPickListSelection.custom_list ?? []).forEach(({ value }, idx) => {
       addPotentialReference(
         value,
-        '@',
+        FIELD_REFERENCE_SEPARATOR,
         path.createNestedID('dynamicPickListSelection', 'custom_list', String(idx)),
       )
     })

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
@@ -1,0 +1,103 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  InstanceElement, ElemID, ReferenceExpression, Values,
+} from '@salto-io/adapter-api'
+import { values as lowerdashValues } from '@salto-io/lowerdash'
+import { NetsuiteIndex } from '../element_indexes'
+import { isNetsuiteBlock, NetsuiteBlock } from './recipe_block_types'
+import { addReferencesForService, FormulaReferenceFinder, MappedReference, ReferenceFinder, createMatcher, Matcher } from './shared'
+
+const { isDefined } = lowerdashValues
+
+type NetsuiteFieldMatchGroup = { field: string }
+const isNetsuiteFieldMatchGroup = (val: Values): val is NetsuiteFieldMatchGroup => (
+  _.isString(val.field)
+)
+const createFormulaFieldMatcher = (application: string): Matcher<NetsuiteFieldMatchGroup> => (
+  // note: for netsuite standard fields / salesforce fields we'd need to parse the block's id
+  // and (optional) object type to know which object to look for the field under - but
+  // for custom fields we have the script id which is globally unique, so we can use it directly
+  createMatcher(
+    [new RegExp(`\\('data\\.${application}\\.(?:\\w+\\.)+custom_fields\\.f_?(?:[0-9]+_)*(?<field>\\w*)'\\)`, 'g')],
+    isNetsuiteFieldMatchGroup,
+  )
+)
+
+export const addNetsuiteRecipeReferences = (
+  inst: InstanceElement,
+  indexedElements: NetsuiteIndex,
+  appName: string,
+): boolean => {
+  const referenceFinder: ReferenceFinder<NetsuiteBlock> = (blockValue, path) => {
+    const references: MappedReference[] = []
+
+    const { dynamicPickListSelection, input } = blockValue
+
+    const addPotentialReference = (value: unknown, separator: string, nestedPath: ElemID): void => {
+      if (_.isString(value) && value.split(separator).length === 2) {
+        const scriptId = _.last(value.toLowerCase().split(separator))
+        if (scriptId !== undefined) {
+          const referencedId = indexedElements[scriptId]
+          if (referencedId !== undefined) {
+            references.push({
+              srcPath: nestedPath,
+              ref: new ReferenceExpression(referencedId),
+            })
+          }
+        }
+      }
+    }
+
+    const netsuiteObject = input?.netsuite_object
+    if (netsuiteObject !== undefined) {
+      addPotentialReference(netsuiteObject, '@@', path.createNestedID('input', 'netsuite_object'))
+    }
+    (dynamicPickListSelection.custom_list ?? []).forEach(({ value }, idx) => {
+      addPotentialReference(
+        value,
+        '@',
+        path.createNestedID('dynamicPickListSelection', 'custom_list', String(idx)),
+      )
+    })
+    return references
+  }
+
+  const formulaFieldMatcher = createFormulaFieldMatcher(appName)
+
+  const formulaReferenceFinder: FormulaReferenceFinder = value => {
+    const potentialFields = [...formulaFieldMatcher(value)].map(match => match.field)
+    return potentialFields.map(fieldNameScriptId => {
+      const referencedId = indexedElements[fieldNameScriptId]
+      if (referencedId !== undefined) {
+        return {
+          srcPath: undefined,
+          ref: new ReferenceExpression(referencedId),
+        }
+      }
+      return undefined
+    }).filter(isDefined)
+  }
+
+  return addReferencesForService<NetsuiteBlock>(
+    inst,
+    appName,
+    isNetsuiteBlock,
+    referenceFinder,
+    formulaReferenceFinder,
+  )
+}

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
@@ -84,7 +84,7 @@ export const addNetsuiteRecipeReferences = (
   const formulaFieldMatcher = createFormulaFieldMatcher(appName)
 
   const formulaReferenceFinder: FormulaReferenceFinder = value => {
-    const potentialFields = [...formulaFieldMatcher(value)].map(match => match.field)
+    const potentialFields = formulaFieldMatcher(value).map(match => match.field)
     return potentialFields.map(fieldNameScriptId => {
       const referencedId = indexedElements[fieldNameScriptId]
       if (referencedId !== undefined) {

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/recipe_block_types.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/recipe_block_types.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS } from '../../constants'
+import { SALESFORCE, CROSS_SERVICE_SUPPORTED_APPS, NETSUITE } from '../../../constants'
 
 type RefListItem = {
   label: string
@@ -22,7 +22,8 @@ type RefListItem = {
 }
 
 export type SalesforceBlock = {
-  provider: 'salesforce'
+  as: string
+  provider: 'salesforce' | 'salesforce_secondary'
   dynamicPickListSelection: {
     sobject_name: string
     field_list?: RefListItem[]
@@ -32,8 +33,9 @@ export type SalesforceBlock = {
     sobject_name: string
   }
 }
+
 export type NetsuiteBlock = {
-  provider: 'netsuite'
+  provider: 'netsuite' | 'netsuite_secondary'
   dynamicPickListSelection: {
     netsuite_object: string
     custom_list?: RefListItem[]
@@ -49,21 +51,24 @@ const isListItem = (value: any): value is RefListItem => (
 )
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const isSalesforceBlock = (value: any): value is SalesforceBlock => (
+export const isSalesforceBlock = (value: any, application: string): value is SalesforceBlock => (
   _.isObjectLike(value)
-  && value.provider === CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS.salesforce
+  && CROSS_SERVICE_SUPPORTED_APPS[SALESFORCE].includes(application)
+  && value.provider === application
   && _.isObjectLike(value.dynamicPickListSelection)
   && _.isString(value.dynamicPickListSelection.sobject_name)
   && (value.dynamicPickListSelection.table_list ?? []).every(isListItem)
   && (value.dynamicPickListSelection.field_list ?? []).every(isListItem)
   && _.isObjectLike(value.input)
   && _.isString(value.input.sobject_name)
+  && _.isString(value.as)
 )
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const isNetsuiteBlock = (value: any): value is NetsuiteBlock => (
+export const isNetsuiteBlock = (value: any, application: string): value is NetsuiteBlock => (
   _.isObjectLike(value)
-  && value.provider === CROSS_SERVICE_REFERENCE_SUPPORTED_ADAPTERS.netsuite
+  && CROSS_SERVICE_SUPPORTED_APPS[NETSUITE].includes(application)
+  && value.provider === application
   && _.isObjectLike(value.dynamicPickListSelection)
   && _.isString(value.dynamicPickListSelection.netsuite_object)
   && (value.dynamicPickListSelection.custom_list ?? []).every(isListItem)

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/salesforce.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/salesforce.ts
@@ -61,7 +61,7 @@ export const addSalesforceRecipeReferences = (
   inst: InstanceElement,
   indexedElements: SalesforceIndex,
   appName: string,
-): boolean => {
+): void => {
   const sobjectByBlock: Record<string, string> = {}
 
   const getObjectDetails = (objectName: string): {
@@ -72,8 +72,8 @@ export const addSalesforceRecipeReferences = (
     const refObjectFragments = (
       indexedElements.CustomObject?.[objectName] ?? indexedElements[objectName]?.[objectName]
     )
-    if (refObjectFragments !== undefined && refObjectFragments.every(isObjectType)) {
-      const fields: Record<string, Field> = _.assign(
+    if (!_.isEmpty(refObjectFragments) && refObjectFragments.every(isObjectType)) {
+      const fields: Record<string, Field> = Object.assign(
         {},
         ...(refObjectFragments as ObjectType[]).map(fragment => fragment.fields),
       )

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/salesforce.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/salesforce.ts
@@ -1,0 +1,217 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  InstanceElement, ElemID, ReferenceExpression,
+  isObjectType, ObjectType, Field, Values,
+} from '@salto-io/adapter-api'
+import { values as lowerdashValues } from '@salto-io/lowerdash'
+import { SalesforceIndex } from '../element_indexes'
+import { isSalesforceBlock, SalesforceBlock } from './recipe_block_types'
+import { addReferencesForService, FormulaReferenceFinder, MappedReference, ReferenceFinder, createMatcher, Matcher } from './shared'
+
+const { isDefined } = lowerdashValues
+
+const SALESFORCE_LABEL_ANNOTATION = 'label'
+
+type SalesforceFieldMatchGroup = { obj?: string; field: string; block: string }
+const isSalesforceFieldMatchGroup = (val: Values): val is SalesforceFieldMatchGroup => (
+  (val.obj === undefined || _.isString(val.obj))
+  && _.isString(val.field)
+  && _.isString(val.block)
+)
+
+const createFormulaFieldMatcher = (application: string): Matcher<SalesforceFieldMatchGroup> => {
+  // example: ('data.salesforce.1234abcd.Account.first.Name')
+  const objectAndFieldMatcher = new RegExp(`\\('data\\.${application}\\.(?<block>\\w+)\\.(?!sobject\\.)(?<obj>\\w+)\\.(?:\\w+)\\.(?<field>\\w+)'\\)`, 'g')
+  // example: ('data.salesforce.1234abcd.sobject.Account.Name')
+  const relatedObjectAndFieldMatcher = new RegExp(`\\('data\\.${application}\\.(?<block>\\w+)\\.sobject\\.(?<obj>\\w+)\\.(?<field>\\w+)'\\)`, 'g')
+  // example: ('data.salesforce.1234abcd.sobject.Name')
+  const sobjectFieldMatcher = new RegExp(`\\('data\\.${application}\\.(?<block>\\w+)\\.sobject\\.(?<field>\\w+)'\\)`, 'g')
+  // example: ('data.salesforce.1234abcd.Name')
+  const fieldOnlyMatcher = new RegExp(`\\('data\\.${application}\\.(?<block>\\w+)\\.(?<field>\\w+)'\\)`, 'g')
+  return createMatcher(
+    [objectAndFieldMatcher, relatedObjectAndFieldMatcher, sobjectFieldMatcher, fieldOnlyMatcher],
+    isSalesforceFieldMatchGroup,
+  )
+}
+
+const fieldListRelatedObjectAndFieldMatcher = createMatcher(
+  // example: Account$Account ID.Id
+  [new RegExp('^(?<obj>\\w+)\\$([^.]+)\\.(?<field>\\w+)$', 'g')],
+  (val: Values): val is { obj: string; field: string } => (
+    _.isString(val.obj) && _.isString(val.field)
+  ),
+)
+
+export const addSalesforceRecipeReferences = (
+  inst: InstanceElement,
+  indexedElements: SalesforceIndex,
+  appName: string,
+): boolean => {
+  const sobjectByBlock: Record<string, string> = {}
+
+  const getObjectDetails = (objectName: string): {
+    id: ElemID
+    fields: Record<string, Readonly<Field>>
+    label?: string
+   } | undefined => {
+    const refObjectFragments = (
+      indexedElements.CustomObject?.[objectName] ?? indexedElements[objectName]?.[objectName]
+    )
+    if (refObjectFragments !== undefined && refObjectFragments.every(isObjectType)) {
+      const fields: Record<string, Field> = _.assign(
+        {},
+        ...(refObjectFragments as ObjectType[]).map(fragment => fragment.fields),
+      )
+      const label = refObjectFragments.map(
+        ref => ref.annotations[SALESFORCE_LABEL_ANNOTATION]
+      ).find(_.isString)
+      return {
+        id: refObjectFragments[0].elemID,
+        fields,
+        label,
+      }
+    }
+    return undefined
+  }
+
+  const referenceFinder: ReferenceFinder<SalesforceBlock> = (blockValue, path) => {
+    const { dynamicPickListSelection, input } = blockValue
+    sobjectByBlock[blockValue.as] = input.sobject_name
+    const objectDetails = getObjectDetails(input.sobject_name)
+    if (objectDetails === undefined) {
+      return []
+    }
+
+    const references: MappedReference[] = [{
+      srcPath: path.createNestedID('input', 'sobject_name'),
+      ref: new ReferenceExpression(objectDetails.id),
+    }]
+
+    const inputFieldNames = Object.keys(_.omit(input, 'sobject_name'))
+    inputFieldNames.forEach(fieldName => {
+      if (objectDetails.fields[fieldName] !== undefined) {
+        references.push(
+          {
+            // no srcPath because we can't override the field keys in the current format
+            srcPath: undefined,
+            ref: new ReferenceExpression(objectDetails.fields[fieldName].elemID),
+          },
+        )
+      }
+    })
+
+    // dynamicPickListSelection uses the label, not the api name
+    if (dynamicPickListSelection.sobject_name === objectDetails.label) {
+      references.push({
+        srcPath: path.createNestedID('dynamicPickListSelection', 'sobject_name'),
+        ref: new ReferenceExpression(objectDetails.id),
+      })
+
+      if (dynamicPickListSelection.field_list !== undefined) {
+        const potentialFields: string[] = (dynamicPickListSelection.field_list).map(
+          (f: { value: string }) => f.value
+        )
+        potentialFields.forEach((fieldName, idx) => {
+          const relatedObjectCheck = [...fieldListRelatedObjectAndFieldMatcher(fieldName)][0]
+          if (relatedObjectCheck !== undefined) {
+            const { obj, field } = relatedObjectCheck
+            const relatedObjectDetails = getObjectDetails(obj)
+            if (relatedObjectDetails === undefined) {
+              return
+            }
+            if (relatedObjectDetails.fields[field] !== undefined) {
+              references.push(
+                {
+                  srcPath: path.createNestedID('dynamicPickListSelection', 'field_list', String(idx)),
+                  ref: new ReferenceExpression(relatedObjectDetails.fields[field].elemID),
+                },
+              )
+              references.push(
+                {
+                  srcPath: undefined,
+                  ref: new ReferenceExpression(relatedObjectDetails.id),
+                },
+              )
+            }
+          } else if (objectDetails.fields[fieldName] !== undefined) {
+            references.push(
+              {
+                srcPath: path.createNestedID('dynamicPickListSelection', 'field_list', String(idx)),
+                ref: new ReferenceExpression(objectDetails.fields[fieldName].elemID),
+              },
+            )
+          }
+        })
+      }
+      if (dynamicPickListSelection.table_list !== undefined) {
+        const potentialReferencedTypes: string[] = (dynamicPickListSelection.table_list).map(
+          (f: { value: string }) => f.value
+        )
+        potentialReferencedTypes.forEach((typeName, idx) => {
+          const refObjectDetails = getObjectDetails(typeName)
+          if (refObjectDetails !== undefined) {
+            references.push(
+              {
+                srcPath: path.createNestedID('dynamicPickListSelection', 'table_list', String(idx)),
+                ref: new ReferenceExpression(refObjectDetails.id),
+              },
+            )
+          }
+        })
+      }
+    }
+    return references
+  }
+
+  const formulaFieldMatcher = createFormulaFieldMatcher(appName)
+
+  const formulaReferenceFinder: FormulaReferenceFinder = value => {
+    const potentialMatchGroups = [...formulaFieldMatcher(value)]
+    return potentialMatchGroups.map(({ block, obj, field }) => {
+      const blockSObject = sobjectByBlock[block]
+      const objName = obj ?? blockSObject
+      if (objName === undefined || blockSObject === undefined) {
+        // we check that blockSObject is defined to make sure this block has the right application
+        return undefined
+      }
+
+      const objectDetails = getObjectDetails(objName)
+      if (field !== undefined && objectDetails?.fields[field] !== undefined) {
+        return {
+          srcPath: undefined,
+          ref: new ReferenceExpression(objectDetails.fields[field].elemID),
+        }
+      }
+      if (objectDetails !== undefined) {
+        return {
+          srcPath: undefined,
+          ref: new ReferenceExpression(objectDetails.id),
+        }
+      }
+      return undefined
+    }).filter(isDefined)
+  }
+
+  return addReferencesForService<SalesforceBlock>(
+    inst,
+    appName,
+    isSalesforceBlock,
+    referenceFinder,
+    formulaReferenceFinder,
+  )
+}

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/salesforce.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/salesforce.ts
@@ -127,7 +127,7 @@ export const addSalesforceRecipeReferences = (
           (f: { value: string }) => f.value
         )
         potentialFields.forEach((fieldName, idx) => {
-          const relatedObjectCheck = [...fieldListRelatedObjectAndFieldMatcher(fieldName)][0]
+          const relatedObjectCheck = fieldListRelatedObjectAndFieldMatcher(fieldName)[0]
           if (relatedObjectCheck !== undefined) {
             const { obj, field } = relatedObjectCheck
             const relatedObjectDetails = getObjectDetails(obj)
@@ -181,7 +181,7 @@ export const addSalesforceRecipeReferences = (
   const formulaFieldMatcher = createFormulaFieldMatcher(appName)
 
   const formulaReferenceFinder: FormulaReferenceFinder = value => {
-    const potentialMatchGroups = [...formulaFieldMatcher(value)]
+    const potentialMatchGroups = formulaFieldMatcher(value)
     return potentialMatchGroups.map(({ block, obj, field }) => {
       const blockSObject = sobjectByBlock[block]
       const objName = obj ?? blockSObject

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/shared.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/shared.ts
@@ -83,22 +83,19 @@ export const addReferencesForService = <T extends SalesforceBlock | NetsuiteBloc
   extendGeneratedDependencies(inst, dependencyMapping.map(dep => dep.ref))
 }
 
-export type Matcher<T> = (value: string) => Iterable<T>
+export type Matcher<T> = (value: string) => T[]
 export const createMatcher = <T>(
   matchers: RegExp[],
   typeGuard: types.TypeGuard<Values, T>,
 ): Matcher<T> => (
-    function *fieldMatcher(value) {
+    value => {
       const matchGroups = (
         matchers
           .flatMap(m => [...matchAll(value, m)])
           .map(r => r.groups)
           .filter(isDefined)
-      )
-      for (const m of matchGroups) {
-        if (typeGuard(m)) {
-          yield m
-        }
-      }
+      ) as Values[]
+      const x: T[] = matchGroups.filter(typeGuard)
+      return x
     }
   )

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/shared.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/shared.ts
@@ -1,0 +1,107 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  InstanceElement, ElemID, ReferenceExpression,
+  Value,
+  Values,
+} from '@salto-io/adapter-api'
+import { transformElement, TransformFunc, safeJsonStringify, setPath, extendGeneratedDependencies } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { types } from '@salto-io/lowerdash'
+import { NetsuiteBlock, SalesforceBlock } from './recipe_block_types'
+
+const log = logger(module)
+
+export type MappedReference = {
+  srcPath: ElemID | undefined
+  ref: ReferenceExpression
+}
+
+export type ReferenceFinder<T extends SalesforceBlock | NetsuiteBlock> = (
+  value: T,
+  path: ElemID,
+) => MappedReference[]
+
+export type FormulaReferenceFinder = (
+  value: string,
+  path: ElemID,
+) => MappedReference[]
+
+export const addReferencesForService = <T extends SalesforceBlock | NetsuiteBlock>(
+  inst: InstanceElement,
+  appName: string,
+  typeGuard: (value: Value, appName: string) => value is T,
+  addReferences: ReferenceFinder<T>,
+  addFormulaReferences?: FormulaReferenceFinder,
+): boolean => {
+  const dependencyMapping: MappedReference[] = []
+
+  const findReferences: TransformFunc = ({ value, path }) => {
+    if (typeGuard(value, appName)) {
+      dependencyMapping.push(...addReferences(
+        value,
+        path ?? inst.elemID,
+      ))
+    }
+    if (
+      addFormulaReferences !== undefined
+      && path !== undefined
+      && _.isString(value)
+    ) {
+      dependencyMapping.push(...addFormulaReferences(value, path))
+    }
+    return value
+  }
+
+  // used for traversal, the transform result is ignored
+  transformElement({
+    element: inst,
+    transformFunc: findReferences,
+    strict: false,
+  })
+  if (dependencyMapping.length === 0) {
+    return false
+  }
+  log.debug('found the following references: %s', safeJsonStringify(dependencyMapping.map(dep => [dep.srcPath?.getFullName(), dep.ref.elemId.getFullName()])))
+  dependencyMapping.forEach(({ srcPath, ref }) => {
+    if (srcPath !== undefined) {
+      setPath(inst, srcPath, ref)
+    }
+  })
+  extendGeneratedDependencies(inst, dependencyMapping.map(dep => dep.ref))
+  return true
+}
+
+export type Matcher<T> = (value: string) => Iterable<T>
+export const createMatcher = <T>(
+  matchers: RegExp[],
+  typeGuard: types.TypeGuard<Values, T>,
+): Matcher<T> => (
+    function *fieldMatcher(value) {
+      for (const matcher of matchers) {
+        while (true) {
+          const match = matcher.exec(value)?.groups
+          if (match === undefined || match === null) {
+            break
+          }
+          if (typeGuard(match)) {
+            yield match
+          }
+        }
+      }
+    }
+  )

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -313,8 +313,8 @@ describe('adapter', () => {
               [FETCH_CONFIG]: {
                 includeTypes: [...Object.keys(DEFAULT_TYPES)].sort(),
                 serviceConnectionNames: {
-                  salesforce: 'sfdev1',
-                  netsuite: 'Test NetSuite account',
+                  salesforce: ['sfdev1'],
+                  netsuite: ['Test NetSuite account'],
                 },
               },
             }
@@ -327,13 +327,12 @@ describe('adapter', () => {
         })
         const currentAdapterElements = fetchResult.elements
         expect(adapterOperations.postFetch).toBeDefined()
-        const postFetchRes = await adapterOperations.postFetch({
+        await adapterOperations.postFetch({
           currentAdapterElements,
           elementsByAdapter: {
             salesforce: [fishCustomObject],
           },
         })
-        expect(postFetchRes).toBeTruthy()
         const recipeCodeWithRefs = currentAdapterElements.filter(isInstanceElement).find(e => e.elemID.getFullName().startsWith('workato.recipe__code.instance.pubsub_recipe_412'))
         expect(recipeCodeWithRefs).toBeDefined()
         const deps = recipeCodeWithRefs?.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]

--- a/packages/workato-adapter/test/adapter_creator.test.ts
+++ b/packages/workato-adapter/test/adapter_creator.test.ts
@@ -124,8 +124,8 @@ describe('adapter creator', () => {
           fetch: {
             includeTypes: [],
             serviceConnectionNames: {
-              salesforce: 'abc',
-              unsupportedName: 'def',
+              salesforce: ['abc'],
+              unsupportedName: ['def'],
             },
           },
           apiDefinitions: {
@@ -140,7 +140,7 @@ describe('adapter creator', () => {
         },
       ),
       elementsSource: buildElementsSourceFromElements([]),
-    })).toThrow(new Error('Unsupported service names in fetch: unsupportedName. The supported services are: salesforce,netsuite'))
+    })).toThrow(new Error('Unsupported service names in fetch.serviceConnectionNames: unsupportedName. The supported services are: salesforce,netsuite'))
   })
 
   it('should validate credentials using createConnection', async () => {


### PR DESCRIPTION
Extend the workato reference filter to find more references:
* Changing the configuration to support listing multiple connections per adapter (also preparing for supporting multiple accounts under the same adapter in SALTO-1264, which will require some additional changes but can keep this config format)
  * The user doesn't need to specify if this is the primary or secondary connector - we conclude that from the connection and look only at the relevant blocks for each connection
* Extending workato->salesforce reference coverage:
  * Parsing salesforce object+field details from formulas - there are a few different patterns, I assume we may discover a couple more later on and can add them as well
  * Adding references to objects other than the primary sobject from `field_list`

---

* Also includes a refactor splitting some of the adapter-specific logic to its own files + removing the unused `boolean` response value (this was already done in the `lazy-element-intg` branch including some fixes, so no point keeping the old structure here).
* The configuration format for `fetch.serviceConnectionNames` was changed from a single string to an array (see upgrade instructions) - but the code is backward-compatible for now. I can add a change suggestion if that's preferred.

---
_Release Notes_: 
Workato adapter - extend cross-service references to support secondary connectors, and also references to salesforce in workato formulas and salesforce related objects.

_Upgrade instructions_: 
Workato adapter - If the cross-service configuration under `fetch.serviceConnectionNames` is set, each value should be converted to an array, e.g.:
```
    serviceConnectionNames = {
      salesforce = "my sandbox"
    }
```
should become
```
    serviceConnectionNames = {
      salesforce = [
        "my sandbox",
      ]
    }
```
