### PR TITLE
SALTO-1269: Partially support deploying instances with ACCOUNT_SPECIFIC_VALUES

### DIFF
--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -15,6 +15,7 @@
 */
 import { ChangeValidator } from '@salto-io/adapter-api'
 import { createChangeValidator } from '@salto-io/adapter-utils'
+import accountSpecificValuesValidator from './change_validators/account_specific_values'
 import removeCustomTypesValidator from './change_validators/remove_custom_types'
 import removeFileCabinetValidator from './change_validators/remove_file_cabinet'
 import removeListItemValidator from './change_validators/remove_list_item'
@@ -25,6 +26,7 @@ import { validateDependsOnInvalidElement } from './change_validators/dependencie
 
 
 const changeValidators: ChangeValidator[] = [
+  accountSpecificValuesValidator,
   removeCustomTypesValidator,
   instanceChangesValidator,
   immutableChangesValidator,

--- a/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
@@ -45,7 +45,7 @@ const hasAccountSpecificValue = (instance: InstanceElement): boolean => {
 }
 
 const changeValidator: ChangeValidator = async changes => (
-  _.flatten(changes
+  changes
     .filter(isAdditionOrModificationChange)
     .filter(isInstanceChange)
     .map(change => {
@@ -77,7 +77,7 @@ const changeValidator: ChangeValidator = async changes => (
         detailedMessage: 'Fields with ACCOUNT_SPECIFIC_VALUE will be skipped and not deployed',
       } as ChangeError
     })
-    .filter(isDefined))
+    .filter(isDefined)
 )
 
 export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
@@ -1,0 +1,83 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { values } from '@salto-io/lowerdash'
+import {
+  ChangeError,
+  ChangeValidator,
+  getChangeElement,
+  InstanceElement, isAdditionChange,
+  isAdditionOrModificationChange,
+  isInstanceChange,
+} from '@salto-io/adapter-api'
+import { transformValues } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { isCustomType } from '../types'
+
+const { isDefined } = values
+export const ACCOUNT_SPECIFIC_VALUE = '[ACCOUNT_SPECIFIC_VALUE]'
+
+const hasAccountSpecificValue = (instance: InstanceElement): boolean => {
+  let foundAccountSpecificValue = false
+  transformValues({
+    values: instance.value,
+    type: instance.type,
+    transformFunc: ({ value }) => {
+      if (_.isString(value) && value.includes(ACCOUNT_SPECIFIC_VALUE)) {
+        foundAccountSpecificValue = true
+      }
+      return value
+    },
+  })
+  return foundAccountSpecificValue
+}
+
+const changeValidator: ChangeValidator = async changes => (
+  _.flatten(changes
+    .filter(isAdditionOrModificationChange)
+    .filter(isInstanceChange)
+    .map(change => {
+      const instance = getChangeElement(change)
+      if (!isCustomType(instance.type)) {
+        return undefined
+      }
+      if (!hasAccountSpecificValue(instance)) {
+        return undefined
+      }
+      // We identified ACCOUNT_SPECIFIC_VALUE only in workflows and script related types,
+      // e.g. clientscript, restlet etc.
+      // These types have an isinactive field. If it indicates that the instance is enabled and
+      // we deploy it, without the real value behind the ACCOUNT_SPECIFIC_VALUE, it might be
+      // created invalid since some data is missing.
+      // Since the SAAS doesn't present the validation output yet (SAAS-1542), we set it to ERROR.
+      if (isAdditionChange(change) && !instance.value.isinactive) {
+        return {
+          elemID: instance.elemID,
+          severity: 'Error',
+          message: 'New instances that have fields with ACCOUNT_SPECIFIC_VALUE can be deployed only when they are inactive',
+          detailedMessage: 'New instances that have fields with ACCOUNT_SPECIFIC_VALUE can be deployed only when they are inactive',
+        } as ChangeError
+      }
+      return {
+        elemID: instance.elemID,
+        severity: 'Warning',
+        message: 'Fields with ACCOUNT_SPECIFIC_VALUE will be skipped and not deployed',
+        detailedMessage: 'Fields with ACCOUNT_SPECIFIC_VALUE will be skipped and not deployed',
+      } as ChangeError
+    })
+    .filter(isDefined))
+)
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -645,7 +645,11 @@ export default class SdfClient {
   private async runDeployCommands({ executor, projectPath }: Project): Promise<void> {
     await this.executeProjectAction(COMMANDS.ADD_PROJECT_DEPENDENCIES, {}, executor)
     await SdfClient.cleanInvalidDependencies(projectPath)
-    await this.executeProjectAction(COMMANDS.DEPLOY_PROJECT, {}, executor)
+    await this.executeProjectAction(
+      COMMANDS.DEPLOY_PROJECT,
+      { accountspecificvalues: 'WARNING' },
+      executor
+    )
   }
 
   private static async addCustomTypeInfoToProject(customTypeInfo: CustomTypeInfo,

--- a/packages/netsuite-adapter/test/change_validators/account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/account_specific_values.test.ts
@@ -1,0 +1,105 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, toChange } from '@salto-io/adapter-api'
+import accountSpecificValueValidator, { ACCOUNT_SPECIFIC_VALUE } from '../../src/change_validators/account_specific_values'
+import { customTypes, fileCabinetTypes } from '../../src/types'
+import { FILE, PATH, SCRIPT_ID, WORKFLOW } from '../../src/constants'
+
+
+describe('account specific value validator', () => {
+  const origInstance = new InstanceElement(
+    'instance',
+    customTypes[WORKFLOW],
+    {
+      isinactive: false,
+      [SCRIPT_ID]: 'customworkflow1',
+      name: 'WokrflowName',
+    }
+  )
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    instance = origInstance.clone()
+  })
+
+  it('should not have ChangeError when deploying a file cabinet instance', async () => {
+    const newFileInstance = new InstanceElement(
+      'instance',
+      fileCabinetTypes[FILE],
+      {
+        [PATH]: '/Path/to/file',
+        content: ACCOUNT_SPECIFIC_VALUE,
+      }
+    )
+    const changeErrors = await accountSpecificValueValidator(
+      [toChange({ after: newFileInstance })]
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('should not have ChangeError when deploying an instance without ACCOUNT_SPECIFIC_VALUE', async () => {
+    const after = instance.clone()
+    after.value.name = 'NewName'
+    const changeErrors = await accountSpecificValueValidator(
+      [toChange({ before: instance, after })]
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('should have Warning ChangeError when modifying an instance with ACCOUNT_SPECIFIC_VALUE', async () => {
+    const after = instance.clone()
+    after.value.name = ACCOUNT_SPECIFIC_VALUE
+    const changeErrors = await accountSpecificValueValidator(
+      [toChange({ before: instance, after })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Warning')
+    expect(changeErrors[0].elemID).toEqual(instance.elemID)
+  })
+
+  it('should have Warning ChangeError when modifying an instance with value that includes ACCOUNT_SPECIFIC_VALUE', async () => {
+    const after = instance.clone()
+    after.value.name = `${ACCOUNT_SPECIFIC_VALUE}|${ACCOUNT_SPECIFIC_VALUE}|${ACCOUNT_SPECIFIC_VALUE}`
+    const changeErrors = await accountSpecificValueValidator(
+      [toChange({ before: instance, after })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Warning')
+    expect(changeErrors[0].elemID).toEqual(instance.elemID)
+  })
+
+  it('should have Warning ChangeError when creating an inactive instance with ACCOUNT_SPECIFIC_VALUE', async () => {
+    instance.value.name = ACCOUNT_SPECIFIC_VALUE
+    instance.value.isinactive = true
+    const changeErrors = await accountSpecificValueValidator(
+      [toChange({ after: instance })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Warning')
+    expect(changeErrors[0].elemID).toEqual(instance.elemID)
+  })
+
+  it('should have Error ChangeError when creating an active instance with ACCOUNT_SPECIFIC_VALUE', async () => {
+    instance.value.name = ACCOUNT_SPECIFIC_VALUE
+    instance.value.isinactive = false
+    const changeErrors = await accountSpecificValueValidator(
+      [toChange({ after: instance })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].elemID).toEqual(instance.elemID)
+  })
+})


### PR DESCRIPTION
_Release Notes_: 
Netsuite Adapter: Allow deploying instances with ACCOUNT_SPECIFIC_VALUE, while not deploying the real value behind it. Add a deployment warning in case it happens.
