### PR TITLE
Add regenerateSaltoIds flag to fetch (ignore state id mapping)

### DIFF
--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -56,6 +56,7 @@ export type FetchCommandArgs = {
   shouldCalcTotalSize: boolean
   stateOnly: boolean
   services: string[]
+  regenerateSaltoIds: boolean
 }
 
 export const fetchCommand = async (
@@ -63,7 +64,7 @@ export const fetchCommand = async (
     workspace, force, mode,
     getApprovedChanges, shouldUpdateConfig, services,
     cliTelemetry, output, fetch, shouldCalcTotalSize,
-    stateOnly,
+    stateOnly, regenerateSaltoIds,
   }: FetchCommandArgs): Promise<CliExitCode> => {
   const bindedOutputline = (text: string): void => outputLine(text, output)
   const workspaceTags = await getWorkspaceTelemetryTags(workspace)
@@ -124,6 +125,7 @@ export const fetchCommand = async (
     workspace,
     fetchProgress,
     services,
+    regenerateSaltoIds,
   )
   if (fetchResult.success === false) {
     errorOutputLine(formatFatalFetchError(fetchResult.mergeErrors), output)
@@ -212,6 +214,7 @@ type FetchArgs = {
   force: boolean
   stateOnly: boolean
   mode: nacl.RoutingMode
+  regenerateSaltoIds: boolean
 } & ServicesArg & EnvArg
 
 export const action: WorkspaceCommandAction<FetchArgs> = async ({
@@ -222,7 +225,7 @@ export const action: WorkspaceCommandAction<FetchArgs> = async ({
   spinnerCreator,
   workspace,
 }): Promise<CliExitCode> => {
-  const { force, stateOnly, services, mode } = input
+  const { force, stateOnly, services, mode, regenerateSaltoIds } = input
   const { shouldCalcTotalSize } = config
   await validateAndSetEnv(workspace, input, output)
   const activeServices = getAndValidateActiveServices(workspace, services)
@@ -265,6 +268,7 @@ export const action: WorkspaceCommandAction<FetchArgs> = async ({
     mode: useAlignMode ? 'align' : mode,
     shouldCalcTotalSize,
     stateOnly,
+    regenerateSaltoIds,
   })
 }
 
@@ -297,6 +301,13 @@ const fetchDef = createWorkspaceCommand({
         type: 'string',
         choices: ['default', 'align', 'override', 'isolated'],
         default: 'default',
+      },
+      {
+        name: 'regenerateSaltoIds',
+        alias: 'r',
+        required: false,
+        description: 'Ignore current SaltoIDs and regenerate them according to current config and fetch results',
+        type: 'boolean',
       },
     ],
   },

--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -306,7 +306,7 @@ const fetchDef = createWorkspaceCommand({
         name: 'regenerateSaltoIds',
         alias: 'r',
         required: false,
-        description: 'Ignore current SaltoIDs and regenerate them according to current config and fetch results',
+        description: 'Regenerate configuration elements Salto IDs based on the current settings and fetch results',
         type: 'boolean',
       },
     ],

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -72,6 +72,7 @@ describe('fetch command', () => {
             mode: 'default',
             services,
             stateOnly: false,
+            regenerateSaltoIds: false,
           },
           workspace,
         })
@@ -94,6 +95,7 @@ describe('fetch command', () => {
             mode: 'default',
             services,
             stateOnly: false,
+            regenerateSaltoIds: false,
           },
           workspace,
         })
@@ -149,6 +151,7 @@ describe('fetch command', () => {
             shouldCalcTotalSize: true,
             services,
             stateOnly: false,
+            regenerateSaltoIds: false,
           })
         })
         it('should start at least one step', () => {
@@ -177,6 +180,7 @@ describe('fetch command', () => {
             mode: 'default',
             shouldCalcTotalSize: true,
             stateOnly: false,
+            regenerateSaltoIds: false,
           })
         })
         it('should not update workspace', () => {
@@ -214,6 +218,7 @@ describe('fetch command', () => {
             mode: 'default',
             shouldCalcTotalSize: true,
             stateOnly: false,
+            regenerateSaltoIds: false,
           }
         })
 
@@ -258,6 +263,7 @@ describe('fetch command', () => {
               mode: 'default',
               shouldCalcTotalSize: true,
               stateOnly: false,
+              regenerateSaltoIds: false,
             })
             expect(result).toBe(CliExitCode.Success)
           })
@@ -283,6 +289,7 @@ describe('fetch command', () => {
               shouldUpdateConfig: mockUpdateConfig,
               shouldCalcTotalSize: true,
               stateOnly: false,
+              regenerateSaltoIds: false,
             })
             expect(result).toBe(CliExitCode.Success)
           })
@@ -308,6 +315,7 @@ describe('fetch command', () => {
               shouldUpdateConfig: mockUpdateConfig,
               shouldCalcTotalSize: true,
               stateOnly: false,
+              regenerateSaltoIds: false,
             })
             expect(result).toBe(CliExitCode.Success)
           })
@@ -333,6 +341,7 @@ describe('fetch command', () => {
               shouldUpdateConfig: mockUpdateConfig,
               shouldCalcTotalSize: true,
               stateOnly: false,
+              regenerateSaltoIds: false,
             })
             expect(result).toBe(CliExitCode.Success)
           })
@@ -356,6 +365,7 @@ describe('fetch command', () => {
               shouldUpdateConfig: mockUpdateConfig,
               shouldCalcTotalSize: true,
               stateOnly: true,
+              regenerateSaltoIds: false,
             })).rejects.toThrow())
           })
           describe('when state is updated', () => {
@@ -374,6 +384,7 @@ describe('fetch command', () => {
                 shouldUpdateConfig: mockUpdateConfig,
                 shouldCalcTotalSize: true,
                 stateOnly: true,
+                regenerateSaltoIds: false,
               })
             })
             it('should return OK status when state is updated', () => {
@@ -400,6 +411,7 @@ describe('fetch command', () => {
                 shouldUpdateConfig: mockUpdateConfig,
                 shouldCalcTotalSize: true,
                 stateOnly: true,
+                regenerateSaltoIds: false,
               })
             })
             it('should return AppError status when state is updated', () => {
@@ -427,6 +439,7 @@ describe('fetch command', () => {
               mode: 'default',
               shouldCalcTotalSize: true,
               stateOnly: false,
+              regenerateSaltoIds: false,
             })
           })
           it('should deploy all changes', () => {
@@ -454,6 +467,7 @@ describe('fetch command', () => {
                 mode: 'default',
                 shouldCalcTotalSize: true,
                 stateOnly: false,
+                regenerateSaltoIds: false,
               })
               expect(workspace.updateNaclFiles).toHaveBeenCalledWith([changes[0].change], 'default')
             })
@@ -483,6 +497,7 @@ describe('fetch command', () => {
                 mode: 'default',
                 shouldCalcTotalSize: true,
                 stateOnly: false,
+                regenerateSaltoIds: false,
               })
               expect(workspace.updateNaclFiles).toHaveBeenCalledWith([changes[0].change], 'default')
               expect(res).toBe(CliExitCode.AppError)
@@ -511,6 +526,7 @@ describe('fetch command', () => {
                 mode: 'default',
                 shouldCalcTotalSize: true,
                 stateOnly: false,
+                regenerateSaltoIds: false,
               })
               expect(workspace.updateNaclFiles).toHaveBeenCalledWith([changes[0].change], 'default')
               expect(res).toBe(CliExitCode.Success)
@@ -529,6 +545,7 @@ describe('fetch command', () => {
                 mode: 'default',
                 shouldCalcTotalSize: true,
                 stateOnly: false,
+                regenerateSaltoIds: false,
               })
               expect(output.stderr.content).toContain('Error')
               expect(workspace.updateNaclFiles).not.toHaveBeenCalled()
@@ -568,6 +585,7 @@ describe('fetch command', () => {
             shouldCalcTotalSize: true,
             stateOnly: false,
             services: [],
+            regenerateSaltoIds: false,
           })
         })
         it('should succeed', () => {
@@ -610,6 +628,7 @@ describe('fetch command', () => {
           mode: 'default',
           services,
           stateOnly: false,
+          regenerateSaltoIds: false,
         },
         workspace,
       })
@@ -630,6 +649,7 @@ describe('fetch command', () => {
           mode: 'override',
           services,
           stateOnly: false,
+          regenerateSaltoIds: false,
         },
         workspace,
       })
@@ -649,6 +669,7 @@ describe('fetch command', () => {
           mode: 'default',
           services,
           stateOnly: false,
+          regenerateSaltoIds: false,
         },
         workspace,
       })
@@ -667,6 +688,7 @@ describe('fetch command', () => {
           mode: 'override',
           services,
           stateOnly: false,
+          regenerateSaltoIds: false,
         },
         workspace,
       })
@@ -689,6 +711,7 @@ describe('fetch command', () => {
           mode: 'default',
           services,
           stateOnly: false,
+          regenerateSaltoIds: false,
         },
         workspace,
       })
@@ -708,6 +731,7 @@ describe('fetch command', () => {
           mode: 'align',
           services,
           stateOnly: false,
+          regenerateSaltoIds: false,
         },
         workspace,
       })
@@ -727,6 +751,7 @@ describe('fetch command', () => {
           mode: 'default',
           services,
           stateOnly: false,
+          regenerateSaltoIds: false,
         },
         workspace,
       })
@@ -750,6 +775,7 @@ describe('fetch command', () => {
           force: false,
           mode: 'override',
           stateOnly: false,
+          regenerateSaltoIds: false,
         },
         workspace,
       })
@@ -769,6 +795,7 @@ describe('fetch command', () => {
           mode: 'default',
           services,
           stateOnly: false,
+          regenerateSaltoIds: false,
         },
         workspace,
       })
@@ -784,6 +811,7 @@ describe('fetch command', () => {
           services,
           stateOnly: false,
           env: mocks.withEnvironmentParam,
+          regenerateSaltoIds: false,
         },
         workspace,
       })
@@ -798,6 +826,7 @@ describe('fetch command', () => {
           services,
           stateOnly: false,
           env: 'envThatDoesNotExist',
+          regenerateSaltoIds: false,
         },
         workspace: mocks.mockWorkspace({}),
       })).rejects.toThrow(new CliError(CliExitCode.AppError))

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -195,12 +195,14 @@ export type FetchFunc = (
   workspace: Workspace,
   progressEmitter?: EventEmitter<FetchProgressEvents>,
   services?: string[],
+  ignoreStateElemIdMapping?: boolean,
 ) => Promise<FetchResult>
 
 export const fetch: FetchFunc = async (
   workspace,
   progressEmitter?,
   services?,
+  ignoreStateElemIdMapping?,
 ) => {
   log.debug('fetch starting..')
 
@@ -216,7 +218,7 @@ export const fetch: FetchFunc = async (
     await workspace.servicesCredentials(services),
     workspace.serviceConfig.bind(workspace),
     buildElementsSourceFromElements(stateElements),
-    createElemIdGetter(filteredStateElements)
+    ignoreStateElemIdMapping ? undefined : createElemIdGetter(filteredStateElements)
   )
   const currentConfigs = Object.values(adaptersCreatorConfigs)
     .map(creatorConfig => creatorConfig.config)


### PR DESCRIPTION
Add regenerateSaltoIds flag to fetch (ignore state id mapping)

*** Need to add tests ***
---
_Release Notes_: 

**CLI:** 
* Add a regenerateSaltoIds flag to fetch that ignores current ElemID mapping from the state if active
