### PR TITLE
SALTO-1282: Add retry to Netsuite SDF authentication command

### DIFF
--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -275,19 +275,30 @@ export default class SdfClient {
     projectCommandActionExecutor: CommandActionExecutor,
     authId: string
   ): Promise<void> {
+    const setupCommandArguments = {
+      authid: authId,
+      account: this.credentials.accountId,
+      tokenid: this.credentials.tokenId,
+      tokensecret: this.credentials.tokenSecret,
+      savetoken: true,
+    }
     await this.withAuthIdsLock(async () => {
       log.debug(`Setting up account using authId: ${authId}`)
-      await this.executeProjectAction(
-        COMMANDS.SETUP_ACCOUNT,
-        {
-          authid: authId,
-          account: this.credentials.accountId,
-          tokenid: this.credentials.tokenId,
-          tokensecret: this.credentials.tokenSecret,
-          savetoken: true,
-        },
-        projectCommandActionExecutor
-      )
+      try {
+        await this.executeProjectAction(
+          COMMANDS.SETUP_ACCOUNT,
+          setupCommandArguments,
+          projectCommandActionExecutor
+        )
+      } catch (e) {
+        log.warn(`Failed to setup account using authId: ${authId}`, e)
+        log.debug(`Retrying to setup account using authId: ${authId}`)
+        await this.executeProjectAction(
+          COMMANDS.SETUP_ACCOUNT,
+          setupCommandArguments,
+          projectCommandActionExecutor
+        )
+      }
     })
   }
 


### PR DESCRIPTION
I chose to implement it with a very naive solution and not create a util function for that
_Release Notes_: 
None
