### PR TITLE
adapter-components - use named parameters in function validating credentials

### DIFF
--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -107,7 +107,10 @@ type AxiosConnectionParams<TCredentials> = {
     headers?: Record<string, unknown>
   }>
   baseURLFunc: (creds: TCredentials) => string
-  credValidateFunc: (creds: TCredentials, conn: APIConnection) => Promise<AccountId>
+  credValidateFunc: ({ credentials, connection }: {
+    credentials: TCredentials
+    connection: APIConnection
+  }) => Promise<AccountId>
 }
 
 export const axiosConnection = <TCredentials>({
@@ -126,7 +129,7 @@ export const axiosConnection = <TCredentials>({
     axiosRetry(httpClient, retryOptions)
 
     try {
-      const accountId = await credValidateFunc(creds, httpClient)
+      const accountId = await credValidateFunc({ credentials: creds, connection: httpClient })
       return {
         ...httpClient,
         accountId,

--- a/packages/adapter-components/test/client/common.ts
+++ b/packages/adapter-components/test/client/common.ts
@@ -20,12 +20,12 @@ export type Credentials = { username: string; password: string}
 
 export const BASE_URL = 'http://localhost:1234/api/v1'
 
-export const validateCreds = async (
-  creds: Credentials,
-  conn: APIConnection,
-): Promise<AccountId> => {
-  const user = await conn.get('/users/me')
-  return `${user.data.accountId}:${creds.username}`
+export const validateCreds = async ({ credentials, connection }: {
+  credentials: Credentials
+  connection: APIConnection
+}): Promise<AccountId> => {
+  const user = await connection.get('/users/me')
+  return `${user.data.accountId}:${credentials.username}`
 }
 
 export const createConnection: ConnectionCreator<Credentials> = retryOptions => (

--- a/packages/workato-adapter/src/client/connection.ts
+++ b/packages/workato-adapter/src/client/connection.ts
@@ -19,10 +19,10 @@ import { Credentials } from '../auth'
 
 const BASE_URL = 'https://www.workato.com/api'
 
-export const validateCredentials = async (
-  _creds: Credentials, conn: clientUtils.APIConnection,
-): Promise<AccountId> => {
-  await conn.get('/users/me')
+export const validateCredentials = async ({ connection }: {
+  connection: clientUtils.APIConnection
+}): Promise<AccountId> => {
+  await connection.get('/users/me')
   // there is no good stable account id in workato, so we default to empty string to avoid
   // preventing users from refreshing their credentials in the SaaS.
   return ''

--- a/packages/workato-adapter/test/client/connection.test.ts
+++ b/packages/workato-adapter/test/client/connection.test.ts
@@ -37,8 +37,8 @@ describe('client connection', () => {
       post: mockFunction<clientUtils.APIConnection['post']>(),
     }
     it('should always extract empty account id', async () => {
-      expect(await validateCredentials({ username: 'user123', token: 'token456' }, mockConnection)).toEqual('')
-      expect(await validateCredentials({ username: 'user123', token: 'token456' }, mockConnection)).toEqual('')
+      expect(await validateCredentials({ connection: mockConnection })).toEqual('')
+      expect(await validateCredentials({ connection: mockConnection })).toEqual('')
     })
   })
 

--- a/packages/zuora-billing-adapter/src/client/connection.ts
+++ b/packages/zuora-billing-adapter/src/client/connection.ts
@@ -22,12 +22,12 @@ const log = logger(module)
 
 const { oauthClientCredentialsBearerToken } = authUtils
 
-export const validateCredentials = async (
-  _creds: Credentials, conn: clientUtils.APIConnection,
-): Promise<AccountId> => {
+export const validateCredentials = async ({ connection }: {
+  connection: clientUtils.APIConnection
+}): Promise<AccountId> => {
   // oauth was already authenticated when the connection was created, but validating just in case
   try {
-    const res = await conn.post('/v1/connections', {})
+    const res = await connection.post('/v1/connections', {})
     if (res.status !== 200 || !res.data.success) {
       throw new clientUtils.UnauthorizedError('Authentication failed')
     }


### PR DESCRIPTION
We often don't use the credentials, so switching to named parameters to avoid having unused args following @ori-moisis 's suggestion

---
_Release Notes_: 
None
