### PR TITLE
SALTO-825: added features to adapter components for Netsuite

### DIFF
--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -16,5 +16,5 @@
 export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateFetchConfig as validateDuckTypeFetchConfig } from './ducktype'
 export { createRequestConfigs, validateRequestConfig, RequestConfig } from './request'
 export { createAdapterApiConfigType, createUserFetchConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig } from './shared'
-export { createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig } from './swagger'
+export { createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, SwaggerContent, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig } from './swagger'
 export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType } from './transformation'

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -39,6 +39,7 @@ export type AdapterApiConfig<
   apiVersion?: string
   typeDefaults: TypeDefaultsConfig<TD>
   types: Record<string, TypeConfig<T>>
+  fieldsAnnotations?: string[]
 }
 
 export type UserFetchConfig = {

--- a/packages/adapter-components/src/config/swagger.ts
+++ b/packages/adapter-components/src/config/swagger.ts
@@ -16,6 +16,7 @@
 import _ from 'lodash'
 import { ObjectType, ElemID, BuiltinTypes, CORE_ANNOTATIONS, FieldDefinition, ListType } from '@salto-io/adapter-api'
 import { types, values as lowerDashValues } from '@salto-io/lowerdash'
+import { OpenAPI } from 'openapi-types'
 import { AdapterApiConfig, createAdapterApiConfigType, TypeConfig, TypeDefaultsConfig } from './shared'
 import { createRequestConfigs, validateRequestConfig } from './request'
 import { createTransformationConfigTypes, validateTransoformationConfig } from './transformation'
@@ -38,8 +39,11 @@ export type AdditionalTypeConfig = {
   cloneFrom: string
 }
 
-export type SwaggerDefinitionBaseConfig = {
-  url: string
+export type SwaggerContent = OpenAPI.Document
+
+export type SwaggerSource = { url: string } | { swaggerContent: SwaggerContent }
+
+export type SwaggerDefinitionBaseConfig = SwaggerSource & {
   // rename types
   // NOTE: this applies everywhere and the old names will not be accessible
   typeNameOverrides?: TypeNameOverrideConfig[]

--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -48,6 +48,7 @@ const typeAdder = ({
   definedTypes,
   parsedConfigs,
   refs,
+  fieldsAnnotations,
 }: {
   adapterName: string
   toUpdatedResourceName: (origResourceName: string) => string
@@ -55,6 +56,7 @@ const typeAdder = ({
   definedTypes: Record<string, ObjectType>
   parsedConfigs: Record<string, RequestableTypeSwaggerConfig>
   refs: SwaggerRefs
+  fieldsAnnotations: string[]
 }): TypeAdderType => {
   // keep track of the top-level schemas, so that even if they are reached from another
   // endpoint before being reached directly, they will be treated as top-level
@@ -149,6 +151,7 @@ const typeAdder = ({
             fieldSchema,
             toNestedTypeName(fieldSchema),
           ),
+          _.pick(fieldSchema, fieldsAnnotations),
         )
       }),
     )
@@ -258,6 +261,7 @@ export const generateTypes = async (
     swagger,
     types,
     typeDefaults,
+    fieldsAnnotations = [],
   }: AdapterSwaggerApiConfig,
   preParsedDefs?: SchemasAndRefs,
 ): Promise<ParsedTypes> => {
@@ -272,7 +276,7 @@ export const generateTypes = async (
   const definedTypes: Record<string, ObjectType> = {}
   const parsedConfigs: Record<string, RequestableTypeSwaggerConfig> = {}
 
-  const { schemas: getResponseSchemas, refs } = preParsedDefs ?? await getParsedDefs(swagger.url)
+  const { schemas: getResponseSchemas, refs } = preParsedDefs ?? await getParsedDefs(swagger)
 
   const addType = typeAdder({
     adapterName,
@@ -281,6 +285,7 @@ export const generateTypes = async (
     definedTypes,
     parsedConfigs,
     refs,
+    fieldsAnnotations,
   })
 
   Object.entries(getResponseSchemas).forEach(

--- a/packages/adapter-components/src/elements/swagger/type_elements/swagger_parser.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/swagger_parser.ts
@@ -20,6 +20,7 @@ import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import SwaggerParser from '@apidevtools/swagger-parser'
 import { OpenAPI, OpenAPIV2, IJsonSchema, OpenAPIV3 } from 'openapi-types'
+import { SwaggerSource } from '../../../config/swagger'
 
 const { isDefined } = lowerdashValues
 const { makeArray } = collections.array
@@ -109,10 +110,12 @@ export type SchemasAndRefs = {
   refs: SwaggerRefs
 }
 
-export const getParsedDefs = async (swaggerPath: string):
+export const getParsedDefs = async (source: SwaggerSource):
   Promise<SchemasAndRefs> => {
   const parser = new SwaggerParser()
-  const parsedSwagger: OpenAPI.Document = await parser.bundle(swaggerPath)
+
+  const swaggerApi = 'swaggerContent' in source ? source.swaggerContent : source.url
+  const parsedSwagger: OpenAPI.Document = await parser.bundle(swaggerApi)
 
   const toSchemaV2 = (def?: OpenAPIV2.OperationObject): (undefined | OpenAPIV2.Schema) => (
     def?.responses?.[200]?.schema


### PR DESCRIPTION
Added the option to pass to `generateTypes` the swagger content instead of the URL and added to option to pass `fieldsAnnotations` to make `generateTypes` add annotations to the field in the created types based the the field schema.

---
_Release Notes_: 
None