### PR TITLE
Add ability to fetch an instance from multiple endpoints in adapter components

### DIFF
--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateFetchConfig as validateDuckTypeFetchConfig } from './ducktype'
-export { createRequestConfigs, validateRequestConfig, RequestConfig } from './request'
+export { createRequestConfigs, validateRequestConfig, RequestConfig, RecurseIntoCondition, isRecurseIntoConditionByField } from './request'
 export { createAdapterApiConfigType, createUserFetchConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig } from './shared'
 export { createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig } from './swagger'
 export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType } from './transformation'

--- a/packages/adapter-components/src/config/request.ts
+++ b/packages/adapter-components/src/config/request.ts
@@ -28,11 +28,25 @@ export type DependsOnConfig = {
   }
 }
 
+export type RecurseIntoConfig = {
+  toField: string
+  type: string
+  param: {
+    name: string
+    fromField: string
+  }
+  condition?: {
+    field: string
+    matchValues: string[]
+  }
+}
+
 export type RequestConfig = {
   url: string
   queryParams?: Record<string, string>
   recursiveQueryByResponseField?: Record<string, string>
   dependsOn?: DependsOnConfig[]
+  recurseInto?: RecurseIntoConfig[]
   paginationField?: string
 }
 

--- a/packages/adapter-components/src/config/request.ts
+++ b/packages/adapter-components/src/config/request.ts
@@ -28,17 +28,32 @@ export type DependsOnConfig = {
   }
 }
 
-export type RecurseIntoConfig = {
+type RecurseIntoConditionBase = { match: string[] }
+type RecurseIntoConditionByField = RecurseIntoConditionBase & {
+  fromField: string
+}
+type RecurseIntoConditionByContext = RecurseIntoConditionBase & {
+  fromContext: string
+}
+
+export type RecurseIntoCondition = RecurseIntoConditionByField | RecurseIntoConditionByContext
+
+export const isRecurseIntoConditionByField = (
+  condition: RecurseIntoCondition
+): condition is RecurseIntoConditionByField => (
+  'fromField' in condition
+)
+
+type RecurseIntoContext = {
+  name: string
+  fromField: string
+}
+
+type RecurseIntoConfig = {
   toField: string
   type: string
-  param: {
-    name: string
-    fromField: string
-  }
-  condition?: {
-    field: string
-    matchValues: string[]
-  }
+  context: RecurseIntoContext[]
+  conditions?: RecurseIntoCondition[]
 }
 
 export type RequestConfig = {

--- a/packages/adapter-components/src/elements/request_parameters.ts
+++ b/packages/adapter-components/src/elements/request_parameters.ts
@@ -25,10 +25,11 @@ const log = logger(module)
 export type ComputeGetArgsFunc = (
   request: RequestConfig,
   contextElements?: Record<string, Element[]>,
+  urlParams?: Record<string, string>,
 ) => ClientGetWithPaginationParams[]
 
 /**
- * Convert an endpoint's request details into get argumets.
+ * Convert an endpoint's request details into get arguments.
  * Supports recursive queries (subsequent queries to the same endpoint based on response data).
  */
 export const simpleGetArgs: ComputeGetArgsFunc = (
@@ -90,7 +91,16 @@ const computeDependsOnURLs = (
 export const computeGetArgs: ComputeGetArgsFunc = (
   args,
   contextElements,
+  urlParams
 ) => {
-  const urls = computeDependsOnURLs(args, contextElements)
+  // Replace known url params
+  const baseUrl = args.url.replace(
+    ARG_PLACEHOLDER_MATCHER,
+    (val => urlParams?.[val.slice(1, -1)] ?? val)
+  )
+  const urls = computeDependsOnURLs(
+    { url: baseUrl, dependsOn: args.dependsOn },
+    contextElements,
+  )
   return urls.flatMap(url => simpleGetArgs({ ...args, url }, contextElements))
 }

--- a/packages/adapter-components/src/elements/request_parameters.ts
+++ b/packages/adapter-components/src/elements/request_parameters.ts
@@ -25,7 +25,7 @@ const log = logger(module)
 export type ComputeGetArgsFunc = (
   request: RequestConfig,
   contextElements?: Record<string, Element[]>,
-  requestContext?: Values,
+  requestContext?: Record<string, unknown>,
 ) => ClientGetWithPaginationParams[]
 
 /**
@@ -99,7 +99,7 @@ export const computeGetArgs: ComputeGetArgsFunc = (
     val => {
       const replacement = requestContext?.[val.slice(1, -1)] ?? val
       if (!isPrimitiveValue(replacement)) {
-        throw new Error(`Cannot replace arg ${val} in ${args.url} with non-string value ${replacement}`)
+        throw new Error(`Cannot replace arg ${val} in ${args.url} with non-primitive value ${replacement}`)
       }
       return replacement.toString()
     }

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -225,7 +225,7 @@ const normalizeType = (type: ObjectType | undefined): ObjectType | undefined => 
 
 const shouldRecurseIntoEntry = (
   entry: Values,
-  context?: Record<string, string>,
+  context?: Record<string, unknown>,
   conditions?: RecurseIntoCondition[]
 ): boolean => (
   (conditions ?? []).every(condition => {
@@ -243,7 +243,7 @@ type GetEntriesParams = {
   typesConfig: Record<string, TypeSwaggerConfig>
   typeDefaultConfig: TypeSwaggerDefaultConfig
   contextElements?: Record<string, InstanceElement[]>
-  requestContext?: Values
+  requestContext?: Record<string, unknown>
   nestedFieldFinder: FindNestedFieldFunc
   computeGetArgs: ComputeGetArgsFunc
 }

--- a/packages/adapter-components/test/elements/request_parameters.test.ts
+++ b/packages/adapter-components/test/elements/request_parameters.test.ts
@@ -99,9 +99,15 @@ describe('request_parameters', () => {
       expect(res[0].recursiveQueryParams?.parentId({ id: 'id' })).toEqual('id')
     })
 
-    it('should resolve urlParams from the provided params', () => {
+    it('should resolve url params from the provided context', () => {
       const urls = computeGetArgs({ url: '/a/{p1}/{p2}' }, undefined, { p1: 'b', p2: 'c' })
       expect(urls).toEqual([{ url: '/a/b/c' }])
+    })
+
+    it('should fail if the provided context is not a primitive', () => {
+      expect(
+        () => computeGetArgs({ url: '/a/{p}' }, undefined, { p: { complex: true } })
+      ).toThrow()
     })
 
     it('should compute dependsOn urls', () => {

--- a/packages/adapter-components/test/elements/request_parameters.test.ts
+++ b/packages/adapter-components/test/elements/request_parameters.test.ts
@@ -99,6 +99,11 @@ describe('request_parameters', () => {
       expect(res[0].recursiveQueryParams?.parentId({ id: 'id' })).toEqual('id')
     })
 
+    it('should resolve urlParams from the provided params', () => {
+      const urls = computeGetArgs({ url: '/a/{p1}/{p2}' }, undefined, { p1: 'b', p2: 'c' })
+      expect(urls).toEqual([{ url: '/a/b/c' }])
+    })
+
     it('should compute dependsOn urls', () => {
       const Pet = new ObjectType({ elemID: new ElemID('bla', 'Pet') })
       const Owner = new ObjectType({ elemID: new ElemID('bla', 'Owner') })
@@ -157,7 +162,7 @@ describe('request_parameters', () => {
         },
       )).toThrow(new Error('cannot resolve endpoint /a/b/{pet_id} - missing context'))
     })
-    it('should fail if url is not tvalid', () => {
+    it('should fail if url is not valid', () => {
       expect(() => computeGetArgs(
         {
           url: '/a/b/{pet_id',

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { collections } from '@salto-io/lowerdash'
 import { ObjectType, ElemID, BuiltinTypes, ListType, MapType, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { getAllInstances } from '../../../src/elements/swagger'
 import { returnFullEntry } from '../../../src/elements/field_finder'
@@ -22,11 +22,13 @@ import { Paginator } from '../../../src/client'
 import { simpleGetArgs } from '../../../src/elements/request_parameters'
 import { mockFunction } from '../../common'
 
+const { toAsyncIterable } = collections.asynciterable
+
 const ADAPTER_NAME = 'myAdapter'
 
 describe('swagger_instance_elements', () => {
   describe('getAllInstances', () => {
-    let mockPaginator: Paginator
+    let mockPaginator: jest.MockedFunction<Paginator>
 
     const generateObjectTypes = (): Record<string, ObjectType> => {
       const Owner = new ObjectType({
@@ -37,7 +39,7 @@ describe('swagger_instance_elements', () => {
         },
       })
       const Food = new ObjectType({
-        elemID: new ElemID(ADAPTER_NAME, 'Owner'),
+        elemID: new ElemID(ADAPTER_NAME, 'Food'),
         fields: {
           id: { type: BuiltinTypes.STRING },
           name: { type: BuiltinTypes.STRING },
@@ -811,6 +813,109 @@ describe('swagger_instance_elements', () => {
         },
         [ADAPTER_NAME, 'CustomObjectDefinition', 'Owner', 'Pet'],
       ))).toBeTruthy()
+    })
+
+    describe('with types that require recursing', () => {
+      let instances: InstanceElement[]
+      beforeEach(async () => {
+        mockPaginator.mockImplementation(({ url }) => {
+          if (url === '/pet') {
+            return toAsyncIterable([[
+              { id: 'dog', name: 'def' },
+              { id: 'cat', name: 'def' },
+            ]])
+          }
+          if (url === '/pet/dog/owner') {
+            return toAsyncIterable([[
+              { name: 'o1' },
+              { name: 'o2' },
+            ]])
+          }
+          if (url === '/pet/dog/owner/o1/nicknames') {
+            return toAsyncIterable([[{ names: ['n1', 'n2'] }]])
+          }
+          if (url === '/pet/dog/owner/o2/nicknames') {
+            return toAsyncIterable([[{ names: ['n3'] }]])
+          }
+          return toAsyncIterable([[]])
+        })
+
+        const objectTypes = generateObjectTypes()
+        instances = await getAllInstances({
+          paginator: mockPaginator,
+          apiConfig: {
+            swagger: {
+              url: 'ignored',
+            },
+            typeDefaults: {
+              transformation: {
+                idFields: ['id'],
+              },
+            },
+            types: {
+              Pet: {
+                request: {
+                  url: '/pet',
+                  recurseInto: [
+                    {
+                      type: 'Owner',
+                      toField: 'owners',
+                      param: { name: 'petId', fromField: 'id' },
+                      condition: { field: 'id', matchValues: ['dog'] },
+                    },
+                  ],
+                },
+              },
+              Owner: {
+                request: {
+                  url: '/pet/{petId}/owner',
+                  recurseInto: [
+                    {
+                      type: 'OwnerNickNames',
+                      toField: 'nicknames',
+                      param: { name: 'ownerName', fromField: 'name' },
+                    },
+                  ],
+                },
+              },
+              OwnerNickNames: {
+                request: {
+                  url: '/pet/{petId}/owner/{ownerName}/nicknames',
+                },
+                transformation: { dataField: 'items' },
+              },
+            },
+          },
+          fetchConfig: {
+            includeTypes: ['Pet'],
+          },
+          objectTypes: {
+            ...objectTypes,
+            OwnerNickNames: new ObjectType({
+              elemID: new ElemID(ADAPTER_NAME, 'OwnerNickNames'),
+              fields: { names: { type: new ListType(BuiltinTypes.STRING) } },
+            }),
+          },
+        })
+      })
+      it('should get inner types recursively for instances that match the condition', () => {
+        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/dog/owner' }))
+        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/dog/owner/o1/nicknames' }))
+        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/dog/owner/o2/nicknames' }))
+        expect(mockPaginator).not.toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/cat/owner' }))
+      })
+      it('should return nested value list in the instance', () => {
+        expect(instances).toHaveLength(2)
+        const [dog, cat] = instances
+        expect(dog.value).toHaveProperty(
+          'owners',
+          [
+            { name: 'o1', additionalProperties: { nicknames: [{ names: ['n1', 'n2'] }] } },
+            { name: 'o2', additionalProperties: { nicknames: [{ names: ['n3'] }] } },
+          ]
+        )
+        expect(cat.value).not.toHaveProperty('owners')
+      })
     })
 
     it('should fail if type is missing from config', async () => {


### PR DESCRIPTION
Allow "recursing into" an entry to fetch additional fields that do not return from the main endpoint of that type

---

Developed as part of JIRA adapter preparations, used to handle REST resources that have multiple layers like
/mainResource/{resourceID}/subResources
/mainResource/{resourceID}/subResources/{subResourceID}/details
etc...

---
_Release Notes_: 
_None_
