### PR TITLE
Added handleErrorsAsync function to lowerdash

### DIFF
--- a/packages/lowerdash/src/collections/asynciterable.ts
+++ b/packages/lowerdash/src/collections/asynciterable.ts
@@ -100,3 +100,22 @@ export async function *filterAsync<T>(
     index += 1
   }
 }
+
+export const handleErrorsAsync = <T>(
+  itr: AsyncIterable<T>,
+  onError: (error: Error) => void,
+): AsyncIterable<T> => ({
+    [Symbol.asyncIterator]: () => {
+      const it = itr[Symbol.asyncIterator]()
+      return {
+        next: async args => {
+          try {
+            return await it.next(args)
+          } catch (error) {
+            onError(error)
+            return { done: true, value: undefined }
+          }
+        },
+      }
+    },
+  })


### PR DESCRIPTION
handleErrorsAsync can be used to place an error handler on an async iterable

---

there is currently no other way to handle exceptions in async iterables when using the asynciterable.*Async functions.
this is because the callbacks we provide those functions are only called if the iterable resolved its `next` function successfully.
The only places that can handle errors are the functions that fully consume the iterable (toArrayAsync, findAsync, forEachAsync)

---
_Release Notes_: 
_None_
