### PR TITLE
SAAS-1981: Provide getGlobalTags capabilities to BaseLogger

### DIFF
--- a/packages/logging/src/internal/logger.ts
+++ b/packages/logging/src/internal/logger.ts
@@ -28,12 +28,15 @@ export type LogMethod = (message: string | Error, ...args: unknown[]) => void
 
 export type BaseLogger = {
   log(level: LogLevel, ...rest: Parameters<LogMethod>): ReturnType<LogMethod>
-  assignGlobalTags(logTags?: LogTags): void
   assignTags(logTags?: LogTags): void
+}
+
+export type GlobalTags = {
+  assignGlobalTags(logTags?: LogTags): void
   getGlobalTags(): LogTags
 }
 
-export type BaseLoggerMaker = (namespace: Namespace, tags? : LogTags) => BaseLogger
+export type BaseLoggerMaker = (namespace: Namespace, tags? : LogTags) => BaseLogger & GlobalTags
 
 export type BaseLoggerRepo = BaseLoggerMaker & {
   setMinLevel(level: LogLevel): void
@@ -45,7 +48,7 @@ type HasLoggerFuncs = {
   [level in LogLevel]: LogMethod
 }
 
-export type Logger = BaseLogger & HasLoggerFuncs & {
+export type Logger = BaseLogger & GlobalTags & HasLoggerFuncs & {
   readonly namespace: Namespace
   readonly time: <T>(inner: () => T, desc: string, ...descArgs: unknown[]) => T
 }

--- a/packages/logging/src/internal/logger.ts
+++ b/packages/logging/src/internal/logger.ts
@@ -30,6 +30,7 @@ export type BaseLogger = {
   log(level: LogLevel, ...rest: Parameters<LogMethod>): ReturnType<LogMethod>
   assignGlobalTags(logTags?: LogTags): void
   assignTags(logTags?: LogTags): void
+  getGlobalTags(): LogTags
 }
 
 export type BaseLoggerMaker = (namespace: Namespace, tags? : LogTags) => BaseLogger

--- a/packages/logging/src/internal/pino.ts
+++ b/packages/logging/src/internal/pino.ts
@@ -249,7 +249,7 @@ export const loggerRepo = (
         else global.globalLogTags = mergeLogTags(global.globalLogTags, logTags)
       },
       getGlobalTags(): LogTags {
-        return global.globalLogTags
+        return normalizeLogTags(global.globalLogTags)
       },
       assignTags(logTags?: LogTags): void {
         if (!logTags) tagsByNamespace.set(namespace, {})

--- a/packages/logging/src/internal/pino.ts
+++ b/packages/logging/src/internal/pino.ts
@@ -248,6 +248,9 @@ export const loggerRepo = (
         if (!logTags) global.globalLogTags = {}
         else global.globalLogTags = mergeLogTags(global.globalLogTags, logTags)
       },
+      getGlobalTags(): LogTags {
+        return global.globalLogTags
+      },
       assignTags(logTags?: LogTags): void {
         if (!logTags) tagsByNamespace.set(namespace, {})
         else tagsByNamespace.set(namespace, mergeLogTags(tagsByNamespace.get(namespace), logTags))

--- a/packages/logging/test/internal/pino_logger.test.ts
+++ b/packages/logging/test/internal/pino_logger.test.ts
@@ -16,6 +16,7 @@
 import * as fs from 'fs'
 import * as tmp from 'tmp-promise'
 import { EOL } from 'os'
+import { LogTags } from '../../src'
 import { mockConsoleStream, MockWritableStream } from '../console'
 import { LogLevel, LOG_LEVELS } from '../../src/internal/level'
 import { Config, mergeConfigs } from '../../src/internal/config'
@@ -429,6 +430,28 @@ describe('pino based logger', () => {
             expect(line).toContain(NAMESPACE)
             expect(line).toContain('warn')
             expect(line).toContain('hello { world: true }')
+          })
+        })
+        describe('Get All Tags', () => {
+          let globalTagsRespons: LogTags| undefined
+          beforeEach(async () => {
+            initialConfig.globalTags = logTags
+            logger = createLogger()
+            logger.assignGlobalTags({ newTag: 'data', superNewTag: 'tag', functionTag: () => 5 })
+            globalTagsRespons = logger.getGlobalTags()
+          })
+          afterEach(() => {
+            logger.assignGlobalTags(undefined)
+          })
+          it('should contain all global tags', () => {
+            expect(globalTagsRespons).toEqual({
+              bool: true,
+              functionTag: 5,
+              newTag: 'data',
+              number: 1,
+              string: '1',
+              superNewTag: 'tag',
+            })
           })
         })
         describe('globalTags transfer between 2 repos', () => {

--- a/packages/logging/test/internal/pino_logger.test.ts
+++ b/packages/logging/test/internal/pino_logger.test.ts
@@ -432,19 +432,19 @@ describe('pino based logger', () => {
             expect(line).toContain('hello { world: true }')
           })
         })
-        describe('Get All Tags', () => {
-          let globalTagsRespons: LogTags| undefined
+        describe('getGlobalTags', () => {
+          let globalTagsResponse: LogTags| undefined
           beforeEach(async () => {
             initialConfig.globalTags = logTags
             logger = createLogger()
             logger.assignGlobalTags({ newTag: 'data', superNewTag: 'tag', functionTag: () => 5 })
-            globalTagsRespons = logger.getGlobalTags()
+            globalTagsResponse = logger.getGlobalTags()
           })
           afterEach(() => {
             logger.assignGlobalTags(undefined)
           })
           it('should contain all global tags', () => {
-            expect(globalTagsRespons).toEqual({
+            expect(globalTagsResponse).toEqual({
               bool: true,
               functionTag: 5,
               newTag: 'data',


### PR DESCRIPTION
Provide capabilities for getting the global tags from the logger.

---

_Additional context for reviewer_
This will be useful for adding tracing capabilities and utilizing the existing tags in our logger infra.

---
_Release Notes_: 
None