### PR TITLE
Allow more concurency in validation

### DIFF
--- a/packages/lang-server/src/workspace.ts
+++ b/packages/lang-server/src/workspace.ts
@@ -171,6 +171,9 @@ export class EditorWorkspace {
   }
 
   private async validateElements(ids: Set<string>): Promise<errors.ValidationError[]> {
+    if (ids.size === 0) {
+      return []
+    }
     const elements = await this.workspace.elements()
     const elementsToValidate = (await Promise.all(
       [...ids].map(async id => elements.get(ElemID.fromFullName(id)))

--- a/packages/lang-server/src/workspace.ts
+++ b/packages/lang-server/src/workspace.ts
@@ -171,10 +171,11 @@ export class EditorWorkspace {
   }
 
   private async validateElements(ids: Set<string>): Promise<errors.ValidationError[]> {
+    const elements = await this.workspace.elements()
     const elementsToValidate = (await Promise.all(
-      [...ids].map(async id => (await this.workspace.elements()).get(ElemID.fromFullName(id)))
+      [...ids].map(async id => elements.get(ElemID.fromFullName(id)))
     )).filter(values.isDefined)
-    return validateElements(elementsToValidate, await this.workspace.elements())
+    return validateElements(elementsToValidate, elements)
   }
 
   private async getValidationErrors(files: string[], changes: Change[]):

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -250,10 +250,8 @@ export const loadWorkspace = async (
       validatedElementsIDs: ElemID[]
     }> => {
       const dependentsID = await getElementsDependents(relevantElementIDs, new Set())
-      const dependents = await awu(dependentsID)
-        .map(id => elementSource.get(id))
-        .filter(values.isDefined)
-        .toArray()
+      const dependents = await Promise.all(dependentsID.map(id => elementSource.get(id))
+        .filter(values.isDefined))
       const elementsToValidate = [...elements, ...dependents]
       return {
         errors: await validateElements(elementsToValidate, elementSource),


### PR DESCRIPTION
Change some implementations in validation flow to support concurrency

---

Required to allow batching in SaaS

---
Should improve performance of some flows