### PR TITLE
Allow spaces in env names

### DIFF
--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -128,7 +128,7 @@ remoteMap.RemoteMapCreator => async <T, K extends string = string>(
   if (!await fileUtils.exists(location)) {
     await fileUtils.mkdirp(location)
   }
-  if (!/^[a-z0-9-_/]+$/i.test(namespace)) {
+  if (!/^[a-z0-9-_\s/]+$/i.test(namespace)) {
     throw new Error(
       `Invalid namespace: ${namespace}. Must include only alphanumeric characters or -`
     )

--- a/packages/core/test/workspace/local/remote_map.test.ts
+++ b/packages/core/test/workspace/local/remote_map.test.ts
@@ -68,7 +68,8 @@ describe('test operations on remote db', () => {
     elements = await createElements()
     sortedElements = _.sortBy(elements, e => e.elemID.getFullName())
       .map(e => e.elemID.getFullName())
-    remoteMap = await createMap(Math.random().toString(36).substring(2, 15))
+    remoteMap = await createMap(`${Math.random().toString(36).substring(2, 15)} -_${Math.random()
+      .toString(36).substring(2, 15)}`)
   })
   afterEach(async () => {
     await remoteMap.revert()


### PR DESCRIPTION
Change the validation regex in remote map to allow spaces in env name
---

---
environments with spaces in their name should be supported