### PR TITLE
Filter generate types

### DIFF
--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -39,7 +39,6 @@ export type AdapterApiConfig<
   apiVersion?: string
   typeDefaults: TypeDefaultsConfig<TD>
   types: Record<string, TypeConfig<T>>
-  supportedEndpoints?: string[]
 }
 
 export type UserFetchConfig = {

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -39,6 +39,7 @@ export type AdapterApiConfig<
   apiVersion?: string
   typeDefaults: TypeDefaultsConfig<TD>
   types: Record<string, TypeConfig<T>>
+  supportedEndpoints?: string[]
 }
 
 export type UserFetchConfig = {

--- a/packages/adapter-components/src/config/swagger.ts
+++ b/packages/adapter-components/src/config/swagger.ts
@@ -53,6 +53,7 @@ export type TypeSwaggerDefaultConfig = TypeDefaultsConfig
 
 export type AdapterSwaggerApiConfig = AdapterApiConfig & {
   swagger: SwaggerDefinitionBaseConfig
+  supportedEndpoints?: string[]
 }
 export type RequestableAdapterSwaggerApiConfig = AdapterSwaggerApiConfig & {
   types: Record<string, RequestableTypeSwaggerConfig>

--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -258,6 +258,7 @@ export const generateTypes = async (
     swagger,
     types,
     typeDefaults,
+    supportedEndpoints,
   }: AdapterSwaggerApiConfig,
   preParsedDefs?: SchemasAndRefs,
 ): Promise<ParsedTypes> => {
@@ -283,13 +284,19 @@ export const generateTypes = async (
     refs,
   })
 
-  Object.entries(getResponseSchemas).forEach(
-    ([endpointName, schema]) => addType(
-      schema,
-      toTypeName(endpointName),
-      endpointName,
-    )
+  const isEndpointSupported = (endpointName: string): boolean => (
+    supportedEndpoints === undefined || supportedEndpoints?.includes(endpointName)
   )
+
+  Object.entries(getResponseSchemas)
+    .filter(([endpointName]) => isEndpointSupported(endpointName))
+    .forEach(
+      ([endpointName, schema]) => addType(
+        schema,
+        toTypeName(endpointName),
+        endpointName,
+      )
+    )
 
   if (swagger.additionalTypes !== undefined) {
     defineAdditionalTypes(adapterName, swagger.additionalTypes, definedTypes, types)

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -279,6 +279,25 @@ describe('swagger_type_elements', () => {
       })
     })
 
+    describe('with supportedEndpoints', () => {
+      let allTypes: Record<string, TypeElement>
+      beforeAll(async () => {
+        const res = await generateTypes(
+          ADAPTER_NAME,
+          {
+            swagger: { url: `${BASE_DIR}/petstore_swagger.v2.yaml` },
+            typeDefaults: { transformation: { idFields: ['name'] } },
+            types: {},
+            supportedEndpoints: ['/pet/{petId}'],
+          },
+        )
+        allTypes = res.allTypes
+      })
+      it('should generate the right types', () => {
+        expect(Object.keys(allTypes).sort()).toEqual(['Pet', 'Category', 'Tag'].sort())
+      })
+    })
+
     describe('invalid versions', () => {
       it('should fail on invalid swagger version (v2)', async () => {
         await expect(() => generateTypes(


### PR DESCRIPTION
Added an optional field to the apiDefinitions in the config of adapters that use the adapter-components infrastructure with **swagger**.
It could be used to specify the endpoints supported by salto, and only the types based on those endpoints will be generated from the yaml.

---

Note that this new config field will be hidden once the whole `apiDefinitions` part of the config will be hidden

---

*Release Notes*: None
