### PR TITLE
SALTO-1301: Add ContentAsset to default skip list

### DIFF
--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -400,6 +400,7 @@ export const configType = new ObjectType({
               { metadataType: 'PermissionSet' },
               { metadataType: 'SiteDotCom' },
               { metadataType: 'EmailTemplate' },
+              { metadataType: 'ContentAsset' },
               {
                 metadataType: 'StandardValueSet',
                 name: '^(AddressCountryCode)|(AddressStateCode)$',


### PR DESCRIPTION
---

Already encountered two real accounts where fetching this type caused an internal server error on salesforce, deemed not valuable enough to fetch by default

---
_Release Notes_: 
Salesforce Adapter:
- Added ContentAsset to default skip list
