### PR TITLE
SALTO-1296: Add ability to disable extra dependencies filter in salesforce adapter

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -122,6 +122,7 @@ salesforce {
 | [metadata](#metadata-configuration-options)                 | Fetch all metdata                                | Specified the metadata fetch
 | [data](#data-management-configuration-options) | {} (do not manage data)       | Data management configuration object names will not be fetched in case they are matched in includeObjects
 | fetchAllCustomSettings                                      | true                                             | Whether to fetch all the custom settings instances. When false, it is still possible to choose specific custom settings instances via the `data` option
+| optionalFeatures (#optional-features)                       | {} (all enabled)                                 | Granular control over with features are enabled in the adapter, by default all features are enabled in order to get the most information. can be used to turn off features that cause problems until they are solved
 
 ## Metadata configuration options
 
@@ -137,6 +138,11 @@ salesforce {
 | metadataType                                                | ".*" (All types)                                 | A regular expression of a metadata type to query with
 | name                                                        | ".*" (All names)                                 | A regular expression of a metadata instance name to query with
 
+## Optional Features
+
+| Name                                                        | Default when undefined                           | Description
+| ------------------------------------------------------------| -------------------------------------------------| -----------
+| extraDependencies                                           | true                                             | Find additional dependencies between configuration elements by using the salesforce tooling API
 
 ### Data management configuration options
 

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -122,7 +122,7 @@ salesforce {
 | [metadata](#metadata-configuration-options)                 | Fetch all metdata                                | Specified the metadata fetch
 | [data](#data-management-configuration-options) | {} (do not manage data)       | Data management configuration object names will not be fetched in case they are matched in includeObjects
 | fetchAllCustomSettings                                      | true                                             | Whether to fetch all the custom settings instances. When false, it is still possible to choose specific custom settings instances via the `data` option
-| optionalFeatures (#optional-features)                       | {} (all enabled)                                 | Granular control over with features are enabled in the adapter, by default all features are enabled in order to get the most information. can be used to turn off features that cause problems until they are solved
+| optionalFeatures (#optional-features)                       | {} (all enabled)                                 | Granular control over which features are enabled in the adapter, by default all features are enabled in order to get the most information. can be used to turn off features that cause problems until they are solved
 
 ## Metadata configuration options
 

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { DATA_CONFIGURATION, FetchParameters, METADATA_CONFIG } from '../types'
+import { DATA_CONFIGURATION, FetchParameters, METADATA_CONFIG, OptionalFeatures } from '../types'
 import { buildDataManagement, DataManagement, validateDataManagementConfig } from './data_management'
 import { buildMetadataQuery, MetadataQuery, validateMetadataParams } from './metadata_query'
 
@@ -22,6 +22,7 @@ import { buildMetadataQuery, MetadataQuery, validateMetadataParams } from './met
 export type FetchProfile = {
   readonly metadataQuery: MetadataQuery
   readonly dataManagement?: DataManagement
+  readonly isFeatureEnabled: (name: keyof OptionalFeatures) => boolean
   readonly shouldFetchAllCustomSettings: () => boolean
 }
 
@@ -29,10 +30,12 @@ export const buildFetchProfile = ({
   metadata = {},
   data,
   fetchAllCustomSettings,
+  optionalFeatures,
   target,
 }: FetchParameters): FetchProfile => ({
   metadataQuery: buildMetadataQuery(metadata, target),
   dataManagement: data && buildDataManagement(data),
+  isFeatureEnabled: name => optionalFeatures?.[name] ?? true,
   shouldFetchAllCustomSettings: () => fetchAllCustomSettings ?? true,
 })
 

--- a/packages/salesforce-adapter/src/filters/extra_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/extra_dependencies.ts
@@ -185,6 +185,9 @@ const addExtraReferences = async (
  */
 const creator: FilterCreator = ({ client, config }) => ({
   onFetch: async (elements: Element[]) => {
+    if (!config.fetchProfile.isFeatureEnabled('extraDependencies')) {
+      return
+    }
     const groupedDeps = await getDependencies(client)
     const fetchedElements = buildElementsSourceFromElements(elements)
     const allElements = buildElementsSourceForFetch(elements, config)

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import {
   ElemID, ObjectType, InstanceElement, BuiltinTypes, CORE_ANNOTATIONS, ListType, createRestriction,
   FieldDefinition,
@@ -27,7 +28,6 @@ export const FETCH_CONFIG = 'fetch'
 export const METADATA_CONFIG = 'metadata'
 const METADATA_INCLUDE_LIST = 'include'
 const METADATA_EXCLUDE_LIST = 'exclude'
-const FETCH_TARGET = 'target'
 const METADATA_TYPE = 'metadataType'
 const METADATA_NAME = 'name'
 const METADATA_NAMESPACE = 'namespace'
@@ -51,10 +51,15 @@ export type MetadataParams = {
   exclude?: MetadataQueryParams[]
 }
 
+export type OptionalFeatures = {
+  extraDependencies?: boolean
+}
+
 export type FetchParameters = {
   metadata?: MetadataParams
   data?: DataManagementConfig
-  fetchAllCustomSettings?: boolean
+  fetchAllCustomSettings?: boolean // TODO - move this into optional features
+  optionalFeatures?: OptionalFeatures
   target?: string[]
 }
 
@@ -365,13 +370,21 @@ const metadataConfigType = new ObjectType({
   },
 })
 
-const fetchConfigType = new ObjectType({
-  elemID: new ElemID(SALESFORCE, 'metadataQuery'),
+const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
+  elemID: new ElemID(SALESFORCE, 'optionalFeatures'),
   fields: {
-    [METADATA_CONFIG]: { type: metadataConfigType },
-    [DATA_CONFIGURATION]: { type: dataManagementType },
-    [SHOULD_FETCH_ALL_CUSTOM_SETTINGS]: { type: BuiltinTypes.BOOLEAN },
-    [FETCH_TARGET]: { type: new ListType(BuiltinTypes.STRING) },
+    extraDependencies: { type: BuiltinTypes.BOOLEAN },
+  },
+})
+
+const fetchConfigType = createMatchingObjectType<FetchParameters>({
+  elemID: new ElemID(SALESFORCE, 'fetchConfig'),
+  fields: {
+    metadata: { type: metadataConfigType },
+    data: { type: dataManagementType },
+    optionalFeatures: { type: optionalFeaturesType },
+    fetchAllCustomSettings: { type: BuiltinTypes.BOOLEAN },
+    target: { type: new ListType(BuiltinTypes.STRING) },
   },
 })
 


### PR DESCRIPTION
The extra dependencies filter seems to fail on some accounts, unclear why, but since this filter only gets information that does not affect the correctness of the rest of the configuration (and cannot be deployed back) we would like to allow users to skip it


---
_Release Notes_: 
Salesforce Adapter:
- Allow disabling the extra dependencies filter
