### PR TITLE
SALTO-1303 - Add CustomObjectTranslation to default exclude metadataType

### DIFF
--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -401,6 +401,7 @@ export const configType = new ObjectType({
               { metadataType: 'SiteDotCom' },
               { metadataType: 'EmailTemplate' },
               { metadataType: 'ContentAsset' },
+              { metadataType: 'CustomObjectTranslation' },
               {
                 metadataType: 'StandardValueSet',
                 name: '^(AddressCountryCode)|(AddressStateCode)$',


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
* Added CustomObjectTranslation to default exclude metadataType
