### PR TITLE
SALTO-1256 Custom Object instances omitting & warning

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -320,6 +320,10 @@ export const TERRITORY2_RULE_TYPE = 'Territory2Rule'
 // Retrieve constants
 export const RETRIEVE_LOAD_OF_METADATA_ERROR_REGEX = /Load of metadata from db failed for metadata of type:(?<type>\w+) and file name:(?<instance>\w+).$/
 
+// According to Salesforce spec the keyPrefix length is 3
+// If this changes in the future we need to change this and add further logic where it's used
+export const KEY_PREFIX_LENGTH = 3
+
 // CPQ CustomObjects
 export const CPQ_PRODUCT_RULE = 'SBQQ__ProductRule__c'
 export const CPQ_PRICE_RULE = 'SBQQ__PriceRule__c'

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -17,78 +17,135 @@ import _ from 'lodash'
 import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
 import { transformValues, TransformFunc } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import {
-  Element, Values, ObjectType, Field, InstanceElement,
-  ReferenceExpression,
-} from '@salto-io/adapter-api'
+import { Element, Values, Field, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
 import { apiName, isInstanceOfCustomObject } from '../transformers/transformer'
 import { FIELD_ANNOTATIONS, CUSTOM_OBJECT_ID_FIELD } from '../constants'
 import { isLookupField, isMasterDetailField } from './utils'
 
 const { makeArray } = collections.array
+const { isDefined } = lowerdashValues
+const { DefaultMap } = collections.map
 
 const log = logger(module)
 
-const replaceReferenceValues = (
-  values: Values,
-  type: ObjectType,
-  instancesByType: Record<string, Record<string, InstanceElement>>
-): Values => {
-  const shouldReplace = (field: Field): boolean => (
-    isLookupField(field) || isMasterDetailField(field)
-  )
+const serializeInternalID = (typeName: string, id: string): string =>
+  (`${typeName}&${id}`)
 
-  const transformFunc: TransformFunc = ({ value, field }) => {
-    if (_.isUndefined(field) || !shouldReplace(field)) {
-      return value
+const serializeInstanceInternalID = (instance: InstanceElement): string =>
+  serializeInternalID(apiName(instance.type, true), instance.value[CUSTOM_OBJECT_ID_FIELD])
+
+const createInternalToInstance = (instances: InstanceElement[]): Record<string, InstanceElement> =>
+  (_.keyBy(instances, serializeInstanceInternalID))
+
+const shouldReplaceFieldVal = (field: Field): boolean => (
+  isLookupField(field) || isMasterDetailField(field)
+)
+
+const replaceLookupsWithReferencesAndCreateRefMap = (
+  instances: InstanceElement[],
+  internalToInstance: Record<string, InstanceElement>,
+): {
+  reverseRefsMap: collections.map.DefaultMap<string, Set<string>>
+  referenceToNothing: Set<InstanceElement>
+} => {
+  const internalToReferencedFrom = new DefaultMap<string, Set<string>>(() => new Set())
+  const referenceToNothing = new Set<InstanceElement>()
+  const replaceLookups = (
+    instance: InstanceElement
+  ): Values => {
+    const transformFunc: TransformFunc = ({ value, field }) => {
+      if (_.isUndefined(field) || !shouldReplaceFieldVal(field)) {
+        return value
+      }
+      const refTo = makeArray(field?.annotations?.[FIELD_ANNOTATIONS.REFERENCE_TO])
+      const refTarget = refTo
+        .map(typeName => internalToInstance[serializeInternalID(typeName, value)])
+        .filter(isDefined)
+        .pop()
+      if (refTarget === undefined) {
+        referenceToNothing.add(instance)
+        return value
+      }
+      internalToReferencedFrom.get(serializeInstanceInternalID(refTarget))
+        .add(serializeInstanceInternalID(instance))
+      return new ReferenceExpression(refTarget.elemID)
     }
-    const refTo = makeArray(field?.annotations?.[FIELD_ANNOTATIONS.REFERENCE_TO])
-    const refTarget = refTo
-      .map(typeName => instancesByType[typeName]?.[value])
-      .filter(lowerdashValues.isDefined)
-      .pop()
-    return refTarget === undefined ? value : new ReferenceExpression(refTarget.elemID)
+
+    return transformValues(
+      {
+        values: instance.value,
+        type: instance.type,
+        transformFunc,
+        strict: false,
+      }
+    ) ?? instance.value
   }
 
-  return transformValues(
-    {
-      values,
-      type,
-      transformFunc,
-      strict: false,
-    }
-  ) ?? values
-}
-
-const replaceLookupsWithReferences = (elements: Element[]): void => {
-  const customObjectInstances = elements.filter(isInstanceOfCustomObject)
-  const instancesByType = _.mapValues(
-    _.groupBy(
-      customObjectInstances,
-      instance => apiName(instance.type, true)
-    ),
-    typeInstances =>
-      _.keyBy(
-        typeInstances,
-        inst => inst.value[CUSTOM_OBJECT_ID_FIELD]
-      )
-  ) as Record<string, Record<string, InstanceElement>>
-  customObjectInstances.forEach((instance, index) => {
-    instance.value = replaceReferenceValues(
-      instance.value,
-      instance.type,
-      instancesByType,
-    )
-    if (index % 500 === 0) {
+  instances.forEach((instance, index) => {
+    instance.value = replaceLookups(instance)
+    if (index > 0 && index % 500 === 0) {
       log.debug(`Replaced lookup with references for ${index} instances`)
     }
   })
+  return {
+    reverseRefsMap: internalToReferencedFrom, referenceToNothing,
+  }
+}
+
+const getIllegalRefsFrom = (
+  referencesToNothing: Set<InstanceElement>,
+  duplicates: InstanceElement[],
+  reverseRefsMap: collections.map.DefaultMap<string, Set<string>>,
+): Set<string> => {
+  const illegalRefsFromSet = new Set<string>()
+  const illegalRefsTargets = [
+    ...[...referencesToNothing].flatMap(serializeInstanceInternalID),
+    ...duplicates.flatMap(serializeInstanceInternalID),
+  ]
+  while (illegalRefsTargets.length > 0) {
+    const currentBrokenRef = illegalRefsTargets.pop()
+    if (currentBrokenRef === undefined) {
+      break
+    }
+    const refsToCurrentIllegal = [...reverseRefsMap.get(currentBrokenRef)]
+    refsToCurrentIllegal.filter(r => !illegalRefsFromSet.has(r))
+      .forEach(newIllegalRefFrom => {
+        illegalRefsTargets.push(newIllegalRefFrom)
+        illegalRefsFromSet.add(newIllegalRefFrom)
+      })
+  }
+  return illegalRefsFromSet
 }
 
 const filter: FilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
-    replaceLookupsWithReferences(elements)
+    const customObjectInstances = elements.filter(isInstanceOfCustomObject)
+    const internalToInstance = createInternalToInstance(customObjectInstances)
+    const { reverseRefsMap, referenceToNothing } = replaceLookupsWithReferencesAndCreateRefMap(
+      customObjectInstances,
+      internalToInstance,
+    )
+    const instancesWithDuplicateElemID = Object
+      .values(_.groupBy(customObjectInstances, instance => instance.elemID.getFullName()))
+      .filter(instances => instances.length > 1)
+      .flat()
+    const illegalRefsFrom = getIllegalRefsFrom(
+      referenceToNothing, instancesWithDuplicateElemID, reverseRefsMap,
+    )
+    const invalidInstances = new Set(
+      [
+        ...illegalRefsFrom,
+        ...[...referenceToNothing].flatMap(serializeInstanceInternalID),
+        ...instancesWithDuplicateElemID.flatMap(serializeInstanceInternalID),
+      ]
+    )
+    _.remove(
+      elements,
+      element =>
+        (isInstanceOfCustomObject(element)
+        && !invalidInstances.has(serializeInstanceInternalID(element))),
+    )
   },
 })
 

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -144,7 +144,7 @@ const filter: FilterCreator = () => ({
       elements,
       element =>
         (isInstanceOfCustomObject(element)
-        && !invalidInstances.has(serializeInstanceInternalID(element))),
+        && invalidInstances.has(serializeInstanceInternalID(element))),
     )
   },
 })

--- a/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
@@ -215,9 +215,13 @@ describe('Custom Object Instances References filter', () => {
     const allElements = [
       ...objects, ...legalInstances, ...illegalInstances,
     ]
+    let warnings: string[]
     beforeAll(async () => {
       elements = allElements.map(e => e.clone())
-      await filter.onFetch(elements)
+      const fetchResult = await filter.onFetch(elements)
+      if (fetchResult) {
+        warnings = fetchResult.warnings ?? []
+      }
     })
 
     it('Should drop the illegal instances and not change the objects and the ref to instances', () => {
@@ -273,6 +277,15 @@ describe('Custom Object Instances References filter', () => {
         e => e.elemID.isEqual(refFromToRefToDupInst.elemID)
       )
       expect(afterFilterRefFromToRefToDup).toBeUndefined()
+    })
+    it('Should have warnings that include all illegal instances names/Ids', () => {
+      expect(warnings).toBeDefined()
+      illegalInstances.forEach(instance => {
+        const warningsIncludeNameOrId = warnings.some(
+          warning => warning.includes(instance.elemID.name)
+        ) || warnings.some(warning => warning.includes(instance.value.Id))
+        expect(warningsIncludeNameOrId).toBeTruthy()
+      })
     })
   })
 })

--- a/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { Element, ElemID, ObjectType, PrimitiveTypes, PrimitiveType, CORE_ANNOTATIONS, InstanceElement, ReferenceExpression, isInstanceElement, SaltoError } from '@salto-io/adapter-api'
+import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 import { FilterWith } from '../../src/filter'
 import SalesforceClient from '../../src/client/client'
 import filterCreator from '../../src/filters/custom_object_instances_references'
@@ -132,7 +133,20 @@ describe('Custom Object Instances References filter', () => {
 
   beforeAll(() => {
     client = mockClient().client
-    filter = filterCreator({ client, config: defaultFilterContext }) as FilterType
+    filter = filterCreator({
+      client,
+      config: {
+        ...defaultFilterContext,
+        fetchProfile: buildFetchProfile({
+          data: {
+            includeObjects: ['*'],
+            saltoIDSettings: {
+              defaultIdFields: ['Name'],
+            },
+          },
+        }),
+      },
+    }) as FilterType
   })
 
   describe('lookup ref to', () => {
@@ -225,11 +239,16 @@ describe('Custom Object Instances References filter', () => {
       refFromEmptyRefsInstance,
       firstDupInst,
       secondDupInst,
+    ]
+    const sideEffectIllegalInstances = [
       refFromToDupInst,
       refFromToRefToDupInst,
     ]
     const allElements = [
-      ...objects, ...legalInstances, ...illegalInstances,
+      ...objects,
+      ...legalInstances,
+      ...illegalInstances,
+      ...sideEffectIllegalInstances,
     ]
     let errors: SaltoError[]
     beforeAll(async () => {


### PR DESCRIPTION
Change the CustomObject Instances Reference logic to include not only the referencing itself but also logic about invalid Instances. 
There are 3 "invalid" reasons - 
1. Colliding ElemID
2. Missing references (reference to a missing instance)
3. References to an Instance we chose to omit (due to 1/2/3)

This PR has 2 parts - 
1. The implementation of the above logic
2. Warnings about the omitted instances based on https://www.notion.so/saltoio/Salesforce-Data-Management-0b397279069b4f368f692d617f721487

---
_Release Notes_: 

Salesforce Adapter - 
* CustomObject Instances with collisions in ElemID or references to non-Fetched Instances are now omitted from the fetch. Information about these Instances is available through Fetch Errors (Warnings).