### PR TITLE
added return-await lint rule

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -124,6 +124,7 @@ module.exports = {
         ],
         // This rule is already enforced on all functions so no need to enforce it in addition on module boundary
         '@typescript-eslint/explicit-module-boundary-types': ['off'],
+        '@typescript-eslint/return-await': ['error', 'in-try-catch'],
         'jest/valid-describe': ['off'],
         'import/extensions': [ 'error', 'never', {
             'json': 'always',

--- a/packages/adapter-components/src/client/decorators.ts
+++ b/packages/adapter-components/src/client/decorators.ts
@@ -58,6 +58,7 @@ export const logDecorator = (
     ): Promise<unknown> {
       const desc = logOperationDecorator(originalMethod, this.clientName, keys)
       try {
+        // eslint-disable-next-line @typescript-eslint/return-await
         return await log.time(originalMethod.call, desc)
       } catch (e) {
         log.error('failed to run %s client call %s: %s', this.clientName, desc, e.message)

--- a/packages/e2e-credentials-store/.eslintrc.js
+++ b/packages/e2e-credentials-store/.eslintrc.js
@@ -19,18 +19,11 @@ const deepMerge = require('../../build_utils/deep_merge')
 module.exports = deepMerge(
   require('../../eslintrc.js'),
   {
-    overrides: [
-      {
-        files: ['*.ts'],
-        parserOptions: {
-          tsconfigRootDir: __dirname,
-          project: path.resolve(__dirname, './tsconfig.json'),
-        },
-      }
-    ],
     parserOptions: {
-      project: [],
-    }
+      tsconfigRootDir: __dirname,
+      project: path.resolve(__dirname, './tsconfig.json'),
+    },
+    ignorePatterns: ['jest-dynalite-config.js']
   },
 )
 

--- a/packages/lang-server/src/usage.ts
+++ b/packages/lang-server/src/usage.ts
@@ -93,7 +93,7 @@ export const getReferencingFiles = async (
 ): Promise<string[]> => {
   try {
     const id = ElemID.fromFullName(fullName)
-    return workspace.getElementReferencedFiles(id)
+    return await workspace.getElementReferencedFiles(id)
   } catch (e) {
     return []
   }

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -164,6 +164,7 @@ export default class NetsuiteClient {
     ): Promise<unknown> => {
       const desc = `client.${name}`
       try {
+        // eslint-disable-next-line @typescript-eslint/return-await
         return await log.time(call, desc)
       } catch (e) {
         log.error('failed to run Netsuite client command on: %o', e)

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -211,6 +211,7 @@ export default class SdfClient {
       { call }: decorators.OriginalCall,
     ): Promise<unknown> => {
       try {
+        // eslint-disable-next-line @typescript-eslint/return-await
         return await call()
       } catch (e) {
         throw _.isObject(e) ? e : new Error(String(e))

--- a/packages/salesforce-adapter/src/filters/settings_type.ts
+++ b/packages/salesforce-adapter/src/filters/settings_type.ts
@@ -37,7 +37,7 @@ const createSettingsType = async (
   const typeFields = await client.describeMetadataType(settingsTypesName)
   const baseTypeNames = new Set([settingsTypesName])
   try {
-    return createMetadataTypeElements({
+    return await createMetadataTypeElements({
       name: settingsTypesName,
       fields: typeFields.valueTypeFields,
       knownTypes,


### PR DESCRIPTION
Added a lint rule to prevent bugs like this:
```
const async x() => {
  ...
}

const async y() => {
   try {
       return x()
   } catch (e) {
       ...
   }
}
```

The rule found two missed awaits

---
_Release Notes_: 
None