### PR TITLE
Add SALTO_ prefix for test env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
           command: yarn test --reporters=default --reporters=jest-junit --coverage=false
           no_output_timeout: 20m
           environment:
-            RUN_E2E_TESTS: '1'
+            SALTO_RUN_E2E_TESTS: '1'
             SALTO_LOG_LEVEL: 'info'
             # enable telemetry for end2end so we can count more events
             # webpack configuration is irrelevant in this case and therefore

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ $ yarn test
 
 By default, `yarn test` will run only unit tests - stored at the `tests` directory of each package.
 
-E2E (end-to-end) tests are stored at the `e2e_tests` directories. To run them, define the `RUN_E2E_TESTS=1` environment variable:
+E2E (end-to-end) tests are stored at the `e2e_tests` directories. To run them, define the `SALTO_RUN_E2E_TESTS=1` environment variable:
 
 ```bash
-RUN_E2E_TESTS=1 yarn test
+SALTO_RUN_E2E_TESTS=1 yarn test
 ```
 
 E2E tests are run on CircleCI builds, and you should also run them locally before creating a PR.

--- a/jest.base.config.js
+++ b/jest.base.config.js
@@ -17,7 +17,7 @@ module.exports = {
   verbose: true,
   testEnvironment: 'node',
   testMatch: [
-    process.env['RUN_E2E_TESTS']
+    process.env['SALTO_RUN_E2E_TESTS']
       ? '<rootDir>/dist/e2e_test/**/*.test.js'
       : '<rootDir>/dist/test/**/*.test.js'
   ],

--- a/packages/cli/.vscode/launch.json
+++ b/packages/cli/.vscode/launch.json
@@ -25,7 +25,7 @@
             "name": "cli Debug Jest E2E Tests",
             "cwd": "${workspaceFolder}",
             "env": {
-              "RUN_E2E_TESTS": "1"
+              "SALTO_RUN_E2E_TESTS": "1"
             },
             "args": [
               "${workspaceRoot}/node_modules/.bin/jest",

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -27,7 +27,7 @@ module.exports = deepMerge(
       '!<rootDir>/package_native.js',
       '!<rootDir>/dist/bundle.js'
     ],
-    testEnvironment: process.env.RUN_E2E_TESTS
+    testEnvironment: process.env.SALTO_RUN_E2E_TESTS
       ? '@salto-io/cli/dist/e2e_test/jest_environment'
       : undefined,
     coverageThreshold: {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "clean": "rm -rf ./dist ./pkg .eslintcache src/generated",
     "clean-ts-test": "yarn clean-ts && yarn test",
     "watch-test": "yarn tsc-watch --onSuccess 'yarn clean-ts-test'",
-    "e2e-test": "RUN_E2E_TESTS=1 jest",
+    "e2e-test": "SALTO_RUN_E2E_TESTS=1 jest",
     "generate": "./generate.sh",
     "package": "node ./package_native.js"
   },

--- a/packages/e2e-credentials-store/src/process_env.ts
+++ b/packages/e2e-credentials-store/src/process_env.ts
@@ -15,12 +15,16 @@
 */
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export default (env: NodeJS.ProcessEnv) => ({
-  required: (name: string): string => {
-    if (!(name in env)) {
-      throw new Error(`required env var ${name} missing`)
-    }
-    return env[name] ?? ''
-  },
-  bool: (k: string): boolean => ['1', 'true', 'yes'].includes(env[k] ?? ''),
-})
+export default (env: NodeJS.ProcessEnv) => {
+  const getSaltoEnvVar = (name: string): string => (env[`SALTO_${name}`] ?? '')
+  return {
+    optional: getSaltoEnvVar,
+    required: (name: string): string => {
+      if (!(name in env)) {
+        throw new Error(`required env var ${name} missing`)
+      }
+      return getSaltoEnvVar(name)
+    },
+    bool: (k: string): boolean => ['1', 'true', 'yes'].includes(getSaltoEnvVar(k)),
+  }
+}

--- a/packages/netsuite-adapter/jest.config.js
+++ b/packages/netsuite-adapter/jest.config.js
@@ -24,7 +24,7 @@ module.exports = deepMerge(
         collectCoverageFrom: [
             '!<rootDir>/dist/index.js',
         ],
-        testEnvironment: process.env.RUN_E2E_TESTS
+        testEnvironment: process.env.SALTO_RUN_E2E_TESTS
             ? '@salto-io/netsuite-adapter/dist/e2e_test/jest_environment'
             : undefined,
         coverageThreshold: {

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "yarn concurrently \"yarn lint\" \"yarn build-ts\"",
     "test": "jest",
-    "e2e-test": "RUN_E2E_TESTS=1 jest",
+    "e2e-test": "SALTO_RUN_E2E_TESTS=1 jest",
     "clean": "rm -rf ./dist .eslintcache",
     "clean-ts": "../../build_utils/clean-old-ts.sh",
     "clean-ts-test": "yarn clean-ts && yarn test",

--- a/packages/salesforce-adapter/.vscode/launch.json
+++ b/packages/salesforce-adapter/.vscode/launch.json
@@ -25,7 +25,7 @@
         "name": "salesforce-adapter Debug Jest E2E Tests",
         "cwd": "${workspaceFolder}",
         "env": {
-          "RUN_E2E_TESTS": "1"
+          "SALTO_RUN_E2E_TESTS": "1"
         },
         "args": [
           "${workspaceRoot}/node_modules/.bin/jest",

--- a/packages/salesforce-adapter/e2e_test/jest_environment.ts
+++ b/packages/salesforce-adapter/e2e_test/jest_environment.ts
@@ -48,7 +48,7 @@ export const credsSpec = (envName?: string): CredsSpec<UsernamePasswordCredentia
       return {
         username: envUtils.required(userEnvVarName),
         password: envUtils.required(passwordEnvVarName),
-        apiToken: env[tokenEnvVarName] ?? '',
+        apiToken: envUtils.optional(tokenEnvVarName),
         isSandbox: envUtils.bool(sandboxEnvVarName),
       }
     },

--- a/packages/salesforce-adapter/jest.config.js
+++ b/packages/salesforce-adapter/jest.config.js
@@ -24,7 +24,7 @@ module.exports = deepMerge(
     collectCoverageFrom: [
       '!<rootDir>/dist/index.js',
     ],
-    testEnvironment: process.env.RUN_E2E_TESTS	
+    testEnvironment: process.env.SALTO_RUN_E2E_TESTS
       ? '@salto-io/salesforce-adapter/dist/e2e_test/jest_environment'	
       : undefined,
     coverageThreshold: {

--- a/packages/salesforce-adapter/package.json
+++ b/packages/salesforce-adapter/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "yarn concurrently \"yarn lint\" \"yarn build-ts\"",
     "test": "jest",
-    "e2e-test": "RUN_E2E_TESTS=1 jest",
+    "e2e-test": "SALTO_RUN_E2E_TESTS=1 jest",
     "clean": "rm -rf ./dist .eslintcache",
     "clean-ts": "../../build_utils/clean-old-ts.sh",
     "clean-ts-test": "yarn clean-ts && yarn test",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -115,7 +115,7 @@
         "watch-ts": "tsc -b -w",
         "clean": "rm -rf ./dist .eslintcache",
         "test": "jest --passWithNoTests",
-        "e2e-test": "RUN_E2E_TESTS=1 jest",
+        "e2e-test": "SALTO_RUN_E2E_TESTS=1 jest",
         "clean-ts": "../../build_utils/clean-old-ts.sh",
         "clean-ts-test": "yarn clean-ts && yarn test",
         "watch-test": "yarn tsc-watch --onSuccess 'yarn clean-ts-test'",

--- a/packages/zuora-billing-adapter/.vscode/launch.json
+++ b/packages/zuora-billing-adapter/.vscode/launch.json
@@ -25,7 +25,7 @@
       "name": "zuora-billing-adapter Debug Jest E2E Tests",
       "cwd": "${workspaceFolder}",
       "env": {
-        "RUN_E2E_TESTS": "1",
+        "SALTO_RUN_E2E_TESTS": "1",
       },
       "args": [
         "${workspaceRoot}/node_modules/.bin/jest",

--- a/packages/zuora-billing-adapter/jest.config.js
+++ b/packages/zuora-billing-adapter/jest.config.js
@@ -24,7 +24,7 @@ module.exports = deepMerge(
     collectCoverageFrom: [
       '!<rootDir>/dist/index.js',
     ],
-    testEnvironment: process.env.RUN_E2E_TESTS
+    testEnvironment: process.env.SALTO_RUN_E2E_TESTS
       ? '@salto-io/zuora-billing-adapter/dist/e2e_test/jest_environment'
       : undefined,
     coverageThreshold: {

--- a/packages/zuora-billing-adapter/package.json
+++ b/packages/zuora-billing-adapter/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "yarn concurrently \"yarn lint\" \"yarn build-ts\"",
     "test": "jest",
-    "e2e-test": "RUN_E2E_TESTS=1 jest",
+    "e2e-test": "SALTO_RUN_E2E_TESTS=1 jest",
     "clean": "rm -rf ./dist .eslintcache",
     "clean-ts": "../../build_utils/clean-old-ts.sh",
     "clean-ts-test": "yarn clean-ts && yarn test",


### PR DESCRIPTION
Following @ori-moisis 's suggestion from https://github.com/salto-io/salto/pull/2004#discussion_r619798713 .
Note that this also includes renaming `RUN_E2E_TESTS` - if it's better to keep it we can do this just for the credentials-related env vars (I changed everything I could find in our org but maybe it's defined manually somewhere else, besides in circle which will also be updated?).

---
This will require updating the build env vars as well (will do that after confirming the new names)

---
_Release Notes_: 
(not sure if we should include it?)
For local development - add `SALTO_` prefix to e2e-related environment variables (`RUN_E2E_TESTS` is now `SALTO_RUN_E2E_TESTS`, and similarly for environment variables used for test credentials)
