### PR TITLE
Fix dummy adapter failure on 2nd unittest run

### DIFF
--- a/packages/dummy-adapter/generate.sh
+++ b/packages/dummy-adapter/generate.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 mkdir -p dist/src/data/
 cp src/data/strings.dat dist/src/data/strings.dat
-cp -R src/data/fixtures dist/src/data/fixtures
+cp -R src/data/fixtures dist/src/data/


### PR DESCRIPTION
Running `yarn build && yarn test` locally after a previous build without running `yarn clean` fails, because more fixtures are created under `dist/src/data/fixtures/fixtures`. 
I think it may be safer to completely re-generate these as part of the `test` command, but since it looks like this was added for a SaaS test, starting with the smaller fix.

---
_Release Notes_: 
None (internal)
