### PR TITLE
SALTO-825: added fetch for dataTypes

### DIFF
--- a/packages/adapter-components/src/elements/soap/type_elements/types_generator.ts
+++ b/packages/adapter-components/src/elements/soap/type_elements/types_generator.ts
@@ -82,7 +82,7 @@ export const extractTypes = async (
     .value()
 
   if (duplicateTypes.length > 0) {
-    throw new Error(`There are duplicate type names in the WSDL: ${duplicateTypes}`)
+    log.debug(`There are duplicate type names in the WSDL: ${duplicateTypes}`)
   }
 
   log.debug('Finished generating SOAP types')

--- a/packages/adapter-components/test/elements/soap/types_generator.test.ts
+++ b/packages/adapter-components/test/elements/soap/types_generator.test.ts
@@ -80,7 +80,7 @@ describe('extractTypes', () => {
     expect(testedType).toBeDefined()
   })
 
-  it('should throw error when there are duplicate types', async () => {
-    await expect(extractTypes('adapterName', INVALID_WSDL_PATH)).rejects.toThrow()
+  it('should not throw error when there are duplicate types', async () => {
+    await expect(extractTypes('adapterName', INVALID_WSDL_PATH)).resolves.toBeDefined()
   })
 })

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@salto-io/adapter-api": "0.2.10",
+    "@salto-io/adapter-components": "0.2.10",
     "@salto-io/adapter-utils": "0.2.10",
     "@salto-io/e2e-credentials-store": "0.2.10",
     "@salto-io/file": "0.2.10",

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -18,6 +18,7 @@ import { AccountId, Change, ChangeGroup, DeployResult, getChangeElement, Instanc
 import { logger } from '@salto-io/logging'
 import { decorators } from '@salto-io/lowerdash'
 import { resolveValues } from '@salto-io/adapter-utils'
+import * as soap from 'soap'
 import { NetsuiteQuery } from '../query'
 import { Credentials, toUrlAccountId } from './credentials'
 import SdfClient from './sdf_client'
@@ -177,4 +178,8 @@ export default class NetsuiteClient {
       }
     }
   )
+
+  public async getNetsuiteWsdl(): Promise<soap.WSDL | undefined> {
+    return this.suiteAppClient?.getNetsuiteWsdl()
+  }
 }

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -252,6 +252,11 @@ export default class SoapClient {
     })
   }
 
+  public async getNetsuiteWsdl(): Promise<soap.WSDL> {
+    const { wsdl } = (await this.getClient()) as unknown as { wsdl: soap.WSDL }
+    return wsdl
+  }
+
   private async sendSoapRequest(operation: string, body: object): Promise<unknown> {
     const client = await this.getClient()
     return this.callsLimiter(async () => (await client[`${operation}Async`](body))[0])

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -21,6 +21,7 @@ import Ajv from 'ajv'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
+import * as soap from 'soap'
 import { CallsLimiter, ExistingFileCabinetInstanceDetails, FileCabinetInstanceDetails,
   FILES_READ_SCHEMA, HttpMethod, isError, ReadResults, RestletOperation, RestletResults,
   RESTLET_RESULTS_SCHEMA, SavedSearchQuery, SavedSearchResults, SAVED_SEARCH_RESULTS_SCHEMA,
@@ -284,5 +285,9 @@ export default class SuiteAppClient {
   public async deleteFileCabinetInstances(fileCabinetInstances:
     ExistingFileCabinetInstanceDetails[]): Promise<(number | Error)[]> {
     return this.soapClient.deleteFileCabinetInstances(fileCabinetInstances)
+  }
+
+  public async getNetsuiteWsdl(): Promise<soap.WSDL> {
+    return this.soapClient.getNetsuiteWsdl()
   }
 }

--- a/packages/netsuite-adapter/src/data_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements.ts
@@ -1,0 +1,52 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { elements as elementsComponents } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import NetsuiteClient from './client/client'
+import { NETSUITE } from './constants'
+
+const log = logger(module)
+
+export const getDataTypes = async (
+  typeNames: string[],
+  client: NetsuiteClient
+): Promise<ObjectType[]> => {
+  if (typeNames.length === 0) {
+    return []
+  }
+
+  const wsdl = await client.getNetsuiteWsdl()
+  if (wsdl === undefined) {
+    log.warn('Failed to get WSDL, skipping dataTypes')
+    return []
+  }
+  const topLevelTypes = (await elementsComponents.soap.extractTypes('netsuite', wsdl))
+
+  const types = elementsComponents.filterTypes(NETSUITE, topLevelTypes, typeNames)
+
+  const duplicateTypes = _(types)
+    .countBy(type => type.elemID.name)
+    .pickBy(count => count > 1)
+    .keys()
+    .value()
+
+  if (duplicateTypes.length > 0) {
+    throw new Error(`There are duplicate type names: ${duplicateTypes}`)
+  }
+  return types
+}

--- a/packages/netsuite-adapter/src/filters/hidden_fields.ts
+++ b/packages/netsuite-adapter/src/filters/hidden_fields.ts
@@ -1,0 +1,34 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, isObjectType } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+
+const HIDDEN_FIELDS = ['internalId']
+
+const filterCreator: FilterCreator = () => ({
+  onFetch: async ({ elements }) => {
+    elements
+      .filter(isObjectType)
+      .forEach(type => Object.values(type.fields)
+        .forEach(field => {
+          if (HIDDEN_FIELDS.includes(field.elemID.name)) {
+            field.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
+          }
+        }))
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/remove_redundant_types.ts
+++ b/packages/netsuite-adapter/src/filters/remove_redundant_types.ts
@@ -1,0 +1,38 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { isContainerType, isObjectType } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { FilterCreator } from '../filter'
+
+const REDUNDANT_TYPES = ['NullField', 'CustomFieldList', 'CustomFieldRef']
+
+
+const filterCreator: FilterCreator = () => ({
+  onFetch: async ({ elements }) => {
+    elements.filter(isObjectType).forEach(e => {
+      REDUNDANT_TYPES.forEach(type => {
+        e.fields = _.pickBy(e.fields, (field => {
+          const fieldType = isContainerType(field.type) ? field.type.innerType : field.type
+          return fieldType.elemID.name !== type
+        }))
+      })
+    })
+
+    _.remove(elements, e => REDUNDANT_TYPES.includes(e.elemID.name))
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/replace_record_ref.ts
+++ b/packages/netsuite-adapter/src/filters/replace_record_ref.ts
@@ -1,0 +1,56 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, isContainerType, isObjectType, PrimitiveType, PrimitiveTypes } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { NETSUITE, SUBTYPES_PATH, TYPES_PATH } from '../constants'
+import { FilterCreator } from '../filter'
+
+
+const filterCreator: FilterCreator = () => ({
+  onFetch: async ({ elements }) => {
+    const recordRefElemId = new ElemID(NETSUITE, 'RecordRef')
+    const recordRefType = new PrimitiveType({
+      elemID: recordRefElemId,
+      primitive: PrimitiveTypes.UNKNOWN,
+      path: [NETSUITE, TYPES_PATH, SUBTYPES_PATH, 'RecordRef'],
+    })
+
+    const removedElements = _.remove(elements, e => e.elemID.isEqual(recordRefElemId))
+    if (removedElements.length === 0) {
+      return
+    }
+
+    elements.push(recordRefType)
+
+    elements
+      .filter(isObjectType)
+      .forEach(element => {
+        Object.values(element.fields).forEach(field => {
+          const type = isContainerType(field.type) ? field.type.innerType : field.type
+
+          if (type.elemID.isEqual(recordRefElemId)) {
+            if (isContainerType(field.type)) {
+              field.type.innerType = recordRefType
+            } else {
+              field.type = recordRefType
+            }
+          }
+        })
+      })
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/test/data_elements.test.ts
+++ b/packages/netsuite-adapter/test/data_elements.test.ts
@@ -1,0 +1,90 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, ObjectType } from '@salto-io/adapter-api'
+import * as soap from 'soap'
+import Bottleneck from 'bottleneck'
+import { elements as elementsComponents } from '@salto-io/adapter-components'
+import SuiteAppClient from '../src/client/suiteapp_client/suiteapp_client'
+import NetsuiteClient from '../src/client/client'
+import { NETSUITE } from '../src/constants'
+import SdfClient from '../src/client/sdf_client'
+import { getDataTypes } from '../src/data_elements'
+
+jest.mock('@salto-io/adapter-components', () => ({
+  ...jest.requireActual<{}>('@salto-io/adapter-components'),
+  elements: {
+    ...jest.requireActual('@salto-io/adapter-components').elements,
+    soap: {
+      extractTypes: jest.fn(),
+    },
+  },
+}))
+
+describe('getDataTypes', () => {
+  const createClientMock = jest.spyOn(soap, 'createClientAsync')
+  const extractTypesMock = elementsComponents.soap.extractTypes as jest.Mock
+  const wsdl = {}
+
+  const creds = {
+    accountId: 'accountId',
+    tokenId: 'tokenId',
+    tokenSecret: 'tokenSecret',
+    suiteAppTokenId: 'suiteAppTokenId',
+    suiteAppTokenSecret: 'suiteAppTokenSecret',
+  }
+  const client = new NetsuiteClient(
+    new SdfClient({ credentials: creds, globalLimiter: new Bottleneck() }),
+    new SuiteAppClient({ credentials: creds, globalLimiter: new Bottleneck() }),
+  )
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    createClientMock.mockResolvedValue({ wsdl, addSoapHeader: jest.fn() } as unknown as soap.Client)
+  })
+
+  it('should return the requested types', async () => {
+    const typeA = new ObjectType({ elemID: new ElemID(NETSUITE, 'A') })
+    const typeB = new ObjectType({ elemID: new ElemID(NETSUITE, 'B'), fields: { A: { type: typeA } } })
+    const typeC = new ObjectType({ elemID: new ElemID(NETSUITE, 'C') })
+
+
+    extractTypesMock.mockResolvedValue([typeA, typeB, typeC])
+
+    const types = await getDataTypes(['B', 'D'], client)
+    expect(types.map(t => t.elemID.name)).toEqual(['B', 'A'])
+  })
+
+  it('should throw error if there is a duplication', async () => {
+    extractTypesMock.mockResolvedValue([
+      new ObjectType({ elemID: new ElemID(NETSUITE, 'A') }),
+      new ObjectType({ elemID: new ElemID(NETSUITE, 'B'), fields: { a: { type: new ObjectType({ elemID: new ElemID(NETSUITE, 'A') }) } } }),
+    ])
+
+    await expect(getDataTypes(['A', 'B'], client)).rejects.toThrow()
+  })
+
+  it('should do nothing if not types were requested', async () => {
+    const types = await getDataTypes([], client)
+    expect(types).toHaveLength(0)
+    expect(createClientMock).not.toHaveBeenCalled()
+  })
+
+  it('should return empty list if failed to get wsdl', async () => {
+    jest.spyOn(client, 'getNetsuiteWsdl').mockResolvedValue(undefined)
+    const types = await getDataTypes(['A'], client)
+    expect(types).toHaveLength(0)
+  })
+})

--- a/packages/netsuite-adapter/test/filters/hidden_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/hidden_fields.test.ts
@@ -1,0 +1,38 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ObjectType } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/hidden_fields'
+import NetsuiteClient from '../../src/client/client'
+import { NETSUITE } from '../../src/constants'
+
+describe('hidden_fields', () => {
+  it('should hide requested fields', async () => {
+    const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'someType'),
+      fields: {
+        internalId: { type: BuiltinTypes.STRING },
+        otherField: { type: BuiltinTypes.STRING },
+      } })
+    const onFetchParameters = {
+      elements: [type],
+      client: {} as NetsuiteClient,
+      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      isPartial: false,
+    }
+    await filterCreator().onFetch(onFetchParameters)
+    expect(type.fields.internalId.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toBeTruthy()
+    expect(type.fields.otherField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toBeUndefined()
+  })
+})

--- a/packages/netsuite-adapter/test/filters/remove_redundant_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/remove_redundant_types.test.ts
@@ -1,0 +1,49 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, ObjectType, BuiltinTypes, ListType } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/remove_redundant_types'
+import { OnFetchParameters } from '../../src/filter'
+import { NETSUITE } from '../../src/constants'
+import NetsuiteClient from '../../src/client/client'
+
+describe('replaceRecordRef', () => {
+  const typeToRemove = new ObjectType({ elemID: new ElemID(NETSUITE, 'NullField') })
+  const typeWithFieldToRemove = new ObjectType({ elemID: new ElemID(NETSUITE, 'typeWithFieldToRemove'),
+    fields: {
+      fieldToRemove: { type: typeToRemove },
+      listToRemove: { type: new ListType(typeToRemove) },
+      numberField: { type: BuiltinTypes.NUMBER },
+    } })
+  let onFetchParameters: OnFetchParameters
+  let elements: ObjectType[]
+
+  beforeEach(() => {
+    elements = [typeToRemove, typeWithFieldToRemove]
+    onFetchParameters = {
+      elements,
+      client: {} as NetsuiteClient,
+      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      isPartial: false,
+    }
+  })
+  it('should remove the types and the fields', () => {
+    filterCreator().onFetch(onFetchParameters)
+    expect(elements.length).toEqual(1)
+    expect(typeWithFieldToRemove.fields.fieldToRemove).toBeUndefined()
+    expect(typeWithFieldToRemove.fields.listToRemove).toBeUndefined()
+    expect(typeWithFieldToRemove.fields.numberField).toBeDefined()
+  })
+})

--- a/packages/netsuite-adapter/test/filters/replace_record_ref.test.ts
+++ b/packages/netsuite-adapter/test/filters/replace_record_ref.test.ts
@@ -1,0 +1,59 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ContainerType, ElemID, isPrimitiveType, ListType, ObjectType, Element, BuiltinTypes } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/replace_record_ref'
+import { OnFetchParameters } from '../../src/filter'
+import { NETSUITE } from '../../src/constants'
+import NetsuiteClient from '../../src/client/client'
+
+describe('replaceRecordRef', () => {
+  const beforeRecordRef = new ObjectType({ elemID: new ElemID(NETSUITE, 'RecordRef') })
+  const typeWithRecordRef = new ObjectType({ elemID: new ElemID(NETSUITE, 'typeWithRecordRef'),
+    fields: {
+      recordRef: { type: beforeRecordRef },
+      recordRefList: { type: new ListType(beforeRecordRef) },
+      numberField: { type: BuiltinTypes.NUMBER },
+    } })
+  let onFetchParameters: OnFetchParameters
+  let elements: ObjectType[]
+
+  beforeEach(() => {
+    elements = [typeWithRecordRef, beforeRecordRef]
+    onFetchParameters = {
+      elements,
+      client: {} as NetsuiteClient,
+      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      isPartial: false,
+    }
+  })
+  it('should replace all record refs references', () => {
+    filterCreator().onFetch(onFetchParameters)
+    expect(elements.length).toEqual(2)
+    expect(isPrimitiveType(elements[0].fields.recordRef.type)).toBeTruthy()
+    expect(
+      isPrimitiveType((elements[0].fields.recordRefList.type as ContainerType).innerType)
+    ).toBeTruthy()
+    expect(isPrimitiveType(elements[1])).toBeTruthy()
+  })
+
+  it('should not add RecordRef if there was not one before', () => {
+    const noElements: Element[] = []
+    onFetchParameters.elements = noElements
+
+    filterCreator().onFetch(onFetchParameters)
+    expect(noElements.length).toEqual(0)
+  })
+})

--- a/packages/netsuite-adapter/tsconfig.json
+++ b/packages/netsuite-adapter/tsconfig.json
@@ -15,6 +15,7 @@
   ],
   "references": [
     { "path": "../adapter-api" },
+    { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
     { "path": "../e2e-credentials-store" },
     { "path": "../file" },


### PR DESCRIPTION
Added support for fetching the SOAP types in Netsuite.

Right now fetching the soap types is not exposed in the user configuration so this PR does not affect the current behavior.

---
_Release Notes_: 
None