### PR TITLE
SALTO-1305: fix validation of broken references in built in annotations

### DIFF
--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -69,7 +69,7 @@ type RestrictionAnnotationType = Partial<{
 }>
 
 const StandardCoreAnnotationTypes: TypeMap = {
-  [CORE_ANNOTATIONS.DEFAULT]: StandardBuiltinTypes.STRING,
+  [CORE_ANNOTATIONS.DEFAULT]: StandardBuiltinTypes.UNKNOWN,
   [CORE_ANNOTATIONS.REQUIRED]: StandardBuiltinTypes.BOOLEAN,
   [CORE_ANNOTATIONS.RESTRICTION]: restrictionType,
   [CORE_ANNOTATIONS.HIDDEN]: StandardBuiltinTypes.BOOLEAN,

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -22,7 +22,7 @@ import {
   isReferenceExpression, StaticFile, isContainerType, isMapType, ObjectType,
   InstanceAnnotationTypes, GLOBAL_ADAPTER, SaltoError,
 } from '@salto-io/adapter-api'
-import { toObjectType } from '@salto-io/adapter-utils'
+import { toObjectType, elementAnnotationTypes } from '@salto-io/adapter-utils'
 import { InvalidStaticFile } from './workspace/static_files/common'
 import { UnresolvedReference, resolve, CircularReference } from './expressions'
 import { IllegalReference } from './parser/parse'
@@ -415,22 +415,25 @@ const validateFieldValue = (elemID: ElemID, value: Value, field: Field): Validat
   ))
 }
 
-const validateField = (field: Field): ValidationError[] =>
-  Object.keys(field.annotations)
-    .filter(k => field.type.annotationTypes[k])
+const validateField = (field: Field): ValidationError[] => {
+  const annotationTypes = elementAnnotationTypes(field)
+  return Object.keys(field.annotations)
+    .filter(k => annotationTypes[k])
     .flatMap(k => validateValue(
       field.elemID.createNestedID(k),
       field.annotations[k],
-      field.type.annotationTypes[k],
+      annotationTypes[k],
     ))
+}
 
 const validateType = (element: TypeElement): ValidationError[] => {
+  const annotationTypes = elementAnnotationTypes(element)
   const errors = Object.keys(element.annotations)
-    .filter(k => element.annotationTypes[k]).flatMap(
+    .filter(k => annotationTypes[k]).flatMap(
       k => validateValue(
         element.elemID.createNestedID('attr', k),
         element.annotations[k],
-        element.annotationTypes[k],
+        annotationTypes[k],
       )
     )
 

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -316,6 +316,24 @@ describe('Elements validation', () => {
       const errors = validateElements([objWithListAnnotation])
       expect(errors).toHaveLength(2)
     })
+
+    it('should return unresolved reference error in core annotations', () => {
+      const objWithUnresolvedRef = new ObjectType({
+        elemID: new ElemID('salto', 'test'),
+        fields: {
+          bad: {
+            type: BuiltinTypes.STRING,
+            annotations: {
+              [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [
+                new ReferenceExpression(new ElemID('salto', 'test', 'field', 'noSuchField')),
+              ],
+            },
+          },
+        },
+      })
+      const errors = validateElements([objWithUnresolvedRef])
+      expect(errors).toHaveLength(1)
+    })
   })
 
   describe('validate instances', () => {


### PR DESCRIPTION
- Before this change the validator would not check built in annotations because it would not get their types correctly
- Also changed the type of the `_default` core annotation to Unknown because it should support any type

---

_Release Notes_: 
- Fixed issue where broken references would not be detected when they were in built in annotations such as _generated_dependencies
