### PR TITLE
Remove the FatalMergeError logic - Drop all MergeError related elemen…

### DIFF
--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -24,7 +24,7 @@ import { logger } from '@salto-io/logging'
 import { progressOutputer, outputLine, errorOutputLine } from '../outputer'
 import { WorkspaceCommandAction, createWorkspaceCommand } from '../command_builder'
 import { CliOutput, CliExitCode, CliTelemetry } from '../types'
-import { formatMergeErrors, formatFatalFetchError, formatFetchHeader, formatFetchFinish, formatStateChanges, formatStateRecencies, formatAppliedChanges, formatFetchWarnings } from '../formatter'
+import { formatMergeErrors, formatFetchHeader, formatFetchFinish, formatStateChanges, formatStateRecencies, formatAppliedChanges, formatFetchWarnings } from '../formatter'
 import { getApprovedChanges as cliGetApprovedChanges, shouldUpdateConfig as cliShouldUpdateConfig, getChangeToAlignAction } from '../callbacks'
 import { getWorkspaceTelemetryTags, updateStateOnly, applyChangesToWorkspace, isValidWorkspaceForCommand } from '../workspace/workspace'
 import Prompts from '../prompts'
@@ -127,10 +127,6 @@ export const fetchCommand = async (
     services,
     regenerateSaltoIds,
   )
-  if (fetchResult.success === false) {
-    errorOutputLine(formatFatalFetchError(fetchResult.mergeErrors), output)
-    return CliExitCode.AppError
-  }
 
   // A few merge errors might have occurred,
   // but since it's fetch flow, we omitted the elements

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -452,11 +452,6 @@ export const formatFetchWarnings = (warnings: string[]): string => [
   `${Prompts.FETCH_WARNINGS}\n${warnings.join('\n\n')}`,
 ].join('\n')
 
-export const formatFatalFetchError = (mergeErrors: FetchResult['mergeErrors']): string =>
-  formatSimpleError(`${Prompts.FETCH_FATAL_MERGE_ERROR_PREFIX}${
-    mergeErrors.map(c => `Error: ${c.error.message}, Elements: ${c.elements.map(e => e.elemID.getFullName()).join(', ')}\n`)
-  }`)
-
 export const formatWorkspaceLoadFailed = (numErrors: number): string =>
   formatSimpleError(`${Prompts.WORKSPACE_LOAD_FAILED(numErrors)}`)
 

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -94,7 +94,6 @@ The steps are: I. Fetching configs, II. Calculating difference and III. Applying
   public static readonly FETCH_CONFLICTING_CHANGE = 'This change conflicts with the following pending change from your workspace:'
   public static readonly FETCH_MERGE_ERRORS = 'These errors occurred as part of the fetch:'
   public static readonly FETCH_WARNINGS = 'The fetch concluded with the following warnings:'
-  public static readonly FETCH_FATAL_MERGE_ERROR_PREFIX = 'Error occurred during fetch, cause:\n'
   public static readonly FETCH_CHANGES_APPLIED = (appliedChanges: number): string => `${appliedChanges} changes were applied to the local workspace`
   public static readonly APPLYING_CHANGES = 'Applying changes'
 

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -116,9 +116,6 @@ describe('fetch command', () => {
       const mockFetch = jest.fn().mockResolvedValue(
         { changes: [], mergeErrors: [], success: true }
       )
-      const mockFailedFetch = jest.fn().mockResolvedValue(
-        { changes: [], mergeErrors: [], success: false }
-      )
       const mockEmptyApprove = jest.fn().mockResolvedValue([])
       const mockUpdateConfig = jest.fn().mockResolvedValue(true)
 
@@ -530,25 +527,6 @@ describe('fetch command', () => {
               })
               expect(workspace.updateNaclFiles).toHaveBeenCalledWith([changes[0].change], 'default')
               expect(res).toBe(CliExitCode.Success)
-            })
-            it('should not update workspace if fetch failed', async () => {
-              const workspace = mocks.mockWorkspace({})
-              await fetchCommand({
-                workspace,
-                force: false,
-                services,
-                cliTelemetry,
-                output,
-                fetch: mockFailedFetch,
-                getApprovedChanges: mockSingleChangeApprove,
-                shouldUpdateConfig: mockUpdateConfig,
-                mode: 'default',
-                shouldCalcTotalSize: true,
-                stateOnly: false,
-                regenerateSaltoIds: false,
-              })
-              expect(output.stderr.content).toContain('Error')
-              expect(workspace.updateNaclFiles).not.toHaveBeenCalled()
             })
           })
         })

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -353,22 +353,6 @@ describe('fetch', () => {
         fields: {},
         annotations: { bla: 'blu' },
       })
-      describe('when state', () => {
-        describe('contains elements with errored elem ids', () => {
-          it('should throw an exception', async () => {
-            try {
-              mockAdapters.dummy.fetch.mockResolvedValueOnce(
-                Promise.resolve({ elements: [dupTypeBase, dupTypeBase2] })
-              )
-              await fetchChanges(mockAdapters, [], [dupTypeBase], [], [])
-              expect(false).toBeTruthy()
-            } catch (e) {
-              expect(e.message).toMatch(/.*duplicate annotation.*/)
-              expect(e.message).toMatch(/.*bla.*/)
-            }
-          })
-        })
-      })
       describe('when instance type has merge error', () => {
         let fetchChangesResult: FetchChangesResult
         let dupInstance: InstanceElement


### PR DESCRIPTION
…ts and do not fail the fetch

---

---
_Release Notes_: 
Core:
* MergeErrors on Elements that already exist in the workspace on Fetch do no longer fail the fetch. These errors are dropped.
