### PR TITLE
Fix salesforce flaky test timeout

### DIFF
--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -47,7 +47,7 @@ describe('SalesforceAdapter fetch', () => {
     { metadataType: '.*AssignmentRules', name: 'MyRules.*' },
   ]
 
-  const testMaxItemsInRetrieveRequest = 100
+  const testMaxItemsInRetrieveRequest = 20
 
   const mockFetchOpts: MockInterface<FetchOptions> = {
     progressReporter: { reportProgress: jest.fn() },


### PR DESCRIPTION
In the past few weeks one of the discovery tests fails occasionally on timeouts (mostly locally). It looks like it just got a little slower due to a recent change, and since it was already close to the time limit the extra slowness is causing the flakiness.

---

It looks like this started happening when the query throttling was added in https://github.com/salto-io/salto/commit/fda83465a99f58b9730bd634cc5743410132a035#diff-c8aa71d139bb13eaefbf09c63a685d3b7b071585b9751074a0dc53afeadd52d3R501 - and it's just some extra slowness that was added (using unlimited concurrent queries is still just a little too slow, but removing the decorator from the new functions is enough to get the tests to pass). We could increase the timeout by 1-2s, but it doesn't look like the current number of concurrent requests is really needed, so lowering it instead.

---
_Release Notes_: 
None
