### PR TITLE
SALTO-1304 Report progress post-fetch

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -54,6 +54,7 @@ export type DeployOptions = {
 export type PostFetchOptions = {
   currentAdapterElements: Element[]
   elementsByAdapter: Readonly<Record<string, ReadonlyArray<Readonly<Element>>>>
+  progressReporter: ProgressReporter
 }
 
 

--- a/packages/adapter-components/test/filter_utils.test.ts
+++ b/packages/adapter-components/test/filter_utils.test.ts
@@ -89,6 +89,7 @@ describe('filter utils', () => {
       const onPostFetchRes = runner.onPostFetch({
         elementsByAdapter: {},
         currentAdapterElements: [],
+        progressReporter: { reportProgress: jest.fn() },
       })
       await new Promise(resolve => setTimeout(resolve, 2))
       expect(mockOnPostFetch2).not.toHaveBeenCalled()

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -891,6 +891,7 @@ describe('fetch', () => {
               typeWithField,
             ]),
           },
+          progressReporter: expect.anything(),
         })
       })
     })
@@ -916,6 +917,7 @@ describe('fetch', () => {
               newTypeBaseModified,
             ]),
           },
+          progressReporter: expect.anything(),
         })
       })
     })
@@ -962,6 +964,7 @@ describe('fetch', () => {
             dummy2: expect.arrayContaining([dummy2Type1]),
             dummy3: expect.arrayContaining([dummy3Type1]),
           },
+          progressReporter: expect.anything(),
         })
         expect(adapters.dummy3.postFetch).toHaveBeenCalledWith({
           currentAdapterElements: expect.arrayContaining([dummy3Type1]),
@@ -970,6 +973,7 @@ describe('fetch', () => {
             dummy2: expect.arrayContaining([dummy2Type1]),
             dummy3: expect.arrayContaining([dummy3Type1]),
           },
+          progressReporter: expect.anything(),
         })
       })
       it('should call postFetch only for fetched adapters (with postFetch defined) when not all are fetched', async () => {
@@ -989,6 +993,7 @@ describe('fetch', () => {
             // dummy3 was not fetched so it includes only elements from the workspace
             dummy3: expect.arrayContaining([dummy3]),
           },
+          progressReporter: expect.anything(),
         })
         expect(adapters.dummy3.postFetch).not.toHaveBeenCalled()
       })
@@ -1010,6 +1015,7 @@ describe('fetch', () => {
             // dummy3 was not fetched so it includes only elements from the workspace
             dummy3: expect.arrayContaining([dummy3]),
           },
+          progressReporter: expect.anything(),
         })
         expect(adapters.dummy3.postFetch).not.toHaveBeenCalled()
       })

--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -106,6 +106,7 @@ export default class WorkatoAdapter implements AdapterOperations {
 
   @logDuration('updating cross-service references')
   async postFetch(args: PostFetchOptions): Promise<void> {
+    args.progressReporter.reportProgress({ message: 'Adding references to other services post-fetch' })
     await this.filtersRunner.onPostFetch(args)
   }
 

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -332,6 +332,7 @@ describe('adapter', () => {
           elementsByAdapter: {
             salesforce: [fishCustomObject],
           },
+          progressReporter: { reportProgress: () => null },
         })
         const recipeCodeWithRefs = currentAdapterElements.filter(isInstanceElement).find(e => e.elemID.getFullName().startsWith('workato.recipe__code.instance.pubsub_recipe_412'))
         expect(recipeCodeWithRefs).toBeDefined()

--- a/packages/workato-adapter/test/filters/recipe_references.test.ts
+++ b/packages/workato-adapter/test/filters/recipe_references.test.ts
@@ -714,6 +714,7 @@ describe('Recipe references filter', () => {
           salesforce: salesforceElements,
           netsuite: netsuiteElements,
         },
+        progressReporter: { reportProgress: () => null },
       })
     })
 
@@ -922,6 +923,7 @@ describe('Recipe references filter', () => {
           salesforce: [],
           netsuite: [],
         },
+        progressReporter: { reportProgress: () => null },
       })).toBeFalsy()
     })
 
@@ -955,6 +957,7 @@ describe('Recipe references filter', () => {
           salesforce: [],
           netsuite: [],
         },
+        progressReporter: { reportProgress: () => null },
       })).toBeFalsy()
       expect(
         elements.filter(e => e.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] !== undefined)
@@ -997,6 +1000,7 @@ describe('Recipe references filter', () => {
           salesforce: generateSalesforceElements(),
           netsuite: generateNetsuiteElements(),
         },
+        progressReporter: { reportProgress: () => null },
       })
       expect(
         elements.filter(e => e.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] !== undefined)
@@ -1060,6 +1064,7 @@ describe('Recipe references filter', () => {
           salesforce: salesforceElements,
           netsuite: netsuiteElements,
         },
+        progressReporter: { reportProgress: () => null },
       })
     })
 


### PR DESCRIPTION
Support reporting progress post-fetch as well, and use it in workato.

---

For now reusing the adapter's fetch progress report - we may want to revisit it later (see discussion on the ticket).

---
_Release Notes_: 
None
