### PR TITLE
SALTO-1319: JIRA adapter initial implementation

### DIFF
--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -405,7 +405,7 @@ export const getAllInstances = async ({
   computeGetArgs = defaultComputeGetArgs,
 }: {
   paginator: Paginator
-  apiConfig: AdapterSwaggerApiConfig
+  apiConfig: Pick<AdapterSwaggerApiConfig, 'types' | 'typeDefaults'>
   fetchConfig: UserFetchConfig
   objectTypes: Record<string, ObjectType>
   nestedFieldFinder?: FindNestedFieldFunc

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -118,9 +118,6 @@ describe('swagger_instance_elements', () => {
       const res = await getAllInstances({
         paginator: mockPaginator,
         apiConfig: {
-          swagger: {
-            url: 'ignored',
-          },
           typeDefaults: {
             transformation: {
               idFields: ['id'],
@@ -203,9 +200,6 @@ describe('swagger_instance_elements', () => {
       const res = await getAllInstances({
         paginator: mockPaginator,
         apiConfig: {
-          swagger: {
-            url: 'ignored',
-          },
           typeDefaults: {
             request: {
               paginationField: 'abc',
@@ -257,9 +251,6 @@ describe('swagger_instance_elements', () => {
       const res = await getAllInstances({
         paginator: mockPaginator,
         apiConfig: {
-          swagger: {
-            url: 'ignored',
-          },
           typeDefaults: {
             transformation: {
               idFields: ['id'],
@@ -372,9 +363,6 @@ describe('swagger_instance_elements', () => {
       const res = await getAllInstances({
         paginator: mockPaginator,
         apiConfig: {
-          swagger: {
-            url: 'ignored',
-          },
           typeDefaults: {
             transformation: {
               idFields: ['id'],
@@ -426,9 +414,6 @@ describe('swagger_instance_elements', () => {
       const res = await getAllInstances({
         paginator: mockPaginator,
         apiConfig: {
-          swagger: {
-            url: 'ignored',
-          },
           typeDefaults: {
             transformation: {
               idFields: ['id'],
@@ -508,9 +493,6 @@ describe('swagger_instance_elements', () => {
       const res = await getAllInstances({
         paginator: mockPaginator,
         apiConfig: {
-          swagger: {
-            url: 'ignored',
-          },
           typeDefaults: {
             transformation: {
               idFields: ['id'],
@@ -582,9 +564,6 @@ describe('swagger_instance_elements', () => {
       const res = await getAllInstances({
         paginator: mockPaginator,
         apiConfig: {
-          swagger: {
-            url: 'ignored',
-          },
           typeDefaults: {
             transformation: {
               idFields: ['id'],
@@ -656,9 +635,6 @@ describe('swagger_instance_elements', () => {
       const res = await getAllInstances({
         paginator: mockPaginator,
         apiConfig: {
-          swagger: {
-            url: 'ignored',
-          },
           typeDefaults: {
             transformation: {
               idFields: ['id'],
@@ -767,9 +743,6 @@ describe('swagger_instance_elements', () => {
       const res = await getAllInstances({
         paginator: mockPaginator,
         apiConfig: {
-          swagger: {
-            url: 'ignored',
-          },
           typeDefaults: {
             transformation: {
               idFields: ['name'],
@@ -848,9 +821,6 @@ describe('swagger_instance_elements', () => {
         instances = await getAllInstances({
           paginator: mockPaginator,
           apiConfig: {
-            swagger: {
-              url: 'ignored',
-            },
             typeDefaults: {
               transformation: {
                 idFields: ['id'],
@@ -977,9 +947,6 @@ describe('swagger_instance_elements', () => {
       await expect(() => getAllInstances({
         paginator: mockPaginator,
         apiConfig: {
-          swagger: {
-            url: 'ignored',
-          },
           typeDefaults: {
             transformation: {
               idFields: ['id'],
@@ -1001,9 +968,6 @@ describe('swagger_instance_elements', () => {
       await expect(() => getAllInstances({
         paginator: mockPaginator,
         apiConfig: {
-          swagger: {
-            url: 'ignored',
-          },
           typeDefaults: {
             transformation: {
               idFields: ['id'],
@@ -1025,9 +989,6 @@ describe('swagger_instance_elements', () => {
       await expect(() => getAllInstances({
         paginator: mockPaginator,
         apiConfig: {
-          swagger: {
-            url: 'ignored',
-          },
           typeDefaults: {
             transformation: {
               idFields: ['id'],

--- a/packages/cli/e2e_test/salto.test.ts
+++ b/packages/cli/e2e_test/salto.test.ts
@@ -140,7 +140,7 @@ describe('cli e2e', () => {
       await client.delete(ROLE, newInstance2FullName)
     }
     await runSalesforceLogin(fetchOutputDir)
-    await runFetch(fetchOutputDir) // TODO:ORI - uncomment
+    await runFetch(fetchOutputDir)
   })
 
   afterAll(async () => {

--- a/packages/core/src/core/adapters/creators.ts
+++ b/packages/core/src/core/adapters/creators.ts
@@ -21,6 +21,7 @@ import { adapter as marketoAdapter } from '@salto-io/marketo-adapter'
 import { adapter as dummyAdapter } from '@salto-io/dummy-adapter'
 import { adapter as workatoAdapter } from '@salto-io/workato-adapter'
 import { adapter as zuoraBillingAdapter } from '@salto-io/zuora-billing-adapter'
+import { adapter as jiraAdapter } from '@salto-io/jira-adapter'
 
 const adapterCreators: Record<string, Adapter> = {
   salesforce: salesforceAdapter,
@@ -31,6 +32,7 @@ const adapterCreators: Record<string, Adapter> = {
   workato: workatoAdapter,
   // eslint-disable-next-line @typescript-eslint/camelcase
   zuora_billing: zuoraBillingAdapter,
+  jira: jiraAdapter,
 }
 
 export default adapterCreators

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -25,16 +25,17 @@
         { "path": "../adapter-api" },
         { "path": "../adapter-utils" },
         { "path": "../dag" },
+        { "path": "../dummy-adapter" },
         { "path": "../file" },
-        { "path": "../workspace" },
         { "path": "../hubspot-adapter" },
-        { "path": "../netsuite-adapter" },
+        { "path": "../jira-adapter" },
         { "path": "../logging" },
         { "path": "../lowerdash" },
-        { "path": "../salesforce-adapter" },
         { "path": "../marketo-adapter" },
+        { "path": "../netsuite-adapter" },
+        { "path": "../salesforce-adapter" },
         { "path": "../workato-adapter" },
+        { "path": "../workspace" },
         { "path": "../zuora-billing-adapter" },
-        { "path": "../dummy-adapter" }
     ]
 }

--- a/packages/jira-adapter/.env.example
+++ b/packages/jira-adapter/.env.example
@@ -1,0 +1,5 @@
+
+# Note we depend on NODE_ENV being set to dictate which of the env variables below get loaded at runtime. 
+
+# Put lots of randomness in these
+SESSION_SECRET=ashdfjhasdlkjfhalksdjhflak

--- a/packages/jira-adapter/.env.example
+++ b/packages/jira-adapter/.env.example
@@ -1,5 +1,0 @@
-
-# Note we depend on NODE_ENV being set to dictate which of the env variables below get loaded at runtime. 
-
-# Put lots of randomness in these
-SESSION_SECRET=ashdfjhasdlkjfhalksdjhflak

--- a/packages/jira-adapter/.eslintignore
+++ b/packages/jira-adapter/.eslintignore
@@ -1,0 +1,7 @@
+/dist
+*.d.ts
+*.config.js
+coverage
+src/tools/
+/src/generated
+/package_native.js

--- a/packages/jira-adapter/.eslintrc.js
+++ b/packages/jira-adapter/.eslintrc.js
@@ -1,0 +1,27 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+const deepMerge = require('../../build_utils/deep_merge')
+
+module.exports = deepMerge(
+  require('../../eslintrc.js'),
+  require('../../eslint/adapter-api.rules.js'),
+  {
+    parserOptions: {
+      tsconfigRootDir: __dirname,
+    },
+  },
+)
+

--- a/packages/jira-adapter/.gitignore
+++ b/packages/jira-adapter/.gitignore
@@ -1,0 +1,9 @@
+# Coverage reports
+coverage
+/reports
+
+# API keys and secrets
+.env
+
+/dist
+

--- a/packages/jira-adapter/.vscode/launch.json
+++ b/packages/jira-adapter/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "jira-adapter Debug Jest Tests",
+      "cwd": "${workspaceFolder}",
+      "args": [
+        "${workspaceRoot}/node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceRoot}/jest.config.js"
+      ],
+      "outFiles": [],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}

--- a/packages/jira-adapter/README.md
+++ b/packages/jira-adapter/README.md
@@ -1,0 +1,3 @@
+# JIRA adapter
+
+Atlassian JIRA adapter for salto.io

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -1,0 +1,45 @@
+# JIRA adapter configuration
+## Configuration example
+```hcl
+jira {
+  client = {
+    retry = {
+      maxAttempts = 5
+      retryDelay = 5000
+      retryStrategy = "NetworkError"
+    }
+    rateLimit = {
+      total = -1
+      get = 10
+    }
+  }
+}
+```
+
+## Configuration options
+
+| Name                                                     | Default when undefined        | Description
+| ---------------------------------------------------------| ------------------------------| -----------
+| [client](#client-configuration-options)                  | {} (no overrides)             | Configuration relating to the client used to interact with JIRA
+
+### Client configuration options
+
+| Name                                                          | Default when undefined   | Description
+|---------------------------------------------------------------|--------------------------|------------
+| [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
+| [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
+
+#### Client retry options
+
+| Name           | Default when undefined | Description
+|----------------|------------------------|------------
+| maxAttempts    | `5`                    | The number of attempts to make for each request
+| retryDelay     | `5000` (5 seconds)     | The time (milliseconds) to wait between attempts
+| retryStrategy  | `NetworkError`         | In which cases to retry. Supported choices: `NetworkError` (retry on network errors), `HttpError` (retry on HTTP 5xx errors), or `HTTPOrNetworkError` (both)
+
+### Rate limit configuration options
+
+| Name                                                        | Default when undefined                           | Description
+| ------------------------------------------------------------| -------------------------------------------------| -----------
+| get                                                         | `10`                                             | Max number of concurrent get requests
+| total                                                       | `-1` (unlimited)                                 | Shared limit for all concurrent requests

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -13,6 +13,15 @@ jira {
       get = 10
     }
   }
+  fetch = {
+    includeTypes = [
+      "PageBeanDashboard",
+      "PageBeanField",
+      "PageBeanFieldConfiguration",
+      "PageBeanFieldConfigurationScheme",
+      "PageBeanFieldConfigurationIssueTypeItem",
+    ]
+  }
 }
 ```
 
@@ -20,7 +29,8 @@ jira {
 
 | Name                                                     | Default when undefined        | Description
 | ---------------------------------------------------------| ------------------------------| -----------
-| [client](#client-configuration-options)                  | {} (no overrides)             | Configuration relating to the client used to interact with JIRA
+| [client](#client-configuration-options)                  | `{}` (no overrides)             | Configuration relating to the client used to interact with JIRA
+| [fetch](#fetch-configuration-options)                    | `{}` (no overrides)             | Configuration relating to the endpoints that will be queried during fetch
 
 ### Client configuration options
 
@@ -43,3 +53,9 @@ jira {
 | ------------------------------------------------------------| -------------------------------------------------| -----------
 | get                                                         | `10`                                             | Max number of concurrent get requests
 | total                                                       | `-1` (unlimited)                                 | Shared limit for all concurrent requests
+
+## Fetch configuration options
+
+| Name                                        | Default when undefined          | Description
+|---------------------------------------------|---------------------------------|------------
+| includeTypes                                | []                              | List of types to fetch

--- a/packages/jira-adapter/index.ts
+++ b/packages/jira-adapter/index.ts
@@ -1,0 +1,17 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+export { adapter } from './src/adapter_creator'

--- a/packages/jira-adapter/jest.config.js
+++ b/packages/jira-adapter/jest.config.js
@@ -1,0 +1,37 @@
+/*
+*                      Copyright 2020 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+const deepMerge = require('../../build_utils/deep_merge')
+
+module.exports = deepMerge(
+  require('../../jest.base.config.js'),
+  {
+    name: 'jira-adapter',
+    displayName: 'jira-adapter',
+    rootDir: `${__dirname}`,
+    collectCoverageFrom: [
+      '!<rootDir>/dist/index.js',
+    ],
+    coverageThreshold: {
+      'global': {
+        branches: 95,
+        functions: 95,
+        lines: 95,
+        statements: 95,
+      },
+    },
+  },
+)
+

--- a/packages/jira-adapter/package.json
+++ b/packages/jira-adapter/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@salto-io/core",
+  "name": "@salto-io/jira-adapter",
   "version": "0.2.10",
   "license": "Apache-2.0",
-  "description": "Salto core",
+  "description": "Salto JIRA adapter",
   "repository": {
     "type": "git",
     "url": "https://github.com/salto-io/salto"
@@ -13,58 +13,37 @@
   "files": [
     "dist",
     "src",
-    "test",
     "index.ts"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "clean-ts": "../../build_utils/clean-old-ts.sh",
     "build": "yarn concurrently \"yarn lint\" \"yarn build-ts\"",
     "test": "jest",
-    "clean": "rm -rf ./dist .eslintcache  ./src/generated",
+    "clean": "rm -rf ./dist .eslintcache",
+    "clean-ts": "../../build_utils/clean-old-ts.sh",
     "clean-ts-test": "yarn clean-ts && yarn test",
     "watch-test": "yarn tsc-watch --onSuccess 'yarn clean-ts-test'",
     "build-ts": "tsc -b && yarn clean-ts",
     "watch-ts": "tsc -b -w",
     "lint": "eslint --cache --max-warnings 0 --ext .js,.jsx,.ts,.tsx ./",
-    "lint-fix": "yarn lint --fix",
-    "generate": "./generate.sh"
+    "lint-fix": "yarn lint --fix"
   },
   "dependencies": {
     "@salto-io/adapter-api": "0.2.10",
+    "@salto-io/adapter-components": "0.2.10",
     "@salto-io/adapter-utils": "0.2.10",
-    "@salto-io/dag": "0.2.10",
-    "@salto-io/dummy-adapter": "0.2.10",
-    "@salto-io/file": "0.2.10",
-    "@salto-io/hubspot-adapter": "0.2.10",
-    "@salto-io/jira-adapter": "0.2.10",
     "@salto-io/logging": "0.2.10",
     "@salto-io/lowerdash": "0.2.10",
-    "@salto-io/marketo-adapter": "0.2.10",
-    "@salto-io/netsuite-adapter": "0.2.10",
-    "@salto-io/salesforce-adapter": "0.2.10",
-    "@salto-io/workato-adapter": "0.2.10",
-    "@salto-io/workspace": "0.2.10",
-    "@salto-io/zuora-billing-adapter": "0.2.10",
-    "axios": "^0.21.1",
-    "glob": "^7.1.6",
-    "lodash": "^4.17.21",
-    "pietile-eventemitter": "^1.0.0",
-    "readdirp": "^3.1.1",
-    "semver": "^7.3.2",
-    "uuid": "^3.3.3",
-    "wu": "^2.1.0"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",
     "@types/lodash": "^4.14.168",
-    "@types/node": "^12.7.1",
-    "@types/tmp": "^0.1.0",
-    "@types/uuid": "^3.4.6",
-    "@types/wu": "^2.1.40",
     "@typescript-eslint/eslint-plugin": "2.31.0",
     "@typescript-eslint/parser": "2.31.0",
+    "axios": "^0.21.1",
+    "axios-mock-adapter": "^1.19.0",
     "eslint": "^6.2.2",
     "eslint-config-airbnb": "18.0.1",
     "eslint-plugin-header": "^3.0.0",
@@ -74,11 +53,8 @@
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^1.7.0",
     "jest": "^26.6.3",
-    "jest-circus": "^26.6.3",
     "jest-junit": "^12.0.0",
-    "nock": "^12.0.1",
     "tsc-watch": "^2.2.1",
-    "typescript": "3.9.3",
-    "wait-for-expect": "^3.0.2"
+    "typescript": "3.9.3"
   }
 }

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -1,0 +1,130 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  FetchResult, AdapterOperations, DeployResult, InstanceElement, TypeMap, isObjectType,
+} from '@salto-io/adapter-api'
+import { config as configUtils, elements as elementUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { logDuration } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import JiraClient from './client/client'
+import changeValidator from './change_validator'
+import { JiraConfig, getApiDefinitions } from './config'
+import { FilterCreator, Filter, filtersRunner } from './filter'
+import { JIRA } from './constants'
+import { pageByOffsetWithoutScopes } from './client/pagination'
+
+const { generateTypes, getAllInstances } = elementUtils.swagger
+const { createPaginator } = clientUtils
+const log = logger(module)
+
+export const DEFAULT_FILTERS = [
+]
+
+export interface JiraAdapterParams {
+  filterCreators?: FilterCreator[]
+  client: JiraClient
+  config: JiraConfig
+}
+
+export default class JiraAdapter implements AdapterOperations {
+  private filtersRunner: Required<Filter>
+  private client: JiraClient
+  private userConfig: JiraConfig
+  private paginator: clientUtils.Paginator
+
+  public constructor({
+    filterCreators = DEFAULT_FILTERS,
+    client,
+    config,
+  }: JiraAdapterParams) {
+    this.userConfig = config
+    this.client = client
+    this.paginator = createPaginator(
+      { paginationFunc: pageByOffsetWithoutScopes, client: this.client }
+    )
+    this.filtersRunner = filtersRunner(
+      this.client,
+      this.paginator,
+      config,
+      filterCreators
+    )
+  }
+
+  @logDuration('generating types from swagger')
+  private async getAllTypes(): Promise<{
+    allTypes: TypeMap
+    parsedConfigs: Record<string, configUtils.RequestableTypeSwaggerConfig>
+  }> {
+    const results = await Promise.all(
+      getApiDefinitions(this.userConfig.apiDefinitions).map(config => generateTypes(JIRA, config))
+    )
+    return _.merge({}, ...results)
+  }
+
+  @logDuration('generating instances from service')
+  private async getInstances(
+    allTypes: TypeMap,
+    parsedConfigs: Record<string, configUtils.RequestableTypeSwaggerConfig>
+  ): Promise<InstanceElement[]> {
+    const updatedApiDefinitionsConfig = {
+      ...this.userConfig.apiDefinitions,
+      types: {
+        ...parsedConfigs,
+        ..._.mapValues(
+          this.userConfig.apiDefinitions.types,
+          (def, typeName) => ({ ...parsedConfigs[typeName], ...def })
+        ),
+      },
+    }
+    return getAllInstances({
+      paginator: this.paginator,
+      objectTypes: _.pickBy(allTypes, isObjectType),
+      apiConfig: updatedApiDefinitionsConfig,
+      fetchConfig: this.userConfig.fetch,
+    })
+  }
+
+  @logDuration('fetching account configuration')
+  async fetch(): Promise<FetchResult> {
+    log.debug('going to fetch jira account configuration..')
+    const { allTypes, parsedConfigs } = await this.getAllTypes()
+    const instances = await this.getInstances(allTypes, parsedConfigs)
+
+    const elements = [
+      ...Object.values(allTypes),
+      ...instances,
+    ]
+
+    log.debug('going to run filters on %d fetched elements', elements.length)
+    await this.filtersRunner.onFetch(elements)
+    return { elements }
+  }
+
+  /**
+   * Deploy configuration elements to the given account.
+   */
+  @logDuration('deploying account configuration')
+  // eslint-disable-next-line class-methods-use-this
+  async deploy(): Promise<DeployResult> {
+    throw new Error('Not implemented.')
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get deployModifiers(): AdapterOperations['deployModifiers'] {
+    return { changeValidator }
+  }
+}

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -56,6 +56,9 @@ function validateConfig(config?: Readonly<InstanceElement>): asserts config is J
   if (!_.isPlainObject(apiDefinitions)) {
     throw new Error('Missing apiDefinitions from configuration')
   }
+  // Note - this is a temporary way of handling multiple swagger defs in the same adapter
+  // this will be replaced by built-in infrastructure support for multiple swagger defs
+  // in the configuration
   getApiDefinitions(apiDefinitions).forEach(swaggerDef => {
     validateSwaggerApiDefinitionConfig('apiDefinitions', swaggerDef)
   })

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -1,0 +1,105 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import {
+  InstanceElement, Adapter,
+} from '@salto-io/adapter-api'
+import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
+import JiraClient from './client/client'
+import JiraAdapter from './adapter'
+import { Credentials, basicAuthCredentialsType } from './auth'
+import { configType, JiraConfig, getApiDefinitions } from './config'
+import { createConnection, validateCredentials } from './client/connection'
+
+const log = logger(module)
+const { validateClientConfig, createRetryOptions, DEFAULT_RETRY_OPTS } = clientUtils
+const { validateSwaggerApiDefinitionConfig } = configUtils
+
+const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials => (
+  config.value as Credentials
+)
+
+type JiraConfigInstance = InstanceElement & { value: InstanceElement['value'] & JiraConfig }
+
+const validateFetchConfig = (config?: JiraConfig['fetch']): void => {
+  if (
+    config === undefined
+    || !Array.isArray(config.includeTypes)
+    || config.includeTypes.some(val => !_.isString(val))
+  ) {
+    throw new Error('fetch.includeTypes must be array of strings')
+  }
+}
+
+function validateConfig(config?: Readonly<InstanceElement>): asserts config is JiraConfigInstance {
+  if (config === undefined) {
+    throw new Error('configuration must not be empty')
+  }
+
+  const { client, apiDefinitions, fetch } = config.value
+
+  validateClientConfig('client', client)
+  if (!_.isPlainObject(apiDefinitions)) {
+    throw new Error('Missing apiDefinitions from configuration')
+  }
+  getApiDefinitions(apiDefinitions).forEach(swaggerDef => {
+    validateSwaggerApiDefinitionConfig('apiDefinitions', swaggerDef)
+  })
+  validateFetchConfig(fetch)
+}
+
+const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined): JiraConfig => {
+  validateConfig(config)
+
+  // Hack to make sure this is coupled with the type definition of JiraConfig
+  const adapterConfig: Record<keyof Required<JiraConfig>, null> = {
+    apiDefinitions: null,
+    client: null,
+    fetch: null,
+  }
+  Object.keys(config.value)
+    .filter(k => !Object.keys(adapterConfig).includes(k))
+    .forEach(k => log.debug('Unknown config property was found: %s', k))
+
+  return config.value
+}
+
+export const adapter: Adapter = {
+  operations: context => {
+    const config = adapterConfigFromConfig(context.config)
+    const credentials = credentialsFromConfig(context.credentials)
+    return new JiraAdapter({
+      client: new JiraClient({
+        credentials,
+        config: config.client,
+      }),
+      config,
+    })
+  },
+  validateCredentials: async config => {
+    const connection = createConnection(createRetryOptions(DEFAULT_RETRY_OPTS))
+    return validateCredentials({
+      connection: await connection.login(credentialsFromConfig(config)),
+    })
+  },
+  authenticationMethods: {
+    basic: {
+      credentialsType: basicAuthCredentialsType,
+    },
+  },
+  configType,
+}

--- a/packages/jira-adapter/src/auth.ts
+++ b/packages/jira-adapter/src/auth.ts
@@ -1,0 +1,35 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, BuiltinTypes } from '@salto-io/adapter-api'
+import { createMatchingObjectType } from '@salto-io/adapter-utils'
+import * as constants from './constants'
+
+type BasicAuthCredentials = {
+  baseUrl: string
+  user: string
+  token: string
+}
+
+export const basicAuthCredentialsType = createMatchingObjectType<BasicAuthCredentials>({
+  elemID: new ElemID(constants.JIRA),
+  fields: {
+    baseUrl: { type: BuiltinTypes.STRING, annotations: { _required: true } },
+    user: { type: BuiltinTypes.STRING, annotations: { _required: true } },
+    token: { type: BuiltinTypes.STRING, annotations: { _required: true } },
+  },
+})
+
+export type Credentials = BasicAuthCredentials

--- a/packages/jira-adapter/src/change_validator.ts
+++ b/packages/jira-adapter/src/change_validator.ts
@@ -1,0 +1,24 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator } from '@salto-io/adapter-api'
+import { createChangeValidator } from '@salto-io/adapter-utils'
+import { changeValidators } from '@salto-io/adapter-components'
+
+const { deployNotSupportedValidator } = changeValidators
+
+const validators: ChangeValidator[] = [deployNotSupportedValidator]
+
+export default createChangeValidator(validators)

--- a/packages/jira-adapter/src/client/client.ts
+++ b/packages/jira-adapter/src/client/client.ts
@@ -1,0 +1,51 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { createConnection } from './connection'
+import { JIRA } from '../constants'
+import { Credentials } from '../auth'
+
+const {
+  DEFAULT_RETRY_OPTS, RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
+} = clientUtils
+
+const DEFAULT_MAX_CONCURRENT_API_REQUESTS: Required<clientUtils.ClientRateLimitConfig> = {
+  total: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
+  get: 20,
+}
+
+const DEFAULT_PAGE_SIZE: Required<clientUtils.ClientPageSizeConfig> = {
+  get: 50,
+}
+
+export default class JiraClient extends clientUtils.AdapterHTTPClient<
+  Credentials, clientUtils.ClientRateLimitConfig
+> {
+  constructor(
+    clientOpts: clientUtils.ClientOpts<Credentials, clientUtils.ClientRateLimitConfig>,
+  ) {
+    super(
+      JIRA,
+      clientOpts,
+      createConnection,
+      {
+        pageSize: DEFAULT_PAGE_SIZE,
+        rateLimit: DEFAULT_MAX_CONCURRENT_API_REQUESTS,
+        retry: DEFAULT_RETRY_OPTS,
+      }
+    )
+  }
+}

--- a/packages/jira-adapter/src/client/connection.ts
+++ b/packages/jira-adapter/src/client/connection.ts
@@ -1,0 +1,39 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { AccountId } from '@salto-io/adapter-api'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { Credentials } from '../auth'
+
+export const validateCredentials = async (
+  { connection }: { connection: clientUtils.APIConnection },
+): Promise<AccountId> => {
+  const res = await connection.get('/rest/api/3/serverInfo')
+  return res.data.baseUrl
+}
+
+export const createConnection: clientUtils.ConnectionCreator<Credentials> = retryOptions => (
+  clientUtils.axiosConnection({
+    retryOptions,
+    authParamsFunc: async credentials => ({
+      auth: {
+        username: credentials.user,
+        password: credentials.token,
+      },
+    }),
+    baseURLFunc: ({ baseUrl }) => baseUrl,
+    credValidateFunc: async () => '', // There is no login endpoint to call
+  })
+)

--- a/packages/jira-adapter/src/client/pagination.ts
+++ b/packages/jira-adapter/src/client/pagination.ts
@@ -1,0 +1,56 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { client as clientUtils } from '@salto-io/adapter-components'
+
+const log = logger(module)
+const { mapAsync, handleErrorsAsync } = collections.asynciterable
+const { getWithOffsetAndLimit } = clientUtils
+
+const removeScopedObjects = <T extends unknown>(response: T): T => {
+  if (Array.isArray(response)) {
+    return response
+      .filter(item => !(_.isPlainObject(item) && Object.keys(item).includes('scope')))
+      .map(removeScopedObjects) as T
+  }
+  if (_.isObject(response)) {
+    return _.mapValues(response, removeScopedObjects) as T
+  }
+  return response
+}
+
+const suppressPageNotFoundError = (error: Error): void => {
+  // TODO - currently the http_client code catches the original error
+  // and transforms it such that it removes the parsed information (like the status code)
+  // we should probably stop doing that so that this code won't have to rely on the message
+  if (error.message.endsWith('Request failed with status code 404')) {
+    log.warn('%o', error)
+    return
+  }
+  throw error
+}
+
+export const pageByOffsetWithoutScopes: clientUtils.GetAllItemsFunc = args => (
+  mapAsync(
+    handleErrorsAsync(
+      getWithOffsetAndLimit(args),
+      suppressPageNotFoundError,
+    ),
+    removeScopedObjects,
+  )
+)

--- a/packages/jira-adapter/src/client/pagination.ts
+++ b/packages/jira-adapter/src/client/pagination.ts
@@ -35,9 +35,9 @@ const removeScopedObjects = <T extends unknown>(response: T): T => {
 }
 
 const suppressPageNotFoundError = (error: Error): void => {
-  // TODO - currently the http_client code catches the original error
-  // and transforms it such that it removes the parsed information (like the status code)
-  // we should probably stop doing that so that this code won't have to rely on the message
+  // The http_client code catches the original error and transforms it such that it removes
+  // the parsed information (like the status code), so we have to parse the string here in order
+  // to realize what type of error was thrown
   if (error.message.endsWith('Request failed with status code 404')) {
     log.warn('%o', error)
     return

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -338,15 +338,14 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       },
     },
   },
+  Workflow: {
+    transformation: {
+      idFields: ['id.name'],
+    },
+  },
   PageBeanWorkflowScheme: {
     request: {
       url: '/rest/api/3/workflowscheme',
-      paginationField: 'startAt',
-    },
-  },
-  Labels: {
-    request: {
-      url: '/rest/api/3/label',
       paginationField: 'startAt',
     },
   },
@@ -369,7 +368,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     },
   },
 
-  'agile__1_0__board_values@uuvuuu': {
+  Board: {
     transformation: {
       fieldTypeOverrides: [
         { fieldName: 'config', fieldType: 'list<agile__1_0__board___boardId___configuration@uuvuuuu_00123_00125uu>' },
@@ -387,15 +386,15 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
 export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
   platformSwagger: {
     url: 'https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json',
-    typeNameOverrides: [
-      {
-        originalName: 'PageBeanString',
-        newName: 'Labels',
-      },
-    ],
   },
   jiraSwagger: {
     url: 'https://developer.atlassian.com/cloud/jira/software/swagger.v3.json',
+    typeNameOverrides: [
+      {
+        originalName: 'agile__1_0__board_values@uuvuuu',
+        newName: 'Board',
+      },
+    ],
   },
   typeDefaults: {
     transformation: {
@@ -436,12 +435,10 @@ export const DEFAULT_INCLUDE_ENDPOINTS: string[] = [
   'rest__api__3__role',
   'PageBeanScreen',
   'PageBeanScreenScheme',
-  'rest__api__3__settings__columns',
   'rest__api__3__status',
   'rest__api__3__statuscategory',
   'PageBeanWorkflow',
   'PageBeanWorkflowScheme',
-  'Labels',
   'ServerInformation',
 
   // jira api

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -35,6 +35,15 @@ type JiraApiConfig = Omit<configUtils.AdapterSwaggerApiConfig, 'swagger'> & {
   jiraSwagger: configUtils.AdapterSwaggerApiConfig['swagger']
 }
 
+// A list of custom field types that support options
+// according to https://support.atlassian.com/jira-cloud-administration/docs/edit-a-custom-fields-options/
+const FIELD_TYPES_WITH_OPTIONS = [
+  'com.atlassian.jira.plugin.system.customfieldtypes:select',
+  'com.atlassian.jira.plugin.system.customfieldtypes:multiselect',
+  'com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect',
+  'com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons',
+  'com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes',
+]
 
 const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   // Cloud platform API
@@ -78,12 +87,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           context: [{ name: 'fieldId', fromField: 'id' }],
           conditions: [{
             fromField: 'schema.custom',
-            // TODO - not all types allow defaults and options
-            // not clear which types allow options and which do not
-            match: [
-              'com.atlassian.jira.plugin.system.customfieldtypes:select',
-              'com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect',
-            ],
+            match: FIELD_TYPES_WITH_OPTIONS,
           }],
         },
         {
@@ -106,7 +110,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       idFields: ['id'],
       fieldTypeOverrides: [
         { fieldName: 'contexts', fieldType: 'list<CustomFieldContext>' },
-        // TODO:ORI - move this to a "mapping" type fetch logic?
         { fieldName: 'contextDefaults', fieldType: 'list<CustomFieldContextDefaultValue>' },
         { fieldName: 'contextIssueTypes', fieldType: 'list<IssueTypeToContextMapping>' },
         { fieldName: 'contextProjects', fieldType: 'list<CustomFieldContextProjectMapping>' },
@@ -124,12 +127,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           context: [{ name: 'contextId', fromField: 'id' }],
           conditions: [{
             fromContext: 'fieldSchema',
-            // TODO - not all types allow defaults and options
-            // not clear which types allow options and which do not
-            match: [
-              'com.atlassian.jira.plugin.system.customfieldtypes:select',
-              'com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect',
-            ],
+            match: FIELD_TYPES_WITH_OPTIONS,
           }],
         },
       ],
@@ -247,7 +245,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   },
   Permissions: {
     request: {
-      // TODO - can we use "standalone fields" to extract the permissions to instances?
       url: '/rest/api/3/permissions',
     },
   },
@@ -348,8 +345,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     },
   },
   Labels: {
-    // TODO - need to handle this in a filter probably, this currently fetches each page
-    // as an instance, it cannot fetch the values because the values are strings
     request: {
       url: '/rest/api/3/label',
       paginationField: 'startAt',
@@ -425,7 +420,7 @@ export const DEFAULT_INCLUDE_ENDPOINTS: string[] = [
   'PageBeanFieldConfigurationIssueTypeItem',
   'PageBeanFilterDetails',
   'IssueLinkTypes',
-  'SecuritySchemes', // TODO - extend support for this (only supported on paid accounts)
+  'SecuritySchemes',
   'PageBeanIssueTypeScheme',
   'PageBeanIssueTypeSchemeMapping',
   'PageBeanIssueTypeScreenScheme',
@@ -441,7 +436,7 @@ export const DEFAULT_INCLUDE_ENDPOINTS: string[] = [
   'rest__api__3__role',
   'PageBeanScreen',
   'PageBeanScreenScheme',
-  'rest__api__3__settings__columns', // TODO - group these into one element
+  'rest__api__3__settings__columns',
   'rest__api__3__status',
   'rest__api__3__statuscategory',
   'PageBeanWorkflow',

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1,0 +1,518 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { createMatchingObjectType } from '@salto-io/adapter-utils'
+import { ElemID, CORE_ANNOTATIONS, BuiltinTypes, ObjectType } from '@salto-io/adapter-api'
+import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
+import { JIRA } from './constants'
+
+const { createClientConfigType } = clientUtils
+const { createUserFetchConfigType, createSwaggerAdapterApiConfigType } = configUtils
+
+const DEFAULT_ID_FIELDS = ['name']
+const FIELDS_TO_OMIT: configUtils.FieldToOmitType[] = [
+  { fieldName: 'expand', fieldType: 'string' },
+]
+
+type JiraClientConfig = clientUtils.ClientBaseConfig<clientUtils.ClientRateLimitConfig>
+
+type JiraFetchConfig = configUtils.UserFetchConfig
+type JiraApiConfig = Omit<configUtils.AdapterSwaggerApiConfig, 'swagger'> & {
+  platformSwagger: configUtils.AdapterSwaggerApiConfig['swagger']
+  jiraSwagger: configUtils.AdapterSwaggerApiConfig['swagger']
+}
+
+
+const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
+  // Cloud platform API
+  Configuration: {
+    transformation: {
+      dataField: '.',
+    },
+  },
+  PageBeanDashboard: {
+    request: {
+      url: '/rest/api/3/dashboard/search',
+      paginationField: 'startAt',
+      queryParams: {
+        expand: 'description,owner,viewUrl,favouritedCount,sharePermissions',
+      },
+    },
+  },
+  PageBeanField: {
+    request: {
+      url: '/rest/api/3/field/search',
+      paginationField: 'startAt',
+      queryParams: {
+        expand: 'key,searcherKey',
+      },
+      recurseInto: [
+        {
+          type: 'PageBeanCustomFieldContext',
+          toField: 'contexts',
+          context: [
+            { name: 'fieldId', fromField: 'id' },
+            { name: 'fieldSchema', fromField: 'schema.custom' },
+          ],
+          conditions: [{
+            fromField: 'id',
+            match: ['customfield_.*'],
+          }],
+        },
+        {
+          type: 'PageBeanCustomFieldContextDefaultValue',
+          toField: 'contextDefaults',
+          context: [{ name: 'fieldId', fromField: 'id' }],
+          conditions: [{
+            fromField: 'schema.custom',
+            // TODO - not all types allow defaults and options
+            // not clear which types allow options and which do not
+            match: [
+              'com.atlassian.jira.plugin.system.customfieldtypes:select',
+              'com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect',
+            ],
+          }],
+        },
+        {
+          type: 'PageBeanIssueTypeToContextMapping',
+          toField: 'contextIssueTypes',
+          context: [{ name: 'fieldId', fromField: 'id' }],
+          conditions: [{ fromField: 'id', match: ['customfield_.*'] }],
+        },
+        {
+          type: 'PageBeanCustomFieldContextProjectMapping',
+          toField: 'contextProjects',
+          context: [{ name: 'fieldId', fromField: 'id' }],
+          conditions: [{ fromField: 'id', match: ['customfield_.*'] }],
+        },
+      ],
+    },
+  },
+  Field: {
+    transformation: {
+      idFields: ['id'],
+      fieldTypeOverrides: [
+        { fieldName: 'contexts', fieldType: 'list<CustomFieldContext>' },
+        // TODO:ORI - move this to a "mapping" type fetch logic?
+        { fieldName: 'contextDefaults', fieldType: 'list<CustomFieldContextDefaultValue>' },
+        { fieldName: 'contextIssueTypes', fieldType: 'list<IssueTypeToContextMapping>' },
+        { fieldName: 'contextProjects', fieldType: 'list<CustomFieldContextProjectMapping>' },
+      ],
+    },
+  },
+  PageBeanCustomFieldContext: {
+    request: {
+      url: '/rest/api/3/field/{fieldId}/context',
+      paginationField: 'startAt',
+      recurseInto: [
+        {
+          type: 'PageBeanCustomFieldContextOption',
+          toField: 'options',
+          context: [{ name: 'contextId', fromField: 'id' }],
+          conditions: [{
+            fromContext: 'fieldSchema',
+            // TODO - not all types allow defaults and options
+            // not clear which types allow options and which do not
+            match: [
+              'com.atlassian.jira.plugin.system.customfieldtypes:select',
+              'com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect',
+            ],
+          }],
+        },
+      ],
+    },
+  },
+  CustomFieldContext: {
+    transformation: {
+      fieldTypeOverrides: [
+        { fieldName: 'options', fieldType: 'list<CustomFieldContextOption>' },
+      ],
+    },
+  },
+  PageBeanCustomFieldContextOption: {
+    request: {
+      url: '/rest/api/3/field/{fieldId}/context/{contextId}/option',
+      paginationField: 'startAt',
+    },
+  },
+  PageBeanFieldConfiguration: {
+    request: {
+      url: '/rest/api/3/fieldconfiguration',
+      paginationField: 'startAt',
+      recurseInto: [
+        {
+          type: 'PageBeanFieldConfigurationItem',
+          toField: 'fields',
+          context: [{ name: 'id', fromField: 'id' }],
+        },
+      ],
+    },
+  },
+  FieldConfiguration: {
+    transformation: {
+      fieldTypeOverrides: [
+        { fieldName: 'fields', fieldType: 'list<FieldConfigurationItem>' },
+      ],
+    },
+  },
+  PageBeanFieldConfigurationItem: {
+    request: {
+      url: '/rest/api/3/fieldconfiguration/{id}/fields',
+      paginationField: 'startAt',
+    },
+  },
+  PageBeanFieldConfigurationScheme: {
+    request: {
+      url: '/rest/api/3/fieldconfigurationscheme',
+      paginationField: 'startAt',
+    },
+  },
+  PageBeanFieldConfigurationIssueTypeItem: {
+    request: {
+      url: '/rest/api/3/fieldconfigurationscheme/mapping',
+      paginationField: 'startAt',
+    },
+  },
+  PageBeanFilterDetails: {
+    request: {
+      url: '/rest/api/3/filter/search',
+      queryParams: {
+        expand: 'description,owner,jql,searchUrl,viewUrl,sharePermissions,subscriptions',
+      },
+      paginationField: 'startAt',
+      recurseInto: [
+        {
+          // note - when the columns are default we get a 404 error if we try to get them
+          // there is no way to know ahead of time if a filter has columns configured
+          // but we suppress 404 errors so this works
+          type: 'rest__api__3__filter___id___columns@uuuuuuuu_00123_00125uu',
+          toField: 'columns',
+          context: [{ name: 'id', fromField: 'id' }],
+        },
+      ],
+    },
+  },
+  FilterDetails: {
+    transformation: {
+      fieldTypeOverrides: [
+        { fieldName: 'columns', fieldType: 'ColumnItem' },
+      ],
+    },
+  },
+  PageBeanIssueTypeScheme: {
+    request: {
+      url: '/rest/api/3/issuetypescheme',
+      paginationField: 'startAt',
+    },
+  },
+  PageBeanIssueTypeSchemeMapping: {
+    request: {
+      url: '/rest/api/3/issuetypescheme/mapping',
+      paginationField: 'startAt',
+    },
+  },
+  PageBeanIssueTypeScreenScheme: {
+    request: {
+      url: '/rest/api/3/issuetypescreenscheme',
+      paginationField: 'startAt',
+    },
+  },
+  PageBeanIssueTypeScreenSchemeItem: {
+    request: {
+      url: '/rest/api/3/issuetypescreenscheme/mapping',
+      paginationField: 'startAt',
+    },
+  },
+  PageBeanNotificationScheme: {
+    request: {
+      url: '/rest/api/3/notificationscheme',
+      queryParams: {
+        expand: 'all',
+      },
+      paginationField: 'startAt',
+    },
+  },
+  Permissions: {
+    request: {
+      // TODO - can we use "standalone fields" to extract the permissions to instances?
+      url: '/rest/api/3/permissions',
+    },
+  },
+  PermissionSchemes: {
+    request: {
+      url: '/rest/api/3/permissionscheme',
+      queryParams: {
+        expand: 'all',
+      },
+    },
+  },
+  ProjectType: {
+    transformation: {
+      idFields: ['key'],
+    },
+  },
+  PageBeanProject: {
+    request: {
+      url: '/rest/api/3/project/search',
+      queryParams: {
+        expand: 'description,lead,issueTypes,url,projectKeys,permissions',
+      },
+    },
+  },
+  PageBeanScreen: {
+    request: {
+      url: '/rest/api/3/screens',
+      paginationField: 'startAt',
+      recurseInto: [
+        {
+          type: 'rest__api__3__screens___screenId___tabs@uuuuuuuu_00123_00125uu',
+          toField: 'tabs',
+          context: [{ name: 'screenId', fromField: 'id' }],
+        },
+        {
+          type: 'rest__api__3__screens___screenId___availableFields@uuuuuuuu_00123_00125uu',
+          toField: 'availableFields',
+          context: [{ name: 'screenId', fromField: 'id' }],
+        },
+      ],
+    },
+  },
+  Screen: {
+    transformation: {
+      fieldTypeOverrides: [
+        { fieldName: 'tabs', fieldType: 'list<ScreenableTab>' },
+        { fieldName: 'availableFields', fieldType: 'list<ScreenableField>' },
+      ],
+    },
+  },
+  'rest__api__3__screens___screenId___tabs@uuuuuuuu_00123_00125uu': {
+    request: {
+      url: '/rest/api/3/screens/{screenId}/tabs',
+      recurseInto: [
+        {
+          type: 'rest__api__3__screens___screenId___tabs___tabId___fields@uuuuuuuu_00123_00125uuuu_00123_00125uu',
+          toField: 'fields',
+          context: [{ name: 'tabId', fromField: 'id' }],
+        },
+      ],
+    },
+    transformation: {
+      dataField: '.',
+    },
+  },
+  ScreenableTab: {
+    transformation: {
+      fieldTypeOverrides: [
+        { fieldName: 'fields', fieldType: 'list<ScreenableField>' },
+      ],
+    },
+  },
+  PageBeanScreenScheme: {
+    request: {
+      url: '/rest/api/3/screenscheme',
+      paginationField: 'startAt',
+    },
+  },
+  // eslint-disable-next-line @typescript-eslint/camelcase
+  rest__api__3__status: {
+    transformation: {
+      dataField: '.',
+    },
+  },
+  PageBeanWorkflow: {
+    request: {
+      url: '/rest/api/3/workflow/search',
+      paginationField: 'startAt',
+      queryParams: {
+        expand: 'transitions,transitions.rules,statuses,statuses.properties',
+      },
+    },
+  },
+  PageBeanWorkflowScheme: {
+    request: {
+      url: '/rest/api/3/workflowscheme',
+      paginationField: 'startAt',
+    },
+  },
+  Labels: {
+    // TODO - need to handle this in a filter probably, this currently fetches each page
+    // as an instance, it cannot fetch the values because the values are strings
+    request: {
+      url: '/rest/api/3/label',
+      paginationField: 'startAt',
+    },
+  },
+
+  // Jira API
+  'agile__1_0__board@uuvuu': {
+    request: {
+      url: '/rest/agile/1.0/board',
+      paginationField: 'startAt',
+      queryParams: {
+        expand: 'admins,permissions',
+      },
+      recurseInto: [
+        {
+          type: 'agile__1_0__board___boardId___configuration@uuvuuuu_00123_00125uu',
+          toField: 'config',
+          context: [{ name: 'boardId', fromField: 'id' }],
+        },
+      ],
+    },
+  },
+
+  'agile__1_0__board_values@uuvuuu': {
+    transformation: {
+      fieldTypeOverrides: [
+        { fieldName: 'config', fieldType: 'list<agile__1_0__board___boardId___configuration@uuvuuuu_00123_00125uu>' },
+      ],
+    },
+  },
+
+  'agile__1_0__board___boardId___configuration@uuvuuuu_00123_00125uu': {
+    request: {
+      url: '/rest/agile/1.0/board/{boardId}/configuration',
+    },
+  },
+}
+
+export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
+  platformSwagger: {
+    url: 'https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json',
+    typeNameOverrides: [
+      {
+        originalName: 'PageBeanString',
+        newName: 'Labels',
+      },
+    ],
+  },
+  jiraSwagger: {
+    url: 'https://developer.atlassian.com/cloud/jira/software/swagger.v3.json',
+  },
+  typeDefaults: {
+    transformation: {
+      idFields: DEFAULT_ID_FIELDS,
+      fieldsToOmit: FIELDS_TO_OMIT,
+    },
+  },
+  types: DEFAULT_TYPE_CUSTOMIZATIONS,
+}
+
+export const DEFAULT_INCLUDE_ENDPOINTS: string[] = [
+  // platform api
+  'rest__api__3__application_properties@uuuuuub', // ApplicationProperty
+  'rest__api__3__applicationrole',
+  'AttachmentSettings',
+  'Configuration',
+  'rest__api__3__configuration__timetracking__list', // TimeTrackingProvider
+  'PageBeanDashboard',
+  'PageBeanField',
+  'PageBeanFieldConfiguration',
+  'PageBeanFieldConfigurationScheme',
+  'PageBeanFieldConfigurationIssueTypeItem',
+  'PageBeanFilterDetails',
+  'IssueLinkTypes',
+  'SecuritySchemes', // TODO - extend support for this (only supported on paid accounts)
+  'PageBeanIssueTypeScheme',
+  'PageBeanIssueTypeSchemeMapping',
+  'PageBeanIssueTypeScreenScheme',
+  'PageBeanIssueTypeScreenSchemeItem',
+  'PageBeanNotificationScheme',
+  'Permissions',
+  'PermissionSchemes',
+  'rest__api__3__priority',
+  'rest__api__3__projectCategory',
+  'PageBeanProject',
+  'rest__api__3__project__type',
+  'rest__api__3__resolution',
+  'rest__api__3__role',
+  'PageBeanScreen',
+  'PageBeanScreenScheme',
+  'rest__api__3__settings__columns', // TODO - group these into one element
+  'rest__api__3__status',
+  'rest__api__3__statuscategory',
+  'PageBeanWorkflow',
+  'PageBeanWorkflowScheme',
+  'Labels',
+  'ServerInformation',
+
+  // jira api
+  'agile__1_0__board@uuvuu',
+]
+
+export type JiraConfig = {
+  client?: JiraClientConfig
+  fetch: JiraFetchConfig
+  apiDefinitions: JiraApiConfig
+}
+
+const defaultApiDefinitionsType = createSwaggerAdapterApiConfigType({ adapter: JIRA })
+
+const apiDefinitionsType = createMatchingObjectType<JiraApiConfig>({
+  elemID: new ElemID(JIRA, 'apiDefinitions'),
+  fields: {
+    apiVersion: { type: BuiltinTypes.STRING },
+    typeDefaults: {
+      type: defaultApiDefinitionsType.fields.typeDefaults.type as ObjectType,
+      annotations: { _required: true },
+    },
+    types: {
+      type: defaultApiDefinitionsType.fields.types.type as ObjectType,
+      annotations: { _required: true },
+    },
+    jiraSwagger: {
+      type: defaultApiDefinitionsType.fields.swagger.type as ObjectType,
+      annotations: { _required: true },
+    },
+    platformSwagger: {
+      type: defaultApiDefinitionsType.fields.swagger.type as ObjectType,
+      annotations: { _required: true },
+    },
+  },
+})
+
+export const configType = createMatchingObjectType<JiraConfig>({
+  elemID: new ElemID(JIRA),
+  fields: {
+    client: { type: createClientConfigType(JIRA) },
+    fetch: {
+      type: createUserFetchConfigType(JIRA),
+      annotations: {
+        _required: true,
+        [CORE_ANNOTATIONS.DEFAULT]: {
+          includeTypes: DEFAULT_INCLUDE_ENDPOINTS,
+        },
+      },
+    },
+    apiDefinitions: {
+      type: apiDefinitionsType,
+      annotations: {
+        _required: true,
+        [CORE_ANNOTATIONS.DEFAULT]: DEFAULT_API_DEFINITIONS,
+      },
+    },
+  },
+})
+
+export const getApiDefinitions = (config: JiraApiConfig): configUtils.AdapterSwaggerApiConfig[] => {
+  const baseConfig = _.omit(config, ['platformSwagger', 'jiraSwagger'])
+  return [
+    { ...baseConfig, swagger: config.platformSwagger },
+    { ...baseConfig, swagger: config.jiraSwagger },
+  ]
+}
+
+export type FilterContext = Pick<JiraConfig, 'fetch' | 'apiDefinitions'>

--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -1,0 +1,16 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+export const JIRA = 'jira'

--- a/packages/jira-adapter/src/filter.ts
+++ b/packages/jira-adapter/src/filter.ts
@@ -1,0 +1,24 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { filterUtils } from '@salto-io/adapter-components'
+import JiraClient from './client/client'
+import { FilterContext } from './config'
+
+export const { filtersRunner } = filterUtils
+
+export type Filter = filterUtils.Filter
+
+export type FilterCreator = filterUtils.FilterCreator<JiraClient, FilterContext>

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -1,0 +1,119 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { AdapterOperations, ObjectType, ElemID, ProgressReporter, FetchResult, InstanceElement } from '@salto-io/adapter-api'
+import { elements } from '@salto-io/adapter-components'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { adapter as adapterCreator } from '../src/adapter_creator'
+import { DEFAULT_INCLUDE_ENDPOINTS, DEFAULT_API_DEFINITIONS } from '../src/config'
+import { JIRA } from '../src/constants'
+import { createCredentialsInstance, createConfigInstance, mockFunction } from './utils'
+
+const { generateTypes, getAllInstances } = elements.swagger
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    elements: {
+      ...actual.elements,
+      swagger: {
+        ...actual.elements.swagger,
+        generateTypes: jest.fn().mockImplementation(actual.elements.swagger.generateTypes),
+        getAllInstances: jest.fn().mockImplementation(actual.elements.swagger.getAllInstances),
+      },
+    },
+  }
+})
+
+describe('adapter', () => {
+  let adapter: AdapterOperations
+  beforeEach(() => {
+    const elementsSource = buildElementsSourceFromElements([])
+    adapter = adapterCreator.operations({
+      elementsSource,
+      credentials: createCredentialsInstance({ baseUrl: 'http:/jira.net', user: 'u', token: 't' }),
+      config: createConfigInstance({
+        apiDefinitions: DEFAULT_API_DEFINITIONS,
+        fetch: { includeTypes: DEFAULT_INCLUDE_ENDPOINTS },
+      }),
+    })
+  })
+  describe('deploy', () => {
+    it('should throw not implemented', async () => {
+      await expect(
+        adapter.deploy({ changeGroup: { groupID: '', changes: [] } })
+      ).rejects.toThrow(new Error('Not implemented.'))
+    })
+  })
+  describe('deployModifiers', () => {
+    it('should have change validator', () => {
+      expect(adapter.deployModifiers?.changeValidator).toBeDefined()
+    })
+  })
+
+  describe('fetch', () => {
+    let progressReporter: ProgressReporter
+    let result: FetchResult
+    beforeEach(async () => {
+      progressReporter = {
+        reportProgress: mockFunction<ProgressReporter['reportProgress']>(),
+      }
+      const platformTestType = new ObjectType({
+        elemID: new ElemID(JIRA, 'platform'),
+      })
+      const jiraTestType = new ObjectType({
+        elemID: new ElemID(JIRA, 'jira'),
+      })
+      const testInstance = new InstanceElement('test', jiraTestType);
+
+      (generateTypes as jest.MockedFunction<typeof generateTypes>)
+        .mockResolvedValueOnce({
+          allTypes: { PlatformTest: platformTestType },
+          parsedConfigs: { PlatformTest: { request: { url: 'platform' } } },
+        })
+        .mockResolvedValueOnce({
+          allTypes: { JiraTest: jiraTestType },
+          parsedConfigs: { JiraTest: { request: { url: 'jira' } } },
+        });
+
+      (getAllInstances as jest.MockedFunction<typeof getAllInstances>)
+        .mockResolvedValue([testInstance])
+
+      result = await adapter.fetch({ progressReporter })
+    })
+    it('should generate types for the platform and the jira apis', () => {
+      expect(generateTypes).toHaveBeenCalledWith(
+        JIRA,
+        expect.objectContaining({
+          swagger: expect.objectContaining({
+            url: 'https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json',
+          }),
+        })
+      )
+      expect(generateTypes).toHaveBeenCalledWith(
+        JIRA,
+        expect.objectContaining({
+          swagger: expect.objectContaining({
+            url: 'https://developer.atlassian.com/cloud/jira/software/swagger.v3.json',
+          }),
+        })
+      )
+    })
+    it('should return all types and instances returned from the infrastructure', () => {
+      expect(result.elements).toHaveLength(3)
+    })
+  })
+})

--- a/packages/jira-adapter/test/adapter_creator.test.ts
+++ b/packages/jira-adapter/test/adapter_creator.test.ts
@@ -1,0 +1,137 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { ObjectType, InstanceElement, AccountId, ReadOnlyElementsSource, AdapterOperations } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { adapter } from '../src/adapter_creator'
+import JiraAdapter from '../src/adapter'
+import { JiraConfig, DEFAULT_API_DEFINITIONS, DEFAULT_INCLUDE_ENDPOINTS } from '../src/config'
+import { createCredentialsInstance, createConfigInstance } from './utils'
+
+describe('adapter creator', () => {
+  let mockAxiosAdapter: MockAdapter
+  beforeEach(() => {
+    mockAxiosAdapter = new MockAdapter(axios, { delayResponse: 1, onNoMatch: 'throwException' })
+  })
+
+  afterEach(() => {
+    mockAxiosAdapter.restore()
+  })
+
+  it('should have a config type', () => {
+    expect(adapter.configType).toBeInstanceOf(ObjectType)
+  })
+
+  it('should support basic auth', () => {
+    expect(adapter.authenticationMethods.basic.credentialsType).toBeInstanceOf(ObjectType)
+  })
+
+  describe('validateCredentials', () => {
+    describe('with valid credentials', () => {
+      let accountId: AccountId
+      beforeEach(async () => {
+        mockAxiosAdapter.onGet().reply(200, { baseUrl: 'http://my_account.net' })
+        accountId = await adapter.validateCredentials(
+          createCredentialsInstance({ baseUrl: 'http://my.net', user: 'u', token: 't' })
+        )
+      })
+      it('should make an authenticated rest call', () => {
+        expect(mockAxiosAdapter.history).toBeDefined()
+      })
+      it('should return base url as account ID', () => {
+        expect(accountId).toEqual('http://my_account.net')
+      })
+    })
+
+    describe('with invalid credentials', () => {
+      let result: Promise<AccountId>
+      beforeEach(() => {
+        mockAxiosAdapter.onGet().reply(403)
+        result = adapter.validateCredentials(
+          createCredentialsInstance({ baseUrl: 'http://my.net', user: 'u', token: 't' })
+        )
+      })
+      it('should fail', async () => {
+        await expect(result).rejects.toThrow()
+      })
+    })
+  })
+
+  describe('create adapter', () => {
+    let elementsSource: ReadOnlyElementsSource
+    let credentialsInstance: InstanceElement
+    const defaultConfig: JiraConfig = {
+      apiDefinitions: DEFAULT_API_DEFINITIONS,
+      fetch: { includeTypes: DEFAULT_INCLUDE_ENDPOINTS },
+    }
+    beforeEach(() => {
+      elementsSource = buildElementsSourceFromElements([])
+      credentialsInstance = createCredentialsInstance({ baseUrl: 'url', user: 'u', token: 't' })
+    })
+    describe('with valid config', () => {
+      let result: AdapterOperations
+      beforeEach(() => {
+        const configWithExtraValue = {
+          ...defaultConfig,
+          extraValue: true,
+        }
+        result = adapter.operations({
+          elementsSource,
+          credentials: credentialsInstance,
+          config: createConfigInstance(configWithExtraValue),
+        })
+      })
+      it('should return jira operations', () => {
+        expect(result).toBeInstanceOf(JiraAdapter)
+      })
+    })
+
+    describe('without config', () => {
+      it('should fail to create operations', () => {
+        expect(
+          () => adapter.operations({ elementsSource, credentials: credentialsInstance })
+        ).toThrow()
+      })
+    })
+
+    describe('without fetch config', () => {
+      it('should fail to create operations', () => {
+        expect(() => adapter.operations({
+          elementsSource,
+          credentials: credentialsInstance,
+          config: createConfigInstance({
+            ...defaultConfig,
+            fetch: undefined,
+          } as unknown as JiraConfig),
+        })).toThrow()
+      })
+    })
+
+    describe('without api config', () => {
+      it('should fail to create operations', () => {
+        expect(() => adapter.operations({
+          elementsSource,
+          credentials: credentialsInstance,
+          config: createConfigInstance({
+            ...defaultConfig,
+            apiDefinitions: undefined,
+          } as unknown as JiraConfig),
+        })).toThrow()
+      })
+    })
+  })
+})

--- a/packages/jira-adapter/test/change_validator.test.ts
+++ b/packages/jira-adapter/test/change_validator.test.ts
@@ -1,0 +1,46 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID } from '@salto-io/adapter-api'
+import changeValidator from '../src/change_validator'
+import { JIRA } from '../src/constants'
+
+describe('change validator creator', () => {
+  describe('deployNotSupportedValidator', () => {
+    it('should not fail if there are no deploy changes', async () => {
+      expect(await changeValidator([])).toEqual([])
+    })
+
+    it('should fail each change individually', async () => {
+      expect(await changeValidator([
+        toChange({ after: new ObjectType({ elemID: new ElemID(JIRA, 'obj') }) }),
+        toChange({ before: new ObjectType({ elemID: new ElemID(JIRA, 'obj2') }) }),
+      ])).toEqual([
+        {
+          elemID: new ElemID(JIRA, 'obj'),
+          severity: 'Error',
+          message: 'Deploy is not supported.',
+          detailedMessage: 'Deploy is not supported.',
+        },
+        {
+          elemID: new ElemID(JIRA, 'obj2'),
+          severity: 'Error',
+          message: 'Deploy is not supported.',
+          detailedMessage: 'Deploy is not supported.',
+        },
+      ])
+    })
+  })
+})

--- a/packages/jira-adapter/test/client/client.test.ts
+++ b/packages/jira-adapter/test/client/client.test.ts
@@ -1,0 +1,66 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import JiraClient from '../../src/client/client'
+
+describe('client', () => {
+  let client: JiraClient
+  let mockAxios: MockAdapter
+  beforeEach(() => {
+    mockAxios = new MockAdapter(axios)
+    client = new JiraClient({ credentials: { baseUrl: 'http://myjira.net', user: 'me', token: 'tok' } })
+  })
+  afterEach(() => {
+    mockAxios.restore()
+  })
+
+  describe('getSinglePage', () => {
+    let result: clientUtils.ResponseValue
+    beforeEach(async () => {
+      mockAxios.onGet().reply(200, { response: 'asd' })
+      result = await client.getSinglePage({ url: '/myPath' })
+    })
+    it('should not try to call a login endpoint', () => {
+      expect(mockAxios.history.get).toHaveLength(1)
+    })
+    it('should request the correct path with auth headers', () => {
+      const request = mockAxios.history.get[0]
+      expect(request.auth).toEqual({ username: 'me', password: 'tok' })
+      expect(request.baseURL).toEqual('http://myjira.net')
+      expect(request.url).toEqual('/myPath')
+    })
+    it('should return the response', () => {
+      expect(result).toEqual({ status: 200, data: { response: 'asd' } })
+    })
+  })
+})

--- a/packages/jira-adapter/test/client/connection.test.ts
+++ b/packages/jira-adapter/test/client/connection.test.ts
@@ -1,0 +1,61 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { validateCredentials, createConnection } from '../../src/client/connection'
+
+describe('validateCredentials', () => {
+  let mockAxios: MockAdapter
+  let result: string
+  beforeEach(async () => {
+    mockAxios = new MockAdapter(axios)
+    mockAxios.onGet().reply(200, { baseUrl: 'http://my.jira.net' })
+    const connection = await createConnection({ retries: 1 }).login(
+      { baseUrl: 'http://myJira.net', user: 'me', token: 'tok' }
+    )
+    result = await validateCredentials({ connection })
+  })
+  afterEach(() => {
+    mockAxios.restore()
+  })
+
+  it('should get server info with auth headers', () => {
+    expect(mockAxios.history.get).toHaveLength(1)
+    const request = mockAxios.history.get[0]
+    expect(request.url).toEqual('/rest/api/3/serverInfo')
+    expect(request.baseURL).toEqual('http://myJira.net')
+    expect(request.auth).toEqual({ username: 'me', password: 'tok' })
+  })
+
+  it('should return the base url from the response as account id', () => {
+    expect(result).toEqual('http://my.jira.net')
+  })
+})

--- a/packages/jira-adapter/test/client/pagination.test.ts
+++ b/packages/jira-adapter/test/client/pagination.test.ts
@@ -1,0 +1,99 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { collections } from '@salto-io/lowerdash'
+import JiraClient from '../../src/client/client'
+import { pageByOffsetWithoutScopes } from '../../src/client/pagination'
+
+const { toArrayAsync } = collections.asynciterable
+
+describe('pageByOffsetWithoutScopes', () => {
+  let client: JiraClient
+  let mockAxios: MockAdapter
+  beforeEach(() => {
+    mockAxios = new MockAdapter(axios)
+    client = new JiraClient({ credentials: { baseUrl: 'http://myjira.net', user: 'me', token: 'tok' } })
+  })
+  afterEach(() => {
+    mockAxios.restore()
+  })
+
+  describe('when there are scoped entities in the response', () => {
+    let responses: clientUtils.ResponseValue[][]
+    beforeEach(async () => {
+      mockAxios.onGet().reply(
+        200,
+        [
+          { name: 'thing' },
+          { name: 'scoped', scope: {} },
+          { name: 'nested scope', nested: [{ name: 'valid' }, { name: 'bad', scope: {} }] },
+        ],
+      )
+      responses = await toArrayAsync(
+        pageByOffsetWithoutScopes(
+          { client, getParams: { url: 'http://myjira.net/thing' }, pageSize: 1 }
+        )
+      )
+    })
+    it('should omit the scoped entities from the response', () => {
+      expect(responses).toHaveLength(1)
+      const [page] = responses
+      expect(page).not.toContainEqual(expect.objectContaining({ scope: expect.anything() }))
+    })
+    it('should keep non-scoped entities', () => {
+      const [page] = responses
+      expect(page[0]).toEqual({ name: 'thing' })
+    })
+    it('should omit nested scoped entities from the response', () => {
+      const [page] = responses
+      expect(page[1]).toEqual({ name: 'nested scope', nested: [{ name: 'valid' }] })
+    })
+  })
+
+  describe('when there is a 404 response', () => {
+    let responses: clientUtils.ResponseValue[][]
+    beforeEach(async () => {
+      mockAxios.onGet().reply(404)
+      responses = await toArrayAsync(
+        pageByOffsetWithoutScopes({
+          client,
+          getParams: { url: 'http://myjira.net/thing/1', paginationField: 'startAt' },
+          pageSize: 1,
+        })
+      )
+    })
+    it('should return an empty result', () => {
+      expect(responses).toHaveLength(0)
+    })
+  })
+
+  describe('when there is a non-404 error response', () => {
+    let responseIter: AsyncIterable<clientUtils.ResponseValue[]>
+    beforeEach(() => {
+      mockAxios.onGet().reply(400)
+      responseIter = pageByOffsetWithoutScopes({
+        client,
+        getParams: { url: 'http://myjira.net/thing/1', paginationField: 'startAt' },
+        pageSize: 1,
+      })
+    })
+    it('should throw the error', async () => {
+      await expect(toArrayAsync(responseIter)).rejects.toThrow()
+    })
+  })
+})

--- a/packages/jira-adapter/test/utils.ts
+++ b/packages/jira-adapter/test/utils.ts
@@ -1,0 +1,49 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, ElemID, ObjectType } from '@salto-io/adapter-api'
+import { adapter } from '../src/adapter_creator'
+import { Credentials } from '../src/auth'
+import { JiraConfig } from '../src/config'
+
+export type MockFunction<T extends (...args: never[]) => unknown> =
+  jest.Mock<ReturnType<T>, Parameters<T>>
+
+export type MockInterface<T extends {}> = {
+  [k in keyof T]: T[k] extends (...args: never[]) => unknown
+    ? MockFunction<T[k]>
+    : MockInterface<T[k]>
+}
+
+export const mockFunction = <T extends (...args: never[]) => unknown>(): MockFunction<T> => (
+  jest.fn()
+)
+
+
+export const createCredentialsInstance = (credentials: Credentials): InstanceElement => (
+  new InstanceElement(
+    ElemID.CONFIG_NAME,
+    adapter.authenticationMethods.basic.credentialsType,
+    credentials,
+  )
+)
+
+export const createConfigInstance = (config: JiraConfig): InstanceElement => (
+  new InstanceElement(
+    ElemID.CONFIG_NAME,
+    adapter.configType as ObjectType,
+    config,
+  )
+)

--- a/packages/jira-adapter/tsconfig.json
+++ b/packages/jira-adapter/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "baseUrl": ".",
+        "declaration": true,
+        "resolveJsonModule": true,
+    },
+    "include": [
+        "src/**/*",
+        "src/**/*.json",
+        "test/**/*",
+        "test/**/*.json",
+        "e2e_test/**/*",
+        "index.ts"
+    ],
+    "references": [
+        { "path": "../adapter-api" },
+        { "path": "../adapter-components" },
+        { "path": "../adapter-utils" },
+        { "path": "../logging" },
+        { "path": "../lowerdash" },
+    ]
+}


### PR DESCRIPTION
A very initial implementation of a JIRA read-only adapter.
Only basic auth supported for now and only infrastructure features are used to fetch information.

---

[Sample workspace](https://github.com/salto-io/adapter-sample-jira-workspace)

---
_Release Notes_: 
None (this adapter is not ready to be announced as released yet)
