### PR TITLE
SALTO-1314 Update generated dependencies format

### DIFF
--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -51,7 +51,7 @@ const StandardBuiltinTypes = {
 }
 
 const restrictionType = new ObjectType({
-  elemID: new ElemID('', 'restriction'),
+  elemID: new ElemID(GLOBAL_ADAPTER, 'restriction'),
   fields: {
     // eslint-disable-next-line camelcase
     enforce_value: {
@@ -84,6 +84,24 @@ const restrictionType = new ObjectType({
         StandardBuiltinTypes.STRING,
       ),
     },
+  },
+})
+
+const dependencyOccurrenceType = new ObjectType({
+  elemID: new ElemID(GLOBAL_ADAPTER, 'dependencyOccurrence'),
+  fields: {
+    direction: { refType: StandardBuiltinTypes.STRING },
+    location: { refType: StandardBuiltinTypes.UNKNOWN },
+  },
+})
+const dependencyType = new ObjectType({
+  elemID: new ElemID(GLOBAL_ADAPTER, 'dependency'),
+  fields: {
+    reference: {
+      refType: StandardBuiltinTypes.UNKNOWN,
+      annotations: { [CORE_ANNOTATIONS.REQUIRED]: true },
+    },
+    occurrences: { refType: new ListType(dependencyOccurrenceType) },
   },
 })
 
@@ -127,9 +145,9 @@ export const BuiltinTypesRefByFullName = _.mapValues(
 )
 
 export const InstanceAnnotationTypes: TypeMap = {
-  [INSTANCE_ANNOTATIONS.DEPENDS_ON]: new ListType(StandardBuiltinTypes.STRING),
+  [INSTANCE_ANNOTATIONS.DEPENDS_ON]: new ListType(dependencyType),
   [INSTANCE_ANNOTATIONS.PARENT]: new ListType(StandardBuiltinTypes.STRING),
-  [INSTANCE_ANNOTATIONS.GENERATED_DEPENDENCIES]: new ListType(StandardBuiltinTypes.UNKNOWN),
+  [INSTANCE_ANNOTATIONS.GENERATED_DEPENDENCIES]: new ListType(dependencyType),
   [INSTANCE_ANNOTATIONS.HIDDEN]: StandardBuiltinTypes.BOOLEAN,
   [INSTANCE_ANNOTATIONS.SERVICE_URL]: BuiltinTypes.HIDDEN_STRING,
 }

--- a/packages/adapter-utils/index.ts
+++ b/packages/adapter-utils/index.ts
@@ -13,11 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export * from './src/utils'
-export * from './src/nacl_case_utils'
 export * from './src/change_validator'
-export * from './src/decorators'
-export * from './src/deploy'
 export * from './src/compare'
+export * from './src/decorators'
+export * from './src/dependencies'
+export * from './src/deploy'
 export * from './src/element_source'
 export * from './src/element'
+export * from './src/nacl_case_utils'
+export * from './src/utils'

--- a/packages/adapter-utils/src/dependencies.ts
+++ b/packages/adapter-utils/src/dependencies.ts
@@ -1,0 +1,128 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
+import {
+  Element, ReferenceExpression, CORE_ANNOTATIONS,
+} from '@salto-io/adapter-api'
+
+export type DependencyDirection = 'input' | 'output'
+
+type DependencyOccurrence = {
+  direction?: DependencyDirection
+  location?: ReferenceExpression
+}
+export type DetailedDependency = {
+  reference: ReferenceExpression
+  occurrences?: DependencyOccurrence[]
+}
+export type FlatDetailedDependency = {
+  reference: ReferenceExpression
+} & DependencyOccurrence
+
+/**
+ * Add additional generated dependencies while keeping the structure sorted and filtered
+ */
+export const extendGeneratedDependencies = (
+  elem: Element,
+  newDependencies: FlatDetailedDependency[],
+): void => {
+  if (newDependencies.length === 0) {
+    return
+  }
+
+  /**
+   * Remove entries that are not adding information:
+   * - For each direction (input/output), prefer an entry with a specific location
+   * - For each location, prefer an entry with a specific direction
+   * - Do not include a no-location no-direction entry if any other entries are listed
+   */
+  const preferSpecific = (
+    occurrences?: DependencyOccurrence[]
+  ): DependencyOccurrence[] | undefined => {
+    if (
+      occurrences === undefined
+      || occurrences.length === 0
+      || occurrences.every(oc => oc.location === undefined && oc.direction === undefined)
+    ) {
+      return undefined
+    }
+
+    const byDirection = _.groupBy(occurrences, oc => oc.direction ?? '')
+    const byLocation = _.groupBy(occurrences, oc => oc.location?.elemID.getFullName() ?? '')
+    return occurrences.filter(({ location, direction }) => (
+      (
+        location !== undefined
+        && (direction !== undefined || byLocation[location.elemID.getFullName()]?.every(
+          entry => entry.direction === undefined
+        ))
+      ) || (
+        direction !== undefined
+        && (location !== undefined || byDirection[direction]?.every(
+          entry => entry.location === undefined
+        ))
+      )
+    ))
+  }
+  const occurrenceIndex = (item: DependencyOccurrence): string => [item.direction ?? '', item.location?.elemID.getFullName() ?? ''].join(':')
+
+  const existingDepsLookup = _.keyBy(
+    collections.array.makeArray(elem.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]),
+    ({ reference }) => reference.elemID.getFullName(),
+  )
+  const newDepsLookup = _.mapValues(
+    _.groupBy(
+      newDependencies,
+      ({ reference }) => reference.elemID.getFullName(),
+    ),
+    items => ({
+      reference: items[0].reference,
+      occurrences: _.uniqBy(
+        items.map(({ reference: _ref, ...occurrences }) => occurrences),
+        occurrenceIndex,
+      ),
+    })
+  )
+  const allDeps: Record<string, DetailedDependency> = _.mergeWith(
+    {},
+    existingDepsLookup,
+    newDepsLookup,
+    (existingDeps: DetailedDependency | undefined, newDeps: DetailedDependency) => {
+      if (existingDeps === undefined) {
+        return newDeps
+      }
+      return {
+        reference: newDeps.reference,
+        occurrences: _.sortedUniqBy(
+          _.sortBy(
+            [...(existingDeps.occurrences ?? []), ...(newDeps.occurrences ?? [])],
+            occurrenceIndex,
+          ),
+          occurrenceIndex,
+        ),
+      }
+    },
+  )
+
+  const filteredUniqueDeps = Object.values(allDeps).map(dep => ({
+    ...dep, occurrences: preferSpecific(dep.occurrences),
+  }))
+
+  elem.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] = _.sortBy(
+    filteredUniqueDeps,
+    ({ reference }) => reference.elemID.getFullName(),
+  )
+}

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -892,22 +892,6 @@ export const getParents = (instance: Element): Array<Value> => (
   collections.array.makeArray(instance.annotations[CORE_ANNOTATIONS.PARENT])
 )
 
-export const extendGeneratedDependencies = (
-  elem: Element,
-  newDependencies: ReferenceExpression[],
-): void => {
-  elem.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] = _.sortedUniqBy(
-    _.sortBy(
-      [
-        ...collections.array.makeArray(elem.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]),
-        ...newDependencies,
-      ],
-      ref => ref.elemID.getFullName(),
-    ),
-    ref => ref.elemID.getFullName(),
-  )
-}
-
 // In the current use-cases for resolveTypeShallow it makes sense
 // to use the value on the ref over the elementsSource, unlike the
 // current Reference.getResolvedValue implementation

--- a/packages/adapter-utils/test/dependencies.test.ts
+++ b/packages/adapter-utils/test/dependencies.test.ts
@@ -1,0 +1,324 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  InstanceElement, ObjectType, PrimitiveTypes, PrimitiveType, ReferenceExpression, ElemID, ListType,
+  BuiltinTypes, CORE_ANNOTATIONS, MapType,
+} from '@salto-io/adapter-api'
+import { extendGeneratedDependencies, FlatDetailedDependency, DetailedDependency } from '../src/dependencies'
+
+describe('dependencies', () => {
+  const mockStrType = new PrimitiveType({
+    elemID: new ElemID('mockAdapter', 'str'),
+    primitive: PrimitiveTypes.STRING,
+    annotations: { testAnno: 'TEST ANNO TYPE' },
+    path: ['here', 'we', 'go'],
+  })
+  const mockElem = new ElemID('mockAdapter', 'test')
+  const mockType = new ObjectType({
+    elemID: mockElem,
+    annotationRefsOrTypes: {
+      testAnno: mockStrType,
+    },
+    annotations: {
+      testAnno: 'TEST ANNO',
+    },
+    fields: {
+      ref: { refType: BuiltinTypes.STRING },
+      str: { refType: BuiltinTypes.STRING, annotations: { testAnno: 'TEST FIELD ANNO' } },
+      file: { refType: BuiltinTypes.STRING },
+      bool: { refType: BuiltinTypes.BOOLEAN },
+      num: { refType: BuiltinTypes.NUMBER },
+      numArray: { refType: new ListType(BuiltinTypes.NUMBER) },
+      strArray: { refType: new ListType(BuiltinTypes.STRING) },
+      numMap: { refType: new MapType(BuiltinTypes.NUMBER) },
+      strMap: { refType: new MapType(BuiltinTypes.STRING) },
+      obj: {
+        refType: new ListType(new ObjectType({
+          elemID: mockElem,
+          fields: {
+            field: { refType: BuiltinTypes.STRING },
+            otherField: {
+              refType: BuiltinTypes.STRING,
+            },
+            value: { refType: BuiltinTypes.STRING },
+            mapOfStringList: { refType: new MapType(new ListType(BuiltinTypes.STRING)) },
+            innerObj: {
+
+              refType: new ObjectType({
+                elemID: mockElem,
+                fields: {
+                  name: { refType: BuiltinTypes.STRING },
+                  listOfNames: { refType: new ListType(BuiltinTypes.STRING) },
+                  magical: {
+                    refType: new ObjectType({
+                      elemID: mockElem,
+                      fields: {
+                        deepNumber: { refType: BuiltinTypes.NUMBER },
+                        deepName: { refType: BuiltinTypes.STRING },
+                      },
+                    }),
+                  },
+                },
+              }),
+            },
+          },
+        })),
+      },
+    },
+    path: ['this', 'is', 'happening'],
+  })
+
+  describe('extendGeneratedDependencies', () => {
+    it('should create the _generated_dependencies annotation if it does not exist', () => {
+      const type = new ObjectType({
+        elemID: mockElem,
+        annotationRefsOrTypes: {
+          testAnno: mockStrType,
+        },
+        annotations: {
+          testAnno: 'TEST ANNO',
+        },
+        fields: {
+          f1: { refType: BuiltinTypes.STRING },
+        },
+      })
+      const inst = new InstanceElement('something', mockType, {})
+
+      const reference = new ReferenceExpression(new ElemID('adapter', 'type123'))
+      const flatRefs: FlatDetailedDependency[] = [{ reference, direction: 'input' }]
+      const structuredRefs = [{ reference, occurrences: [{ direction: 'input' }] }]
+
+      extendGeneratedDependencies(type, flatRefs)
+      expect(type.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(type.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(structuredRefs)
+
+      extendGeneratedDependencies(inst, flatRefs)
+      expect(inst.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(inst.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(structuredRefs)
+
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeUndefined()
+      extendGeneratedDependencies(type.fields.f1, flatRefs)
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(
+        structuredRefs
+      )
+    })
+    it('should extend the _generated_dependencies annotation if it already exists', () => {
+      const oldRefs = [{ reference: new ReferenceExpression(new ElemID('adapter', 'type123')) }]
+      const type = new ObjectType({
+        elemID: mockElem,
+        annotationRefsOrTypes: {
+          testAnno: mockStrType,
+        },
+        annotations: {
+          testAnno: 'TEST ANNO',
+          [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [...oldRefs],
+        },
+        fields: {
+          f1: {
+            refType: BuiltinTypes.STRING,
+            annotations: { [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [...oldRefs] },
+          },
+        },
+      })
+      const inst = new InstanceElement(
+        'something',
+        mockType,
+        {},
+        undefined,
+        { [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [...oldRefs] },
+      )
+
+      const newRefs: FlatDetailedDependency[] = [
+        { reference: new ReferenceExpression(new ElemID('adapter', 'type456')) },
+      ]
+
+      extendGeneratedDependencies(type, newRefs)
+      expect(type.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(type.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(
+        [...oldRefs, ...newRefs]
+      )
+
+      extendGeneratedDependencies(inst, newRefs)
+      expect(inst.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(inst.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(
+        [...oldRefs, ...newRefs]
+      )
+
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      extendGeneratedDependencies(type.fields.f1, newRefs)
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(
+        [...oldRefs, ...newRefs]
+      )
+    })
+    it('should do nothing if no new annotations are added', () => {
+      const oldRefs = [{ reference: new ReferenceExpression(new ElemID('adapter', 'type123')) }]
+      const type = new ObjectType({
+        elemID: mockElem,
+        annotationRefsOrTypes: {
+          testAnno: mockStrType,
+        },
+        annotations: {
+          testAnno: 'TEST ANNO',
+          [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [...oldRefs],
+        },
+        fields: {
+          f1: {
+            refType: BuiltinTypes.STRING,
+            annotations: { [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [...oldRefs] },
+          },
+        },
+      })
+      const inst = new InstanceElement(
+        'something',
+        mockType,
+        {},
+        undefined,
+        { [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [...oldRefs] },
+      )
+
+      extendGeneratedDependencies(type, [])
+      expect(type.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(type.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(oldRefs)
+
+      extendGeneratedDependencies(inst, [])
+      expect(inst.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(inst.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(oldRefs)
+
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      extendGeneratedDependencies(type.fields.f1, [])
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
+      expect(type.fields.f1.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual(oldRefs)
+    })
+    describe('annotation structure', () => {
+      let type: ObjectType
+      beforeAll(() => {
+        type = new ObjectType({
+          elemID: mockElem,
+          annotations: {
+            [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [
+              { reference: new ReferenceExpression(new ElemID('adapter', 'type123')) },
+              { reference: new ReferenceExpression(new ElemID('adapter', 'type456')) },
+              {
+                reference: new ReferenceExpression(new ElemID('adapter', 'type789')),
+                occurrences: [
+                  // intentionally not sorted correctly
+                  { direction: 'output' },
+                  { direction: 'input' },
+                ],
+              },
+            ],
+          },
+        })
+
+        extendGeneratedDependencies(type, [
+          {
+            reference: new ReferenceExpression(new ElemID('adapter', 'type456')),
+            location: new ReferenceExpression(mockElem.createNestedID('attr', 'def1')),
+            direction: 'output',
+          },
+          {
+            reference: new ReferenceExpression(new ElemID('adapter', 'type456')),
+            location: new ReferenceExpression(mockElem.createNestedID('attr', 'def2')),
+            direction: 'input',
+          },
+          {
+            reference: new ReferenceExpression(new ElemID('adapter', 'type456', 'instance', 'inst456')),
+            location: new ReferenceExpression(mockElem.createNestedID('attr', 'def2')),
+            direction: 'input',
+          },
+          {
+            reference: new ReferenceExpression(new ElemID('adapter', 'type456', 'instance', 'inst456')),
+            location: new ReferenceExpression(mockElem.createNestedID('attr', 'def2')),
+            direction: 'output',
+          },
+          {
+            reference: new ReferenceExpression(new ElemID('adapter', 'type456', 'instance', 'inst456')),
+          },
+          { reference: new ReferenceExpression(new ElemID('adapter', 'type123')) },
+          {
+            reference: new ReferenceExpression(new ElemID('adapter', 'type456')),
+            location: new ReferenceExpression(mockElem.createNestedID('attr', 'def3')),
+          },
+          {
+            reference: new ReferenceExpression(new ElemID('adapter', 'type456')),
+            location: new ReferenceExpression(mockElem.createNestedID('attr', 'def2')),
+          },
+          { reference: new ReferenceExpression(new ElemID('adapter', 'aaa')) },
+        ])
+      })
+
+      const findRefDeps = (id: ElemID): DetailedDependency => (
+        type.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].find(
+          (e: DetailedDependency) => e.reference.elemID.isEqual(id)
+        )
+      )
+      const getOccurrences = (
+        dep: DetailedDependency
+      ): { direction?: string; location?: string}[] | undefined => (
+        dep.occurrences?.map(oc => ({ ...oc, location: oc.location?.elemID.getFullName() }))
+      )
+
+      it('should have one entry for each reference, sorted by the referenced elem id', () => {
+        expect(type.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
+          (e: DetailedDependency) => e.reference.elemID.getFullName()
+        )).toEqual([
+          'adapter.aaa',
+          'adapter.type123',
+          'adapter.type456',
+          'adapter.type456.instance.inst456',
+          'adapter.type789',
+        ])
+      })
+      it('should have an empty list of occurrences when no additional details are provided', () => {
+        const type123Refs = findRefDeps(new ElemID('adapter', 'type123'))
+        expect(type123Refs).toBeDefined()
+        expect(type123Refs.occurrences).toBeUndefined()
+        const aaaRefs = findRefDeps(new ElemID('adapter', 'aaa'))
+        expect(aaaRefs).toBeDefined()
+        expect(aaaRefs.occurrences).toBeUndefined()
+      })
+      it('should keep the existing annotation value when no new details are addded', () => {
+        const type789Refs = findRefDeps(new ElemID('adapter', 'type789'))
+        expect(type789Refs).toBeDefined()
+        expect(type789Refs.occurrences).toBeDefined()
+        expect(getOccurrences(type789Refs)).toEqual([
+          { direction: 'output' },
+          { direction: 'input' },
+        ])
+      })
+      it('should omit less-specific occurrences when more detailed ones are provided', () => {
+        const type456Refs = findRefDeps(new ElemID('adapter', 'type456'))
+        expect(type456Refs).toBeDefined()
+        expect(type456Refs.occurrences).toBeDefined()
+        expect(getOccurrences(type456Refs)).toEqual([
+          { location: mockElem.createNestedID('attr', 'def3').getFullName() },
+          { location: mockElem.createNestedID('attr', 'def2').getFullName(), direction: 'input' },
+          { location: mockElem.createNestedID('attr', 'def1').getFullName(), direction: 'output' },
+        ])
+
+        const inst456Refs = findRefDeps(new ElemID('adapter', 'type456', 'instance', 'inst456'))
+        expect(inst456Refs).toBeDefined()
+        expect(inst456Refs.occurrences).toBeDefined()
+        expect(getOccurrences(inst456Refs)).toEqual([
+          { location: mockElem.createNestedID('attr', 'def2').getFullName(), direction: 'input' },
+          { location: mockElem.createNestedID('attr', 'def2').getFullName(), direction: 'output' },
+        ])
+      })
+    })
+  })
+})

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -1090,11 +1090,6 @@ describe('Test utils.ts', () => {
         expect(resolvedInstance.value.mapValues.valueRef).toEqual(regValue)
         expect(resolvedInstance.value.fileValue).toEqual(Buffer.from(fileContent))
         expect(resolvedInstance.value.objValue).toEqual(firstRef.value.obj)
-
-        // this is not a realistic scenario, we should remove it
-        expect(resolvedInstance.annotations[CORE_ANNOTATIONS.DEPENDS_ON]).toEqual({
-          reference: regValue,
-        })
       })
 
       it('should transform back to instance', async () => {

--- a/packages/salesforce-adapter/src/filters/extra_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/extra_dependencies.ts
@@ -109,7 +109,10 @@ const addGeneratedDependencies = async (elem: Element, refElemIDs: ElemID[]): Pr
     .map(elemId => new ReferenceExpression(elemId))
 
   if (newDependencies.length !== 0) {
-    extendGeneratedDependencies(elem, newDependencies)
+    extendGeneratedDependencies(
+      elem,
+      newDependencies.map(reference => ({ reference })),
+    )
   }
 }
 

--- a/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
@@ -273,36 +273,36 @@ describe('extra dependencies filter', () => {
       const firstFieldRef = new ReferenceExpression(customObjType.fields.first.elemID)
       const secondFieldRef = new ReferenceExpression(customObjType.fields.second.elemID)
       const leadFieldRef = new ReferenceExpression(leadObjType.fields.custom.elemID)
-      expect(getGeneratedDeps(instances[0])).toContainEqual(secondFieldRef)
+      expect(getGeneratedDeps(instances[0])).toContainEqual({ reference: secondFieldRef })
       expect(getGeneratedDeps(instances[1])).toEqual(
-        expect.arrayContaining([firstFieldRef, leadFieldRef])
+        expect.arrayContaining([{ reference: firstFieldRef }, { reference: leadFieldRef }])
       )
-      expect(getGeneratedDeps(instances[2])).toEqual([firstFieldRef])
+      expect(getGeneratedDeps(instances[2])).toEqual([{ reference: firstFieldRef }])
     })
 
     it('should not add generated dependencies to targets that already have a reference in the element', () => {
       expect(getGeneratedDeps(instances[0])).not.toContainEqual(
-        new ReferenceExpression(customObjType.fields.first.elemID)
+        { reference: new ReferenceExpression(customObjType.fields.first.elemID) }
       )
     })
 
     it('should add dependencies to standard objects', () => {
       expect(getGeneratedDeps(instances[1])).toEqual(
-        expect.arrayContaining([new ReferenceExpression(leadObjType.elemID)])
+        expect.arrayContaining([{ reference: new ReferenceExpression(leadObjType.elemID) }])
       )
     })
 
     it('should add generated dependencies annotation to fields', () => {
       expect(getGeneratedDeps(leadObjType.fields.custom)).toEqual(
-        [new ReferenceExpression(customObjType.fields.second.elemID)]
+        [{ reference: new ReferenceExpression(customObjType.fields.second.elemID) }]
       )
     })
 
     it('should sort generated dependencies by name', () => {
       expect(getGeneratedDeps(instances[1])).toEqual([
-        new ReferenceExpression(leadObjType.elemID),
-        new ReferenceExpression(leadObjType.fields.custom.elemID),
-        new ReferenceExpression(customObjType.fields.first.elemID),
+        { reference: new ReferenceExpression(leadObjType.elemID) },
+        { reference: new ReferenceExpression(leadObjType.fields.custom.elemID) },
+        { reference: new ReferenceExpression(customObjType.fields.first.elemID) },
       ])
     })
 
@@ -312,7 +312,7 @@ describe('extra dependencies filter', () => {
 
     it('should add generated dependencies to elements that were not fetched', () => {
       expect(getGeneratedDeps(instances[0])).toContainEqual(
-        new ReferenceExpression(workspaceInstance.elemID)
+        { reference: new ReferenceExpression(workspaceInstance.elemID) }
       )
     })
 

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
@@ -59,8 +59,8 @@ export const addNetsuiteRecipeReferences = async (
           const referencedId = indexedElements[scriptId]
           if (referencedId !== undefined) {
             references.push({
-              srcPath: nestedPath,
-              ref: new ReferenceExpression(referencedId),
+              pathToOverride: nestedPath,
+              reference: new ReferenceExpression(referencedId),
             })
           }
         }
@@ -89,8 +89,7 @@ export const addNetsuiteRecipeReferences = async (
       const referencedId = indexedElements[fieldNameScriptId]
       if (referencedId !== undefined) {
         return {
-          srcPath: undefined,
-          ref: new ReferenceExpression(referencedId),
+          reference: new ReferenceExpression(referencedId),
         }
       }
       return undefined

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/salesforce.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/salesforce.ts
@@ -108,8 +108,8 @@ export const addSalesforceRecipeReferences = async (
     }
 
     const references: MappedReference[] = [{
-      srcPath: path.createNestedID('input', 'sobject_name'),
-      ref: new ReferenceExpression(objectDetails.id),
+      pathToOverride: path.createNestedID('input', 'sobject_name'),
+      reference: new ReferenceExpression(objectDetails.id),
     }]
 
     const inputFieldNames = Object.keys(_.omit(input, 'sobject_name'))
@@ -117,9 +117,8 @@ export const addSalesforceRecipeReferences = async (
       if (objectDetails.fields[fieldName] !== undefined) {
         references.push(
           {
-            // no srcPath because we can't override the field keys in the current format
-            srcPath: undefined,
-            ref: new ReferenceExpression(objectDetails.fields[fieldName].elemID),
+            // no pathToOverride because we can't override the field keys in the current format
+            reference: new ReferenceExpression(objectDetails.fields[fieldName].elemID),
           },
         )
       }
@@ -128,8 +127,8 @@ export const addSalesforceRecipeReferences = async (
     // dynamicPickListSelection uses the label, not the api name
     if (dynamicPickListSelection.sobject_name === objectDetails.label) {
       references.push({
-        srcPath: path.createNestedID('dynamicPickListSelection', 'sobject_name'),
-        ref: new ReferenceExpression(objectDetails.id),
+        pathToOverride: path.createNestedID('dynamicPickListSelection', 'sobject_name'),
+        reference: new ReferenceExpression(objectDetails.id),
       })
 
       if (dynamicPickListSelection.field_list !== undefined) {
@@ -147,22 +146,21 @@ export const addSalesforceRecipeReferences = async (
             if (relatedObjectDetails.fields[field] !== undefined) {
               references.push(
                 {
-                  srcPath: path.createNestedID('dynamicPickListSelection', 'field_list', String(idx)),
-                  ref: new ReferenceExpression(relatedObjectDetails.fields[field].elemID),
+                  pathToOverride: path.createNestedID('dynamicPickListSelection', 'field_list', String(idx)),
+                  reference: new ReferenceExpression(relatedObjectDetails.fields[field].elemID),
                 },
               )
               references.push(
                 {
-                  srcPath: undefined,
-                  ref: new ReferenceExpression(relatedObjectDetails.id),
+                  reference: new ReferenceExpression(relatedObjectDetails.id),
                 },
               )
             }
           } else if (objectDetails.fields[fieldName] !== undefined) {
             references.push(
               {
-                srcPath: path.createNestedID('dynamicPickListSelection', 'field_list', String(idx)),
-                ref: new ReferenceExpression(objectDetails.fields[fieldName].elemID),
+                pathToOverride: path.createNestedID('dynamicPickListSelection', 'field_list', String(idx)),
+                reference: new ReferenceExpression(objectDetails.fields[fieldName].elemID),
               },
             )
           }
@@ -177,8 +175,8 @@ export const addSalesforceRecipeReferences = async (
           if (refObjectDetails !== undefined) {
             references.push(
               {
-                srcPath: path.createNestedID('dynamicPickListSelection', 'table_list', String(idx)),
-                ref: new ReferenceExpression(refObjectDetails.id),
+                pathToOverride: path.createNestedID('dynamicPickListSelection', 'table_list', String(idx)),
+                reference: new ReferenceExpression(refObjectDetails.id),
               },
             )
           }
@@ -203,14 +201,12 @@ export const addSalesforceRecipeReferences = async (
       const objectDetails = getObjectDetails(objName)
       if (field !== undefined && objectDetails?.fields[field] !== undefined) {
         return {
-          srcPath: undefined,
-          ref: new ReferenceExpression(objectDetails.fields[field].elemID),
+          reference: new ReferenceExpression(objectDetails.fields[field].elemID),
         }
       }
       if (objectDetails !== undefined) {
         return {
-          srcPath: undefined,
-          ref: new ReferenceExpression(objectDetails.id),
+          reference: new ReferenceExpression(objectDetails.id),
         }
       }
       return undefined

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -338,8 +338,8 @@ describe('adapter', () => {
         const deps = recipeCodeWithRefs?.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]
         expect(deps).toBeDefined()
         expect(deps).toHaveLength(1)
-        expect(deps[0]).toBeInstanceOf(ReferenceExpression)
-        expect(deps[0].elemID.getFullName()).toEqual('salesforce.Fish__c')
+        expect(deps[0].reference).toBeInstanceOf(ReferenceExpression)
+        expect(deps[0].reference.elemID.getFullName()).toEqual('salesforce.Fish__c')
       })
     })
   })

--- a/packages/workato-adapter/test/filters/recipe_references.test.ts
+++ b/packages/workato-adapter/test/filters/recipe_references.test.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, BuiltinTypes, ListType, CORE_ANNOTATIONS, isReferenceExpression } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
-import { createRefToElmWithValue } from '@salto-io/adapter-utils'
+import { createRefToElmWithValue, DetailedDependency } from '@salto-io/adapter-utils'
 import filterCreator from '../../src/filters/cross_service/recipe_references'
 import WorkatoClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -798,11 +798,8 @@ describe('Recipe references filter', () => {
         expect(recipeCode).toBeDefined()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(19)
-        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].every(
-          isReferenceExpression
-        )).toBeTruthy()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
-          (ref: ReferenceExpression) => ref.elemID.getFullName()
+          (dep: DetailedDependency) => dep.reference.elemID.getFullName()
         )).toEqual([
           'netsuite.customrecordtype.instance.customrecord16',
           'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.0',
@@ -906,11 +903,8 @@ describe('Recipe references filter', () => {
         expect(recipeCode).toBeDefined()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(5)
-        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].every(
-          isReferenceExpression
-        )).toBeTruthy()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
-          (ref: ReferenceExpression) => ref.elemID.getFullName()
+          (dep: DetailedDependency) => dep.reference.elemID.getFullName()
         )).toEqual([
           'netsuite.customrecordtype.instance.customrecord16',
           'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.0',
@@ -979,11 +973,8 @@ describe('Recipe references filter', () => {
         expect(recipeCode).toBeDefined()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(2)
-        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].every(
-          isReferenceExpression
-        )).toBeTruthy()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
-          (ref: ReferenceExpression) => ref.elemID.getFullName()
+          (dep: DetailedDependency) => dep.reference.elemID.getFullName()
         )).toEqual([
           'salesforce.MyCustom__c',
           'salesforce.MyCustom__c.field.customField__c',
@@ -1084,7 +1075,7 @@ describe('Recipe references filter', () => {
       expect(
         elements
           .flatMap(e => e.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] ?? [])
-          .map(e => e.elemID.getFullName())
+          .map((dep: DetailedDependency) => dep.reference.elemID.getFullName())
       ).toEqual([
         'netsuite.customrecordtype.instance.customrecord16',
         'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.0',
@@ -1150,11 +1141,8 @@ describe('Recipe references filter', () => {
         expect(recipeCode).toBeDefined()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(12)
-        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].every(
-          isReferenceExpression
-        )).toBeTruthy()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
-          (ref: ReferenceExpression) => ref.elemID.getFullName()
+          (dep: DetailedDependency) => dep.reference.elemID.getFullName()
         )).toEqual([
           'netsuite.customrecordtype.instance.customrecord16',
           'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.0',

--- a/packages/zuora-billing-adapter/src/filters/object_defs.ts
+++ b/packages/zuora-billing-adapter/src/filters/object_defs.ts
@@ -179,7 +179,7 @@ const addRelationships = (
           [...refObjectNames]
             .map(findType)
             .filter(isDefined)
-            .map(refObj => new ReferenceExpression(refObj.elemID))
+            .map(refObj => ({ reference: new ReferenceExpression(refObj.elemID) }))
         )
       }
     })

--- a/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
@@ -87,7 +87,7 @@ const addTaskDependencies = (
   })
 
   if (deps.length > 0) {
-    extendGeneratedDependencies(inst, deps)
+    extendGeneratedDependencies(inst, deps.map(dep => ({ reference: dep })))
   }
 }
 

--- a/packages/zuora-billing-adapter/test/filters/object_defs.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/object_defs.test.ts
@@ -18,6 +18,7 @@ import {
   ObjectType, ElemID, InstanceElement, Element, isEqualElements, isObjectType, ReferenceExpression,
 } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { DetailedDependency } from '@salto-io/adapter-utils'
 import ZuoraClient from '../../src/client/client'
 import { ZUORA_BILLING, CUSTOM_OBJECT_DEFINITION_TYPE, STANDARD_OBJECT_DEFINITION_TYPE } from '../../src/constants'
 import filterCreator from '../../src/filters/object_defs'
@@ -454,16 +455,17 @@ describe('Object defs filter', () => {
       const fieldRef = custom1.fields.AccountId__c.annotations.referenceTo[0] as ReferenceExpression
       expect(fieldRef.elemID.getFullName()).toEqual('zuora_billing.account.field.Id')
       expect(custom1.annotations).toEqual({
-        _generated_dependencies: [expect.any(ReferenceExpression), expect.any(ReferenceExpression)],
+        // eslint-disable-next-line camelcase
+        _generated_dependencies: [expect.anything(), expect.anything()],
         description: 'this is a decription',
         id: 'some id',
         label: 'Custom1',
         metadataType: 'CustomObject',
       })
       // eslint-disable-next-line no-underscore-dangle
-      const objRefs = custom1.annotations._generated_dependencies as ReferenceExpression[]
-      expect(objRefs[0].elemID.getFullName()).toEqual('zuora_billing.Custom2__c')
-      expect(objRefs[1].elemID.getFullName()).toEqual('zuora_billing.account')
+      const objRefs = custom1.annotations._generated_dependencies as DetailedDependency[]
+      expect(objRefs[0].reference.elemID.getFullName()).toEqual('zuora_billing.Custom2__c')
+      expect(objRefs[1].reference.elemID.getFullName()).toEqual('zuora_billing.account')
     })
   })
 })

--- a/packages/zuora-billing-adapter/test/filters/workflow_and_task_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/workflow_and_task_references.test.ts
@@ -18,6 +18,7 @@ import {
   isInstanceElement, isReferenceExpression,
 } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { DetailedDependency } from '@salto-io/adapter-utils'
 import ZuoraClient from '../../src/client/client'
 import { ZUORA_BILLING, WORKFLOW_TYPE, TASK_TYPE, STANDARD_OBJECT, METADATA_TYPE } from '../../src/constants'
 import filterCreator from '../../src/filters/workflow_and_task_references'
@@ -291,9 +292,10 @@ describe('Workflow and task references filter', () => {
       expect(tasks[0].value.object).toBeInstanceOf(ReferenceExpression)
       expect((tasks[0].value.object as ReferenceExpression).elemID.getFullName()).toEqual('zuora_billing.RefundInvoicePayment')
       // eslint-disable-next-line no-underscore-dangle
-      const task1Deps = tasks[0].annotations._generated_dependencies as ReferenceExpression[]
-      expect(task1Deps.every(isReferenceExpression)).toBeTruthy()
-      expect(task1Deps.map(e => e.elemID.getFullName())).toEqual([
+      const task1Deps = tasks[0].annotations._generated_dependencies as DetailedDependency[]
+      expect(task1Deps.map(e => e.reference).every(isReferenceExpression)).toBeTruthy()
+      expect(task1Deps.map(e => e.occurrences).every(oc => oc === undefined)).toBeTruthy()
+      expect(task1Deps.map(e => e.reference.elemID.getFullName())).toEqual([
         'zuora_billing.Invoice.field.Id',
         // Invoice.Balance and InvoiceDate do not exist on the object so they are not referenced
         'zuora_billing.Invoice.field.InvoiceNumber',


### PR DESCRIPTION
Extend the `_generated_dependencies` + `_depends_on` annotations to support optional details about the location and direction. See the ticket for more details.

---

* We still need to decide if we want a flat format or an aggregate - I started with an aggregate, but the flat one is a little simpler so we can switch to it if it's preferred.
* Starting by supporting only `input` / `output` (/ undefined = unknown) for directions - we can consider also adding a `both` option, but since it seems to not be common right now and requires more careful maintenance, we can start without it and add it later as needed.

---
_Release Notes_: 
Updated the structure of some core annotations (`_generated_dependencies` and `_depends_on`) to allow specifying more granular information about the references used in each element.
Note: This will cause fetch changes in existing workspaces with SFDC accounts.
