### PR TITLE
SALTO-1315 ignore builtins when checking field existence in parser

### DIFF
--- a/packages/workspace/src/parser/internal/native/consumers/blocks.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/blocks.ts
@@ -128,7 +128,7 @@ export const consumeBlockBody = (context: ParseContext, idPrefix: ElemID): Consu
           filename: context.filename,
         }))
       }
-      if (fields[fieldName] === undefined) {
+      if (!Object.prototype.hasOwnProperty.call(fields, fieldName)) {
         fields[fieldName] = {
           type: createFieldType(context, fieldType),
           annotations: consumedBlock.value.attrs,

--- a/packages/workspace/test/parser/errors.test.ts
+++ b/packages/workspace/test/parser/errors.test.ts
@@ -527,6 +527,22 @@ describe('parsing errors', () => {
         expect(element.fields.mycar.type.elemID.getFullName()).toEqual('can.drive')
       })
     })
+    describe('when there is a field with the name of a builtin function', () => {
+      const nacl = `
+      type baby.you {
+        can.drive toString {
+
+        }
+      }
+    `
+      let res: ParseResult
+      beforeAll(async () => {
+        res = await parse(Buffer.from(nacl), 'file.nacl', {})
+      })
+      it('should not create an error', () => {
+        expect(res.errors).toHaveLength(0)
+      })
+    })
     describe('has a duplicated attribute', () => {
       const nacl = `
       type baby.you {


### PR DESCRIPTION
Ran into this when looking into a sample workspace with a `toString` field. There might be other places that will need to change (or we can decide to rename fields with problematic names?)

---

Also see https://github.com/salto-io/salto/pull/1937 for a previous related fix.

---
_Release Notes_: 
None (not known to exist in any of the current adapter fields)
