### PR TITLE
SALTO-1314 Add location and direction in workato cross-service references

### DIFF
--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
@@ -17,10 +17,11 @@ import _ from 'lodash'
 import {
   InstanceElement, ElemID, ReferenceExpression, Values,
 } from '@salto-io/adapter-api'
+import { DependencyDirection } from '@salto-io/adapter-utils'
 import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { NetsuiteIndex } from '../element_indexes'
 import { isNetsuiteBlock, NetsuiteBlock } from './recipe_block_types'
-import { addReferencesForService, FormulaReferenceFinder, MappedReference, ReferenceFinder, createMatcher, Matcher } from './shared'
+import { addReferencesForService, FormulaReferenceFinder, MappedReference, ReferenceFinder, createMatcher, Matcher, getBlockDependencyDirection } from './shared'
 
 const { isDefined } = lowerdashValues
 
@@ -60,6 +61,8 @@ export const addNetsuiteRecipeReferences = async (
           if (referencedId !== undefined) {
             references.push({
               pathToOverride: nestedPath,
+              location: new ReferenceExpression(path),
+              direction: getBlockDependencyDirection(blockValue),
               reference: new ReferenceExpression(referencedId),
             })
           }
@@ -83,12 +86,15 @@ export const addNetsuiteRecipeReferences = async (
 
   const formulaFieldMatcher = createFormulaFieldMatcher(appName)
 
-  const formulaReferenceFinder: FormulaReferenceFinder = value => {
+  const formulaReferenceFinder: FormulaReferenceFinder = (value, path) => {
     const potentialFields = formulaFieldMatcher(value).map(match => match.field)
     return potentialFields.map(fieldNameScriptId => {
       const referencedId = indexedElements[fieldNameScriptId]
       if (referencedId !== undefined) {
         return {
+          location: new ReferenceExpression(path),
+          // references inside formulas are always used as input
+          direction: 'input' as DependencyDirection,
           reference: new ReferenceExpression(referencedId),
         }
       }

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
@@ -17,7 +17,6 @@ import _ from 'lodash'
 import {
   InstanceElement, ElemID, ReferenceExpression, Values,
 } from '@salto-io/adapter-api'
-import { DependencyDirection } from '@salto-io/adapter-utils'
 import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { NetsuiteIndex } from '../element_indexes'
 import { isNetsuiteBlock, NetsuiteBlock } from './recipe_block_types'
@@ -88,13 +87,13 @@ export const addNetsuiteRecipeReferences = async (
 
   const formulaReferenceFinder: FormulaReferenceFinder = (value, path) => {
     const potentialFields = formulaFieldMatcher(value).map(match => match.field)
-    return potentialFields.map(fieldNameScriptId => {
+    return potentialFields.map((fieldNameScriptId: string): MappedReference | undefined => {
       const referencedId = indexedElements[fieldNameScriptId]
       if (referencedId !== undefined) {
         return {
           location: new ReferenceExpression(path),
           // references inside formulas are always used as input
-          direction: 'input' as DependencyDirection,
+          direction: 'input',
           reference: new ReferenceExpression(referencedId),
         }
       }

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/recipe_block_types.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/recipe_block_types.ts
@@ -21,7 +21,11 @@ type RefListItem = {
   value: string
 }
 
-export type SalesforceBlock = {
+export type BlockBase = {
+  keyword: string
+}
+
+export type SalesforceBlock = BlockBase & {
   as: string
   provider: 'salesforce' | 'salesforce_secondary'
   dynamicPickListSelection: {
@@ -38,7 +42,7 @@ export type SalesforceBlock = {
   }
 }
 
-export type NetsuiteBlock = {
+export type NetsuiteBlock = BlockBase & {
   provider: 'netsuite' | 'netsuite_secondary'
   dynamicPickListSelection: {
     // eslint-disable-next-line camelcase
@@ -62,6 +66,7 @@ export const isSalesforceBlock = (value: any, application: string): value is Sal
   _.isObjectLike(value)
   && CROSS_SERVICE_SUPPORTED_APPS[SALESFORCE].includes(application)
   && value.provider === application
+  && _.isString(value.keyword)
   && _.isObjectLike(value.dynamicPickListSelection)
   && _.isString(value.dynamicPickListSelection.sobject_name)
   && (value.dynamicPickListSelection.table_list ?? []).every(isListItem)
@@ -76,6 +81,7 @@ export const isNetsuiteBlock = (value: any, application: string): value is Netsu
   _.isObjectLike(value)
   && CROSS_SERVICE_SUPPORTED_APPS[NETSUITE].includes(application)
   && value.provider === application
+  && _.isString(value.keyword)
   && _.isObjectLike(value.dynamicPickListSelection)
   && _.isString(value.dynamicPickListSelection.netsuite_object)
   && (value.dynamicPickListSelection.custom_list ?? []).every(isListItem)

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/salesforce.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/salesforce.ts
@@ -108,11 +108,14 @@ export const addSalesforceRecipeReferences = async (
       return []
     }
 
+    const location = new ReferenceExpression(path)
+    const direction = getBlockDependencyDirection(blockValue)
+
     const references: MappedReference[] = [{
       pathToOverride: path.createNestedID('input', 'sobject_name'),
-      location: new ReferenceExpression(path),
+      location,
       reference: new ReferenceExpression(objectDetails.id),
-      direction: getBlockDependencyDirection(blockValue),
+      direction,
     }]
 
     const inputFieldNames = Object.keys(_.omit(input, 'sobject_name'))
@@ -121,8 +124,8 @@ export const addSalesforceRecipeReferences = async (
         references.push(
           {
             // no pathToOverride because we can't override the field keys in the current format
-            location: new ReferenceExpression(path),
-            direction: getBlockDependencyDirection(blockValue),
+            location,
+            direction,
             reference: new ReferenceExpression(objectDetails.fields[fieldName].elemID),
           },
         )
@@ -133,8 +136,8 @@ export const addSalesforceRecipeReferences = async (
     if (dynamicPickListSelection.sobject_name === objectDetails.label) {
       references.push({
         pathToOverride: path.createNestedID('dynamicPickListSelection', 'sobject_name'),
-        location: new ReferenceExpression(path),
-        direction: getBlockDependencyDirection(blockValue),
+        location,
+        direction,
         reference: new ReferenceExpression(objectDetails.id),
       })
 
@@ -154,15 +157,15 @@ export const addSalesforceRecipeReferences = async (
               references.push(
                 {
                   pathToOverride: path.createNestedID('dynamicPickListSelection', 'field_list', String(idx)),
-                  location: new ReferenceExpression(path),
-                  direction: getBlockDependencyDirection(blockValue),
+                  location,
+                  direction,
                   reference: new ReferenceExpression(relatedObjectDetails.fields[field].elemID),
                 },
               )
               references.push(
                 {
-                  location: new ReferenceExpression(path),
-                  direction: getBlockDependencyDirection(blockValue),
+                  location,
+                  direction,
                   reference: new ReferenceExpression(relatedObjectDetails.id),
                 },
               )
@@ -171,8 +174,8 @@ export const addSalesforceRecipeReferences = async (
             references.push(
               {
                 pathToOverride: path.createNestedID('dynamicPickListSelection', 'field_list', String(idx)),
-                location: new ReferenceExpression(path),
-                direction: getBlockDependencyDirection(blockValue),
+                location,
+                direction,
                 reference: new ReferenceExpression(objectDetails.fields[fieldName].elemID),
               },
             )
@@ -189,8 +192,8 @@ export const addSalesforceRecipeReferences = async (
             references.push(
               {
                 pathToOverride: path.createNestedID('dynamicPickListSelection', 'table_list', String(idx)),
-                location: new ReferenceExpression(path),
-                direction: getBlockDependencyDirection(blockValue),
+                location,
+                direction,
                 reference: new ReferenceExpression(refObjectDetails.id),
               },
             )

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/shared.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/shared.ts
@@ -45,7 +45,7 @@ export type FormulaReferenceFinder = (
 export const addReferencesForService = async <T extends SalesforceBlock | NetsuiteBlock>(
   inst: InstanceElement,
   appName: string,
-  typeGuard: (value: Value, appName: string) => value is T,
+  typeGuard: (value: Value, app: string) => value is T,
   addReferences: ReferenceFinder<T>,
   addFormulaReferences?: FormulaReferenceFinder,
 ): Promise<void> => {

--- a/packages/workato-adapter/test/filters/recipe_references.test.ts
+++ b/packages/workato-adapter/test/filters/recipe_references.test.ts
@@ -30,6 +30,14 @@ describe('Recipe references filter', () => {
   type FilterType = filterUtils.FilterWith<'onPostFetch'>
   let filter: FilterType
 
+  const dereferenceDep = (dep: DetailedDependency): unknown => ({
+    reference: dep.reference.elemID.getFullName(),
+    occurrences: dep.occurrences?.map(
+      oc => ({ ...oc, location: oc.location?.elemID.getFullName() })
+    ),
+  })
+
+
   beforeAll(() => {
     client = new WorkatoClient({
       credentials: { username: 'a', token: 'b' },
@@ -279,6 +287,7 @@ describe('Recipe references filter', () => {
       as: '1234aaaa',
       provider: 'salesforce',
       name: 'updated_custom_object',
+      keyword: 'trigger',
       dynamicPickListSelection: {
         sobject_name: 'Opportunity',
         field_list: [
@@ -326,6 +335,7 @@ describe('Recipe references filter', () => {
       block: [
         {
           as: 'nestedid1',
+          keyword: 'action',
           provider: 'netsuite',
           name: 'add_object',
           dynamicPickListSelection: {
@@ -341,6 +351,7 @@ describe('Recipe references filter', () => {
             {
               as: 'nestedid2',
               provider: 'salesforce',
+              keyword: 'action',
               name: 'updated_custom_object',
               dynamicPickListSelection: {
                 sobject_name: 'My Custom',
@@ -491,6 +502,7 @@ describe('Recipe references filter', () => {
         as: '1234aaaa',
         provider: 'salesforce_secondary',
         name: 'updated_custom_object',
+        keyword: 'trigger',
         dynamicPickListSelection: {
           sobject_name: 'Opportunity',
         },
@@ -503,6 +515,7 @@ describe('Recipe references filter', () => {
           {
             as: 'nestedid1',
             provider: 'netsuite_secondary',
+            keyword: 'action',
             name: 'add_object',
             dynamicPickListSelection: {
               netsuite_object: 'custom record type label',
@@ -517,6 +530,7 @@ describe('Recipe references filter', () => {
               {
                 as: 'nestedid2',
                 provider: 'salesforce',
+                keyword: 'action',
                 name: 'updated_custom_object',
                 dynamicPickListSelection: {
                   sobject_name: 'My Custom',
@@ -799,27 +813,33 @@ describe('Recipe references filter', () => {
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(19)
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
-          (dep: DetailedDependency) => dep.reference.elemID.getFullName()
+          dereferenceDep
         )).toEqual([
-          'netsuite.customrecordtype.instance.customrecord16',
-          'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.0',
-          'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.2',
-          'netsuite.entitycustomfield.instance.custentitycustom_account_city',
-          'netsuite.othercustomfield.instance.custrecord2',
-          'salesforce.MyCustom__c',
-          'salesforce.MyCustom__c.field.customField__c',
-          'salesforce.Opportunity',
-          'salesforce.Opportunity.field.Custom__c',
-          'salesforce.Opportunity.field.FormulaRef1__c',
-          'salesforce.Opportunity.field.FormulaRef2__c',
-          'salesforce.Opportunity.field.FormulaRef3__c',
-          'salesforce.Opportunity.field.FormulaRef4__c',
-          'salesforce.Opportunity.field.Id',
-          'salesforce.Opportunity.field.Name',
-          'salesforce.User',
-          'salesforce.User.field.Field111__c',
-          'salesforce.User.field.Field222__c',
-          'salesforce.User.field.Name__c',
+          { reference: 'netsuite.customrecordtype.instance.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0', direction: 'output' }] },
+          { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.0', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.2', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.entitycustomfield.instance.custentitycustom_account_city', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.othercustomfield.instance.custrecord2', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0', direction: 'output' }] },
+          { reference: 'salesforce.MyCustom__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0.block.0', direction: 'output' }] },
+          { reference: 'salesforce.MyCustom__c.field.customField__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0.block.0', direction: 'output' }] },
+          { reference: 'salesforce.Opportunity', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code', direction: 'input' }] },
+          { reference: 'salesforce.Opportunity.field.Custom__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code', direction: 'input' }] },
+          { reference: 'salesforce.Opportunity.field.FormulaRef1__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0.block.0.input.customField__c', direction: 'input' }] },
+          { reference: 'salesforce.Opportunity.field.FormulaRef2__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0.block.0.input.something1', direction: 'input' }] },
+          { reference: 'salesforce.Opportunity.field.FormulaRef3__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0.block.0.input.something2', direction: 'input' }] },
+          { reference: 'salesforce.Opportunity.field.FormulaRef4__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0.block.0.input.getCustomObject', direction: 'input' }] },
+          { reference: 'salesforce.Opportunity.field.Id', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code', direction: 'input' }] },
+          { reference: 'salesforce.Opportunity.field.Name', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code', direction: 'input' }] },
+          {
+            reference: 'salesforce.User',
+            occurrences: [
+              { location: 'workato.recipe__code.instance.recipe1_code', direction: 'input' },
+              { location: 'workato.recipe__code.instance.recipe1_code.block.0.block.0.input.unknown1', direction: 'input' },
+            ],
+          },
+          { reference: 'salesforce.User.field.Field111__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code', direction: 'input' }] },
+          { reference: 'salesforce.User.field.Field222__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0.block.0.input.something3', direction: 'input' }] },
+          { reference: 'salesforce.User.field.Name__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0.block.0.input.getCustomObject', direction: 'input' }] },
         ])
       })
 
@@ -904,13 +924,13 @@ describe('Recipe references filter', () => {
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(5)
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
-          (dep: DetailedDependency) => dep.reference.elemID.getFullName()
+          dereferenceDep
         )).toEqual([
-          'netsuite.customrecordtype.instance.customrecord16',
-          'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.0',
-          'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.2',
-          'netsuite.entitycustomfield.instance.custentitycustom_account_city',
-          'netsuite.othercustomfield.instance.custrecord2',
+          { reference: 'netsuite.customrecordtype.instance.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.block.0', direction: 'output' }] },
+          { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.0', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.2', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.entitycustomfield.instance.custentitycustom_account_city', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.othercustomfield.instance.custrecord2', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.block.0', direction: 'output' }] },
         ])
       })
 
@@ -974,10 +994,10 @@ describe('Recipe references filter', () => {
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(2)
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
-          (dep: DetailedDependency) => dep.reference.elemID.getFullName()
+          dereferenceDep
         )).toEqual([
-          'salesforce.MyCustom__c',
-          'salesforce.MyCustom__c.field.customField__c',
+          { reference: 'salesforce.MyCustom__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.block.0.block.0', direction: 'output' }] },
+          { reference: 'salesforce.MyCustom__c.field.customField__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.block.0.block.0', direction: 'output' }] },
         ])
       })
     })
@@ -1075,18 +1095,18 @@ describe('Recipe references filter', () => {
       expect(
         elements
           .flatMap(e => e.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] ?? [])
-          .map((dep: DetailedDependency) => dep.reference.elemID.getFullName())
+          .map(dereferenceDep)
       ).toEqual([
-        'netsuite.customrecordtype.instance.customrecord16',
-        'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.0',
-        'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.2',
-        'netsuite.entitycustomfield.instance.custentitycustom_account_city',
-        'netsuite.othercustomfield.instance.custrecord2',
-        'netsuite.customrecordtype.instance.customrecord16',
-        'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.0',
-        'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.2',
-        'netsuite.entitycustomfield.instance.custentitycustom_account_city',
-        'netsuite.othercustomfield.instance.custrecord2',
+        { reference: 'netsuite.customrecordtype.instance.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0', direction: 'output' }] },
+        { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.0', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
+        { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.2', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
+        { reference: 'netsuite.entitycustomfield.instance.custentitycustom_account_city', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.input.Custom__c', direction: 'input' }] },
+        { reference: 'netsuite.othercustomfield.instance.custrecord2', occurrences: [{ location: 'workato.recipe__code.instance.recipe1_code.block.0', direction: 'output' }] },
+        { reference: 'netsuite.customrecordtype.instance.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.block.0', direction: 'output' }] },
+        { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.0', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
+        { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.2', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
+        { reference: 'netsuite.entitycustomfield.instance.custentitycustom_account_city', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.input.Custom__c', direction: 'input' }] },
+        { reference: 'netsuite.othercustomfield.instance.custrecord2', occurrences: [{ location: 'workato.recipe__code.instance.recipe3_code.block.0', direction: 'output' }] },
       ])
     })
   })
@@ -1142,20 +1162,20 @@ describe('Recipe references filter', () => {
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(12)
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].map(
-          (dep: DetailedDependency) => dep.reference.elemID.getFullName()
+          dereferenceDep
         )).toEqual([
-          'netsuite.customrecordtype.instance.customrecord16',
-          'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.0',
-          'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.2',
-          'netsuite.entitycustomfield.instance.custentitycustom_account_city',
-          'netsuite.othercustomfield.instance.custrecord2',
-          'salesforce.MyCustom__c',
-          'salesforce.MyCustom__c.field.customField__c',
-          'salesforce.Opportunity',
-          'salesforce.Opportunity.field.Custom__c',
-          'salesforce.Opportunity.field.FormulaRef1__c',
-          'salesforce.Opportunity.field.FormulaRef2__c',
-          'salesforce.Opportunity.field.FormulaRef3__c',
+          { reference: 'netsuite.customrecordtype.instance.customrecord16', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.block.0', direction: 'output' }] },
+          { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.0', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.customrecordtype.instance.customrecord16.customrecordcustomfields.customrecordcustomfield.2', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.entitycustomfield.instance.custentitycustom_account_city', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.input.Custom__c', direction: 'input' }] },
+          { reference: 'netsuite.othercustomfield.instance.custrecord2', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.block.0', direction: 'output' }] },
+          { reference: 'salesforce.MyCustom__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.block.0.block.0', direction: 'output' }] },
+          { reference: 'salesforce.MyCustom__c.field.customField__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.block.0.block.0', direction: 'output' }] },
+          { reference: 'salesforce.Opportunity', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code', direction: 'input' }] },
+          { reference: 'salesforce.Opportunity.field.Custom__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code', direction: 'input' }] },
+          { reference: 'salesforce.Opportunity.field.FormulaRef1__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.block.0.block.0.input.customField__c', direction: 'input' }] },
+          { reference: 'salesforce.Opportunity.field.FormulaRef2__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.block.0.block.0.input.something1', direction: 'input' }] },
+          { reference: 'salesforce.Opportunity.field.FormulaRef3__c', occurrences: [{ location: 'workato.recipe__code.instance.recipe5_code.block.0.block.0.input.something2', direction: 'input' }] },
         ])
       })
     })


### PR DESCRIPTION
Note: also includes the changes from https://github.com/salto-io/salto/pull/2076, please only review the workato part here.

Include details about the reference location and direction in workato references.

---

WIP - This is an initial suggestion for discussion, we still need to finalize the `location` details for consistency (right now, formula references point to the specific formula field, but some others point at the whole block).

---
_Release Notes_: 
Workato adapter - Add more specific details in cross-service references in recipes.
