### PR TITLE
SALTO-1280 Extract references from get_custom_object

### DIFF
--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/salesforce.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/salesforce.ts
@@ -43,8 +43,18 @@ const createFormulaFieldMatcher = (application: string): Matcher<SalesforceField
   const sobjectFieldMatcher = new RegExp(`\\('data\\.${application}\\.(?<block>\\w+)\\.sobject\\.(?<field>\\w+)'\\)`, 'g')
   // example: ('data.salesforce.1234abcd.Name')
   const fieldOnlyMatcher = new RegExp(`\\('data\\.${application}\\.(?<block>\\w+)\\.(?<field>\\w+)'\\)`, 'g')
+  // examples:
+  //  - ('data.salesforce.aaa.get_custom_object(AccountId>id, sobject_name: Account).Name')
+  // eslint-disable-next-line max-len
+  //  - ('data.salesforce.aaa.get_custom_object(AccountId>id, sobject_name: Account).get_custom_object(ParentId>id, sobject_name: User).Name')
+  const customObjectFunctionUnnamedMatcher = '\\.get_custom_object\\([A-Za-z0-9_<>\\.]+\\, sobject_name\\: \\w+\\)'
+  const customObjectFunctionNamedMatcher = '\\.get_custom_object\\([A-Za-z0-9_<>\\.]+\\, sobject_name\\: (?<obj>\\w+)\\)'
+  const getCustomObjectMatcher = new RegExp(`\\('data\\.${application}\\.(?<block>\\w+)(${customObjectFunctionUnnamedMatcher})*${customObjectFunctionNamedMatcher}\\.(?<field>\\w+)'\\)`, 'g')
   return createMatcher(
-    [objectAndFieldMatcher, relatedObjectAndFieldMatcher, sobjectFieldMatcher, fieldOnlyMatcher],
+    [
+      objectAndFieldMatcher, relatedObjectAndFieldMatcher, sobjectFieldMatcher, fieldOnlyMatcher,
+      getCustomObjectMatcher,
+    ],
     isSalesforceFieldMatchGroup,
   )
 }

--- a/packages/workato-adapter/test/filters/recipe_references.test.ts
+++ b/packages/workato-adapter/test/filters/recipe_references.test.ts
@@ -294,6 +294,7 @@ describe('Recipe references filter', () => {
                 something1: '#{_(\'data.salesforce.1234aaaa.sobject.FormulaRef2__c\')}',
                 something2: '#{_(\'data.salesforce.1234aaaa.FormulaRef3__c\')}',
                 something3: '#{_(\'data.salesforce.1234aaaa.sobject.User.Field222__c\')}',
+                getCustomObject: '#{_(\'data.salesforce.1234aaaa.get_custom_object(UserId>id, sobject_name: User).Name__c\')}#{_(\'data.salesforce.1234aaaa.get_custom_object(CampaignId>id, sobject_name: Campaign).get_custom_object(CampaignMemberRecordTypeId>id, sobject_name: Opportunity).FormulaRef4__c\')}',
                 unknown1: '#{_(\'data.salesforce.1234aaaa.sobject.User.unknown\')}',
                 unknown2: '#{_(\'data.salesforce.1234aaaa.unknown.first.FormulaRef1__c\')}',
               },
@@ -576,6 +577,12 @@ describe('Recipe references filter', () => {
             apiName: 'Opportunity.FormulaRef3__c',
           },
         },
+        FormulaRef4__c: {
+          type: BuiltinTypes.STRING,
+          annotations: {
+            apiName: 'Opportunity.FormulaRef4__c',
+          },
+        },
       },
       annotations: {
         metadataType: 'CustomObject',
@@ -596,6 +603,12 @@ describe('Recipe references filter', () => {
           type: BuiltinTypes.NUMBER,
           annotations: {
             apiName: 'User.Field222__c',
+          },
+        },
+        Name__c: {
+          type: BuiltinTypes.STRING,
+          annotations: {
+            apiName: 'User.Name__c',
           },
         },
       },
@@ -723,7 +736,7 @@ describe('Recipe references filter', () => {
         const recipeCode = currentAdapterElements.find(e => e.elemID.getFullName() === 'workato.recipe__code.instance.recipe1_code')
         expect(recipeCode).toBeDefined()
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toBeDefined()
-        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(17)
+        expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toHaveLength(19)
         expect(recipeCode?.annotations?.[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].every(
           isReferenceExpression
         )).toBeTruthy()
@@ -742,11 +755,13 @@ describe('Recipe references filter', () => {
           'salesforce.Opportunity.field.FormulaRef1__c',
           'salesforce.Opportunity.field.FormulaRef2__c',
           'salesforce.Opportunity.field.FormulaRef3__c',
+          'salesforce.Opportunity.field.FormulaRef4__c',
           'salesforce.Opportunity.field.Id',
           'salesforce.Opportunity.field.Name',
           'salesforce.User',
           'salesforce.User.field.Field111__c',
           'salesforce.User.field.Field222__c',
+          'salesforce.User.field.Name__c',
         ])
       })
 


### PR DESCRIPTION
Extract references from related objects using `get_custom_object` in workato recipes.

---
_Release Notes_: 
_(only if not already mentioned in another PR's notes in the same release)_
Workato adapter - extract additional salesforce references
