### PR TITLE
SALTO-825: added fetch for dataTypes

### DIFF
--- a/packages/adapter-api/src/utils.ts
+++ b/packages/adapter-api/src/utils.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { TypeElement, ObjectType, Element, PrimitiveType, ContainerType, isContainerType, Field, isObjectType, isField, isListType, isMapType, ReadOnlyElementsSource } from './elements'
+import { TypeElement, ObjectType, Element, PrimitiveType, isContainerType, Field, isObjectType, isField, isListType, isMapType, ReadOnlyElementsSource } from './elements'
 import { Values } from './values'
 
 interface AnnoRef {
@@ -30,14 +30,13 @@ type SubElementSearchResult = {
 export const isIndexPathPart = (key: string): boolean => !Number.isNaN(Number(key))
 
 export const getDeepInnerType = async (
-  containerType: ContainerType,
+  type: TypeElement,
   elementsSource?: ReadOnlyElementsSource,
 ): Promise<ObjectType | PrimitiveType> => {
-  const innerType = await containerType.getInnerType(elementsSource)
-  if (!isContainerType(innerType)) {
-    return innerType
+  if (!isContainerType(type)) {
+    return type
   }
-  return getDeepInnerType(innerType, elementsSource)
+  return getDeepInnerType(await type.getInnerType(elementsSource), elementsSource)
 }
 
 export const getSubElement = async (

--- a/packages/adapter-api/test/utils.test.ts
+++ b/packages/adapter-api/test/utils.test.ts
@@ -192,6 +192,9 @@ describe('Test utils.ts & isXXX in elements.ts', () => {
         await mockObjectType.fields.listOfMapFieldTest.getType() as ListType
       )).toEqual(BuiltinTypes.NUMBER)
     })
+    it('should return the type if not container', async () => {
+      expect(await getDeepInnerType(primitiveNum)).toEqual(primitiveNum)
+    })
   })
   describe('getField, getFieldType funcs', () => {
     describe('With ElementsSource', () => {

--- a/packages/adapter-components/src/elements/soap/type_elements/types_generator.ts
+++ b/packages/adapter-components/src/elements/soap/type_elements/types_generator.ts
@@ -82,7 +82,7 @@ export const extractTypes = async (
     .value()
 
   if (duplicateTypes.length > 0) {
-    throw new Error(`There are duplicate type names in the WSDL: ${duplicateTypes}`)
+    log.debug(`There are duplicate type names in the WSDL: ${duplicateTypes}`)
   }
 
   log.debug('Finished generating SOAP types')

--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -64,9 +64,13 @@ export const filterTypes = async (
     return type
   }).filter(values.isDefined)
 
-  relevantTypes.forEach(t => { t.path = [adapterName, TYPES_PATH, t.elemID.name] })
+  relevantTypes
+    .filter(t => t.path === undefined)
+    .forEach(t => { t.path = [adapterName, TYPES_PATH, t.elemID.name] })
   const subtypes = await getSubtypes(relevantTypes)
-  subtypes.forEach(t => { t.path = [adapterName, TYPES_PATH, SUBTYPES_PATH, t.elemID.name] })
+  subtypes
+    .filter(t => t.path === undefined)
+    .forEach(t => { t.path = [adapterName, TYPES_PATH, SUBTYPES_PATH, t.elemID.name] })
 
   return [...relevantTypes, ...subtypes]
 }

--- a/packages/adapter-components/test/elements/soap/types_generator.test.ts
+++ b/packages/adapter-components/test/elements/soap/types_generator.test.ts
@@ -80,7 +80,8 @@ describe('extractTypes', () => {
     expect(testedType).toBeDefined()
   })
 
-  it('should throw error when there are duplicate types', async () => {
-    await expect(extractTypes('adapterName', INVALID_WSDL_PATH)).rejects.toThrow()
+  it('should return duplicate types', async () => {
+    const typesWithDups = await extractTypes('adapterName', INVALID_WSDL_PATH)
+    expect(typesWithDups.filter(type => type.elemID.name === 'testedType')).toHaveLength(2)
   })
 })

--- a/packages/adapter-components/test/elements/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/type_elements.test.ts
@@ -91,19 +91,22 @@ describe('type_elements', () => {
 
   describe('filterTypes', () => {
     it('should filter the right types', async () => {
-      const typeA = new ObjectType({ elemID: new ElemID('adapterName', 'A'), path: ['adapterName', 'A'] })
-      const typeB = new ObjectType({ elemID: new ElemID('adapterName', 'B'),
+      const typeA = new ObjectType({ elemID: new ElemID('adapterName', 'A') })
+      const typeB = new ObjectType({ elemID: new ElemID('adapterName', 'B'), path: ['adapter', 'somePath'] })
+      const typeC = new ObjectType({ elemID: new ElemID('adapterName', 'C'),
         fields: {
           a: { refType: createRefToElmWithValue(typeA) },
-        },
-        path: ['adapterName', 'B'] })
-      const typeC = new ObjectType({ elemID: new ElemID('adapterName', 'C'), path: ['adapterName', 'C'] })
-      const filteredTypes = await filterTypes('adapterName', [typeA, typeB, typeC], ['B', 'D'])
+          b: { refType: createRefToElmWithValue(typeB) },
+        } })
+      const typeD = new ObjectType({ elemID: new ElemID('adapterName', 'D') })
+      const filteredTypes = await filterTypes('adapterName', [typeA, typeC, typeD], ['C', 'E'])
 
-      expect(filteredTypes[0].elemID.getFullNameParts()).toEqual(['adapterName', 'B'])
-      expect(filteredTypes[0].path).toEqual(['adapterName', TYPES_PATH, 'B'])
+      expect(filteredTypes[0].elemID.getFullNameParts()).toEqual(['adapterName', 'C'])
+      expect(filteredTypes[0].path).toEqual(['adapterName', TYPES_PATH, 'C'])
       expect(filteredTypes[1].elemID.getFullNameParts()).toEqual(['adapterName', 'A'])
       expect(filteredTypes[1].path).toEqual(['adapterName', TYPES_PATH, SUBTYPES_PATH, 'A'])
+      expect(filteredTypes[2].elemID.getFullNameParts()).toEqual(['adapterName', 'B'])
+      expect(filteredTypes[2].path).toEqual(['adapter', 'somePath'])
     })
   })
 })

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@salto-io/adapter-api": "0.2.11",
+    "@salto-io/adapter-components": "0.2.11",
     "@salto-io/adapter-utils": "0.2.11",
     "@salto-io/e2e-credentials-store": "0.2.11",
     "@salto-io/file": "0.2.11",

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -16,7 +16,7 @@
 import {
   FetchResult, isInstanceElement, AdapterOperations, DeployResult, DeployOptions,
   ElemIdGetter, Element, ReadOnlyElementsSource,
-  FetchOptions, Field, BuiltinTypes, CORE_ANNOTATIONS, DeployModifiers, ObjectType,
+  FetchOptions, Field, BuiltinTypes, CORE_ANNOTATIONS, DeployModifiers,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
@@ -49,6 +49,7 @@ import { createElementsSourceIndex } from './elements_source_index/elements_sour
 import { LazyElementsSourceIndex } from './elements_source_index/types'
 import getChangeValidator from './change_validator'
 import { getChangeGroupIdsFunc } from './group_changes'
+import { getDataTypes } from './data_elements/data_elements'
 
 const { makeArray } = collections.array
 const { awu } = collections.asynciterable
@@ -159,10 +160,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
 
     const isPartial = this.fetchTarget !== undefined
 
-
-    // TODO: uncomment when dataTypes is ready
-    // const dataTypesPromise = getDataTypes(this.client)
-    const dataTypesPromise: ObjectType[] = []
+    const dataTypesPromise = getDataTypes(this.client)
 
     const getCustomObjectsResult = this.client.getCustomObjects(
       Object.keys(customTypes),

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -18,6 +18,7 @@ import { AccountId, Change, ChangeGroup, DeployResult, getChangeElement, Instanc
 import { logger } from '@salto-io/logging'
 import { decorators, collections } from '@salto-io/lowerdash'
 import { resolveValues } from '@salto-io/adapter-utils'
+import { WSDL } from 'soap'
 import { NetsuiteQuery } from '../query'
 import { Credentials, toUrlAccountId } from './credentials'
 import SdfClient from './sdf_client'
@@ -180,4 +181,8 @@ export default class NetsuiteClient {
       }
     }
   )
+
+  public async getNetsuiteWsdl(): Promise<WSDL | undefined> {
+    return this.suiteAppClient?.getNetsuiteWsdl()
+  }
 }

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -252,6 +252,13 @@ export default class SoapClient {
     })
   }
 
+  public async getNetsuiteWsdl(): Promise<soap.WSDL> {
+    // Though wsdl is private on the client, it is available publicly when using
+    // the library without typescript so we rely on it to not change
+    const { wsdl } = (await this.getClient()) as unknown as { wsdl: soap.WSDL }
+    return wsdl
+  }
+
   private async sendSoapRequest(operation: string, body: object): Promise<unknown> {
     const client = await this.getClient()
     return this.callsLimiter(async () => (await client[`${operation}Async`](body))[0])

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -21,6 +21,7 @@ import Ajv from 'ajv'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { WSDL } from 'soap'
 import { CallsLimiter, ExistingFileCabinetInstanceDetails, FileCabinetInstanceDetails,
   FILES_READ_SCHEMA, HttpMethod, isError, ReadResults, RestletOperation, RestletResults,
   RESTLET_RESULTS_SCHEMA, SavedSearchQuery, SavedSearchResults, SAVED_SEARCH_RESULTS_SCHEMA,
@@ -284,5 +285,9 @@ export default class SuiteAppClient {
   public async deleteFileCabinetInstances(fileCabinetInstances:
     ExistingFileCabinetInstanceDetails[]): Promise<(number | Error)[]> {
     return this.soapClient.deleteFileCabinetInstances(fileCabinetInstances)
+  }
+
+  public async getNetsuiteWsdl(): Promise<WSDL> {
+    return this.soapClient.getNetsuiteWsdl()
   }
 }

--- a/packages/netsuite-adapter/src/data_elements/data_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/data_elements.ts
@@ -1,0 +1,45 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { elements as elementsComponents } from '@salto-io/adapter-components'
+import NetsuiteClient from '../client/client'
+
+export const SUPPORTED_TYPES = ['Account', 'Subsidiary', 'Department', 'Classification', 'Location', 'Currency']
+
+const log = logger(module)
+
+
+export const getDataTypes = async (
+  client: NetsuiteClient
+): Promise<ObjectType[]> => {
+  if (!client.isSuiteAppConfigured()) {
+    return []
+  }
+
+  const wsdl = await client.getNetsuiteWsdl()
+  if (wsdl === undefined) {
+    log.warn('Failed to get WSDL, skipping dataTypes')
+    return []
+  }
+  const types = await elementsComponents.soap.extractTypes('netsuite', wsdl)
+
+  types.forEach(type => {
+    type.annotationRefTypes.source = new ReferenceExpression(BuiltinTypes.HIDDEN_STRING.elemID)
+    type.annotations.source = 'soap'
+  })
+  return types
+}

--- a/packages/netsuite-adapter/src/data_elements/data_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/data_elements.ts
@@ -19,7 +19,19 @@ import { elements as elementsComponents } from '@salto-io/adapter-components'
 import NetsuiteClient from '../client/client'
 import { NETSUITE } from '../constants'
 
-export const SUPPORTED_TYPES = ['Account', 'Subsidiary', 'Department', 'Classification', 'Location', 'Currency']
+export const SUPPORTED_TYPES = [
+  'Account',
+  'Subsidiary',
+  'Department',
+  'Classification',
+  'Location',
+  'Currency',
+  'Opportunity',
+  'Customer',
+  'InventoryItem',
+  'SalesOrder',
+  'Order',
+]
 
 const log = logger(module)
 

--- a/packages/netsuite-adapter/src/data_elements/data_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/data_elements.ts
@@ -17,6 +17,7 @@ import { BuiltinTypes, ObjectType, ReferenceExpression } from '@salto-io/adapter
 import { logger } from '@salto-io/logging'
 import { elements as elementsComponents } from '@salto-io/adapter-components'
 import NetsuiteClient from '../client/client'
+import { NETSUITE } from '../constants'
 
 export const SUPPORTED_TYPES = ['Account', 'Subsidiary', 'Department', 'Classification', 'Location', 'Currency']
 
@@ -35,7 +36,7 @@ export const getDataTypes = async (
     log.warn('Failed to get WSDL, skipping dataTypes')
     return []
   }
-  const types = await elementsComponents.soap.extractTypes('netsuite', wsdl)
+  const types = await elementsComponents.soap.extractTypes(NETSUITE, wsdl)
 
   types.forEach(type => {
     type.annotationRefTypes.source = new ReferenceExpression(BuiltinTypes.HIDDEN_STRING.elemID)

--- a/packages/netsuite-adapter/src/filters/hidden_fields.ts
+++ b/packages/netsuite-adapter/src/filters/hidden_fields.ts
@@ -1,0 +1,34 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, isObjectType } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+
+const HIDDEN_FIELDS = ['internalId']
+
+const filterCreator: FilterCreator = () => ({
+  onFetch: async ({ elements }) => {
+    elements
+      .filter(isObjectType)
+      .forEach(type => Object.values(type.fields)
+        .forEach(field => {
+          if (HIDDEN_FIELDS.includes(field.elemID.name)) {
+            field.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
+          }
+        }))
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/hidden_fields.ts
+++ b/packages/netsuite-adapter/src/filters/hidden_fields.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS, isObjectType } from '@salto-io/adapter-api'
+import { isDataObjectType } from '../types'
 import { FilterCreator } from '../filter'
 
 const HIDDEN_FIELDS = ['internalId']
@@ -22,6 +23,7 @@ const filterCreator: FilterCreator = () => ({
   onFetch: async ({ elements }) => {
     elements
       .filter(isObjectType)
+      .filter(isDataObjectType)
       .forEach(type => Object.values(type.fields)
         .forEach(field => {
           if (HIDDEN_FIELDS.includes(field.elemID.name)) {

--- a/packages/netsuite-adapter/src/filters/remove_redundant_fields.ts
+++ b/packages/netsuite-adapter/src/filters/remove_redundant_fields.ts
@@ -1,0 +1,42 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { isContainerType, isObjectType } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { FilterCreator } from '../filter'
+
+const { awu } = collections.asynciterable
+
+const REDUNDANT_TYPES = ['NullField', 'CustomFieldList', 'CustomFieldRef']
+
+
+const filterCreator: FilterCreator = () => ({
+  onFetch: async ({ elements }) => {
+    await awu(elements).filter(isObjectType).forEach(async e =>
+      awu(REDUNDANT_TYPES).forEach(async type => {
+        e.fields = Object.fromEntries(await awu(Object.entries(e.fields))
+          .filter(async ([_name, field]) => {
+            const rawType = await field.getType()
+            const fieldType = isContainerType(rawType) ? await rawType.getInnerType() : rawType
+            return fieldType.elemID.name !== type
+          }).toArray())
+      }))
+
+    _.remove(elements, e => REDUNDANT_TYPES.includes(e.elemID.name))
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
+++ b/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
@@ -1,0 +1,43 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { elements as elementsComponents } from '@salto-io/adapter-components'
+import { isObjectType } from '@salto-io/adapter-api'
+import { NETSUITE, TYPES_PATH } from '../constants'
+import { FilterCreator } from '../filter'
+import { SUPPORTED_TYPES } from '../data_elements/data_elements'
+import { customTypes, fileCabinetTypes, getAllTypes } from '../types'
+
+
+const filterCreator: FilterCreator = () => ({
+  onFetch: async ({ elements }) => {
+    const sdfTypeNames = new Set(getAllTypes().map(e => e.elemID.getFullName()))
+    const supportedDataTypes = (await elementsComponents
+      .filterTypes(NETSUITE, elements.filter(isObjectType), SUPPORTED_TYPES))
+      .filter(e => !sdfTypeNames.has(e.elemID.getFullName()))
+
+    // In case an sdf type was miss-classified as sub type because it was referenced from data type
+    const topLevelSdfTypes = [...Object.values(customTypes), ...Object.values(fileCabinetTypes)]
+    topLevelSdfTypes.forEach(type => {
+      type.path = [NETSUITE, TYPES_PATH, type.elemID.name]
+    })
+
+    _.remove(elements, e => isObjectType(e) && e.annotations.source === 'soap')
+    elements.push(...supportedDataTypes)
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
+++ b/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
@@ -23,7 +23,10 @@ import { getAllTypes, isDataObjectType } from '../types'
 
 
 const filterCreator: FilterCreator = () => ({
-  onFetch: async ({ elements }) => {
+  onFetch: async ({ elements, client }) => {
+    if (!client.isSuiteAppConfigured()) {
+      return
+    }
     const sdfTypeNames = new Set(getAllTypes().map(e => e.elemID.getFullName()))
     const supportedDataTypes = (await elementsComponents
       .filterTypes(

--- a/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
+++ b/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
@@ -16,10 +16,10 @@
 import _ from 'lodash'
 import { elements as elementsComponents } from '@salto-io/adapter-components'
 import { isObjectType } from '@salto-io/adapter-api'
-import { NETSUITE, TYPES_PATH } from '../constants'
+import { NETSUITE } from '../constants'
 import { FilterCreator } from '../filter'
 import { SUPPORTED_TYPES } from '../data_elements/data_elements'
-import { customTypes, fileCabinetTypes, getAllTypes, isDataObjectType } from '../types'
+import { getAllTypes, isDataObjectType } from '../types'
 
 
 const filterCreator: FilterCreator = () => ({
@@ -32,12 +32,6 @@ const filterCreator: FilterCreator = () => ({
         SUPPORTED_TYPES
       ))
       .filter(e => !sdfTypeNames.has(e.elemID.getFullName()))
-
-    // In case an sdf type was miss-classified as sub type because it was referenced from data type
-    const topLevelSdfTypes = [...Object.values(customTypes), ...Object.values(fileCabinetTypes)]
-    topLevelSdfTypes.forEach(type => {
-      type.path = [NETSUITE, TYPES_PATH, type.elemID.name]
-    })
 
     _.remove(elements, e => isObjectType(e) && isDataObjectType(e))
     elements.push(...supportedDataTypes)

--- a/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
+++ b/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
@@ -19,14 +19,18 @@ import { isObjectType } from '@salto-io/adapter-api'
 import { NETSUITE, TYPES_PATH } from '../constants'
 import { FilterCreator } from '../filter'
 import { SUPPORTED_TYPES } from '../data_elements/data_elements'
-import { customTypes, fileCabinetTypes, getAllTypes } from '../types'
+import { customTypes, fileCabinetTypes, getAllTypes, isDataObjectType } from '../types'
 
 
 const filterCreator: FilterCreator = () => ({
   onFetch: async ({ elements }) => {
     const sdfTypeNames = new Set(getAllTypes().map(e => e.elemID.getFullName()))
     const supportedDataTypes = (await elementsComponents
-      .filterTypes(NETSUITE, elements.filter(isObjectType), SUPPORTED_TYPES))
+      .filterTypes(
+        NETSUITE,
+        elements.filter(isObjectType).filter(isDataObjectType),
+        SUPPORTED_TYPES
+      ))
       .filter(e => !sdfTypeNames.has(e.elemID.getFullName()))
 
     // In case an sdf type was miss-classified as sub type because it was referenced from data type
@@ -35,7 +39,7 @@ const filterCreator: FilterCreator = () => ({
       type.path = [NETSUITE, TYPES_PATH, type.elemID.name]
     })
 
-    _.remove(elements, e => isObjectType(e) && e.annotations.source === 'soap')
+    _.remove(elements, e => isObjectType(e) && isDataObjectType(e))
     elements.push(...supportedDataTypes)
   },
 })

--- a/packages/netsuite-adapter/src/filters/replace_record_ref.ts
+++ b/packages/netsuite-adapter/src/filters/replace_record_ref.ts
@@ -1,0 +1,99 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, ElemID, Field, isObjectType, ListType, ObjectType, TypeElement } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
+import { getAllTypes } from '../types'
+import { NETSUITE } from '../constants'
+import { FilterCreator } from '../filter'
+
+const { awu } = collections.asynciterable
+
+const fieldNameToTypeName: Record<string, string | undefined> = {
+  taxEngine: undefined,
+  billableExpensesAcct: undefined,
+  pageLogo: 'file',
+  restrictToAccountingBookList: undefined,
+  accountingContext: undefined,
+  nexusId: 'Nexus',
+  nexus: 'Nexus',
+  logo: 'file',
+  location: 'Location',
+  unitsType: 'UnitsType',
+  interCoAccount: undefined,
+  unit: undefined,
+  checkLayout: undefined,
+  taxFiscalCalendar: undefined,
+  taxAgency: undefined,
+  fiscalCalendar: undefined,
+  currency: 'Currency',
+  accountingBook: undefined,
+  class: 'Classification',
+  deferralAcct: undefined,
+  subsidiaryList: 'Subsidiary',
+  category1099misc: undefined,
+  contact: 'Contact',
+  terms: 'Term',
+  department: 'Department',
+  region: undefined,
+}
+
+const getFieldType = (
+  type: ObjectType,
+  field: Field,
+  typeMap: Record<string, TypeElement>
+): TypeElement | undefined => {
+  if (field.name === 'parent') {
+    return type
+  }
+  const typeName = fieldNameToTypeName[field.name]
+  return typeName !== undefined ? typeMap[typeName] : undefined
+}
+
+const filterCreator: FilterCreator = () => ({
+  onFetch: async ({ elements }) => {
+    const recordRefElemId = new ElemID(NETSUITE, 'RecordRef')
+
+    const recordRefType = elements.filter(isObjectType).find(e => e.elemID.isEqual(recordRefElemId))
+    if (recordRefType === undefined) {
+      return
+    }
+
+    recordRefType.fields.id = new Field(recordRefType, 'id', BuiltinTypes.STRING)
+
+    const types = elements.filter(isObjectType)
+    const typeMap = _.keyBy([...types, ...getAllTypes()], e => e.elemID.name)
+
+    await awu(types).forEach(async element => {
+      element.fields = Object.fromEntries(await awu(Object.entries(element.fields))
+        .map(async ([name, field]) => {
+          let newField = field
+          const fieldRealType = getFieldType(element, field, typeMap)
+          if (fieldRealType !== undefined) {
+            if ((await field.getType()).elemID.isEqual(recordRefElemId)) {
+              newField = new Field(element, name, fieldRealType, field.annotations)
+            }
+            if ((await field.getType()).elemID.isEqual(new ElemID(NETSUITE, 'RecordRefList'))) {
+              newField = new Field(element, name, new ListType(fieldRealType), field.annotations)
+            }
+          }
+          return [name, newField]
+        }).toArray())
+    })
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -224,6 +224,8 @@ export const isFileCabinetInstance = (element: Element): element is InstanceElem
 export const isFileInstance = (element: Element): boolean =>
   isInstanceElement(element) && element.refType.elemID.name === 'file'
 
+export const isDataObjectType = (element: ObjectType): boolean =>
+  element.annotations.source === 'soap'
 
 export const getAllTypes = (): TypeElement[] => [
   ...Object.values(customTypes),

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -555,6 +555,7 @@ describe('Adapter', () => {
 
       const suiteAppClient = {
         getSystemInformation: getSystemInformationMock,
+        getNetsuiteWsdl: () => undefined,
       } as unknown as SuiteAppClient
 
       adapter = new NetsuiteAdapter({
@@ -583,6 +584,7 @@ describe('Adapter', () => {
     it('should not create serverTime elements when fetchTarget parameter was passed', async () => {
       const suiteAppClient = {
         getSystemInformation: getSystemInformationMock,
+        getNetsuiteWsdl: () => undefined,
       } as unknown as SuiteAppClient
 
       adapter = new NetsuiteAdapter({
@@ -632,6 +634,7 @@ describe('Adapter', () => {
 
         suiteAppClient = {
           getSystemInformation: getSystemInformationMock,
+          getNetsuiteWsdl: () => undefined,
         } as unknown as SuiteAppClient
 
         adapter = new NetsuiteAdapter({

--- a/packages/netsuite-adapter/test/data_elements/data_elements.test.ts
+++ b/packages/netsuite-adapter/test/data_elements/data_elements.test.ts
@@ -1,0 +1,82 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, ObjectType } from '@salto-io/adapter-api'
+import * as soap from 'soap'
+import Bottleneck from 'bottleneck'
+import { elements as elementsComponents } from '@salto-io/adapter-components'
+import SuiteAppClient from '../../src/client/suiteapp_client/suiteapp_client'
+import NetsuiteClient from '../../src/client/client'
+import { NETSUITE } from '../../src/constants'
+import SdfClient from '../../src/client/sdf_client'
+import { getDataTypes } from '../../src/data_elements/data_elements'
+
+jest.mock('@salto-io/adapter-components', () => ({
+  ...jest.requireActual<{}>('@salto-io/adapter-components'),
+  elements: {
+    ...jest.requireActual('@salto-io/adapter-components').elements,
+    soap: {
+      extractTypes: jest.fn(),
+    },
+  },
+}))
+
+describe('getDataTypes', () => {
+  const createClientMock = jest.spyOn(soap, 'createClientAsync')
+  const extractTypesMock = elementsComponents.soap.extractTypes as jest.Mock
+  const wsdl = {}
+
+  const creds = {
+    accountId: 'accountId',
+    tokenId: 'tokenId',
+    tokenSecret: 'tokenSecret',
+    suiteAppTokenId: 'suiteAppTokenId',
+    suiteAppTokenSecret: 'suiteAppTokenSecret',
+  }
+  const client = new NetsuiteClient(
+    new SdfClient({ credentials: creds, globalLimiter: new Bottleneck() }),
+    new SuiteAppClient({ credentials: creds, globalLimiter: new Bottleneck() }),
+  )
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    createClientMock.mockResolvedValue({ wsdl, addSoapHeader: jest.fn() } as unknown as soap.Client)
+  })
+
+  it('should return all the types', async () => {
+    const typeA = new ObjectType({ elemID: new ElemID(NETSUITE, 'A') })
+    const typeB = new ObjectType({ elemID: new ElemID(NETSUITE, 'Subsidiary'), fields: { A: { refType: typeA } } })
+    const typeC = new ObjectType({ elemID: new ElemID(NETSUITE, 'C') })
+
+
+    extractTypesMock.mockResolvedValue([typeA, typeB, typeC])
+
+    const types = await getDataTypes(client)
+    expect(types.map(t => t.elemID.name)).toEqual(['A', 'Subsidiary', 'C'])
+  })
+
+  it('should do nothing if SuiteApp is not configured ', async () => {
+    jest.spyOn(client, 'isSuiteAppConfigured').mockReturnValue(false)
+    const types = await getDataTypes(client)
+    expect(types).toHaveLength(0)
+    expect(createClientMock).not.toHaveBeenCalled()
+  })
+
+  it('should return empty list if failed to get wsdl', async () => {
+    jest.spyOn(client, 'getNetsuiteWsdl').mockResolvedValue(undefined)
+    const types = await getDataTypes(client)
+    expect(types).toHaveLength(0)
+  })
+})

--- a/packages/netsuite-adapter/test/filters/hidden_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/hidden_fields.test.ts
@@ -1,0 +1,39 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ObjectType } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/hidden_fields'
+import NetsuiteClient from '../../src/client/client'
+import { NETSUITE } from '../../src/constants'
+import { OnFetchParameters } from '../../src/filter'
+
+describe('hidden_fields', () => {
+  it('should hide requested fields', async () => {
+    const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'someType'),
+      fields: {
+        internalId: { refType: BuiltinTypes.STRING },
+        otherField: { refType: BuiltinTypes.STRING },
+      } })
+    const onFetchParameters: OnFetchParameters = {
+      elements: [type],
+      client: {} as NetsuiteClient,
+      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      isPartial: false,
+    }
+    await filterCreator().onFetch(onFetchParameters)
+    expect(type.fields.internalId.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toBeTruthy()
+    expect(type.fields.otherField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toBeUndefined()
+  })
+})

--- a/packages/netsuite-adapter/test/filters/hidden_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/hidden_fields.test.ts
@@ -21,11 +21,14 @@ import { OnFetchParameters } from '../../src/filter'
 
 describe('hidden_fields', () => {
   it('should hide requested fields', async () => {
-    const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'someType'),
+    const type = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'someType'),
       fields: {
         internalId: { refType: BuiltinTypes.STRING },
         otherField: { refType: BuiltinTypes.STRING },
-      } })
+      },
+      annotations: { source: 'soap' },
+    })
     const onFetchParameters: OnFetchParameters = {
       elements: [type],
       client: {} as NetsuiteClient,

--- a/packages/netsuite-adapter/test/filters/remove_redundant_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/remove_redundant_fields.test.ts
@@ -1,0 +1,49 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, ObjectType, BuiltinTypes, ListType } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/remove_redundant_fields'
+import { OnFetchParameters } from '../../src/filter'
+import { NETSUITE } from '../../src/constants'
+import NetsuiteClient from '../../src/client/client'
+
+describe('removeRedundantFields', () => {
+  const typeToRemove = new ObjectType({ elemID: new ElemID(NETSUITE, 'NullField') })
+  const typeWithFieldToRemove = new ObjectType({ elemID: new ElemID(NETSUITE, 'typeWithFieldToRemove'),
+    fields: {
+      fieldToRemove: { refType: typeToRemove },
+      listToRemove: { refType: new ListType(typeToRemove) },
+      numberField: { refType: BuiltinTypes.NUMBER },
+    } })
+  let onFetchParameters: OnFetchParameters
+  let elements: ObjectType[]
+
+  beforeEach(() => {
+    elements = [typeToRemove, typeWithFieldToRemove]
+    onFetchParameters = {
+      elements,
+      client: {} as NetsuiteClient,
+      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      isPartial: false,
+    }
+  })
+  it('should remove the types and the fields', async () => {
+    await filterCreator().onFetch(onFetchParameters)
+    expect(elements.length).toEqual(1)
+    expect(typeWithFieldToRemove.fields.fieldToRemove).toBeUndefined()
+    expect(typeWithFieldToRemove.fields.listToRemove).toBeUndefined()
+    expect(typeWithFieldToRemove.fields.numberField).toBeDefined()
+  })
+})

--- a/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
@@ -1,0 +1,44 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, ObjectType, TypeElement } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/remove_unsupported_types'
+import { NETSUITE } from '../../src/constants'
+import NetsuiteClient from '../../src/client/client'
+import { OnFetchParameters } from '../../src/filter'
+import { file } from '../../src/types/file_cabinet_types'
+
+describe('remove_unsupported_types', () => {
+  let onFetchParameters: OnFetchParameters
+  let elements: TypeElement[]
+  const sdfType = file
+  const supportedSoapType = new ObjectType({ elemID: new ElemID(NETSUITE, 'Subsidiary'), annotations: { source: 'soap' } })
+  const unsupportedSoapType = new ObjectType({ elemID: new ElemID(NETSUITE, 'someType'), annotations: { source: 'soap' } })
+
+  beforeEach(() => {
+    elements = [sdfType, supportedSoapType, unsupportedSoapType]
+    onFetchParameters = {
+      elements,
+      client: {} as NetsuiteClient,
+      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      isPartial: false,
+    }
+  })
+
+  it('should remove the unsupported types', async () => {
+    await filterCreator().onFetch(onFetchParameters)
+    expect(elements.map(e => e.elemID.name)).toEqual(['file', 'Subsidiary'])
+  })
+})

--- a/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
@@ -26,12 +26,15 @@ describe('remove_unsupported_types', () => {
   const sdfType = file
   const supportedSoapType = new ObjectType({ elemID: new ElemID(NETSUITE, 'Subsidiary'), annotations: { source: 'soap' } })
   const unsupportedSoapType = new ObjectType({ elemID: new ElemID(NETSUITE, 'someType'), annotations: { source: 'soap' } })
+  const isSuiteAppConfiguredMock = jest.fn()
 
   beforeEach(() => {
     elements = [sdfType, supportedSoapType, unsupportedSoapType]
+    isSuiteAppConfiguredMock.mockReset()
+    isSuiteAppConfiguredMock.mockReturnValue(true)
     onFetchParameters = {
       elements,
-      client: {} as NetsuiteClient,
+      client: { isSuiteAppConfigured: isSuiteAppConfiguredMock } as unknown as NetsuiteClient,
       elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
       isPartial: false,
     }
@@ -40,5 +43,11 @@ describe('remove_unsupported_types', () => {
   it('should remove the unsupported types', async () => {
     await filterCreator().onFetch(onFetchParameters)
     expect(elements.map(e => e.elemID.name)).toEqual(['file', 'Subsidiary'])
+  })
+
+  it('should do nothing if suiteApp is not installed', async () => {
+    isSuiteAppConfiguredMock.mockReturnValue(false)
+    await filterCreator().onFetch(onFetchParameters)
+    expect(elements.map(e => e.elemID.name)).toEqual(['file', 'Subsidiary', 'someType'])
   })
 })

--- a/packages/netsuite-adapter/test/filters/replace_record_ref.test.ts
+++ b/packages/netsuite-adapter/test/filters/replace_record_ref.test.ts
@@ -1,0 +1,64 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ContainerType, ElemID, ObjectType, TypeElement } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/replace_record_ref'
+import { NETSUITE } from '../../src/constants'
+import NetsuiteClient from '../../src/client/client'
+import { OnFetchParameters } from '../../src/filter'
+
+describe('replaceRecordRef', () => {
+  let recordRefType: ObjectType
+  let typeWithRecordRef: ObjectType
+  let onFetchParameters: OnFetchParameters
+  let elements: TypeElement[]
+  const departmentType = new ObjectType({ elemID: new ElemID(NETSUITE, 'Department') })
+  const subsidiaryType = new ObjectType({ elemID: new ElemID(NETSUITE, 'Subsidiary') })
+
+  beforeEach(() => {
+    recordRefType = new ObjectType({ elemID: new ElemID(NETSUITE, 'RecordRef') })
+    typeWithRecordRef = new ObjectType({ elemID: new ElemID(NETSUITE, 'typeWithRecordRef'),
+      fields: {
+        department: { refType: recordRefType },
+        parent: { refType: recordRefType },
+        subsidiaryList: { refType: new ObjectType({ elemID: new ElemID(NETSUITE, 'RecordRefList') }) },
+        recordRef: { refType: recordRefType },
+      } })
+    elements = [typeWithRecordRef, recordRefType, departmentType, subsidiaryType]
+    onFetchParameters = {
+      elements,
+      client: {} as NetsuiteClient,
+      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      isPartial: false,
+    }
+  })
+
+  it('should add field to record ref type', async () => {
+    await filterCreator().onFetch(onFetchParameters)
+    expect((await typeWithRecordRef.fields.recordRef.getType() as ObjectType).fields.id)
+      .toBeDefined()
+  })
+
+  it('should replace all record refs references', async () => {
+    await filterCreator().onFetch(onFetchParameters)
+    expect((await typeWithRecordRef.fields.department.getType()).elemID.name).toBe('Department')
+    expect(
+      (await (await typeWithRecordRef.fields.subsidiaryList.getType() as ContainerType)
+        .getInnerType()).elemID.name
+    ).toBe('Subsidiary')
+    expect((await typeWithRecordRef.fields.parent.getType()).elemID.name).toBe('typeWithRecordRef')
+    expect((await typeWithRecordRef.fields.recordRef.getType()).elemID.name).toBe('RecordRef')
+  })
+})

--- a/packages/netsuite-adapter/tsconfig.json
+++ b/packages/netsuite-adapter/tsconfig.json
@@ -15,6 +15,7 @@
   ],
   "references": [
     { "path": "../adapter-api" },
+    { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
     { "path": "../e2e-credentials-store" },
     { "path": "../file" },


### PR DESCRIPTION
Added support for fetching the SOAP types in Netsuite.

Currently, all the lines that use the new functionality in adapter.ts are commented out, so this PR does not affect the user.

---
_Release Notes_: 
None