### PR TITLE
Fixed bug for partial fetch of type that are not supproted by the changes detector

### DIFF
--- a/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
@@ -169,7 +169,9 @@ export const getChangedObjects = async (
   log.debug(`${folderPaths.length} folder paths changes were detected`)
 
   return {
-    isTypeMatch: () => scriptIds.size !== 0 || types.size !== 0,
+    isTypeMatch: typeName => !SUPPORTED_TYPES.has(typeName)
+      || scriptIds.size !== 0
+      || types.size !== 0,
     isObjectMatch: objectID => !SUPPORTED_TYPES.has(objectID.type)
       || scriptIds.has(objectID.scriptId)
       || types.has(objectID.type),

--- a/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
@@ -115,10 +115,25 @@ describe('changes_detector', () => {
     const changedObjectsQuery = await getChangedObjects(
       client,
       query,
-      createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z')),
+      createDateRange(new Date('2022-01-11T18:55:17.949Z'), new Date('2022-02-22T18:55:17.949Z')),
       elementsSourceIndex,
     )
     expect(changedObjectsQuery.isFileMatch('/Templates/path/to/anyFile')).toBeTruthy()
+  })
+
+  it('should match types that are not supported by the changes detector', async () => {
+    getCustomRecordTypeChangesMock.mockResolvedValue([])
+    getChangedFilesMock.mockResolvedValue([])
+    getChangesFoldersMock.mockResolvedValue([])
+    runSavedSearchQueryMock.mockResolvedValue([])
+
+    const changedObjectsQuery = await getChangedObjects(
+      client,
+      query,
+      createDateRange(new Date('2021-01-11T18:55:17.949Z'), new Date('2021-02-22T18:55:17.949Z')),
+      elementsSourceIndex,
+    )
+    expect(changedObjectsQuery.isTypeMatch('addressForm')).toBeTruthy()
   })
 
   it('should return all the results of system note query failed', async () => {


### PR DESCRIPTION
Fixed a bug that if the changes detection would return there are no changes at all, we would not attempt to fetch types that are not supported by the changes detector.

---
_Release Notes_: 
None