### PR TITLE
SALTO-1323: service list command

### DIFF
--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -20,7 +20,7 @@ import { Workspace } from '@salto-io/workspace'
 import { getCredentialsFromUser } from '../callbacks'
 import { CliOutput, CliExitCode, KeyedOption } from '../types'
 import { createCommandGroupDef, WorkspaceCommandAction, createWorkspaceCommand } from '../command_builder'
-import { formatServiceAlreadyAdded, formatServiceAdded, formatLoginToServiceFailed, formatCredentialsHeader, formatLoginUpdated, formatConfiguredServices, formatServiceNotConfigured, formatLoginOverride } from '../formatter'
+import { formatServiceAlreadyAdded, formatServiceAdded, formatLoginToServiceFailed, formatCredentialsHeader, formatLoginUpdated, formatServiceNotConfigured, formatLoginOverride, formatConfiguredAndAdditionalServices } from '../formatter'
 import { errorOutputLine, outputLine } from '../outputer'
 import { processOauthCredentials } from '../cli_oauth_authenticator'
 import { EnvArg, ENVIRONMENT_OPTION, validateAndSetEnv } from './common/env'
@@ -159,7 +159,7 @@ export const listAction: WorkspaceCommandAction<ServiceListArgs> = async (
   { input, output, workspace },
 ): Promise<CliExitCode> => {
   await validateAndSetEnv(workspace, input, output)
-  outputLine(formatConfiguredServices(workspace.services()), output)
+  outputLine(formatConfiguredAndAdditionalServices(workspace.services()), output)
   return CliExitCode.Success
 }
 

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -523,10 +523,10 @@ const formatConfiguredServices = (serviceNames: ReadonlyArray<string>): string =
   return formattedServices.join('\n')
 }
 
-const formatAdditionalConfigurableServices = (services: ReadonlyArray<string>): string => {
+const formattedAdditionalServices = (services: ReadonlyArray<string>): string => {
   const formattedServices = getSupportedServiceAdapterNames()
     .filter(serviceName => !services.includes(serviceName))
-    .map(serviceName => indent(`* ${serviceName}`, 1))
+    .map(serviceName => indent(`- ${serviceName}`, 1))
   if (formattedServices.length === 0) {
     return Prompts.NO_ADDITIONAL_CONFIGURED_SERVICES.concat(EOL)
   }
@@ -537,7 +537,7 @@ const formatAdditionalConfigurableServices = (services: ReadonlyArray<string>): 
 }
 
 export const formatConfiguredAndAdditionalServices = (services: ReadonlyArray<string>): string =>
-  [formatConfiguredServices(services), formatAdditionalConfigurableServices(services)].join(EOL)
+  [formatConfiguredServices(services), formattedAdditionalServices(services)].join(EOL)
 
 export const formatServiceAdded = (serviceName: string): string => [
   formatSuccess(Prompts.SERVICE_ADDED(serviceName)),

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -530,6 +530,7 @@ const formatAdditionalConfigurableServices = (services: ReadonlyArray<string>): 
   if (formattedServices.length === 0) {
     return Prompts.NO_ADDITIONAL_CONFIGURED_SERVICES.concat(EOL)
   }
+  
   formattedServices.unshift(Prompts.ADDITIONAL_SUPPORTED_SERVICES_TITLE)
   formattedServices.push(emptyLine())
   return formattedServices.join(EOL)

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -530,7 +530,7 @@ const formatAdditionalConfigurableServices = (services: ReadonlyArray<string>): 
   if (formattedServices.length === 0) {
     return Prompts.NO_ADDITIONAL_CONFIGURED_SERVICES.concat(EOL)
   }
-  
+
   formattedServices.unshift(Prompts.ADDITIONAL_SUPPORTED_SERVICES_TITLE)
   formattedServices.push(emptyLine())
   return formattedServices.join(EOL)

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -23,7 +23,7 @@ import {
   ActionName, ChangeError, SaltoError, isElement, TypeMap, DetailedChange, ChangeDataType,
   isStaticFile,
 } from '@salto-io/adapter-api'
-import { Plan, PlanItem, FetchChange, FetchResult, LocalChange } from '@salto-io/core'
+import { Plan, PlanItem, FetchChange, FetchResult, LocalChange, getSupportedServiceAdapterNames } from '@salto-io/core'
 import { errors, SourceFragment, parser, WorkspaceComponents, StateRecency } from '@salto-io/workspace'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -509,7 +509,7 @@ export const formatServiceNotConfigured = (serviceName: string): string => [
   emptyLine(),
 ].join('\n')
 
-export const formatConfiguredServices = (serviceNames: ReadonlyArray<string>): string => {
+const formatConfiguredServices = (serviceNames: ReadonlyArray<string>): string => {
   if (serviceNames.length === 0) {
     return [
       Prompts.NO_CONFIGURED_SERVICES,
@@ -522,6 +522,18 @@ export const formatConfiguredServices = (serviceNames: ReadonlyArray<string>): s
   formattedServices.push(emptyLine())
   return formattedServices.join('\n')
 }
+
+const formatAdditionalConfigurableServices = (services: ReadonlyArray<string>): string => {
+  const formattedServices = getSupportedServiceAdapterNames()
+    .filter(serviceName => !services.includes(serviceName))
+    .map(serviceName => indent(`* ${serviceName}`, 1))
+  formattedServices.unshift(Prompts.ADDITIONAL_SUPPORTED_SERVICES_TITLE)
+  formattedServices.push(emptyLine())
+  return formattedServices.join(EOL)
+}
+
+export const formatConfiguredAndAdditionalServices = (services: ReadonlyArray<string>): string =>
+  [formatConfiguredServices(services), formatAdditionalConfigurableServices(services)].join(EOL)
 
 export const formatServiceAdded = (serviceName: string): string => [
   formatSuccess(Prompts.SERVICE_ADDED(serviceName)),

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -523,9 +523,7 @@ const formatConfiguredServices = (serviceNames: ReadonlyArray<string>): string =
   return formattedServices.join('\n')
 }
 
-const privateAdapters = ['dummy']
-
-export const getPrivateAdaptersNames = (): string[] => privateAdapters
+export const getPrivateAdaptersNames = (): ReadonlyArray<string> => ['dummy']
 
 const formatAdditionalServices = (services: ReadonlyArray<string>): string => {
   const formattedServices = getSupportedServiceAdapterNames()

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -23,7 +23,7 @@ import {
   ActionName, ChangeError, SaltoError, isElement, TypeMap, DetailedChange, ChangeDataType,
   isStaticFile,
 } from '@salto-io/adapter-api'
-import { Plan, PlanItem, FetchChange, FetchResult, LocalChange, getSupportedServiceAdapterNames } from '@salto-io/core'
+import { Plan, PlanItem, FetchChange, FetchResult, LocalChange, getSupportedServiceAdapterNames, getPrivateAdaptersNames } from '@salto-io/core'
 import { errors, SourceFragment, parser, WorkspaceComponents, StateRecency } from '@salto-io/workspace'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -523,9 +523,9 @@ const formatConfiguredServices = (serviceNames: ReadonlyArray<string>): string =
   return formattedServices.join('\n')
 }
 
-const formattedAdditionalServices = (services: ReadonlyArray<string>): string => {
+const formatAdditionalServices = (services: ReadonlyArray<string>): string => {
   const formattedServices = getSupportedServiceAdapterNames()
-    .filter(serviceName => !services.includes(serviceName))
+    .filter(serviceName => !services.includes(serviceName) && !getPrivateAdaptersNames().includes(serviceName))
     .map(serviceName => indent(`- ${serviceName}`, 1))
   if (formattedServices.length === 0) {
     return Prompts.NO_ADDITIONAL_CONFIGURED_SERVICES.concat(EOL)
@@ -537,7 +537,7 @@ const formattedAdditionalServices = (services: ReadonlyArray<string>): string =>
 }
 
 export const formatConfiguredAndAdditionalServices = (services: ReadonlyArray<string>): string =>
-  [formatConfiguredServices(services), formattedAdditionalServices(services)].join(EOL)
+  [formatConfiguredServices(services), formatAdditionalServices(services)].join(EOL)
 
 export const formatServiceAdded = (serviceName: string): string => [
   formatSuccess(Prompts.SERVICE_ADDED(serviceName)),

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -23,7 +23,7 @@ import {
   ActionName, ChangeError, SaltoError, isElement, TypeMap, DetailedChange, ChangeDataType,
   isStaticFile,
 } from '@salto-io/adapter-api'
-import { Plan, PlanItem, FetchChange, FetchResult, LocalChange, getSupportedServiceAdapterNames, getPrivateAdaptersNames } from '@salto-io/core'
+import { Plan, PlanItem, FetchChange, FetchResult, LocalChange, getSupportedServiceAdapterNames } from '@salto-io/core'
 import { errors, SourceFragment, parser, WorkspaceComponents, StateRecency } from '@salto-io/workspace'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -523,9 +523,14 @@ const formatConfiguredServices = (serviceNames: ReadonlyArray<string>): string =
   return formattedServices.join('\n')
 }
 
+const privateAdapters = ['dummy']
+
+export const getPrivateAdaptersNames = (): string[] => privateAdapters
+
 const formatAdditionalServices = (services: ReadonlyArray<string>): string => {
   const formattedServices = getSupportedServiceAdapterNames()
-    .filter(serviceName => !services.includes(serviceName) && !getPrivateAdaptersNames().includes(serviceName))
+    .filter(serviceName => !services.includes(serviceName)
+      && !getPrivateAdaptersNames().includes(serviceName))
     .map(serviceName => indent(`- ${serviceName}`, 1))
   if (formattedServices.length === 0) {
     return Prompts.NO_ADDITIONAL_CONFIGURED_SERVICES.concat(EOL)

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -527,6 +527,9 @@ const formatAdditionalConfigurableServices = (services: ReadonlyArray<string>): 
   const formattedServices = getSupportedServiceAdapterNames()
     .filter(serviceName => !services.includes(serviceName))
     .map(serviceName => indent(`* ${serviceName}`, 1))
+  if (formattedServices.length === 0) {
+    return Prompts.NO_ADDITIONAL_CONFIGURED_SERVICES.concat(EOL)
+  }
   formattedServices.unshift(Prompts.ADDITIONAL_SUPPORTED_SERVICES_TITLE)
   formattedServices.push(emptyLine())
   return formattedServices.join(EOL)

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -153,6 +153,7 @@ The steps are: I. Fetching configs, II. Calculating difference and III. Applying
   public static readonly CONFIGURED_SERVICES_TITLE = 'The configured services are:'
   public static readonly ADDITIONAL_SUPPORTED_SERVICES_TITLE = 'Additional supported services are:'
   public static readonly NO_CONFIGURED_SERVICES = 'There are not configured services in this environment'
+  public static readonly NO_ADDITIONAL_CONFIGURED_SERVICES = 'There are no additional configurable services for this environment'
   public static readonly SERVICE_ALREADY_ADDED = (serviceName: string): string => `${serviceName} was already added to this environment`
   public static readonly WORKING_ON_ENV = 'The active environment is'
   public static readonly NO_CURRENT_ENV = 'No active environment is currently set'

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -151,6 +151,7 @@ The steps are: I. Fetching configs, II. Calculating difference and III. Applying
   public static readonly SERVICE_CONFIGURED = (serviceName: string): string => `${serviceName} is configured in this environment`
   public static readonly SERVICE_NOT_CONFIGURED = (serviceName: string): string => `${serviceName} is not configured in this environment`
   public static readonly CONFIGURED_SERVICES_TITLE = 'The configured services are:'
+  public static readonly ADDITIONAL_SUPPORTED_SERVICES_TITLE = 'Additional supported services are:'
   public static readonly NO_CONFIGURED_SERVICES = 'There are not configured services in this environment'
   public static readonly SERVICE_ALREADY_ADDED = (serviceName: string): string => `${serviceName} was already added to this environment`
   public static readonly WORKING_ON_ENV = 'The active environment is'

--- a/packages/cli/test/commands/service.test.ts
+++ b/packages/cli/test/commands/service.test.ts
@@ -15,7 +15,7 @@
 */
 import { AdapterAuthentication, ObjectType } from '@salto-io/adapter-api'
 import {
-  LoginStatus, updateCredentials, addAdapter, installAdapter,
+  LoginStatus, updateCredentials, addAdapter, installAdapter, getPrivateAdaptersNames,
 } from '@salto-io/core'
 import { Workspace } from '@salto-io/workspace'
 import { loginAction, addAction, listAction } from '../../src/commands/service'
@@ -116,12 +116,21 @@ describe('service command group', () => {
             workspace,
           })
         })
-
-        it('should print configured services', () => {
-          expect(output.stdout.content).toContain('The configured services are:')
-          expect(output.stdout.content).toContain('salesforce')
+        it('should not print private services', () => {
+          expect(output.stdout.content).toContain('Additional supported services are:')
+          expect(!getPrivateAdaptersNames().some(privateName =>
+            output.stdout.content.split('Additional supported services are:')[1].includes(privateName))).toBeTruthy()
         })
-
+        it('should print configured services under configured services', () => {
+          expect(output.stdout.content).toContain('The configured services are:')
+          expect(output.stdout.content.split('Additional supported services are:')[0]).toContain('salesforce')
+        })
+        it('should print other services under additional services', () => {
+          expect(output.stdout.content).toContain('Additional supported services are:')
+          expect(!['workato', 'netsuite'].some(serviceName => !output.stdout.content
+            .split('Additional supported services are:')[1]
+            .includes(serviceName))).toBeTruthy()
+        })
         it('should use current env', () => {
           expect(workspace.setCurrentEnv).not.toHaveBeenCalled()
         })

--- a/packages/cli/test/commands/service.test.ts
+++ b/packages/cli/test/commands/service.test.ts
@@ -15,9 +15,10 @@
 */
 import { AdapterAuthentication, ObjectType } from '@salto-io/adapter-api'
 import {
-  LoginStatus, updateCredentials, addAdapter, installAdapter, getPrivateAdaptersNames,
+  LoginStatus, updateCredentials, addAdapter, installAdapter,
 } from '@salto-io/core'
 import { Workspace } from '@salto-io/workspace'
+import { getPrivateAdaptersNames } from '../../src/formatter'
 import { loginAction, addAction, listAction } from '../../src/commands/service'
 import { processOauthCredentials } from '../../src/cli_oauth_authenticator'
 import * as mocks from '../mocks'

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -348,8 +348,4 @@ export const getLoginStatuses = async (
   return promises.object.resolveValues(logins)
 }
 
-const privateAdapters = ['dummy']
-
-export const getPrivateAdaptersNames = (): string[] => privateAdapters
-
 export const getSupportedServiceAdapterNames = (): string[] => Object.keys(adapterCreators)

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -350,7 +350,9 @@ export const getLoginStatuses = async (
 
 const privateAdapters = ['dummy']
 
+export const getPrivateAdaptersNames = (): string[] => privateAdapters
+
 export const getSupportedServiceAdapterNames = (): string[] =>
   Object.keys(adapterCreators).filter(
-    serviceAdapterName => !privateAdapters.includes(serviceAdapterName)
+    serviceAdapterName => !getPrivateAdaptersNames().includes(serviceAdapterName)
   )

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -352,7 +352,4 @@ const privateAdapters = ['dummy']
 
 export const getPrivateAdaptersNames = (): string[] => privateAdapters
 
-export const getSupportedServiceAdapterNames = (): string[] =>
-  Object.keys(adapterCreators).filter(
-    serviceAdapterName => !getPrivateAdaptersNames().includes(serviceAdapterName)
-  )
+export const getSupportedServiceAdapterNames = (): string[] => Object.keys(adapterCreators)

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -347,3 +347,10 @@ export const getLoginStatuses = async (
 
   return promises.object.resolveValues(logins)
 }
+
+const privateAdapters = ['dummy']
+
+export const getSupportedServiceAdapterNames = (): string[] =>
+  Object.keys(adapterCreators).filter(
+    serviceAdapterName => !privateAdapters.includes(serviceAdapterName)
+  )


### PR DESCRIPTION
add more information for the users about what configurable services are open for him to use.
services already listed under configured services will not be seen in the new text.
services which are private (like dummyadapter) will not be seen by the user.
in case there are no more services to be configured there is a different message for it without listing anything.

---

add tests for what i can test easily.
there might be more to check but i dont think this feature deserves any more tests...
![Screen Shot 2021-05-30 at 16 36 54](https://user-images.githubusercontent.com/56266307/120107092-4eef5780-c168-11eb-98b0-22ceb9439ee5.png)

---
_Release Notes_: 
CLI:
add additional configurable services to the "salto service list command" in cli. 
