### PR TITLE
SALTO-1317 - custom object instances go to service

### DIFF
--- a/packages/salesforce-adapter/src/elements_url_retreiver/lightining_url_resolvers.ts
+++ b/packages/salesforce-adapter/src/elements_url_retreiver/lightining_url_resolvers.ts
@@ -15,9 +15,11 @@
 */
 import { isObjectType, Element, isField, Field, isType, isReferenceExpression, ElemID, isInstanceElement } from '@salto-io/adapter-api'
 import { getParents } from '@salto-io/adapter-utils'
-import { isDefined } from '@salto-io/lowerdash/src/values'
+import { values } from '@salto-io/lowerdash'
 import { apiName, metadataType, isCustomObject, isFieldOfCustomObject, isInstanceOfCustomObject } from '../transformers/transformer'
 import { getInternalId, isInstanceOfType } from '../filters/utils'
+
+const { isDefined } = values
 
 export type ElementIDResolver = (id: ElemID) => Promise<Element | undefined>
 

--- a/packages/salesforce-adapter/src/elements_url_retreiver/lightining_url_resolvers.ts
+++ b/packages/salesforce-adapter/src/elements_url_retreiver/lightining_url_resolvers.ts
@@ -163,12 +163,12 @@ const internalIdResolver: UrlResolver = async (element, baseUrl) => {
 
 
 const instanceCustomObjectResolver: UrlResolver = async (element, baseUrl) => {
-  const instanceId = await apiName(element)
-  const typeId = isInstanceElement(element) ? await apiName(await element.getType()) : undefined
-  if (await isInstanceOfCustomObject(element)
-    && instanceId !== undefined
-    && typeId !== undefined) {
-    return new URL(`${baseUrl}lightning/r/${typeId}/${instanceId}/view`)
+  if (await isInstanceOfCustomObject(element)) {
+    const instanceId = await apiName(element)
+    const typeId = isInstanceElement(element) ? await apiName(await element.getType()) : undefined
+    if (typeId !== undefined) {
+      return new URL(`${baseUrl}lightning/r/${typeId}/${instanceId}/view`)
+    }
   }
   return undefined
 }

--- a/packages/salesforce-adapter/src/elements_url_retreiver/lightining_url_resolvers.ts
+++ b/packages/salesforce-adapter/src/elements_url_retreiver/lightining_url_resolvers.ts
@@ -19,7 +19,6 @@ import { isDefined } from '@salto-io/lowerdash/src/values'
 import { apiName, metadataType, isCustomObject, isFieldOfCustomObject, isInstanceOfCustomObject } from '../transformers/transformer'
 import { getInternalId, isInstanceOfType } from '../filters/utils'
 
-
 export type ElementIDResolver = (id: ElemID) => Promise<Element | undefined>
 
 export type UrlResolver = (element: Element, baseUrl: URL, elementIDResolver: ElementIDResolver) =>

--- a/packages/salesforce-adapter/src/elements_url_retreiver/lightining_url_resolvers.ts
+++ b/packages/salesforce-adapter/src/elements_url_retreiver/lightining_url_resolvers.ts
@@ -15,7 +15,7 @@
 */
 import { isObjectType, Element, isField, Field, isType, isReferenceExpression, ElemID, isInstanceElement } from '@salto-io/adapter-api'
 import { getParents } from '@salto-io/adapter-utils'
-import { apiName, metadataType, isCustomObject, isFieldOfCustomObject } from '../transformers/transformer'
+import { apiName, metadataType, isCustomObject, isFieldOfCustomObject, isInstanceOfCustomObject } from '../transformers/transformer'
 import { getInternalId, isInstanceOfType } from '../filters/utils'
 
 export type ElementIDResolver = (id: ElemID) => Promise<Element | undefined>
@@ -161,7 +161,19 @@ const internalIdResolver: UrlResolver = async (element, baseUrl) => {
   return undefined
 }
 
+
+const instanceCustomObjectResolver: UrlResolver = async (element, baseUrl) => {
+  const instanceId = await apiName(element)
+  const typeId = isInstanceElement(element) ? await apiName(await element.getType()) : undefined
+  if (await isInstanceOfCustomObject(element)
+    && instanceId !== undefined
+    && typeId !== undefined) {
+    return new URL(`${baseUrl}lightning/r/${typeId}/${instanceId}/view`)
+  }
+  return undefined
+}
+
 export const resolvers: UrlResolver[] = [genernalConstantsResolver,
   settingsConstantsResolver, assignmentRulesResolver, metadataTypeResolver,
   objectResolver, fieldResolver, flowResolver, workflowResolver, layoutResolver, queueResolver,
-  internalIdResolver]
+  internalIdResolver, instanceCustomObjectResolver]

--- a/packages/salesforce-adapter/src/elements_url_retreiver/lightining_url_resolvers.ts
+++ b/packages/salesforce-adapter/src/elements_url_retreiver/lightining_url_resolvers.ts
@@ -15,8 +15,10 @@
 */
 import { isObjectType, Element, isField, Field, isType, isReferenceExpression, ElemID, isInstanceElement } from '@salto-io/adapter-api'
 import { getParents } from '@salto-io/adapter-utils'
+import { isDefined } from '@salto-io/lowerdash/src/values'
 import { apiName, metadataType, isCustomObject, isFieldOfCustomObject, isInstanceOfCustomObject } from '../transformers/transformer'
 import { getInternalId, isInstanceOfType } from '../filters/utils'
+
 
 export type ElementIDResolver = (id: ElemID) => Promise<Element | undefined>
 
@@ -166,9 +168,7 @@ const instanceCustomObjectResolver: UrlResolver = async (element, baseUrl) => {
   if (await isInstanceOfCustomObject(element)) {
     const instanceId = await apiName(element)
     const typeId = isInstanceElement(element) ? await apiName(await element.getType()) : undefined
-    if (typeId !== undefined) {
-      return new URL(`${baseUrl}lightning/r/${typeId}/${instanceId}/view`)
-    }
+    return isDefined(typeId) ? new URL(`${baseUrl}lightning/r/${typeId}/${instanceId}/view`) : undefined
   }
   return undefined
 }

--- a/packages/salesforce-adapter/test/elements_url_retreiver.test.ts
+++ b/packages/salesforce-adapter/test/elements_url_retreiver.test.ts
@@ -159,6 +159,11 @@ describe('lightningElementsUrlRetriever', () => {
         await expect(elementUrlRetriever?.retrieveUrl(element)).resolves.toEqual(new URL('https://salto5-dev-ed.lightning.force.com/lightning/_classic/%2FsomeId'))
       })
 
+      it('instance of custom object', async () => {
+        const element = new InstanceElement('InstanceOfCustomObject', customObject, { fullName: 'InstanceOfCustomObject', Id: 'instanceId' })
+        await expect(elementUrlRetriever?.retrieveUrl(element)).resolves.toEqual(new URL(`https://salto5-dev-ed.lightning.force.com/lightning/r/${customObject.annotations.apiName}/instanceId/view`))
+      })
+
       it('unknown element', async () => {
         const element = new ObjectType({ elemID: new ElemID('salesforce', 'someType') })
         expect(elementUrlRetriever).toBeDefined()

--- a/packages/salesforce-adapter/test/elements_url_retreiver.test.ts
+++ b/packages/salesforce-adapter/test/elements_url_retreiver.test.ts
@@ -160,7 +160,7 @@ describe('lightningElementsUrlRetriever', () => {
       })
 
       it('instance of custom object', async () => {
-        const element = new InstanceElement('InstanceOfCustomObject', customObject, { fullName: 'InstanceOfCustomObject', Id: 'instanceId' })
+        const element = new InstanceElement('InstanceOfCustomObject', customObject, { Id: 'instanceId' })
         await expect(elementUrlRetriever?.retrieveUrl(element)).resolves.toEqual(new URL(`https://salto5-dev-ed.lightning.force.com/lightning/r/${customObject.annotations.apiName}/instanceId/view`))
       })
 


### PR DESCRIPTION
---
_Release Notes_: 

Salesforce Adapter:
* Added go to service functionality for instances of custom objects

