### PR TITLE
switch hidden_values diff to handle nested arrays and undefined values

### DIFF
--- a/packages/lowerdash/src/values.ts
+++ b/packages/lowerdash/src/values.ts
@@ -13,4 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
+
 export const isDefined = <T>(val: T | undefined | void): val is T => val !== undefined
+
+export const isPlainObject = (val: unknown): val is object => _.isPlainObject(val)

--- a/packages/lowerdash/test/values.test.ts
+++ b/packages/lowerdash/test/values.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isDefined } from '../src/values'
+import { isDefined, isPlainObject } from '../src/values'
 
 describe('isDefined', () => {
   describe('with undefined value', () => {
@@ -40,5 +40,19 @@ describe('isDefined', () => {
     it('should return true with object', () => {
       expect(isDefined({})).toBeTruthy()
     })
+  })
+})
+
+describe('isPlainObject', () => {
+  it('should return false for undefined', () => {
+    expect(isPlainObject(undefined)).toBeFalsy()
+  })
+  it('should return true for object', () => {
+    expect(isPlainObject({})).toBeTruthy()
+    expect(isPlainObject({ a: 'a', b: ['c', 'd'] })).toBeTruthy()
+  })
+  it('should return false for array', () => {
+    expect(isPlainObject([])).toBeFalsy()
+    expect(isPlainObject([{ a: 'a', b: ['c', 'd'] }])).toBeFalsy()
   })
 })

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -36,7 +36,6 @@
     "@salto-io/adapter-utils": "0.2.11",
     "@salto-io/logging": "0.2.11",
     "@salto-io/lowerdash": "0.2.11",
-    "deep-object-diff": "^1.1.0",
     "is-promise": "4.0.0",
     "lodash": "^4.17.21",
     "moo": "^0.5.1",

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -608,13 +608,19 @@ export const filterOutHiddenChanges = async (
             state,
           ),
         )
-        return { visible,
+        const hidden = calcHiddenPart(change.data.after, visible.data.after)
+        if (hidden === undefined) {
+          return { visible }
+        }
+        return {
+          visible,
           hidden: {
             ...change,
             data: {
-              after: calcHiddenPart(change.data.after, visible.data.after),
+              after: hidden,
             },
-          } as DetailedChange }
+          } as DetailedChange,
+        }
       }
     }
 

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -408,12 +408,14 @@ const calcHiddenPart = <V extends object>(
     if (Array.isArray(full)) {
       if (!Array.isArray(visible) || full.length !== visible.length) {
         // should never happen
-        log.warn('Unexpected diff found in array: %s', safeJsonStringify([full, visible]))
+        log.error('Unexpected hidden part found in array: %s', safeJsonStringify([full, visible]))
         return full
       }
 
       const arrayDiff = full.map((val, idx) => calcHiddenInner(val, visible[idx]))
       if (arrayDiff.some(val => !_.isEmpty(val))) {
+        // invalid scenario - hidden parts within arrays are not supported
+        log.error('Unexpected hidden part found in array: %s', safeJsonStringify([full, visible]))
         return arrayDiff as RecursivePartialWithUndefined<T>
       }
       return undefined

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -526,7 +526,7 @@ export const filterOutHiddenChanges = async (
           ...change,
           data: {
             ...change.data,
-            after: diffElements(visible.data.after, change.data.after),
+            after,
           },
         } as DetailedChange }
     }

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -327,27 +327,25 @@ describe('handleHiddenChanges', () => {
     })
   })
 
-  describe('arrays and undefined values', () => {
-    const object = new ObjectType({
-      elemID: new ElemID('test', 'type'),
-      fields: {
-        field: {
-          refType: createRefToElmWithValue(BuiltinTypes.STRING),
-          annotations: { [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [{ reference: 'aaa', occurrences: undefined }] },
-        },
-      },
-    })
+  describe('undefined values', () => {
+    const workspaceInstance = new InstanceElement(
+      'instance',
+      new ObjectType({
+        elemID: new ElemID('test', 'type'),
+      }),
+      { [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [{ reference: 'aaa', occurrences: undefined }] },
+    )
 
     const change: DetailedChange = {
-      id: object.fields.field.elemID.createNestedID(CORE_ANNOTATIONS.GENERATED_DEPENDENCIES),
+      id: workspaceInstance.elemID,
       action: 'add',
-      data: { after: [{ reference: 'aaa' }] },
+      data: { after: workspaceInstance },
     }
 
-    it('should not hide anything', async () => {
+    it('should not hide anything if there is no hidden part, even if nested values are undefined', async () => {
       const result = await handleHiddenChanges(
         [change],
-        mockState([object]),
+        mockState([]),
         mockFunction<() => Promise<AsyncIterable<Element>>>().mockResolvedValue(awu([])),
       )
       expect(result.visible.length).toBe(1)

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -326,4 +326,32 @@ describe('handleHiddenChanges', () => {
       })
     })
   })
+
+  describe('arrays and undefined values', () => {
+    const object = new ObjectType({
+      elemID: new ElemID('test', 'type'),
+      fields: {
+        field: {
+          refType: createRefToElmWithValue(BuiltinTypes.STRING),
+          annotations: { [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [{ reference: 'aaa', occurrences: undefined }] },
+        },
+      },
+    })
+
+    const change: DetailedChange = {
+      id: object.fields.field.elemID.createNestedID(CORE_ANNOTATIONS.GENERATED_DEPENDENCIES),
+      action: 'add',
+      data: { after: [{ reference: 'aaa' }] },
+    }
+
+    it('should not hide anything', async () => {
+      const result = await handleHiddenChanges(
+        [change],
+        mockState([object]),
+        mockFunction<() => Promise<AsyncIterable<Element>>>().mockResolvedValue(awu([])),
+      )
+      expect(result.visible.length).toBe(1)
+      expect(result.hidden.length).toBe(0)
+    })
+  })
 })

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -352,4 +352,36 @@ describe('handleHiddenChanges', () => {
       expect(result.hidden.length).toBe(0)
     })
   })
+
+  describe('with nested visible change', () => {
+    const type = new ObjectType({
+      elemID: new ElemID('test', 'type'),
+      fields: {
+        val: { refType: new ObjectType({
+          elemID: new ElemID('test', 'type'),
+          fields: { inner: { refType: BuiltinTypes.STRING } },
+        }) },
+      },
+    })
+
+    const stateInstance = new InstanceElement('instance', type, {})
+
+    const change: DetailedChange = {
+      id: stateInstance.elemID.createNestedID('val'),
+      action: 'add',
+      data: {
+        after: { inner: 'abc' },
+      },
+    }
+
+    it('should not have a hidden change', async () => {
+      const result = await handleHiddenChanges(
+        [change],
+        mockState([stateInstance]),
+        mockFunction<() => Promise<AsyncIterable<Element>>>().mockResolvedValue(awu([])),
+      )
+      expect(result.visible.length).toBe(1)
+      expect(result.hidden.length).toBe(0)
+    })
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4190,11 +4190,6 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deep-object-diff@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
-  integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
-
 deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"


### PR DESCRIPTION
Switch new diff implementation to something that can handle arrays + objects with `{ key: undefined }` without generating an incorrect diff.

blocker for https://github.com/salto-io/salto/pull/2078


---
_Release Notes_: 
None (not released yet)
