### PR TITLE
fix issue with over-large parameters to route changes

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -466,14 +466,12 @@ export const routeChanges = async (
       default: return routeDefault(c, primarySource, commonSource, secondarySources)
     }
   }))
-
-  const secondaryEnvsChanges = _.mergeWith(
-    {},
-    ...routedChanges.map(r => r.secondarySources || {}),
-    (objValue: DetailedChange[], srcValue: DetailedChange[]) => (
-      objValue ? [...objValue, ...srcValue] : srcValue
-    )
-  ) as Record<string, DetailedChange[]>
+  const secondaryEnvsChanges = routedChanges
+    .map(r => r.secondarySources || {}).reduce((previousValue: Record<string, DetailedChange[]>,
+      currentValue: Record<string, DetailedChange[]>) => _.mergeWith(previousValue, currentValue,
+      (objValue: DetailedChange[], srcValue: DetailedChange[]) => (
+        objValue ? [...objValue, ...srcValue] : srcValue
+      ))) as Record<string, DetailedChange[]>
   return {
     primarySource: await createUpdateChanges(
       _.flatten(routedChanges.map(r => r.primarySource || [])),

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -467,11 +467,17 @@ export const routeChanges = async (
     }
   }))
   const secondaryEnvsChanges = routedChanges
-    .map(r => r.secondarySources || {}).reduce((previousValue: Record<string, DetailedChange[]>,
-      currentValue: Record<string, DetailedChange[]>) => _.mergeWith(previousValue, currentValue,
-      (objValue: DetailedChange[], srcValue: DetailedChange[]) => (
-        objValue ? [...objValue, ...srcValue] : srcValue
-      ))) as Record<string, DetailedChange[]>
+    .map(r => r.secondarySources || {})
+    .reduce(
+      (previousValue: Record<string, DetailedChange[]>,
+        currentValue: Record<string, DetailedChange[]>) => _.mergeWith(
+        previousValue,
+        currentValue,
+        (objValue: DetailedChange[], srcValue: DetailedChange[]) => (
+          objValue ? [...objValue, ...srcValue] : srcValue
+        )
+      )
+    ) as Record<string, DetailedChange[]>
   return {
     primarySource: await createUpdateChanges(
       _.flatten(routedChanges.map(r => r.primarySource || [])),

--- a/packages/workspace/test/workspace/multi_env/routers.test.ts
+++ b/packages/workspace/test/workspace/multi_env/routers.test.ts
@@ -210,6 +210,19 @@ describe('default fetch routing', () => {
     expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
   })
 
+  it('should handle ridiculously large changeset without stack overflow', async () => {
+    const change: DetailedChange = {
+      action: 'add',
+      data: { after: newObj },
+      id: newObj.elemID,
+    }
+    const changes: DetailedChange[] = []
+    for (let i = 0; i < 140000; i += 1) {
+      changes.push(change)
+    }
+    await routeChanges(changes, envSource, commonSource, { sec: secEnv }, 'default')
+  })
+
   it('should route nested add changes to primary env when the containing element is not in common', async () => {
     const change: DetailedChange = {
       action: 'add',


### PR DESCRIPTION
Instead of unpacking a large record we need to merge, we merge it with reduce, avoiding a stack maximum size issue.
Solves jira [SALTO-1325]:

---

---
_Release Notes_: 
should enable support for larger fetches

[SALTO-1325]: https://salto-io.atlassian.net/browse/SALTO-1325