### PR TITLE
modify handle hidden changes to return a removal change as both visib…

### DIFF
--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -452,7 +452,7 @@ export const filterOutHiddenChanges = async (
       // There should be no harm in letting remove changes through here. remove should be resilient
       // to its subject not existing. We create both visible and hidden changes in order
       // to make sure that hidden parts are removed from the cache as well.
-      return { visible: change }
+      return { visible: change, hidden: change }
     }
 
     const { parent, path } = change.id.createTopLevelParentID()

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -373,6 +373,11 @@ export const loadWorkspace = async (
         return changes as Change[]
       }
       const before = await state().get(refID.createTopLevelParentID().parent)
+      // In remove changes, the change target won't be in the state since the
+      // state is updated prior to this function invokation during the fetch itself.
+      if (before === undefined) {
+        return []
+      }
       const clonedBefore = before.clone()
       applyDetailedChanges(clonedBefore, changes)
       const after = await getElementHiddenParts(

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -370,11 +370,9 @@ export const loadWorkspace = async (
     return awu(Object.values(changesByID)).flatMap(async changes => {
       const refID = changes[0].id
       if (refID.isTopLevel()) {
-        return changes as Change[]
+        return changes
       }
       const before = await state().get(refID.createTopLevelParentID().parent)
-      // In remove changes, the change target won't be in the state since the
-      // state is updated prior to this function invokation during the fetch itself.
       if (before === undefined) {
         return []
       }

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -230,6 +230,33 @@ describe('handleHiddenChanges', () => {
         expect(result).toHaveLength(0)
       })
     })
+
+    describe('when converting a remove change', () => {
+      const obj = new ObjectType({
+        elemID: new ElemID('salto', 'obj'),
+      })
+      const inst = new InstanceElement('hidden', obj, {}, [], {
+        [INSTANCE_ANNOTATIONS.HIDDEN]: true,
+      })
+      const change: DetailedChange = {
+        id: inst.elemID,
+        action: 'remove',
+        data: {
+          before: inst,
+        },
+      }
+      it('should return the entire change and both hidden and visible', async () => {
+        const res = (await handleHiddenChanges(
+          [change],
+          mockState([instanceType, instance]),
+          mockFunction<() => Promise<AsyncIterable<Element>>>().mockResolvedValue(awu([])),
+        ))
+        expect(res.visible).toHaveLength(1)
+        expect(res.hidden).toHaveLength(1)
+        expect(res.hidden[0].id).toEqual(change.id)
+        expect(res.visible[0].id).toEqual(change.id)
+      })
+    })
   })
 
   describe('hidden annotation of field', () => {

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -1552,7 +1552,7 @@ describe('workspace', () => {
       const elem = await workspace.getValue(queueHiddenInstanceToRemove.elemID)
       expect(elem).toBeUndefined()
     })
-    
+
     describe('on secondary envs', () => {
       const primarySourceName = 'default'
       const secondarySourceName = 'inactive'


### PR DESCRIPTION

_Modified the handle hidden changes method to return the entire change as both hidden and visible in order to make sure changes that are hidden only are deleted from the cache._

---

_Lazy elements uses handle hidden changes to separate changes into a visible part and a hidden part. There modified changes are used in order to know which ids should be updated in the cache after the sub sources are updated. Since the method considered a remove change to be fully visible, hidden only elements were not removed from the cache after their deletion, _

---
_Release Notes_: 
_NA_
