### PR TITLE
Limit pathNaclCase to a 200 char

### DIFF
--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -114,7 +114,7 @@ export const toBasicInstance = ({
       adapterName,
       RECORDS_PATH,
       pathNaclCase(type.elemID.name),
-      (fileName ? pathNaclCase(naclCase(fileName)) : pathNaclCase(naclName)).slice(0, 100),
+      (fileName ? pathNaclCase(naclCase(fileName)) : pathNaclCase(naclName)),
     ],
     parent ? { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parent.elemID)] } : undefined,
   )

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -114,7 +114,7 @@ export const toBasicInstance = ({
       adapterName,
       RECORDS_PATH,
       pathNaclCase(type.elemID.name),
-      (fileName ? pathNaclCase(naclCase(fileName)) : pathNaclCase(naclName)),
+      fileName ? pathNaclCase(naclCase(fileName)) : pathNaclCase(naclName),
     ],
     parent ? { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parent.elemID)] } : undefined,
   )

--- a/packages/adapter-utils/src/nacl_case_utils.ts
+++ b/packages/adapter-utils/src/nacl_case_utils.ts
@@ -15,9 +15,10 @@
 */
 
 const NACL_ESCAPING_SUFFIX_SEPARATOR = '@'
+const MAX_PATH_LENGTH = 200
 
 export const pathNaclCase = (name?: string): string =>
-  (name ? name.split(NACL_ESCAPING_SUFFIX_SEPARATOR)[0] : '')
+  (name ? name.split(NACL_ESCAPING_SUFFIX_SEPARATOR)[0] : '').slice(0, MAX_PATH_LENGTH)
 
 /* eslint-disable quote-props */
 // Current values in this mapping should not be changed

--- a/packages/adapter-utils/src/nacl_case_utils.ts
+++ b/packages/adapter-utils/src/nacl_case_utils.ts
@@ -15,6 +15,9 @@
 */
 
 const NACL_ESCAPING_SUFFIX_SEPARATOR = '@'
+// Windows has the lowest known limit, of 255
+// This can have an effect at a time we add a ~15 chars suffix
+// So we are taking an extra buffer and limit it to 200
 const MAX_PATH_LENGTH = 200
 
 export const pathNaclCase = (name?: string): string =>

--- a/packages/adapter-utils/test/nacl_case_utils.test.ts
+++ b/packages/adapter-utils/test/nacl_case_utils.test.ts
@@ -81,20 +81,31 @@ describe('naclCase utils', () => {
   })
 
   describe('pathNaclCase func', () => {
-    describe('Without naclCase seperator', () => {
-      const noSeperatorNames = [
+    describe('Without naclCase separator', () => {
+      const noSeparatorNames = [
         'lalala', 'Lead', 'LALA__Lead__c', 'NameWithNumber2',
       ]
       it('Should remain the same', () => {
-        noSeperatorNames.forEach(name => expect(pathNaclCase(name)).toEqual(name))
+        noSeparatorNames.forEach(name => expect(pathNaclCase(name)).toEqual(name))
       })
     })
 
-    describe('With naclCase seperator', () => {
-      it('Should return up to the seperator', () => {
+    describe('With naclCase separator', () => {
+      it('Should return up to the separator', () => {
         expect(pathNaclCase('Lead@1234')).toEqual('Lead')
         expect(pathNaclCase('LALA__Lead__c@12_34')).toEqual('LALA__Lead__c')
         expect(pathNaclCase('NameWithNumber2@12_34')).toEqual('NameWithNumber2')
+      })
+    })
+
+    describe('With a very long string', () => {
+      const longString = new Array(30).fill('123456789_').join('')
+      it('Should return at most 200 chars', () => {
+        expect(pathNaclCase(longString).length).toBeLessThanOrEqual(200)
+      })
+
+      it('Should return the first 200 chars', () => {
+        expect(pathNaclCase(longString)).toEqual(longString.slice(0, 200))
       })
     })
   })


### PR DESCRIPTION
Limit pathNaclCase to a 200 chars to avoid issues with certain OS that limit the length of file names

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
* New elements will create files with a length limited to 200 chars. This will not effect current file names for existing worksapces.
