### PR TITLE
SALTO-1314 Add workato references to Netsuite standard objects and fields

### DIFF
--- a/packages/workato-adapter/src/filters/cross_service/element_indexes.ts
+++ b/packages/workato-adapter/src/filters/cross_service/element_indexes.ts
@@ -117,9 +117,8 @@ export const indexNetsuiteByTypeAndScriptId = (
   const indexTypesAndFields = (): Record<string, Readonly<ObjectType>> => {
     const types = elements.filter(isObjectType)
     return _.keyBy(
-      // TODO (once SALTO-825 is ready):
-      //  1. filter only types returned from SuiteApp?
-      //  2. prefer to use scriptId / apiName over elem id name when available
+      // We can use the elem id (and not an apiName / scriptId annotation)
+      // as long as we don't support renaming type elem ids
       types,
       e => e.elemID.name.toLowerCase(),
     )

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
@@ -55,11 +55,10 @@ export const addNetsuiteRecipeReferences = async (
     const addPotentialReference = (
       value: unknown, separator: string, nestedPath: ElemID,
     ): Readonly<ObjectType> | undefined => {
-      const lowercaseSeparator = separator.toLowerCase()
       if (!_.isString(value) || value.length === 0) {
         return undefined
       }
-      const valueParts = value.toLowerCase().split(lowercaseSeparator)
+      const valueParts = value.toLowerCase().split(separator.toLowerCase())
       if (valueParts.length > 2) {
         return undefined
       }

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders/netsuite.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  InstanceElement, ElemID, ReferenceExpression, Values,
+  InstanceElement, ElemID, ReferenceExpression, Values, ObjectType,
 } from '@salto-io/adapter-api'
 import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { NetsuiteIndex } from '../element_indexes'
@@ -26,6 +26,7 @@ const { isDefined } = lowerdashValues
 
 const OBJECT_REFERENCE_SEEPARATOR = '@@'
 const FIELD_REFERENCE_SEPARATOR = '@'
+const SCRIPT_SUFFIX = 'script'
 
 type NetsuiteFieldMatchGroup = { field: string }
 const isNetsuiteFieldMatchGroup = (val: Values): val is NetsuiteFieldMatchGroup => (
@@ -51,12 +52,22 @@ export const addNetsuiteRecipeReferences = async (
 
     const { dynamicPickListSelection, input } = blockValue
 
-    const addPotentialReference = (value: unknown, separator: string, nestedPath: ElemID): void => {
+    const addPotentialReference = (
+      value: unknown, separator: string, nestedPath: ElemID,
+    ): Readonly<ObjectType> | undefined => {
       const lowercaseSeparator = separator.toLowerCase()
-      if (_.isString(value) && value.split(lowercaseSeparator).length === 2) {
-        const scriptId = _.last(value.toLowerCase().split(lowercaseSeparator))
+      if (!_.isString(value) || value.length === 0) {
+        return undefined
+      }
+      const valueParts = value.toLowerCase().split(lowercaseSeparator)
+      if (valueParts.length > 2) {
+        return undefined
+      }
+      if (valueParts.length === 2 && valueParts[1] !== SCRIPT_SUFFIX) {
+        // TODO use object types / fields instead of instances when available (SALTO-825)
+        const scriptId = valueParts[1]
         if (scriptId !== undefined) {
-          const referencedId = indexedElements[scriptId]
+          const referencedId = indexedElements.scriptId[scriptId]
           if (referencedId !== undefined) {
             references.push({
               pathToOverride: nestedPath,
@@ -65,14 +76,44 @@ export const addNetsuiteRecipeReferences = async (
               reference: new ReferenceExpression(referencedId),
             })
           }
+          return undefined
         }
       }
+
+      const referencedElem = indexedElements.type[valueParts[0]]
+      if (referencedElem !== undefined) {
+        references.push({
+          pathToOverride: nestedPath,
+          location: new ReferenceExpression(path),
+          direction: getBlockDependencyDirection(blockValue),
+          reference: new ReferenceExpression(referencedElem.elemID),
+        })
+        return referencedElem
+      }
+
+      return undefined
     }
 
     const netsuiteObject = input?.netsuite_object
     if (netsuiteObject !== undefined) {
-      addPotentialReference(netsuiteObject, OBJECT_REFERENCE_SEEPARATOR, path.createNestedID('input', 'netsuite_object'))
+      const type = addPotentialReference(netsuiteObject, OBJECT_REFERENCE_SEEPARATOR, path.createNestedID('input', 'netsuite_object'))
+      if (type !== undefined) {
+        const inputFieldNames = Object.keys(_.omit(input, 'netsuite_object'))
+        inputFieldNames.forEach(fieldName => {
+          if (type.fields[fieldName] !== undefined) {
+            references.push(
+              {
+                // no pathToOverride because we can't override the field keys in the current format
+                location: new ReferenceExpression(path),
+                direction: getBlockDependencyDirection(blockValue),
+                reference: new ReferenceExpression(type.fields[fieldName].elemID),
+              },
+            )
+          }
+        })
+      }
     }
+
     (dynamicPickListSelection.custom_list ?? []).forEach(({ value }, idx) => {
       addPotentialReference(
         value,
@@ -88,7 +129,7 @@ export const addNetsuiteRecipeReferences = async (
   const formulaReferenceFinder: FormulaReferenceFinder = (value, path) => {
     const potentialFields = formulaFieldMatcher(value).map(match => match.field)
     return potentialFields.map((fieldNameScriptId: string): MappedReference | undefined => {
-      const referencedId = indexedElements[fieldNameScriptId]
+      const referencedId = indexedElements.scriptId[fieldNameScriptId]
       if (referencedId !== undefined) {
         return {
           location: new ReferenceExpression(path),


### PR DESCRIPTION
Support referenencing Netsuite standard types and fields - this will allow generating more Netsuite references once SALTO-825 is merged (first part is in https://github.com/salto-io/salto/pull/2081 but will need to be enabled - verified that when enabled the references are generated).

---
_Release Notes_: 
Workato adapter:
* Support generating references from recipes to Netsuite standard types and fields
