### PR TITLE
SALTO-1308 - added validation for Read Only annotations modification…

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -23,6 +23,7 @@ import customFieldTypeValidator from './change_validators/custom_field_type'
 import standardFieldLabelValidator from './change_validators/standard_field_label'
 import profileMapKeysValidator from './change_validators/profile_map_keys'
 import multipleDefaultsValidator from './change_validators/multiple_deafults'
+import fieldAnnotationsReadOnlyValidator from './change_validators/field_annotations'
 
 const changeValidators: ChangeValidator[] = [
   packageValidator,
@@ -33,6 +34,7 @@ const changeValidators: ChangeValidator[] = [
   standardFieldLabelValidator,
   profileMapKeysValidator,
   multipleDefaultsValidator,
+  fieldAnnotationsReadOnlyValidator,
 ]
 
 export default createChangeValidator(changeValidators)

--- a/packages/salesforce-adapter/src/change_validators/field_annotations.ts
+++ b/packages/salesforce-adapter/src/change_validators/field_annotations.ts
@@ -1,0 +1,63 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeError, Field, getChangeElement,
+  ChangeValidator, isModificationChange, ModificationChange, isFieldChange,
+} from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { isFieldOfCustomObject } from '../transformers/transformer'
+import { FIELD_ANNOTATIONS } from '../constants'
+
+const { awu } = collections.asynciterable
+
+const READONLY_ANNOTATIONS = [
+  FIELD_ANNOTATIONS.CREATABLE,
+  FIELD_ANNOTATIONS.UPDATEABLE,
+  FIELD_ANNOTATIONS.QUERYABLE,
+]
+
+const isReadOnlyAnnotationHasChanged = (change: ModificationChange<Field>): boolean => {
+  const readOnlyAnnotationBefore = READONLY_ANNOTATIONS
+    .map(key => change.data.before.annotations[key])
+  const readOnlyAnnotationAfter = READONLY_ANNOTATIONS
+    .map(key => change.data.after.annotations[key])
+  return readOnlyAnnotationBefore.length !== readOnlyAnnotationAfter.length
+      || !readOnlyAnnotationBefore
+        .every((element, index): boolean => element === readOnlyAnnotationAfter[index])
+}
+
+const createChangeError = (field: Field): ChangeError => ({
+  elemID: field.elemID,
+  severity: 'Warning',
+  message: `You cannot modify READ ONLY annotations such as {${READONLY_ANNOTATIONS}} changes made to these annotations will NOT be deployed`,
+  detailedMessage: `You cannot modify READ ONLY annotations such as {${READONLY_ANNOTATIONS}} changes made to these annotations will NOT be deployed`,
+})
+
+/**
+* It is forbidden to modify READ ONLY annotations.
+*/
+const changeValidator: ChangeValidator = async changes => (
+  awu(changes)
+    .filter(isModificationChange)
+    .filter(isFieldChange)
+    .filter(change => isFieldOfCustomObject(getChangeElement(change)))
+    .filter(isReadOnlyAnnotationHasChanged)
+    .map(getChangeElement)
+    .map(createChangeError)
+    .toArray()
+)
+
+export default changeValidator

--- a/packages/salesforce-adapter/test/change_validators/field_annotations.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/field_annotations.test.ts
@@ -1,0 +1,78 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeError, ElemID, Field, ObjectType, toChange,
+} from '@salto-io/adapter-api'
+import { Types } from '../../src/transformers/transformer'
+import readOnlyAnnotationsValidator from '../../src/change_validators/field_annotations'
+import { CUSTOM_OBJECT, FIELD_ANNOTATIONS } from '../../src/constants'
+import { createField } from '../utils'
+
+describe('READ ONLY annotations modification change validator', () => {
+  describe('onUpdate', () => {
+    let afterField: Field
+    let beforeField: Field
+    let customObj: ObjectType
+    beforeAll(() => {
+      customObj = new ObjectType({
+        elemID: new ElemID('salesforce', 'obj'),
+        annotations: { metadataType: CUSTOM_OBJECT, apiName: 'obj__c' },
+      })
+      beforeField = createField(customObj, Types.primitiveDataTypes.Text, 'Something', { [FIELD_ANNOTATIONS.CREATABLE]: 'testCreatable',
+        [FIELD_ANNOTATIONS.UPDATEABLE]: 'testUpdateable',
+        [FIELD_ANNOTATIONS.QUERYABLE]: 'testQueryable' })
+    })
+    beforeEach(() => {
+      afterField = beforeField.clone()
+    })
+
+    const runChangeValidator = (before: Field | undefined, after: Field):
+            Promise<ReadonlyArray<ChangeError>> =>
+      readOnlyAnnotationsValidator([toChange({ before, after })])
+
+    it('should have Error for READ ONLY annotation been modified, "creatable" annotation', async () => {
+      afterField.annotations[FIELD_ANNOTATIONS.CREATABLE] = 'different'
+      const changeErrors = await runChangeValidator(beforeField, afterField)
+      expect(changeErrors).toHaveLength(1)
+      const [changeError] = changeErrors
+      expect(changeError.elemID).toEqual(beforeField.elemID)
+      expect(changeError.severity).toEqual('Warning')
+    })
+
+    it('should have Error for READ ONLY annotation been modified, "Queyable" annotation', async () => {
+      afterField.annotations[FIELD_ANNOTATIONS.QUERYABLE] = 'different'
+      const changeErrors = await runChangeValidator(beforeField, afterField)
+      expect(changeErrors).toHaveLength(1)
+      const [changeError] = changeErrors
+      expect(changeError.elemID).toEqual(beforeField.elemID)
+      expect(changeError.severity).toEqual('Warning')
+    })
+
+    it('should have Error for READ ONLY annotation been modified, "Updateable" annotation', async () => {
+      afterField.annotations[FIELD_ANNOTATIONS.UPDATEABLE] = 'different'
+      const changeErrors = await runChangeValidator(beforeField, afterField)
+      expect(changeErrors).toHaveLength(1)
+      const [changeError] = changeErrors
+      expect(changeError.elemID).toEqual(beforeField.elemID)
+      expect(changeError.severity).toEqual('Warning')
+    })
+
+    it('should have no errors, because no modification has been made', async () => {
+      const changeErrors = await runChangeValidator(beforeField, afterField)
+      expect(changeErrors).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION

_Release Notes_: 
added validation that checks if READ ONLY annotations had been modified, if so, throwing warning message to user
