### PR TITLE
SALTO-825: fetching instances from SOAP

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -25,7 +25,7 @@ import _ from 'lodash'
 import each from 'jest-each'
 import NetsuiteAdapter from '../src/adapter'
 import { credsLease, realAdapter } from './adapter'
-import { customTypes, fileCabinetTypes, getAllTypes } from '../src/types'
+import { customTypes, fileCabinetTypes, getMetadataTypes } from '../src/types'
 import { adapter as adapterCreator } from '../src/adapter_creator'
 import {
   CUSTOM_RECORD_TYPE, EMAIL_TEMPLATE, ENTITY_CUSTOM_FIELD, FETCH_ALL_TYPES_AT_ONCE,
@@ -269,7 +269,7 @@ describe('Netsuite adapter E2E with real account', () => {
       })
 
       it('should fetch account successfully', async () => {
-        expect(fetchResult.elements.length).toBeGreaterThan(getAllTypes().length)
+        expect(fetchResult.elements.length).toBeGreaterThan(getMetadataTypes().length)
         validateConfigSuggestions(fetchResult.updatedConfig?.config)
       })
 

--- a/packages/netsuite-adapter/scripts/types_generator.py
+++ b/packages/netsuite-adapter/scripts/types_generator.py
@@ -176,7 +176,7 @@ export const isCustomType = (typeElemID: ElemID): boolean =>
 export const isFileCabinetType = (typeElemID: ElemID): boolean =>
   !_.isUndefined(fileCabinetTypes[ypeElemID.name])
 
-export const getAllTypes = (): TypeElement[] => [
+export const getMetadataTypes = (): TypeElement[] => [
   ...Object.values(customTypes),
   ...innerCustomTypes,
   ...Object.values(enums),

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -38,6 +38,8 @@ import redundantFields from './filters/remove_redundant_fields'
 import hiddenFields from './filters/hidden_fields'
 import replaceRecordRef from './filters/replace_record_ref'
 import removeUnsupportedTypes from './filters/remove_unsupported_types'
+import dataInstancesInternalId from './filters/data_instances_internal_id'
+import dataInstancesReferences from './filters/data_instances_references'
 import { FilterCreator } from './filter'
 import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_USE_CHANGES_DETECTION } from './config'
 import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery } from './query'
@@ -101,6 +103,8 @@ export default class NetsuiteAdapter implements AdapterOperations {
       hiddenFields,
       replaceRecordRef,
       removeUnsupportedTypes,
+      dataInstancesReferences,
+      dataInstancesInternalId,
     ],
     typesToSkip = [
       INTEGRATION, // The imported xml has no values, especially no SCRIPT_ID, for standard
@@ -160,7 +164,9 @@ export default class NetsuiteAdapter implements AdapterOperations {
 
     const isPartial = this.fetchTarget !== undefined
 
-    const dataTypesPromise = getDataTypes(this.client)
+    // TODO: Replace when data instances are ready
+    // const dataElementsPromise = await getDataElements(this.client)
+    const dataElementsPromise = await getDataTypes(this.client)
 
     const getCustomObjectsResult = this.client.getCustomObjects(
       Object.keys(customTypes),
@@ -200,11 +206,11 @@ export default class NetsuiteAdapter implements AdapterOperations {
         : undefined
     }).filter(isInstanceElement).toArray()
 
-    const dataTypes = await dataTypesPromise
+    const dataElements = await dataElementsPromise
 
     const elements = [
       ...getAllTypes(),
-      ...dataTypes,
+      ...dataElements ?? [],
       ...instances,
       ...serverTimeElements,
     ]

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -25,7 +25,7 @@ import {
   createInstanceElement,
 } from './transformer'
 import {
-  customTypes, getAllTypes, fileCabinetTypes,
+  customTypes, getMetadataTypes, fileCabinetTypes,
 } from './types'
 import { TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST, DEPLOY_REFERENCED_ELEMENTS,
   INTEGRATION, FETCH_TARGET, SKIP_LIST, LAST_FETCH_TIME, USE_CHANGES_DETECTION } from './constants'
@@ -209,8 +209,8 @@ export default class NetsuiteAdapter implements AdapterOperations {
     const dataElements = await dataElementsPromise
 
     const elements = [
-      ...getAllTypes(),
-      ...dataElements ?? [],
+      ...getMetadataTypes(),
+      ...dataElements,
       ...instances,
       ...serverTimeElements,
     ]

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -51,7 +51,7 @@ import { createElementsSourceIndex } from './elements_source_index/elements_sour
 import { LazyElementsSourceIndex } from './elements_source_index/types'
 import getChangeValidator from './change_validator'
 import { getChangeGroupIdsFunc } from './group_changes'
-import { getDataTypes } from './data_elements/data_elements'
+import { getDataElements } from './data_elements/data_elements'
 
 const { makeArray } = collections.array
 const { awu } = collections.asynciterable
@@ -165,8 +165,8 @@ export default class NetsuiteAdapter implements AdapterOperations {
     const isPartial = this.fetchTarget !== undefined
 
     // TODO: Replace when data instances are ready
-    // const dataElementsPromise = await getDataElements(this.client)
-    const dataElementsPromise = await getDataTypes(this.client)
+    const dataElementsPromise = await getDataElements(this.client)
+    // const dataElementsPromise = await getDataTypes(this.client)
 
     const getCustomObjectsResult = this.client.getCustomObjects(
       Object.keys(customTypes),

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -185,4 +185,8 @@ export default class NetsuiteClient {
   public async getNetsuiteWsdl(): Promise<WSDL | undefined> {
     return this.suiteAppClient?.getNetsuiteWsdl()
   }
+
+  public async getAllRecords(type: string): Promise<Record<string, unknown>[] | undefined> {
+    return this.suiteAppClient?.getAllRecords(type)
+  }
 }

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -186,7 +186,10 @@ export default class NetsuiteClient {
     return this.suiteAppClient?.getNetsuiteWsdl()
   }
 
-  public async getAllRecords(type: string): Promise<Record<string, unknown>[] | undefined> {
-    return this.suiteAppClient?.getAllRecords(type)
+  public async getAllRecords(type: string): Promise<Record<string, unknown>[]> {
+    if (this.suiteAppClient === undefined) {
+      throw new Error('Cannot call getAllRecords when SuiteApp is not installed')
+    }
+    return this.suiteAppClient.getAllRecords(type)
   }
 }

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/schemas.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/schemas.ts
@@ -345,3 +345,86 @@ export const DEPLOY_LIST_SCHEMA = {
     },
   ],
 }
+
+export const SEARCH_RESPONSE_SCHEMA = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  definitions: {
+    'Record<string,unknown>': {
+      type: 'object',
+    },
+  },
+  properties: {
+    searchResult: {
+      properties: {
+        recordList: {
+          properties: {
+            record: {
+              items: {
+                $ref: '#/definitions/Record<string,unknown>',
+              },
+              type: 'array',
+            },
+          },
+          required: [
+            'record',
+          ],
+          type: 'object',
+          nullable: true,
+        },
+        searchId: {
+          type: 'string',
+        },
+        totalPages: {
+          type: 'number',
+        },
+      },
+      required: [
+        'recordList',
+        'searchId',
+        'totalPages',
+      ],
+      type: 'object',
+    },
+  },
+  required: [
+    'searchResult',
+  ],
+  type: 'object',
+}
+
+export const GET_ALL_RESPONSE_SCHEMA = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  definitions: {
+    'Record<string,unknown>': {
+      type: 'object',
+    },
+  },
+  properties: {
+    getAllResult: {
+      properties: {
+        recordList: {
+          properties: {
+            record: {
+              items: {
+                $ref: '#/definitions/Record<string,unknown>',
+              },
+              type: 'array',
+            },
+          },
+          required: [
+            'record',
+          ],
+          type: 'object',
+        },
+      },
+      required: [
+        'recordList',
+      ],
+      type: 'object',
+    },
+  },
+  required: [
+    'getAllResult',
+  ],
+  type: 'object',
+}

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/types.ts
@@ -87,3 +87,22 @@ export type DeployListResults = DeployListError | DeployListSuccess
 
 export const isDeployListSuccess = (result: DeployListResults): result is DeployListSuccess =>
   result.writeResponseList.status.attributes.isSuccess === 'true'
+
+
+export type SearchResponse = {
+  searchResult: {
+    totalPages: number
+    searchId: string
+    recordList: {
+      record: Record<string, unknown>[]
+    } | null
+  }
+}
+
+export type GetAllResponse = {
+  getAllResult: {
+    recordList: {
+      record: Record<string, unknown>[]
+    }
+  }
+}

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -290,4 +290,8 @@ export default class SuiteAppClient {
   public async getNetsuiteWsdl(): Promise<WSDL> {
     return this.soapClient.getNetsuiteWsdl()
   }
+
+  public async getAllRecords(type: string): Promise<Record<string, unknown>[]> {
+    return this.soapClient.getAllRecords(type)
+  }
 }

--- a/packages/netsuite-adapter/src/data_elements/data_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/data_elements.ts
@@ -13,40 +13,41 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { InstanceElement, ObjectType, Element, BuiltinTypes, ReferenceExpression } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { elements as elementsComponents } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { naclCase, pathNaclCase, transformValues } from '@salto-io/adapter-utils'
 import NetsuiteClient from '../client/client'
-import { NETSUITE } from '../constants'
+import { NETSUITE, RECORDS_PATH } from '../constants'
 
-export const SUPPORTED_TYPES = [
-  'Account',
-  'Subsidiary',
-  'Department',
-  'Classification',
-  'Location',
-  'Currency',
-  'Opportunity',
-  'Customer',
-  'InventoryItem',
-  'SalesOrder',
-  'Order',
-]
+const TYPE_TO_IDENTIFIER: Record<string, string> = {
+  Account: 'acctName',
+  Subsidiary: 'name',
+  Department: 'name',
+  Classification: 'name',
+  Location: 'name',
+  Currency: 'name',
+  Customer: 'entityId',
+}
+
+export const SUPPORTED_TYPES = Object.keys(TYPE_TO_IDENTIFIER)
 
 const log = logger(module)
 
+export type DataTypeConfig = Record<string, string[]>
 
 export const getDataTypes = async (
   client: NetsuiteClient
-): Promise<ObjectType[]> => {
+): Promise<ObjectType[] | undefined> => {
   if (!client.isSuiteAppConfigured()) {
-    return []
+    return undefined
   }
 
   const wsdl = await client.getNetsuiteWsdl()
   if (wsdl === undefined) {
-    log.warn('Failed to get WSDL, skipping dataTypes')
-    return []
+    log.warn('Failed to get WSDL, skipping data elements')
+    return undefined
   }
   const types = await elementsComponents.soap.extractTypes(NETSUITE, wsdl)
 
@@ -55,4 +56,70 @@ export const getDataTypes = async (
     type.annotations.source = 'soap'
   })
   return types
+}
+
+const createInstance = async (
+  record: Record<string, unknown>,
+  type: ObjectType,
+): Promise<InstanceElement> => {
+  const fixedRecord = await transformValues({
+    values: record,
+    type,
+    strict: false,
+    transformFunc: async ({ value, field }) => {
+      if (typeof value === 'object' && 'attributes' in value) {
+        _.assign(value, value.attributes)
+        delete value.attributes
+        delete value['xsi:type']
+      }
+
+      if (value instanceof Date) {
+        return value.toString()
+      }
+
+      if (typeof value === 'string') {
+        const fieldType = await field?.getType()
+        if (fieldType?.elemID.isEqual(BuiltinTypes.BOOLEAN.elemID)) {
+          return value === 'true'
+        }
+        if (fieldType?.elemID.isEqual(BuiltinTypes.NUMBER.elemID)) {
+          return parseInt(value, 10)
+        }
+      }
+      return value
+    },
+  })
+  const id = naclCase(fixedRecord?.[TYPE_TO_IDENTIFIER[type.elemID.name]])
+  return new InstanceElement(
+    id,
+    type,
+    fixedRecord,
+    [NETSUITE, RECORDS_PATH, type.elemID.name, pathNaclCase(id)],
+  )
+}
+
+export const getDataElements = async (
+  client: NetsuiteClient
+): Promise<Element[]> => {
+  const types = await getDataTypes(client)
+  if (types === undefined) {
+    return []
+  }
+
+  const typesMap = _.keyBy(types, e => e.elemID.name)
+
+  const instances = _.flatten(await Promise.all(SUPPORTED_TYPES.map(
+    typeName => client.getAllRecords(typeName)
+      .then(records => {
+        if (records === undefined) {
+          throw new Error(`Search for type ${typeName} failed`)
+        }
+
+        return Promise.all(records.map(
+          record => createInstance(record, typesMap[typeName])
+        ))
+      })
+  )))
+
+  return [...types, ...instances]
 }

--- a/packages/netsuite-adapter/src/data_elements/data_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/data_elements.ts
@@ -20,7 +20,7 @@ import _ from 'lodash'
 import { naclCase, pathNaclCase, transformValues } from '@salto-io/adapter-utils'
 import NetsuiteClient from '../client/client'
 import { NETSUITE, RECORDS_PATH } from '../constants'
-import { SUPPORTED_TYPES, TYPE_TO_IDENTIFIER } from './types'
+import { TYPE_TO_IDENTIFIER } from './types'
 
 const log = logger(module)
 
@@ -94,7 +94,7 @@ export const getDataElements = async (
 
   const typesMap = _.keyBy(types, e => e.elemID.name)
 
-  const instances = _.flatten(await Promise.all(SUPPORTED_TYPES
+  const instances = _.flatten(await Promise.all(Object.keys(TYPE_TO_IDENTIFIER)
     .filter(typeName => typeName in typesMap)
     .map(typeName => client.getAllRecords(typeName)
       .then(records =>

--- a/packages/netsuite-adapter/src/data_elements/types.ts
+++ b/packages/netsuite-adapter/src/data_elements/types.ts
@@ -1,0 +1,156 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+
+export const TYPE_TO_IDENTIFIER: Record<string, string> = {
+  Account: 'acctName',
+  Subsidiary: 'name',
+  Department: 'name',
+  Classification: 'name',
+  Location: 'name',
+  Currency: 'name',
+  Customer: 'entityId',
+  AccountingPeriod: 'periodName',
+  Employee: 'entityId',
+  Job: 'entityId',
+  ManufacturingCostTemplate: 'name',
+  Partner: 'partnerCode',
+  Solution: 'solutionCode',
+}
+
+// Was taken from http://www.netsuiterp.com/2019/05/internal-ids-for-netsuite-record-types.html
+export const TYPES_TO_INTERNAL_ID: Record<string, string> = {
+  Account: '-112',
+  AccountingPeriod: '-105',
+  AssemblyBuild: '-30',
+  AssemblyItem: '-10',
+  AssemblyUnbuild: '-30',
+  BillingSchedule: '-141',
+  Bin: '-242',
+  BinTransfer: '-30',
+  BinWorksheet: '-30',
+  CalendarEvent: '-20',
+  Campaign: '-24',
+  CampaignResponse: '-130',
+  CashRefund: '-30',
+  CashSale: '-30',
+  Charge: '-290',
+  Check: '-30',
+  Classification: '-101',
+  Contact: '-6',
+  ContactCategory: '-158',
+  ContactRole: '-157',
+  CostCategory: '-155',
+  CreditMemo: '-30',
+  Currency: '-122',
+  Customer: '-2',
+  CustomerCategory: '-109',
+  CustomerDeposit: '-30',
+  CustomerMessage: '-161',
+  CustomerPayment: '-30',
+  CustomerRefund: '-30',
+  CustomerStatus: '-104',
+  Department: '-102',
+  DepositApplication: '-30',
+  DescriptionItem: '-10',
+  DiscountItem: '-10',
+  DownloadItem: '-10',
+  Employee: '-4',
+  Estimate: '-30',
+  ExpenseCategory: '-126',
+  ExpenseReport: '-30',
+  GiftCertificateItem: '-10',
+  GlobalAccountMapping: '-250',
+  InterCompanyJournalEntry: '-30',
+  InterCompanyTransferOrder: '-30',
+  InventoryAdjustment: '-30',
+  InventoryCostRevaluation: '-30',
+  InventoryDetail: '-260',
+  InventoryItem: '-10',
+  InventoryNumber: '-266',
+  InventoryTransfer: '-30',
+  Invoice: '-30',
+  Issue: '-26',
+  ItemAccountMapping: '-251',
+  ItemDemandPlan: '-246',
+  ItemFulfillment: '-30',
+  ItemGroup: '-10',
+  ItemReceipt: '-30',
+  ItemRevision: '-269',
+  ItemSupplyPlan: '-247',
+  Job: '-7',
+  JobType: '-177',
+  JournalEntry: '-30',
+  KitItem: '-10',
+  Location: '-103',
+  LotNumberedAssemblyItem: '-10',
+  LotNumberedInventoryItem: '-10',
+  ManufacturingCostTemplate: '-294',
+  ManufacturingOperationTask: '-36',
+  ManufacturingRouting: '-288',
+  MarkupItem: '-10',
+  Note: '-303',
+  NoteType: '-180',
+  Opportunity: '-31',
+  OtherNameCategory: '-181',
+  Partner: '-5',
+  PartnerCategory: '-182',
+  PaycheckJournal: '-30',
+  PaymentItem: '-10',
+  PaymentMethod: '-183',
+  PayrollItem: '-265',
+  PhoneCall: '-22',
+  PriceLevel: '-186',
+  PricingGroup: '-187',
+  ProjectTask: '-27',
+  PromotionCode: '-121',
+  PurchaseOrder: '-30',
+  ResourceAllocation: '-28',
+  ReturnAuthorization: '-30',
+  SalesOrder: '-30',
+  SalesRole: '-191',
+  SalesTaxItem: '-128',
+  SerializedAssemblyItem: '-10',
+  SerializedInventoryItem: '-10',
+  Solution: '-25',
+  Subsidiary: '-117',
+  SubtotalItem: '-10',
+  SupportCase: '-23',
+  Task: '-21',
+  Term: '-199',
+  TimeBill: '-256',
+  TransferOrder: '-30',
+  UnitsType: '-201',
+  Vendor: '-3',
+  VendorBill: '-30',
+  VendorCategory: '-110',
+  VendorCredit: '-30',
+  VendorPayment: '-30',
+  VendorReturnAuthorization: '-30',
+  WinLossReason: '-203',
+  WorkOrder: '-30',
+  WorkOrderClose: '-30',
+  WorkOrderCompletion: '-30',
+  WorkOrderIssue: '-30',
+}
+
+export const INTERNAL_ID_TO_TYPES: Record<string, string[]> = _(TYPES_TO_INTERNAL_ID)
+  .entries()
+  .groupBy(([_type, internalId]) => internalId)
+  .mapValues(values => values.map(([type]) => type))
+  .value()
+
+export const SUPPORTED_TYPES = Object.keys(TYPES_TO_INTERNAL_ID)

--- a/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
@@ -1,0 +1,82 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, isInstanceElement, isObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { NETSUITE, RECORDS_PATH } from '../constants'
+import { FilterCreator } from '../filter'
+
+const { awu } = collections.asynciterable
+
+const isNumberStr = (str: string): boolean => !Number.isNaN(Number(str))
+
+const getSubInstanceName = (path: ElemID, internalId: string): string => {
+  const name = _.findLast(path.getFullNameParts(), part => !isNumberStr(part) && !['customField', 'customFieldList', 'recordRef'].includes(part))
+  return `${path.typeName}_${name}_${internalId}`
+}
+
+const filterCreator: FilterCreator = () => ({
+  onFetch: async ({ elements }) => {
+    const recordRefType = elements.find(e => e.elemID.name === 'RecordRef')
+
+    const newInstancesMap: Record<string, InstanceElement> = {}
+
+    const transformIds: TransformFunc = async ({ value, field, path }) => {
+      if ((await field?.getType())?.elemID.name === 'RecordRef') {
+        value.id = '[ACCOUNT_SPECIFIC_VALUE]'
+      }
+
+      // TODO: remove the ?? recordRefType when custom fields will be appropriately supported
+      const fieldType = await field?.getType() ?? recordRefType
+      const isInsideList = path?.getFullNameParts().some(part => isNumberStr(part))
+      if (path !== undefined
+        && value.internalId !== undefined
+        && isObjectType(fieldType)
+        && isInsideList) {
+        const instanceName = getSubInstanceName(path, value.internalId)
+
+        if (!(instanceName in newInstancesMap)) {
+          const newInstance = new InstanceElement(
+            instanceName,
+            fieldType,
+            value,
+            [NETSUITE, RECORDS_PATH, fieldType.elemID.name, instanceName]
+          )
+          newInstancesMap[instanceName] = newInstance
+        }
+
+        return new ReferenceExpression(newInstancesMap[instanceName].elemID)
+      }
+      return value
+    }
+
+    await awu(elements)
+      .filter(isInstanceElement)
+      .forEach(async element => {
+        const updatedElement = await transformElement({
+          element,
+          transformFunc: transformIds,
+          strict: false,
+        })
+        element.value = updatedElement.value
+      })
+
+    elements.push(...Object.values(newInstancesMap))
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
@@ -80,7 +80,7 @@ const filterCreator: FilterCreator = () => ({
           transformFunc: transformIds,
           strict: false,
           pathID: element.elemID,
-        }) ?? {}
+        }) ?? element.value
         element.value = values
       })
 

--- a/packages/netsuite-adapter/src/filters/data_instances_references.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_references.ts
@@ -21,7 +21,7 @@ import { FilterCreator } from '../filter'
 
 const { awu } = collections.asynciterable
 
-const getId = (value: Value, type: TypeElement): string => `${type.elemID.name}-${value.internalId}`
+const getId = (internalId: string, type: TypeElement): string => `${type.elemID.name}-${internalId}`
 
 const generateReference = (
   value: Value,
@@ -29,8 +29,8 @@ const generateReference = (
   elementsMap: Record<string, InstanceElement>,
 ): ReferenceExpression | undefined =>
   value.internalId
-  && elementsMap[getId(value, type)]
-  && new ReferenceExpression(elementsMap[getId(value, type)].elemID)
+  && elementsMap[getId(value.internalId, type)]
+  && new ReferenceExpression(elementsMap[getId(value.internalId, type)].elemID)
 
 const replaceReference: (
   elementsMap: Record<string, InstanceElement>
@@ -65,15 +65,15 @@ const filterCreator: FilterCreator = () => ({
 
     await awu(instances)
       .filter(async e => isDataObjectType(await e.getType()))
-      .forEach(async element => {
+      .forEach(async instance => {
         const values = await transformValues({
-          values: element.value,
-          type: await element.getType(),
+          values: instance.value,
+          type: await instance.getType(),
           transformFunc: replaceReference(dataInstancesMap),
           strict: false,
-          pathID: element.elemID,
-        }) ?? {}
-        element.value = values
+          pathID: instance.elemID,
+        }) ?? instance.value
+        instance.value = values
       })
   },
 })

--- a/packages/netsuite-adapter/src/filters/data_instances_references.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_references.ts
@@ -1,0 +1,70 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, isInstanceElement, isListType, ReferenceExpression, TypeElement, Value } from '@salto-io/adapter-api'
+import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import { FilterCreator } from '../filter'
+
+const { awu } = collections.asynciterable
+
+const getReference = (
+  value: Value,
+  type: TypeElement,
+  elementsMap: Record<string, InstanceElement>,
+): ReferenceExpression | undefined =>
+  value.internalId
+  && elementsMap[`${type.elemID.name}-${value.internalId}`]
+  && new ReferenceExpression(elementsMap[`${type.elemID.name}-${value.internalId}`].elemID)
+
+const replaceReference: (
+  elementsMap: Record<string, InstanceElement>
+) => TransformFunc = elementsMap => async ({ value, path, field }) => {
+  if (path?.isTopLevel()) {
+    return value
+  }
+
+  const fieldType = await field?.getType()
+  if (isListType(fieldType) && value.recordRef !== undefined) {
+    return Promise.all(value.recordRef.map(
+      async (val: Value) => (getReference(val, await fieldType.getInnerType(), elementsMap)) ?? val
+    ))
+  }
+
+  const reference = fieldType && getReference(value, fieldType, elementsMap)
+  if (reference !== undefined) {
+    return reference
+  }
+  return value
+}
+
+const filterCreator: FilterCreator = () => ({
+  onFetch: async ({ elements }) => {
+    const instances = elements.filter(isInstanceElement)
+    const elementsMap = await awu(instances.filter(e => e.value.internalId !== undefined))
+      .keyBy(async e => `${(await e.getType()).elemID.name}-${e.value.internalId}`)
+
+    await awu(instances).forEach(async element => {
+      const updatedElement = await transformElement({
+        element,
+        transformFunc: replaceReference(elementsMap),
+        strict: false,
+      })
+      element.value = updatedElement.value
+    })
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
+++ b/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
@@ -18,8 +18,8 @@ import { elements as elementsComponents } from '@salto-io/adapter-components'
 import { isObjectType } from '@salto-io/adapter-api'
 import { NETSUITE } from '../constants'
 import { FilterCreator } from '../filter'
-import { SUPPORTED_TYPES } from '../data_elements/data_elements'
-import { getAllTypes, isDataObjectType } from '../types'
+import { getMetadataTypes, isDataObjectType } from '../types'
+import { SUPPORTED_TYPES } from '../data_elements/types'
 
 
 const filterCreator: FilterCreator = () => ({
@@ -27,7 +27,7 @@ const filterCreator: FilterCreator = () => ({
     if (!client.isSuiteAppConfigured()) {
       return
     }
-    const sdfTypeNames = new Set(getAllTypes().map(e => e.elemID.getFullName()))
+    const sdfTypeNames = new Set(getMetadataTypes().map(e => e.elemID.getFullName()))
     const supportedDataTypes = (await elementsComponents
       .filterTypes(
         NETSUITE,

--- a/packages/netsuite-adapter/src/filters/replace_record_ref.ts
+++ b/packages/netsuite-adapter/src/filters/replace_record_ref.ts
@@ -16,7 +16,7 @@
 import { BuiltinTypes, ElemID, Field, isObjectType, ListType, ObjectType, TypeElement } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
-import { getAllTypes } from '../types'
+import { getMetadataTypes } from '../types'
 import { NETSUITE } from '../constants'
 import { FilterCreator } from '../filter'
 
@@ -75,7 +75,7 @@ const filterCreator: FilterCreator = () => ({
     recordRefType.fields.id = new Field(recordRefType, 'id', BuiltinTypes.STRING)
 
     const types = elements.filter(isObjectType)
-    const typeMap = _.keyBy([...types, ...getAllTypes()], e => e.elemID.name)
+    const typeMap = _.keyBy([...types, ...getMetadataTypes()], e => e.elemID.name)
 
     await awu(types).forEach(async element => {
       element.fields = Object.fromEntries(await awu(Object.entries(element.fields))

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -226,6 +226,7 @@ Promise<FileResult[]> => {
         bundleable: folder.bundleable ?? 'F',
         isinactive: folder.isinactive,
         isprivate: folder.isprivate,
+        internalId: folder.id,
       },
     })).filter(folder => query.isFileMatch(`/${folder.path.join('/')}`))
 
@@ -239,6 +240,7 @@ Promise<FileResult[]> => {
         availablewithoutlogin: file.isonline,
         generateurltimestamp: file.addtimestamptourl,
         hideinbundle: file.hideinbundle,
+        internalId: file.id,
       },
       id: file.id,
       size: parseInt(file.filesize, 10),

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -227,7 +227,7 @@ export const isFileInstance = (element: Element): boolean =>
 export const isDataObjectType = (element: ObjectType): boolean =>
   element.annotations.source === 'soap'
 
-export const getAllTypes = (): TypeElement[] => [
+export const getMetadataTypes = (): TypeElement[] => [
   ...Object.values(customTypes),
   ...innerCustomTypes,
   ...Object.values(enums),
@@ -276,7 +276,7 @@ export const FIELD_TYPES = [
 export const typesElementSourceWrapper = (
 ): ReadOnlyElementsSource => {
   const typesByKey = _.keyBy(
-    getAllTypes(),
+    getMetadataTypes(),
     type => type.elemID.getFullName()
   )
   return {

--- a/packages/netsuite-adapter/src/types/file_cabinet_types.ts
+++ b/packages/netsuite-adapter/src/types/file_cabinet_types.ts
@@ -71,6 +71,12 @@ export const file = new ObjectType({
       annotations: {
       },
     },
+    internalId: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+      },
+    },
   },
   path: [constants.NETSUITE, constants.TYPES_PATH, fileElemID.name],
 })
@@ -109,6 +115,12 @@ export const folder = new ObjectType({
     isprivate: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
+      },
+    },
+    internalId: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
       },
     },
   },

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -22,7 +22,7 @@ import _ from 'lodash'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import createClient from './client/sdf_client'
 import NetsuiteAdapter from '../src/adapter'
-import { customTypes, fileCabinetTypes, getAllTypes } from '../src/types'
+import { customTypes, fileCabinetTypes, getMetadataTypes } from '../src/types'
 import {
   ENTITY_CUSTOM_FIELD, SCRIPT_ID, SAVED_SEARCH, FILE, FOLDER, PATH, TRANSACTION_FORM, TYPES_TO_SKIP,
   FILE_PATHS_REGEX_SKIP_LIST, FETCH_ALL_TYPES_AT_ONCE, DEPLOY_REFERENCED_ELEMENTS,
@@ -164,7 +164,7 @@ describe('Adapter', () => {
       expect(fileCabinetQuery.isFileMatch('Some/File/Regex')).toBeFalsy()
       expect(fileCabinetQuery.isFileMatch('Some/anotherFile/Regex')).toBeTruthy()
 
-      expect(elements).toHaveLength(getAllTypes().length + 3)
+      expect(elements).toHaveLength(getMetadataTypes().length + 3)
       const customFieldType = customTypes[ENTITY_CUSTOM_FIELD]
       expect(elements).toContainEqual(customFieldType)
       expect(elements).toContainEqual(
@@ -258,7 +258,7 @@ describe('Adapter', () => {
           failedTypeToInstances: {},
         })
       const { elements } = await netsuiteAdapter.fetch(mockFetchOpts)
-      expect(elements).toHaveLength(getAllTypes().length)
+      expect(elements).toHaveLength(getMetadataTypes().length)
     })
 
     it('should call filters by their order', async () => {

--- a/packages/netsuite-adapter/test/data_elements/data_elements.test.ts
+++ b/packages/netsuite-adapter/test/data_elements/data_elements.test.ts
@@ -73,12 +73,12 @@ describe('data_elements', () => {
 
     it('should do nothing if SuiteApp is not configured', async () => {
       jest.spyOn(client, 'isSuiteAppConfigured').mockReturnValue(false)
-      await expect(getDataTypes(client)).resolves.toBeUndefined()
+      await expect(getDataTypes(client)).resolves.toEqual([])
     })
 
     it('should return empty list if failed to get wsdl', async () => {
       jest.spyOn(client, 'getNetsuiteWsdl').mockResolvedValue(undefined)
-      await expect(getDataTypes(client)).resolves.toBeUndefined()
+      await expect(getDataTypes(client)).resolves.toEqual([])
     })
   })
 
@@ -115,7 +115,7 @@ describe('data_elements', () => {
     })
 
     it('should throw an error if failed to getAllRecords', async () => {
-      getAllRecordsMock.mockResolvedValue(undefined)
+      getAllRecordsMock.mockRejectedValue(new Error())
       await expect(getDataElements(client)).rejects.toThrow()
     })
 

--- a/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
@@ -1,0 +1,71 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/data_instances_internal_id'
+import NetsuiteClient from '../../src/client/client'
+import { NETSUITE } from '../../src/constants'
+
+describe('data_instances_internal_id', () => {
+  const recordRefType = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'RecordRef'),
+    fields: {
+      internalId: {
+        refType: BuiltinTypes.STRING,
+        annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+      },
+    },
+  })
+  it('should add account specific value to record refs', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      new ObjectType({ elemID: new ElemID(NETSUITE, 'type'), fields: { recordRef: { refType: recordRefType } } }),
+      { recordRef: {} }
+    )
+
+    const onFetchParameters = {
+      elements: [instance],
+      client: {} as NetsuiteClient,
+      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      isPartial: false,
+      dataTypeNames: new Set<string>(),
+    }
+    await filterCreator().onFetch(onFetchParameters)
+    expect(instance.value.recordRef.id).toEqual('[ACCOUNT_SPECIFIC_VALUE]')
+  })
+
+  it('should extract list items with internal id', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      new ObjectType({ elemID: new ElemID(NETSUITE, 'type'), fields: { someList: { refType: new ListType(recordRefType) } } }),
+      { someList: [{ internalId: '1' }, { internalId: '1' }] }
+    )
+
+    const elements = [instance]
+    const onFetchParameters = {
+      elements,
+      client: {} as NetsuiteClient,
+      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      isPartial: false,
+      dataTypeNames: new Set<string>(),
+    }
+
+    await filterCreator().onFetch(onFetchParameters)
+    expect(elements[1].elemID.name).toBe('type_someList_1')
+    expect((instance.value.someList[0] as ReferenceExpression).elemID.getFullName())
+      .toBe(elements[1].elemID.getFullName())
+    expect(elements.length).toBe(2)
+  })
+})

--- a/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
@@ -31,7 +31,7 @@ describe('data_instances_internal_id', () => {
   it('should add account specific value to record refs', async () => {
     const instance = new InstanceElement(
       'instance',
-      new ObjectType({ elemID: new ElemID(NETSUITE, 'type'), fields: { recordRef: { refType: recordRefType } } }),
+      new ObjectType({ elemID: new ElemID(NETSUITE, 'type'), fields: { recordRef: { refType: recordRefType } }, annotations: { source: 'soap' } }),
       { recordRef: {} }
     )
 
@@ -49,7 +49,7 @@ describe('data_instances_internal_id', () => {
   it('should extract list items with internal id', async () => {
     const instance = new InstanceElement(
       'instance',
-      new ObjectType({ elemID: new ElemID(NETSUITE, 'type'), fields: { someList: { refType: new ListType(recordRefType) } } }),
+      new ObjectType({ elemID: new ElemID(NETSUITE, 'type'), fields: { someList: { refType: new ListType(recordRefType) } }, annotations: { source: 'soap' } }),
       { someList: [{ internalId: '1' }, { internalId: '1' }] }
     )
 

--- a/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
@@ -27,6 +27,7 @@ describe('data_instances_references', () => {
         annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
       },
     },
+    annotations: { source: 'soap' },
   })
   const secondType = new ObjectType({
     elemID: new ElemID(NETSUITE, 'secondType'),
@@ -34,6 +35,7 @@ describe('data_instances_references', () => {
       field: { refType: firstType },
       recordRefList: { refType: new ListType(firstType) },
     },
+    annotations: { source: 'soap' },
   })
   it('should add replace with reference', async () => {
     const instance = new InstanceElement(

--- a/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
@@ -37,7 +37,7 @@ describe('data_instances_references', () => {
     },
     annotations: { source: 'soap' },
   })
-  it('should add replace with reference', async () => {
+  it('should replace with reference', async () => {
     const instance = new InstanceElement(
       'instance',
       secondType,

--- a/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
@@ -1,0 +1,87 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/data_instances_references'
+import NetsuiteClient from '../../src/client/client'
+import { NETSUITE } from '../../src/constants'
+
+describe('data_instances_references', () => {
+  const firstType = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'firstType'),
+    fields: {
+      internalId: {
+        refType: BuiltinTypes.STRING,
+        annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+      },
+    },
+  })
+  const secondType = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'secondType'),
+    fields: {
+      field: { refType: firstType },
+      recordRefList: { refType: new ListType(firstType) },
+    },
+  })
+  it('should add replace with reference', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      secondType,
+      { field: { internalId: '1' } }
+    )
+
+    const referencedInstance = new InstanceElement(
+      'referencedInstance',
+      firstType,
+      { internalId: '1' }
+    )
+
+    const onFetchParameters = {
+      elements: [instance, referencedInstance],
+      client: {} as NetsuiteClient,
+      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      isPartial: false,
+      dataTypeNames: new Set<string>(),
+    }
+    await filterCreator().onFetch(onFetchParameters)
+    expect((instance.value.field as ReferenceExpression).elemID.getFullName())
+      .toBe(referencedInstance.elemID.getFullName())
+  })
+
+  it('should replace recordRefList references', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      secondType,
+      { recordRefList: { recordRef: [{ internalId: '1' }] } }
+    )
+
+    const referencedInstance = new InstanceElement(
+      'referencedInstance',
+      firstType,
+      { internalId: '1' }
+    )
+
+    const onFetchParameters = {
+      elements: [instance, referencedInstance],
+      client: {} as NetsuiteClient,
+      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      isPartial: false,
+      dataTypeNames: new Set<string>(),
+    }
+    await filterCreator().onFetch(onFetchParameters)
+    expect((instance.value.recordRefList[0] as ReferenceExpression).elemID.getFullName())
+      .toBe(referencedInstance.elemID.getFullName())
+  })
+})

--- a/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
@@ -84,6 +84,7 @@ describe('suiteapp_file_cabinet', () => {
         description: 'desc3',
         isinactive: 'F',
         isprivate: 'F',
+        internalId: '3',
       },
     },
     {
@@ -94,6 +95,7 @@ describe('suiteapp_file_cabinet', () => {
         description: 'desc4',
         isinactive: 'T',
         isprivate: 'T',
+        internalId: '4',
       },
     },
     {
@@ -104,6 +106,7 @@ describe('suiteapp_file_cabinet', () => {
         isinactive: 'F',
         isprivate: 'T',
         description: '',
+        internalId: '5',
       },
     },
     {
@@ -117,6 +120,7 @@ describe('suiteapp_file_cabinet', () => {
         generateurltimestamp: 'F',
         hideinbundle: 'F',
         bundleable: 'F',
+        internalId: '1',
       },
     },
     {
@@ -130,6 +134,7 @@ describe('suiteapp_file_cabinet', () => {
         description: 'desc2',
         generateurltimestamp: 'T',
         hideinbundle: 'T',
+        internalId: '2',
       },
     },
   ]
@@ -246,6 +251,7 @@ describe('suiteapp_file_cabinet', () => {
             description: '',
             generateurltimestamp: 'T',
             hideinbundle: 'T',
+            internalId: '6',
           },
         },
       ])


### PR DESCRIPTION
This PR is to fetch instances of data types.

The line that fetches the instances is commented out to not affect the user until SALTO-825 is done.

---

There are two methods of fetching using SOAP: `search` and `getAll`.
`search` supports paging, so if possible, we use search. If a certain type does not support search, we use `getAll`.

In addition, in this PR, two filters were added:
- data_instances_internal_id - extract to a new instance every object in a list that contains an internal id (since the internal id is hidden, and we don't support hidden values in lists, the objects in the list need to be extracted to new instances).
- data_instances_references - creates references between the instances based on the types of the field and the internal id in the value.

---
_Release Notes_: 
Netsuite Adapter:
An "internalId" field was added to the "file" and "folder" types 