### PR TITLE
Modified remote map to have different db for tmp

### DIFF
--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -492,7 +492,8 @@ remoteMap.RemoteMapCreator => {
         throw new Error('Failed to open rocksdb connection - too much open connections already')
       }
       await createDBIfNotExist(location)
-      const connection = getOpenDBConnection(location, !persistent)
+      const readOnly = !persistent
+      const connection = getOpenDBConnection(location, readOnly)
       persistentDB = await connection
 
       currnetConnectionsCount += 2

--- a/packages/core/src/local-workspace/state.ts
+++ b/packages/core/src/local-workspace/state.ts
@@ -83,7 +83,8 @@ const deserializeAndFlatten = async (elementsJSON: string): Promise<Element[]> =
 export const localState = (
   filePrefix: string,
   envName: string,
-  remoteMapCreator: remoteMap.RemoteMapCreator
+  remoteMapCreator: remoteMap.RemoteMapCreator,
+  persistent = true
 ): state.State => {
   let dirty = false
   let pathToClean = ''
@@ -143,7 +144,11 @@ export const localState = (
     getHashFromContent((await Promise.all(filePaths.map(readTextFile))))
 
   const loadStateData = async (): Promise<state.StateData> => {
-    const quickAccessStateData = await state.buildStateData(envName, remoteMapCreator)
+    const quickAccessStateData = await state.buildStateData(
+      envName,
+      remoteMapCreator,
+      persistent
+    )
     const filePaths = await getRelevantStateFiles()
     const stateFilesHash = await getHash(filePaths)
     const quickAccessHash = (await quickAccessStateData.saltoMetadata.get('hash'))

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -137,7 +137,11 @@ const persistentMockCreateRemoteMap = ():
   return creator
 }
 
-const buildMockWorkspace = async (files: Record<string, string>, staticFileNames: string[]):
+const buildMockWorkspace = async (
+  files: Record<string, string>,
+  staticFileNames: string[],
+  persistent = false
+):
 Promise<Workspace> => {
   const mockStaticFilesCache: staticFiles.StaticFilesCache = {
     get: mockFunction<staticFiles.StaticFilesCache['get']>(),
@@ -159,6 +163,7 @@ Promise<Workspace> => {
     mockedDirStore,
     commonStaticFilesSource,
     mockCreateRemoteMap,
+    persistent
   )
   const defaultStaticFilesSource = staticFiles.buildStaticFilesSource(
     mockDirStore({}),
@@ -180,6 +185,7 @@ Promise<Workspace> => {
           mockDirStore({}),
           defaultStaticFilesSource,
           mockCreateRemoteMap,
+          persistent
         ),
         state: state.buildInMemState(async () => ({
           elements: createInMemoryElementSource(
@@ -197,6 +203,7 @@ Promise<Workspace> => {
           mockDirStore({}),
           inactiveStaticFilesSource,
           mockCreateRemoteMap,
+          persistent
         ),
         state: state.buildInMemState(async () => ({
           elements: createInMemoryElementSource([]),

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -36,7 +36,11 @@ const onActivate = async (context: vscode.ExtensionContext): Promise<void> => {
   const { name, rootPath } = vscode.workspace
   if (name && rootPath) {
     const diagCollection = vscode.languages.createDiagnosticCollection('@salto-io/core')
-    const workspace = new ws.EditorWorkspace(rootPath, await loadLocalWorkspace(rootPath))
+    const workspace = new ws.EditorWorkspace(rootPath, await loadLocalWorkspace(
+      rootPath,
+      undefined,
+      false
+    ))
 
     const completionProvider = vscode.languages.registerCompletionItemProvider(
       { scheme: 'file', pattern: { base: rootPath, pattern: '**/*.nacl' } },

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -94,6 +94,7 @@ const buildMultiEnvSource = (
   initPrimarySourceName: string,
   commonSourceName: string,
   remoteMapCreator: RemoteMapCreator,
+  persistent: boolean,
   initState?: MultiEnvState
 ): MultiEnvSource => {
   let primarySourceName = initPrimarySourceName
@@ -112,11 +113,14 @@ const buildMultiEnvSource = (
     [commonSourceName]: sources[commonSourceName],
   })
 
-  const buildStateForSingleEnv = async (envName: string): Promise<SingleState> => {
+  const buildStateForSingleEnv = async (
+    envName: string,
+  ): Promise<SingleState> => {
     const elements = new RemoteElementSource(await remoteMapCreator<Element>({
       namespace: getRemoteMapNamespace('merged', envName),
       serialize: element => serialize([element]),
       deserialize: deserializeSingleElement,
+      persistent,
     }))
     return {
       elements,
@@ -124,6 +128,7 @@ const buildMultiEnvSource = (
         namespace: getRemoteMapNamespace('errors', envName),
         serialize: errors => serialize(errors),
         deserialize: async data => deserializeMergeErrors(data),
+        persistent,
       }),
     }
   }
@@ -135,7 +140,8 @@ const buildMultiEnvSource = (
     const current = Object.fromEntries(
       await awu(Object.keys(sources))
         .filter(name => name !== commonSourceName)
-        .map(async name => [name, state?.[name] ?? (await buildStateForSingleEnv(name))])
+        .map(async name => [name, state?.[name]
+          ?? (await buildStateForSingleEnv(name))])
         .toArray()
     )
     const changesInCommon = (envChanges[commonSourceName] ?? []).length > 0
@@ -332,6 +338,9 @@ const buildMultiEnvSource = (
   }
 
   const flush = async (): Promise<void> => {
+    if (!persistent) {
+      throw new Error('can not flush a non persistent multi env source.')
+    }
     await awu([
       primarySource(),
       commonSource(),
@@ -510,6 +519,7 @@ const buildMultiEnvSource = (
       primarySourceName,
       commonSourceName,
       remoteMapCreator,
+      persistent,
       state
     ),
     load,
@@ -534,9 +544,11 @@ export const multiEnvSource = (
   primarySourceName: string,
   commonSourceName: string,
   remoteMapCreator: RemoteMapCreator,
+  persistent: boolean
 ): MultiEnvSource => buildMultiEnvSource(
   sources,
   primarySourceName,
   commonSourceName,
-  remoteMapCreator
+  remoteMapCreator,
+  persistent
 )

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
@@ -76,7 +76,7 @@ const isCacheDataRelevant = (
 
 const parseNaclFileFromCacheSources = async (
   cacheSources: CacheSources,
-  filename: string
+  filename: string,
 ): Promise<ParsedNaclFile> => ({
   filename,
   elements: () => cacheSources.elements.get(filename),
@@ -98,22 +98,26 @@ const getRemoteMapCacheNamespace = (
 const getMetadata = async (
   cacheName: string,
   remoteMapCreator: RemoteMapCreator,
+  persistent: boolean
 ): Promise<RemoteMap<FileCacheMetdata>> => (
   remoteMapCreator({
     namespace: getRemoteMapCacheNamespace(cacheName, 'metadata'),
     serialize: (val: FileCacheMetdata) => safeJsonStringify(val),
     deserialize: data => JSON.parse(data),
+    persistent,
   })
 )
 
 const getErrors = async (
   cacheName: string,
   remoteMapCreator: RemoteMapCreator,
+  persistent: boolean
 ): Promise<RemoteMap<ParseError[]>> => (
   remoteMapCreator({
     namespace: getRemoteMapCacheNamespace(cacheName, 'errors'),
     serialize: (errors: ParseError[]) => safeJsonStringify(errors ?? []),
     deserialize: data => JSON.parse(data),
+    persistent,
   })
 )
 
@@ -121,8 +125,9 @@ const getCacheSources = async (
   cacheName: string,
   remoteMapCreator: RemoteMapCreator,
   staticFilesSource: StaticFilesSource,
+  persistent: boolean
 ): Promise<CacheSources> => ({
-  metadata: await getMetadata(cacheName, remoteMapCreator),
+  metadata: await getMetadata(cacheName, remoteMapCreator, persistent),
   elements: await remoteMapCreator({
     namespace: getRemoteMapCacheNamespace(cacheName, 'elements'),
     serialize: (elements: Element[]) => serialize(elements ?? []),
@@ -130,17 +135,20 @@ const getCacheSources = async (
       data,
       async sf => staticFilesSource.getStaticFile(sf.filepath, sf.encoding),
     )),
+    persistent,
   }),
   sourceMap: (await remoteMapCreator({
     namespace: getRemoteMapCacheNamespace(cacheName, 'sourceMap'),
     serialize: (sourceMap: SourceMap) => safeJsonStringify(Array.from(sourceMap.entries())),
     deserialize: async data => (new SourceMap(JSON.parse(data))),
+    persistent,
   })),
-  errors: await getErrors(cacheName, remoteMapCreator),
+  errors: await getErrors(cacheName, remoteMapCreator, persistent),
   referenced: (await remoteMapCreator({
     namespace: getRemoteMapCacheNamespace(cacheName, 'referenced'),
     serialize: (val: string[]) => safeJsonStringify(val ?? []),
     deserialize: data => (JSON.parse(data)),
+    persistent,
   })),
 })
 
@@ -159,13 +167,15 @@ export const createParseResultCache = (
   cacheName: string,
   remoteMapCreator: RemoteMapCreator,
   staticFilesSource: StaticFilesSource,
+  persistent: boolean
 ): ParsedNaclFileCache => {
   // To allow renames
   let actualCacheName = cacheName
   let cacheSources = getCacheSources(
     actualCacheName,
     remoteMapCreator,
-    staticFilesSource
+    staticFilesSource,
+    persistent
   )
   return {
     put: async (filename: string, value: ParsedNaclFile): Promise<void> => {
@@ -265,7 +275,8 @@ export const createParseResultCache = (
       const newCacheSources = await getCacheSources(
         newName,
         remoteMapCreator,
-        staticFilesSource
+        staticFilesSource,
+        persistent
       )
       await awu(Object.values(newCacheSources)).forEach(async source => source.clear())
       const oldCacheSources = await cacheSources
@@ -277,8 +288,18 @@ export const createParseResultCache = (
       actualCacheName = newName
       cacheSources = Promise.resolve(newCacheSources)
     },
-    flush: async () => awu(Object.values((await cacheSources))).forEach(source => source.flush()),
+    flush: async () => {
+      if (!persistent) {
+        throw new Error('can not flush an non persistent parsed nacl file cache')
+      }
+      await awu(Object.values((await cacheSources))).forEach(source => source.flush())
+    },
     clone: (): ParsedNaclFileCache =>
-      createParseResultCache(cacheName, remoteMapCreator, staticFilesSource.clone()),
+      createParseResultCache(
+        cacheName,
+        remoteMapCreator,
+        staticFilesSource.clone(),
+        persistent
+      ),
   }
 }

--- a/packages/workspace/src/workspace/remote_map.ts
+++ b/packages/workspace/src/workspace/remote_map.ts
@@ -46,6 +46,7 @@ export type RemoteMapType = 'workspace' | 'state'
 export interface CreateRemoteMapParams<T> {
   namespace: string
   batchInterval?: number
+  persistent: boolean
   serialize: (value: T) => string
   deserialize: (s: string) => Promise<T>
 }

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -26,7 +26,10 @@ type InMemoryState = State & {
   setVersion(version: string): Promise<void>
 }
 
-export const buildInMemState = (loadData: () => Promise<StateData>): InMemoryState => {
+export const buildInMemState = (
+  loadData: () => Promise<StateData>,
+  persistent = true
+): InMemoryState => {
   let innerStateData: Promise<StateData>
   const stateData = async (): Promise<StateData> => {
     if (innerStateData === undefined) {
@@ -80,6 +83,9 @@ export const buildInMemState = (loadData: () => Promise<StateData>): InMemorySta
       await currentStateData.saltoMetadata.clear()
     },
     flush: async () => {
+      if (!persistent) {
+        throw new Error('can not flush a non persistent state')
+      }
       const currentStateData = await stateData()
       await currentStateData.elements.flush()
       await currentStateData.pathIndex.flush()

--- a/packages/workspace/src/workspace/state/state.ts
+++ b/packages/workspace/src/workspace/state/state.ts
@@ -48,27 +48,35 @@ export interface State extends ElementsSource {
 export const createStateNamespace = (envName: string, namespace: string): string =>
   `state-${envName}-${namespace}`
 
-export const buildStateData = async (envName: string, remoteMapCreator: RemoteMapCreator):
+export const buildStateData = async (
+  envName: string,
+  remoteMapCreator: RemoteMapCreator,
+  persistent: boolean
+):
 Promise<StateData> => ({
   elements: new RemoteElementSource(await remoteMapCreator<Element>({
     namespace: createStateNamespace(envName, 'elements'),
     serialize: elem => serialize([elem]),
     // TODO: I don't think we should add reviver here but I need to think about it more
     deserialize: deserializeSingleElement,
+    persistent,
   })),
   pathIndex: await remoteMapCreator<Path[]>({
     namespace: createStateNamespace(envName, 'path_index'),
     serialize: paths => safeJsonStringify(paths),
     deserialize: async data => JSON.parse(data),
+    persistent,
   }),
   servicesUpdateDate: await remoteMapCreator<Date>({
     namespace: createStateNamespace(envName, 'service_update_date'),
     serialize: date => date.toISOString(),
     deserialize: async data => new Date(data),
+    persistent,
   }),
   saltoMetadata: await remoteMapCreator<string, 'version'>({
     namespace: createStateNamespace(envName, 'salto_metadata'),
     serialize: data => data,
     deserialize: async data => data,
+    persistent,
   }),
 })

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -186,6 +186,7 @@ const source = multiEnvSource(
   activePrefix,
   commonPrefix,
   () => Promise.resolve(new InMemoryRemoteMap()),
+  true
 )
 
 
@@ -253,6 +254,7 @@ describe('multi env source', () => {
         primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
@@ -283,6 +285,7 @@ describe('multi env source', () => {
         primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
@@ -332,6 +335,7 @@ describe('multi env source', () => {
         primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
@@ -393,6 +397,7 @@ describe('multi env source', () => {
         activePrefix,
         commonPrefix,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await src.load({})
       expect(await src.isEmpty()).toBeTruthy()
@@ -408,6 +413,7 @@ describe('multi env source', () => {
         activePrefix,
         commonPrefix,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await src.load({})
       expect(await src.isEmpty()).toBeFalsy()
@@ -422,6 +428,7 @@ describe('multi env source', () => {
         activePrefix,
         commonPrefix,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await src.load({})
       expect(await src.isEmpty()).toBeTruthy()
@@ -529,6 +536,7 @@ describe('multi env source', () => {
         primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
@@ -557,6 +565,7 @@ describe('multi env source', () => {
         primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
@@ -588,6 +597,7 @@ describe('multi env source', () => {
         primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
@@ -631,6 +641,7 @@ describe('multi env source', () => {
         primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
@@ -665,6 +676,7 @@ describe('multi env source', () => {
         primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
@@ -706,6 +718,7 @@ describe('multi env source', () => {
         primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
@@ -734,6 +747,7 @@ describe('multi env source', () => {
         primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
@@ -854,6 +868,19 @@ describe('multi env source', () => {
       expect(routers.routeDemote).toHaveBeenCalledWith(
         [envElemID, objectElemID], envSource, commonSource, { inactive: inactiveSource }
       )
+    })
+  })
+
+  describe('non persistent multiEnvSource', () => {
+    it('should not allow flush when the ws is non-persistent', async () => {
+      const nonPSource = multiEnvSource(
+        sources,
+        activePrefix,
+        commonPrefix,
+        () => Promise.resolve(new InMemoryRemoteMap()),
+        false
+      )
+      await expect(() => nonPSource.flush()).rejects.toThrow()
     })
   })
 })

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
@@ -107,6 +107,7 @@ describe('Nacl Files Source', () => {
         mockDirStore,
         mockedStaticFilesSource,
         persistentMockCreateRemoteMap(),
+        true,
         parsedNaclFiles
       )
       await naclFileSourceTest.getAll()
@@ -339,6 +340,7 @@ describe('Nacl Files Source', () => {
               mockDirStore,
               mockedStaticFilesSource,
               persistentMockCreateRemoteMap(),
+              true,
               parsedNaclFiles,
             )
           })

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -130,6 +130,7 @@ describe('Nacl Files Source', () => {
       'test',
       persistentMockCreateRemoteMap(),
       mockStaticFilesSource(),
+      true
     )
     mockParse.mockResolvedValue({ elements: [], errors: [] })
   })
@@ -144,6 +145,7 @@ describe('Nacl Files Source', () => {
         mockDirStore,
         mockedStaticFilesSource,
         mockRemoteMapCreator,
+        true
       )
       await naclSrc.load({})
       await naclSrc.clear()
@@ -161,6 +163,7 @@ describe('Nacl Files Source', () => {
         mockDirStore,
         mockedStaticFilesSource,
         mockRemoteMapCreator,
+        true
       )
       await naclSrc.load({})
       await naclSrc.clear(
@@ -179,7 +182,8 @@ describe('Nacl Files Source', () => {
         '',
         mockDirStore,
         mockedStaticFilesSource,
-        mockRemoteMapCreator,
+        mockRemoteMapCreator, true
+
       )
       await naclSrc.load({})
       await expect(naclSrc.clear(
@@ -201,6 +205,7 @@ describe('Nacl Files Source', () => {
         mockDirStore,
         mockedStaticFilesSource,
         mockRemoteMapCreator,
+        true
       )
       await naclSrc.load({})
       await naclSrc.flush()
@@ -218,6 +223,7 @@ describe('Nacl Files Source', () => {
         mockDirStore,
         mockedStaticFilesSource,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await naclSrc.load({})
       await naclSrc.isEmpty()
@@ -233,6 +239,7 @@ describe('Nacl Files Source', () => {
         mockDirStore,
         mockedStaticFilesSource,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )).load({})
       expect(mockDirStore.list as jest.Mock).toHaveBeenCalled()
     })
@@ -243,6 +250,7 @@ describe('Nacl Files Source', () => {
         mockDirStore,
         mockedStaticFilesSource,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )).load({ ignoreFileChanges: true })
       expect(mockDirStore.list as jest.Mock).not.toHaveBeenCalled()
     })
@@ -258,7 +266,8 @@ describe('Nacl Files Source', () => {
         '',
         mockDirStore,
         mockedStaticFilesSource,
-        mockRemoteMapCreator
+        mockRemoteMapCreator,
+        true
       )
       await naclSrc.load({})
       await naclSrc.rename(newName)
@@ -291,6 +300,7 @@ describe('Nacl Files Source', () => {
           mockDirStore,
           mockedStaticFilesSource,
           () => Promise.resolve(new InMemoryRemoteMap()),
+          true
         )
       ).getTotalSize()
       expect(totalSize).toEqual(300)
@@ -307,6 +317,7 @@ describe('Nacl Files Source', () => {
         mockDirStore,
         mockedStaticFilesSource,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await naclSrc.load({})
       await naclSrc.updateNaclFiles([change])
@@ -325,6 +336,7 @@ describe('Nacl Files Source', () => {
         mockDirStore,
         mockedStaticFilesSource,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await src.load({})
     })
@@ -363,6 +375,7 @@ describe('Nacl Files Source', () => {
         mockDirStore,
         mockedStaticFilesSource,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true,
         parsedFiles
       )
       const parsed = await (await naclSource).getParsedNaclFile(filename)
@@ -383,6 +396,7 @@ describe('Nacl Files Source', () => {
         mockDirStore,
         mockedStaticFilesSource,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
     })
 
@@ -417,6 +431,7 @@ describe('Nacl Files Source', () => {
         mockDirStore,
         mockedStaticFilesSource,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await src.load({})
       await src.updateNaclFiles([createChange()])
@@ -435,6 +450,7 @@ describe('Nacl Files Source', () => {
         mockDirStore,
         mockedStaticFilesSource,
         () => Promise.resolve(new InMemoryRemoteMap()),
+        true
       )
       await src.load({})
       await src.updateNaclFiles([createChange()])
@@ -443,6 +459,19 @@ describe('Nacl Files Source', () => {
     it('should list all searchable elements', async () => {
       expect(await src.getSearchableNames())
         .toEqual(['salesforce.new_elem', 'salesforce.new_elem.field.myField'])
+    })
+  })
+
+  describe('non persistent naclFileSource', () => {
+    it('should not allow flush when the ws is non-persistent', async () => {
+      const nonPSrc = await naclFilesSource(
+        '',
+        mockDirStore,
+        mockedStaticFilesSource,
+        () => Promise.resolve(new InMemoryRemoteMap()),
+        false
+      )
+      await expect(nonPSrc.flush()).rejects.toThrow()
     })
   })
 })

--- a/packages/workspace/test/workspace/nacl_files/parsed_nacl_files_cache.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/parsed_nacl_files_cache.test.ts
@@ -127,7 +127,8 @@ describe('ParsedNaclFileCache', () => {
     cache = createParseResultCache(
       'mockCache',
       inMemoryRemoteMapsCreator,
-      mockedStaticFilesSource
+      mockedStaticFilesSource,
+      true
     )
   })
 
@@ -362,6 +363,18 @@ describe('ParsedNaclFileCache', () => {
       const errors = await cache.getAllErrors()
       expect(errors.includes(errorA)).toBeTruthy()
       expect(errors.includes(errorB)).toBeFalsy()
+    })
+  })
+
+  describe('non persistent workspace', () => {
+    it('should not allow flush when the ws is non-persistent', async () => {
+      const nonPCache = createParseResultCache(
+        'mockCache',
+        inMemoryRemoteMapsCreator,
+        mockedStaticFilesSource,
+        false
+      )
+      await expect(() => nonPCache.flush()).rejects.toThrow()
     })
   })
 

--- a/packages/workspace/test/workspace/state.test.ts
+++ b/packages/workspace/test/workspace/state.test.ts
@@ -125,4 +125,11 @@ describe('state', () => {
       expect(await state.getStateSaltoVersion()).toEqual('0.0.1')
     })
   })
+
+  describe('non persistent state', () => {
+    it('should not allow flush when the ws is non-persistent', async () => {
+      const nonPState = buildInMemState(loadStateData, false)
+      await expect(() => nonPState.flush()).rejects.toThrow()
+    })
+  })
 })


### PR DESCRIPTION
_Add a new location that holds the tmp storage db in remote app_

---

_rocksDB prevents us when we attempt to open two write connections to the same location at the same time. This creates a situation that prevent the editor to be open along side a shell operation. In order to solve this, we added a way to specify a ws as a non-persistent ws. In such a case, the ws won't be flushable, and the connection to the main location will be read only_

---
_Release Notes_: 
_NA_
