### PR TITLE
fixed cache regeneration

### DIFF
--- a/packages/cli/src/commands/clean.ts
+++ b/packages/cli/src/commands/clean.ts
@@ -47,7 +47,7 @@ export const action: WorkspaceCommandAction<CleanArgs> = async ({
     return CliExitCode.UserInputError
   }
   const cleanArgs = {
-    ..._.omit(allCleanArgs, 'regenerateCache', 'cache'),
+    ..._.omit(allCleanArgs, 'cache'),
     // should still clear the cache before re-generating it
     cache: allCleanArgs.cache || allCleanArgs.regenerateCache,
   }

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -681,7 +681,7 @@ export const formatInvalidElementCommand = (command: string): string => [
 ].join('\n')
 
 export const formatCleanWorkspace = (
-  cleanArgs: WorkspaceComponents & { regenerateCache: boolean }
+  cleanArgs: WorkspaceComponents
 ): string => {
   const componentsToClean = Object.entries(cleanArgs)
     .filter(([_comp, shouldClean]) => shouldClean)

--- a/packages/cli/test/commands/clean.test.ts
+++ b/packages/cli/test/commands/clean.test.ts
@@ -160,6 +160,7 @@ describe('clean command', () => {
         state: true,
         cache: true,
         staticResources: true,
+        regenerateCache: false,
         credentials: true,
         serviceConfig: true,
       })
@@ -189,6 +190,7 @@ describe('clean command', () => {
         state: false,
         cache: true,
         staticResources: false,
+        regenerateCache: true,
         credentials: false,
         serviceConfig: false,
       })
@@ -248,6 +250,7 @@ describe('clean command', () => {
         nacl: true,
         state: true,
         cache: true,
+        regenerateCache: false,
         staticResources: true,
         credentials: true,
         serviceConfig: true,

--- a/packages/cli/test/commands/clean.test.ts
+++ b/packages/cli/test/commands/clean.test.ts
@@ -54,7 +54,7 @@ describe('clean command', () => {
           staticResources: false,
           credentials: false,
           serviceConfig: false,
-          regenerateCache: false,
+
         },
         workspace: mocks.mockWorkspace({}),
       })).toBe(CliExitCode.UserInputError)
@@ -75,7 +75,7 @@ describe('clean command', () => {
           staticResources: true,
           credentials: true,
           serviceConfig: true,
-          regenerateCache: false,
+
         },
         workspace: mocks.mockWorkspace({}),
       })).toBe(CliExitCode.Success)
@@ -94,7 +94,7 @@ describe('clean command', () => {
           staticResources: false,
           credentials: false,
           serviceConfig: false,
-          regenerateCache: true,
+
         },
         workspace: mocks.mockWorkspace({}),
       })).toBe(CliExitCode.Success)
@@ -112,7 +112,7 @@ describe('clean command', () => {
           staticResources: true,
           credentials: true,
           serviceConfig: true,
-          regenerateCache: false,
+
         },
         workspace: mocks.mockWorkspace({}),
       })).toBe(CliExitCode.UserInputError)
@@ -120,24 +120,6 @@ describe('clean command', () => {
       expect(output.stderr.content.search('Cannot clear static resources without clearing the state, cache and nacls')).toBeGreaterThanOrEqual(0)
     })
 
-    it('should fail if attempting to regenerate and clean the cache at the same time', async () => {
-      expect(await action({
-        ...cliCommandArgs,
-        input: {
-          force: false,
-          nacl: false,
-          state: false,
-          cache: true,
-          staticResources: false,
-          credentials: false,
-          serviceConfig: false,
-          regenerateCache: true,
-        },
-        workspace: mocks.mockWorkspace({}),
-      })).toBe(CliExitCode.UserInputError)
-      expect(callbacks.getUserBooleanInput).not.toHaveBeenCalled()
-      expect(output.stderr.content.search('Cannot re-generate and clear the cache in the same operation')).toBeGreaterThanOrEqual(0)
-    })
     it('should prompt user and continue if yes', async () => {
       const workspace = mocks.mockWorkspace({})
       expect(await action({
@@ -150,7 +132,6 @@ describe('clean command', () => {
           staticResources: true,
           credentials: true,
           serviceConfig: true,
-          regenerateCache: false,
         },
         workspace,
       })).toBe(CliExitCode.Success)
@@ -160,43 +141,9 @@ describe('clean command', () => {
         state: true,
         cache: true,
         staticResources: true,
-        regenerateCache: false,
         credentials: true,
         serviceConfig: true,
       })
-
-      expect(output.stdout.content.search('Starting to clean')).toBeGreaterThan(0)
-      expect(output.stdout.content.search('Finished cleaning')).toBeGreaterThan(0)
-    })
-    it('should prompt user and continue if yes (regenerate-cache)', async () => {
-      const workspace = mocks.mockWorkspace({})
-      expect(await action({
-        ...cliCommandArgs,
-        input: {
-          force: false,
-          nacl: false,
-          state: false,
-          cache: false,
-          staticResources: false,
-          credentials: false,
-          serviceConfig: false,
-          regenerateCache: true,
-        },
-        workspace,
-      })).toBe(CliExitCode.Success)
-      expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith('Do you want to perform these actions?')
-      expect(core.cleanWorkspace).toHaveBeenCalledWith(workspace, {
-        nacl: false,
-        state: false,
-        cache: true,
-        staticResources: false,
-        regenerateCache: true,
-        credentials: false,
-        serviceConfig: false,
-      })
-      expect(workspace.errors).toHaveBeenCalledTimes(1)
-      // expecting 1 because there is no call from the mocked cleanWorkspace
-      expect(workspace.flush).toHaveBeenCalledTimes(1)
 
       expect(output.stdout.content.search('Starting to clean')).toBeGreaterThan(0)
       expect(output.stdout.content.search('Finished cleaning')).toBeGreaterThan(0)
@@ -215,7 +162,7 @@ describe('clean command', () => {
           staticResources: true,
           credentials: true,
           serviceConfig: true,
-          regenerateCache: false,
+
         },
         workspace: mocks.mockWorkspace({}),
       })).toBe(CliExitCode.AppError)
@@ -241,7 +188,7 @@ describe('clean command', () => {
           staticResources: true,
           credentials: true,
           serviceConfig: true,
-          regenerateCache: false,
+
         },
         workspace,
       })).toBe(CliExitCode.Success)
@@ -250,7 +197,6 @@ describe('clean command', () => {
         nacl: true,
         state: true,
         cache: true,
-        regenerateCache: false,
         staticResources: true,
         credentials: true,
         serviceConfig: true,

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -509,6 +509,7 @@ const buildMultiEnvSource = (
         await s.elements.clear()
         await s.mergeErrors.clear()
       })
+      state = undefined
     },
     rename: async (name: string): Promise<void> => {
       await series([primarySource(), commonSource(), ...Object.values(secondarySources())]

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -793,6 +793,8 @@ const buildNaclFilesSource = (
         await currentState.parsedNaclFiles.clear()
         await currentState.searchableNamesIndex.clear()
       }
+      initChanges = undefined
+      state = undefined
     },
 
     rename: async (name: string) => {

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -74,9 +74,7 @@ export type WorkspaceComponents = {
   serviceConfig: boolean
 }
 
-export type ClearFlags = Omit<WorkspaceComponents, 'serviceConfig'> & {
-  regenerateCache?: boolean
-}
+export type ClearFlags = Omit<WorkspaceComponents, 'serviceConfig'>
 
 export type Workspace = {
   uid: string

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -634,7 +634,7 @@ export const loadWorkspace = async (
             await s.errors.clear()
             await s.validationErrors.clear()
           })
-        await (await getLoadedNaclFilesSource()).clear(args)
+        await naclFilesSource.clear(args)
       }
       if (args.state) {
         await promises.array.series(envs().map(e => (() => state(e).clear())))
@@ -643,7 +643,6 @@ export const loadWorkspace = async (
         await promises.array.series(envs().map(e => (() => credentials.delete(e))))
       }
       workspaceState = undefined
-      // We want to ignore file changes if the user doesn't want to regerenarte the cache
       await getWorkspaceState()
     },
     addService: async (service: string): Promise<void> => {

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -74,6 +74,10 @@ export type WorkspaceComponents = {
   serviceConfig: boolean
 }
 
+export type ClearFlags = Omit<WorkspaceComponents, 'serviceConfig'> & {
+  regenerateCache?: boolean
+}
+
 export type Workspace = {
   uid: string
   name: string
@@ -113,7 +117,7 @@ export type Workspace = {
   getParsedNaclFile: (filename: string) => Promise<ParsedNaclFile | undefined>
   flush: () => Promise<void>
   clone: () => Promise<Workspace>
-  clear: (args: Omit<WorkspaceComponents, 'serviceConfig'>) => Promise<void>
+  clear: (args: ClearFlags) => Promise<void>
 
   addService: (service: string) => Promise<void>
   addEnvironment: (env: string) => Promise<void>
@@ -620,7 +624,7 @@ export const loadWorkspace = async (
       const envSources = { commonSourceName: enviormentsSources.commonSourceName, sources }
       return loadWorkspace(config, credentials, envSources, remoteMapCreator)
     },
-    clear: async (args: Omit<WorkspaceComponents, 'serviceConfig'>) => {
+    clear: async (args: ClearFlags) => {
       const currentWSState = await getWorkspaceState()
       if (args.cache || args.nacl || args.staticResources) {
         if (args.staticResources && !(args.state && args.cache && args.nacl)) {
@@ -641,6 +645,7 @@ export const loadWorkspace = async (
         await promises.array.series(envs().map(e => (() => credentials.delete(e))))
       }
       workspaceState = undefined
+      // We want to ignore file changes if the user doesn't want to regerenarte the cache
       await getWorkspaceState()
     },
     addService: async (service: string): Promise<void> => {

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -640,7 +640,8 @@ export const loadWorkspace = async (
       if (args.credentials) {
         await promises.array.series(envs().map(e => (() => credentials.delete(e))))
       }
-      workspaceState = buildWorkspaceState({})
+      workspaceState = undefined
+      await getWorkspaceState()
     },
     addService: async (service: string): Promise<void> => {
       const currentServices = services() || []


### PR DESCRIPTION
_Fix cache is not being create when the regenerate flag is passed to clean_

---

_The cache was not regenerated since the regenerate command cleans the cache after the load. In order to fix that, full ws load is now invoked after the clean._ 

Note regarding tests - I'm still trying to find a way to unit-test this, I'm not sure it makes real sense. Either way - gonna add an e2e test for it in the dummy adapter e2e PR.

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_
