### PR TITLE
changed suiteapp integration keys

### DIFF
--- a/packages/netsuite-adapter/e2e_test/cred_store
+++ b/packages/netsuite-adapter/e2e_test/cred_store
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 require('@salto-io/e2e-credentials-store').cli.main({
   adapters: {
-    netsuite: require('../dist/e2e_test/credentials_store/adapter').default
+    netsuite_tmp: require('../dist/e2e_test/credentials_store/adapter').default
   },
 })

--- a/packages/netsuite-adapter/e2e_test/credentials_store/adapter.ts
+++ b/packages/netsuite-adapter/e2e_test/credentials_store/adapter.ts
@@ -24,7 +24,7 @@ type Args = {
 }
 
 const adapter: Adapter<Args, Credentials> = {
-  name: 'netsuite',
+  name: 'netsuite_tmp',
   credentialsOpts: {
     accountId: {
       type: 'string',

--- a/packages/netsuite-adapter/e2e_test/jest_environment.ts
+++ b/packages/netsuite-adapter/e2e_test/jest_environment.ts
@@ -49,7 +49,7 @@ export const credsSpec = (envName?: string): CredsSpec<Required<Credentials>> =>
       // when running against staging and prod from the test runner, opposed to regular backend e2e
       // tests. Thus we skip the credentials validation in e2e tests.
     },
-    typeName: 'netsuite',
+    typeName: 'netsuite_tmp',
     globalProp: envName ? `netsuite_${envName}` : 'netsuite',
   }
 }

--- a/packages/netsuite-adapter/src/client/suiteapp_client/constants.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/constants.ts
@@ -13,5 +13,5 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export const CONSUMER_KEY = '3db2f2ec0bd98c4eee526ea0b8da876d1d739597e50ee593c67c0f2c34294073'
-export const CONSUMER_SECRET = '4c8399c03043f4ff2889610d260fc76037d126c840f83b3e6a4e6f4ddf3b0b79'
+export const CONSUMER_KEY = '9dc4d9f6c593fcc417636990a7581ee1272c824eca0847fed5075276d630c338'
+export const CONSUMER_SECRET = '13f886e062f985b96068994b231f1b28c53d89b0dde04cc74244653f94226a38'


### PR DESCRIPTION
In order for the SuiteApp bundle to include the integration, I had to create new integration in the same account I created the bundle. Therefore I had to change the consumer keys.

The `netsuite` to `netsuite_tmp` is to not break the e2e tests in master since the old credentials won't work with the new integration.

---
_Release Notes_: 
None