### PR TITLE
SALTO-1359: restored the e2e pool type name

### DIFF
--- a/packages/netsuite-adapter/e2e_test/cred_store
+++ b/packages/netsuite-adapter/e2e_test/cred_store
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 require('@salto-io/e2e-credentials-store').cli.main({
   adapters: {
-    netsuite_tmp: require('../dist/e2e_test/credentials_store/adapter').default
+    netsuite: require('../dist/e2e_test/credentials_store/adapter').default
   },
 })

--- a/packages/netsuite-adapter/e2e_test/credentials_store/adapter.ts
+++ b/packages/netsuite-adapter/e2e_test/credentials_store/adapter.ts
@@ -24,7 +24,7 @@ type Args = {
 }
 
 const adapter: Adapter<Args, Credentials> = {
-  name: 'netsuite_tmp',
+  name: 'netsuite',
   credentialsOpts: {
     accountId: {
       type: 'string',

--- a/packages/netsuite-adapter/e2e_test/jest_environment.ts
+++ b/packages/netsuite-adapter/e2e_test/jest_environment.ts
@@ -49,7 +49,7 @@ export const credsSpec = (envName?: string): CredsSpec<Required<Credentials>> =>
       // when running against staging and prod from the test runner, opposed to regular backend e2e
       // tests. Thus we skip the credentials validation in e2e tests.
     },
-    typeName: 'netsuite_tmp',
+    typeName: 'netsuite',
     globalProp: envName ? `netsuite_${envName}` : 'netsuite',
   }
 }


### PR DESCRIPTION
Restored the e2e pool type name in PR https://github.com/salto-io/salto/pull/2126/files

---
_Release Notes_: 
None