### PR TITLE
SALTO-1360 - Added indicative error message for invalid suiteApp credentials

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -256,7 +256,7 @@ export default class SoapClient {
   private async sendSoapRequest(operation: string, body: object): Promise<unknown> {
     const client = await this.getClient()
     try {
-      return this.callsLimiter(async () => (await client[`${operation}Async`](body))[0])
+      return await this.callsLimiter(async () => (await client[`${operation}Async`](body))[0])
     } catch (e) {
       if (e.message.includes('Invalid login attempt.')) {
         throw new InvalidSuiteAppCredentialsError()

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -255,16 +255,14 @@ export default class SoapClient {
 
   private async sendSoapRequest(operation: string, body: object): Promise<unknown> {
     const client = await this.getClient()
-    let response
     try {
-      response = await this.callsLimiter(async () => (await client[`${operation}Async`](body))[0])
+      return this.callsLimiter(async () => (await client[`${operation}Async`](body))[0])
     } catch (e) {
       if (e.message.includes('Invalid login attempt.')) {
         throw new InvalidSuiteAppCredentialsError()
       }
       throw e
     }
-    return response
   }
 
   private generateSoapHeader(): object {

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -175,7 +175,7 @@ export default class SuiteAppClient {
     headers: unknown
   ): Promise<AxiosResponse> {
     try {
-      return this.callsLimiter(() => axios.post(
+      return await this.callsLimiter(() => axios.post(
         href,
         data,
         { headers },

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -68,6 +68,6 @@ export type ImportObjectsResult = {
 
 export class InvalidSuiteAppCredentialsError extends Error {
   constructor() {
-    super('Invalid suite app credentials')
+    super('Invalid SuiteApp credentials')
   }
 }

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -65,3 +65,9 @@ export type ImportObjectsResult = {
     referencedFileImportResult: unknown
   }[]
 }
+
+export class InvalidSuiteAppCredentialsError extends Error {
+  constructor() {
+    super('Invalid suite app credentials')
+  }
+}

--- a/packages/netsuite-adapter/test/client/soap_client.test.ts
+++ b/packages/netsuite-adapter/test/client/soap_client.test.ts
@@ -17,6 +17,7 @@ import * as soap from 'soap'
 import { ExistingFileCabinetInstanceDetails } from '../../src/client/suiteapp_client/types'
 import { ReadFileError } from '../../src/client/suiteapp_client/errors'
 import SoapClient from '../../src/client/suiteapp_client/soap_client/soap_client'
+import { InvalidSuiteAppCredentialsError } from '../../src/client/types'
 
 describe('soap_client', () => {
   const addListAsyncMock = jest.fn()
@@ -97,6 +98,11 @@ describe('soap_client', () => {
     it('should throw an error when got invalid response', async () => {
       getAsyncMock.mockResolvedValue([{}])
       await expect(client.readFile(1)).rejects.toThrow(Error)
+    })
+
+    it('should throw InvalidSuiteAppCredentialsError', async () => {
+      getAsyncMock.mockRejectedValue(new Error('bla bla Invalid login attempt. bla bla'))
+      await expect(client.readFile(1)).rejects.toThrow(InvalidSuiteAppCredentialsError)
     })
   })
   describe('updateFileCabinetInstances', () => {
@@ -211,6 +217,32 @@ describe('soap_client', () => {
         },
       ])).rejects.toThrow('Got invalid response from updateList request. Errors:')
     })
+    it('should throw InvalidSuiteAppCredentialsError', async () => {
+      updateListAsyncMock.mockRejectedValue(new Error('bla bla Invalid login attempt. bla bla'))
+      await expect(client.updateFileCabinetInstances([
+        {
+          type: 'file',
+          path: 'somePath',
+          id: 6233,
+          folder: -6,
+          bundleable: true,
+          isInactive: false,
+          isOnline: false,
+          hideInBundle: true,
+          content: Buffer.from('aaa'),
+          description: 'desc',
+        },
+        {
+          type: 'folder',
+          path: 'somePath2',
+          id: 62330,
+          bundleable: true,
+          isInactive: false,
+          isPrivate: false,
+          description: 'desc',
+        },
+      ])).rejects.toThrow(InvalidSuiteAppCredentialsError)
+    })
   })
 
   describe('addFileCabinetInstances', () => {
@@ -321,6 +353,32 @@ describe('soap_client', () => {
         },
       ])).rejects.toThrow('Got invalid response from addList request. Errors:')
     })
+
+    it('should throw InvalidSuiteAppCredentialsError', async () => {
+      addListAsyncMock.mockRejectedValue(new Error('bla bla Invalid login attempt. bla bla'))
+      await expect(client.addFileCabinetInstances([
+        {
+          type: 'file',
+          path: 'addedFile',
+          folder: -6,
+          bundleable: true,
+          isInactive: false,
+          isOnline: false,
+          hideInBundle: true,
+          content: Buffer.from('aaa'),
+          description: 'desc',
+        },
+        {
+          type: 'folder',
+          path: 'addedFile2',
+          parent: -600,
+          bundleable: true,
+          isInactive: false,
+          isPrivate: false,
+          description: 'desc',
+        },
+      ])).rejects.toThrow(InvalidSuiteAppCredentialsError)
+    })
   })
 
   describe('deleteFileCabinetInstances', () => {
@@ -400,6 +458,22 @@ describe('soap_client', () => {
           path: 'somePath2',
         },
       ] as ExistingFileCabinetInstanceDetails[])).rejects.toThrow('Got invalid response from deleteList request. Errors:')
+    })
+
+    it('should throw InvalidSuiteAppCredentialsError', async () => {
+      deleteListAsyncMock.mockRejectedValue(new Error('bla bla Invalid login attempt. bla bla'))
+      await expect(client.deleteFileCabinetInstances([
+        {
+          type: 'file',
+          id: 7148,
+          path: 'somePath1',
+        },
+        {
+          type: 'folder',
+          id: 99999,
+          path: 'somePath2',
+        },
+      ] as ExistingFileCabinetInstanceDetails[])).rejects.toThrow(InvalidSuiteAppCredentialsError)
     })
   })
 })

--- a/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
@@ -19,6 +19,7 @@ import _ from 'lodash'
 import SoapClient from '../../src/client/suiteapp_client/soap_client/soap_client'
 import { ReadFileEncodingError, ReadFileError } from '../../src/client/suiteapp_client/errors'
 import SuiteAppClient from '../../src/client/suiteapp_client/suiteapp_client'
+import { InvalidSuiteAppCredentialsError } from '../../src/client/types'
 
 jest.mock('axios')
 
@@ -103,6 +104,19 @@ describe('SuiteAppClient', () => {
           },
         }
       )
+    })
+
+    it('should throw InvalidSuiteAppCredentialsError', async () => {
+      class MockedAxiosError extends Error {
+        response: { status: number }
+        constructor() {
+          super('Invalid SuiteApp credentials')
+          this.response = { status: 401 }
+        }
+      }
+      const unauthorizedError = new MockedAxiosError()
+      postMock.mockRejectedValue(unauthorizedError)
+      await expect(client.runSuiteQL('query')).rejects.toThrow(InvalidSuiteAppCredentialsError)
     })
 
     describe('query failure', () => {


### PR DESCRIPTION
Suiteapp invalid creds don't throw an indicative error on fetch/deploy - fixed.
---

Due to SaaS requirements, may support revoked tokens as well.

---
_Release Notes_: 

