### PR TITLE
SALTO-1364 Add log when merging fetch change with local parent

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -155,6 +155,12 @@ const toFetchChanges = (
   return serviceChange => {
     const pendingChange = getMatchingChange(serviceChange.id, pendingChanges)
     const change = getMatchingChange(serviceChange.id, workspaceToServiceChanges)
+    if (change !== undefined && !change.id.isEqual(serviceChange.id)) {
+      // temporary log - should be replaced by SALTO-1364
+      log.warn('service %s change for id %s was replaced by containing %s change for id %s',
+        serviceChange.action, serviceChange.id.getFullName(),
+        change.action, change.id.getFullName())
+    }
     return change === undefined
       ? []
       : [{ change, pendingChange, serviceChange }]


### PR DESCRIPTION
Internal log to track cases where multiple incoming service changes conflict with a workspace change, which can result (if accepted by the user) in invalid nacls.
Note that this is not a fix yet.


---
_Release Notes_: 
None
