### PR TITLE
SALTO-825: added support for skip list for data instances

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -48,10 +48,10 @@ import { getChangedObjects } from './changes_detector/changes_detector'
 import NetsuiteClient from './client/client'
 import { createDateRange } from './changes_detector/date_formats'
 import { createElementsSourceIndex } from './elements_source_index/elements_source_index'
-import { LazyElementsSourceIndex } from './elements_source_index/types'
+import { LazyElementsSourceIndexes } from './elements_source_index/types'
 import getChangeValidator from './change_validator'
 import { getChangeGroupIdsFunc } from './group_changes'
-import { getDataElements } from './data_elements/data_elements'
+import { getDataTypes } from './data_elements/data_elements'
 
 const { makeArray } = collections.array
 const { awu } = collections.asynciterable
@@ -165,8 +165,8 @@ export default class NetsuiteAdapter implements AdapterOperations {
     const isPartial = this.fetchTarget !== undefined
 
     // TODO: Replace when data instances are ready
-    const dataElementsPromise = await getDataElements(this.client)
-    // const dataElementsPromise = await getDataTypes(this.client)
+    // const dataElementsPromise = await getDataElements(this.client, fetchQuery)
+    const dataElementsPromise = await getDataTypes(this.client)
 
     const getCustomObjectsResult = this.client.getCustomObjects(
       Object.keys(customTypes),
@@ -233,7 +233,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
 
   private async runSuiteAppOperations(
     fetchQuery: NetsuiteQuery,
-    elementsSourceIndex: LazyElementsSourceIndex
+    elementsSourceIndex: LazyElementsSourceIndexes
   ):
     Promise<{
       changedObjectsQuery?: NetsuiteQuery
@@ -293,7 +293,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
 
   private async runFiltersOnFetch(
     elements: Element[],
-    elementsSourceIndex: LazyElementsSourceIndex,
+    elementsSourceIndex: LazyElementsSourceIndexes,
     isPartial: boolean,
   ): Promise<void> {
     // Fetch filters order is important so they should run one after the other

--- a/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
@@ -26,7 +26,7 @@ import savedSearchDetector from './changes_detectors/savedsearch'
 import { ChangedObject, ChangedType, DateRange } from './types'
 import NetsuiteClient from '../client/client'
 import { convertSavedSearchStringToDate } from './date_formats'
-import { ElementsSourceValue, LazyElementsSourceIndex } from '../elements_source_index/types'
+import { ElementsSourceValue, LazyElementsSourceIndexes } from '../elements_source_index/types'
 
 const log = logger(module)
 
@@ -118,7 +118,7 @@ export const getChangedObjects = async (
   client: NetsuiteClient,
   query: NetsuiteQuery,
   dateRange: DateRange,
-  elementsSourceIndex: LazyElementsSourceIndex,
+  elementsSourceIndex: LazyElementsSourceIndexes,
 ): Promise<NetsuiteQuery> => {
   log.debug('Starting to look for changed objects')
 
@@ -128,7 +128,7 @@ export const getChangedObjects = async (
       .map(detector => detector.getChanges(client, dateRange))
   ).then(output => output.flat())
 
-  const idToLastFetchDate = await elementsSourceIndex.getIndex()
+  const idToLastFetchDate = (await elementsSourceIndex.getIndexes()).serviceIdsIndex
 
   const [
     systemNoteChanges,
@@ -172,8 +172,9 @@ export const getChangedObjects = async (
     isTypeMatch: typeName => !SUPPORTED_TYPES.has(typeName)
       || scriptIds.size !== 0
       || types.size !== 0,
+    areAllObjectsMatch: () => false,
     isObjectMatch: objectID => !SUPPORTED_TYPES.has(objectID.type)
-      || scriptIds.has(objectID.scriptId)
+      || scriptIds.has(objectID.instanceId)
       || types.has(objectID.type),
     isFileMatch: filePath => filePaths.has(filePath)
       || unresolvedFolderPaths.some(path => filePath.startsWith(path)),

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -437,7 +437,7 @@ export default class SdfClient {
     const idsChunks = wu.entries(instancesIdsByType).map(
       ([type, ids]: [string, ObjectID[]]) =>
         wu(ids)
-          .map(id => id.scriptId)
+          .map(id => id.instanceId)
           .chunk(this.maxItemsInImportObjectsRequest)
           .enumerate()
           .map(([chunk, index]) => ({
@@ -499,7 +499,9 @@ export default class SdfClient {
       },
       executor,
     )
-    return results.data
+    return results.data.map(
+      ({ type, scriptId }: { type: string; scriptId: string }) => ({ type, instanceId: scriptId })
+    )
   }
 
   private async listFilePaths(executor: CommandActionExecutor):

--- a/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, isInstanceElement, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { InstanceElement, isInstanceElement, ReadOnlyElementsSource, TypeElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
@@ -24,6 +24,8 @@ import { ElementsSourceIndexes, ElementsSourceValue, LazyElementsSourceIndexes }
 
 const { awu } = collections.asynciterable
 const log = logger(module)
+
+export const getDataInstanceId = (internalId: string, type: TypeElement): string => `${type.elemID.name}-${internalId}`
 
 
 const createIndexes = async (elementsSource: ReadOnlyElementsSource):
@@ -54,7 +56,10 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource):
     const rawLastFetchTime = element.value[LAST_FETCH_TIME]
     const lastFetchTime = rawLastFetchTime && new Date(rawLastFetchTime)
 
-    internalIdsIndex[`${element.elemID.typeName}-${internalId}`] = { elemID: element.elemID, lastFetchTime }
+    internalIdsIndex[getDataInstanceId(internalId, await element.getType(elementsSource))] = {
+      elemID: element.elemID,
+      lastFetchTime,
+    }
   }
 
   await awu(await elementsSource.getAll())

--- a/packages/netsuite-adapter/src/elements_source_index/types.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/types.ts
@@ -17,9 +17,14 @@ import { ElemID } from '@salto-io/adapter-api'
 
 export type ElementsSourceValue = {
   lastFetchTime?: Date
-  elemID?: ElemID
+  elemID: ElemID
 }
 
-export type LazyElementsSourceIndex = {
-  getIndex: () => Promise<Record<string, ElementsSourceValue>>
+export type ElementsSourceIndexes = {
+  serviceIdsIndex: Record<string, ElementsSourceValue>
+  internalIdsIndex: Record<string, ElementsSourceValue>
+}
+
+export type LazyElementsSourceIndexes = {
+  getIndexes: () => Promise<ElementsSourceIndexes>
 }

--- a/packages/netsuite-adapter/src/filter.ts
+++ b/packages/netsuite-adapter/src/filter.ts
@@ -15,12 +15,12 @@
 */
 import { Element } from '@salto-io/adapter-api'
 import NetsuiteClient from './client/client'
-import { LazyElementsSourceIndex } from './elements_source_index/types'
+import { LazyElementsSourceIndexes } from './elements_source_index/types'
 
 export type OnFetchParameters = {
   elements: Element[]
   client: NetsuiteClient
-  elementsSourceIndex: LazyElementsSourceIndex
+  elementsSourceIndex: LazyElementsSourceIndexes
   isPartial: boolean
 }
 

--- a/packages/netsuite-adapter/src/filters/instance_references.ts
+++ b/packages/netsuite-adapter/src/filters/instance_references.ts
@@ -32,7 +32,7 @@ import {
 import { serviceId } from '../transformer'
 import { FilterCreator } from '../filter'
 import { isCustomType, typesElementSourceWrapper } from '../types'
-import { LazyElementsSourceIndex } from '../elements_source_index/types'
+import { LazyElementsSourceIndexes } from '../elements_source_index/types'
 
 const { awu } = collections.asynciterable
 // e.g. '[/Templates/filename.html]' & '[/SuiteScripts/script.js]'
@@ -136,14 +136,14 @@ const replaceReferenceValues = async (
 }
 
 const createElementsSourceServiceIdToElemID = async (
-  elementsSourceIndex: LazyElementsSourceIndex,
+  elementsSourceIndex: LazyElementsSourceIndexes,
   isPartial: boolean,
 ): Promise<Record<string, ElemID>> => {
   if (!isPartial) {
     return {}
   }
 
-  return _(await elementsSourceIndex.getIndex())
+  return _((await elementsSourceIndex.getIndexes()).serviceIdsIndex)
     .mapValues(val => val.elemID)
     .pickBy(lowerdashValues.isDefined)
     .value()

--- a/packages/netsuite-adapter/test/elements_source_index.test.ts
+++ b/packages/netsuite-adapter/test/elements_source_index.test.ts
@@ -31,13 +31,13 @@ describe('createElementsSourceIndex', () => {
   })
   it('should create the index only once and cache it', async () => {
     const elementsSourceIndex = createElementsSourceIndex(elementsSource)
-    const index = await elementsSourceIndex.getIndex()
-    const anotherIndex = await elementsSourceIndex.getIndex()
+    const index = await elementsSourceIndex.getIndexes()
+    const anotherIndex = await elementsSourceIndex.getIndexes()
     expect(index).toBe(anotherIndex)
     expect(getAllMock).toHaveBeenCalledTimes(1)
   })
 
-  it('should create the right index', async () => {
+  it('should create the right service ids index', async () => {
     getAllMock.mockImplementation(buildElementsSourceFromElements([
       new InstanceElement(
         'name',
@@ -48,7 +48,22 @@ describe('createElementsSourceIndex', () => {
     ]).getAll)
 
     const elementsSourceIndex = createElementsSourceIndex(elementsSource)
-    const index = await elementsSourceIndex.getIndex()
+    const index = (await elementsSourceIndex.getIndexes()).serviceIdsIndex
     expect(index.path).toEqual({ lastFetchTime: new Date('2021-02-22T18:55:17.949Z'), elemID: new ElemID(NETSUITE, 'someType', 'instance', 'name', PATH) })
+  })
+
+  it('should create the right internal ids index', async () => {
+    getAllMock.mockImplementation(buildElementsSourceFromElements([
+      new InstanceElement(
+        'name',
+        new ObjectType({ elemID: new ElemID(NETSUITE, 'someType') }),
+        { internalId: '4', [LAST_FETCH_TIME]: '2021-02-22T18:55:17.949Z' },
+        [],
+      ),
+    ]).getAll)
+
+    const elementsSourceIndex = createElementsSourceIndex(elementsSource)
+    const index = (await elementsSourceIndex.getIndexes()).internalIdsIndex
+    expect(index['someType-4']).toEqual({ lastFetchTime: new Date('2021-02-22T18:55:17.949Z'), elemID: new ElemID(NETSUITE, 'someType', 'instance', 'name') })
   })
 })

--- a/packages/netsuite-adapter/test/elements_source_index.test.ts
+++ b/packages/netsuite-adapter/test/elements_source_index.test.ts
@@ -21,12 +21,15 @@ import { createElementsSourceIndex } from '../src/elements_source_index/elements
 
 describe('createElementsSourceIndex', () => {
   const getAllMock = jest.fn()
+  const getMock = jest.fn()
   const elementsSource = {
     getAll: getAllMock,
+    get: getMock,
   } as unknown as ReadOnlyElementsSource
 
   beforeEach(() => {
     getAllMock.mockReset()
+    getMock.mockReset()
     getAllMock.mockImplementation(buildElementsSourceFromElements([]).getAll)
   })
   it('should create the index only once and cache it', async () => {
@@ -53,14 +56,19 @@ describe('createElementsSourceIndex', () => {
   })
 
   it('should create the right internal ids index', async () => {
+    const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'someType') })
     getAllMock.mockImplementation(buildElementsSourceFromElements([
       new InstanceElement(
         'name',
-        new ObjectType({ elemID: new ElemID(NETSUITE, 'someType') }),
+        type,
         { internalId: '4', [LAST_FETCH_TIME]: '2021-02-22T18:55:17.949Z' },
         [],
       ),
+      type,
     ]).getAll)
+    getMock.mockImplementation(buildElementsSourceFromElements([
+      type,
+    ]).get)
 
     const elementsSourceIndex = createElementsSourceIndex(elementsSource)
     const index = (await elementsSourceIndex.getIndexes()).internalIdsIndex

--- a/packages/netsuite-adapter/test/filters/add_parent_folder.test.ts
+++ b/packages/netsuite-adapter/test/filters/add_parent_folder.test.ts
@@ -33,7 +33,9 @@ describe('add_parent_folder filter', () => {
     onFetchParameters = {
       elements: [instance],
       client: {} as NetsuiteClient,
-      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      elementsSourceIndex: {
+        getIndexes: () => Promise.resolve({ serviceIdsIndex: {}, internalIdsIndex: {} }),
+      },
       isPartial: false,
     }
   })

--- a/packages/netsuite-adapter/test/filters/consistent_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/consistent_values.test.ts
@@ -52,7 +52,9 @@ describe('consistent_values filter', () => {
     onFetchParameters = {
       elements: [instance, instanceWithNestedInconsistentValue],
       client: {} as NetsuiteClient,
-      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      elementsSourceIndex: {
+        getIndexes: () => Promise.resolve({ serviceIdsIndex: {}, internalIdsIndex: {} }),
+      },
       isPartial: false,
     }
   })

--- a/packages/netsuite-adapter/test/filters/convert_lists.test.ts
+++ b/packages/netsuite-adapter/test/filters/convert_lists.test.ts
@@ -36,7 +36,9 @@ describe('convert_lists filter', () => {
     onFetchParameters = {
       elements: [instance],
       client: {} as NetsuiteClient,
-      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      elementsSourceIndex: {
+        getIndexes: () => Promise.resolve({ serviceIdsIndex: {}, internalIdsIndex: {} }),
+      },
       isPartial: false,
     }
   })

--- a/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
@@ -38,7 +38,9 @@ describe('data_instances_internal_id', () => {
     const onFetchParameters = {
       elements: [instance],
       client: {} as NetsuiteClient,
-      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      elementsSourceIndex: {
+        getIndexes: () => Promise.resolve({ serviceIdsIndex: {}, internalIdsIndex: {} }),
+      },
       isPartial: false,
       dataTypeNames: new Set<string>(),
     }
@@ -57,7 +59,9 @@ describe('data_instances_internal_id', () => {
     const onFetchParameters = {
       elements,
       client: {} as NetsuiteClient,
-      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      elementsSourceIndex: {
+        getIndexes: () => Promise.resolve({ serviceIdsIndex: {}, internalIdsIndex: {} }),
+      },
       isPartial: false,
       dataTypeNames: new Set<string>(),
     }

--- a/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
@@ -53,8 +53,60 @@ describe('data_instances_references', () => {
     const onFetchParameters = {
       elements: [instance, referencedInstance],
       client: {} as NetsuiteClient,
-      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      elementsSourceIndex: {
+        getIndexes: () => Promise.resolve({ serviceIdsIndex: {}, internalIdsIndex: {} }),
+      },
       isPartial: false,
+      dataTypeNames: new Set<string>(),
+    }
+    await filterCreator().onFetch(onFetchParameters)
+    expect((instance.value.field as ReferenceExpression).elemID.getFullName())
+      .toBe(referencedInstance.elemID.getFullName())
+  })
+
+  it('should change nothing if reference was not found', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      secondType,
+      { field: { internalId: '1' } }
+    )
+
+    const onFetchParameters = {
+      elements: [instance],
+      client: {} as NetsuiteClient,
+      elementsSourceIndex: {
+        getIndexes: () => Promise.resolve({ serviceIdsIndex: {}, internalIdsIndex: {} }),
+      },
+      isPartial: false,
+      dataTypeNames: new Set<string>(),
+    }
+    await filterCreator().onFetch(onFetchParameters)
+    expect(instance.value.field.internalId).toBe('1')
+  })
+
+  it('should use the elementsSource if partial', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      secondType,
+      { field: { internalId: '1' } }
+    )
+
+    const referencedInstance = new InstanceElement(
+      'referencedInstance',
+      firstType,
+      { internalId: '1' }
+    )
+
+    const onFetchParameters = {
+      elements: [instance],
+      client: {} as NetsuiteClient,
+      elementsSourceIndex: {
+        getIndexes: () => Promise.resolve({ serviceIdsIndex: {},
+          internalIdsIndex: {
+            'firstType-1': { elemID: referencedInstance.elemID },
+          } }),
+      },
+      isPartial: true,
       dataTypeNames: new Set<string>(),
     }
     await filterCreator().onFetch(onFetchParameters)
@@ -78,7 +130,9 @@ describe('data_instances_references', () => {
     const onFetchParameters = {
       elements: [instance, referencedInstance],
       client: {} as NetsuiteClient,
-      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      elementsSourceIndex: {
+        getIndexes: () => Promise.resolve({ serviceIdsIndex: {}, internalIdsIndex: {} }),
+      },
       isPartial: false,
       dataTypeNames: new Set<string>(),
     }

--- a/packages/netsuite-adapter/test/filters/hidden_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/hidden_fields.test.ts
@@ -32,7 +32,9 @@ describe('hidden_fields', () => {
     const onFetchParameters: OnFetchParameters = {
       elements: [type],
       client: {} as NetsuiteClient,
-      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      elementsSourceIndex: {
+        getIndexes: () => Promise.resolve({ serviceIdsIndex: {}, internalIdsIndex: {} }),
+      },
       isPartial: false,
     }
     await filterCreator().onFetch(onFetchParameters)

--- a/packages/netsuite-adapter/test/filters/instance_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/instance_references.test.ts
@@ -30,14 +30,17 @@ describe('instance_references filter', () => {
     let workflowInstance: InstanceElement
     let instanceWithRefs: InstanceElement
 
-    const getIndexMock = jest.fn()
+    const getIndexesMock = jest.fn()
     const elementsSourceIndex = {
-      getIndex: getIndexMock,
+      getIndexes: getIndexesMock,
     }
 
     beforeEach(async () => {
-      getIndexMock.mockReset()
-      getIndexMock.mockResolvedValue({})
+      getIndexesMock.mockReset()
+      getIndexesMock.mockResolvedValue({
+        serviceIdsIndex: {},
+        internalIdsIndex: {},
+      })
 
       fileInstance = new InstanceElement('fileInstance', fileCabinetTypes[FILE], {
         [PATH]: '/Templates/file.name',
@@ -204,8 +207,11 @@ describe('instance_references filter', () => {
     })
 
     it('should use elements source for creating the references with fetch is partial', async () => {
-      getIndexMock.mockResolvedValue({
-        '/Templates/instanceInElementsSource': { elemID: instanceInElementsSource.elemID.createNestedID(PATH) },
+      getIndexesMock.mockResolvedValue({
+        serviceIdsIndex: {
+          '/Templates/instanceInElementsSource': { elemID: instanceInElementsSource.elemID.createNestedID(PATH) },
+        },
+        internalIdsIndex: {},
       })
       await filterCreator().onFetch({
         elements: [fileInstance, workflowInstance, instanceWithRefs],
@@ -219,8 +225,11 @@ describe('instance_references filter', () => {
     })
 
     it('should not use elements source for creating the references when fetch is not partial', async () => {
-      getIndexMock.mockResolvedValue({
-        '/Templates/instanceInElementsSource': { elemID: instanceInElementsSource.elemID.createNestedID(PATH) },
+      getIndexesMock.mockResolvedValue({
+        serviceIdsIndex: {
+          '/Templates/instanceInElementsSource': { elemID: instanceInElementsSource.elemID.createNestedID(PATH) },
+        },
+        internalIdsIndex: {},
       })
       await filterCreator().onFetch({
         elements: [fileInstance, workflowInstance, instanceWithRefs],

--- a/packages/netsuite-adapter/test/filters/remove_redundant_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/remove_redundant_fields.test.ts
@@ -35,7 +35,10 @@ describe('removeRedundantFields', () => {
     onFetchParameters = {
       elements,
       client: {} as NetsuiteClient,
-      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      elementsSourceIndex: { getIndexes: () => Promise.resolve({
+        serviceIdsIndex: {},
+        internalIdsIndex: {},
+      }) },
       isPartial: false,
     }
   })

--- a/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
@@ -35,7 +35,10 @@ describe('remove_unsupported_types', () => {
     onFetchParameters = {
       elements,
       client: { isSuiteAppConfigured: isSuiteAppConfiguredMock } as unknown as NetsuiteClient,
-      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      elementsSourceIndex: { getIndexes: () => Promise.resolve({
+        serviceIdsIndex: {},
+        internalIdsIndex: {},
+      }) },
       isPartial: false,
     }
   })

--- a/packages/netsuite-adapter/test/filters/replace_record_ref.test.ts
+++ b/packages/netsuite-adapter/test/filters/replace_record_ref.test.ts
@@ -40,7 +40,10 @@ describe('replaceRecordRef', () => {
     onFetchParameters = {
       elements,
       client: {} as NetsuiteClient,
-      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      elementsSourceIndex: { getIndexes: () => Promise.resolve({
+        serviceIdsIndex: {},
+        internalIdsIndex: {},
+      }) },
       isPartial: false,
     }
   })

--- a/packages/netsuite-adapter/test/filters/service_urls.test.ts
+++ b/packages/netsuite-adapter/test/filters/service_urls.test.ts
@@ -42,7 +42,10 @@ describe('serviceUrls', () => {
     await serviceUrls().onFetch({
       elements,
       client,
-      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      elementsSourceIndex: { getIndexes: () => Promise.resolve({
+        serviceIdsIndex: {},
+        internalIdsIndex: {},
+      }) },
       isPartial: false,
     })
     expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBe('https://accountid.app.netsuite.com/app/common/media/mediaitem.nl?id=1')
@@ -52,7 +55,10 @@ describe('serviceUrls', () => {
     await serviceUrls().onFetch({
       elements,
       client,
-      elementsSourceIndex: { getIndex: () => Promise.resolve({}) },
+      elementsSourceIndex: { getIndexes: () => Promise.resolve({
+        serviceIdsIndex: {},
+        internalIdsIndex: {},
+      }) },
       isPartial: false,
     })
     expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()

--- a/packages/netsuite-adapter/test/query.test.ts
+++ b/packages/netsuite-adapter/test/query.test.ts
@@ -23,6 +23,7 @@ describe('NetsuiteQuery', () => {
         types: {
           addressForm: ['aaa.*', 'bbb.*'],
           advancedpdftemplate: ['ccc.*', 'ddd.*'],
+          Account: ['.*'],
         },
         filePaths: ['eee.*', 'fff.*'],
       })
@@ -51,13 +52,13 @@ describe('NetsuiteQuery', () => {
 
       describe('isObjectMatch', () => {
         it('should match objects that match the received regexes', () => {
-          expect(query.isObjectMatch({ scriptId: 'aaaaaa', type: 'addressForm' })).toBeTruthy()
-          expect(query.isObjectMatch({ scriptId: 'cccccc', type: 'advancedpdftemplate' })).toBeTruthy()
+          expect(query.isObjectMatch({ instanceId: 'aaaaaa', type: 'addressForm' })).toBeTruthy()
+          expect(query.isObjectMatch({ instanceId: 'cccccc', type: 'advancedpdftemplate' })).toBeTruthy()
         })
 
         it('should not match objects that do not match the received regexes', () => {
-          expect(query.isObjectMatch({ scriptId: 'aaaaaa', type: 'notExists' })).toBeFalsy()
-          expect(query.isObjectMatch({ scriptId: 'cccccc', type: 'addressForm' })).toBeFalsy()
+          expect(query.isObjectMatch({ instanceId: 'aaaaaa', type: 'notExists' })).toBeFalsy()
+          expect(query.isObjectMatch({ instanceId: 'cccccc', type: 'addressForm' })).toBeFalsy()
         })
       })
 
@@ -75,6 +76,12 @@ describe('NetsuiteQuery', () => {
             filePaths: [],
           })
           expect(q.areSomeFilesMatch()).toBeFalsy()
+        })
+      })
+      describe('areAllObjectsMatch', () => {
+        it('when there is .* should return true', () => {
+          expect(query.areAllObjectsMatch('Account')).toBeTruthy()
+          expect(query.areAllObjectsMatch('addressForm')).toBeFalsy()
         })
       })
     })
@@ -135,6 +142,7 @@ describe('NetsuiteQuery', () => {
       types: {
         addressForm: ['aaa.*'],
         advancedpdftemplate: ['.*'],
+        Account: ['.*'],
       },
       filePaths: ['bbb.*'],
     })
@@ -142,6 +150,7 @@ describe('NetsuiteQuery', () => {
       types: {
         addressForm: ['.*ccc'],
         bankstatementparserplugin: ['.*'],
+        Account: ['.*'],
       },
       filePaths: ['.*ddd'],
     })
@@ -153,6 +162,11 @@ describe('NetsuiteQuery', () => {
       expect(bothQuery.isTypeMatch('bankstatementparserplugin')).toBeFalsy()
     })
 
+    it('should match all objects if both queries match all objects', () => {
+      expect(bothQuery.areAllObjectsMatch('Account')).toBeTruthy()
+      expect(bothQuery.areAllObjectsMatch('bankstatementparserplugin')).toBeFalsy()
+    })
+
     it('should match only files that match both queries', () => {
       expect(bothQuery.isFileMatch('bbbdddd')).toBeTruthy()
       expect(bothQuery.isFileMatch('bbb')).toBeFalsy()
@@ -160,9 +174,9 @@ describe('NetsuiteQuery', () => {
     })
 
     it('should match only objects that match both queries', () => {
-      expect(bothQuery.isObjectMatch({ scriptId: 'aaacccc', type: 'addressForm' })).toBeTruthy()
-      expect(bothQuery.isObjectMatch({ scriptId: 'aaa', type: 'addressForm' })).toBeFalsy()
-      expect(bothQuery.isObjectMatch({ scriptId: 'aaa', type: 'advancedpdftemplate' })).toBeFalsy()
+      expect(bothQuery.isObjectMatch({ instanceId: 'aaacccc', type: 'addressForm' })).toBeTruthy()
+      expect(bothQuery.isObjectMatch({ instanceId: 'aaa', type: 'addressForm' })).toBeFalsy()
+      expect(bothQuery.isObjectMatch({ instanceId: 'aaa', type: 'advancedpdftemplate' })).toBeFalsy()
     })
 
     it('should return whether both queries has some files match', () => {
@@ -184,15 +198,20 @@ describe('NetsuiteQuery', () => {
       expect(inverseQuery.isTypeMatch('advancedpdftemplate')).toBeTruthy()
     })
 
+    it('should match all objects if did not match any object before', () => {
+      expect(inverseQuery.areAllObjectsMatch('Account')).toBeTruthy()
+      expect(inverseQuery.areAllObjectsMatch('addressForm')).toBeFalsy()
+    })
+
     it('should match only files that do not match the original query', () => {
       expect(inverseQuery.isFileMatch('bbb')).toBeFalsy()
       expect(inverseQuery.isFileMatch('ddd')).toBeTruthy()
     })
 
     it('should match only objects that do not match the original query', () => {
-      expect(inverseQuery.isObjectMatch({ scriptId: 'aaa', type: 'addressForm' })).toBeFalsy()
-      expect(inverseQuery.isObjectMatch({ scriptId: 'aaa', type: 'advancedpdftemplate' })).toBeTruthy()
-      expect(inverseQuery.isObjectMatch({ scriptId: 'bbb', type: 'addressForm' })).toBeTruthy()
+      expect(inverseQuery.isObjectMatch({ instanceId: 'aaa', type: 'addressForm' })).toBeFalsy()
+      expect(inverseQuery.isObjectMatch({ instanceId: 'aaa', type: 'advancedpdftemplate' })).toBeTruthy()
+      expect(inverseQuery.isObjectMatch({ instanceId: 'bbb', type: 'addressForm' })).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
This PR is to make the new Netsuite instances to support the skip list and partial fetch. 

The changes in the element index are to make the references work when using partial fetch

---
_Release Notes_: 
None