### PR TITLE
use keep ref in workspace remote maps

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -115,14 +115,14 @@ const buildMultiEnvSource = (
   const buildStateForSingleEnv = async (envName: string): Promise<SingleState> => {
     const elements = new RemoteElementSource(await remoteMapCreator<Element>({
       namespace: getRemoteMapNamespace('merged', envName),
-      serialize: element => serialize([element]),
+      serialize: element => serialize([element], 'keepRef'),
       deserialize: deserializeSingleElement,
     }))
     return {
       elements,
       mergeErrors: await remoteMapCreator<MergeError[]>({
         namespace: getRemoteMapNamespace('errors', envName),
-        serialize: errors => serialize(errors),
+        serialize: errors => serialize(errors, 'keepRef'),
         deserialize: async data => deserializeMergeErrors(data),
       }),
     }

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -198,12 +198,12 @@ const createNaclFilesState = async (
   }),
   mergeErrors: await remoteMapCreator<MergeError[]>({
     namespace: getRemoteMapNamespace('errors', sourceName),
-    serialize: errors => serialize(errors),
+    serialize: errors => serialize(errors, 'keepRef'),
     deserialize: async data => deserializeMergeErrors(data),
   }),
   mergedElements: new RemoteElementSource(await remoteMapCreator<Element>({
     namespace: getRemoteMapNamespace('merged', sourceName),
-    serialize: element => serialize([element]),
+    serialize: element => serialize([element], 'keepRef'),
     deserialize: async data => deserializeSingleElement(
       data,
       async sf => staticFilesSource.getStaticFile(sf.filepath, sf.encoding)

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
@@ -125,7 +125,7 @@ const getCacheSources = async (
   metadata: await getMetadata(cacheName, remoteMapCreator),
   elements: await remoteMapCreator({
     namespace: getRemoteMapCacheNamespace(cacheName, 'elements'),
-    serialize: (elements: Element[]) => serialize(elements ?? []),
+    serialize: (elements: Element[]) => serialize(elements ?? [], 'keepRef'),
     deserialize: async data => (deserialize(
       data,
       async sf => staticFilesSource.getStaticFile(sf.filepath, sf.encoding),

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -198,19 +198,19 @@ export const loadWorkspace = async (
           merged: new RemoteElementSource(
             await remoteMapCreator<Element>({
               namespace: getRemoteMapNamespace('merged', envName),
-              serialize: element => serialize([element]),
+              serialize: element => serialize([element], 'keepRef'),
               // TODO: we might need to pass static file reviver to the deserialization func
               deserialize: deserializeSingleElement,
             })
           ),
           errors: await remoteMapCreator<MergeError[]>({
             namespace: getRemoteMapNamespace('errors', envName),
-            serialize: mergeErrors => serialize(mergeErrors),
+            serialize: mergeErrors => serialize(mergeErrors, 'keepRef'),
             deserialize: async data => deserializeMergeErrors(data),
           }),
           validationErrors: await remoteMapCreator<ValidationError[]>({
             namespace: getRemoteMapNamespace('validationErrors', envName),
-            serialize: validationErrors => serialize(validationErrors),
+            serialize: validationErrors => serialize(validationErrors, 'keepRef'),
             deserialize: async data => deserializeValidationErrors(data),
           }),
         }]).toArray())

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -26,6 +26,7 @@ import { mockStaticFilesSource, persistentMockCreateRemoteMap } from '../../util
 import * as parser from '../../../src/parser'
 import { InMemoryRemoteMap, RemoteMapCreator, RemoteMap, CreateRemoteMapParams } from '../../../src/workspace/remote_map'
 import { ParsedNaclFile } from '../../../src/workspace/nacl_files/parsed_nacl_file'
+import { createRefToElmWithValue } from '@salto-io/adapter-utils'
 
 const { awu } = collections.asynciterable
 

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -26,7 +26,6 @@ import { mockStaticFilesSource, persistentMockCreateRemoteMap } from '../../util
 import * as parser from '../../../src/parser'
 import { InMemoryRemoteMap, RemoteMapCreator, RemoteMap, CreateRemoteMapParams } from '../../../src/workspace/remote_map'
 import { ParsedNaclFile } from '../../../src/workspace/nacl_files/parsed_nacl_file'
-import { createRefToElmWithValue } from '@salto-io/adapter-utils'
 
 const { awu } = collections.asynciterable
 


### PR DESCRIPTION
_Use keep ref in workspace remote maps serializers_
---

_IThe keepRef attribute should be passed to workspace serializer in order to make sure that if a reference to value is passed, it will be saved as a reference and not a value_

---
_Release Notes_: 
_NA_
