### PR TITLE
Salto 1355: Allow init command without interactive input

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -31,7 +31,7 @@ type InitArgs = {
 }
 
 export const action: CommandDefAction<InitArgs> = async (
-  { input: { workspaceName , envName }, cliTelemetry, output, workspacePath },
+  { input: { workspaceName, envName }, cliTelemetry, output, workspacePath },
 ): Promise<CliExitCode> => {
   log.debug('running env init command on \'%s\'', workspaceName)
   cliTelemetry.start()

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -27,11 +27,11 @@ const log = logger(module)
 
 type InitArgs = {
   workspaceName?: string
-  environment?: string
+  envName?: string
 }
 
 export const action: CommandDefAction<InitArgs> = async (
-  { input: { workspaceName , environment }, cliTelemetry, output, workspacePath },
+  { input: { workspaceName , envName }, cliTelemetry, output, workspacePath },
 ): Promise<CliExitCode> => {
   log.debug('running env init command on \'%s\'', workspaceName)
   cliTelemetry.start()
@@ -45,16 +45,11 @@ export const action: CommandDefAction<InitArgs> = async (
       )
       return CliExitCode.AppError
     }
-    const defaultEnvName = environment ?? (await getEnvName())
+    const defaultEnvName = envName ?? (await getEnvName())
     const workspace = await initLocalWorkspace(baseDir, workspaceName, defaultEnvName)
     const workspaceTags = await getWorkspaceTelemetryTags(workspace)
     cliTelemetry.success(workspaceTags)
-    if (defaultEnvName==environment){
-      outputLine(Prompts.initWithEnvCompleted(workspace.name, defaultEnvName , baseDir), output)
-    }
-    else{
-      outputLine(Prompts.initCompleted(workspace.name, baseDir), output)
-        }
+    outputLine(Prompts.initCompleted(), output)
   } catch (e) {
     errorOutputLine(Prompts.initFailed(e.message), output)
     cliTelemetry.failure()
@@ -70,10 +65,10 @@ const initDef = createPublicCommandDef({
     description: 'Initialize a new Salto workspace in the current directory',
     keyedOptions: [
       {
-        name: 'environment',
+        name: 'envName',
         alias: 'e',
         required: false,
-        description: 'Set the new environment name',
+        description: 'The name of the first environment in the workspace',
         type: 'string',
       },
     ],

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -70,6 +70,12 @@ export default class Prompts {
 
   private static readonly SERVICE_ADD_HELP = 'Use `salto service add <service-name>` to add services to the environment'
 
+  public static initWithEnvCompleted(name: string, envName: string, baseDir: string): string {
+    return `Initiated a ${name} workspace with environment ${envName} at ${baseDir}
+${Prompts.SERVICE_ADD_HELP}
+`
+  }
+  
   public static initCompleted(name: string, baseDir: string): string {
     return `Initiated empty workspace ${name} at ${baseDir}
 ${Prompts.SERVICE_ADD_HELP}

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -70,14 +70,8 @@ export default class Prompts {
 
   private static readonly SERVICE_ADD_HELP = 'Use `salto service add <service-name>` to add services to the environment'
 
-  public static initWithEnvCompleted(name: string, envName: string, baseDir: string): string {
-    return `Initiated a ${name} workspace with environment ${envName} at ${baseDir}
-${Prompts.SERVICE_ADD_HELP}
-`
-  }
-  
-  public static initCompleted(name: string, baseDir: string): string {
-    return `Initiated empty workspace ${name} at ${baseDir}
+  public static initCompleted(): string {
+    return `Initiated empty workspace
 ${Prompts.SERVICE_ADD_HELP}
 `
   }

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -73,34 +73,33 @@ describe('init command', () => {
     output = cliArgs.output
   })
   describe('with interactive env input ', () => {
-
     it('should invoke api\'s init', async () => {
-     await action({
-       ...cliCommandArgs,
-       input: {
-         workspaceName: 'test',
-      
+      await action({
+        ...cliCommandArgs,
+        input: {
+          workspaceName: 'test',
+
         },
-     })
-     expect(output.stdout.content.includes('Initiated')).toBeTruthy()
-     expect(telemetry.getEvents()).toHaveLength(2)
-     expect(telemetry.getEventsMap()[eventsNames.failure]).toBeUndefined()
-     expect(telemetry.getEventsMap()[eventsNames.success]).not.toBeUndefined()
-     expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
-  })
-  it('should print errors', async () => {
-    await action({
-      ...cliCommandArgs,
-      input: {
-        workspaceName: 'error',
-      },
+      })
+      expect(output.stdout.content.includes('Initiated')).toBeTruthy()
+      expect(telemetry.getEvents()).toHaveLength(2)
+      expect(telemetry.getEventsMap()[eventsNames.failure]).toBeUndefined()
+      expect(telemetry.getEventsMap()[eventsNames.success]).not.toBeUndefined()
+      expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
     })
-    expect(output.stderr.content.search('failed')).toBeGreaterThan(0)
-    expect(telemetry.getEvents()).toHaveLength(2)
-    expect(telemetry.getEventsMap()[eventsNames.success]).toBeUndefined()
-    expect(telemetry.getEventsMap()[eventsNames.failure]).not.toBeUndefined()
-    expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
-  })
+    it('should print errors', async () => {
+      await action({
+        ...cliCommandArgs,
+        input: {
+          workspaceName: 'error',
+        },
+      })
+      expect(output.stderr.content.search('failed')).toBeGreaterThan(0)
+      expect(telemetry.getEvents()).toHaveLength(2)
+      expect(telemetry.getEventsMap()[eventsNames.success]).toBeUndefined()
+      expect(telemetry.getEventsMap()[eventsNames.failure]).not.toBeUndefined()
+      expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
+    })
   })
   describe('without interactive env input ', () => {
     it('should invoke api\'s init', async () => {
@@ -109,31 +108,31 @@ describe('init command', () => {
         input: {
           workspaceName: 'test',
           envName: 'env1',
-       
-         },
+
+        },
       })
       expect(output.stdout.content.includes('Initiated')).toBeTruthy()
       expect(telemetry.getEvents()).toHaveLength(2)
       expect(telemetry.getEventsMap()[eventsNames.failure]).toBeUndefined()
       expect(telemetry.getEventsMap()[eventsNames.success]).not.toBeUndefined()
       expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
-   })
-   it('should print errors', async () => {
-    await action({
-      ...cliCommandArgs,
-      input: {
-        workspaceName: 'error',
-        envName: 'env1',
-      },
     })
-    expect(output.stderr.content.search('failed')).toBeGreaterThan(0)
-    expect(telemetry.getEvents()).toHaveLength(2)
-    expect(telemetry.getEventsMap()[eventsNames.success]).toBeUndefined()
-    expect(telemetry.getEventsMap()[eventsNames.failure]).not.toBeUndefined()
-    expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
+    it('should print errors', async () => {
+      await action({
+        ...cliCommandArgs,
+        input: {
+          workspaceName: 'error',
+          envName: 'env1',
+        },
+      })
+      expect(output.stderr.content.search('failed')).toBeGreaterThan(0)
+      expect(telemetry.getEvents()).toHaveLength(2)
+      expect(telemetry.getEventsMap()[eventsNames.success]).toBeUndefined()
+      expect(telemetry.getEventsMap()[eventsNames.failure]).not.toBeUndefined()
+      expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
+    })
   })
-  })
-  
+
 
   it('should avoid initiating a workspace which already exists', async () => {
     const path = '/some/path/to/workspace'

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -72,21 +72,22 @@ describe('init command', () => {
     telemetry = cliArgs.telemetry
     output = cliArgs.output
   })
+  describe('with interactive env input ', () => {
 
-  it('should invoke api\'s init', async () => {
-    await action({
-      ...cliCommandArgs,
-      input: {
-        workspaceName: 'test',
-      },
-    })
-    expect(output.stdout.content.search('test')).toBeGreaterThan(0)
-    expect(telemetry.getEvents()).toHaveLength(2)
-    expect(telemetry.getEventsMap()[eventsNames.failure]).toBeUndefined()
-    expect(telemetry.getEventsMap()[eventsNames.success]).not.toBeUndefined()
-    expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
+    it('should invoke api\'s init', async () => {
+     await action({
+       ...cliCommandArgs,
+       input: {
+         workspaceName: 'test',
+      
+        },
+     })
+     expect(output.stdout.content.includes('Initiated')).toBeTruthy()
+     expect(telemetry.getEvents()).toHaveLength(2)
+     expect(telemetry.getEventsMap()[eventsNames.failure]).toBeUndefined()
+     expect(telemetry.getEventsMap()[eventsNames.success]).not.toBeUndefined()
+     expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
   })
-
   it('should print errors', async () => {
     await action({
       ...cliCommandArgs,
@@ -100,6 +101,39 @@ describe('init command', () => {
     expect(telemetry.getEventsMap()[eventsNames.failure]).not.toBeUndefined()
     expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
   })
+  })
+  describe('without interactive env input ', () => {
+    it('should invoke api\'s init', async () => {
+      await action({
+        ...cliCommandArgs,
+        input: {
+          workspaceName: 'test',
+          envName: 'env1',
+       
+         },
+      })
+      expect(output.stdout.content.includes('Initiated')).toBeTruthy()
+      expect(telemetry.getEvents()).toHaveLength(2)
+      expect(telemetry.getEventsMap()[eventsNames.failure]).toBeUndefined()
+      expect(telemetry.getEventsMap()[eventsNames.success]).not.toBeUndefined()
+      expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
+   })
+   it('should print errors', async () => {
+    await action({
+      ...cliCommandArgs,
+      input: {
+        workspaceName: 'error',
+        envName: 'env1',
+      },
+    })
+    expect(output.stderr.content.search('failed')).toBeGreaterThan(0)
+    expect(telemetry.getEvents()).toHaveLength(2)
+    expect(telemetry.getEventsMap()[eventsNames.success]).toBeUndefined()
+    expect(telemetry.getEventsMap()[eventsNames.failure]).not.toBeUndefined()
+    expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
+  })
+  })
+  
 
   it('should avoid initiating a workspace which already exists', async () => {
     const path = '/some/path/to/workspace'


### PR DESCRIPTION
added a keyed option flag to the init command that allows an optional input for the first environment name to spare the interactive input.

also changed the output massage of the init command for Tomer's request to a shorter message that doesn't include the environment name and the path

---

_Additional context for reviewer_

---
_Release Notes_: 
added a flag to init command that allows to create the first environment as an init command input