### PR TITLE
Salto 1324: Improve service add command error in case of invalid service name

### DIFF
--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -113,7 +113,6 @@ export const addAction: WorkspaceCommandAction<ServiceAddArgs> = async ({
     return CliExitCode.UserInputError
   }
 
-
   await installAdapter(serviceName)
   if (login) {
     const adapterCredentialsTypes = getAdaptersCredentialsTypes([serviceName])[serviceName]

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -15,12 +15,12 @@
 */
 import { AdapterAuthMethod, AdapterAuthentication, InstanceElement, ObjectType, OAuthMethod, ElemID } from '@salto-io/adapter-api'
 import { EOL } from 'os'
-import { addAdapter, getLoginStatuses, LoginStatus, updateCredentials, getAdaptersCredentialsTypes, installAdapter } from '@salto-io/core'
+import { addAdapter, getLoginStatuses, LoginStatus, updateCredentials, getAdaptersCredentialsTypes, installAdapter, getSupportedServiceAdapterNames } from '@salto-io/core'
 import { Workspace } from '@salto-io/workspace'
 import { getCredentialsFromUser } from '../callbacks'
 import { CliOutput, CliExitCode, KeyedOption } from '../types'
 import { createCommandGroupDef, WorkspaceCommandAction, createWorkspaceCommand } from '../command_builder'
-import { formatServiceAlreadyAdded, formatServiceAdded, formatLoginToServiceFailed, formatCredentialsHeader, formatLoginUpdated, formatServiceNotConfigured, formatLoginOverride, formatConfiguredAndAdditionalServices, formatAddServiceFailed } from '../formatter'
+import { formatServiceAlreadyAdded, formatServiceAdded, formatLoginToServiceFailed, formatCredentialsHeader, formatLoginUpdated, formatServiceNotConfigured, formatLoginOverride, formatConfiguredAndAdditionalServices, formatAddServiceFailed, formatInvalidServiceInput } from '../formatter'
 import { errorOutputLine, outputLine } from '../outputer'
 import { processOauthCredentials } from '../cli_oauth_authenticator'
 import { EnvArg, ENVIRONMENT_OPTION, validateAndSetEnv } from './common/env'
@@ -102,10 +102,17 @@ export const addAction: WorkspaceCommandAction<ServiceAddArgs> = async ({
   const { login, serviceName, authType } = input
   await validateAndSetEnv(workspace, input, output)
 
+  const supportedServiceAdapters = getSupportedServiceAdapterNames()
+  if (!supportedServiceAdapters.includes(serviceName)) {
+    errorOutputLine(formatInvalidServiceInput(serviceName, supportedServiceAdapters), output)
+    return CliExitCode.UserInputError
+  }
+
   if (workspace.services().includes(serviceName)) {
     errorOutputLine(formatServiceAlreadyAdded(serviceName), output)
     return CliExitCode.UserInputError
   }
+
 
   await installAdapter(serviceName)
   if (login) {

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -553,23 +553,22 @@ export const formatServiceAlreadyAdded = (serviceName: string): string => [
   emptyLine(),
 ].join('\n')
 
-
 export const formatInvalidServiceInput = (
   serviceName: string, supportedServiceAdapters:string[]
-): string => 
-{
-  const privateAdapterNames = getPrivateAdaptersNames() 
+): string => {
+  const privateAdapterNames = getPrivateAdaptersNames()
   const isPrivateServiceName = (service: string) : boolean =>
     privateAdapterNames.includes(service)
-  
   return [
-  formatSimpleError(Prompts.SERVICE_NAME_NOT_VALID(
-    serviceName, supportedServiceAdapters.filter(supportedServiceAdapter => !isPrivateServiceName(supportedServiceAdapter)).map(
-      nonPrivateServiceName => indent(`- ${nonPrivateServiceName}`, 1)
-    )
-  )),
-  emptyLine(),
-].join('\n')}
+    formatSimpleError(Prompts.SERVICE_NAME_NOT_VALID(
+      serviceName, supportedServiceAdapters.filter(supportedServiceAdapter =>
+        !isPrivateServiceName(supportedServiceAdapter)).map(
+        nonPrivateServiceName => indent(`- ${nonPrivateServiceName}`, 1)
+      )
+    )),
+    emptyLine(),
+  ].join('\n')
+}
 
 export const formatLoginToServiceFailed = (serviceName: string, errorMessage: string): string => [
   formatSimpleError(Prompts.SERVICE_LOGIN_FAILED(serviceName, errorMessage)),

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -553,18 +553,23 @@ export const formatServiceAlreadyAdded = (serviceName: string): string => [
   emptyLine(),
 ].join('\n')
 
+
 export const formatInvalidServiceInput = (
   serviceName: string, supportedServiceAdapters:string[]
-): string => [
-  formatSimpleError(Prompts.SERVICE_NOT_VALID(
-    serviceName, supportedServiceAdapters.filter(
-      supportedServiceName => !getPrivateAdaptersNames().includes(supportedServiceName)
-    ).map(
+): string => 
+{
+  const privateAdapterNames = getPrivateAdaptersNames() 
+  const isPrivateServiceName = (service: string) : boolean =>
+    privateAdapterNames.includes(service)
+  
+  return [
+  formatSimpleError(Prompts.SERVICE_NAME_NOT_VALID(
+    serviceName, supportedServiceAdapters.filter(supportedServiceAdapter => !isPrivateServiceName(supportedServiceAdapter)).map(
       nonPrivateServiceName => indent(`- ${nonPrivateServiceName}`, 1)
     )
   )),
   emptyLine(),
-].join('\n')
+].join('\n')}
 
 export const formatLoginToServiceFailed = (serviceName: string, errorMessage: string): string => [
   formatSimpleError(Prompts.SERVICE_LOGIN_FAILED(serviceName, errorMessage)),

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -553,6 +553,19 @@ export const formatServiceAlreadyAdded = (serviceName: string): string => [
   emptyLine(),
 ].join('\n')
 
+export const formatInvalidServiceInput = (
+  serviceName: string, supportedServiceAdapters:string[]
+): string => [
+  formatSimpleError(Prompts.SERVICE_NOT_VALID(
+    serviceName, supportedServiceAdapters.filter(
+      supportedServiceName => !getPrivateAdaptersNames().includes(supportedServiceName)
+    ).map(
+      nonPrivateServiceName => indent(`- ${nonPrivateServiceName}`, 1)
+    )
+  )),
+  emptyLine(),
+].join('\n')
+
 export const formatLoginToServiceFailed = (serviceName: string, errorMessage: string): string => [
   formatSimpleError(Prompts.SERVICE_LOGIN_FAILED(serviceName, errorMessage)),
   Prompts.SERVICE_LOGIN_FAILED_TRY_AGAIN(serviceName),

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -156,6 +156,7 @@ The steps are: I. Fetching configs, II. Calculating difference and III. Applying
   public static readonly NO_CONFIGURED_SERVICES = 'There are not configured services in this environment'
   public static readonly NO_ADDITIONAL_CONFIGURED_SERVICES = 'There are no additional configurable services for this environment'
   public static readonly SERVICE_ALREADY_ADDED = (serviceName: string): string => `${serviceName} was already added to this environment`
+  public static readonly SERVICE_NOT_VALID = (serviceName: string, supportedServiceAdapters:string[]): string => `${serviceName} is not a valid service name, available service names are:\n${supportedServiceAdapters.join('\n')}`
   public static readonly WORKING_ON_ENV = 'The active environment is'
   public static readonly NO_CURRENT_ENV = 'No active environment is currently set'
   public static readonly SET_ENV = 'Active environment is set to'

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -156,7 +156,7 @@ The steps are: I. Fetching configs, II. Calculating difference and III. Applying
   public static readonly NO_CONFIGURED_SERVICES = 'There are not configured services in this environment'
   public static readonly NO_ADDITIONAL_CONFIGURED_SERVICES = 'There are no additional configurable services for this environment'
   public static readonly SERVICE_ALREADY_ADDED = (serviceName: string): string => `${serviceName} was already added to this environment`
-  public static readonly SERVICE_NOT_VALID = (serviceName: string, supportedServiceAdapters:string[]): string => `${serviceName} is not a valid service name, available service names are:\n${supportedServiceAdapters.join('\n')}`
+  public static readonly SERVICE_NAME_NOT_VALID = (serviceName: string, supportedServiceAdapters:string[]): string => `${serviceName} is not a valid service name, available service names are:\n${supportedServiceAdapters.join('\n')}`
   public static readonly WORKING_ON_ENV = 'The active environment is'
   public static readonly NO_CURRENT_ENV = 'No active environment is currently set'
   public static readonly SET_ENV = 'Active environment is set to'

--- a/packages/cli/test/commands/service.test.ts
+++ b/packages/cli/test/commands/service.test.ts
@@ -338,26 +338,31 @@ describe('service command group', () => {
       })
 
       describe('when called with a new adapter that does not exist', () => {
-        describe('with login', () => {
-          it('should throw an error', async () => {
-            expect(await addAction({
+        describe('with login', () => { 
+          let errCode: CliExitCode
+          beforeEach(async () => {
+            errCode= await addAction({
               ...cliCommandArgs,
               input: {
-                login: true,
                 serviceName: 'noAdapter',
                 authType: 'basic',
+                login: true,
               },
               workspace,
-            })).toBe(CliExitCode.UserInputError)
+            })
           })
-          it('should not print private services', () => {
+          it('should return user input error', async () => {
+            expect(errCode).toBe(CliExitCode.UserInputError)
+          })
+          it('should not print private services', async () => {
             expect(getPrivateAdaptersNames().some(privateName =>
               output.stdout.content.includes(privateName))).toBeFalsy()
           })
         })
         describe('without login', () => {
-          it('should throw an error', async () => {
-            expect(await addAction({
+          let errCode: CliExitCode
+          beforeEach(async () => {
+            errCode= await addAction({
               ...cliCommandArgs,
               input: {
                 serviceName: 'noAdapter',
@@ -365,9 +370,12 @@ describe('service command group', () => {
                 login: false,
               },
               workspace,
-            })).toBe(CliExitCode.UserInputError)
+            })
           })
-          it('should not print private services', () => {
+          it('should return user input error', async () => {
+            expect(errCode).toBe(CliExitCode.UserInputError)
+          })
+          it('should not print private services', async () => {
             expect(getPrivateAdaptersNames().some(privateName =>
               output.stdout.content.includes(privateName))).toBeFalsy()
           })

--- a/packages/cli/test/commands/service.test.ts
+++ b/packages/cli/test/commands/service.test.ts
@@ -105,7 +105,6 @@ describe('service command group', () => {
     output = cliArgs.output
     workspace = mocks.mockWorkspace({ services: ['salesforce', 'hubspot', 'oauthAdapter'] })
   })
-
   describe('list command', () => {
     let cliCommandArgs: mocks.MockCommandArgs
     beforeEach(() => {
@@ -338,10 +337,10 @@ describe('service command group', () => {
       })
 
       describe('when called with a new adapter that does not exist', () => {
-        describe('with login', () => { 
+        describe('with login', () => {
           let errCode: CliExitCode
           beforeEach(async () => {
-            errCode= await addAction({
+            errCode = await addAction({
               ...cliCommandArgs,
               input: {
                 serviceName: 'noAdapter',
@@ -362,7 +361,7 @@ describe('service command group', () => {
         describe('without login', () => {
           let errCode: CliExitCode
           beforeEach(async () => {
-            errCode= await addAction({
+            errCode = await addAction({
               ...cliCommandArgs,
               input: {
                 serviceName: 'noAdapter',


### PR DESCRIPTION
changed the error that return when running salto service add with an in valid adapter name.
also change the exit code to the user input error code

---

_Additional context for reviewer_

---
_Release Notes_: 
Improve service add command error in case of invalid service name