### PR TITLE
Salto 739: Add Core validation for string field's length limit

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -314,7 +314,7 @@ Type:
 - min: `number` - relevant for number fields, specifies the minimum valid value (inclusive).
 - max: `number`- relevant for number fields, specifies the maximum valid value (inclusive).
 - regex: `string` - relevant for string fields, specifies a pattern that values must match.
-- max_length: `number` - relevant for string fields, specifies the maximum valid string length for the field.
+- max_length: `number` - relevant for string fields, specifies the maximum valid length for the field.
 
 Default: `undefined`
 Applicable to: Fields

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -314,6 +314,7 @@ Type:
 - min: `number` - relevant for number fields, specifies the minimum valid value (inclusive).
 - max: `number`- relevant for number fields, specifies the maximum valid value (inclusive).
 - regex: `string` - relevant for string fields, specifies a pattern that values must match.
+- max_length: `number` - relevant for string fields, specifies the maximum valid string length for the field.
 
 Default: `undefined`
 Applicable to: Fields

--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -84,7 +84,7 @@ const restrictionType = new ObjectType({
         StandardBuiltinTypes.STRING,
       ),
     },
-    length_limit: {
+    max_length: {
       refType: new ReferenceExpression(
         StandardBuiltinTypes.NUMBER.elemID,
         StandardBuiltinTypes.NUMBER,
@@ -119,7 +119,7 @@ type RestrictionAnnotationType = Partial<{
   max: number
   regex: string
   // eslint-disable-next-line camelcase
-  length_limit: number
+  max_length: number
 }>
 
 const StandardCoreAnnotationTypes: TypeMap = {

--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -118,6 +118,7 @@ type RestrictionAnnotationType = Partial<{
   min: number
   max: number
   regex: string
+  // eslint-disable-next-line camelcase
   length_limit: number
 }>
 

--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -84,6 +84,12 @@ const restrictionType = new ObjectType({
         StandardBuiltinTypes.STRING,
       ),
     },
+    length_limit: {
+      refType: new ReferenceExpression(
+        StandardBuiltinTypes.NUMBER.elemID,
+        StandardBuiltinTypes.NUMBER,
+      ),
+    },
   },
 })
 
@@ -112,6 +118,7 @@ type RestrictionAnnotationType = Partial<{
   min: number
   max: number
   regex: string
+  length_limit: number
 }>
 
 const StandardCoreAnnotationTypes: TypeMap = {

--- a/packages/netsuite-adapter/scripts/types_generator.py
+++ b/packages/netsuite-adapter/scripts/types_generator.py
@@ -56,7 +56,7 @@ field_types_import = '''import { fieldTypes } from '../field_types'
 import_statements_for_type_def_template = '''import {{
   BuiltinTypes, CORE_ANNOTATIONS, ElemID, ObjectType, createRestriction,{list_type_import}
 }} from '@salto-io/adapter-api'
-import {{ createRefToElmWithValue }} from '@salto-io/adapter-utils
+import {{ createRefToElmWithValue }} from '@salto-io/adapter-utils'
 import * as constants from '../../constants'
 {enums_import}{field_types_import}
 '''
@@ -244,8 +244,8 @@ def parse_field_def(type_name, cells, is_attribute, is_inner_type, script_id_pre
             annotations['[CORE_ANNOTATIONS.RESTRICTION]'] = "createRestriction({{ regex: '{0}' }})".format(create_script_id_regex(description))
     if has_length_limitations:
       regex_matches = re.match("[\s\S]*value can be up to (\d*) characters long\.[\s\S]*", description)
-      length_limit = regex_matches.groups()[0]
-      annotations['// [CORE_ANNOTATIONS.LENGTH_LIMIT]'] = length_limit
+      limit = regex_matches.groups()[0]
+      annotations['[CORE_ANNOTATIONS.RESTRICTION]'] = "createRestriction({{ max_length: {0} }})".format(limit)
 
     return { NAME: field_name, TYPE: field_type, ANNOTATIONS: annotations, DESCRIPTION: '   '.join(description.splitlines()) }
 

--- a/packages/netsuite-adapter/scripts/types_generator.py
+++ b/packages/netsuite-adapter/scripts/types_generator.py
@@ -244,8 +244,8 @@ def parse_field_def(type_name, cells, is_attribute, is_inner_type, script_id_pre
             annotations['[CORE_ANNOTATIONS.RESTRICTION]'] = "createRestriction({{ regex: '{0}' }})".format(create_script_id_regex(description))
     if has_length_limitations:
       regex_matches = re.match("[\s\S]*value can be up to (\d*) characters long\.[\s\S]*", description)
-      length_limit = regex_matches.groups()[0]
-      annotations['[CORE_ANNOTATIONS.RESTRICTION]'] = "createRestriction({{ max_length: {0} }})".format(length_limit)
+      max_length = regex_matches.groups()[0]
+      annotations['[CORE_ANNOTATIONS.RESTRICTION]'] = "createRestriction({{ max_length: {0} }})".format(max_length)
 
     return { NAME: field_name, TYPE: field_type, ANNOTATIONS: annotations, DESCRIPTION: '   '.join(description.splitlines()) }
 

--- a/packages/netsuite-adapter/scripts/types_generator.py
+++ b/packages/netsuite-adapter/scripts/types_generator.py
@@ -244,8 +244,8 @@ def parse_field_def(type_name, cells, is_attribute, is_inner_type, script_id_pre
             annotations['[CORE_ANNOTATIONS.RESTRICTION]'] = "createRestriction({{ regex: '{0}' }})".format(create_script_id_regex(description))
     if has_length_limitations:
       regex_matches = re.match("[\s\S]*value can be up to (\d*) characters long\.[\s\S]*", description)
-      limit = regex_matches.groups()[0]
-      annotations['[CORE_ANNOTATIONS.RESTRICTION]'] = "createRestriction({{ max_length: {0} }})".format(limit)
+      length_limit = regex_matches.groups()[0]
+      annotations['[CORE_ANNOTATIONS.RESTRICTION]'] = "createRestriction({{ max_length: {0} }})".format(length_limit)
 
     return { NAME: field_name, TYPE: field_type, ANNOTATIONS: annotations, DESCRIPTION: '   '.join(description.splitlines()) }
 

--- a/packages/netsuite-adapter/src/types/custom_types/addressForm.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/addressForm.ts
@@ -58,10 +58,10 @@ const addressForm_mainFields_defaultFieldGroup_fields_field = new ObjectType({
       },
     }, /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see addressform_fieldid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -155,10 +155,10 @@ const addressForm_mainFields_fieldGroup_fields_field = new ObjectType({
       },
     }, /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see addressform_fieldid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -235,11 +235,11 @@ const addressForm_mainFields_fieldGroup = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 99 characters long. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -307,15 +307,15 @@ export const addressForm = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [constants.IS_ATTRIBUTE]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 99 }),
       },
     }, /* Original description: This attribute value can be up to 99 characters long. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     mainFields: {
       refType: createRefToElmWithValue(addressForm_mainFields),
       annotations: {

--- a/packages/netsuite-adapter/src/types/custom_types/advancedpdftemplate.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/advancedpdftemplate.ts
@@ -50,13 +50,13 @@ export const advancedpdftemplate = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 297,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 297 }),
       },
     }, /* Original description: This field value can be up to 297 characters long. */
     description: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 4000,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 4000 }),
       },
     }, /* Original description: This field value can be up to 4000 characters long. */
     displaysourcecode: {

--- a/packages/netsuite-adapter/src/types/custom_types/bankstatementparserplugin.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/bankstatementparserplugin.ts
@@ -40,10 +40,10 @@ export const bankstatementparserplugin = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -53,9 +53,9 @@ export const bankstatementparserplugin = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -71,7 +71,7 @@ export const bankstatementparserplugin = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/bundleinstallationscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/bundleinstallationscript.ts
@@ -244,7 +244,7 @@ const bundleinstallationscript_scriptcustomfields_scriptcustomfield = new Object
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {
@@ -486,10 +486,10 @@ export const bundleinstallationscript = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -499,9 +499,9 @@ export const bundleinstallationscript = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -517,7 +517,7 @@ export const bundleinstallationscript = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifyowner: {

--- a/packages/netsuite-adapter/src/types/custom_types/centercategory.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/centercategory.ts
@@ -48,7 +48,7 @@ const centercategory_links_link = new ObjectType({
       },
     }, /* Original description: This field is mandatory when the linkobject value is defined.   For information about possible values, see centercategory_tasktype. */
     linklabel: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
     }, /* Original description: This field accepts references to the string custom type. */
@@ -111,7 +111,7 @@ export const centercategory = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 99 }),
       },
     }, /* Original description: This field value can be up to 99 characters long.   This field accepts references to the string custom type. */
     links: {

--- a/packages/netsuite-adapter/src/types/custom_types/centerlink.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/centerlink.ts
@@ -42,14 +42,14 @@ export const centerlink = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 50,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 50 }),
       },
     }, /* Original description: This field value can be up to 50 characters long. */
     url: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
   },

--- a/packages/netsuite-adapter/src/types/custom_types/clientscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/clientscript.ts
@@ -249,7 +249,7 @@ const clientscript_scriptcustomfields_scriptcustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {
@@ -551,10 +551,10 @@ export const clientscript = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -564,9 +564,9 @@ export const clientscript = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -582,7 +582,7 @@ export const clientscript = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/cmscontenttype.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/cmscontenttype.ts
@@ -42,14 +42,14 @@ export const cmscontenttype = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     label: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 18,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 18 }),
       },
     }, /* Original description: This field value can be up to 18 characters long. */
     customrecordid: {
@@ -61,13 +61,13 @@ export const cmscontenttype = new ObjectType({
     description: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     iconimagepath: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
   },

--- a/packages/netsuite-adapter/src/types/custom_types/crmcustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/crmcustomfield.ts
@@ -170,7 +170,7 @@ export const crmcustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {

--- a/packages/netsuite-adapter/src/types/custom_types/customglplugin.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/customglplugin.ts
@@ -77,10 +77,10 @@ export const customglplugin = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -90,9 +90,9 @@ export const customglplugin = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -108,7 +108,7 @@ export const customglplugin = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/customlist.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/customlist.ts
@@ -96,7 +96,7 @@ export const customlist = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 30,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 30 }),
       },
     }, /* Original description: This field value can be up to 30 characters long.   This field accepts references to the string custom type. */
     description: {

--- a/packages/netsuite-adapter/src/types/custom_types/customrecordactionscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/customrecordactionscript.ts
@@ -244,7 +244,7 @@ const customrecordactionscript_scriptcustomfields_scriptcustomfield = new Object
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {
@@ -541,10 +541,10 @@ export const customrecordactionscript = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -554,9 +554,9 @@ export const customrecordactionscript = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -572,7 +572,7 @@ export const customrecordactionscript = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/customrecordtype.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/customrecordtype.ts
@@ -170,7 +170,7 @@ const customrecordtype_customrecordcustomfields_customrecordcustomfield = new Ob
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {
@@ -662,7 +662,7 @@ export const customrecordtype = new ObjectType({
     recordname: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field is available when the customsegment value is equal to   This field is mandatory when the customsegment value is equal to   This field accepts references to the string custom type. */
     customsegment: {

--- a/packages/netsuite-adapter/src/types/custom_types/customsegment.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/customsegment.ts
@@ -540,7 +540,7 @@ export const customsegment = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long. */
     recordtype: {
@@ -562,13 +562,13 @@ export const customsegment = new ObjectType({
     description: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     help: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     hasglimpact: {

--- a/packages/netsuite-adapter/src/types/custom_types/customtransactiontype.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/customtransactiontype.ts
@@ -204,7 +204,7 @@ const customtransactiontype_statuses_status = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 480,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 480 }),
       },
     }, /* Original description: This field value can be up to 480 characters long.   This field accepts references to the string custom type. */
     id: {
@@ -260,7 +260,7 @@ export const customtransactiontype = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 96,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 96 }),
       },
     }, /* Original description: This field value can be up to 96 characters long.   This field accepts references to the string custom type. */
     subliststyle: {

--- a/packages/netsuite-adapter/src/types/custom_types/dataset.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/dataset.ts
@@ -59,10 +59,10 @@ export const dataset = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custdataset’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 50,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 50 }),
       },
     }, /* Original description: This field value can be up to 50 characters long.   This field accepts references to the string custom type. */
     definition: {

--- a/packages/netsuite-adapter/src/types/custom_types/datasetbuilderplugin.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/datasetbuilderplugin.ts
@@ -40,10 +40,10 @@ export const datasetbuilderplugin = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -53,9 +53,9 @@ export const datasetbuilderplugin = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -71,7 +71,7 @@ export const datasetbuilderplugin = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/emailcaptureplugin.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/emailcaptureplugin.ts
@@ -77,10 +77,10 @@ export const emailcaptureplugin = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -90,9 +90,9 @@ export const emailcaptureplugin = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -108,7 +108,7 @@ export const emailcaptureplugin = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/emailtemplate.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/emailtemplate.ts
@@ -44,7 +44,7 @@ export const emailtemplate = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 60,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 60 }),
       },
     }, /* Original description: This field value can be up to 60 characters long. */
     mediaitem: {
@@ -55,7 +55,7 @@ export const emailtemplate = new ObjectType({
     description: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 1000,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 1000 }),
       },
     }, /* Original description: This field value can be up to 1000 characters long. */
     recordtype: {
@@ -71,7 +71,7 @@ export const emailtemplate = new ObjectType({
     subject: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 199,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 199 }),
       },
     }, /* Original description: This field value can be up to 199 characters long. */
     isprivate: {

--- a/packages/netsuite-adapter/src/types/custom_types/entitycustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/entitycustomfield.ts
@@ -170,7 +170,7 @@ export const entitycustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {

--- a/packages/netsuite-adapter/src/types/custom_types/entryForm.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/entryForm.ts
@@ -41,7 +41,7 @@ const entryForm_actionbar_buttons_button = new ObjectType({
     label: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long. */
     visible: {
@@ -84,13 +84,13 @@ const entryForm_actionbar_customButtons_customButton = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 99 }),
       },
     }, /* Original description: This field value can be up to 99 characters long. */
     function: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long. */
   },
@@ -128,13 +128,13 @@ const entryForm_actionbar_customMenu_customMenuItem = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 99 }),
       },
     }, /* Original description: This field value can be up to 99 characters long. */
     function: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long. */
   },
@@ -177,7 +177,7 @@ const entryForm_actionbar_menu_menuitem = new ObjectType({
     label: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long. */
     visible: {
@@ -344,10 +344,10 @@ const entryForm_mainFields_defaultFieldGroup_fields_field = new ObjectType({
       },
     }, /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_fieldid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -446,10 +446,10 @@ const entryForm_mainFields_fieldGroup_fields_field = new ObjectType({
       },
     }, /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_fieldid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -531,11 +531,11 @@ const entryForm_mainFields_fieldGroup = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 99 characters long. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -636,10 +636,10 @@ const entryForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_field = new Object
       },
     }, /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_fieldid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -738,10 +738,10 @@ const entryForm_tabs_tab_fieldGroups_fieldGroup_fields_field = new ObjectType({
       },
     }, /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_fieldid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -823,11 +823,11 @@ const entryForm_tabs_tab_fieldGroups_fieldGroup = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 99 characters long. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -891,11 +891,11 @@ const entryForm_tabs_tab_subItems_subList = new ObjectType({
       },
     }, /* Original description: This field accepts references to the following custom types:   transactionbodycustomfield   itemcustomfield   entitycustomfield   recordsublist   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_sublistid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -926,11 +926,11 @@ const entryForm_tabs_tab_subItems_subLists_subList = new ObjectType({
       },
     }, /* Original description: This field accepts references to the following custom types:   transactionbodycustomfield   itemcustomfield   entitycustomfield   recordsublist   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_sublistid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -979,10 +979,10 @@ const entryForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fields_fi
       },
     }, /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_fieldid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1081,10 +1081,10 @@ const entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_field = n
       },
     }, /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see entryform_fieldid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1166,11 +1166,11 @@ const entryForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup = new ObjectType
       },
     }, /* Original description: This attribute value can be up to 99 characters long. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1234,11 +1234,11 @@ const entryForm_tabs_tab_subItems_subTab = new ObjectType({
       },
     }, /* Original description: This field accepts references to the following custom types:   subtab   subtab   For information about other possible values, see entryform_subtabid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1302,11 +1302,11 @@ const entryForm_tabs_tab = new ObjectType({
       },
     }, /* Original description: This field accepts references to the following custom types:   subtab   subtab   For information about other possible values, see entryform_tabid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1367,11 +1367,11 @@ export const entryForm = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 99 characters long.   For information about possible values, see entryform_standard. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     recordType: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {

--- a/packages/netsuite-adapter/src/types/custom_types/ficonnectivityplugin.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/ficonnectivityplugin.ts
@@ -40,10 +40,10 @@ export const ficonnectivityplugin = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -53,9 +53,9 @@ export const ficonnectivityplugin = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -71,7 +71,7 @@ export const ficonnectivityplugin = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/fiparserplugin.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/fiparserplugin.ts
@@ -40,10 +40,10 @@ export const fiparserplugin = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -53,9 +53,9 @@ export const fiparserplugin = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -71,7 +71,7 @@ export const fiparserplugin = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/itemcustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/itemcustomfield.ts
@@ -170,7 +170,7 @@ export const itemcustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {

--- a/packages/netsuite-adapter/src/types/custom_types/itemnumbercustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/itemnumbercustomfield.ts
@@ -170,7 +170,7 @@ export const itemnumbercustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {

--- a/packages/netsuite-adapter/src/types/custom_types/itemoptioncustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/itemoptioncustomfield.ts
@@ -170,7 +170,7 @@ export const itemoptioncustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {

--- a/packages/netsuite-adapter/src/types/custom_types/kpiscorecard.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/kpiscorecard.ts
@@ -233,7 +233,7 @@ const kpiscorecard_kpis_kpi = new ObjectType({
     formula: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field is available when the kpi value is present in kpi_snapshots_formula. */
     lessismore: {
@@ -247,9 +247,9 @@ const kpiscorecard_kpis_kpi = new ObjectType({
       },
     }, /* Original description: The default value is F. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 99 }),
       },
     }, /* Original description: This field value can be up to 99 characters long.   This field accepts references to the string custom type. */
   },
@@ -310,9 +310,9 @@ const kpiscorecard_ranges_range = new ObjectType({
       },
     }, /* Original description: The default value is F. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 99 }),
       },
     }, /* Original description: This field value can be up to 99 characters long.   This field accepts references to the string custom type. */
   },
@@ -354,10 +354,10 @@ export const kpiscorecard = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custkpiscorecard’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 25,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 25 }),
       },
     }, /* Original description: This field value can be up to 25 characters long.   This field accepts references to the string custom type. */
     useperiods: {
@@ -367,9 +367,9 @@ export const kpiscorecard = new ObjectType({
       },
     }, /* Original description: For information about possible values, see kpiscorecards_useperiods. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     audience: {

--- a/packages/netsuite-adapter/src/types/custom_types/mapreducescript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/mapreducescript.ts
@@ -207,7 +207,7 @@ const mapreducescript_scriptcustomfields_scriptcustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {
@@ -892,10 +892,10 @@ export const mapreducescript = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -905,9 +905,9 @@ export const mapreducescript = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -923,7 +923,7 @@ export const mapreducescript = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/massupdatescript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/massupdatescript.ts
@@ -207,7 +207,7 @@ const massupdatescript_scriptcustomfields_scriptcustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {
@@ -494,10 +494,10 @@ export const massupdatescript = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -512,9 +512,9 @@ export const massupdatescript = new ObjectType({
       },
     },
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -530,7 +530,7 @@ export const massupdatescript = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/othercustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/othercustomfield.ts
@@ -170,7 +170,7 @@ export const othercustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     rectype: {

--- a/packages/netsuite-adapter/src/types/custom_types/pluginimplementation.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/pluginimplementation.ts
@@ -77,10 +77,10 @@ export const pluginimplementation = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -102,9 +102,9 @@ export const pluginimplementation = new ObjectType({
       },
     }, /* Original description: For information about possible values, see plugintype_status.   The default value is 'TESTING'. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -120,7 +120,7 @@ export const pluginimplementation = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/plugintype.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/plugintype.ts
@@ -73,13 +73,13 @@ const plugintype_methods_method = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 30,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 30 }),
       },
     }, /* Original description: This field value can be up to 30 characters long. */
     description: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 30,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 30 }),
       },
     }, /* Original description: This field value can be up to 30 characters long. */
   },
@@ -121,10 +121,10 @@ export const plugintype = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -146,9 +146,9 @@ export const plugintype = new ObjectType({
       },
     }, /* Original description: For information about possible values, see plugintype_status.   The default value is 'TESTING'. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -164,7 +164,7 @@ export const plugintype = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {
@@ -185,7 +185,7 @@ export const plugintype = new ObjectType({
     class: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long. */
     documentationfile: {

--- a/packages/netsuite-adapter/src/types/custom_types/portlet.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/portlet.ts
@@ -244,7 +244,7 @@ const portlet_scriptcustomfields_scriptcustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {
@@ -536,10 +536,10 @@ export const portlet = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -554,9 +554,9 @@ export const portlet = new ObjectType({
       },
     },
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -572,7 +572,7 @@ export const portlet = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/promotionsplugin.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/promotionsplugin.ts
@@ -77,10 +77,10 @@ export const promotionsplugin = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -90,9 +90,9 @@ export const promotionsplugin = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -108,7 +108,7 @@ export const promotionsplugin = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/publisheddashboard.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/publisheddashboard.ts
@@ -52,7 +52,7 @@ const publisheddashboard_dashboards_dashboard_centercolumn_analytics = new Objec
     name: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 50,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 50 }),
       },
     }, /* Original description: This field value can be up to 50 characters long. */
     height: {
@@ -153,13 +153,15 @@ const publisheddashboard_dashboards_dashboard_centercolumn_customportlet_paramet
   },
   fields: {
     id: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
       },
     }, /* Original description: This field accepts references to the scriptcustomfield custom type. */
     value: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
+        [CORE_ANNOTATIONS.REQUIRED]: true,
       },
     }, /* Original description: This field accepts values of the custom field type specified in the id. */
   },
@@ -260,7 +262,7 @@ const publisheddashboard_dashboards_dashboard_centercolumn_customsearch = new Ob
     title: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long. */
   },
@@ -1472,10 +1474,10 @@ export const publisheddashboard = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custpubdashboard’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 30,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 30 }),
       },
     }, /* Original description: This field value can be up to 30 characters long.   This field accepts references to the string custom type. */
     center: {
@@ -1495,9 +1497,9 @@ export const publisheddashboard = new ObjectType({
       },
     }, /* Original description: The default value is F. */
     notes: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 4000,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 4000 }),
       },
     }, /* Original description: This field value can be up to 4000 characters long.   This field accepts references to the string custom type. */
     dashboards: {

--- a/packages/netsuite-adapter/src/types/custom_types/restlet.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/restlet.ts
@@ -244,7 +244,7 @@ const restlet_scriptcustomfields_scriptcustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {
@@ -526,10 +526,10 @@ export const restlet = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -539,9 +539,9 @@ export const restlet = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -557,7 +557,7 @@ export const restlet = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/role.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/role.ts
@@ -141,13 +141,13 @@ export const role = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customrole’. */
     centertype: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
     }, /* Original description: This field accepts references to the center custom type.   For information about other possible values, see role_centertype. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },

--- a/packages/netsuite-adapter/src/types/custom_types/savedcsvimport.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/savedcsvimport.ts
@@ -263,7 +263,7 @@ export const savedcsvimport = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 64,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 64 }),
       },
     }, /* Original description: This field value can be up to 64 characters long.   This field accepts references to the string custom type. */
     datahandling: {
@@ -352,13 +352,13 @@ export const savedcsvimport = new ObjectType({
     multiselectdelimiter: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 1,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 1 }),
       },
     }, /* Original description: This field value can be up to 1 characters long.   The default value is '|'. */
     description: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 499,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 499 }),
       },
     }, /* Original description: This field value can be up to 499 characters long.   This field accepts references to the string custom type. */
     audience: {

--- a/packages/netsuite-adapter/src/types/custom_types/scheduledscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/scheduledscript.ts
@@ -244,7 +244,7 @@ const scheduledscript_scriptcustomfields_scriptcustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {
@@ -904,10 +904,10 @@ export const scheduledscript = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -922,9 +922,9 @@ export const scheduledscript = new ObjectType({
       },
     },
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -940,7 +940,7 @@ export const scheduledscript = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/sdfinstallationscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/sdfinstallationscript.ts
@@ -207,7 +207,7 @@ const sdfinstallationscript_scriptcustomfields_scriptcustomfield = new ObjectTyp
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {
@@ -444,10 +444,10 @@ export const sdfinstallationscript = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -457,9 +457,9 @@ export const sdfinstallationscript = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -475,7 +475,7 @@ export const sdfinstallationscript = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/sspapplication.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/sspapplication.ts
@@ -47,7 +47,7 @@ const sspapplication_entrypoints_entrypoint = new ObjectType({
     entryparameter: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 60,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 60 }),
       },
     }, /* Original description: This field value can be up to 60 characters long. */
   },
@@ -129,7 +129,7 @@ export const sspapplication = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long. */
     status: {
@@ -142,7 +142,7 @@ export const sspapplication = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     appfolder: {
@@ -155,13 +155,13 @@ export const sspapplication = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   The default value is '1.0'. */
     description: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 3999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 3999 }),
       },
     }, /* Original description: This field value can be up to 3999 characters long. */
     isinactive: {

--- a/packages/netsuite-adapter/src/types/custom_types/suitelet.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/suitelet.ts
@@ -244,7 +244,7 @@ const suitelet_scriptcustomfields_scriptcustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {
@@ -593,10 +593,10 @@ export const suitelet = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -611,9 +611,9 @@ export const suitelet = new ObjectType({
       },
     },
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -629,7 +629,7 @@ export const suitelet = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/transactionForm.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/transactionForm.ts
@@ -41,7 +41,7 @@ const transactionForm_actionbar_buttons_button = new ObjectType({
     label: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long. */
     visible: {
@@ -84,13 +84,13 @@ const transactionForm_actionbar_customButtons_customButton = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 99 }),
       },
     }, /* Original description: This field value can be up to 99 characters long. */
     function: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long. */
   },
@@ -128,13 +128,13 @@ const transactionForm_actionbar_customMenu_customMenuItem = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 99,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 99 }),
       },
     }, /* Original description: This field value can be up to 99 characters long. */
     function: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long. */
   },
@@ -177,7 +177,7 @@ const transactionForm_actionbar_menu_menuitem = new ObjectType({
     label: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long. */
     visible: {
@@ -385,10 +385,10 @@ const transactionForm_mainFields_defaultFieldGroup_fields_field = new ObjectType
       },
     }, /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see transactionform_fieldid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -492,10 +492,10 @@ const transactionForm_mainFields_fieldGroup_fields_field = new ObjectType({
       },
     }, /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see transactionform_fieldid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -582,11 +582,11 @@ const transactionForm_mainFields_fieldGroup = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 99 characters long. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -838,10 +838,10 @@ const transactionForm_tabs_tab_fieldGroups_defaultFieldGroup_fields_field = new 
       },
     }, /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see transactionform_fieldid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -945,10 +945,10 @@ const transactionForm_tabs_tab_fieldGroups_fieldGroup_fields_field = new ObjectT
       },
     }, /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see transactionform_fieldid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1035,11 +1035,11 @@ const transactionForm_tabs_tab_fieldGroups_fieldGroup = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 99 characters long. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1103,10 +1103,10 @@ const transactionForm_tabs_tab_subItems_subList_columns_column = new ObjectType(
       },
     }, /* Original description: This field accepts references to the transactioncolumncustomfield custom type.   For information about other possible values, see transactionform_columnid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1150,10 +1150,10 @@ const transactionForm_tabs_tab_subItems_subList = new ObjectType({
       },
     }, /* Original description: For information about possible values, see transactionform_sublistid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1189,11 +1189,11 @@ const transactionForm_tabs_tab_subItems_subLists_subList = new ObjectType({
       },
     }, /* Original description: For information about possible values, see transactionform_sublistid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1242,10 +1242,10 @@ const transactionForm_tabs_tab_subItems_subTab_fieldGroups_defaultFieldGroup_fie
       },
     }, /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see transactionform_fieldid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1349,10 +1349,10 @@ const transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup_fields_fie
       },
     }, /* Original description: This field accepts references to the following custom types:   transactioncolumncustomfield   transactionbodycustomfield   othercustomfield   itemoptioncustomfield   itemnumbercustomfield   itemcustomfield   entitycustomfield   customrecordcustomfield   crmcustomfield   For information about other possible values, see transactionform_fieldid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1439,11 +1439,11 @@ const transactionForm_tabs_tab_subItems_subTab_fieldGroups_fieldGroup = new Obje
       },
     }, /* Original description: This attribute value can be up to 99 characters long. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1507,11 +1507,11 @@ const transactionForm_tabs_tab_subItems_subTab = new ObjectType({
       },
     }, /* Original description: This field accepts references to the following custom types:   subtab   subtab   For information about other possible values, see transactionform_subtabid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1575,11 +1575,11 @@ const transactionForm_tabs_tab = new ObjectType({
       },
     }, /* Original description: This field accepts references to the following custom types:   subtab   subtab   For information about other possible values, see transactionform_tabid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1632,10 +1632,10 @@ const transactionForm_totalBox_totalBoxField = new ObjectType({
       },
     }, /* Original description: For information about possible values, see transactionform_totalboxid. */
     label: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     visible: {
       refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
       annotations: {
@@ -1686,11 +1686,11 @@ export const transactionForm = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 99 characters long.   For information about possible values, see transactionform_standard. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
       },
-    },
+    }, /* Original description: This field accepts references to the string custom type. */
     recordType: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {

--- a/packages/netsuite-adapter/src/types/custom_types/transactionbodycustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/transactionbodycustomfield.ts
@@ -170,7 +170,7 @@ export const transactionbodycustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {

--- a/packages/netsuite-adapter/src/types/custom_types/transactioncolumncustomfield.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/transactioncolumncustomfield.ts
@@ -170,7 +170,7 @@ export const transactioncolumncustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {

--- a/packages/netsuite-adapter/src/types/custom_types/translationcollection.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/translationcollection.ts
@@ -43,13 +43,13 @@ const translationcollection_strings_string = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 1000,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 1000 }),
       },
     }, /* Original description: This field value can be up to 1000 characters long. */
     description: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 1000,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 1000 }),
       },
     }, /* Original description: This field value can be up to 1000 characters long. */
   },
@@ -94,7 +94,7 @@ export const translationcollection = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 100,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 100 }),
       },
     }, /* Original description: This field value can be up to 100 characters long.   This field accepts references to the string custom type. */
     defaultlanguage: {
@@ -106,7 +106,7 @@ export const translationcollection = new ObjectType({
     description: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 1000,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 1000 }),
       },
     }, /* Original description: This field value can be up to 1000 characters long.   This field accepts references to the string custom type. */
     strings: {

--- a/packages/netsuite-adapter/src/types/custom_types/usereventscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/usereventscript.ts
@@ -244,7 +244,7 @@ const usereventscript_scriptcustomfields_scriptcustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {
@@ -551,10 +551,10 @@ export const usereventscript = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -564,9 +564,9 @@ export const usereventscript = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -582,7 +582,7 @@ export const usereventscript = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/workbook.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/workbook.ts
@@ -173,10 +173,10 @@ export const workbook = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 99 characters long.   The default value is ‘custworkbook’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 50,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 50 }),
       },
     }, /* Original description: This field value can be up to 50 characters long.   This field accepts references to the string custom type. */
     definition: {

--- a/packages/netsuite-adapter/src/types/custom_types/workbookbuilderplugin.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/workbookbuilderplugin.ts
@@ -40,10 +40,10 @@ export const workbookbuilderplugin = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -53,9 +53,9 @@ export const workbookbuilderplugin = new ObjectType({
       },
     }, /* Original description: This field must reference a .js file. */
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -71,7 +71,7 @@ export const workbookbuilderplugin = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/netsuite-adapter/src/types/custom_types/workflow.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/workflow.ts
@@ -679,7 +679,7 @@ const workflow_workflowcustomfields_workflowcustomfield = new ObjectType({
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {
@@ -7044,7 +7044,7 @@ const workflow_workflowstates_workflowstate_workflowstatecustomfields_workflowst
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {

--- a/packages/netsuite-adapter/src/types/custom_types/workflowactionscript.ts
+++ b/packages/netsuite-adapter/src/types/custom_types/workflowactionscript.ts
@@ -244,7 +244,7 @@ const workflowactionscript_scriptcustomfields_scriptcustomfield = new ObjectType
       refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 200,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 200 }),
       },
     }, /* Original description: This field value can be up to 200 characters long.   This field accepts references to the string custom type. */
     selectrecordtype: {
@@ -531,10 +531,10 @@ export const workflowactionscript = new ObjectType({
       },
     }, /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customscript’. */
     name: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
         [CORE_ANNOTATIONS.REQUIRED]: true,
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 40,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 40 }),
       },
     }, /* Original description: This field value can be up to 40 characters long.   This field accepts references to the string custom type. */
     scriptfile: {
@@ -554,9 +554,9 @@ export const workflowactionscript = new ObjectType({
       },
     },
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING) /* Original type was single-select list */,
+      refType: createRefToElmWithValue(BuiltinTypes.STRING /* Original type was single-select list */),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long.   This field accepts references to the string custom type. */
     isinactive: {
@@ -572,7 +572,7 @@ export const workflowactionscript = new ObjectType({
     notifyemails: {
       refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
-        // [CORE_ANNOTATIONS.LENGTH_LIMIT]: 999,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ max_length: 999 }),
       },
     }, /* Original description: This field value can be up to 999 characters long. */
     notifygroup: {

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -32,7 +32,7 @@ import { DuplicateVariableNameError } from '../merger/internal/variables'
 import { MultiplePrimitiveTypesError } from '../merger/internal/primitives'
 
 import { InvalidStaticFile } from '../workspace/static_files/common'
-import { ValidationError, InvalidValueValidationError, InvalidValueTypeValidationError, InvalidStaticFileError, CircularReferenceValidationError, IllegalReferenceValidationError, UnresolvedReferenceValidationError, MissingRequiredFieldValidationError, RegexMismatchValidationError, InvalidValueRangeValidationError, InvalidValueLengthValidationError, isValidationError } from '../validator'
+import { ValidationError, InvalidValueValidationError, InvalidValueTypeValidationError, InvalidStaticFileError, CircularReferenceValidationError, IllegalReferenceValidationError, UnresolvedReferenceValidationError, MissingRequiredFieldValidationError, RegexMismatchValidationError, InvalidValueRangeValidationError, InvalidValueMaxLengthValidationError, isValidationError } from '../validator'
 
 const { awu } = collections.asynciterable
 // There are two issues with naive json stringification:
@@ -83,7 +83,7 @@ const NameToType = {
   MissingRequiredFieldValidationError: MissingRequiredFieldValidationError,
   RegexMismatchValidationError: RegexMismatchValidationError,
   InvalidValueRangeValidationError: InvalidValueRangeValidationError,
-  InvalidValueLengthValidationError: InvalidValueLengthValidationError,
+  InvalidValueMaxLengthValidationError: InvalidValueMaxLengthValidationError,
 }
 const nameToTypeEntries = Object.entries(NameToType)
 const possibleTypes = Object.values(NameToType)
@@ -372,8 +372,8 @@ Promise<{ elements: T[]; staticFiles: Record<string, StaticFile> }> => {
         minValue: v.minValue,
       })
     ),
-    InvalidValueLengthValidationError: v => (
-      new InvalidValueLengthValidationError({
+    InvalidValueMaxLengthValidationError: v => (
+      new InvalidValueMaxLengthValidationError({
         elemID: reviveElemID(v.elemID),
         fieldName: v.fieldName,
         value: v.value,

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -378,7 +378,6 @@ Promise<{ elements: T[]; staticFiles: Record<string, StaticFile> }> => {
         fieldName: v.fieldName,
         value: v.value,
         maxLength: v.max_length,
-
       })
     ),
   }

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -377,7 +377,7 @@ Promise<{ elements: T[]; staticFiles: Record<string, StaticFile> }> => {
         elemID: reviveElemID(v.elemID),
         fieldName: v.fieldName,
         value: v.value,
-        length: v.length_limit,
+        maxLength: v.max_length,
 
       })
     ),

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -32,7 +32,7 @@ import { DuplicateVariableNameError } from '../merger/internal/variables'
 import { MultiplePrimitiveTypesError } from '../merger/internal/primitives'
 
 import { InvalidStaticFile } from '../workspace/static_files/common'
-import { ValidationError, InvalidValueValidationError, InvalidValueTypeValidationError, InvalidStaticFileError, CircularReferenceValidationError, IllegalReferenceValidationError, UnresolvedReferenceValidationError, MissingRequiredFieldValidationError, RegexMismatchValidationError, InvalidValueRangeValidationError, isValidationError } from '../validator'
+import { ValidationError, InvalidValueValidationError, InvalidValueTypeValidationError, InvalidStaticFileError, CircularReferenceValidationError, IllegalReferenceValidationError, UnresolvedReferenceValidationError, MissingRequiredFieldValidationError, RegexMismatchValidationError, InvalidValueRangeValidationError, InvalidValueLengthValidationError, isValidationError } from '../validator'
 
 const { awu } = collections.asynciterable
 // There are two issues with naive json stringification:
@@ -83,6 +83,7 @@ const NameToType = {
   MissingRequiredFieldValidationError: MissingRequiredFieldValidationError,
   RegexMismatchValidationError: RegexMismatchValidationError,
   InvalidValueRangeValidationError: InvalidValueRangeValidationError,
+  InvalidValueLengthValidationError: InvalidValueLengthValidationError,
 }
 const nameToTypeEntries = Object.entries(NameToType)
 const possibleTypes = Object.values(NameToType)
@@ -369,6 +370,15 @@ Promise<{ elements: T[]; staticFiles: Record<string, StaticFile> }> => {
         value: v.value,
         maxValue: v.maxValue,
         minValue: v.minValue,
+      })
+    ),
+    InvalidValueLengthValidationError: v => (
+      new InvalidValueLengthValidationError({
+        elemID: reviveElemID(v.elemID),
+        fieldName: v.fieldName,
+        value: v.value,
+        length: v.length_limit,
+     
       })
     ),
   }

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -378,7 +378,7 @@ Promise<{ elements: T[]; staticFiles: Record<string, StaticFile> }> => {
         fieldName: v.fieldName,
         value: v.value,
         length: v.length_limit,
-     
+
       })
     ),
   }

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -296,11 +296,9 @@ const validateAnnotationsValue = async (
     const validateLengthLimit = (): ValidationError[] => {
       const maxLength = restrictions.length_limit
       if ((values.isDefined(maxLength) && (!_.isString(val) || (val.length > maxLength)))) {
-        return [
-          new InvalidValueLengthValidationError(
-            { elemID, value, fieldName: elemID.name, length: maxLength }
-          ),
-        ]
+        return [new InvalidValueLengthValidationError(
+          { elemID, value, fieldName: elemID.name, length: maxLength }
+        )]
       }
       return []
     }

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -164,8 +164,8 @@ export class InvalidValueLengthValidationError extends ValidationError {
     { elemID: ElemID; value: Value; fieldName: string; length: number }) {
     super({
       elemID,
-      error: `Value "${value}" is too long for field ${fieldName}.`
-        + ` expected value maximum length is "${length}"`,
+      error: `Value "${value}" is too long for field.`
+        + ` ${fieldName} maximum length is "${length}"`,
       severity: 'Warning',
     })
     this.value = value

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -155,7 +155,7 @@ export class RegexMismatchValidationError extends ValidationError {
   }
 }
 
-export class InvalidValueLengthValidationError extends ValidationError {
+export class InvalidValueMaxLengthValidationError extends ValidationError {
   readonly value: Value
   readonly fieldName: string
   readonly maxLength: number
@@ -165,7 +165,7 @@ export class InvalidValueLengthValidationError extends ValidationError {
     super({
       elemID,
       error: `Value "${value}" is too long for field.`
-        + ` ${fieldName} maximum length is "${maxLength}"`,
+        + ` ${fieldName} maximum length is ${maxLength}`,
       severity: 'Warning',
     })
     this.value = value
@@ -293,10 +293,10 @@ const validateAnnotationsValue = async (
       return []
     }
 
-    const validateLengthLimit = (): ValidationError[] => {
+    const validateMaxLengthLimit = (): ValidationError[] => {
       const maxLength = restrictions.max_length
       if ((values.isDefined(maxLength) && (!_.isString(val) || (val.length > maxLength)))) {
-        return [new InvalidValueLengthValidationError(
+        return [new InvalidValueMaxLengthValidationError(
           { elemID, value, fieldName: elemID.name, maxLength }
         )]
       }
@@ -307,7 +307,7 @@ const validateAnnotationsValue = async (
       validateValueInsideRange,
       validateValueInList,
       validateRegexMatches,
-      validateLengthLimit,
+      validateMaxLengthLimit,
     ]
     return restrictionValidations.flatMap(validation => validation())
   }

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -297,7 +297,7 @@ const validateAnnotationsValue = async (
       const maxLength = restrictions.max_length
       if ((values.isDefined(maxLength) && (!_.isString(val) || (val.length > maxLength)))) {
         return [new InvalidValueLengthValidationError(
-          { elemID, value, fieldName: elemID.name, maxLength: maxLength }
+          { elemID, value, fieldName: elemID.name, maxLength }
         )]
       }
       return []

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -158,19 +158,19 @@ export class RegexMismatchValidationError extends ValidationError {
 export class InvalidValueLengthValidationError extends ValidationError {
   readonly value: Value
   readonly fieldName: string
-  readonly length: number
+  readonly maxLength: number
 
-  constructor({ elemID, value, fieldName, length }:
-    { elemID: ElemID; value: Value; fieldName: string; length: number }) {
+  constructor({ elemID, value, fieldName, maxLength }:
+    { elemID: ElemID; value: Value; fieldName: string; maxLength: number }) {
     super({
       elemID,
       error: `Value "${value}" is too long for field.`
-        + ` ${fieldName} maximum length is "${length}"`,
+        + ` ${fieldName} maximum length is "${maxLength}"`,
       severity: 'Warning',
     })
     this.value = value
     this.fieldName = fieldName
-    this.length = length
+    this.maxLength = maxLength
   }
 }
 export class MissingRequiredFieldValidationError extends ValidationError {
@@ -294,10 +294,10 @@ const validateAnnotationsValue = async (
     }
 
     const validateLengthLimit = (): ValidationError[] => {
-      const maxLength = restrictions.length_limit
+      const maxLength = restrictions.max_length
       if ((values.isDefined(maxLength) && (!_.isString(val) || (val.length > maxLength)))) {
         return [new InvalidValueLengthValidationError(
-          { elemID, value, fieldName: elemID.name, length: maxLength }
+          { elemID, value, fieldName: elemID.name, maxLength: maxLength }
         )]
       }
       return []

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -21,7 +21,7 @@ import {
   validateElements, InvalidValueValidationError, CircularReferenceValidationError,
   InvalidValueRangeValidationError, IllegalReferenceValidationError,
   UnresolvedReferenceValidationError, InvalidValueTypeValidationError,
-  InvalidStaticFileError, RegexMismatchValidationError, InvalidValueLengthValidationError, 
+  InvalidStaticFileError, RegexMismatchValidationError, InvalidValueMaxLengthValidationError,
 } from '../src/validator'
 import { MissingStaticFile, AccessDeniedStaticFile } from '../src/workspace/static_files/common'
 import { IllegalReference } from '../src/parser/parse'
@@ -90,7 +90,7 @@ describe('Elements validation', () => {
       },
       annotations: {
         withRestriction: '1',
-      }
+      },
     }
   )
 
@@ -909,7 +909,7 @@ describe('Elements validation', () => {
             ])
           )
           expect(errors).toHaveLength(1)
-          expect(errors[0]).toBeInstanceOf(InvalidValueLengthValidationError)
+          expect(errors[0]).toBeInstanceOf(InvalidValueMaxLengthValidationError)
         })
 
         it('should return validation error on max_length validation on an instance through the field type', async () => {
@@ -923,7 +923,7 @@ describe('Elements validation', () => {
             ])
           )
           expect(errors).toHaveLength(1)
-          expect(errors[0]).toBeInstanceOf(InvalidValueLengthValidationError)
+          expect(errors[0]).toBeInstanceOf(InvalidValueMaxLengthValidationError)
         })
 
         it('should return error on max_length validation on a restriction on annotation type of a type', async () => {
@@ -936,7 +936,7 @@ describe('Elements validation', () => {
             ])
           )
           expect(errors).toHaveLength(1)
-          expect(errors[0]).toBeInstanceOf(InvalidValueLengthValidationError)
+          expect(errors[0]).toBeInstanceOf(InvalidValueMaxLengthValidationError)
         })
 
         it('should succeed on max_length validation on an instance through the field type', async () => {

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -29,7 +29,6 @@ import { createInMemoryElementSource } from '../src/workspace/elements_source'
 import { getFieldsAndAnnoTypes } from './utils'
 
 describe('Elements validation', () => {
-  
   const baseElemID = new ElemID('salto', 'simple')
   const simpleType = new ObjectType({
     elemID: baseElemID,
@@ -89,6 +88,9 @@ describe('Elements validation', () => {
       annotationRefsOrTypes: {
         withRestriction: restrictedStringMaxLengthType,
       },
+      annotations: {
+        withRestriction: '1',
+      }
     }
   )
 
@@ -194,7 +196,7 @@ describe('Elements validation', () => {
         refType: createRefToElmWithValue(BuiltinTypes.STRING),
         annotations: {
           [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
-            max_length: 15,
+            max_length: 5,
           }),
         },
       },
@@ -924,8 +926,8 @@ describe('Elements validation', () => {
           expect(errors[0]).toBeInstanceOf(InvalidValueLengthValidationError)
         })
 
-        it('should return an error when annotations value length is bigger than length limit restriction-3', async () => {
-          restrictedStringMaxLengthType.annotations.withRestriction = 'TOOOOOOOOO LONGGGGGGGGGGGG'
+        it('should return error on max_length validation on a restriction on annotation type of a type', async () => {
+          objWithRestirctedAnnoType.annotations.withRestriction = 'toooo longgggg'
           const errors = await validateElements(
             [objWithRestirctedAnnoType],
             createInMemoryElementSource([
@@ -935,44 +937,45 @@ describe('Elements validation', () => {
           )
           expect(errors).toHaveLength(1)
           expect(errors[0]).toBeInstanceOf(InvalidValueLengthValidationError)
-          // extType.annotate({ restrictedStringLengthPrimitive: 'string to longashdkaskdhkajshdkjah' })
-          // const errors = await validateElements(
-          //   [extInst],
-          //   createInMemoryElementSource([
-          //     extInst,
-          //     extType,
-          //     ...await getFieldsAndAnnoTypes(extType),
-          //   ])
-          // )
-          // expect(errors).toHaveLength(1)
-          // expect(errors[0]).toBeInstanceOf(InvalidValueLengthValidationError)
         })
 
-        // it('should succeed when annotations value length maches the length limit restriction -1 ', async () => {
-        //   extInst.value.restrictStringLength = 'validLenStr'
-        //   extInst.refType = new ReferenceExpression(extType.elemID, extType)
-        //   expect(await validateElements(
-        //     [extInst],
-        //     createInMemoryElementSource([
-        //       extInst,
-        //       extType,
-        //       ...await getFieldsAndAnnoTypes(extType),
-        //     ]),
-        //   )).toHaveLength(0)
-        // })
+        it('should succeed on max_length validation on an instance through the field type', async () => {
+          extInst.value.restrictedStringMaxLengthType = 'a'
+          const errors = await validateElements(
+            [extInst],
+            createInMemoryElementSource([
+              extInst,
+              extType,
+              ...await getFieldsAndAnnoTypes(extType),
+            ])
+          )
+          expect(errors).toHaveLength(0)
+        })
 
-        // it('should succeed when annotations value length maches the length limit restriction -2', async () => {
-        //   extInst.refType = new ReferenceExpression(extType.elemID, extType)
-        //   extInst.annotations.restrictedLengthType = 'str'
-        //   expect(await validateElements(
-        //     [extInst],
-        //     createInMemoryElementSource([
-        //       extInst,
-        //       extType,
-        //       ...await getFieldsAndAnnoTypes(extType),
-        //     ]),
-        //   )).toHaveLength(0)
-        // })
+        it('should succeed on max_length validation on a restriction on annotation type of a type', async () => {
+          objWithRestirctedAnnoType.annotations.withRestriction = 't'
+          const errors = await validateElements(
+            [objWithRestirctedAnnoType],
+            createInMemoryElementSource([
+              objWithRestirctedAnnoType,
+              restrictedStringMaxLengthType,
+            ])
+          )
+          expect(errors).toHaveLength(0)
+        })
+
+        it('should succeed max_length validation on an instance through field annotation', async () => {
+          extInst.value.restrictStringLength = 'a'
+          const errors = await validateElements(
+            [extInst],
+            createInMemoryElementSource([
+              extInst,
+              extType,
+              ...await getFieldsAndAnnoTypes(extType),
+            ])
+          )
+          expect(errors).toHaveLength(0)
+        })
 
         it('should return an error when annotations value does not match regex restriction', async () => {
           extType.fields.restrictedAnnotation.annotations.regexOnlyLower = 'ABC'

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -912,8 +912,8 @@ describe('Elements validation', () => {
           expect(errors[0]).toBeInstanceOf(InvalidValueMaxLengthValidationError)
         })
 
-        it('should return validation error on max_length validation on an instance through the field type', async () => {
-          extInst.value.restrictedStringMaxLengthType = 'very long str'
+        it('should succeed max_length validation on an instance through field annotation', async () => {
+          extInst.value.restrictStringLength = 'a'
           const errors = await validateElements(
             [extInst],
             createInMemoryElementSource([
@@ -922,17 +922,17 @@ describe('Elements validation', () => {
               ...await getFieldsAndAnnoTypes(extType),
             ])
           )
-          expect(errors).toHaveLength(1)
-          expect(errors[0]).toBeInstanceOf(InvalidValueMaxLengthValidationError)
+          expect(errors).toHaveLength(0)
         })
 
-        it('should return error on max_length validation on a restriction on annotation type of a type', async () => {
-          objWithRestirctedAnnoType.annotations.withRestriction = 'toooo longgggg'
+        it('should return validation error on max_length validation on an instance through the field type', async () => {
+          extInst.value.restrictedStringMaxLengthType = 'very long str'
           const errors = await validateElements(
-            [objWithRestirctedAnnoType],
+            [extInst],
             createInMemoryElementSource([
-              objWithRestirctedAnnoType,
-              restrictedStringMaxLengthType,
+              extInst,
+              extType,
+              ...await getFieldsAndAnnoTypes(extType),
             ])
           )
           expect(errors).toHaveLength(1)
@@ -952,8 +952,8 @@ describe('Elements validation', () => {
           expect(errors).toHaveLength(0)
         })
 
-        it('should succeed on max_length validation on a restriction on annotation type of a type', async () => {
-          objWithRestirctedAnnoType.annotations.withRestriction = 't'
+        it('should return error on max_length validation on a restriction on annotation type of a type', async () => {
+          objWithRestirctedAnnoType.annotations.withRestriction = 'toooo longgggg'
           const errors = await validateElements(
             [objWithRestirctedAnnoType],
             createInMemoryElementSource([
@@ -961,17 +961,17 @@ describe('Elements validation', () => {
               restrictedStringMaxLengthType,
             ])
           )
-          expect(errors).toHaveLength(0)
+          expect(errors).toHaveLength(1)
+          expect(errors[0]).toBeInstanceOf(InvalidValueMaxLengthValidationError)
         })
 
-        it('should succeed max_length validation on an instance through field annotation', async () => {
-          extInst.value.restrictStringLength = 'a'
+        it('should succeed on max_length validation on a restriction on annotation type of a type', async () => {
+          objWithRestirctedAnnoType.annotations.withRestriction = 't'
           const errors = await validateElements(
-            [extInst],
+            [objWithRestirctedAnnoType],
             createInMemoryElementSource([
-              extInst,
-              extType,
-              ...await getFieldsAndAnnoTypes(extType),
+              objWithRestirctedAnnoType,
+              restrictedStringMaxLengthType,
             ])
           )
           expect(errors).toHaveLength(0)


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

added a length validation error ,
added a length limit restriction for string

_Additional context for reviewer_

---
_Release Notes_: 
Add Core validation for string field's length limit restriction
This PR will create nacl changes for all workspaces that include NetSuite service. Many modification will be created for NetSuite types. We will be adding string max_length restrictions to many types.