### PR TITLE
Simple adapters config type fix

### DIFF
--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -15,9 +15,9 @@
 */
 import _ from 'lodash'
 import {
-  ElemID, ObjectType, BuiltinTypes, CORE_ANNOTATIONS, FieldDefinition, ListType, MapType,
+  ElemID, ObjectType, BuiltinTypes, FieldDefinition, ListType, MapType,
 } from '@salto-io/adapter-api'
-import { createRefToElmWithValue } from '@salto-io/adapter-utils'
+import { createRefToElmWithValue, createMatchingObjectType } from '@salto-io/adapter-utils'
 import { RequestConfig, RequestDefaultConfig } from './request'
 import { TransformationConfig, TransformationDefaultConfig } from './transformation'
 
@@ -57,44 +57,44 @@ export const createAdapterApiConfigType = ({
   requestTypes: { request: ObjectType; requestDefault: ObjectType }
   transformationTypes: { transformation: ObjectType; transformationDefault: ObjectType }
 }): ObjectType => {
-  const typeDefaultsConfigType = new ObjectType({
+  const typeDefaultsConfigType = createMatchingObjectType<TypeDefaultsConfig>({
     elemID: new ElemID(adapter, 'typeDefaultsConfig'),
     fields: {
-      request: { refType: createRefToElmWithValue(new MapType(requestTypes.requestDefault)) },
+      request: { refType: requestTypes.requestDefault },
       transformation: {
-        refType: createRefToElmWithValue(new MapType(transformationTypes.transformationDefault)),
+        refType: transformationTypes.transformationDefault,
         annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
+          _required: true,
         },
       },
     },
   })
 
-  const typesConfigType = new ObjectType({
+  const typesConfigType = createMatchingObjectType<TypeConfig>({
     elemID: new ElemID(adapter, 'typesConfig'),
     fields: {
-      request: { refType: createRefToElmWithValue(requestTypes.request) },
-      transformation: { refType: createRefToElmWithValue(transformationTypes.transformation) },
+      request: { refType: requestTypes.request },
+      transformation: { refType: transformationTypes.transformation },
     },
   })
 
-  const adapterApiConfigType = new ObjectType({
+  const adapterApiConfigType = createMatchingObjectType<AdapterApiConfig>({
     elemID: new ElemID(adapter, 'adapterApiConfig'),
     fields: {
       types: {
-        refType: createRefToElmWithValue(new MapType(typesConfigType)),
+        refType: new MapType(typesConfigType),
         annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
+          _required: true,
         },
       },
       typeDefaults: {
-        refType: createRefToElmWithValue(typeDefaultsConfigType),
+        refType: typeDefaultsConfigType,
         annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
+          _required: true,
         },
       },
       apiVersion: {
-        refType: createRefToElmWithValue(BuiltinTypes.STRING),
+        refType: BuiltinTypes.STRING,
       },
       ...additionalFields,
     },

--- a/packages/adapter-utils/src/element.ts
+++ b/packages/adapter-utils/src/element.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ObjectType, FieldDefinition, PrimitiveType, ListType, PrimitiveTypes, Value } from '@salto-io/adapter-api'
+import { ObjectType, FieldDefinition, PrimitiveType, ListType, MapType, PrimitiveTypes, Value } from '@salto-io/adapter-api'
 import { types } from '@salto-io/lowerdash'
 
 type SaltoPrimitiveTypeForType<T> = (
@@ -26,12 +26,16 @@ type SaltoPrimitiveTypeForType<T> = (
         : PrimitiveTypes.UNKNOWN
 )
 
+type RecordOf<T, S> = string extends keyof T ? Record<string, S> : never
+
 type SaltoTypeForType<T> = (
   T extends Array<Value>
     ? ListType
     : T extends (string | number | boolean | undefined)
       ? PrimitiveType<SaltoPrimitiveTypeForType<T>>
-      : T extends {} ? ObjectType : unknown
+      : T extends Record<string, Value> & RecordOf<T, Value>
+        ? MapType
+        : T extends {} ? ObjectType : unknown
 )
 
 type OptionalKeys<T> = types.KeysOfExtendingType<T, undefined>

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
-import { ElemID, CORE_ANNOTATIONS, BuiltinTypes, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { ElemID, CORE_ANNOTATIONS, BuiltinTypes, ObjectType, MapType, ReferenceExpression } from '@salto-io/adapter-api'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
 import { JIRA } from './constants'
 
@@ -460,6 +460,12 @@ const createObjectTypeFromRefType = (refType: ReferenceExpression): ObjectType =
   })
 )
 
+const createMapTypeFromRefType = (refType: ReferenceExpression): MapType => (
+  new MapType(new ObjectType({
+    elemID: refType.elemID,
+  }))
+)
+
 const apiDefinitionsType = createMatchingObjectType<JiraApiConfig>({
   elemID: new ElemID(JIRA, 'apiDefinitions'),
   fields: {
@@ -471,7 +477,7 @@ const apiDefinitionsType = createMatchingObjectType<JiraApiConfig>({
       annotations: { _required: true },
     },
     types: {
-      refType: createObjectTypeFromRefType(
+      refType: createMapTypeFromRefType(
         defaultApiDefinitionsType.fields.types.refType
       ),
       annotations: { _required: true },

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -460,7 +460,7 @@ const createObjectTypeFromRefType = (refType: ReferenceExpression): ObjectType =
   })
 )
 
-const createMapTypeFromRefType = (refType: ReferenceExpression): MapType => (
+const createObjectMapTypeFromRefType = (refType: ReferenceExpression): MapType => (
   new MapType(new ObjectType({
     elemID: refType.elemID,
   }))
@@ -477,7 +477,7 @@ const apiDefinitionsType = createMatchingObjectType<JiraApiConfig>({
       annotations: { _required: true },
     },
     types: {
-      refType: createMapTypeFromRefType(
+      refType: createObjectMapTypeFromRefType(
         defaultApiDefinitionsType.fields.types.refType
       ),
       annotations: { _required: true },


### PR DESCRIPTION
Added usage of createMatchingObjectType in the shared config for simple adapters. This raised the need to add validation of MapType in `SaltoTypeForType`, which revealed a bug in Jira's config (`types` should be a `MapType` instead of an `ObjectType`).


---
_Release Notes_: 
None
