### PR TITLE
Swagger Simple Adapters infra: added supportedTypes field to config

### DIFF
--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -16,5 +16,5 @@
 export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateFetchConfig as validateDuckTypeFetchConfig } from './ducktype'
 export { createRequestConfigs, validateRequestConfig, RequestConfig, RecurseIntoCondition, isRecurseIntoConditionByField } from './request'
 export { createAdapterApiConfigType, createUserFetchConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig } from './shared'
-export { createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig } from './swagger'
+export { createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig, validateFetchConfig as validateSwaggerFetchConfig } from './swagger'
 export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType } from './transformation'

--- a/packages/adapter-components/src/config/swagger.ts
+++ b/packages/adapter-components/src/config/swagger.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { ObjectType, ElemID, BuiltinTypes, CORE_ANNOTATIONS, FieldDefinition, ListType } from '@salto-io/adapter-api'
 import { types, values as lowerDashValues } from '@salto-io/lowerdash'
 import { createRefToElmWithValue } from '@salto-io/adapter-utils'
-import { AdapterApiConfig, createAdapterApiConfigType, TypeConfig, TypeDefaultsConfig } from './shared'
+import { AdapterApiConfig, createAdapterApiConfigType, TypeConfig, TypeDefaultsConfig, UserFetchConfig } from './shared'
 import { createRequestConfigs, validateRequestConfig } from './request'
 import { createTransformationConfigTypes, validateTransoformationConfig } from './transformation'
 import { findDuplicates } from './validation_utils'
@@ -54,6 +54,9 @@ export type TypeSwaggerDefaultConfig = TypeDefaultsConfig
 
 export type AdapterSwaggerApiConfig = AdapterApiConfig & {
   swagger: SwaggerDefinitionBaseConfig
+
+  // if undefined - generate all types. if defined - should not be empty
+  supportedTypes?: string[]
 }
 export type RequestableAdapterSwaggerApiConfig = AdapterSwaggerApiConfig & {
   types: Record<string, RequestableTypeSwaggerConfig>
@@ -141,8 +144,9 @@ export const createSwaggerAdapterApiConfigType = ({
     additionalFields: {
       ...additionalFields,
       swagger: {
-        refType: createRefToElmWithValue(createSwaggerDefinitionsBaseConfigType(adapter)),
+        refType: createSwaggerDefinitionsBaseConfigType(adapter),
       },
+      supportedTypes: { refType: new ListType(BuiltinTypes.STRING) },
     },
   })
 }
@@ -180,5 +184,29 @@ export const validateApiDefinitionConfig = (
   const invalidTypes = explicitTypes.filter(r => invalidTypeNames.has(r))
   if (invalidTypes.length > 0) {
     throw new Error(`Invalid type names in ${apiDefinitionConfigPath}: ${[...invalidTypes].sort()} were renamed in ${apiDefinitionConfigPath}.typeNameOverrides`)
+  }
+  if (adapterApiConfig.supportedTypes !== undefined
+     && adapterApiConfig.supportedTypes.length === 0) {
+    throw new Error(`Empty supportedTypes field in ${apiDefinitionConfigPath}. Should either be undefined or non-empty.`)
+  }
+}
+
+/**
+ * Verify that all fetch types are supported.
+ * Note: This validation is only relevant for swagger adapters.
+ */
+export const validateFetchConfig = (
+  fetchConfigPath: string,
+  userFetchConfig: UserFetchConfig,
+  adapterApiConfig: AdapterSwaggerApiConfig,
+): void => {
+  if (adapterApiConfig.supportedTypes !== undefined) {
+    const supportedTypesNames = adapterApiConfig.supportedTypes
+    const invalidIncludedTypes = userFetchConfig.includeTypes.filter(
+      name => !supportedTypesNames.includes(name)
+    )
+    if (invalidIncludedTypes.length > 0) {
+      throw Error(`Type names are not supported in ${fetchConfigPath}: ${invalidIncludedTypes}`)
+    }
   }
 }

--- a/packages/adapter-components/src/config/swagger.ts
+++ b/packages/adapter-components/src/config/swagger.ts
@@ -185,10 +185,6 @@ export const validateApiDefinitionConfig = (
   if (invalidTypes.length > 0) {
     throw new Error(`Invalid type names in ${apiDefinitionConfigPath}: ${[...invalidTypes].sort()} were renamed in ${apiDefinitionConfigPath}.typeNameOverrides`)
   }
-  if (adapterApiConfig.supportedTypes !== undefined
-     && adapterApiConfig.supportedTypes.length === 0) {
-    throw new Error(`Empty supportedTypes field in ${apiDefinitionConfigPath}. Should either be undefined or non-empty.`)
-  }
 }
 
 /**
@@ -197,16 +193,17 @@ export const validateApiDefinitionConfig = (
  */
 export const validateFetchConfig = (
   fetchConfigPath: string,
+  apiConfigPath: string,
   userFetchConfig: UserFetchConfig,
   adapterApiConfig: AdapterSwaggerApiConfig,
 ): void => {
   if (adapterApiConfig.supportedTypes !== undefined) {
-    const supportedTypesNames = adapterApiConfig.supportedTypes
+    const supportedTypesNames = new Set(adapterApiConfig.supportedTypes)
     const invalidIncludedTypes = userFetchConfig.includeTypes.filter(
-      name => !supportedTypesNames.includes(name)
+      name => !supportedTypesNames.has(name)
     )
     if (invalidIncludedTypes.length > 0) {
-      throw Error(`Type names are not supported in ${fetchConfigPath}: ${invalidIncludedTypes}`)
+      throw Error(`Invalid type names in ${fetchConfigPath}.includeTypes: ${invalidIncludedTypes} are not listed as supported types in ${apiConfigPath}.supportedTypes.`)
     }
   }
 }

--- a/packages/adapter-components/src/elements/subtypes.ts
+++ b/packages/adapter-components/src/elements/subtypes.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isContainerType, ObjectType } from '@salto-io/adapter-api'
+import { isContainerType, ObjectType, isObjectType } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 
 const { awu } = collections.asynciterable
@@ -23,12 +23,12 @@ export const getSubtypes = async (types: ObjectType[]): Promise<ObjectType[]> =>
 
   const findSubtypes = async (type: ObjectType): Promise<void> => {
     await awu(Object.values(type.fields)).forEach(async field => {
-      const filedContainerOrType = await field.getType()
-      const fieldType = isContainerType(filedContainerOrType)
-        ? await filedContainerOrType.getInnerType()
-        : filedContainerOrType
+      const fieldContainerOrType = await field.getType()
+      const fieldType = isContainerType(fieldContainerOrType)
+        ? await fieldContainerOrType.getInnerType()
+        : fieldContainerOrType
 
-      if (!(fieldType instanceof ObjectType)
+      if (!isObjectType(fieldType)
         || fieldType.elemID.getFullName() in subtypes
         || types.includes(fieldType)) {
         return

--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -26,6 +26,7 @@ import {
   SchemaOrReference, SWAGGER_ARRAY, SWAGGER_OBJECT, isArraySchemaObject, SchemasAndRefs,
 } from './swagger_parser'
 import { fixTypes, defineAdditionalTypes } from './type_config_override'
+import { filterTypes } from '../../type_elements'
 
 const { isDefined } = lowerdashValues
 const { isArrayOfType } = lowerdashTypes
@@ -258,6 +259,7 @@ export const generateTypes = async (
     swagger,
     types,
     typeDefaults,
+    supportedTypes,
   }: AdapterSwaggerApiConfig,
   preParsedDefs?: SchemasAndRefs,
 ): Promise<ParsedTypes> => {
@@ -295,6 +297,16 @@ export const generateTypes = async (
     defineAdditionalTypes(adapterName, swagger.additionalTypes, definedTypes, types)
   }
   fixTypes(definedTypes, types, typeDefaults)
+
+  if (supportedTypes !== undefined) {
+    const filteredTypes = await filterTypes(adapterName,
+      Object.values(definedTypes), supportedTypes)
+
+    return {
+      allTypes: _.keyBy(filteredTypes, type => type.elemID.name),
+      parsedConfigs,
+    }
+  }
 
   return {
     allTypes: definedTypes,

--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -299,8 +299,11 @@ export const generateTypes = async (
   fixTypes(definedTypes, types, typeDefaults)
 
   if (supportedTypes !== undefined) {
-    const filteredTypes = await filterTypes(adapterName,
-      Object.values(definedTypes), supportedTypes)
+    const filteredTypes = await filterTypes(
+      adapterName,
+      Object.values(definedTypes),
+      supportedTypes
+    )
 
     return {
       allTypes: _.keyBy(filteredTypes, type => type.elemID.name),

--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -15,7 +15,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { FieldDefinition, Field, CORE_ANNOTATIONS, TypeElement, isObjectType, isContainerType } from '@salto-io/adapter-api'
+import { FieldDefinition, Field, CORE_ANNOTATIONS, TypeElement, isObjectType, isContainerType, getDeepInnerType } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { values, collections } from '@salto-io/lowerdash'
 import { FieldToHideType } from '../config/transformation'
@@ -72,7 +72,7 @@ export const filterTypes = async (
 
   const innerObjectTypes = await awu(relevantTypes)
     .filter(isContainerType)
-    .map(async type => type.getInnerType())
+    .map(async type => getDeepInnerType(type))
     .filter(isObjectType)
     .toArray()
 

--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -14,10 +14,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { FieldDefinition, Field, CORE_ANNOTATIONS, ObjectType } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { FieldDefinition, Field, CORE_ANNOTATIONS, TypeElement, isObjectType } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { values } from '@salto-io/lowerdash'
-import _ from 'lodash'
 import { FieldToHideType } from '../config/transformation'
 import { SUBTYPES_PATH, TYPES_PATH } from './constants'
 import { getSubtypes } from './subtypes'
@@ -51,9 +51,9 @@ export const hideFields = (
 
 export const filterTypes = async (
   adapterName: string,
-  allTypes: ObjectType[],
+  allTypes: TypeElement[],
   typesToFilter: string[]
-): Promise<ObjectType[]> => {
+): Promise<TypeElement[]> => {
   const nameToType = _.keyBy(allTypes, type => type.elemID.name)
 
   const relevantTypes = typesToFilter.map(name => {
@@ -67,7 +67,7 @@ export const filterTypes = async (
   relevantTypes
     .filter(t => t.path === undefined)
     .forEach(t => { t.path = [adapterName, TYPES_PATH, t.elemID.name] })
-  const subtypes = await getSubtypes(relevantTypes)
+  const subtypes = await getSubtypes(relevantTypes.filter(isObjectType))
   subtypes
     .filter(t => t.path === undefined)
     .forEach(t => { t.path = [adapterName, TYPES_PATH, SUBTYPES_PATH, t.elemID.name] })

--- a/packages/adapter-components/test/config/swagger.test.ts
+++ b/packages/adapter-components/test/config/swagger.test.ts
@@ -220,46 +220,13 @@ describe('config_swagger', () => {
         },
       )).not.toThrow()
     })
-    it('should throw when supportedTypes is empty', () => {
-      expect(() => validateSwaggerApiDefinitionConfig(
-        'PATH',
-        {
-          swagger: {
-            url: '/a/b/c',
-            additionalTypes: [
-              { typeName: 'abc', cloneFrom: 'def' },
-            ],
-            typeNameOverrides: [
-              { newName: 'aaa', originalName: 'bbb' },
-            ],
-          },
-          typeDefaults: {
-            transformation: {
-              idFields: ['a', 'b'],
-            },
-          },
-          types: {
-            abc: {
-              transformation: {
-                idFields: ['something', 'else'],
-              },
-            },
-            aaa: {
-              transformation: {
-                idFields: ['something'],
-              },
-            },
-          },
-          supportedTypes: [],
-        },
-      )).toThrow(new Error('Empty supportedTypes field in PATH. Should either be undefined or non-empty.'))
-    })
   })
 
   describe('validateFetchConfig', () => {
     it('should validate successfully when supportedTypes is undefined', () => {
       expect(() => validateSwaggerFetchConfig(
-        'PATH',
+        'FETCH_PATH',
+        'API_PATH',
         {
           includeTypes: ['a', 'bla'],
         },
@@ -290,7 +257,8 @@ describe('config_swagger', () => {
 
     it('should validate successfully when values are valid', () => {
       expect(() => validateSwaggerFetchConfig(
-        'PATH',
+        'FETCH_PATH',
+        'API_PATH',
         {
           includeTypes: ['a', 'bla'],
         },
@@ -322,7 +290,8 @@ describe('config_swagger', () => {
 
     it('should throw when there are invalid includeTypes', () => {
       expect(() => validateSwaggerFetchConfig(
-        'PATH',
+        'FETCH_PATH',
+        'API_PATH',
         {
           includeTypes: ['a', 'unknown'],
         },
@@ -349,7 +318,7 @@ describe('config_swagger', () => {
             },
           },
         },
-      )).toThrow(new Error('Type names are not supported in PATH: unknown'))
+      )).toThrow(new Error('Invalid type names in FETCH_PATH.includeTypes: unknown are not listed as supported types in API_PATH.supportedTypes.'))
     })
   })
 })

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -350,6 +350,25 @@ describe('swagger_type_elements', () => {
     })
   })
 
+  describe('with supportedTypes', () => {
+    let allTypes: Record<string, TypeElement>
+    beforeAll(async () => {
+      const res = await generateTypes(
+        ADAPTER_NAME,
+        {
+          swagger: { url: `${BASE_DIR}/petstore_swagger.v2.yaml` },
+          typeDefaults: { transformation: { idFields: ['name'] } },
+          types: {},
+          supportedTypes: ['Pet'],
+        },
+      )
+      allTypes = res.allTypes
+    })
+    it('should only generate supported types', () => {
+      expect(Object.keys(allTypes).sort()).toEqual(['Pet', 'Category', 'Tag'].sort())
+    })
+  })
+
   describe('toPrimitiveType', () => {
     it('should return the right primitive type when one is specified', () => {
       expect(toPrimitiveType('string')).toEqual(BuiltinTypes.STRING)

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -27,7 +27,7 @@ import { createConnection, validateCredentials } from './client/connection'
 
 const log = logger(module)
 const { validateClientConfig, createRetryOptions, DEFAULT_RETRY_OPTS } = clientUtils
-const { validateSwaggerApiDefinitionConfig } = configUtils
+const { validateSwaggerApiDefinitionConfig, validateSwaggerFetchConfig } = configUtils
 
 const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials => (
   config.value as Credentials
@@ -62,6 +62,7 @@ function validateConfig(config?: Readonly<InstanceElement>): asserts config is J
   getApiDefinitions(apiDefinitions).forEach(swaggerDef => {
     validateSwaggerApiDefinitionConfig('apiDefinitions', swaggerDef)
   })
+  validateSwaggerFetchConfig('fetch', 'apiDefinitions', fetch, apiDefinitions)
   validateFetchConfig(fetch)
 }
 

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
-import { ElemID, CORE_ANNOTATIONS, BuiltinTypes } from '@salto-io/adapter-api'
+import { ElemID, CORE_ANNOTATIONS, BuiltinTypes, ListType } from '@salto-io/adapter-api'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
 import { JIRA } from './constants'
 
@@ -471,6 +471,9 @@ const apiDefinitionsType = createMatchingObjectType<JiraApiConfig>({
     platformSwagger: {
       refType: defaultApiDefinitionsType.fields.swagger.refType,
       annotations: { _required: true },
+    },
+    supportedTypes: {
+      refType: new ListType(BuiltinTypes.STRING),
     },
   },
 })

--- a/packages/stripe-adapter/src/adapter_creator.ts
+++ b/packages/stripe-adapter/src/adapter_creator.ts
@@ -24,15 +24,13 @@ import StripeAdapter from './adapter'
 import {
   Credentials, accessTokenCredentialsType,
 } from './auth'
-import {
-  configType, StripeConfig, CLIENT_CONFIG, DEFAULT_API_DEFINITIONS, API_DEFINITIONS_CONFIG,
-  StripeApiConfig,
-} from './config'
+import { configType, StripeConfig, CLIENT_CONFIG, DEFAULT_API_DEFINITIONS, API_DEFINITIONS_CONFIG,
+  StripeApiConfig, FETCH_CONFIG, StripeFetchConfig, DEFAULT_INCLUDE_TYPES } from './config'
 import { createConnection } from './client/connection'
 
 const log = logger(module)
 const { validateCredentials, validateClientConfig } = clientUtils
-const { validateSwaggerApiDefinitionConfig } = configUtils
+const { validateSwaggerApiDefinitionConfig, validateSwaggerFetchConfig } = configUtils
 
 const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials => ({
   token: config.value.token,
@@ -42,10 +40,18 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
   const apiDefinitions: StripeApiConfig = _.defaults(
     {}, config?.value?.apiDefinitions, DEFAULT_API_DEFINITIONS
   )
+  const fetch: StripeFetchConfig = _.defaults(
+    {}, config?.value?.fetch, { includeTypes: DEFAULT_INCLUDE_TYPES },
+  )
 
   validateClientConfig(CLIENT_CONFIG, config?.value?.client)
   validateSwaggerApiDefinitionConfig(API_DEFINITIONS_CONFIG, apiDefinitions)
-
+  validateSwaggerFetchConfig(
+    FETCH_CONFIG,
+    API_DEFINITIONS_CONFIG,
+    fetch,
+    apiDefinitions
+  )
 
   const adapterConfig: { [K in keyof Required<StripeConfig>]: StripeConfig[K] } = {
     client: config?.value?.client,

--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -58,7 +58,7 @@ const DEFAULT_SWAGGER_CONFIG: StripeApiConfig['swagger'] = {
   additionalTypes: [],
 }
 
-export const ALL_SUPPORTED_TYPES: string[] = [
+export const ALL_SUPPORTED_TYPES = [
   'country_specs',
   'coupons',
   'plans',
@@ -69,7 +69,7 @@ export const ALL_SUPPORTED_TYPES: string[] = [
   'webhook_endpoints',
 ]
 
-export const DEFAULT_INCLUDE_TYPES: string[] = ALL_SUPPORTED_TYPES
+export const DEFAULT_INCLUDE_TYPES = ALL_SUPPORTED_TYPES
 
 export const DEFAULT_API_DEFINITIONS: StripeApiConfig = {
   swagger: DEFAULT_SWAGGER_CONFIG,

--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -79,6 +79,7 @@ export const DEFAULT_API_DEFINITIONS: StripeApiConfig = {
     },
   },
   types: {},
+  supportedTypes: DEFAULT_INCLUDE_TYPES,
 }
 
 

--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -58,8 +58,7 @@ const DEFAULT_SWAGGER_CONFIG: StripeApiConfig['swagger'] = {
   additionalTypes: [],
 }
 
-
-export const DEFAULT_INCLUDE_TYPES: string[] = [
+export const ALL_SUPPORTED_TYPES: string[] = [
   'country_specs',
   'coupons',
   'plans',
@@ -70,6 +69,8 @@ export const DEFAULT_INCLUDE_TYPES: string[] = [
   'webhook_endpoints',
 ]
 
+export const DEFAULT_INCLUDE_TYPES: string[] = ALL_SUPPORTED_TYPES
+
 export const DEFAULT_API_DEFINITIONS: StripeApiConfig = {
   swagger: DEFAULT_SWAGGER_CONFIG,
   typeDefaults: {
@@ -79,7 +80,7 @@ export const DEFAULT_API_DEFINITIONS: StripeApiConfig = {
     },
   },
   types: {},
-  supportedTypes: DEFAULT_INCLUDE_TYPES,
+  supportedTypes: ALL_SUPPORTED_TYPES,
 }
 
 

--- a/packages/stripe-adapter/test/adapter_creator.test.ts
+++ b/packages/stripe-adapter/test/adapter_creator.test.ts
@@ -21,7 +21,7 @@ import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import StripeAdapter from '../src/adapter'
 import { adapter } from '../src/adapter_creator'
 import { accessTokenCredentialsType } from '../src/auth'
-import { configType } from '../src/config'
+import { configType, DEFAULT_API_DEFINITIONS } from '../src/config'
 import { STRIPE } from '../src/constants'
 import * as connection from '../src/client/connection'
 
@@ -154,6 +154,30 @@ describe('adapter creator', () => {
       ),
       elementsSource: buildElementsSourceFromElements([]),
     })).toThrow(new Error('Duplicate fieldsToHide params found in apiDefinitions for the following types: Product'))
+
+    expect(() => adapter.operations({
+      credentials: new InstanceElement(
+        STRIPE,
+        adapter.authenticationMethods.basic.credentialsType,
+        { token: 'aaa' },
+      ),
+      config: new InstanceElement(
+        STRIPE,
+        adapter.configType as ObjectType,
+        {
+          fetch: {
+            includeTypes: [
+              'stripe.v1__country_specs',
+            ],
+          },
+          apiDefinitions: {
+            ...DEFAULT_API_DEFINITIONS,
+            supportedTypes: [],
+          },
+        },
+      ),
+      elementsSource: buildElementsSourceFromElements([]),
+    })).toThrow(new Error('Invalid type names in fetch.includeTypes: stripe.v1__country_specs are not listed as supported types in apiDefinitions.supportedTypes.'))
   })
 
   it('should validate credentials using createConnection', async () => {

--- a/packages/zuora-billing-adapter/src/adapter_creator.ts
+++ b/packages/zuora-billing-adapter/src/adapter_creator.ts
@@ -24,13 +24,14 @@ import ZuoraAdapter from './adapter'
 import { Credentials, oauthClientCredentialsType, isSandboxSubdomain, toZuoraBaseUrl } from './auth'
 import {
   configType, ZuoraConfig, CLIENT_CONFIG, DEFAULT_API_DEFINITIONS, API_DEFINITIONS_CONFIG,
-  ZuoraApiConfig,
+  ZuoraApiConfig, FETCH_CONFIG, ZuoraFetchConfig, DEFAULT_INCLUDE_TYPES,
+  DEFAULT_SETTINGS_INCLUDE_TYPES,
 } from './config'
 import { createConnection } from './client/connection'
 
 const log = logger(module)
 const { validateCredentials, validateClientConfig } = clientUtils
-const { validateSwaggerApiDefinitionConfig } = configUtils
+const { validateSwaggerApiDefinitionConfig, validateSwaggerFetchConfig } = configUtils
 
 const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials => {
   const { clientId, clientSecret, subdomain, production } = config.value
@@ -52,8 +53,21 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
     {}, config?.value?.apiDefinitions, DEFAULT_API_DEFINITIONS
   )
 
+  const fetch: ZuoraFetchConfig = _.defaults(
+    {}, config?.value?.fetch, {
+      includeTypes: DEFAULT_INCLUDE_TYPES,
+      settingsIncludeTypes: DEFAULT_SETTINGS_INCLUDE_TYPES,
+    },
+  )
+
   validateClientConfig(CLIENT_CONFIG, config?.value?.client)
   validateSwaggerApiDefinitionConfig(API_DEFINITIONS_CONFIG, apiDefinitions)
+  validateSwaggerFetchConfig(
+    FETCH_CONFIG,
+    API_DEFINITIONS_CONFIG,
+    fetch,
+    apiDefinitions
+  )
 
   const adapterConfig: { [K in keyof Required<ZuoraConfig>]: ZuoraConfig[K] } = {
     client: config?.value?.client,

--- a/packages/zuora-billing-adapter/src/config.ts
+++ b/packages/zuora-billing-adapter/src/config.ts
@@ -419,7 +419,7 @@ export const DEFAULT_SETTINGS_INCLUDE_TYPES = [
   'UnitsOfMeasureList',
 ]
 
-export const DEFAULT_INCLUDE_TYPES: string[] = [
+export const DEFAULT_INCLUDE_TYPES = [
   'AccountingCodes',
   'AccountingPeriods',
   'CatalogProduct',

--- a/packages/zuora-billing-adapter/test/adapter_creator.test.ts
+++ b/packages/zuora-billing-adapter/test/adapter_creator.test.ts
@@ -158,6 +158,43 @@ describe('adapter creator', () => {
       ),
       elementsSource: buildElementsSourceFromElements([]),
     })).toThrow(new Error('Duplicate fieldsToHide params found in apiDefinitions for the following types: CustomObject'))
+
+    expect(() => adapter.operations({
+      credentials: new InstanceElement(
+        ZUORA_BILLING,
+        adapter.authenticationMethods.basic.credentialsType,
+        { clientId: 'id', clientSecret: 'secret', subdomain: 'sandbox.na', production: false },
+      ),
+      config: new InstanceElement(
+        ZUORA_BILLING,
+        adapter.configType as ObjectType,
+        {
+          fetch: {
+            includeTypes: [
+              'CatalogProduct',
+            ],
+          },
+          apiDefinitions: {
+            swagger: {
+              url: '/tmp/swagger.yaml',
+            },
+            types: {
+              CustomObject: {
+                transformation: {
+                  dataField: 'definitions',
+                  idFields: ['type'],
+                  fieldsToHide: [
+                    { fieldName: 'a' },
+                  ],
+                },
+              },
+            },
+            supportedTypes: [],
+          },
+        },
+      ),
+      elementsSource: buildElementsSourceFromElements([]),
+    })).toThrow(new Error('Invalid type names in fetch.includeTypes: CatalogProduct are not listed as supported types in apiDefinitions.supportedTypes.'))
   })
 
   it('should throw error on invalid credentials', () => {


### PR DESCRIPTION
Added supportedType field to the config of swagger adapters as an optional field.
---
This is important for Stripe adapter since we only support a small subset of Stripe's types, and may be useful for future adapters.
Added validation of the field to enforce it's not empty if defined.
Added usage in Stripe adapter.
---
_Release Notes_: 
Added a supportedTypes field in swagger-based adapters' config.
Stripe Adapter: The only types that will be visible now in the workspace are the ones Salto supports.