### PR TITLE
SALTO-1366: Change cache logic to always use file hash

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/index.ts
+++ b/packages/workspace/src/workspace/nacl_files/index.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { ParsedNaclFile, ParsedNaclFileDataKeys } from './parsed_nacl_file'
+export { ParsedNaclFile, ParsedNaclFileData } from './parsed_nacl_file'
 export { ChangeSet } from './elements_cache'
 export { NaclFile, FILE_EXTENSION, NaclFilesSource, naclFilesSource, getParsedNaclFiles, RoutingMode, getFunctions } from './nacl_files_source'
 export { ENVS_PREFIX } from './multi_env/multi_env_source'

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_file.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_file.ts
@@ -16,12 +16,8 @@
 import { Element } from '@salto-io/adapter-api'
 import { SourceMap, ParseError } from '../../parser'
 
-
-export type ParsedNaclFileDataKeys = 'errors' | 'timestamp' | 'referenced'
-
 export type ParsedNaclFileData = {
   errors: () => Promise<ParseError[] | undefined>
-  timestamp: () => Promise<number | undefined>
   referenced: () => Promise<string[] | undefined>
 }
 

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -271,7 +271,6 @@ export const mockParseCache = (): ParsedNaclFileCache => ({
     data: {
       errors: () => Promise.resolve([]),
       referenced: () => Promise.resolve([]),
-      timestamp: () => Promise.resolve(0),
     },
   }),
   flush: () => Promise.resolve(undefined),

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -358,14 +358,13 @@ describe('Nacl Files Source', () => {
       const elemID = new ElemID('dummy', 'elem')
       const elem = new ObjectType({ elemID, path: ['test', 'new'] })
       const elements = [elem]
-      const parsedFiles = [
+      const parsedFiles: ParsedNaclFile[] = [
         {
           filename,
           elements: () => Promise.resolve(elements),
           buffer: '',
           data: {
             errors: () => Promise.resolve([]),
-            timestamp: () => Promise.resolve(0),
             referenced: () => Promise.resolve([]),
           },
         },

--- a/packages/workspace/test/workspace/nacl_files/parsed_nacl_files_cache.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/parsed_nacl_files_cache.test.ts
@@ -108,17 +108,16 @@ describe('ParsedNaclFileCache', () => {
     expect(await p1.sourceMap?.()).toEqual(await p2.sourceMap?.())
     expect(await p1.data.errors()).toEqual(await p2.data.errors())
     expect(await p1.data.referenced()).toEqual(await p2.data.referenced())
-    expect(await p1.data.timestamp()).toEqual(await p2.data.timestamp())
   }
 
   beforeAll(async () => {
     jest.spyOn(Date, 'now').mockImplementation(() => someDateTimestamp)
     parsedDummy = await toParsedNaclFile(
-      { ...dummyParsedKey, timestamp: dummyParsedKey.lastModified },
+      dummyParsedKey,
       parseResultWithoutMD5
     )
     parsedToDelete = await toParsedNaclFile(
-      { ...toDeleteKey, timestamp: toDeleteKey.lastModified },
+      toDeleteKey,
       toDeleteParseResult
     )
   })
@@ -153,24 +152,21 @@ describe('ParsedNaclFileCache', () => {
       )
     })
 
-    it('Should be true if exists and newer', async () => {
+    it('Should be true if content did not change', async () => {
       expect(await cache.hasValid(dummyParsedKey)).toBeTruthy()
     })
 
-    it('Should be true if content did not change regardless of timestamp', async () => {
-      expect(await cache.hasValid({
-        ...dummyParsedKey,
-        lastModified: afterTimestamp,
-      })).toBeTruthy()
-    })
-
-    it('Should be false if content changed and timestap later', async () => {
+    it('Should be false if content changed', async () => {
       const newerDummyKey = {
         filename: dummyFilename,
         buffer: 'changed',
         lastModified: afterTimestamp,
       }
       expect(await cache.hasValid(newerDummyKey)).toBeFalsy()
+    })
+
+    it('Should be false if the filename does not exist', async () => {
+      expect(await cache.hasValid({ filename: 'noSuchFile.nacl', buffer: 'some data' })).toBeFalsy()
     })
   })
 


### PR DESCRIPTION
Using the modification timestamp is suspected to be incorrect in certain scenarios
Because the effect of using the wrong cache can be critical (corrupts the workspace)
and the performance difference should not be too significant, changing the logic for
additional safety

---

This is the same logical change as #2137 

---
_Release Notes_: 
None (the same change was made on master, so the release notes were there)