### PR TITLE
Enforce list and map types in createMatchingObjectType

### DIFF
--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -163,6 +163,13 @@ abstract class PlaceholderTypeElement extends Element {
 }
 
 export class ListType<T extends TypeElement = TypeElement> extends Element {
+  // This unused value which is always undefined is only here to allow us to enforce
+  // the inner type T in createMatchingObjectType. without this member the only information
+  // about T is in the constructor and the constructor is not part of the instance.
+  // In order to enforce an instance to have a specific T we need some reference to T outside
+  // the constructor and because we currently don't have one, we add an artificial one here
+  protected _typeMarker?: T
+
   public refInnerType: ReferenceExpression
   public constructor(
     innerTypeOrRef: TypeOrRef<T>
@@ -186,13 +193,13 @@ export class ListType<T extends TypeElement = TypeElement> extends Element {
     )
   }
 
-  async getInnerType(elementsSource?: ReadOnlyElementsSource): Promise<T> {
+  async getInnerType(elementsSource?: ReadOnlyElementsSource): Promise<TypeElement> {
     const refInnerTypeVal = await getRefTypeValue(this.refInnerType, elementsSource)
     // eslint-disable-next-line no-use-before-define
     if (!isType(refInnerTypeVal)) {
       throw new Error(`Element with ElemID ${this.elemID.getFullName()}'s innerType is resolved non-TypeElement`)
     }
-    return refInnerTypeVal as T
+    return refInnerTypeVal
   }
 
   setRefInnerType(innerTypeOrRefInnerType: TypeOrRef): void {
@@ -214,6 +221,13 @@ export class ListType<T extends TypeElement = TypeElement> extends Element {
  * Represents a map with string keys and innerType values.
  */
 export class MapType<T extends TypeElement = TypeElement> extends Element {
+  // This unused value which is always undefined is only here to allow us to enforce
+  // the inner type T in createMatchingObjectType. without this member the only information
+  // about T is in the constructor and the constructor is not part of the instance.
+  // In order to enforce an instance to have a specific T we need some reference to T outside
+  // the constructor and because we currently don't have one, we add an artificial one here
+  protected _typeMarker?: T
+
   public refInnerType: ReferenceExpression
   public constructor(
     innerTypeOrRef: TypeOrRef<T>
@@ -237,13 +251,13 @@ export class MapType<T extends TypeElement = TypeElement> extends Element {
     )
   }
 
-  async getInnerType(elementsSource?: ReadOnlyElementsSource): Promise<T> {
+  async getInnerType(elementsSource?: ReadOnlyElementsSource): Promise<TypeElement> {
     const refInnerTypeVal = await getRefTypeValue(this.refInnerType, elementsSource)
     // eslint-disable-next-line no-use-before-define
     if (!isType(refInnerTypeVal)) {
       throw new Error(`Element with ElemID ${this.elemID.getFullName()}'s innerType is resolved non-TypeElement`)
     }
-    return refInnerTypeVal as T
+    return refInnerTypeVal
   }
 
   setRefInnerType(innerTypeOrRefInnerType: TypeOrRef): void {

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -137,7 +137,7 @@ export enum PrimitiveTypes {
 export type ContainerType = ListType | MapType
 export type TypeElement = PrimitiveType | ObjectType | ContainerType
 export type TypeMap = Record<string, TypeElement>
-type TypeOrRef = TypeElement | ReferenceExpression
+type TypeOrRef<T extends TypeElement = TypeElement> = T | ReferenceExpression
 export type TypeRefMap = Record<string, TypeOrRef>
 export type ReferenceMap = Record<string, ReferenceExpression>
 
@@ -162,10 +162,10 @@ abstract class PlaceholderTypeElement extends Element {
   }
 }
 
-export class ListType extends Element {
+export class ListType<T extends TypeElement = TypeElement> extends Element {
   public refInnerType: ReferenceExpression
   public constructor(
-    innerTypeOrRef: TypeOrRef
+    innerTypeOrRef: TypeOrRef<T>
   ) {
     super({
       elemID: new ElemID('', `${LIST_ID_PREFIX}<${innerTypeOrRef.elemID.getFullName()}>`),
@@ -186,13 +186,13 @@ export class ListType extends Element {
     )
   }
 
-  async getInnerType(elementsSource?: ReadOnlyElementsSource): Promise<TypeElement> {
+  async getInnerType(elementsSource?: ReadOnlyElementsSource): Promise<T> {
     const refInnerTypeVal = await getRefTypeValue(this.refInnerType, elementsSource)
     // eslint-disable-next-line no-use-before-define
     if (!isType(refInnerTypeVal)) {
       throw new Error(`Element with ElemID ${this.elemID.getFullName()}'s innerType is resolved non-TypeElement`)
     }
-    return refInnerTypeVal
+    return refInnerTypeVal as T
   }
 
   setRefInnerType(innerTypeOrRefInnerType: TypeOrRef): void {
@@ -213,10 +213,10 @@ export class ListType extends Element {
 /**
  * Represents a map with string keys and innerType values.
  */
-export class MapType extends Element {
+export class MapType<T extends TypeElement = TypeElement> extends Element {
   public refInnerType: ReferenceExpression
   public constructor(
-    innerTypeOrRef: TypeOrRef
+    innerTypeOrRef: TypeOrRef<T>
   ) {
     super({
       elemID: new ElemID('', `${MAP_ID_PREFIX}<${innerTypeOrRef.elemID.getFullName()}>`),
@@ -237,13 +237,13 @@ export class MapType extends Element {
     )
   }
 
-  async getInnerType(elementsSource?: ReadOnlyElementsSource): Promise<TypeElement> {
+  async getInnerType(elementsSource?: ReadOnlyElementsSource): Promise<T> {
     const refInnerTypeVal = await getRefTypeValue(this.refInnerType, elementsSource)
     // eslint-disable-next-line no-use-before-define
     if (!isType(refInnerTypeVal)) {
       throw new Error(`Element with ElemID ${this.elemID.getFullName()}'s innerType is resolved non-TypeElement`)
     }
-    return refInnerTypeVal
+    return refInnerTypeVal as T
   }
 
   setRefInnerType(innerTypeOrRefInnerType: TypeOrRef): void {

--- a/packages/adapter-utils/test/element.test.ts
+++ b/packages/adapter-utils/test/element.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, BuiltinTypes, ObjectType, ListType } from '@salto-io/adapter-api'
+import { ElemID, BuiltinTypes, ObjectType, ListType, MapType } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '../src/element'
 
 describe('createMatchingObjectType', () => {
@@ -26,6 +26,7 @@ describe('createMatchingObjectType', () => {
       obj: InnerType
       lst: number[]
       objLst: InnerType[]
+      numMap: Record<string, number>
     }
     const innerType = createMatchingObjectType<InnerType>({
       elemID: new ElemID('inner'),
@@ -41,6 +42,7 @@ describe('createMatchingObjectType', () => {
         obj: { refType: innerType, annotations: { _required: true } },
         lst: { refType: new ListType(BuiltinTypes.NUMBER), annotations: { _required: true } },
         objLst: { refType: new ListType(innerType), annotations: { _required: true } },
+        numMap: { refType: new MapType(BuiltinTypes.NUMBER), annotations: { _required: true } },
       },
     })).toBeInstanceOf(ObjectType)
   })

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -376,7 +376,10 @@ describe('Test utils.ts', () => {
             path: (string | number)[],
             value: Values,
           ): Promise<Field> => {
-            if (typeof path[0] === 'number' && isListType(type)) {
+            if (isListType(type)) {
+              if (typeof path[0] !== 'number') {
+                throw new Error(`type ${type.elemID.getFullName()} is a list type but path part ${path[0]} is not a number`)
+              }
               return getField(
                 (await type.getInnerType() as ObjectType | ContainerType),
                 path.slice(1),

--- a/packages/hubspot-adapter/src/transformers/transformer.ts
+++ b/packages/hubspot-adapter/src/transformers/transformer.ts
@@ -1270,7 +1270,7 @@ export const createHubspotMetadataFromInstanceElement = async (
             values: val,
             transformFunc,
             strict: false,
-            type: fieldType,
+            type: fieldDeepInnerType,
           })
         }
       }

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
-import { ElemID, CORE_ANNOTATIONS, BuiltinTypes, ObjectType, MapType, ReferenceExpression } from '@salto-io/adapter-api'
+import { ElemID, CORE_ANNOTATIONS, BuiltinTypes } from '@salto-io/adapter-api'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
 import { JIRA } from './constants'
 
@@ -452,46 +452,24 @@ export type JiraConfig = {
 
 const defaultApiDefinitionsType = createSwaggerAdapterApiConfigType({ adapter: JIRA })
 
-// We use this to allow ourselfs to get the IDs of the def fields and enjoy the benefits
-// of the schema validation without having to create uneeded async gets
-const createObjectTypeFromRefType = (refType: ReferenceExpression): ObjectType => (
-  new ObjectType({
-    elemID: refType.elemID,
-  })
-)
-
-const createObjectMapTypeFromRefType = (refType: ReferenceExpression): MapType => (
-  new MapType(new ObjectType({
-    elemID: refType.elemID,
-  }))
-)
-
 const apiDefinitionsType = createMatchingObjectType<JiraApiConfig>({
   elemID: new ElemID(JIRA, 'apiDefinitions'),
   fields: {
     apiVersion: { refType: BuiltinTypes.STRING },
     typeDefaults: {
-      refType: createObjectTypeFromRefType(
-        defaultApiDefinitionsType.fields.typeDefaults.refType
-      ),
+      refType: defaultApiDefinitionsType.fields.typeDefaults.refType,
       annotations: { _required: true },
     },
     types: {
-      refType: createObjectMapTypeFromRefType(
-        defaultApiDefinitionsType.fields.types.refType
-      ),
+      refType: defaultApiDefinitionsType.fields.types.refType,
       annotations: { _required: true },
     },
     jiraSwagger: {
-      refType: createObjectTypeFromRefType(
-        defaultApiDefinitionsType.fields.swagger.refType
-      ),
+      refType: defaultApiDefinitionsType.fields.swagger.refType,
       annotations: { _required: true },
     },
     platformSwagger: {
-      refType: createObjectTypeFromRefType(
-        defaultApiDefinitionsType.fields.swagger.refType
-      ),
+      refType: defaultApiDefinitionsType.fields.swagger.refType,
       annotations: { _required: true },
     },
   },

--- a/packages/workspace/src/parser/internal/nearly/converter/elements.ts
+++ b/packages/workspace/src/parser/internal/nearly/converter/elements.ts
@@ -125,7 +125,7 @@ const parseType = (
   return {
     element: typeObj,
     sourceMap,
-    containerTypes: wu(listElements.values()).toArray().concat(wu(mapElements.values()).toArray()),
+    containerTypes: wu.chain<ContainerType>(listElements.values(), mapElements.values()).toArray(),
   }
 }
 


### PR DESCRIPTION
- Added back the validation on list and map inner types
- We now allow references in createMatchingObjectType because it is
  better than the alternative solution of creating empty object types
- Fixed jira config type which was wrong


---
_Release Notes_: 
None (only real fix is the jira config type and that is not really released yet)
