### PR TITLE
Fixed persistent DB creation is not atomic (fixes SALTO-1377)

### DIFF
--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -174,7 +174,7 @@ AsyncIterable<remoteMap.RemoteMapEntry<string>[]> {
 const MAX_CONNECTIONS = 1000
 const persistentDBConnections: Record<string, Promise<rocksdb>> = {}
 const tmpDBConnections: Record<string, Record<string, Promise<rocksdb>>> = {}
-let currnetConnectionsCount = 0
+let currentConnectionsCount = 0
 
 const closeConnection = async (location: string, connection: Promise<rocksdb>): Promise<void> => {
   const dbConnection = await connection
@@ -448,11 +448,11 @@ remoteMap.RemoteMapCreator => {
     const closeImpl = async (): Promise<void> => {
       if (persistentDB.status === 'open') {
         await closeConnection(location, Promise.resolve(persistentDB))
-        currnetConnectionsCount -= 1
+        currentConnectionsCount -= 1
       }
       if (tmpDB.status === 'open') {
         await closeTmpConnection(location, tmpLocation, Promise.resolve(tmpDB))
-        currnetConnectionsCount -= 1
+        currentConnectionsCount -= 1
       }
     }
     const getOpenDBConnection = async (
@@ -488,11 +488,11 @@ remoteMap.RemoteMapCreator => {
         persistentDB = await persistentDBConnections[location]
         return
       }
-      if (currnetConnectionsCount > MAX_CONNECTIONS) {
+      if (currentConnectionsCount > MAX_CONNECTIONS) {
         throw new Error('Failed to open rocksdb connection - too much open connections already')
       }
       const connectionPromise = (async () => {
-        currnetConnectionsCount += 2
+        currentConnectionsCount += 2
         await createDBIfNotExist(location)
         const readOnly = !persistent
         return getOpenDBConnection(location, readOnly)

--- a/packages/core/test/workspace/local/remote_map.test.ts
+++ b/packages/core/test/workspace/local/remote_map.test.ts
@@ -24,6 +24,7 @@ import rocksdb from '@salto-io/rocksdb'
 import path from 'path'
 import { readdirSync } from 'fs-extra'
 import { createRemoteMapCreator, RocksDBValue, TMP_DB_DIR } from '../../../src/local-workspace/remote_map'
+//import rockdbImpl from '../../../src/local-workspace/rocksdb'
 
 const { serialize, deserialize } = serialization
 const { awu } = collections.asynciterable
@@ -402,6 +403,23 @@ describe('full integration', () => {
     await promisify(db.close.bind(db))()
   })
 })
+
+describe('connection pool', () => {
+  fit('should create a single persistent db connection for a location', async () => {
+    const mockOpen = jest.fn().mockResolvedValue(undefined)
+    jest.mock('../../../src/local-workspace/rocksdb', () => ({
+      default: () => ({
+        open: mockOpen
+      })
+    }))
+    await Promise.all([
+      createMap('integration'),
+      createMap('integration')
+    ])
+    expect(mockOpen).toHaveBeenCalledTimes(1)
+  })
+})
+
 afterAll(async () => {
   leveldown.destroy(DB_LOCATION, _error => {
     // nothing to do with error

--- a/packages/core/test/workspace/local/remote_map.test.ts
+++ b/packages/core/test/workspace/local/remote_map.test.ts
@@ -24,7 +24,7 @@ import rocksdb from '@salto-io/rocksdb'
 import path from 'path'
 import { readdirSync } from 'fs-extra'
 import { createRemoteMapCreator, RocksDBValue, TMP_DB_DIR } from '../../../src/local-workspace/remote_map'
-//import rockdbImpl from '../../../src/local-workspace/rocksdb'
+// import rockdbImpl from '../../../src/local-workspace/rocksdb'
 
 const { serialize, deserialize } = serialization
 const { awu } = collections.asynciterable
@@ -401,22 +401,6 @@ describe('full integration', () => {
       .concat(elem.elemID.getFullName())).sort())
 
     await promisify(db.close.bind(db))()
-  })
-})
-
-describe('connection pool', () => {
-  fit('should create a single persistent db connection for a location', async () => {
-    const mockOpen = jest.fn().mockResolvedValue(undefined)
-    jest.mock('../../../src/local-workspace/rocksdb', () => ({
-      default: () => ({
-        open: mockOpen
-      })
-    }))
-    await Promise.all([
-      createMap('integration'),
-      createMap('integration')
-    ])
-    expect(mockOpen).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/core/test/workspace/local/remote_map_connection.test.ts
+++ b/packages/core/test/workspace/local/remote_map_connection.test.ts
@@ -1,0 +1,58 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { remoteMap as rm } from '@salto-io/workspace'
+import { createRemoteMapCreator } from '../../../src/local-workspace/remote_map'
+
+
+describe('connection creation should be atomic', () => {
+  const DB_LOCATION = '/tmp/test_db'
+  const createMap = async (
+    namespace: string,
+    persistent = true
+  ): Promise<rm.RemoteMap<string>> =>
+    createRemoteMapCreator(DB_LOCATION)({
+      namespace,
+      batchInterval: 1000,
+      serialize: str => str,
+      deserialize: async str => Promise.resolve(str),
+      persistent,
+    })
+
+  const mockOpen = jest.fn().mockImplementation((_opts, cb) => {
+    cb()
+  })
+  beforeEach(() => {
+    jest.mock('../../../src/local-workspace/rocksdb', () => ({
+      default: () => ({
+        open: mockOpen,
+      }),
+    }))
+  })
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+  it('should create a single persistent db connection for a location', async () => {
+    await Promise.all([
+      createMap('integration'),
+      createMap('integration'),
+    ])
+    const mockCalls = mockOpen.mock.calls
+    const readOnlyCalls = mockCalls.filter(args => args[0].readOnly === true)
+    const writeCalls = mockCalls.filter(args => args[0].readOnly === false)
+    expect(readOnlyCalls).toHaveLength(1) // Checking if the DB is there
+    expect(writeCalls).toHaveLength(3) // Two tmp connections and 1 persistent connection
+  })
+})

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import * as vscode from 'vscode'
-import { loadLocalWorkspace } from '@salto-io/core'
+import { loadLocalWorkspace, closeAllRemoteMaps } from '@salto-io/core'
 import { diagnostics, workspace as ws } from '@salto-io/lang-server'
 import { onTextChangeEvent, onFileChange, onFileOpen, createReportErrorsEventListener } from './events'
 import {
@@ -112,3 +112,7 @@ export const activate = async (context: vscode.ExtensionContext): Promise<void> 
   },
   async () => onActivate(context))
 )
+
+export const deactviate = async (): Promise<void> => {
+  await closeAllRemoteMaps()
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -113,6 +113,6 @@ export const activate = async (context: vscode.ExtensionContext): Promise<void> 
   async () => onActivate(context))
 )
 
-export const deactviate = async (): Promise<void> => {
+export const deactivate = async (): Promise<void> => {
   await closeAllRemoteMaps()
 }


### PR DESCRIPTION
_Added connection close in vscode and improved db creation_

---

_The code that creates the persistent db connection was not atomic, causing a failure when two remote maps when the same location were created in the same time_

---
_Release Notes_: 
_NA_
