### PR TITLE
fixed move commands end when invoked with a missing element id

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -304,6 +304,12 @@ const addToSource = async ({
     const topLevelElement = valuesOverrides[topLevelGid.getFullName()]
       ?? await originSource.get(topLevelGid)
     const before = await targetSource.get(topLevelGid)
+    if (!values.isDefined(topLevelElement)) {
+      if (values.isDefined(before)) {
+        return []
+      }
+      throw new Error(`ElemID ${gids[0].getFullName()} does not exist in origin`)
+    }
     if (!values.isDefined(before)) {
       // If there is no top level element to merge into, we best let the nacl file source
       // handle the nested changes
@@ -311,12 +317,6 @@ const addToSource = async ({
         valuesOverrides[id.getFullName()] ?? resolvePath(topLevelElement, id),
         id
       ))
-    }
-    if (!values.isDefined(topLevelElement)) {
-      if (values.isDefined(before)) {
-        return []
-      }
-      throw new Error(`ElemID ${gids[0].getFullName()} does not exist in origin`)
     }
     const topLevelIds = gids.filter(id => id.isTopLevel())
     const wrappedElement = !_.isEmpty(topLevelIds)

--- a/packages/workspace/test/workspace/multi_env/routers.test.ts
+++ b/packages/workspace/test/workspace/multi_env/routers.test.ts
@@ -1113,6 +1113,15 @@ describe('track', () => {
     sec: createMockNaclFileSource(secondaryElements, { 'default.nacl': secondaryElements }),
   }
 
+  it('should throw the proper error when trying to move an element which is not in the origin env', async () => {
+    await expect(() => routePromote(
+      [ElemID.fromFullName('salto.noop')],
+      primarySrc,
+      commonSrc,
+      secondarySources
+    )).rejects.toThrow('does not exist in origin')
+  })
+
   it('should move an entire element in two diff files if not in common and split in source', async () => {
     const changes = await routePromote(
       [onlyInEnvElemID],
@@ -1364,6 +1373,15 @@ describe('untrack', () => {
     sec: createMockNaclFileSource(secondaryElements, { 'default.nacl': secondaryElements }),
   }
 
+  it('should throw the proper error when trying to move an element which is not in the origin env', async () => {
+    await expect(() => routeDemote(
+      [ElemID.fromFullName('salto.noop')],
+      primarySrc,
+      commonSrc,
+      secondarySources
+    )).rejects.toThrow('does not exist in origin')
+  })
+
   it('should move add element which is only in common to all envs', async () => {
     const changes = await routeDemote(
       [onlyInCommon.elemID],
@@ -1540,6 +1558,14 @@ describe('copyTo', () => {
   const secondarySources = {
     sec: createMockNaclFileSource(secondaryElements, { 'default.nacl': secondaryElements }),
   }
+
+  it('should throw the proper error when trying to move an element which is not in the origin env', async () => {
+    await expect(() => routeCopyTo(
+      [ElemID.fromFullName('salto.noop')],
+      primarySrc,
+      secondarySources
+    )).rejects.toThrow('does not exist in origin')
+  })
 
   it('should copy an entire element which does not exist in the target env', async () => {
     const changes = await routeCopyTo(


### PR DESCRIPTION
_Move commands crushed when invoked with an missing element id_

---

_the existence check was to late in the flow_

---
_Release Notes_: 
_NA_
