### PR TITLE
Salto 1296 - optionalFeatures configuration  to filters on fetch

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -102,7 +102,7 @@ salesforce {
         ]
       }
     }
-    fetchAllCustomSettings = false
+    fetchAllCustomSettings = false 
   }
 }
 ```
@@ -143,6 +143,9 @@ salesforce {
 | Name                                                        | Default when undefined                           | Description
 | ------------------------------------------------------------| -------------------------------------------------| -----------
 | extraDependencies                                           | true                                             | Find additional dependencies between configuration elements by using the salesforce tooling API
+| elementsUrl                                                 | true                                             | Find additional dependencies between configuration elements by using the salesforce tooling API
+| addMissingIds                                               | true                                             | Find additional dependencies between configuration elements by using the salesforce tooling API
+| profilePaths                                                | true                                             | Find additional dependencies between configuration elements by using the salesforce tooling API
 
 ### Data management configuration options
 

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -102,7 +102,7 @@ salesforce {
         ]
       }
     }
-    fetchAllCustomSettings = false 
+    fetchAllCustomSettings = false
   }
 }
 ```
@@ -143,10 +143,9 @@ salesforce {
 | Name                                                        | Default when undefined                           | Description
 | ------------------------------------------------------------| -------------------------------------------------| -----------
 | extraDependencies                                           | true                                             | Find additional dependencies between configuration elements by using the salesforce tooling API
-| elementsUrl                                                 | true                                             | Find additional dependencies between configuration elements by using the salesforce tooling API
-| addMissingIds                                               | true                                             | Find additional dependencies between configuration elements by using the salesforce tooling API
-| profilePaths                                                | true                                             | Find additional dependencies between configuration elements by using the salesforce tooling API
-
+| elementsUrl                                                 | true                                             | Add to elements their service url as an annotaion
+| addMissingIds                                               | true                                             | Add missing internal ids
+| profilePaths                                                | true                                             | Replace paths for profile instances upon fetch
 ### Data management configuration options
 
 | Name                                                        | Default when undefined                           | Description

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -143,9 +143,9 @@ salesforce {
 | Name                                                        | Default when undefined                           | Description
 | ------------------------------------------------------------| -------------------------------------------------| -----------
 | extraDependencies                                           | true                                             | Find additional dependencies between configuration elements by using the salesforce tooling API
-| elementsUrl                                                 | true                                             | Add to elements their service url as an annotaion
+| elementsUrls                                                 | true                                             | Populate service URLs for "go to service", which allows getting from a Salto element to its Salesforce URL
 | addMissingIds                                               | true                                             | Add missing internal ids
-| profilePaths                                                | true                                             | Replace paths for profile instances upon fetch
+| profilePaths                                                | true                                             | Update file names for profiles whose API name is different from their display name
 ### Data management configuration options
 
 | Name                                                        | Default when undefined                           | Description

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -144,7 +144,7 @@ salesforce {
 | ------------------------------------------------------------| -------------------------------------------------| -----------
 | extraDependencies                                           | true                                             | Find additional dependencies between configuration elements by using the salesforce tooling API
 | elementsUrls                                                 | true                                             | Populate service URLs for "go to service", which allows getting from a Salto element to its Salesforce URL
-| addMissingIds                                               | true                                             | Add missing internal ids
+| addMissingIds                                               | true                                             | Populate Salesforce internal ids for a few types that require special handling
 | profilePaths                                                | true                                             | Update file names for profiles whose API name is different from their display name
 ### Data management configuration options
 

--- a/packages/salesforce-adapter/src/filter.ts
+++ b/packages/salesforce-adapter/src/filter.ts
@@ -53,7 +53,7 @@ export type FilterCreator = (
   opts: { client: SalesforceClient; config: FilterContext }
 ) => Filter
 
-export const xfiltersRunner = (client: SalesforceClient,
+export const filtersRunner = (client: SalesforceClient,
   config: FilterContext,
   filterCreators: ReadonlyArray<FilterCreator>): Required<Filter> => {
   // Create all filters in advance to allow them to hold context between calls

--- a/packages/salesforce-adapter/src/filter.ts
+++ b/packages/salesforce-adapter/src/filter.ts
@@ -53,7 +53,7 @@ export type FilterCreator = (
   opts: { client: SalesforceClient; config: FilterContext }
 ) => Filter
 
-export const filtersRunner = (client: SalesforceClient,
+export const xfiltersRunner = (client: SalesforceClient,
   config: FilterContext,
   filterCreators: ReadonlyArray<FilterCreator>): Required<Filter> => {
   // Create all filters in advance to allow them to hold context between calls

--- a/packages/salesforce-adapter/src/filters/add_missing_ids.ts
+++ b/packages/salesforce-adapter/src/filters/add_missing_ids.ts
@@ -71,8 +71,11 @@ const elementsWithMissingIds = async (elements: Element[]): Promise<Element[]> =
 /**
  * Add missing env-specific ids using listMetadataObjects.
  */
-const filter: FilterCreator = ({ client }) => ({
+const filter: FilterCreator = ({ client, config }) => ({
   onFetch: async (elements: Element[]) => {
+    if (!config.fetchProfile.isFeatureEnabled('addMissingIds')) {
+      return
+    }
     const groupedElements = await groupByAsync(
       await elementsWithMissingIds(elements),
       metadataType,

--- a/packages/salesforce-adapter/src/filters/elements_url.ts
+++ b/packages/salesforce-adapter/src/filters/elements_url.ts
@@ -30,7 +30,7 @@ const getRelevantElements = (elements: Element[]): AsyncIterable<Element> =>
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
   onFetch: async (elements: Element[]): Promise<void> => {
-    if (!config.fetchProfile.isFeatureEnabled('elementsUrl')) {
+    if (!config.fetchProfile.isFeatureEnabled('elementsUrls')) {
       return
     }
     const url = await client.getUrl()

--- a/packages/salesforce-adapter/src/filters/elements_url.ts
+++ b/packages/salesforce-adapter/src/filters/elements_url.ts
@@ -30,6 +30,9 @@ const getRelevantElements = (elements: Element[]): AsyncIterable<Element> =>
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
   onFetch: async (elements: Element[]): Promise<void> => {
+    if (!config.fetchProfile.isFeatureEnabled('elementsUrl')) {
+      return
+    }
     const url = await client.getUrl()
     if (url === undefined) {
       log.error('Failed to get salesforce URL')

--- a/packages/salesforce-adapter/src/filters/profile_paths.ts
+++ b/packages/salesforce-adapter/src/filters/profile_paths.ts
@@ -58,8 +58,11 @@ const replacePath = async (
 /**
  * replace paths for profile instances upon fetch
  */
-const filterCreator: FilterCreator = ({ client }): FilterWith<'onFetch'> => ({
+const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
   onFetch: async (elements: Element[]) => {
+    if (!config.fetchProfile.isFeatureEnabled('profilePaths')) {
+      return
+    }
     const profiles = await awu(elements)
       .filter(async e => isInstanceOfType(PROFILE_METADATA_TYPE)(e)).toArray()
     if (profiles.length > 0) {

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -54,7 +54,7 @@ export type MetadataParams = {
 
 export type OptionalFeatures = {
   extraDependencies?: boolean
-  elementsUrl?: boolean
+  elementsUrls?: boolean
   profilePaths?: boolean
   addMissingIds?: boolean
 }
@@ -391,7 +391,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
   elemID: new ElemID(SALESFORCE, 'optionalFeatures'),
   fields: {
     extraDependencies: { refType: BuiltinTypes.BOOLEAN },
-    elementsUrl: { refType: BuiltinTypes.BOOLEAN },
+    elementsUrls: { refType: BuiltinTypes.BOOLEAN },
     profilePaths: { refType: BuiltinTypes.BOOLEAN },
     addMissingIds: { refType: BuiltinTypes.BOOLEAN },
   },

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -54,6 +54,9 @@ export type MetadataParams = {
 
 export type OptionalFeatures = {
   extraDependencies?: boolean
+  elementsUrl?: boolean
+  profilePaths?: boolean
+  addMissingIds?: boolean
 }
 
 type ObjectIdSettings = {
@@ -388,6 +391,9 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
   elemID: new ElemID(SALESFORCE, 'optionalFeatures'),
   fields: {
     extraDependencies: { refType: BuiltinTypes.BOOLEAN },
+    elementsUrl: { refType: BuiltinTypes.BOOLEAN },
+    profilePaths: { refType: BuiltinTypes.BOOLEAN },
+    addMissingIds: { refType: BuiltinTypes.BOOLEAN },
   },
 })
 

--- a/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
@@ -23,10 +23,8 @@ import {
   SALESFORCE, API_NAME, METADATA_TYPE, INSTANCE_FULL_NAME_FIELD, INTERNAL_ID_ANNOTATION,
   INTERNAL_ID_FIELD,
 } from '../../src/constants'
-import { defaultFilterContext, MockInterface } from '../utils'
-import Connection from '../../src/client/jsforce'
+import { defaultFilterContext } from '../utils'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 
 
 describe('Internal IDs filter', () => {
@@ -187,25 +185,20 @@ describe('Internal IDs filter', () => {
       expect(elements[2].annotations?.[INTERNAL_ID_ANNOTATION]).toBeUndefined()
       expect(elements[3].annotations?.[INTERNAL_ID_ANNOTATION]).toBeUndefined()
     })
-  })
-  describe('when feature is disabled', () => {
-    let connection: MockInterface<Connection>
-    beforeEach(async () => {
-      const mockClientInst = mockClient()
-      client = mockClientInst.client
-      connection = mockClientInst.connection
+    it('should not run any query when feature is disabled', async () => {
+      const { connection } = mockClient()
+      expect(elements[2]).toBeInstanceOf(InstanceElement)
+      const inst = elements[2] as InstanceElement
       filter = filterCreator({
         client,
         config: {
           ...defaultFilterContext,
-          fetchProfile: buildFetchProfile({ optionalFeatures: { extraDependencies: false } }),
-          elementsSource: buildElementsSourceFromElements(elements),
+          fetchProfile: buildFetchProfile({ optionalFeatures: { addMissingIds: false } }),
         },
       }) as FilterType
-      await filter.onFetch(elements)
-    })
-    it('should not run any query', () => {
+      await filter.onFetch([inst])
+      expect(inst.value[INTERNAL_ID_FIELD]).toBeUndefined()
       expect(connection.query).not.toHaveBeenCalled()
     })
-  }) 
+  })
 })

--- a/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
@@ -23,7 +23,11 @@ import {
   SALESFORCE, API_NAME, METADATA_TYPE, INSTANCE_FULL_NAME_FIELD, INTERNAL_ID_ANNOTATION,
   INTERNAL_ID_FIELD,
 } from '../../src/constants'
-import { defaultFilterContext } from '../utils'
+import { defaultFilterContext, MockInterface } from '../utils'
+import Connection from '../../src/client/jsforce'
+import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+
 
 describe('Internal IDs filter', () => {
   let client: SalesforceClient
@@ -184,4 +188,24 @@ describe('Internal IDs filter', () => {
       expect(elements[3].annotations?.[INTERNAL_ID_ANNOTATION]).toBeUndefined()
     })
   })
+  describe('when feature is disabled', () => {
+    let connection: MockInterface<Connection>
+    beforeEach(async () => {
+      const mockClientInst = mockClient()
+      client = mockClientInst.client
+      connection = mockClientInst.connection
+      filter = filterCreator({
+        client,
+        config: {
+          ...defaultFilterContext,
+          fetchProfile: buildFetchProfile({ optionalFeatures: { extraDependencies: false } }),
+          elementsSource: buildElementsSourceFromElements(elements),
+        },
+      }) as FilterType
+      await filter.onFetch(elements)
+    })
+    it('should not run any query', () => {
+      expect(connection.query).not.toHaveBeenCalled()
+    })
+  }) 
 })

--- a/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
@@ -84,6 +84,15 @@ describe('Internal IDs filter', () => {
           [INSTANCE_FULL_NAME_FIELD]: 'dontChange',
         },
       ),
+      new InstanceElement(
+        'whenEnabledInst',
+        objType,
+        {
+          standard: 'aaa',
+          custom: 'bbb',
+          [INSTANCE_FULL_NAME_FIELD]: 'whenEnabledInst',
+        },
+      ),
     ]
     return [objType, ...instances]
   }
@@ -187,8 +196,8 @@ describe('Internal IDs filter', () => {
     })
     it('should not run any query when feature is disabled', async () => {
       const { connection } = mockClient()
-      expect(elements[2]).toBeInstanceOf(InstanceElement)
-      const inst = elements[2] as InstanceElement
+      expect(elements[4]).toBeInstanceOf(InstanceElement)
+      const inst = elements[4] as InstanceElement
       filter = filterCreator({
         client,
         config: {

--- a/packages/salesforce-adapter/test/filters/elements_url.test.ts
+++ b/packages/salesforce-adapter/test/filters/elements_url.test.ts
@@ -99,7 +99,7 @@ describe('elements url filter', () => {
       client,
       config: {
         ...defaultFilterContext,
-        fetchProfile: buildFetchProfile({ optionalFeatures: { elementsUrl: false } }),
+        fetchProfile: buildFetchProfile({ optionalFeatures: { elementsUrls: false } }),
       },
     })
     await filter.onFetch?.([standardObject])

--- a/packages/salesforce-adapter/test/filters/elements_url.test.ts
+++ b/packages/salesforce-adapter/test/filters/elements_url.test.ts
@@ -20,18 +20,14 @@ import Connection from '../../src/client/jsforce'
 import SalesforceClient from '../../src/client/client'
 import { Filter } from '../../src/filter'
 import elementsUrlFilter from '../../src/filters/elements_url'
-import { defaultFilterContext, MockInterface } from '../utils'
-import filterCreator from '../../src/filters/elements_url'
+import { defaultFilterContext } from '../utils'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 
 describe('elements url filter', () => {
   let filter: Filter
   let client: SalesforceClient
   let connection: Connection
   let standardObject: ObjectType
-  let elements: Element[]
-  
 
   beforeEach(() => {
     ({ connection, client } = mockClient())
@@ -97,26 +93,17 @@ describe('elements url filter', () => {
     expect(element.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 
-  describe('when feature is disabled', () => {
-    let connection: MockInterface<Connection>
-    let elements: Element[]
-    beforeEach(async () => {
-      const mockClientInst = mockClient()
-      client = mockClientInst.client
-      connection = mockClientInst.connection
-      filter = filterCreator({
-        client,
-        config: {
-          ...defaultFilterContext,
-          fetchProfile: buildFetchProfile({ optionalFeatures: { elementsUrl: false } }),
-          elementsSource: buildElementsSourceFromElements(elements),
-
-        },
-      }) 
-      await filter.onFetch?.([element])
+  it('should not run any query when feature is disabled', async () => {
+    connection.instanceUrl = 'https://salto5-dev-ed.my.salesforce.com'
+    filter = elementsUrlFilter({
+      client,
+      config: {
+        ...defaultFilterContext,
+        fetchProfile: buildFetchProfile({ optionalFeatures: { elementsUrl: false } }),
+      },
     })
-    it('should not run any query', () => {
-      expect(connection.query).not.toHaveBeenCalled()
-    })
+    await filter.onFetch?.([standardObject])
+    expect(standardObject.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+    expect(connection.query).not.toHaveBeenCalled()
   })
 })

--- a/packages/salesforce-adapter/test/filters/profile_paths.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_paths.test.ts
@@ -22,7 +22,11 @@ import filterCreator from '../../src/filters/profile_paths'
 import { FilterWith } from '../../src/filter'
 import mockClient from '../client'
 import { mockQueryResult } from '../connection'
-import { defaultFilterContext } from '../utils'
+import { defaultFilterContext, MockInterface } from '../utils'
+import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
+import Connection from '../../src/client/jsforce'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+
 
 describe('profile paths filter', () => {
   const { client, connection } = mockClient()
@@ -84,5 +88,28 @@ describe('profile paths filter', () => {
     instance.path = undefined
     await filter.onFetch([instance])
     expect(instance.path).toBeUndefined()
+  })
+  
+  describe('when feature is disabled', () => {
+    let elements: Element[]
+    let connection: MockInterface<Connection>
+    beforeEach(async () => {
+      const mockClientInst = mockClient()
+      client = mockClientInst.client
+      connection = mockClientInst.connection
+      filter = filterCreator({
+        client,
+        config: {
+          ...defaultFilterContext,
+          fetchProfile: buildFetchProfile({ optionalFeatures: { profilePaths: false } }),
+          elementsSource: buildElementsSourceFromElements(elements),
+
+        },
+      }) 
+      await filter.onFetch?.([element])
+    })
+    it('should not run any query', () => {
+      expect(connection.query).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
Added a configuration option to disable the filters - add_missing_ids , profile_paths and elements_url on fetch.

---

_Additional context for reviewer_

---
_Release Notes_: 
Salesforce Adapter:
- Configurable enabling/disabling of specific filters - add_missing_ids , profile_paths and elements_url on fetch.
