### PR TITLE
SALTO-1399: Netsuite: Limit sdf_client read from FS concurrency

### DIFF
--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -83,6 +83,7 @@ const ALL = 'ALL'
 const ADDITIONAL_FILE_PATTERN = '.template.'
 
 export const MINUTE_IN_MILLISECONDS = 1000 * 60
+const READ_CONCURRENCY = 100
 
 const INVALID_DEPENDENCIES = ['ADVANCEDEXPENSEMANAGEMENT', 'SUBSCRIPTIONBILLING', 'WMSSYSTEM', 'BILLINGACCOUNTS']
 const INVALID_DEPENDENCIES_PATTERN = new RegExp(`^.*(<feature required=".*">${INVALID_DEPENDENCIES.join('|')})</feature>.*\n`, 'gm')
@@ -346,18 +347,25 @@ export default class SdfClient {
     const objectsDirPath = SdfClient.getObjectsDirPath(projectName)
     const filenames = await readDir(objectsDirPath)
     const scriptIdToFiles = _.groupBy(filenames, filename => filename.split(FILE_SEPARATOR)[0])
-    const elements = await Promise.all(
-      Object.entries(scriptIdToFiles).map(async ([scriptId, objectFileNames]) => {
-        const [[additionalFilename], [contentFilename]] = _.partition(objectFileNames,
-          filename => filename.includes(ADDITIONAL_FILE_PATTERN))
-        const xmlContent = readFile(osPath.resolve(objectsDirPath, contentFilename))
-        if (_.isUndefined(additionalFilename)) {
-          return convertToCustomTypeInfo((await xmlContent).toString(), scriptId)
-        }
-        const additionalFileContent = readFile(osPath.resolve(objectsDirPath, additionalFilename))
-        return convertToTemplateCustomTypeInfo((await xmlContent).toString(), scriptId,
-          additionalFilename.split(FILE_SEPARATOR)[2], await additionalFileContent)
-      })
+
+    const transformCustomObject = async (
+      scriptId: string, objectFileNames: string[]
+    ): Promise<CustomTypeInfo> => {
+      const [[additionalFilename], [contentFilename]] = _.partition(objectFileNames,
+        filename => filename.includes(ADDITIONAL_FILE_PATTERN))
+      const xmlContent = readFile(osPath.resolve(objectsDirPath, contentFilename))
+      if (_.isUndefined(additionalFilename)) {
+        return convertToCustomTypeInfo((await xmlContent).toString(), scriptId)
+      }
+      const additionalFileContent = readFile(osPath.resolve(objectsDirPath, additionalFilename))
+      return convertToTemplateCustomTypeInfo((await xmlContent).toString(), scriptId,
+        additionalFilename.split(FILE_SEPARATOR)[2], await additionalFileContent)
+    }
+
+    const elements = await withLimitedConcurrency(
+      Object.entries(scriptIdToFiles).map(([scriptId, objectFileNames]) =>
+        () => transformCustomObject(scriptId, objectFileNames)),
+      READ_CONCURRENCY
     )
     await this.projectCleanup(projectName, authId)
     return { elements, failedToFetchAllAtOnce, failedTypeToInstances }
@@ -585,7 +593,8 @@ export default class SdfClient {
           return [`${folderName}${fileName}`, fileAttrsPath]
         })
       )
-      return Promise.all(filePaths.map(async filePath => {
+
+      const transformFile = async (filePath: string): Promise<FileCustomizationInfo> => {
         const attrsPath = filePathToAttrsPath[filePath]
         const xmlContent = readFile(osPath.resolve(fileCabinetDirPath,
           ...attrsPath.split(FILE_CABINET_PATH_SEPARATOR)))
@@ -593,17 +602,28 @@ export default class SdfClient {
         const fileContent = readFile(osPath.resolve(fileCabinetDirPath, ...filePathParts))
         return convertToFileCustomizationInfo((await xmlContent).toString(),
           filePathParts.slice(1), await fileContent)
-      }))
+      }
+
+      return withLimitedConcurrency(
+        filePaths.map(filePath => () => transformFile(filePath)),
+        READ_CONCURRENCY
+      )
     }
 
     const transformFolders = (folderAttrsPaths: string[], fileCabinetDirPath: string):
-      Promise<FolderCustomizationInfo[]> =>
-      Promise.all(folderAttrsPaths.map(async attrsPath => {
-        const folderPathParts = attrsPath.split(FILE_CABINET_PATH_SEPARATOR)
+      Promise<FolderCustomizationInfo[]> => {
+      const transformFolder = async (folderAttrsPath: string): Promise<FolderCustomizationInfo> => {
+        const folderPathParts = folderAttrsPath.split(FILE_CABINET_PATH_SEPARATOR)
         const xmlContent = readFile(osPath.resolve(fileCabinetDirPath, ...folderPathParts))
         return convertToFolderCustomizationInfo((await xmlContent).toString(),
           folderPathParts.slice(1, -2))
-      }))
+      }
+
+      return withLimitedConcurrency(
+        folderAttrsPaths.map(folderAttrsPath => () => transformFolder(folderAttrsPath)),
+        READ_CONCURRENCY
+      )
+    }
 
     const project = await this.initProject()
     const listFilesResults = await this.listFilePaths(project.executor)


### PR DESCRIPTION
_Release Notes_: 
NetSuite adapter:
Fix fetch failures for accounts with thousands of files in the FileCabinet
