### PR TITLE
fixed top level parent in reference expressions are not resolved (fix SALTO-1400)

### DIFF
--- a/packages/workspace/src/expressions.ts
+++ b/packages/workspace/src/expressions.ts
@@ -114,7 +114,14 @@ export const resolveReferenceExpression = async (
     return expression.createWithValue(new UnresolvedReference(fullElemID))
   }
 
-  const value = resolvePath(rootElement, fullElemID)
+  // eslint-disable-next-line no-use-before-define
+  const resolvedRootElement = await resolveElement(
+    rootElement,
+    elementsSource,
+    workingSetElements
+  )
+
+  const value = resolvePath(resolvedRootElement, fullElemID)
 
   if (value === undefined) {
     return expression.createWithValue(new UnresolvedReference(fullElemID))
@@ -134,13 +141,13 @@ export const resolveReferenceExpression = async (
         workingSetElements,
         visited,
       ) ?? value.value,
-      rootElement,
+      resolvedRootElement,
     )
   }
   return (expression as ReferenceExpression).createWithValue(
     await resolveMaybeExpression(value, elementsSource, workingSetElements, visited)
       ?? value,
-    rootElement,
+    resolvedRootElement,
   )
 }
 

--- a/packages/workspace/test/core/expressions.test.ts
+++ b/packages/workspace/test/core/expressions.test.ts
@@ -408,6 +408,36 @@ describe('Test Salto Expressions', () => {
       expect(resObj.annotationRefTypes.a.elemID).toBe(resPrim.elemID)
       expect(resInst.refType.elemID).toBe(resObj.elemID)
     })
+
+    it('should resolve the top level element in a reference', async () => {
+      const refTargetInstObj = new ObjectType({
+        elemID: ElemID.fromFullName('salto.testObj'),
+      })
+      // We need to object types here since if we were to use the same type, it would have been
+      // resolved when `instanceToResolve` would have been resolved.
+      const instanceToResolveObj = new ObjectType({
+        elemID: ElemID.fromFullName('salto.testObj2'),
+      })
+      const refTargetInst = new InstanceElement('rrr', new ReferenceExpression(refTargetInstObj.elemID), {
+        test: 'okok',
+      })
+      const instanceToResolve = new InstanceElement('rrr', new ReferenceExpression(instanceToResolveObj.elemID), {
+        test: refTo(refTargetInst, 'test'),
+      })
+      const elems = [instanceToResolve]
+      const resovledElems = (await awu(await resolve(
+        elems,
+        createInMemoryElementSource(
+          [
+            refTargetInstObj, instanceToResolveObj, refTargetInst, instanceToResolve,
+          ]
+        )
+      )).toArray()) as [InstanceElement]
+      const resolvedRef = resovledElems[0].value.test as ReferenceExpression
+      const resolvedValue = resolvedRef.topLevelParent as InstanceElement
+      const resolvedValueType = await resolvedValue.getType() as ObjectType
+      expect(resolvedValueType).toEqual(refTargetInstObj)
+    })
   })
 
   describe('Template Expression', () => {


### PR DESCRIPTION
_fixed top level parent in reference expressions are not resolved_

---

_Elements should be fully resolved after the resolve function is called. The bug took place since the top level parent of reference expressions values were not resolved, causing the `type` field to remain unresolved. The netsuite adapter attempted to access the type of said element - causing an error to be thrown._

---
_Release Notes_: 
_NA_
