### PR TITLE
Salto 1296 - warnings mechanism for extra_dependencies, add_missing_ids , profile_paths and elements_url

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -143,7 +143,7 @@ salesforce {
 | Name                                                        | Default when undefined                           | Description
 | ------------------------------------------------------------| -------------------------------------------------| -----------
 | extraDependencies                                           | true                                             | Find additional dependencies between configuration elements by using the salesforce tooling API
-| elementsUrls                                                 | true                                             | Populate service URLs for "go to service", which allows getting from a Salto element to its Salesforce URL
+| elementsUrls                                                 | true                                             | Populate URLs for your salesforce configuration elements and enable quick navigation from Salto to the corresponding salesforce screen
 | addMissingIds                                               | true                                             | Populate Salesforce internal ids for a few types that require special handling
 | profilePaths                                                | true                                             | Update file names for profiles whose API name is different from their display name
 ### Data management configuration options

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -102,7 +102,7 @@ salesforce {
         ]
       }
     }
-    fetchAllCustomSettings = false
+    fetchAllCustomSettings = false 
   }
 }
 ```

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -102,7 +102,7 @@ salesforce {
         ]
       }
     }
-    fetchAllCustomSettings = false 
+    fetchAllCustomSettings = false
   }
 }
 ```

--- a/packages/salesforce-adapter/src/filters/add_missing_ids.ts
+++ b/packages/salesforce-adapter/src/filters/add_missing_ids.ts
@@ -68,12 +68,14 @@ const elementsWithMissingIds = async (elements: Element[]): Promise<Element[]> =
     .toArray()
 )
 
+export const WARNING_MESSAGE = 'Encountered an error while trying populate internal IDs for some of your salesforce configuration elements. This might result in some missing configuration dependencies in your workspace and/or affect the availability of the ‘go to service’ functionality.'
+
 /**
  * Add missing env-specific ids using listMetadataObjects.
  */
 const filter: FilterCreator = ({ client, config }) => ({
   onFetch: ensureSafeFilterFetch({
-    warningMessage: 'Encountered an error while trying populate internal IDs for some of your salesforce configuration elements. This might result in some missing configuration dependencies in your workspace and/or affect the availability of the ‘go to service’ functionality.',
+    warningMessage: WARNING_MESSAGE,
     config,
     filterName: 'addMissingIds',
     fetchFilterFunc: async (elements: Element[]) => {

--- a/packages/salesforce-adapter/src/filters/add_missing_ids.ts
+++ b/packages/salesforce-adapter/src/filters/add_missing_ids.ts
@@ -21,7 +21,7 @@ import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
 import { apiName, metadataType } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
-import { getFullName, getInternalId, setInternalId, toSaltoWarning } from './utils'
+import { getFullName, getInternalId, setInternalId, ensureSafeFilterFetch, ensureFilterEnabled } from './utils'
 
 const log = logger(module)
 const { awu, groupByAsync } = collections.asynciterable
@@ -72,27 +72,24 @@ const elementsWithMissingIds = async (elements: Element[]): Promise<Element[]> =
  * Add missing env-specific ids using listMetadataObjects.
  */
 const filter: FilterCreator = ({ client, config }) => ({
-  onFetch: async (elements: Element[]) => {
-    if (!config.fetchProfile.isFeatureEnabled('addMissingIds')) {
-      return undefined
-    }
-    try {
-      const groupedElements = await groupByAsync(
-        await elementsWithMissingIds(elements),
-        metadataType,
-      )
-      log.debug(`Getting missing ids for the following types: ${Object.keys(groupedElements)}`)
-      await Promise.all(
-        Object.entries(groupedElements)
-          .map(([typeName, typeElements]) => addMissingIds(client, typeName, typeElements))
-      )
-    } catch (error) {
-      return {
-        errors: [toSaltoWarning('unexpected error when adding missing ids')],
-      }
-    }
-    return undefined
-  },
+  onFetch: ensureFilterEnabled(
+    ensureSafeFilterFetch(
+      async (elements: Element[]) => {
+        const groupedElements = await groupByAsync(
+          await elementsWithMissingIds(elements),
+          metadataType,
+        )
+        log.debug(`Getting missing ids for the following types: ${Object.keys(groupedElements)}`)
+        await Promise.all(
+          Object.entries(groupedElements)
+            .map(([typeName, typeElements]) => addMissingIds(client, typeName, typeElements))
+        )
+        return undefined
+      },
+      'Failed to unexpected error when adding missing ids'
+    ),
+    'addMissingIds', config
+  ),
 })
 
 export default filter

--- a/packages/salesforce-adapter/src/filters/add_missing_ids.ts
+++ b/packages/salesforce-adapter/src/filters/add_missing_ids.ts
@@ -84,7 +84,6 @@ const filter: FilterCreator = ({ client, config }) => ({
           Object.entries(groupedElements)
             .map(([typeName, typeElements]) => addMissingIds(client, typeName, typeElements))
         )
-        return undefined
       },
       'Failed to unexpected error when adding missing ids'
     ),

--- a/packages/salesforce-adapter/src/filters/elements_url.ts
+++ b/packages/salesforce-adapter/src/filters/elements_url.ts
@@ -18,7 +18,7 @@ import { CORE_ANNOTATIONS, Element } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
 import { lightningElementsUrlRetriever } from '../elements_url_retreiver/elements_url_retreiver'
-import { buildElementsSourceForFetch, extractFlatCustomObjectFields } from './utils'
+import { buildElementsSourceForFetch, extractFlatCustomObjectFields, toSaltoWarning } from './utils'
 
 const { awu } = collections.asynciterable
 
@@ -29,35 +29,42 @@ const getRelevantElements = (elements: Element[]): AsyncIterable<Element> =>
     .flatMap(extractFlatCustomObjectFields)
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
-  onFetch: async (elements: Element[]): Promise<void> => {
+  onFetch: async (elements: Element[]) => {
     if (!config.fetchProfile.isFeatureEnabled('elementsUrls')) {
-      return
+      return undefined
     }
-    const url = await client.getUrl()
-    if (url === undefined) {
-      log.error('Failed to get salesforce URL')
-      return
-    }
+    try {
+      const url = await client.getUrl()
+      if (url === undefined) {
+        log.error('Failed to get salesforce URL')
+        return undefined
+      }
 
-    const referenceElements = buildElementsSourceForFetch(elements, config)
-    const urlRetriever = lightningElementsUrlRetriever(url, id => referenceElements.get(id))
+      const referenceElements = buildElementsSourceForFetch(elements, config)
+      const urlRetriever = lightningElementsUrlRetriever(url, id => referenceElements.get(id))
 
-    if (urlRetriever === undefined) {
-      log.error('Failed to get salesforce URL')
-      return
-    }
+      if (urlRetriever === undefined) {
+        log.error('Failed to get salesforce URL')
+        return undefined
+      }
 
-    const updateElementUrl = async (element: Element): Promise<void> => {
-      const elementURL = await urlRetriever.retrieveUrl(element)
+      const updateElementUrl = async (element: Element): Promise<void> => {
+        const elementURL = await urlRetriever.retrieveUrl(element)
 
-      if (elementURL !== undefined) {
-        element.annotations[CORE_ANNOTATIONS.SERVICE_URL] = elementURL.href
+        if (elementURL !== undefined) {
+          element.annotations[CORE_ANNOTATIONS.SERVICE_URL] = elementURL.href
+        }
+      }
+
+      await awu(getRelevantElements(elements)).forEach(
+        async element => updateElementUrl(element)
+      )
+    } catch (error) {
+      return {
+        errors: [toSaltoWarning('unexpected error adding services url to elements')],
       }
     }
-
-    await awu(getRelevantElements(elements)).forEach(
-      async element => updateElementUrl(element)
-    )
+    return undefined
   },
 })
 

--- a/packages/salesforce-adapter/src/filters/elements_url.ts
+++ b/packages/salesforce-adapter/src/filters/elements_url.ts
@@ -28,16 +28,18 @@ const getRelevantElements = (elements: Element[]): AsyncIterable<Element> =>
   awu(elements)
     .flatMap(extractFlatCustomObjectFields)
 
+export const WARNING_MESSAGE = 'Encountered an error while trying to populate URLs for some of your salesforce configuration elements. This might affect the availability of the ‘go to service’ functionality in your workspace.'
+
 const filterCreator: FilterCreator = ({ client, config }) => ({
   onFetch: ensureSafeFilterFetch({
-    warningMessage: 'Encountered an error while trying to populate URLs for some of your salesforce configuration elements. This might affect the availability of the ‘go to service’ functionality in your workspace.',
+    warningMessage: WARNING_MESSAGE,
     config,
     filterName: 'elementsUrls',
     fetchFilterFunc: async (elements: Element[]) => {
       const url = await client.getUrl()
       if (url === undefined) {
         log.error('Failed to get salesforce URL')
-        return undefined
+        return
       }
 
       const referenceElements = buildElementsSourceForFetch(elements, config)
@@ -45,7 +47,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
 
       if (urlRetriever === undefined) {
         log.error('Failed to get salesforce URL')
-        return undefined
+        return
       }
 
       const updateElementUrl = async (element: Element): Promise<void> => {
@@ -59,7 +61,6 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
       await awu(getRelevantElements(elements)).forEach(
         async element => updateElementUrl(element)
       )
-      return undefined
     },
 
   }),

--- a/packages/salesforce-adapter/src/filters/elements_url.ts
+++ b/packages/salesforce-adapter/src/filters/elements_url.ts
@@ -18,7 +18,7 @@ import { CORE_ANNOTATIONS, Element } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
 import { lightningElementsUrlRetriever } from '../elements_url_retreiver/elements_url_retreiver'
-import { buildElementsSourceForFetch, extractFlatCustomObjectFields, ensureSafeFilterFetch, ensureFilterEnabled } from './utils'
+import { buildElementsSourceForFetch, extractFlatCustomObjectFields, ensureSafeFilterFetch } from './utils'
 
 const { awu } = collections.asynciterable
 
@@ -29,40 +29,40 @@ const getRelevantElements = (elements: Element[]): AsyncIterable<Element> =>
     .flatMap(extractFlatCustomObjectFields)
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
-  onFetch: ensureFilterEnabled(
-    ensureSafeFilterFetch(
-      async (elements: Element[]) => {
-        const url = await client.getUrl()
-        if (url === undefined) {
-          log.error('Failed to get salesforce URL')
-          return undefined
-        }
-
-        const referenceElements = buildElementsSourceForFetch(elements, config)
-        const urlRetriever = lightningElementsUrlRetriever(url, id => referenceElements.get(id))
-
-        if (urlRetriever === undefined) {
-          log.error('Failed to get salesforce URL')
-          return undefined
-        }
-
-        const updateElementUrl = async (element: Element): Promise<void> => {
-          const elementURL = await urlRetriever.retrieveUrl(element)
-
-          if (elementURL !== undefined) {
-            element.annotations[CORE_ANNOTATIONS.SERVICE_URL] = elementURL.href
-          }
-        }
-
-        await awu(getRelevantElements(elements)).forEach(
-          async element => updateElementUrl(element)
-        )
+  onFetch: ensureSafeFilterFetch({
+    warningMessage: 'Encountered an error while trying to populate URLs for some of your salesforce configuration elements. This might affect the availability of the ‘go to service’ functionality in your workspace.',
+    config,
+    filterName: 'elementsUrls',
+    fetchFilterFunc: async (elements: Element[]) => {
+      const url = await client.getUrl()
+      if (url === undefined) {
+        log.error('Failed to get salesforce URL')
         return undefined
-      },
-      'Failed to unexpected error when adding services url to elements'
-    ),
-    'elementsUrls', config
-  ),
+      }
+
+      const referenceElements = buildElementsSourceForFetch(elements, config)
+      const urlRetriever = lightningElementsUrlRetriever(url, id => referenceElements.get(id))
+
+      if (urlRetriever === undefined) {
+        log.error('Failed to get salesforce URL')
+        return undefined
+      }
+
+      const updateElementUrl = async (element: Element): Promise<void> => {
+        const elementURL = await urlRetriever.retrieveUrl(element)
+
+        if (elementURL !== undefined) {
+          element.annotations[CORE_ANNOTATIONS.SERVICE_URL] = elementURL.href
+        }
+      }
+
+      await awu(getRelevantElements(elements)).forEach(
+        async element => updateElementUrl(element)
+      )
+      return undefined
+    },
+
+  }),
 })
 
 export default filterCreator

--- a/packages/salesforce-adapter/src/filters/extra_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/extra_dependencies.ts
@@ -23,7 +23,7 @@ import { getAllReferencedIds, buildElementsSourceFromElements, extendGeneratedDe
 import { FilterCreator } from '../filter'
 import { metadataType, apiName, isCustomObject } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
-import { getInternalId, buildElementsSourceForFetch, extractFlatCustomObjectFields, hasInternalId } from './utils'
+import { getInternalId, buildElementsSourceForFetch, extractFlatCustomObjectFields, hasInternalId, toSaltoWarning } from './utils'
 
 const { awu } = collections.asynciterable
 const { isDefined } = lowerDashValues
@@ -189,28 +189,35 @@ const addExtraReferences = async (
 const creator: FilterCreator = ({ client, config }) => ({
   onFetch: async (elements: Element[]) => {
     if (!config.fetchProfile.isFeatureEnabled('extraDependencies')) {
-      return
+      return undefined
     }
-    const groupedDeps = await getDependencies(client)
-    const fetchedElements = buildElementsSourceFromElements(elements)
-    const allElements = buildElementsSourceForFetch(elements, config)
+    try {
+      const groupedDeps = await getDependencies(client)
+      const fetchedElements = buildElementsSourceFromElements(elements)
+      const allElements = buildElementsSourceForFetch(elements, config)
 
-    const { elemLookup, customObjectLookup } = await multiIndex.buildMultiIndex<Element>()
-      .addIndex({
-        name: 'elemLookup',
-        filter: hasInternalId,
-        key: async elem => [await metadataType(elem), getInternalId(elem)],
-        map: elem => elem.elemID,
-      })
-      .addIndex({
-        name: 'customObjectLookup',
-        filter: async elem => isCustomObject(elem),
-        key: async elem => [await apiName(elem)],
-        map: elem => elem.elemID,
-      })
-      .process(awu(await allElements.getAll()).flatMap(extractFlatCustomObjectFields))
+      const { elemLookup, customObjectLookup } = await multiIndex.buildMultiIndex<Element>()
+        .addIndex({
+          name: 'elemLookup',
+          filter: hasInternalId,
+          key: async elem => [await metadataType(elem), getInternalId(elem)],
+          map: elem => elem.elemID,
+        })
+        .addIndex({
+          name: 'customObjectLookup',
+          filter: async elem => isCustomObject(elem),
+          key: async elem => [await apiName(elem)],
+          map: elem => elem.elemID,
+        })
+        .process(awu(await allElements.getAll()).flatMap(extractFlatCustomObjectFields))
 
-    await addExtraReferences(groupedDeps, fetchedElements, elemLookup, customObjectLookup)
+      await addExtraReferences(groupedDeps, fetchedElements, elemLookup, customObjectLookup)
+    } catch (error) {
+      return {
+        errors: [toSaltoWarning('unexpected error when getting extra dependencies')],
+      }
+    }
+    return undefined
   },
 })
 

--- a/packages/salesforce-adapter/src/filters/extra_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/extra_dependencies.ts
@@ -183,13 +183,14 @@ const addExtraReferences = async (
   })
 }
 
+export const WARNING_MESSAGE = 'Encountered an error while trying to query your salesforce account for additional configuration dependencies.'
+
 /**
  * Add references using the tooling API.
  */
 const creator: FilterCreator = ({ client, config }) => ({
-
   onFetch: ensureSafeFilterFetch({
-    warningMessage: 'Encountered an error while trying to query your salesforce account for additional configuration dependencies.',
+    warningMessage: WARNING_MESSAGE,
     config,
     filterName: 'extraDependencies',
     fetchFilterFunc: async (elements: Element[]) => {

--- a/packages/salesforce-adapter/src/filters/extra_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/extra_dependencies.ts
@@ -210,7 +210,6 @@ const creator: FilterCreator = ({ client, config }) => ({
           .process(awu(await allElements.getAll()).flatMap(extractFlatCustomObjectFields))
 
         await addExtraReferences(groupedDeps, fetchedElements, elemLookup, customObjectLookup)
-        return undefined
       },
       'Failed to unexpected error when getting extra dependencies'
     ),

--- a/packages/salesforce-adapter/src/filters/profile_paths.ts
+++ b/packages/salesforce-adapter/src/filters/profile_paths.ts
@@ -62,9 +62,6 @@ const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'>
   onFetch: ensureFilterEnabled(
     ensureSafeFilterFetch(
       async (elements: Element[]) => {
-        if (!config.fetchProfile.isFeatureEnabled('profilePaths')) {
-          return undefined
-        }
         const profiles = await awu(elements)
           .filter(async e => isInstanceOfType(PROFILE_METADATA_TYPE)(e)).toArray()
         if (profiles.length > 0) {

--- a/packages/salesforce-adapter/src/filters/profile_paths.ts
+++ b/packages/salesforce-adapter/src/filters/profile_paths.ts
@@ -55,12 +55,14 @@ const replacePath = async (
   }
 }
 
+export const WARNING_MESSAGE = 'Failed to update the NaCl file names for some of your salesforce profiles. Therefore, profiles NaCl file names might differ from their display names in some cases.'
+
 /**
  * replace paths for profile instances upon fetch
  */
 const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
   onFetch: ensureSafeFilterFetch({
-    warningMessage: 'Failed to update the NaCl file names for some of your salesforce profiles. Therefore, profiles NaCl file names might differ from their display names in some cases.',
+    warningMessage: WARNING_MESSAGE,
     config,
     filterName: 'profilePaths',
     fetchFilterFunc: async (elements: Element[]) => {

--- a/packages/salesforce-adapter/src/filters/profile_paths.ts
+++ b/packages/salesforce-adapter/src/filters/profile_paths.ts
@@ -20,7 +20,7 @@ import { collections } from '@salto-io/lowerdash'
 import { FilterCreator, FilterWith } from '../filter'
 import { apiName } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
-import { getInternalId, isInstanceOfType, ensureSafeFilterFetch, ensureFilterEnabled } from './utils'
+import { getInternalId, isInstanceOfType, ensureSafeFilterFetch } from './utils'
 import { PROFILE_METADATA_TYPE } from '../constants'
 
 const { awu } = collections.asynciterable
@@ -59,22 +59,21 @@ const replacePath = async (
  * replace paths for profile instances upon fetch
  */
 const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
-  onFetch: ensureFilterEnabled(
-    ensureSafeFilterFetch(
-      async (elements: Element[]) => {
-        const profiles = await awu(elements)
-          .filter(async e => isInstanceOfType(PROFILE_METADATA_TYPE)(e)).toArray()
-        if (profiles.length > 0) {
-          const profileInternalIdToName = await generateProfileInternalIdToName(client)
-          await awu(profiles)
-            .filter(isInstanceElement)
-            .forEach(async inst => replacePath(inst, profileInternalIdToName))
-        }
-      },
-      'Failed to unexpected error when repalceing path for profile instances'
-    ),
-    'profilePaths', config
-  ),
+  onFetch: ensureSafeFilterFetch({
+    warningMessage: 'Failed to update the NaCl file names for some of your salesforce profiles. Therefore, profiles NaCl file names might differ from their display names in some cases.',
+    config,
+    filterName: 'profilePaths',
+    fetchFilterFunc: async (elements: Element[]) => {
+      const profiles = await awu(elements)
+        .filter(async e => isInstanceOfType(PROFILE_METADATA_TYPE)(e)).toArray()
+      if (profiles.length > 0) {
+        const profileInternalIdToName = await generateProfileInternalIdToName(client)
+        await awu(profiles)
+          .filter(isInstanceElement)
+          .forEach(async inst => replacePath(inst, profileInternalIdToName))
+      }
+    },
+  }),
 })
 
 export default filterCreator

--- a/packages/salesforce-adapter/src/filters/profile_paths.ts
+++ b/packages/salesforce-adapter/src/filters/profile_paths.ts
@@ -70,7 +70,6 @@ const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'>
             .filter(isInstanceElement)
             .forEach(async inst => replacePath(inst, profileInternalIdToName))
         }
-        return undefined
       },
       'Failed to unexpected error when repalceing path for profile instances'
     ),

--- a/packages/salesforce-adapter/src/filters/profile_paths.ts
+++ b/packages/salesforce-adapter/src/filters/profile_paths.ts
@@ -20,7 +20,7 @@ import { collections } from '@salto-io/lowerdash'
 import { FilterCreator, FilterWith } from '../filter'
 import { apiName } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
-import { getInternalId, isInstanceOfType, toSaltoWarning } from './utils'
+import { getInternalId, isInstanceOfType, ensureSafeFilterFetch, ensureFilterEnabled } from './utils'
 import { PROFILE_METADATA_TYPE } from '../constants'
 
 const { awu } = collections.asynciterable
@@ -59,26 +59,26 @@ const replacePath = async (
  * replace paths for profile instances upon fetch
  */
 const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
-  onFetch: async (elements: Element[]) => {
-    if (!config.fetchProfile.isFeatureEnabled('profilePaths')) {
-      return undefined
-    }
-    try {
-      const profiles = await awu(elements)
-        .filter(async e => isInstanceOfType(PROFILE_METADATA_TYPE)(e)).toArray()
-      if (profiles.length > 0) {
-        const profileInternalIdToName = await generateProfileInternalIdToName(client)
-        await awu(profiles)
-          .filter(isInstanceElement)
-          .forEach(async inst => replacePath(inst, profileInternalIdToName))
-      }
-    } catch (error) {
-      return {
-        errors: [toSaltoWarning('unexpected error when repalceing path for profile instances')],
-      }
-    }
-    return undefined
-  },
+  onFetch: ensureFilterEnabled(
+    ensureSafeFilterFetch(
+      async (elements: Element[]) => {
+        if (!config.fetchProfile.isFeatureEnabled('profilePaths')) {
+          return undefined
+        }
+        const profiles = await awu(elements)
+          .filter(async e => isInstanceOfType(PROFILE_METADATA_TYPE)(e)).toArray()
+        if (profiles.length > 0) {
+          const profileInternalIdToName = await generateProfileInternalIdToName(client)
+          await awu(profiles)
+            .filter(isInstanceElement)
+            .forEach(async inst => replacePath(inst, profileInternalIdToName))
+        }
+        return undefined
+      },
+      'Failed to unexpected error when repalceing path for profile instances'
+    ),
+    'profilePaths', config
+  ),
 })
 
 export default filterCreator

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -270,7 +270,7 @@ export const ensureSafeFilterFetch = ({
     try {
       return await fetchFilterFunc(elements)
     } catch (e) {
-      log.error('Failed to run filter with the following error %o, stack %o', e, e.stack)
+      log.error('failed to run filter with the following error %o, stack %o', e, e.stack)
       return {
         errors: [
           ({

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -255,13 +255,6 @@ export const isInstanceOfTypeChange = (type: string) => (
   )
 )
 
-export const toSaltoWarning = (message: string): SaltoError => (
-  ({
-    message,
-    severity: 'Warning',
-  })
-)
-
 export const ensureSafeFilterFetch = (
   fetchFilterFunc: Required<Filter>['onFetch'],
   warningMessage: string,
@@ -272,10 +265,16 @@ export const ensureSafeFilterFetch = (
     } catch (e) {
       log.error('Failed to run filter with the following error %o, stack %o', e, e.stack)
       return {
-        errors: [toSaltoWarning(warningMessage)],
+        errors: [
+          ({
+            message: warningMessage,
+            severity: 'Warning',
+          }),
+        ],
       }
     }
   }
+
 export const ensureFilterEnabled = (
   fetchFilterFunc: Required<Filter>['onFetch'],
   filterName: keyof OptionalFeatures,
@@ -283,7 +282,7 @@ export const ensureFilterEnabled = (
 ): Required<Filter>['onFetch'] =>
   async elements => {
     if (!config.fetchProfile.isFeatureEnabled(filterName)) {
-      log.debug('skipping %o filter due to configuration', filterName)
+      log.debug('skipping %s filter due to configuration', filterName)
       return undefined
     }
     return fetchFilterFunc(elements)

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -20,6 +20,7 @@ import {
   TypeElement, BuiltinTypes, ElemID, CoreAnnotationTypes, TypeMap, Value, ReadOnlyElementsSource,
   isReferenceExpression, ReferenceExpression, ChangeDataType, Change, ChangeData,
   isAdditionOrModificationChange, isRemovalOrModificationChange, getChangeElement, CORE_ANNOTATIONS,
+  SaltoError,
 } from '@salto-io/adapter-api'
 import { getParents, buildElementsSourceFromElements, createRefToElmWithValue } from '@salto-io/adapter-utils'
 import { FileProperties } from 'jsforce-types'
@@ -251,4 +252,11 @@ export const isInstanceOfTypeChange = (type: string) => (
   (change: Change): Promise<boolean> => (
     isInstanceOfType(type)(getChangeElement(change))
   )
+)
+
+export const toSaltoWarning = (message: string): SaltoError => (
+  ({
+    message,
+    severity: 'Warning',
+  })
 )

--- a/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
@@ -17,7 +17,7 @@ import { Element, ElemID, ObjectType, InstanceElement, BuiltinTypes, Field } fro
 import { createRefToElmWithValue } from '@salto-io/adapter-utils'
 import { FilterWith } from '../../src/filter'
 import SalesforceClient from '../../src/client/client'
-import filterCreator from '../../src/filters/add_missing_ids'
+import filterCreator, { WARNING_MESSAGE } from '../../src/filters/add_missing_ids'
 import mockClient from '../client'
 import {
   SALESFORCE, API_NAME, METADATA_TYPE, INSTANCE_FULL_NAME_FIELD, INTERNAL_ID_ANNOTATION,
@@ -209,7 +209,7 @@ describe('Internal IDs filter', () => {
       expect(res.errors).toHaveLength(1)
       expect(err[0]).toEqual({
         severity: 'Warning',
-        message: 'Encountered an error while trying populate internal IDs for some of your salesforce configuration elements. This might result in some missing configuration dependencies in your workspace and/or affect the availability of the ‘go to service’ functionality.',
+        message: WARNING_MESSAGE,
       })
     })
   })

--- a/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
@@ -196,9 +196,11 @@ describe('Internal IDs filter', () => {
       expect(elements[3].annotations?.[INTERNAL_ID_ANNOTATION]).toBeUndefined()
     })
   })
+
   describe('when feature is throwing an error', () => {
     const mockListMetadataObjects: jest.Mock = jest.fn()
     SalesforceClient.prototype.listMetadataObjects = mockListMetadataObjects
+
     it('should return a warning', async () => {
       const { connection } = mockClient()
       connection.query.mockImplementation(() => { throw new Error() })
@@ -206,13 +208,19 @@ describe('Internal IDs filter', () => {
       expect(res).toBeDefined()
       expect(res.errors).toBeDefined()
       const err = res.errors ?? []
-      expect(err[0].message).toEqual('unexpected error when adding missing ids')
+      expect(res.errors).toHaveLength(1)
+      expect(err[0]).toEqual({
+        severity: 'Warning',
+        message: 'Failed to unexpected error when adding missing ids',
+      })
     })
   })
+
   describe('when feature is disabled', () => {
     const mockListMetadataObjects: jest.Mock = jest.fn()
     SalesforceClient.prototype.listMetadataObjects = mockListMetadataObjects
     elements = generateElements()
+
     it('should not run any query', async () => {
       const { connection } = mockClient()
       expect(elements[4]).toBeInstanceOf(InstanceElement)

--- a/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
@@ -195,21 +195,6 @@ describe('Internal IDs filter', () => {
       expect(elements[2].annotations?.[INTERNAL_ID_ANNOTATION]).toBeUndefined()
       expect(elements[3].annotations?.[INTERNAL_ID_ANNOTATION]).toBeUndefined()
     })
-    it('should not run any query when feature is disabled', async () => {
-      const { connection } = mockClient()
-      expect(elements[4]).toBeInstanceOf(InstanceElement)
-      const inst = elements[4] as InstanceElement
-      filter = filterCreator({
-        client,
-        config: {
-          ...defaultFilterContext,
-          fetchProfile: buildFetchProfile({ optionalFeatures: { addMissingIds: false } }),
-        },
-      }) as FilterType
-      await filter.onFetch([inst])
-      expect(inst.value[INTERNAL_ID_FIELD]).toBeUndefined()
-      expect(connection.query).not.toHaveBeenCalled()
-    })
   })
   describe('when feature is throwing an error', () => {
     const mockListMetadataObjects: jest.Mock = jest.fn()
@@ -227,10 +212,11 @@ describe('Internal IDs filter', () => {
   describe('when feature is disabled', () => {
     const mockListMetadataObjects: jest.Mock = jest.fn()
     SalesforceClient.prototype.listMetadataObjects = mockListMetadataObjects
+    elements = generateElements()
     it('should not run any query', async () => {
       const { connection } = mockClient()
-      expect(elements[2]).toBeInstanceOf(InstanceElement)
-      const inst = elements[2] as InstanceElement
+      expect(elements[3]).toBeInstanceOf(InstanceElement)
+      const inst = elements[3] as InstanceElement
       filter = filterCreator({
         client,
         config: {

--- a/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
@@ -215,8 +215,8 @@ describe('Internal IDs filter', () => {
     elements = generateElements()
     it('should not run any query', async () => {
       const { connection } = mockClient()
-      expect(elements[3]).toBeInstanceOf(InstanceElement)
-      const inst = elements[3] as InstanceElement
+      expect(elements[4]).toBeInstanceOf(InstanceElement)
+      const inst = elements[4] as InstanceElement
       filter = filterCreator({
         client,
         config: {

--- a/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
@@ -205,8 +205,6 @@ describe('Internal IDs filter', () => {
       const { connection } = mockClient()
       connection.query.mockImplementation(() => { throw new Error() })
       const res = await filter.onFetch(elements) as FilterResult
-      expect(res).toBeDefined()
-      expect(res.errors).toBeDefined()
       const err = res.errors ?? []
       expect(res.errors).toHaveLength(1)
       expect(err[0]).toEqual({

--- a/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
@@ -209,7 +209,7 @@ describe('Internal IDs filter', () => {
       expect(res.errors).toHaveLength(1)
       expect(err[0]).toEqual({
         severity: 'Warning',
-        message: 'Failed to unexpected error when adding missing ids',
+        message: 'Encountered an error while trying populate internal IDs for some of your salesforce configuration elements. This might result in some missing configuration dependencies in your workspace and/or affect the availability of the ‘go to service’ functionality.',
       })
     })
   })

--- a/packages/salesforce-adapter/test/filters/elements_url.test.ts
+++ b/packages/salesforce-adapter/test/filters/elements_url.test.ts
@@ -19,7 +19,7 @@ import mockClient from '../client'
 import Connection from '../../src/client/jsforce'
 import SalesforceClient from '../../src/client/client'
 import { Filter } from '../../src/filter'
-import elementsUrlFilter from '../../src/filters/elements_url'
+import elementsUrlFilter, { WARNING_MESSAGE } from '../../src/filters/elements_url'
 import { defaultFilterContext, MockInterface } from '../utils'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 import { FilterResult } from '../../src/types'
@@ -119,7 +119,7 @@ describe('elements url filter', () => {
       expect(res.errors).toHaveLength(1)
       expect(err[0]).toEqual({
         severity: 'Warning',
-        message: 'Encountered an error while trying to populate URLs for some of your salesforce configuration elements. This might affect the availability of the ‘go to service’ functionality in your workspace.',
+        message: WARNING_MESSAGE,
       })
     })
   })

--- a/packages/salesforce-adapter/test/filters/elements_url.test.ts
+++ b/packages/salesforce-adapter/test/filters/elements_url.test.ts
@@ -119,7 +119,7 @@ describe('elements url filter', () => {
       expect(res.errors).toHaveLength(1)
       expect(err[0]).toEqual({
         severity: 'Warning',
-        message: 'Failed to unexpected error when adding services url to elements',
+        message: 'Encountered an error while trying to populate URLs for some of your salesforce configuration elements. This might affect the availability of the ‘go to service’ functionality in your workspace.',
       })
     })
   })

--- a/packages/salesforce-adapter/test/filters/elements_url.test.ts
+++ b/packages/salesforce-adapter/test/filters/elements_url.test.ts
@@ -118,7 +118,11 @@ describe('elements url filter', () => {
       expect(res).toBeDefined()
       expect(res.errors).toBeDefined()
       const err = res.errors ?? []
-      expect(err[0].message).toEqual('unexpected error adding services url to elements')
+      expect(res.errors).toHaveLength(1)
+      expect(err[0]).toEqual({
+        severity: 'Warning',
+        message: 'Failed to unexpected error when adding services url to elements',
+      })
     })
   })
   describe('when feature is disabled', () => {

--- a/packages/salesforce-adapter/test/filters/elements_url.test.ts
+++ b/packages/salesforce-adapter/test/filters/elements_url.test.ts
@@ -115,8 +115,6 @@ describe('elements url filter', () => {
       connection.instanceUrl = 'https://salto5-dev-ed.my.salesforce.com'
       const instance = new InstanceElement(ElemID.CONFIG_NAME, new ObjectType({ elemID: new ElemID('salesforce', 'BusinessHoursSettings'), annotations: { metadataType: 'BusinessHoursSettings' } }))
       const res = await filter.onFetch?.([instance]) as FilterResult
-      expect(res).toBeDefined()
-      expect(res.errors).toBeDefined()
       const err = res.errors ?? []
       expect(res.errors).toHaveLength(1)
       expect(err[0]).toEqual({

--- a/packages/salesforce-adapter/test/filters/elements_url.test.ts
+++ b/packages/salesforce-adapter/test/filters/elements_url.test.ts
@@ -20,14 +20,19 @@ import Connection from '../../src/client/jsforce'
 import SalesforceClient from '../../src/client/client'
 import { Filter } from '../../src/filter'
 import elementsUrlFilter from '../../src/filters/elements_url'
-import { defaultFilterContext } from '../utils'
+import { defaultFilterContext, MockInterface } from '../utils'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
+import { FilterResult } from '../../src/types'
+import * as ElementsUrlRetrieverModule from '../../src/elements_url_retreiver/elements_url_retreiver'
 
 describe('elements url filter', () => {
   let filter: Filter
   let client: SalesforceClient
-  let connection: Connection
+  let connection: MockInterface<Connection>
   let standardObject: ObjectType
+  const mockQueryAll: jest.Mock = jest.fn()
+  SalesforceClient.prototype.queryAll = mockQueryAll
+
 
   beforeEach(() => {
     ({ connection, client } = mockClient())
@@ -93,17 +98,41 @@ describe('elements url filter', () => {
     expect(element.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 
-  it('should not run any query when feature is disabled', async () => {
-    connection.instanceUrl = 'https://salto5-dev-ed.my.salesforce.com'
-    filter = elementsUrlFilter({
-      client,
-      config: {
-        ...defaultFilterContext,
-        fetchProfile: buildFetchProfile({ optionalFeatures: { elementsUrls: false } }),
-      },
+  describe('when feature is throwing an error', () => {
+    const elementsUrlRetreiverSpy = jest.spyOn(ElementsUrlRetrieverModule, 'lightningElementsUrlRetriever')
+
+    beforeEach(() => {
+      elementsUrlRetreiverSpy.mockImplementation(() => {
+        throw new Error()
+      })
     })
-    await filter.onFetch?.([standardObject])
-    expect(standardObject.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
-    expect(connection.query).not.toHaveBeenCalled()
+
+    afterEach(() => {
+      elementsUrlRetreiverSpy.mockReset()
+    })
+
+    it('should return a warning', async () => {
+      connection.instanceUrl = 'https://salto5-dev-ed.my.salesforce.com'
+      const instance = new InstanceElement(ElemID.CONFIG_NAME, new ObjectType({ elemID: new ElemID('salesforce', 'BusinessHoursSettings'), annotations: { metadataType: 'BusinessHoursSettings' } }))
+      const res = await filter.onFetch?.([instance]) as FilterResult
+      expect(res).toBeDefined()
+      expect(res.errors).toBeDefined()
+      const err = res.errors ?? []
+      expect(err[0].message).toEqual('unexpected error adding services url to elements')
+    })
+  })
+  describe('when feature is disabled', () => {
+    it('should not run any query', async () => {
+      connection.instanceUrl = 'https://salto5-dev-ed.my.salesforce.com'
+      filter = elementsUrlFilter({
+        client,
+        config: {
+          ...defaultFilterContext,
+          fetchProfile: buildFetchProfile({ optionalFeatures: { elementsUrls: false } }),
+        },
+      })
+      await filter.onFetch?.([standardObject])
+      expect(standardObject.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+    })
   })
 })

--- a/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
@@ -335,7 +335,7 @@ describe('extra dependencies filter', () => {
       expect(res.errors).toHaveLength(1)
       expect(err[0]).toEqual({
         severity: 'Warning',
-        message: 'Failed to unexpected error when getting extra dependencies',
+        message: 'Encountered an error while trying to query your salesforce account for additional configuration dependencies.',
       })
     })
   })

--- a/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
@@ -17,7 +17,7 @@ import { Element, ElemID, ObjectType, InstanceElement, BuiltinTypes, ReferenceEx
 import { buildElementsSourceFromElements, createRefToElmWithValue } from '@salto-io/adapter-utils'
 import { FilterWith } from '../../src/filter'
 import SalesforceClient from '../../src/client/client'
-import filterCreator from '../../src/filters/extra_dependencies'
+import filterCreator, { WARNING_MESSAGE } from '../../src/filters/extra_dependencies'
 import mockClient from '../client'
 import { createMetadataTypeElement, defaultFilterContext, MockInterface } from '../utils'
 import {
@@ -335,7 +335,7 @@ describe('extra dependencies filter', () => {
       expect(res.errors).toHaveLength(1)
       expect(err[0]).toEqual({
         severity: 'Warning',
-        message: 'Encountered an error while trying to query your salesforce account for additional configuration dependencies.',
+        message: WARNING_MESSAGE,
       })
     })
   })

--- a/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
@@ -331,8 +331,6 @@ describe('extra dependencies filter', () => {
       const { connection } = mockClient()
       connection.query.mockImplementation(() => { throw new Error() })
       const res = await filter.onFetch(elements) as FilterResult
-      expect(res).toBeDefined()
-      expect(res.errors).toBeDefined()
       const err = res.errors ?? []
       expect(res.errors).toHaveLength(1)
       expect(err[0]).toEqual({

--- a/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
@@ -323,6 +323,8 @@ describe('extra dependencies filter', () => {
     })
   })
   describe('when feature is throwing an error', () => {
+    const mockQueryAll: jest.Mock = jest.fn()
+    SalesforceClient.prototype.queryAll = mockQueryAll
     it('should return a warning', async () => {
       const { connection } = mockClient()
       connection.query.mockImplementation(() => { throw new Error() })

--- a/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
@@ -28,6 +28,8 @@ import { SalesforceRecord } from '../../src/client/types'
 import { Types } from '../../src/transformers/transformer'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 import Connection from '../../src/client/jsforce'
+import { FilterResult } from '../../src/types'
+
 
 const getGeneratedDeps = (elem: Element): ReferenceExpression[] => (
   elem.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]
@@ -320,7 +322,17 @@ describe('extra dependencies filter', () => {
       expect(getGeneratedDeps(workspaceInstance)).toBeUndefined()
     })
   })
-
+  describe('when feature is throwing an error', () => {
+    it('should return a warning', async () => {
+      const { connection } = mockClient()
+      connection.query.mockImplementation(() => { throw new Error() })
+      const res = await filter.onFetch(elements) as FilterResult
+      expect(res).toBeDefined()
+      expect(res.errors).toBeDefined()
+      const err = res.errors ?? []
+      expect(err[0].message).toEqual('unexpected error when getting extra dependencies')
+    })
+  })
   describe('when feature is disabled', () => {
     let connection: MockInterface<Connection>
     beforeEach(async () => {

--- a/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
@@ -322,9 +322,11 @@ describe('extra dependencies filter', () => {
       expect(getGeneratedDeps(workspaceInstance)).toBeUndefined()
     })
   })
+
   describe('when feature is throwing an error', () => {
     const mockQueryAll: jest.Mock = jest.fn()
     SalesforceClient.prototype.queryAll = mockQueryAll
+
     it('should return a warning', async () => {
       const { connection } = mockClient()
       connection.query.mockImplementation(() => { throw new Error() })
@@ -332,9 +334,14 @@ describe('extra dependencies filter', () => {
       expect(res).toBeDefined()
       expect(res.errors).toBeDefined()
       const err = res.errors ?? []
-      expect(err[0].message).toEqual('unexpected error when getting extra dependencies')
+      expect(res.errors).toHaveLength(1)
+      expect(err[0]).toEqual({
+        severity: 'Warning',
+        message: 'Failed to unexpected error when getting extra dependencies',
+      })
     })
   })
+
   describe('when feature is disabled', () => {
     let connection: MockInterface<Connection>
     beforeEach(async () => {
@@ -351,6 +358,7 @@ describe('extra dependencies filter', () => {
       }) as FilterType
       await filter.onFetch(elements)
     })
+
     it('should not run any query', () => {
       expect(connection.query).not.toHaveBeenCalled()
     })

--- a/packages/salesforce-adapter/test/filters/profile_paths.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_paths.test.ts
@@ -102,7 +102,7 @@ describe('profile paths filter', () => {
       expect(res.errors).toHaveLength(1)
       expect(err[0]).toEqual({
         severity: 'Warning',
-        message: 'Failed to unexpected error when repalceing path for profile instances',
+        message: 'Failed to update the NaCl file names for some of your salesforce profiles. Therefore, profiles NaCl file names might differ from their display names in some cases.',
       })
     })
   })

--- a/packages/salesforce-adapter/test/filters/profile_paths.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_paths.test.ts
@@ -91,8 +91,10 @@ describe('profile paths filter', () => {
   })
   describe('when feature is throwing an error', () => {
     it('should return a warning', async () => {
+      (await instance.getType()).annotations[METADATA_TYPE] = PROFILE_METADATA_TYPE
+      instance.value[INSTANCE_FULL_NAME_FIELD] = 'PlatformPortal'
+      instance.value[INTERNAL_ID_FIELD] = 'PlatformPortalInternalId'
       connection.query.mockImplementation(() => {
-        console.log('im here')
         throw new Error()
       })
       const res = await filter.onFetch([instance]) as FilterResult

--- a/packages/salesforce-adapter/test/filters/profile_paths.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_paths.test.ts
@@ -18,7 +18,7 @@ import {
   INSTANCE_FULL_NAME_FIELD, INTERNAL_ID_FIELD, METADATA_TYPE, PROFILE_METADATA_TYPE, RECORDS_PATH,
   SALESFORCE,
 } from '../../src/constants'
-import filterCreator from '../../src/filters/profile_paths'
+import filterCreator, { WARNING_MESSAGE } from '../../src/filters/profile_paths'
 import { FilterWith } from '../../src/filter'
 import mockClient from '../client'
 import { mockQueryResult } from '../connection'
@@ -102,7 +102,7 @@ describe('profile paths filter', () => {
       expect(res.errors).toHaveLength(1)
       expect(err[0]).toEqual({
         severity: 'Warning',
-        message: 'Failed to update the NaCl file names for some of your salesforce profiles. Therefore, profiles NaCl file names might differ from their display names in some cases.',
+        message: WARNING_MESSAGE,
       })
     })
   })

--- a/packages/salesforce-adapter/test/filters/profile_paths.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_paths.test.ts
@@ -98,8 +98,6 @@ describe('profile paths filter', () => {
         throw new Error()
       })
       const res = await filter.onFetch([instance]) as FilterResult
-      expect(res).toBeDefined()
-      expect(res.errors).toBeDefined()
       const err = res.errors ?? []
       expect(res.errors).toHaveLength(1)
       expect(err[0]).toEqual({

--- a/packages/salesforce-adapter/test/filters/profile_paths.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_paths.test.ts
@@ -101,7 +101,11 @@ describe('profile paths filter', () => {
       expect(res).toBeDefined()
       expect(res.errors).toBeDefined()
       const err = res.errors ?? []
-      expect(err[0].message).toEqual('unexpected error when repalceing path for profile instances')
+      expect(res.errors).toHaveLength(1)
+      expect(err[0]).toEqual({
+        severity: 'Warning',
+        message: 'Failed to unexpected error when repalceing path for profile instances',
+      })
     })
   })
   describe('when feature is disabled', () => {


### PR DESCRIPTION
Adding a try catch for each one of the filter that return a Salto error with severity of warning in case an error was catched.
---

_Additional context for reviewer_

---
_Release Notes_: 
Salesforce Adapter:
In case of an error during fetch in one of the filters below they will return warning and won't crash the fetch process:
extra_dependencies, add_missing_ids, profile_paths and elements_url 
