### PR TITLE
SALTO-1382 added core annotation '_service_id' to check if type is service_id type

### DIFF
--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -39,6 +39,7 @@ const StandardBuiltinTypes = {
   SERVICE_ID: new PrimitiveType({
     elemID: new ElemID(GLOBAL_ADAPTER, 'serviceid'),
     primitive: PrimitiveTypes.STRING,
+    annotations: { [CORE_ANNOTATIONS.SERVICE_ID]: true },
   }),
   JSON: new PrimitiveType({
     elemID: new ElemID(GLOBAL_ADAPTER, 'json'),
@@ -127,6 +128,14 @@ export const BuiltinTypes = {
   HIDDEN_STRING: new PrimitiveType({
     elemID: new ElemID(GLOBAL_ADAPTER, 'hidden_string'),
     primitive: PrimitiveTypes.STRING,
+    annotationRefsOrTypes: StandardCoreAnnotationTypes,
+    annotations: {
+      [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+    },
+  }),
+  HIDDEN_BOOLEAN: new PrimitiveType({
+    elemID: new ElemID(GLOBAL_ADAPTER, 'hidden_boolean'),
+    primitive: PrimitiveTypes.BOOLEAN,
     annotationRefsOrTypes: StandardCoreAnnotationTypes,
     annotations: {
       [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,

--- a/packages/adapter-api/src/core_annotations.ts
+++ b/packages/adapter-api/src/core_annotations.ts
@@ -23,4 +23,5 @@ export const CORE_ANNOTATIONS = {
   PARENT: '_parent',
   GENERATED_DEPENDENCIES: '_generated_dependencies',
   SERVICE_URL: '_service_url',
+  SERVICE_ID: '_service_id',
 }

--- a/packages/cli/e2e_test/salto.test.ts
+++ b/packages/cli/e2e_test/salto.test.ts
@@ -22,6 +22,8 @@ import { testHelpers as salesforceTestHelpers, SalesforceClient, UsernamePasswor
 import { Plan, SALTO_HOME_VAR } from '@salto-io/core'
 import { Workspace, parser } from '@salto-io/workspace'
 // eslint-disable-next-line no-restricted-imports
+import { Types } from '@salto-io/salesforce-adapter/dist/src/transformers/transformer'
+// eslint-disable-next-line no-restricted-imports
 import {
   API_NAME, CUSTOM_OBJECT, INSTANCE_FULL_NAME_FIELD, SALESFORCE, SALESFORCE_CUSTOM_SUFFIX,
   API_NAME_SEPARATOR, OBJECTS_PATH, METADATA_TYPE, CUSTOM_FIELD,
@@ -43,6 +45,7 @@ import {
   runClean,
 } from './helpers/workspace'
 import { instanceExists, objectExists, getSalesforceCredsInstance } from './helpers/salesforce'
+
 
 const { awu } = collections.asynciterable
 // let lastPlan: Plan
@@ -224,7 +227,7 @@ describe('cli e2e', () => {
         SALESFORCE,
         newObjectElemName,
         {
-          [API_NAME]: BuiltinTypes.SERVICE_ID,
+          [API_NAME]: Types.primitiveDataTypes.ServiceId,
           [METADATA_TYPE]: BuiltinTypes.SERVICE_ID,
         },
         { [API_NAME]: newObjectApiName, [METADATA_TYPE]: CUSTOM_OBJECT },
@@ -293,8 +296,8 @@ describe('cli e2e', () => {
         SALESFORCE,
         newObjectElemName,
         {
-          [API_NAME]: BuiltinTypes.SERVICE_ID,
-          [METADATA_TYPE]: BuiltinTypes.SERVICE_ID,
+          [API_NAME]: Types.primitiveDataTypes.ServiceId,
+          [METADATA_TYPE]: Types.primitiveDataTypes.ServiceId,
           enableFeeds: BuiltinTypes.BOOLEAN,
         },
         { [API_NAME]: newObjectApiName, [METADATA_TYPE]: CUSTOM_OBJECT },

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -17,10 +17,10 @@ import wu from 'wu'
 import _ from 'lodash'
 import { EventEmitter } from 'pietile-eventemitter'
 import {
-  Element, ElemID, AdapterOperations, Values, ServiceIds, BuiltinTypes, ObjectType,
+  Element, ElemID, AdapterOperations, Values, ServiceIds, ObjectType,
   toServiceIdsString, Field, OBJECT_SERVICE_ID, InstanceElement, isInstanceElement, isObjectType,
   ADAPTER, FIELD_NAME, INSTANCE_NAME, OBJECT_NAME, ElemIdGetter, DetailedChange, SaltoError,
-  ProgressReporter, ReferenceMap, ReadOnlyElementsSource,
+  ProgressReporter, ReadOnlyElementsSource, TypeMap, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import {
   applyInstancesDefaults, resolvePath, flattenElementStr,
@@ -541,19 +541,21 @@ export const fetchChanges = async (
 
 const id = (elemID: ElemID): string => elemID.getFullName()
 
-const getServiceIdsFromAnnotations = (annotationRefTypes: ReferenceMap, annotations: Values,
+const getServiceIdsFromAnnotations = (annotationRefTypes: TypeMap, annotations: Values,
   elemID: ElemID): ServiceIds =>
   _(Object.entries(annotationRefTypes))
     .filter(([_annotationName, annotationRefType]) =>
-      (annotationRefType.elemID.isEqual(BuiltinTypes.SERVICE_ID.elemID)))
+      (annotationRefType.annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true))
     .map(([annotationName, _annotationType]) =>
       [annotationName, annotations[annotationName] || id(elemID)])
     .fromPairs()
     .value()
 
-const getObjectServiceId = (objectType: ObjectType): string => {
-  const serviceIds = getServiceIdsFromAnnotations(objectType.annotationRefTypes,
-    objectType.annotations, objectType.elemID)
+const getObjectServiceId = async (objectType: ObjectType,
+  elementsSource: ReadOnlyElementsSource): Promise<string> => {
+  const serviceIds = getServiceIdsFromAnnotations(await objectType
+    .getAnnotationTypes(elementsSource),
+  objectType.annotations, objectType.elemID)
   if (_.isEmpty(serviceIds)) {
     serviceIds[OBJECT_NAME] = id(objectType.elemID)
   }
@@ -561,13 +563,14 @@ const getObjectServiceId = (objectType: ObjectType): string => {
   return toServiceIdsString(serviceIds)
 }
 
+
 const getFieldServiceId = async (
   objectServiceId: string,
   field: Field,
   elementsSource: ReadOnlyElementsSource,
 ): Promise<string> => {
   const serviceIds = getServiceIdsFromAnnotations(
-    (await field.getType(elementsSource)).annotationRefTypes,
+    (await (await field.getType(elementsSource)).getAnnotationTypes(elementsSource)),
     field.annotations,
     field.elemID
   )
@@ -584,18 +587,17 @@ const getInstanceServiceId = async (
   elementsSource: ReadOnlyElementsSource,
 ): Promise<string> => {
   const instType = await instanceElement.getType(elementsSource)
-  const serviceIds = _(Object.entries(instType.fields))
-    .filter(([_fieldName, field]) =>
-      (field.refType.elemID.isEqual(BuiltinTypes.SERVICE_ID.elemID)))
+  const serviceIds = Object.fromEntries(await awu(Object.entries(instType.fields))
+    .filter(async ([_fieldName, field]) =>
+      ((await field.getType(elementsSource)).annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true))
     .map(([fieldName, _field]) =>
       [fieldName, instanceElement.value[fieldName] || id(instanceElement.elemID)])
-    .fromPairs()
-    .value()
+    .toArray())
   if (_.isEmpty(serviceIds)) {
     serviceIds[INSTANCE_NAME] = id(instanceElement.elemID)
   }
   serviceIds[ADAPTER] = instanceElement.elemID.adapter
-  serviceIds[OBJECT_SERVICE_ID] = getObjectServiceId(instType)
+  serviceIds[OBJECT_SERVICE_ID] = await getObjectServiceId(instType, elementsSource)
   return toServiceIdsString(serviceIds)
 }
 
@@ -607,7 +609,7 @@ export const generateServiceIdToStateElemId = async (
     .filter(elem => isInstanceElement(elem) || isObjectType(elem))
     .flatMap(async elem => {
       if (isObjectType(elem)) {
-        const objectServiceId = getObjectServiceId(elem)
+        const objectServiceId = await getObjectServiceId(elem, elementsSource)
         const fieldPairs = await Promise.all(Object.values(elem.fields)
           .map(async field => [
             await getFieldServiceId(objectServiceId, field, elementsSource),

--- a/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  BuiltinTypes, ChangeError, ChangeValidator, CORE_ANNOTATIONS, getChangeElement, InstanceElement,
+  ChangeError, ChangeValidator, CORE_ANNOTATIONS, getChangeElement, InstanceElement,
   isInstanceChange, isModificationChange, isReferenceExpression,
 } from '@salto-io/adapter-api'
 import { getParents } from '@salto-io/adapter-utils'
@@ -44,7 +44,8 @@ const changeValidator: ChangeValidator = async changes => (
       const before = change.data.before as InstanceElement
       const after = change.data.after as InstanceElement
       const modifiedImmutableFields = await awu(Object.values((await after.getType()).fields))
-        .filter(async field => await field.getType() === BuiltinTypes.SERVICE_ID)
+        .filter(async field => (await field.getType())
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true)
         .filter(field => before.value[field.name] !== after.value[field.name])
         .map(field => field.name)
         .toArray()

--- a/packages/netsuite-adapter/src/reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/reference_dependencies.ts
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 import {
-  InstanceElement, isInstanceElement, isPrimitiveType, ElemID, getFieldType, BuiltinTypes,
-  isReferenceExpression, Value,
+  InstanceElement, isInstanceElement, isPrimitiveType, ElemID, getFieldType,
+  isReferenceExpression, Value, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
 import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
@@ -40,7 +40,8 @@ export const findDependingInstancesFromRefs = async (
       await topLevelParent.getType(),
       elemId.createTopLevelParentID().path
     )
-    return isPrimitiveType(fieldType) && fieldType.isEqual(BuiltinTypes.SERVICE_ID)
+    return (isPrimitiveType(fieldType)
+      && fieldType.annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true)
   }
 
   const createDependingElementsCallback: TransformFunc = async ({ value }) => {

--- a/packages/netsuite-adapter/test/types.test.ts
+++ b/packages/netsuite-adapter/test/types.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  BuiltinTypes, CORE_ANNOTATIONS, getRestriction, isPrimitiveType,
+  CORE_ANNOTATIONS, getRestriction, isPrimitiveType,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { values, collections } from '@salto-io/lowerdash'
@@ -68,7 +68,8 @@ describe('Types', () => {
       it('should have service_id path field', async () => {
         expect(Object.keys(fileCabinetTypes.file.fields)).toContain(PATH)
         const pathFieldType = await fileCabinetTypes.file.fields[PATH].getType()
-        expect(isPrimitiveType(pathFieldType) && pathFieldType.isEqual(BuiltinTypes.SERVICE_ID))
+        expect(isPrimitiveType(pathFieldType) && pathFieldType
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true)
           .toBe(true)
       })
 
@@ -91,7 +92,8 @@ describe('Types', () => {
       it('should have service_id path field', async () => {
         expect(Object.keys(fileCabinetTypes.folder.fields)).toContain(PATH)
         const pathFieldType = await fileCabinetTypes.folder.fields[PATH].getType()
-        expect(isPrimitiveType(pathFieldType) && pathFieldType.isEqual(BuiltinTypes.SERVICE_ID))
+        expect(isPrimitiveType(pathFieldType) && pathFieldType
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true)
           .toBe(true)
       })
 

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -59,6 +59,7 @@ export enum FIELD_TYPE_NAMES {
 export enum INTERNAL_FIELD_TYPE_NAMES {
   UNKNOWN = 'Unknown', // internal-only placeholder for fields whose type is unknown
   ANY = 'AnyType',
+  SERVICE_ID = 'ServiceId',
 }
 
 export type ALL_FIELD_TYPE_NAMES = FIELD_TYPE_NAMES | INTERNAL_FIELD_TYPE_NAMES

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -88,12 +88,12 @@ void => {
     log.debug(`added API_NAME=${fullApiName} to ${elem.elemID.name}`)
   }
   if (!isField(elem) && !elem.annotationRefTypes[API_NAME]) {
-    elem.annotationRefTypes[API_NAME] = createRefToElmWithValue(BuiltinTypes.SERVICE_ID)
+    elem.annotationRefTypes[API_NAME] = createRefToElmWithValue(Types.primitiveDataTypes.ServiceId)
   }
 }
 
 export const addMetadataType = (elem: ObjectType, metadataTypeValue = CUSTOM_OBJECT): void => {
-  setAnnotationDefault(elem, METADATA_TYPE, metadataTypeValue, BuiltinTypes.SERVICE_ID)
+  setAnnotationDefault(elem, METADATA_TYPE, metadataTypeValue, Types.primitiveDataTypes.ServiceId)
 }
 
 export const addDefaults = async (element: ChangeDataType): Promise<void> => {

--- a/packages/salesforce-adapter/src/filters/workflow.ts
+++ b/packages/salesforce-adapter/src/filters/workflow.ts
@@ -15,7 +15,7 @@
 */
 import {
   Element, InstanceElement, isInstanceElement, isObjectType, ReferenceExpression,
-  ObjectType, getChangeElement, Change, isAdditionChange, BuiltinTypes, ElemID,
+  ObjectType, getChangeElement, Change, isAdditionChange, ElemID,
 } from '@salto-io/adapter-api'
 import { createRefToElmWithValue } from '@salto-io/adapter-utils'
 import { collections, promises } from '@salto-io/lowerdash'
@@ -33,6 +33,7 @@ import { FilterCreator } from '../filter'
 import {
   apiName, metadataType, createInstanceElement, metadataAnnotationTypes, MetadataTypeAnnotations,
   toMetadataInfo,
+  Types,
 } from '../transformers/transformer'
 import { fullApiName, parentApiName, getDataFromChanges, isInstanceOfTypeChange, isInstanceOfType } from './utils'
 
@@ -125,7 +126,9 @@ const createDummyWorkflowInstance = async (
   const workflowType = new ObjectType({
     elemID: new ElemID(SALESFORCE, WORKFLOW_METADATA_TYPE),
     fields: {
-      [INSTANCE_FULL_NAME_FIELD]: { refType: createRefToElmWithValue(BuiltinTypes.SERVICE_ID) },
+      [INSTANCE_FULL_NAME_FIELD]: {
+        refType: createRefToElmWithValue(Types.primitiveDataTypes.ServiceId),
+      },
       ..._.mapValues(
         WORKFLOW_FIELD_TO_TYPE,
         typeName => (

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -396,9 +396,9 @@ export class Types {
     [BUSINESS_STATUS]: Types.BusinessStatusType,
     [SECURITY_CLASSIFICATION]: Types.SecurityClassificationType,
     [COMPLIANCE_GROUP]: BuiltinTypes.STRING,
-    [FIELD_ANNOTATIONS.CREATABLE]: BuiltinTypes.BOOLEAN,
-    [FIELD_ANNOTATIONS.UPDATEABLE]: BuiltinTypes.BOOLEAN,
-    [FIELD_ANNOTATIONS.QUERYABLE]: BuiltinTypes.BOOLEAN,
+    [FIELD_ANNOTATIONS.CREATABLE]: BuiltinTypes.HIDDEN_BOOLEAN,
+    [FIELD_ANNOTATIONS.UPDATEABLE]: BuiltinTypes.HIDDEN_BOOLEAN,
+    [FIELD_ANNOTATIONS.QUERYABLE]: BuiltinTypes.HIDDEN_BOOLEAN,
     [INTERNAL_ID_ANNOTATION]: BuiltinTypes.HIDDEN_STRING,
     [FIELD_ANNOTATIONS.EXTERNAL_ID]: BuiltinTypes.BOOLEAN,
     [FIELD_ANNOTATIONS.TRACK_TRENDING]: BuiltinTypes.BOOLEAN,
@@ -628,6 +628,14 @@ export class Types {
     AnyType: new PrimitiveType({
       elemID: new ElemID(SALESFORCE, INTERNAL_FIELD_TYPE_NAMES.ANY),
       primitive: PrimitiveTypes.UNKNOWN,
+      annotationRefsOrTypes: {
+        ...Types.commonAnnotationTypes,
+      },
+    }),
+    ServiceId: new PrimitiveType({
+      elemID: new ElemID(SALESFORCE, 'serviceid'),
+      primitive: PrimitiveTypes.STRING,
+      annotations: { [CORE_ANNOTATIONS.SERVICE_ID]: true },
       annotationRefsOrTypes: {
         ...Types.commonAnnotationTypes,
       },
@@ -999,7 +1007,7 @@ export const toCustomProperties = async (
 export const getValueTypeFieldElement = (parent: ObjectType, field: ValueTypeField,
   knownTypes: Map<string, TypeElement>, additionalAnnotations?: Values): Field => {
   const naclFieldType = (field.name === INSTANCE_FULL_NAME_FIELD)
-    ? BuiltinTypes.SERVICE_ID
+    ? Types.primitiveDataTypes.ServiceId
     : knownTypes.get(field.soapType) || Types.get(field.soapType, false)
   const annotations: Values = {
     ...(additionalAnnotations || {}),
@@ -1145,7 +1153,7 @@ export const getSObjectFieldElement = (
     // returned from the API is string)
     naclFieldType = getFieldType(FIELD_TYPE_NAMES.AUTONUMBER)
   } else if (field.idLookup && field.type === 'id') {
-    naclFieldType = BuiltinTypes.SERVICE_ID
+    naclFieldType = Types.primitiveDataTypes.ServiceId
   } else if (field.type === 'string' && !field.compoundFieldName) { // string
     naclFieldType = getFieldType(FIELD_TYPE_NAMES.TEXT)
   } else if ((field.type === 'double' && !field.compoundFieldName)) {
@@ -1302,7 +1310,7 @@ export type MetadataTypeAnnotations = {
 }
 
 export const metadataAnnotationTypes: Record<keyof MetadataTypeAnnotations, ReferenceExpression> = {
-  [METADATA_TYPE]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+  [METADATA_TYPE]: createRefToElmWithValue(Types.primitiveDataTypes.ServiceId),
   hasMetaFile: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
   folderType: createRefToElmWithValue(BuiltinTypes.STRING),
   folderContentType: createRefToElmWithValue(BuiltinTypes.STRING),

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -236,11 +236,13 @@ describe('SalesforceAdapter CRUD', () => {
         // Verify object creation
         expect(result).toBeInstanceOf(ObjectType)
         expect(result.annotations[constants.API_NAME]).toBe('Test__c')
-        expect(result.annotationRefTypes[constants.API_NAME].elemID)
-          .toEqual(BuiltinTypes.SERVICE_ID.elemID)
+        expect((await result.getAnnotationTypes())[constants.API_NAME]
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+          .toEqual(true)
         expect(result.annotations[constants.METADATA_TYPE]).toBe(constants.CUSTOM_OBJECT)
-        expect(result.annotationRefTypes[constants.METADATA_TYPE].elemID)
-          .toEqual(BuiltinTypes.SERVICE_ID.elemID)
+        expect((await result.getAnnotationTypes())[constants.METADATA_TYPE]
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+          .toEqual(true)
         const objAnnotations = result.annotations as CustomObject
         expect(objAnnotations.label).toEqual('Test')
         expect(result.annotationRefTypes.label.elemID)
@@ -641,7 +643,7 @@ describe('SalesforceAdapter CRUD', () => {
               token: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
               sandbox: { refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN) },
               [constants.INSTANCE_FULL_NAME_FIELD]: {
-                refType: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+                refType: createRefToElmWithValue(Types.primitiveDataTypes.ServiceId),
               },
             },
             annotationRefsOrTypes: {},
@@ -882,14 +884,14 @@ describe('SalesforceAdapter CRUD', () => {
             elemID: mockElemID,
             fields: {
               [constants.INSTANCE_FULL_NAME_FIELD]: {
-                refType: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+                refType: createRefToElmWithValue(Types.primitiveDataTypes.ServiceId),
               },
               [customLabelsFieldName]: {
                 refType: createRefToElmWithValue(new ObjectType({
                   elemID: mockElemID,
                   fields: {
                     [constants.INSTANCE_FULL_NAME_FIELD]: {
-                      refType: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+                      refType: createRefToElmWithValue(Types.primitiveDataTypes.ServiceId),
                     },
                   },
                   annotations: {

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -158,10 +158,12 @@ describe('SalesforceAdapter fetch', () => {
       // Note the order here is important because we expect restriction values to be sorted
       expect(getRestriction(flow.fields.enum).values).toEqual(['no', 'yes'])
       expect(flow.path).toEqual([constants.SALESFORCE, constants.TYPES_PATH, 'Flow'])
-      expect(await flow.fields[constants.INSTANCE_FULL_NAME_FIELD].getType())
-        .toEqual(BuiltinTypes.SERVICE_ID)
-      expect((await flow.getAnnotationTypes())[constants.METADATA_TYPE])
-        .toEqual(BuiltinTypes.SERVICE_ID)
+      expect((await flow.fields[constants.INSTANCE_FULL_NAME_FIELD].getType())
+        .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+        .toEqual(true)
+      expect((await flow.getAnnotationTypes())[constants.METADATA_TYPE]
+        .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+        .toEqual(true)
       expect(flow.annotations[constants.METADATA_TYPE]).toEqual('Flow')
     })
 

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -496,8 +496,12 @@ describe('Custom Objects filter', () => {
         mockSingleSObject('Lead', [])
         await filter.onFetch(result)
         const lead = findElements(result, 'Lead').pop() as ObjectType
-        expect((await lead.getAnnotationTypes())[API_NAME]).toEqual(BuiltinTypes.SERVICE_ID)
-        expect((await lead.getAnnotationTypes())[METADATA_TYPE]).toEqual(BuiltinTypes.SERVICE_ID)
+        expect((await lead.getAnnotationTypes())[API_NAME]
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+          .toEqual(true)
+        expect((await lead.getAnnotationTypes())[METADATA_TYPE]
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+          .toEqual(true)
         expect(lead.annotations[API_NAME]).toEqual('Lead')
         expect(lead.annotations[METADATA_TYPE]).toEqual(CUSTOM_OBJECT)
       })
@@ -743,7 +747,7 @@ describe('Custom Objects filter', () => {
         const flowElemID = mockGetElemIdFunc(SALESFORCE, {}, 'flow')
         const flowMetadataType = new ObjectType({ elemID: flowElemID,
           annotations: { [METADATA_TYPE]: 'Flow' },
-          annotationRefsOrTypes: { [METADATA_TYPE]: BuiltinTypes.SERVICE_ID },
+          annotationRefsOrTypes: { [METADATA_TYPE]: Types.primitiveDataTypes.ServiceId },
           path: [SALESFORCE, TYPES_PATH, 'flow'] })
         result.push(flowMetadataType)
 
@@ -1615,8 +1619,8 @@ describe('Custom Objects filter', () => {
           },
         },
         annotationRefsOrTypes: {
-          [METADATA_TYPE]: BuiltinTypes.SERVICE_ID,
-          [API_NAME]: BuiltinTypes.SERVICE_ID,
+          [METADATA_TYPE]: Types.primitiveDataTypes.ServiceId,
+          [API_NAME]: Types.primitiveDataTypes.ServiceId,
           [LABEL]: BuiltinTypes.STRING,
           sharingModel: BuiltinTypes.STRING,
         },

--- a/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
@@ -49,7 +49,9 @@ describe('extra dependencies filter', () => {
       {
         fields: {
           fieldName: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
-          [INSTANCE_FULL_NAME_FIELD]: { refType: createRefToElmWithValue(BuiltinTypes.SERVICE_ID) },
+          [INSTANCE_FULL_NAME_FIELD]: {
+            refType: createRefToElmWithValue(Types.primitiveDataTypes.ServiceId),
+          },
         },
       }
     )

--- a/packages/salesforce-adapter/test/filters/topics_for_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/topics_for_objects.test.ts
@@ -16,7 +16,7 @@
 import { ObjectType, ElemID, InstanceElement, isObjectType, BuiltinTypes, toChange, Change, getChangeElement, isInstanceChange } from '@salto-io/adapter-api'
 import { createRefToElmWithValue } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { metadataType, apiName, MetadataTypeAnnotations } from '../../src/transformers/transformer'
+import { metadataType, apiName, MetadataTypeAnnotations, Types } from '../../src/transformers/transformer'
 import * as constants from '../../src/constants'
 import { FilterWith } from '../../src/filter'
 import mockClient from '../client'
@@ -50,7 +50,7 @@ describe('Topics for objects filter', () => {
       [ENABLE_TOPICS]: { refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN) },
       [ENTITY_API_NAME]: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
       [constants.INSTANCE_FULL_NAME_FIELD]: {
-        refType: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+        refType: createRefToElmWithValue(Types.primitiveDataTypes.ServiceId),
       },
     },
     annotationRefsOrTypes: {},

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -92,8 +92,8 @@ describe('addDefaults', () => {
       })
       it('should add annotation types', () => {
         expect(object.annotationRefTypes).toMatchObject({
-          [API_NAME]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
-          [METADATA_TYPE]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+          [API_NAME]: createRefToElmWithValue(Types.primitiveDataTypes.ServiceId),
+          [METADATA_TYPE]: createRefToElmWithValue(Types.primitiveDataTypes.ServiceId),
           [LABEL]: createRefToElmWithValue(BuiltinTypes.STRING),
           deploymentStatus: createRefToElmWithValue(BuiltinTypes.STRING),
           pluralLabel: createRefToElmWithValue(BuiltinTypes.STRING),
@@ -142,7 +142,7 @@ describe('addDefaults', () => {
       })
       it('should add missing annotation types', () => {
         expect(object.annotationRefTypes).toMatchObject({
-          [API_NAME]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+          [API_NAME]: createRefToElmWithValue(Types.primitiveDataTypes.ServiceId),
           [LABEL]: createRefToElmWithValue(BuiltinTypes.STRING),
         })
         expect(object.annotationRefTypes.nameField?.elemID).toEqual(
@@ -191,8 +191,8 @@ describe('addDefaults', () => {
     })
     it('should add annotation types', () => {
       expect(object.annotationRefTypes).toMatchObject({
-        [API_NAME]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
-        [METADATA_TYPE]: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+        [API_NAME]: createRefToElmWithValue(Types.primitiveDataTypes.ServiceId),
+        [METADATA_TYPE]: createRefToElmWithValue(Types.primitiveDataTypes.ServiceId),
         [LABEL]: createRefToElmWithValue(BuiltinTypes.STRING),
       })
     })

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -14,10 +14,10 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ObjectType, ElemID, TypeElement, BuiltinTypes, ListType } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, TypeElement, ListType } from '@salto-io/adapter-api'
 import { createRefToElmWithValue } from '@salto-io/adapter-utils'
 import { SALESFORCE, INSTANCE_FULL_NAME_FIELD, ASSIGNMENT_RULES_METADATA_TYPE, WORKFLOW_METADATA_TYPE, LIGHTNING_COMPONENT_BUNDLE_METADATA_TYPE, SETTINGS_METADATA_TYPE } from '../src/constants'
-import { MetadataTypeAnnotations, MetadataObjectType } from '../src/transformers/transformer'
+import { MetadataTypeAnnotations, MetadataObjectType, Types } from '../src/transformers/transformer'
 import { allMissingSubTypes } from '../src/transformers/salesforce_types'
 import { API_VERSION } from '../src/client/client'
 import { WORKFLOW_FIELD_TO_TYPE } from '../src/filters/workflow'
@@ -34,7 +34,7 @@ const createMetadataObjectType = (
   ...params,
   fields: {
     [INSTANCE_FULL_NAME_FIELD]: {
-      refType: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+      refType: createRefToElmWithValue(Types.primitiveDataTypes.ServiceId),
     },
     ...params.fields,
   },

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -411,7 +411,8 @@ describe('transformer', () => {
         salesforceIdField = _.cloneDeep(origSalesforceIdField)
         const fieldElement = getSObjectFieldElement(dummyElem, salesforceIdField,
           serviceIds, {})
-        expect(await fieldElement.getType()).toEqual(BuiltinTypes.SERVICE_ID)
+        expect((await fieldElement.getType()).annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+          .toEqual(true)
       })
     })
 
@@ -582,7 +583,7 @@ describe('transformer', () => {
       const objType = new ObjectType({
         elemID,
         annotationRefsOrTypes: {
-          [API_NAME]: BuiltinTypes.SERVICE_ID,
+          [API_NAME]: Types.primitiveDataTypes.ServiceId,
           [METADATA_TYPE]: BuiltinTypes.STRING,
           [DESCRIPTION]: BuiltinTypes.STRING,
         },
@@ -673,7 +674,7 @@ describe('transformer', () => {
           const customSettingsObj = new ObjectType({
             elemID,
             annotationRefsOrTypes: {
-              [API_NAME]: BuiltinTypes.SERVICE_ID,
+              [API_NAME]: Types.primitiveDataTypes.ServiceId,
               [METADATA_TYPE]: BuiltinTypes.STRING,
               [DESCRIPTION]: BuiltinTypes.STRING,
               [CUSTOM_SETTINGS_TYPE]: BuiltinTypes.STRING,
@@ -1133,7 +1134,9 @@ describe('transformer', () => {
   describe('type definitions', () => {
     it('should include apiName annotation with service_id type', async () => {
       await awu(Object.values(Types.getAllFieldTypes())).forEach(async type => {
-        expect((await type.getAnnotationTypes())[API_NAME]).toEqual(BuiltinTypes.SERVICE_ID)
+        expect((await type.getAnnotationTypes())[API_NAME]
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+          .toEqual(true)
       })
     })
   })


### PR DESCRIPTION
_Release Notes_: 
Standard built in type "SERVICE_ID" has a new annotation '_service_id' = true
We use this annotation to decide wether a type is a SERVICE_ID or not.
