### PR TITLE
SALTO-1414: changed package change validator to warning

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/package.ts
+++ b/packages/salesforce-adapter/src/change_validators/package.ts
@@ -49,7 +49,7 @@ const packageChangeError = (
   detailedMessage = `Cannot ${action} ${element.elemID.idType} because it is part of a package`,
 ): ChangeError => ({
   elemID: element.elemID,
-  severity: 'Warning',
+  severity: 'Error',
   message: `Cannot change a managed package using Salto. Package namespace: ${getNamespace(element)}`,
   detailedMessage,
 })

--- a/packages/salesforce-adapter/src/change_validators/package.ts
+++ b/packages/salesforce-adapter/src/change_validators/package.ts
@@ -42,7 +42,7 @@ const packageChangeError = (
   detailedMessage = `Cannot ${action} ${element.elemID.idType} because it is part of a package`,
 ): ChangeError => ({
   elemID: element.elemID,
-  severity: 'Error',
+  severity: 'Warning',
   message: `Cannot change a managed package using Salto. Package namespace: ${getNamespace(element)}`,
   detailedMessage,
 })

--- a/packages/salesforce-adapter/src/change_validators/package.ts
+++ b/packages/salesforce-adapter/src/change_validators/package.ts
@@ -15,8 +15,9 @@
 */
 import { Element, getChangeElement, InstanceElement, isAdditionChange, isModificationChange, isObjectType, isRemovalChange, ChangeError, ChangeValidator, ActionName, isInstanceChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { apiName, isCustom, metadataType } from '../transformers/transformer'
+import { apiName, metadataType } from '../transformers/transformer'
 import { NAMESPACE_SEPARATOR } from '../constants'
+import { INSTANCE_SUFFIXES } from '../types'
 
 
 export const hasNamespace = (customElement: Element): boolean => {
@@ -25,8 +26,14 @@ export const hasNamespace = (customElement: Element): boolean => {
     return false
   }
   const partialFullName = apiNameResult.split('-')[0]
-  const cleanFullName = isCustom(partialFullName)
-    ? partialFullName.slice(0, -3) : partialFullName
+
+  const elementSuffix = INSTANCE_SUFFIXES
+    .map(suffix => `__${suffix}`)
+    .find(suffix => partialFullName.endsWith(suffix))
+
+  const cleanFullName = elementSuffix !== undefined
+    ? partialFullName.slice(0, -elementSuffix.length)
+    : partialFullName
   return cleanFullName.includes(NAMESPACE_SEPARATOR)
 }
 

--- a/packages/salesforce-adapter/src/deprecated_config.ts
+++ b/packages/salesforce-adapter/src/deprecated_config.ts
@@ -21,7 +21,7 @@ import _ from 'lodash'
 import { ConfigChange } from './config_change'
 import { ConfigValidationError, validateRegularExpressions } from './config_validation'
 import { validateDataManagementConfig } from './fetch_profile/data_management'
-import { DataManagementConfig, DATA_CONFIGURATION, DATA_MANAGEMENT, DeprecatedFetchParameters, DeprecatedMetadataParams, FetchParameters, FETCH_CONFIG, INSTANCES_REGEX_SKIPPED_LIST, MetadataParams, METADATA_CONFIG, METADATA_TYPES_SKIPPED_LIST } from './types'
+import { DataManagementConfig, DATA_CONFIGURATION, DATA_MANAGEMENT, DeprecatedFetchParameters, DeprecatedMetadataParams, FetchParameters, FETCH_CONFIG, INSTANCES_REGEX_SKIPPED_LIST, INSTANCE_SUFFIXES, MetadataParams, METADATA_CONFIG, METADATA_TYPES_SKIPPED_LIST } from './types'
 
 export const DEPRECATED_OPTIONS_MESSAGE = 'The configuration options "metadataTypesSkippedList", "instancesRegexSkippedList" and "dataManagement" are deprecated.'
 + ' The following changes will update the deprecated options to the "fetch" configuration option.'
@@ -30,11 +30,6 @@ export const DEPRECATED_OPTIONS_MESSAGE = 'The configuration options "metadataTy
 const { makeArray } = collections.array
 const log = logger(module)
 
-// Based on the list in https://salesforce.stackexchange.com/questions/101844/what-are-the-object-and-field-name-suffixes-that-salesforce-uses-such-as-c-an
-const INSTANCE_SUFFIXES = [
-  'c', 'r', 'ka', 'kav', 'Feed', 'ViewStat', 'VoteStat', 'DataCategorySelection', 'x', 'xo', 'mdt', 'Share', 'Tag',
-  'History', 'pc', 'pr', 'hd', 'hqr', 'hst', 'b', 'latitude__s', 'longitude__s', 'e', 'p', 'ChangeEvent', 'chn',
-]
 export const PACKAGES_INSTANCES_REGEX = `^.+\\.(?!standard_)[^_]+__(?!(${INSTANCE_SUFFIXES.join('|')})([^a-zA-Z\\d_]+|$)).+$`
 
 const DEPRECATED_FIELDS = [

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -38,6 +38,11 @@ export const DATA_MANAGEMENT = 'dataManagement'
 export const INSTANCES_REGEX_SKIPPED_LIST = 'instancesRegexSkippedList'
 export const SHOULD_FETCH_ALL_CUSTOM_SETTINGS = 'fetchAllCustomSettings'
 
+// Based on the list in https://salesforce.stackexchange.com/questions/101844/what-are-the-object-and-field-name-suffixes-that-salesforce-uses-such-as-c-an
+export const INSTANCE_SUFFIXES = [
+  'c', 'r', 'ka', 'kav', 'Feed', 'ViewStat', 'VoteStat', 'DataCategorySelection', 'x', 'xo', 'mdt', 'Share', 'Tag',
+  'History', 'pc', 'pr', 'hd', 'hqr', 'hst', 'b', 'latitude__s', 'longitude__s', 'e', 'p', 'ChangeEvent', 'chn',
+]
 
 export type MetadataInstance = {
   metadataType: string

--- a/packages/salesforce-adapter/test/change_validators/package.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/package.test.ts
@@ -42,7 +42,7 @@ describe('package change validator', () => {
         obj.annotate({ [API_NAME]: 'MyNamespace__ObjectName__c' })
         const changeErrors = await packageValidator([toChange({ after: obj })])
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].severity).toEqual('Warning')
         expect(changeErrors[0].elemID).toEqual(obj.elemID)
       })
 
@@ -53,7 +53,7 @@ describe('package change validator', () => {
           [{ after: obj }, { after: obj.fields.field }].map(toChange)
         )
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].severity).toEqual('Warning')
         expect(changeErrors[0].elemID).toEqual(obj.fields.field.elemID)
       })
 
@@ -74,7 +74,7 @@ describe('package change validator', () => {
         inst.value[INSTANCE_FULL_NAME_FIELD] = 'MyNamespace__InstanceName__c'
         const changeErrors = await packageValidator([toChange({ after: inst })])
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].severity).toEqual('Warning')
         expect(changeErrors[0].elemID).toEqual(inst.elemID)
       })
 
@@ -97,7 +97,7 @@ describe('package change validator', () => {
         obj.annotate({ [API_NAME]: 'MyNamespace__ObjectName__c' })
         const changeErrors = await packageValidator([toChange({ before: obj })])
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].severity).toEqual('Warning')
         expect(changeErrors[0].elemID).toEqual(obj.elemID)
       })
 
@@ -108,9 +108,9 @@ describe('package change validator', () => {
           [{ before: obj }, { before: obj.fields.field }].map(toChange)
         )
         expect(changeErrors).toHaveLength(2)
-        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].severity).toEqual('Warning')
         expect(changeErrors[0].elemID).toEqual(obj.fields.field.elemID)
-        expect(changeErrors[1].severity).toEqual('Error')
+        expect(changeErrors[1].severity).toEqual('Warning')
         expect(changeErrors[1].elemID).toEqual(obj.elemID)
       })
 
@@ -130,7 +130,7 @@ describe('package change validator', () => {
         inst.value[INSTANCE_FULL_NAME_FIELD] = 'MyNamespace__InstanceName__c'
         const changeErrors = await packageValidator([toChange({ before: inst })])
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].severity).toEqual('Warning')
         expect(changeErrors[0].elemID).toEqual(inst.elemID)
       })
 
@@ -153,7 +153,7 @@ describe('package change validator', () => {
         const newField = addField('ObjectName__c.MyNamespace__FieldName__c')
         const changeErrors = await packageValidator([toChange({ after: newField })])
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].severity).toEqual('Warning')
         expect(changeErrors[0].elemID).toEqual(newField.elemID)
       })
 
@@ -181,7 +181,7 @@ describe('package change validator', () => {
         const oldField = addField('ObjectName__c.MyNamespace__FieldName__c')
         const changeErrors = await packageValidator([toChange({ before: oldField })])
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].severity).toEqual('Warning')
         expect(changeErrors[0].elemID).toEqual(oldField.elemID)
       })
 
@@ -213,7 +213,7 @@ describe('package change validator', () => {
         after.value[PACKAGE_VERSION_FIELD_NAME] = '1.1'
         const changeErrors = await packageValidator([toChange({ before: inst, after })])
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].severity).toEqual('Warning')
         expect(changeErrors[0].elemID).toEqual(after.elemID)
       })
     })

--- a/packages/salesforce-adapter/test/change_validators/package.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/package.test.ts
@@ -48,7 +48,7 @@ describe('package change validator', () => {
         obj.annotate({ [API_NAME]: 'MyNamespace__ObjectName__c' })
         const changeErrors = await packageValidator([toChange({ after: obj })])
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Warning')
+        expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(obj.elemID)
       })
 
@@ -59,7 +59,7 @@ describe('package change validator', () => {
           [{ after: obj }, { after: obj.fields.field }].map(toChange)
         )
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Warning')
+        expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(obj.fields.field.elemID)
       })
 
@@ -80,7 +80,7 @@ describe('package change validator', () => {
         inst.value[INSTANCE_FULL_NAME_FIELD] = 'MyNamespace__InstanceName__c'
         const changeErrors = await packageValidator([toChange({ after: inst })])
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Warning')
+        expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(inst.elemID)
       })
 
@@ -103,7 +103,7 @@ describe('package change validator', () => {
         obj.annotate({ [API_NAME]: 'MyNamespace__ObjectName__c' })
         const changeErrors = await packageValidator([toChange({ before: obj })])
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Warning')
+        expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(obj.elemID)
       })
 
@@ -114,9 +114,9 @@ describe('package change validator', () => {
           [{ before: obj }, { before: obj.fields.field }].map(toChange)
         )
         expect(changeErrors).toHaveLength(2)
-        expect(changeErrors[0].severity).toEqual('Warning')
+        expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(obj.fields.field.elemID)
-        expect(changeErrors[1].severity).toEqual('Warning')
+        expect(changeErrors[1].severity).toEqual('Error')
         expect(changeErrors[1].elemID).toEqual(obj.elemID)
       })
 
@@ -136,7 +136,7 @@ describe('package change validator', () => {
         inst.value[INSTANCE_FULL_NAME_FIELD] = 'MyNamespace__InstanceName__c'
         const changeErrors = await packageValidator([toChange({ before: inst })])
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Warning')
+        expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(inst.elemID)
       })
 
@@ -159,7 +159,7 @@ describe('package change validator', () => {
         const newField = addField('ObjectName__c.MyNamespace__FieldName__c')
         const changeErrors = await packageValidator([toChange({ after: newField })])
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Warning')
+        expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(newField.elemID)
       })
 
@@ -187,7 +187,7 @@ describe('package change validator', () => {
         const oldField = addField('ObjectName__c.MyNamespace__FieldName__c')
         const changeErrors = await packageValidator([toChange({ before: oldField })])
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Warning')
+        expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(oldField.elemID)
       })
 
@@ -219,7 +219,7 @@ describe('package change validator', () => {
         after.value[PACKAGE_VERSION_FIELD_NAME] = '1.1'
         const changeErrors = await packageValidator([toChange({ before: inst, after })])
         expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Warning')
+        expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(after.elemID)
       })
     })

--- a/packages/salesforce-adapter/test/change_validators/package.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/package.test.ts
@@ -38,6 +38,12 @@ describe('package change validator', () => {
   }
   describe('onAdd', () => {
     describe('Object', () => {
+      it('should have no change errors when adding an object without namespace with __e suffix', async () => {
+        obj.annotate({ [API_NAME]: 'TestEvent2__e' })
+        const changeErrors = await packageValidator([toChange({ after: obj })])
+        expect(changeErrors).toHaveLength(0)
+      })
+
       it('should have change error when adding an object with namespace', async () => {
         obj.annotate({ [API_NAME]: 'MyNamespace__ObjectName__c' })
         const changeErrors = await packageValidator([toChange({ after: obj })])


### PR DESCRIPTION
Fixed package change validator to work for elements with API name with suffixes different than `__c`

---
_Release Notes_: 
Salesforce adapter:
Fixed a bug where for some elements, while deploying them, Salto would misclassify them as elements that belong to a namespace and throw an error about it.
