### PR TITLE
SALTO-1424 escape digit-only identifiers in naclCase

### DIFF
--- a/packages/adapter-components/test/elements/ducktype/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/instance_elements.test.ts
@@ -117,6 +117,28 @@ describe('ducktype_instance_elements', () => {
       ))).toBeTruthy()
       expect(inst?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', 'some_other_name_54775'])
     })
+    it('should escape id part when it only contains digits', async () => {
+      const inst = await toInstance({
+        type,
+        transformationConfigByType: {
+          bla: {
+            idFields: ['id'],
+          },
+        },
+        transformationDefaultConfig: {
+          idFields: ['somethingElse'],
+        },
+        defaultName: 'abc',
+        entry,
+      })
+      expect(inst).toBeDefined()
+      expect(inst?.isEqual(new InstanceElement(
+        '54775@',
+        type,
+        entry,
+      ))).toBeTruthy()
+      expect(inst?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', '54775'])
+    })
     it('should include parent name when nestName is true', async () => {
       const parent = new InstanceElement('abc', type, {})
       const inst = await toInstance({

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -634,6 +634,17 @@ describe('swagger_instance_elements', () => {
             food2: { id: 'f2' },
           },
         ]
+        yield [
+          {
+            id: '33',
+            name: 'def',
+            owners: [
+              { name: 'o3', bla: 'BLA', x: { nested: 'value' } },
+            ],
+            food1: { id: 'f1' },
+            food2: { id: 'f2' },
+          },
+        ]
       })
       const res = await getAllInstances({
         paginator: mockPaginator,
@@ -659,11 +670,12 @@ describe('swagger_instance_elements', () => {
           PetList,
         },
       })
-      expect(res).toHaveLength(3)
+      expect(res).toHaveLength(4)
       expect(res.map(e => e.elemID.getFullName())).toEqual([
         `${ADAPTER_NAME}.Pet.instance.dog`,
         `${ADAPTER_NAME}.Pet.instance.cat`,
         `${ADAPTER_NAME}.Pet.instance.mouse`,
+        `${ADAPTER_NAME}.Pet.instance.33@`, // digit-only ids should be escaped
       ])
       expect(mockPaginator).toHaveBeenCalledTimes(1)
       expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet_list', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined })

--- a/packages/adapter-utils/src/nacl_case_utils.ts
+++ b/packages/adapter-utils/src/nacl_case_utils.ts
@@ -57,6 +57,7 @@ const defaultNaclCaseMapping = {
   '~': 'zb',
   '$': 'zc',
   ',': 'zd',
+  '+': 'ze',
 } as Record<string, string>
 
 const suffixFromList = (specialCharsMappingList: string[]): string => {
@@ -78,6 +79,10 @@ export const naclCase = (name?: string): string => {
   // then add a special chars mapping after the separator for uniqueness
   if (name === undefined) {
     return ''
+  }
+  if (/^\d+$/.test(name)) {
+    // use suffix to avoid having a digit-only identifier
+    return `${name}${NACL_ESCAPING_SUFFIX_SEPARATOR}`
   }
   const specialCharsMappingList: string[] = []
   const replaceChar = (char: string): string => {

--- a/packages/adapter-utils/test/nacl_case_utils.test.ts
+++ b/packages/adapter-utils/test/nacl_case_utils.test.ts
@@ -43,6 +43,24 @@ describe('naclCase utils', () => {
       })
     })
 
+    describe('When all characters are digits', () => {
+      const digitOnly = [
+        '1231', '0000', '0123', '6547587474574',
+      ]
+      it('Should append the escaping separator', () => {
+        digitOnly.forEach(name => expect(naclCase(name)).toEqual(`${name}@`))
+      })
+    })
+    describe('When the value is numeric but not all characters are digits', () => {
+      it('Should use regular escaping', () => {
+        expect(naclCase('-1')).toEqual('_1@b')
+        expect(naclCase('+1')).toEqual('_1@ze')
+        expect(naclCase('23a')).toEqual('23a')
+        expect(naclCase('2-3')).toEqual('2_3@b')
+        expect(naclCase('4.5')).toEqual('4_5@v')
+      })
+    })
+
     describe('When all special chars are same and "mapped"', () => {
       it('Should replace special with _, add seperator and mapped val once', () => {
         expect(naclCase('Name Special Char')).toEqual('Name_Special_Char@s')
@@ -95,6 +113,7 @@ describe('naclCase utils', () => {
         expect(pathNaclCase('Lead@1234')).toEqual('Lead')
         expect(pathNaclCase('LALA__Lead__c@12_34')).toEqual('LALA__Lead__c')
         expect(pathNaclCase('NameWithNumber2@12_34')).toEqual('NameWithNumber2')
+        expect(pathNaclCase('0123@')).toEqual('0123')
       })
     })
 


### PR DESCRIPTION
Escape digit-only identifiers to distinguish them from array indices. See discussion on SALTO-1424 (we may eventually want to add a dedicated notation, but this should hopefully be enough for now).

---

Doesn't look like we enforce anywhere the use of naclCase (the dummy adapter isn't really using it either) - I think maybe we should, at least in some tests, but didn't want to tie that to this change.

---
_Release Notes_: 
Add escaping for element id parts that only contain digits.
