### PR TITLE
SALTO-1416: fix suiteql queries

### DIFF
--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_record_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_record_type.ts
@@ -28,6 +28,7 @@ const changesDetector: TypeChangesDetector = {
         SELECT scriptid, lastmodifieddate
         FROM customrecordtype
         WHERE lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
+        ORDER BY scriptid ASC
       `)
 
     if (results === undefined) {

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
@@ -29,6 +29,7 @@ const getChanges = async (type: string, client: NetsuiteClient, dateRange: DateR
       SELECT scriptid, lastmodifieddate
       FROM ${type}
       WHERE lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
+      ORDER BY scriptid ASC
     `)
 
   if (results === undefined) {

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/file_cabinet.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/file_cabinet.ts
@@ -28,6 +28,7 @@ export const getChangedFiles: FileCabinetChangesDetector = async (client, dateRa
     FROM file
     JOIN mediaitemfolder ON mediaitemfolder.id = file.folder
     WHERE file.lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
+    ORDER BY file.id ASC
   `)
 
   if (results === undefined) {
@@ -56,6 +57,7 @@ export const getChangedFolders: FileCabinetChangesDetector = async (client, date
     SELECT appfolder, id
     FROM mediaitemfolder
     WHERE lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
+    ORDER BY id ASC
   `)
 
   if (results === undefined) {

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/role.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/role.ts
@@ -91,6 +91,7 @@ const changesDetector: TypeChangesDetector = {
       FROM role
       JOIN systemnote ON systemnote.recordid = role.id
       WHERE systemnote.date BETWEEN '${startDate}' AND '${endDate}' AND systemnote.recordtypeid = -118
+      ORDER BY role.id ASC
     `)
 
     const permissionChangesPromise = client.runSavedSearchQuery({
@@ -102,6 +103,7 @@ const changesDetector: TypeChangesDetector = {
     const allRolesPromise = client.runSuiteQL(`
       SELECT scriptid, id
       FROM role
+      ORDER BY id ASC
     `)
 
     const [

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/script.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/script.ts
@@ -57,6 +57,7 @@ const changesDetector: TypeChangesDetector = {
       FROM script
       JOIN systemnote ON systemnote.recordid = script.id
       WHERE systemnote.date BETWEEN '${startDate}' AND '${endDate}' AND systemnote.recordtypeid = -417
+      ORDER BY script.id ASC
     `)
 
     const scriptDeploymentChangesPromise = client.runSuiteQL(`
@@ -65,12 +66,14 @@ const changesDetector: TypeChangesDetector = {
       JOIN systemnote ON systemnote.recordid = scriptdeployment.primarykey
       JOIN script ON scriptdeployment.script = script.id
       WHERE systemnote.date BETWEEN '${startDate}' AND '${endDate}' AND systemnote.recordtypeid = -418
+      ORDER BY scriptdeployment.primarykey ASC
     `)
 
     const scriptFieldsChangesPromise = client.runSuiteQL(`
       SELECT internalid
       FROM customfield
       WHERE fieldtype = 'SCRIPT' AND lastmodifieddate BETWEEN '${startDate}' AND '${endDate}'
+      ORDER BY internalid ASC
     `)
 
     const [

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -22,7 +22,6 @@ import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { WSDL } from 'soap'
-import { values } from '@salto-io/lowerdash'
 import { CallsLimiter, ExistingFileCabinetInstanceDetails, FileCabinetInstanceDetails,
   FILES_READ_SCHEMA, HttpMethod, isError, ReadResults, RestletOperation, RestletResults,
   RESTLET_RESULTS_SCHEMA, SavedSearchQuery, SavedSearchResults, SAVED_SEARCH_RESULTS_SCHEMA,
@@ -80,29 +79,12 @@ export default class SuiteAppClient {
 
   public async runSuiteQL(query: string):
     Promise<Record<string, unknown>[] | undefined> {
-    // There seems to be a bug in Netsuite SuiteQL in which
-    // for each page size we have some results missing.
-    // To handle this we run the query twice with two page sizes and merge the results
-    const results = (await Promise.all([
-      this.runSingleSuiteQL(query, PAGE_SIZE),
-      this.runSingleSuiteQL(query, PAGE_SIZE - 1),
-    ])).flat()
-
-    if (results.some(res => res === undefined)) {
-      return undefined
-    }
-
-    return _.uniqBy(results.filter(values.isDefined), result => safeJsonStringify(result))
-  }
-
-  private async runSingleSuiteQL(query: string, pageSize: number):
-    Promise<Record<string, unknown>[] | undefined> {
     let hasMore = true
     const items: Record<string, unknown>[] = []
-    for (let offset = 0; hasMore; offset += pageSize) {
+    for (let offset = 0; hasMore; offset += PAGE_SIZE) {
       try {
-      // eslint-disable-next-line no-await-in-loop
-        const results = await this.sendSuiteQLRequest(query, offset, pageSize)
+        // eslint-disable-next-line no-await-in-loop
+        const results = await this.sendSuiteQLRequest(query, offset, PAGE_SIZE)
         // For some reason, a "links" field with empty array is returned regardless
         // to the SELECT values in the query.
         items.push(...results.items.map(item => _.omit(item, ['links'])))

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -77,6 +77,12 @@ export default class SuiteAppClient {
     this.soapClient = new SoapClient(this.credentials, this.callsLimiter)
   }
 
+  /**
+   * WARNING:
+   * Due to a bug in NetSuite SuiteQL, make sure to use
+   * ORDER BY <some unique identifier> ASCin your queries.
+   * Otherwise, you might not get all the results.
+   */
   public async runSuiteQL(query: string):
     Promise<Record<string, unknown>[] | undefined> {
     let hasMore = true

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -80,11 +80,14 @@ export default class SuiteAppClient {
   /**
    * WARNING:
    * Due to a bug in NetSuite SuiteQL, make sure to use
-   * ORDER BY <some unique identifier> ASCin your queries.
+   * ORDER BY <some unique identifier> ASC in your queries.
    * Otherwise, you might not get all the results.
    */
   public async runSuiteQL(query: string):
     Promise<Record<string, unknown>[] | undefined> {
+    if (!/ORDER BY .* ASC/.test(query)) {
+      log.warn(`SuiteQL ${query} does not contain ORDER BY <unique identifier> ASC, which can cause the response to not contain all the results`)
+    }
     let hasMore = true
     const items: Record<string, unknown>[] = []
     for (let offset = 0; hasMore; offset += PAGE_SIZE) {

--- a/packages/netsuite-adapter/src/service_url/custom_field.ts
+++ b/packages/netsuite-adapter/src/service_url/custom_field.ts
@@ -48,7 +48,7 @@ const setServiceUrl: ServiceUrlSetter = async (elements, client) =>
     elements,
     client,
     filter: element => FIELD_TYPES.includes(element.refType.elemID.name),
-    query: 'SELECT internalid AS id, scriptid FROM customfield',
+    query: 'SELECT internalid AS id, scriptid FROM customfield ORDER BY internalid ASC',
     generateUrl,
   })
 

--- a/packages/netsuite-adapter/src/service_url/custom_record_type.ts
+++ b/packages/netsuite-adapter/src/service_url/custom_record_type.ts
@@ -21,7 +21,7 @@ const setServiceUrl: ServiceUrlSetter = async (elements, client) =>
     elements,
     client,
     filter: element => ['customrecordtype', 'customsegment'].includes(element.refType.elemID.name),
-    query: 'SELECT internalid AS id, scriptid FROM customrecordtype',
+    query: 'SELECT internalid AS id, scriptid FROM customrecordtype ORDER BY internalid ASC',
     generateUrl: id => `app/common/custom/custrecord.nl?id=${id}`,
     elementToId: element => (element.refType.elemID.name === 'customsegment' ? `customrecord_${element.value.scriptid}` : element.value.scriptid),
   })

--- a/packages/netsuite-adapter/src/service_url/custom_transaction_type.ts
+++ b/packages/netsuite-adapter/src/service_url/custom_transaction_type.ts
@@ -22,7 +22,7 @@ const setServiceUrl: ServiceUrlSetter = async (elements, client) =>
     elements,
     client,
     filter: element => element.refType.elemID.name === 'customtransactiontype',
-    query: 'SELECT id, scriptid FROM customtransactiontype',
+    query: 'SELECT id, scriptid FROM customtransactiontype ORDER BY id ASC',
     generateUrl: id => `app/common/custom/customtransaction.nl?id=${id}`,
   })
 

--- a/packages/netsuite-adapter/src/service_url/emailtemplate.ts
+++ b/packages/netsuite-adapter/src/service_url/emailtemplate.ts
@@ -23,7 +23,7 @@ const setServiceUrl: ServiceUrlSetter = async (elements, client) =>
     elements,
     client,
     filter: element => element.refType.elemID.name === 'emailtemplate',
-    query: 'SELECT id, scriptid FROM emailtemplate',
+    query: 'SELECT id, scriptid FROM emailtemplate ORDER BY id ASC',
     generateUrl: id => `app/crm/common/merge/emailtemplate.nl?id=${id}&cp=F`,
   })
 

--- a/packages/netsuite-adapter/src/service_url/role.ts
+++ b/packages/netsuite-adapter/src/service_url/role.ts
@@ -22,7 +22,7 @@ const setServiceUrl: ServiceUrlSetter = async (elements, client) =>
     elements,
     client,
     filter: element => element.refType.elemID.name === 'role',
-    query: 'SELECT id, scriptid FROM role',
+    query: 'SELECT id, scriptid FROM role ORDER BY id ASC',
     generateUrl: id => `app/setup/role.nl?id=${id}`,
   })
 

--- a/packages/netsuite-adapter/src/service_url/script.ts
+++ b/packages/netsuite-adapter/src/service_url/script.ts
@@ -36,7 +36,7 @@ const setServiceUrl: ServiceUrlSetter = async (elements, client) =>
     elements,
     client,
     filter: element => SUPPORTED_TYPES.includes(element.refType.elemID.name),
-    query: 'SELECT id, scriptid FROM script',
+    query: 'SELECT id, scriptid FROM script ORDER BY id ASC',
     generateUrl,
   })
 

--- a/packages/netsuite-adapter/src/service_url/sublist.ts
+++ b/packages/netsuite-adapter/src/service_url/sublist.ts
@@ -23,7 +23,7 @@ const setServiceUrl: ServiceUrlSetter = async (elements, client) =>
     elements,
     client,
     filter: element => element.refType.elemID.name === 'sublist',
-    query: 'SELECT id, scriptid FROM sublist',
+    query: 'SELECT id, scriptid FROM sublist ORDER BY id ASC',
     generateUrl: id => `app/common/custom/sublist.nl?id=${id}`,
   })
 

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -160,7 +160,7 @@ SuiteAppFileCabinetOperations => {
   const queryFolders = async (): Promise<FolderResult[]> => {
     if (queryFoldersResults === undefined) {
       const foldersResults = await suiteAppClient.runSuiteQL(`SELECT name, id, bundleable, isinactive, isprivate, description, parent 
-      FROM mediaitemfolder`)
+      FROM mediaitemfolder ORDER BY id ASC`)
 
       if (foldersResults === undefined) {
         throw new Error('Failed to list folders')
@@ -181,7 +181,7 @@ SuiteAppFileCabinetOperations => {
 Promise<FileResult[]> => {
     if (queryFoldersResults === undefined) {
       const filesResults = await suiteAppClient.runSuiteQL(`SELECT name, id, filesize, bundleable, isinactive, isonline, addtimestamptourl, hideinbundle, description, folder 
-    FROM file`)
+    FROM file ORDER BY id ASC`)
 
       if (filesResults === undefined) {
         throw new Error('Failed to list files')

--- a/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
@@ -52,6 +52,7 @@ describe('custom_field', () => {
       SELECT scriptid, lastmodifieddate
       FROM customfield
       WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
+      ORDER BY scriptid ASC
     `)
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
@@ -53,6 +53,7 @@ describe('custom_list', () => {
       SELECT scriptid, lastmodifieddate
       FROM customlist
       WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
+      ORDER BY scriptid ASC
     `)
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
@@ -55,6 +55,7 @@ describe('custom_record_type', () => {
         SELECT scriptid, lastmodifieddate
         FROM customrecordtype
         WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
+        ORDER BY scriptid ASC
       `)
     })
   })

--- a/packages/netsuite-adapter/test/changes_detector/file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/file_cabinet.test.ts
@@ -51,6 +51,7 @@ describe('file_cabinet', () => {
     FROM file
     JOIN mediaitemfolder ON mediaitemfolder.id = file.folder
     WHERE file.lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
+    ORDER BY file.id ASC
   `)
       })
     })
@@ -107,6 +108,7 @@ describe('file_cabinet', () => {
     SELECT appfolder, id
     FROM mediaitemfolder
     WHERE lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
+    ORDER BY id ASC
   `)
       })
     })

--- a/packages/netsuite-adapter/test/changes_detector/role.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/role.test.ts
@@ -94,11 +94,13 @@ describe('role', () => {
       FROM role
       JOIN systemnote ON systemnote.recordid = role.id
       WHERE systemnote.date BETWEEN '1/11/2021' AND '2/23/2021' AND systemnote.recordtypeid = -118
+      ORDER BY role.id ASC
     `)
 
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, `
       SELECT scriptid, id
       FROM role
+      ORDER BY id ASC
     `)
 
       expect(runSavedSearchQueryMock).toHaveBeenCalledWith({

--- a/packages/netsuite-adapter/test/changes_detector/script.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/script.test.ts
@@ -96,6 +96,7 @@ describe('script', () => {
       FROM script
       JOIN systemnote ON systemnote.recordid = script.id
       WHERE systemnote.date BETWEEN '1/11/2021' AND '2/23/2021' AND systemnote.recordtypeid = -417
+      ORDER BY script.id ASC
     `)
 
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, `
@@ -104,12 +105,14 @@ describe('script', () => {
       JOIN systemnote ON systemnote.recordid = scriptdeployment.primarykey
       JOIN script ON scriptdeployment.script = script.id
       WHERE systemnote.date BETWEEN '1/11/2021' AND '2/23/2021' AND systemnote.recordtypeid = -418
+      ORDER BY scriptdeployment.primarykey ASC
     `)
 
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(3, `
       SELECT internalid
       FROM customfield
       WHERE fieldtype = 'SCRIPT' AND lastmodifieddate BETWEEN '1/11/2021' AND '2/23/2021'
+      ORDER BY internalid ASC
     `)
     })
   })

--- a/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
@@ -63,48 +63,6 @@ describe('SuiteAppClient', () => {
       )
     })
 
-    it('should merge the two queries results', async () => {
-      postMock.mockResolvedValueOnce({
-        data: {
-          hasMore: false,
-          items: [{ links: [], a: 1 }, { links: [], a: 2 }],
-        },
-      })
-      postMock.mockResolvedValueOnce({
-        data: {
-          hasMore: false,
-          items: [{ links: [], a: 1 }, { links: [], a: 3 }],
-        },
-      })
-
-      const results = await client.runSuiteQL('query')
-
-      expect(results).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }])
-      expect(postMock).toHaveBeenCalledWith(
-        'https://account-id.suitetalk.api.netsuite.com/services/rest/query/v1/suiteql?limit=1000&offset=0',
-        { q: 'query' },
-        {
-          headers: {
-            Authorization: expect.any(String),
-            'Content-Type': 'application/json',
-            prefer: 'transient',
-          },
-        }
-      )
-
-      expect(postMock).toHaveBeenCalledWith(
-        'https://account-id.suitetalk.api.netsuite.com/services/rest/query/v1/suiteql?limit=999&offset=0',
-        { q: 'query' },
-        {
-          headers: {
-            Authorization: expect.any(String),
-            'Content-Type': 'application/json',
-            prefer: 'transient',
-          },
-        }
-      )
-    })
-
     it('should return all pages', async () => {
       const items = _.range(1500).map(i => ({ i }))
 


### PR DESCRIPTION
Netsuite support gave a better workaround to the problem described in https://salto-io.atlassian.net/browse/SALTO-1416: To add the the queries `ORDER BY <unique identifier> ASC` (SuiteQL does not support ORDER BY without ASC)

---
_Release Notes_: 
None