### PR TITLE
Salto 1394 - Add KnowledgeSettings languages missing field

### DIFF
--- a/packages/salesforce-adapter/src/transformers/missing_fields.json
+++ b/packages/salesforce-adapter/src/transformers/missing_fields.json
@@ -2015,6 +2015,62 @@
     ]
   },
   {
+    "id": "KnowledgeSettings",
+    "fields": [
+      {
+        "name": "languages",
+        "type": "KnowledgeLanguageSettings"
+      }
+    ]
+  },
+  {
+    "id": "KnowledgeLanguageSettings",
+    "fields": [
+      {
+        "name": "language",
+        "type": "KnowledgeLanguage"
+      }
+    ]
+  },
+  {
+    "id": "KnowledgeLanguage",
+    "fields": [
+      {
+        "name": "active",
+        "type": "boolean"
+      },
+      {
+        "name": "defaultAssignee",
+        "type": "STRING"
+      },
+      {
+        "name": "defaultAssigneeType",
+        "type": "STRING",
+        "picklistValues": [
+          "User",
+          "Queue"
+        ]
+      },
+      {
+        "name": "defaultReviewer",
+        "type": "STRING"
+      },
+      {
+        "name": "defaultReviewerType",
+        "type": "STRING"
+        ,
+        "picklistValues": [
+          "User",
+          "Queue"
+        ]
+      },
+      {
+        "name": "name",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
     "id": "PermissionSet",
     "fields": [
       {

--- a/packages/salesforce-adapter/src/transformers/missing_fields.json
+++ b/packages/salesforce-adapter/src/transformers/missing_fields.json
@@ -2015,24 +2015,6 @@
     ]
   },
   {
-    "id": "KnowledgeSettings",
-    "fields": [
-      {
-        "name": "languages",
-        "type": "KnowledgeLanguageSettings"
-      }
-    ]
-  },
-  {
-    "id": "KnowledgeLanguageSettings",
-    "fields": [
-      {
-        "name": "language",
-        "type": "KnowledgeLanguage"
-      }
-    ]
-  },
-  {
     "id": "KnowledgeLanguage",
     "fields": [
       {
@@ -2067,6 +2049,24 @@
       {
         "name": "name",
         "type": "STRING"
+      }
+    ]
+  },
+  {
+    "id": "KnowledgeLanguageSettings",
+    "fields": [
+      {
+        "name": "language",
+        "type": "KnowledgeLanguage"
+      }
+    ]
+  },
+  {
+    "id": "KnowledgeSettings",
+    "fields": [
+      {
+        "name": "languages",
+        "type": "KnowledgeLanguageSettings"
       }
     ]
   },

--- a/packages/workspace/.vscode/launch.json
+++ b/packages/workspace/.vscode/launch.json
@@ -4,7 +4,6 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [        
-    
         {
             "type": "node",
             "request": "launch",

--- a/packages/workspace/.vscode/launch.json
+++ b/packages/workspace/.vscode/launch.json
@@ -4,6 +4,7 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [        
+    
         {
             "type": "node",
             "request": "launch",


### PR DESCRIPTION
Add KnowledgeSettings languages missing field
---
_Release Notes_: 
added a few salesforce field’s type related to KnowledgeSettings.