### PR TITLE
SALTO-1414: change package validator to only custom objects and fields lazy

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/package.ts
+++ b/packages/salesforce-adapter/src/change_validators/package.ts
@@ -13,10 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, getChangeElement, InstanceElement, isAdditionChange, isModificationChange, isObjectType, isRemovalChange, ChangeError, ChangeValidator, ActionName, isInstanceChange } from '@salto-io/adapter-api'
+import { Element, getChangeElement, InstanceElement, isAdditionChange, isModificationChange, isRemovalChange, ChangeError, ChangeValidator, ActionName, isInstanceChange, isFieldChange, isObjectType } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
-import { apiName, metadataType } from '../transformers/transformer'
+import { apiName, isCustomObject, metadataType } from '../transformers/transformer'
 import { NAMESPACE_SEPARATOR } from '../constants'
 import { INSTANCE_SUFFIXES } from '../types'
 
@@ -67,6 +67,7 @@ const isInstalledPackageVersionChange = async (
 const changeValidator: ChangeValidator = async changes => {
   const addRemoveErrors = await awu(changes)
     .filter(change => isAdditionChange(change) || isRemovalChange(change))
+    .filter(async change => await isCustomObject(getChangeElement(change)) || isFieldChange(change))
     .filter(change => hasNamespace(getChangeElement(change)))
     .map(change => packageChangeError(change.action, getChangeElement(change)))
     .toArray()

--- a/packages/salesforce-adapter/test/change_validators/package.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/package.test.ts
@@ -18,7 +18,7 @@ import packageValidator, {
   INSTALLED_PACKAGE_METADATA,
   PACKAGE_VERSION_FIELD_NAME,
 } from '../../src/change_validators/package'
-import { API_NAME, INSTANCE_FULL_NAME_FIELD, METADATA_TYPE } from '../../src/constants'
+import { API_NAME, CUSTOM_OBJECT, INSTANCE_FULL_NAME_FIELD, METADATA_TYPE } from '../../src/constants'
 
 describe('package change validator', () => {
   let obj: ObjectType
@@ -44,12 +44,21 @@ describe('package change validator', () => {
         expect(changeErrors).toHaveLength(0)
       })
 
-      it('should have change error when adding an object with namespace', async () => {
-        obj.annotate({ [API_NAME]: 'MyNamespace__ObjectName__c' })
+      it('should have change error when adding a custom object with namespace', async () => {
+        obj.annotate({
+          [API_NAME]: 'MyNamespace__ObjectName__c',
+          [METADATA_TYPE]: CUSTOM_OBJECT,
+        })
         const changeErrors = await packageValidator([toChange({ after: obj })])
         expect(changeErrors).toHaveLength(1)
         expect(changeErrors[0].severity).toEqual('Error')
         expect(changeErrors[0].elemID).toEqual(obj.elemID)
+      })
+
+      it('should have no change errors when adding an object with namespace', async () => {
+        obj.annotate({ [API_NAME]: 'MyNamespace__ObjectName__c' })
+        const changeErrors = await packageValidator([toChange({ after: obj })])
+        expect(changeErrors).toHaveLength(0)
       })
 
       it('should have change error when adding an object containing field with namespace', async () => {
@@ -76,12 +85,10 @@ describe('package change validator', () => {
     })
 
     describe('Instance', () => {
-      it('should have change error when adding an instance with namespace', async () => {
+      it('should not have change errors when adding an instance with namespace', async () => {
         inst.value[INSTANCE_FULL_NAME_FIELD] = 'MyNamespace__InstanceName__c'
         const changeErrors = await packageValidator([toChange({ after: inst })])
-        expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Error')
-        expect(changeErrors[0].elemID).toEqual(inst.elemID)
+        expect(changeErrors).toHaveLength(0)
       })
 
       it('should have no change errors when adding an instance without namespace', async () => {
@@ -99,8 +106,17 @@ describe('package change validator', () => {
 
   describe('onRemove', () => {
     describe('Object', () => {
-      it('should have change error when removing an object with namespace', async () => {
+      it('should have no change errors when removing an object with namespace', async () => {
         obj.annotate({ [API_NAME]: 'MyNamespace__ObjectName__c' })
+        const changeErrors = await packageValidator([toChange({ before: obj })])
+        expect(changeErrors).toHaveLength(0)
+      })
+
+      it('should have change error when removing an object with namespace', async () => {
+        obj.annotate({
+          [API_NAME]: 'MyNamespace__ObjectName__c',
+          [METADATA_TYPE]: CUSTOM_OBJECT,
+        })
         const changeErrors = await packageValidator([toChange({ before: obj })])
         expect(changeErrors).toHaveLength(1)
         expect(changeErrors[0].severity).toEqual('Error')
@@ -131,25 +147,11 @@ describe('package change validator', () => {
         expect(changeErrors).toHaveLength(0)
       })
     })
-    describe('Instance', () => {
-      it('should have change error when removing an instance with namespace', async () => {
-        inst.value[INSTANCE_FULL_NAME_FIELD] = 'MyNamespace__InstanceName__c'
-        const changeErrors = await packageValidator([toChange({ before: inst })])
-        expect(changeErrors).toHaveLength(1)
-        expect(changeErrors[0].severity).toEqual('Error')
-        expect(changeErrors[0].elemID).toEqual(inst.elemID)
-      })
 
-      it('should have no change errors when removing an instance without namespace', async () => {
-        inst.value[INSTANCE_FULL_NAME_FIELD] = 'InstanceName__c'
-        const changeErrors = await packageValidator([toChange({ before: inst })])
-        expect(changeErrors).toHaveLength(0)
-      })
-
-      it('should have no change errors when removing an instance without fullName', async () => {
-        const changeErrors = await packageValidator([toChange({ before: inst })])
-        expect(changeErrors).toHaveLength(0)
-      })
+    it('should have no change errors when removing an instance with namespace', async () => {
+      inst.value[INSTANCE_FULL_NAME_FIELD] = 'MyNamespace__InstanceName__c'
+      const changeErrors = await packageValidator([toChange({ before: inst })])
+      expect(changeErrors).toHaveLength(0)
     })
   })
 


### PR DESCRIPTION
Same as #2176 for lazy

---
_Release Notes_: 
None
