### PR TITLE
SALTO-1431 Avoid omitting annotation types from move-to-common

### DIFF
--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -109,7 +109,7 @@ export class ElemID {
       // First name part is the instance name which is top level
       return this.nameParts.length - 1
     }
-    if (this.idType === 'annotation') {
+    if (this.isAnnotationTypeID()) {
       // annotation is already 1 level nested
       return this.nameParts.length + 1
     }
@@ -186,7 +186,7 @@ export class ElemID {
       // The parent of top level elements is the adapter
       return new ElemID(this.adapter)
     }
-    if (this.idType === 'annotation' && this.nameParts.length === 1) {
+    if (this.isAnnotationTypeID() && this.nameParts.length === 1) {
       // The parent of an annotationType is annotationTypes
       return new ElemID(this.adapter, this.typeName, this.idType)
     }

--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -229,4 +229,8 @@ export class ElemID {
         && Object.values(INSTANCE_ANNOTATIONS).includes(this.nameParts[1])
       )
   }
+
+  isAnnotationTypeID(): boolean {
+    return this.idType === 'annotation'
+  }
 }

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -675,6 +675,14 @@ describe('Test elements.ts', () => {
         expect(nonAnno.isAttrID()).toBeFalsy()
       })
     })
+    describe('isAnnotationTypeID', () => {
+      it('should identify annotation type IDs', () => {
+        const objectAnnoType = new ElemID('salto', 'obj', 'annotation', 'something')
+        const nonAnnoType = new ElemID('salto', 'obj', 'attr', 'ok')
+        expect(objectAnnoType.isAnnotationTypeID()).toBeTruthy()
+        expect(nonAnnoType.isAnnotationTypeID()).toBeFalsy()
+      })
+    })
   })
 
   describe('ListType', () => {

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -497,7 +497,7 @@ export const getPath = (
     return ['fields', fieldName, 'annotations', ...fieldAnnoPath]
   }
 
-  if (isType(rootElement) && fullElemID.idType === 'annotation') {
+  if (isType(rootElement) && fullElemID.isAnnotationTypeID()) {
     const annoTypeName = path[0]
     const annoTypePath = path.slice(1)
     if (_.isEmpty(annoTypePath)) return ['annotationTypes', annoTypeName]

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -110,7 +110,12 @@ const separateChangeByFiles = async (
           change,
           changeData => filterByFile(change.id, changeData, fileElements),
         )
-        if (!isEmptyChangeElm && isEmptyChangeElement(getChangeElement(filteredChange))) {
+        // annotation types are empty but should still be copied
+        if (
+          !isEmptyChangeElm
+          && !filteredChange.id.isAnnotationTypeID()
+          && isEmptyChangeElement(getChangeElement(filteredChange))
+        ) {
           return undefined
         }
         return { ...filteredChange, path: toPathHint(filename) }

--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -129,7 +129,7 @@ const fixEdgeIndentation = (
 export const groupAnnotationTypeChanges = (fileChanges: DetailedChange[],
   existingFileSourceMap?: SourceMap): DetailedChange[] => {
   const isAnnotationTypeAddChange = (change: DetailedChange): boolean =>
-    change.id.idType === 'annotation' && isAdditionChange(change)
+    change.id.isAnnotationTypeID() && isAdditionChange(change)
 
   const objectHasAnnotationTypesBlock = (topLevelIdFullName: string): boolean =>
     !_.isUndefined(existingFileSourceMap)
@@ -197,7 +197,7 @@ export const updateNaclFileData = async (
     if (elem !== undefined) {
       const changeKey = change.id.name
       const isListElement = changeKey.match(/^\d+$/) !== null
-      if (change.id.idType === 'annotation') {
+      if (change.id.isAnnotationTypeID()) {
         if (isType(elem)) {
           newData = dumpSingleAnnotationType(changeKey, elem, indentationLevel)
         } else {
@@ -300,7 +300,7 @@ export const getChangesToUpdate = (
   const isNestedAddition = (dc: DetailedChange): boolean => (dc.path || false)
     && dc.action === 'add'
     && dc.id.idType !== 'instance'
-    && dc.id.nestingLevel === (dc.id.idType === 'annotation' ? 2 : 1)
+    && dc.id.nestingLevel === (dc.id.isAnnotationTypeID() ? 2 : 1)
     && !parentElementExistsInPath(dc, sourceMap)
 
   const [nestedAdditionsWithPath, otherChanges] = _.partition(

--- a/packages/workspace/test/workspace/multi_env/routers.test.ts
+++ b/packages/workspace/test/workspace/multi_env/routers.test.ts
@@ -1057,6 +1057,7 @@ describe('track', () => {
     },
     annotationTypes: {
       env: BuiltinTypes.STRING,
+      internalId: BuiltinTypes.HIDDEN_STRING,
     },
     annotations: {
       env: 'ENV',
@@ -1160,9 +1161,10 @@ describe('track', () => {
       secondarySources
     )
     expect(changes.primarySource).toHaveLength(1)
-    expect(changes.commonSource).toHaveLength(5)
+    expect(changes.commonSource).toHaveLength(6)
     expect(hasChanges(changes.commonSource || [], [
       { action: 'add', id: splitObjEnv.elemID.createNestedID('annotation', 'env') },
+      { action: 'add', id: splitObjEnv.elemID.createNestedID('annotation', 'internalId') },
       { action: 'add', id: splitObjEnv.elemID.createNestedID('attr', 'split', 'env') },
       { action: 'add', id: splitObjEnv.elemID.createNestedID('attr', 'env') },
       { action: 'add', id: splitObjEnv.fields.envField.elemID },


### PR DESCRIPTION
After the [fix](https://github.com/salto-io/salto/pull/1595/files) for SALTO-1003, we omit from the move to common elements that are empty. This has an undesired effect in some scenarios - if we have detailed changes that contain _only_ non-standard primitive annotation types, they may be omitted because they are considered to be empty. 

---

Can happen in cases where a full object is moved to common after some of it is already in common.
Added some more details on the ticket.

---
_Release Notes_: 
_Core_: Fixed bug where non-standard annotation types were dropped on move-to-common of the element, if part of it was already in common.
