### PR TITLE
SALTO-1382 Identify ServiceId By Core Annotation

### DIFF
--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -39,6 +39,7 @@ const StandardBuiltinTypes = {
   SERVICE_ID: new PrimitiveType({
     elemID: new ElemID(GLOBAL_ADAPTER, 'serviceid'),
     primitive: PrimitiveTypes.STRING,
+    annotations: { [CORE_ANNOTATIONS.SERVICE_ID]: true },
   }),
   JSON: new PrimitiveType({
     elemID: new ElemID(GLOBAL_ADAPTER, 'json'),

--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -135,6 +135,10 @@ export const BuiltinTypes = {
   }),
 }
 
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+export const isServiceId = (type: any): boolean =>
+  type.annotations?.[CORE_ANNOTATIONS.SERVICE_ID] ?? false
+
 export const BuiltinTypesByFullName: Record<string, PrimitiveType> = (_.keyBy(
   Object.values(BuiltinTypes),
   builtinType => builtinType.elemID.getFullName(),

--- a/packages/adapter-api/src/core_annotations.ts
+++ b/packages/adapter-api/src/core_annotations.ts
@@ -23,4 +23,5 @@ export const CORE_ANNOTATIONS = {
   PARENT: '_parent',
   GENERATED_DEPENDENCIES: '_generated_dependencies',
   SERVICE_URL: '_service_url',
+  SERVICE_ID: '_service_id',
 }

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -20,7 +20,7 @@ import {
   Element, ElemID, AdapterOperations, Values, ServiceIds, ObjectType,
   toServiceIdsString, Field, OBJECT_SERVICE_ID, InstanceElement, isInstanceElement, isObjectType,
   ADAPTER, FIELD_NAME, INSTANCE_NAME, OBJECT_NAME, ElemIdGetter, DetailedChange, SaltoError,
-  ProgressReporter, ReadOnlyElementsSource, TypeMap, CORE_ANNOTATIONS,
+  ProgressReporter, ReadOnlyElementsSource, TypeMap, isServiceId,
 } from '@salto-io/adapter-api'
 import {
   applyInstancesDefaults, resolvePath, flattenElementStr,
@@ -545,7 +545,7 @@ const getServiceIdsFromAnnotations = (annotationRefTypes: TypeMap, annotations: 
   elemID: ElemID): ServiceIds =>
   _(Object.entries(annotationRefTypes))
     .filter(([_annotationName, annotationRefType]) =>
-      (annotationRefType.annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true))
+      (isServiceId(annotationRefType)))
     .map(([annotationName, _annotationType]) =>
       [annotationName, annotations[annotationName] || id(elemID)])
     .fromPairs()
@@ -589,7 +589,7 @@ const getInstanceServiceId = async (
   const instType = await instanceElement.getType(elementsSource)
   const serviceIds = Object.fromEntries(await awu(Object.entries(instType.fields))
     .filter(async ([_fieldName, field]) =>
-      ((await field.getType(elementsSource)).annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true))
+      (isServiceId(await field.getType(elementsSource))))
     .map(([fieldName, _field]) =>
       [fieldName, instanceElement.value[fieldName] || id(instanceElement.elemID)])
     .toArray())

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -17,10 +17,10 @@ import wu from 'wu'
 import _ from 'lodash'
 import { EventEmitter } from 'pietile-eventemitter'
 import {
-  Element, ElemID, AdapterOperations, Values, ServiceIds, BuiltinTypes, ObjectType,
+  Element, ElemID, AdapterOperations, Values, ServiceIds, ObjectType,
   toServiceIdsString, Field, OBJECT_SERVICE_ID, InstanceElement, isInstanceElement, isObjectType,
   ADAPTER, FIELD_NAME, INSTANCE_NAME, OBJECT_NAME, ElemIdGetter, DetailedChange, SaltoError,
-  ProgressReporter, ReferenceMap, ReadOnlyElementsSource,
+  ProgressReporter, ReadOnlyElementsSource, TypeMap, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import {
   applyInstancesDefaults, resolvePath, flattenElementStr,
@@ -541,19 +541,21 @@ export const fetchChanges = async (
 
 const id = (elemID: ElemID): string => elemID.getFullName()
 
-const getServiceIdsFromAnnotations = (annotationRefTypes: ReferenceMap, annotations: Values,
+const getServiceIdsFromAnnotations = (annotationRefTypes: TypeMap, annotations: Values,
   elemID: ElemID): ServiceIds =>
   _(Object.entries(annotationRefTypes))
     .filter(([_annotationName, annotationRefType]) =>
-      (annotationRefType.elemID.isEqual(BuiltinTypes.SERVICE_ID.elemID)))
+      (annotationRefType.annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true))
     .map(([annotationName, _annotationType]) =>
       [annotationName, annotations[annotationName] || id(elemID)])
     .fromPairs()
     .value()
 
-const getObjectServiceId = (objectType: ObjectType): string => {
-  const serviceIds = getServiceIdsFromAnnotations(objectType.annotationRefTypes,
-    objectType.annotations, objectType.elemID)
+const getObjectServiceId = async (objectType: ObjectType,
+  elementsSource: ReadOnlyElementsSource): Promise<string> => {
+  const serviceIds = getServiceIdsFromAnnotations(await objectType
+    .getAnnotationTypes(elementsSource),
+  objectType.annotations, objectType.elemID)
   if (_.isEmpty(serviceIds)) {
     serviceIds[OBJECT_NAME] = id(objectType.elemID)
   }
@@ -561,13 +563,14 @@ const getObjectServiceId = (objectType: ObjectType): string => {
   return toServiceIdsString(serviceIds)
 }
 
+
 const getFieldServiceId = async (
   objectServiceId: string,
   field: Field,
   elementsSource: ReadOnlyElementsSource,
 ): Promise<string> => {
   const serviceIds = getServiceIdsFromAnnotations(
-    (await field.getType(elementsSource)).annotationRefTypes,
+    (await (await field.getType(elementsSource)).getAnnotationTypes(elementsSource)),
     field.annotations,
     field.elemID
   )
@@ -584,18 +587,17 @@ const getInstanceServiceId = async (
   elementsSource: ReadOnlyElementsSource,
 ): Promise<string> => {
   const instType = await instanceElement.getType(elementsSource)
-  const serviceIds = _(Object.entries(instType.fields))
-    .filter(([_fieldName, field]) =>
-      (field.refType.elemID.isEqual(BuiltinTypes.SERVICE_ID.elemID)))
+  const serviceIds = Object.fromEntries(await awu(Object.entries(instType.fields))
+    .filter(async ([_fieldName, field]) =>
+      ((await field.getType(elementsSource)).annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true))
     .map(([fieldName, _field]) =>
       [fieldName, instanceElement.value[fieldName] || id(instanceElement.elemID)])
-    .fromPairs()
-    .value()
+    .toArray())
   if (_.isEmpty(serviceIds)) {
     serviceIds[INSTANCE_NAME] = id(instanceElement.elemID)
   }
   serviceIds[ADAPTER] = instanceElement.elemID.adapter
-  serviceIds[OBJECT_SERVICE_ID] = getObjectServiceId(instType)
+  serviceIds[OBJECT_SERVICE_ID] = await getObjectServiceId(instType, elementsSource)
   return toServiceIdsString(serviceIds)
 }
 
@@ -607,7 +609,7 @@ export const generateServiceIdToStateElemId = async (
     .filter(elem => isInstanceElement(elem) || isObjectType(elem))
     .flatMap(async elem => {
       if (isObjectType(elem)) {
-        const objectServiceId = getObjectServiceId(elem)
+        const objectServiceId = await getObjectServiceId(elem, elementsSource)
         const fieldPairs = await Promise.all(Object.values(elem.fields)
           .map(async field => [
             await getFieldServiceId(objectServiceId, field, elementsSource),

--- a/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
@@ -15,7 +15,7 @@
 */
 import {
   ChangeError, ChangeValidator, CORE_ANNOTATIONS, getChangeElement, InstanceElement,
-  isInstanceChange, isModificationChange, isReferenceExpression,
+  isInstanceChange, isModificationChange, isReferenceExpression, isServiceId,
 } from '@salto-io/adapter-api'
 import { getParents } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -44,8 +44,7 @@ const changeValidator: ChangeValidator = async changes => (
       const before = change.data.before as InstanceElement
       const after = change.data.after as InstanceElement
       const modifiedImmutableFields = await awu(Object.values((await after.getType()).fields))
-        .filter(async field => (await field.getType())
-          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true)
+        .filter(async field => isServiceId(await field.getType()))
         .filter(field => before.value[field.name] !== after.value[field.name])
         .map(field => field.name)
         .toArray()

--- a/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  BuiltinTypes, ChangeError, ChangeValidator, CORE_ANNOTATIONS, getChangeElement, InstanceElement,
+  ChangeError, ChangeValidator, CORE_ANNOTATIONS, getChangeElement, InstanceElement,
   isInstanceChange, isModificationChange, isReferenceExpression,
 } from '@salto-io/adapter-api'
 import { getParents } from '@salto-io/adapter-utils'
@@ -44,7 +44,8 @@ const changeValidator: ChangeValidator = async changes => (
       const before = change.data.before as InstanceElement
       const after = change.data.after as InstanceElement
       const modifiedImmutableFields = await awu(Object.values((await after.getType()).fields))
-        .filter(async field => await field.getType() === BuiltinTypes.SERVICE_ID)
+        .filter(async field => (await field.getType())
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true)
         .filter(field => before.value[field.name] !== after.value[field.name])
         .map(field => field.name)
         .toArray()

--- a/packages/netsuite-adapter/src/reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/reference_dependencies.ts
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 import {
-  InstanceElement, isInstanceElement, isPrimitiveType, ElemID, getFieldType, BuiltinTypes,
-  isReferenceExpression, Value,
+  InstanceElement, isInstanceElement, isPrimitiveType, ElemID, getFieldType,
+  isReferenceExpression, Value, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
 import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
@@ -40,7 +40,8 @@ export const findDependingInstancesFromRefs = async (
       await topLevelParent.getType(),
       elemId.createTopLevelParentID().path
     )
-    return isPrimitiveType(fieldType) && fieldType.isEqual(BuiltinTypes.SERVICE_ID)
+    return (isPrimitiveType(fieldType)
+      && fieldType.annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true)
   }
 
   const createDependingElementsCallback: TransformFunc = async ({ value }) => {

--- a/packages/netsuite-adapter/src/reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/reference_dependencies.ts
@@ -15,7 +15,7 @@
 */
 import {
   InstanceElement, isInstanceElement, isPrimitiveType, ElemID, getFieldType,
-  isReferenceExpression, Value, CORE_ANNOTATIONS,
+  isReferenceExpression, Value, isServiceId,
 } from '@salto-io/adapter-api'
 import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
 import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
@@ -41,7 +41,7 @@ export const findDependingInstancesFromRefs = async (
       elemId.createTopLevelParentID().path
     )
     return (isPrimitiveType(fieldType)
-      && fieldType.annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true)
+      && isServiceId(fieldType))
   }
 
   const createDependingElementsCallback: TransformFunc = async ({ value }) => {

--- a/packages/netsuite-adapter/test/types.test.ts
+++ b/packages/netsuite-adapter/test/types.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  CORE_ANNOTATIONS, getRestriction, isPrimitiveType,
+  CORE_ANNOTATIONS, getRestriction, isPrimitiveType, isServiceId,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { values, collections } from '@salto-io/lowerdash'
@@ -68,8 +68,7 @@ describe('Types', () => {
       it('should have service_id path field', async () => {
         expect(Object.keys(fileCabinetTypes.file.fields)).toContain(PATH)
         const pathFieldType = await fileCabinetTypes.file.fields[PATH].getType()
-        expect(isPrimitiveType(pathFieldType) && pathFieldType
-          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true)
+        expect(isPrimitiveType(pathFieldType) && isServiceId(pathFieldType))
           .toBe(true)
       })
 
@@ -92,8 +91,7 @@ describe('Types', () => {
       it('should have service_id path field', async () => {
         expect(Object.keys(fileCabinetTypes.folder.fields)).toContain(PATH)
         const pathFieldType = await fileCabinetTypes.folder.fields[PATH].getType()
-        expect(isPrimitiveType(pathFieldType) && pathFieldType
-          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true)
+        expect(isPrimitiveType(pathFieldType) && isServiceId(pathFieldType))
           .toBe(true)
       })
 

--- a/packages/netsuite-adapter/test/types.test.ts
+++ b/packages/netsuite-adapter/test/types.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  BuiltinTypes, CORE_ANNOTATIONS, getRestriction, isPrimitiveType,
+  CORE_ANNOTATIONS, getRestriction, isPrimitiveType,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { values, collections } from '@salto-io/lowerdash'
@@ -68,7 +68,8 @@ describe('Types', () => {
       it('should have service_id path field', async () => {
         expect(Object.keys(fileCabinetTypes.file.fields)).toContain(PATH)
         const pathFieldType = await fileCabinetTypes.file.fields[PATH].getType()
-        expect(isPrimitiveType(pathFieldType) && pathFieldType.isEqual(BuiltinTypes.SERVICE_ID))
+        expect(isPrimitiveType(pathFieldType) && pathFieldType
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true)
           .toBe(true)
       })
 
@@ -91,7 +92,8 @@ describe('Types', () => {
       it('should have service_id path field', async () => {
         expect(Object.keys(fileCabinetTypes.folder.fields)).toContain(PATH)
         const pathFieldType = await fileCabinetTypes.folder.fields[PATH].getType()
-        expect(isPrimitiveType(pathFieldType) && pathFieldType.isEqual(BuiltinTypes.SERVICE_ID))
+        expect(isPrimitiveType(pathFieldType) && pathFieldType
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID] === true)
           .toBe(true)
       })
 

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { collections, promises } from '@salto-io/lowerdash'
 import { createRefToElmWithValue } from '@salto-io/adapter-utils'
-import { ObjectType, ElemID, InstanceElement, BuiltinTypes, CORE_ANNOTATIONS, createRestriction, DeployResult, getChangeElement, Values, Change, toChange, ChangeGroup, isAdditionOrModificationChange } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, InstanceElement, BuiltinTypes, CORE_ANNOTATIONS, createRestriction, DeployResult, getChangeElement, Values, Change, toChange, ChangeGroup, isAdditionOrModificationChange, isServiceId } from '@salto-io/adapter-api'
 import { MetadataInfo, SaveResult, Package } from 'jsforce'
 import JSZip from 'jszip'
 import xmlParser from 'fast-xml-parser'
@@ -236,12 +236,10 @@ describe('SalesforceAdapter CRUD', () => {
         // Verify object creation
         expect(result).toBeInstanceOf(ObjectType)
         expect(result.annotations[constants.API_NAME]).toBe('Test__c')
-        expect((await result.getAnnotationTypes())[constants.API_NAME]
-          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+        expect((isServiceId((await result.getAnnotationTypes())[constants.API_NAME])))
           .toEqual(true)
         expect(result.annotations[constants.METADATA_TYPE]).toBe(constants.CUSTOM_OBJECT)
-        expect((await result.getAnnotationTypes())[constants.METADATA_TYPE]
-          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+        expect(isServiceId((await result.getAnnotationTypes())[constants.METADATA_TYPE]))
           .toEqual(true)
         const objAnnotations = result.annotations as CustomObject
         expect(objAnnotations.label).toEqual('Test')

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -236,11 +236,13 @@ describe('SalesforceAdapter CRUD', () => {
         // Verify object creation
         expect(result).toBeInstanceOf(ObjectType)
         expect(result.annotations[constants.API_NAME]).toBe('Test__c')
-        expect(result.annotationRefTypes[constants.API_NAME].elemID)
-          .toEqual(BuiltinTypes.SERVICE_ID.elemID)
+        expect((await result.getAnnotationTypes())[constants.API_NAME]
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+          .toEqual(true)
         expect(result.annotations[constants.METADATA_TYPE]).toBe(constants.CUSTOM_OBJECT)
-        expect(result.annotationRefTypes[constants.METADATA_TYPE].elemID)
-          .toEqual(BuiltinTypes.SERVICE_ID.elemID)
+        expect((await result.getAnnotationTypes())[constants.METADATA_TYPE]
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+          .toEqual(true)
         const objAnnotations = result.annotations as CustomObject
         expect(objAnnotations.label).toEqual('Test')
         expect(result.annotationRefTypes.label.elemID)

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import {
   ObjectType, InstanceElement, ServiceIds, ElemID, BuiltinTypes, FetchOptions,
-  Element, CORE_ANNOTATIONS, FetchResult, isListType, ListType, getRestriction,
+  Element, CORE_ANNOTATIONS, FetchResult, isListType, ListType, getRestriction, isServiceId,
 } from '@salto-io/adapter-api'
 import { MetadataInfo } from 'jsforce'
 import { values, collections } from '@salto-io/lowerdash'
@@ -158,11 +158,9 @@ describe('SalesforceAdapter fetch', () => {
       // Note the order here is important because we expect restriction values to be sorted
       expect(getRestriction(flow.fields.enum).values).toEqual(['no', 'yes'])
       expect(flow.path).toEqual([constants.SALESFORCE, constants.TYPES_PATH, 'Flow'])
-      expect((await flow.fields[constants.INSTANCE_FULL_NAME_FIELD].getType())
-        .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+      expect(isServiceId(await flow.fields[constants.INSTANCE_FULL_NAME_FIELD].getType()))
         .toEqual(true)
-      expect((await flow.getAnnotationTypes())[constants.METADATA_TYPE]
-        .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+      expect(isServiceId((await flow.getAnnotationTypes())[constants.METADATA_TYPE]))
         .toEqual(true)
       expect(flow.annotations[constants.METADATA_TYPE]).toEqual('Flow')
     })

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -158,10 +158,12 @@ describe('SalesforceAdapter fetch', () => {
       // Note the order here is important because we expect restriction values to be sorted
       expect(getRestriction(flow.fields.enum).values).toEqual(['no', 'yes'])
       expect(flow.path).toEqual([constants.SALESFORCE, constants.TYPES_PATH, 'Flow'])
-      expect(await flow.fields[constants.INSTANCE_FULL_NAME_FIELD].getType())
-        .toEqual(BuiltinTypes.SERVICE_ID)
-      expect((await flow.getAnnotationTypes())[constants.METADATA_TYPE])
-        .toEqual(BuiltinTypes.SERVICE_ID)
+      expect((await flow.fields[constants.INSTANCE_FULL_NAME_FIELD].getType())
+        .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+        .toEqual(true)
+      expect((await flow.getAnnotationTypes())[constants.METADATA_TYPE]
+        .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+        .toEqual(true)
       expect(flow.annotations[constants.METADATA_TYPE]).toEqual('Flow')
     })
 

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -19,6 +19,7 @@ import {
   CORE_ANNOTATIONS, Value, isInstanceElement,
   ReferenceExpression, isListType, FieldDefinition, toChange, Change, ModificationChange,
   getChangeElement,
+  isServiceId,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements, createRefToElmWithValue } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -496,11 +497,9 @@ describe('Custom Objects filter', () => {
         mockSingleSObject('Lead', [])
         await filter.onFetch(result)
         const lead = findElements(result, 'Lead').pop() as ObjectType
-        expect((await lead.getAnnotationTypes())[API_NAME]
-          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+        expect(isServiceId((await lead.getAnnotationTypes())[API_NAME]))
           .toEqual(true)
-        expect((await lead.getAnnotationTypes())[METADATA_TYPE]
-          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+        expect(isServiceId((await lead.getAnnotationTypes())[METADATA_TYPE]))
           .toEqual(true)
         expect(lead.annotations[API_NAME]).toEqual('Lead')
         expect(lead.annotations[METADATA_TYPE]).toEqual(CUSTOM_OBJECT)

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -496,8 +496,12 @@ describe('Custom Objects filter', () => {
         mockSingleSObject('Lead', [])
         await filter.onFetch(result)
         const lead = findElements(result, 'Lead').pop() as ObjectType
-        expect((await lead.getAnnotationTypes())[API_NAME]).toEqual(BuiltinTypes.SERVICE_ID)
-        expect((await lead.getAnnotationTypes())[METADATA_TYPE]).toEqual(BuiltinTypes.SERVICE_ID)
+        expect((await lead.getAnnotationTypes())[API_NAME]
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+          .toEqual(true)
+        expect((await lead.getAnnotationTypes())[METADATA_TYPE]
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+          .toEqual(true)
         expect(lead.annotations[API_NAME]).toEqual('Lead')
         expect(lead.annotations[METADATA_TYPE]).toEqual(CUSTOM_OBJECT)
       })

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ObjectType, ElemID, Field, BuiltinTypes, TypeElement, Field as TypeField, Values, CORE_ANNOTATIONS, ReferenceExpression, InstanceElement, getRestriction, ListType, createRestriction } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, Field, BuiltinTypes, TypeElement, Field as TypeField, Values, CORE_ANNOTATIONS, ReferenceExpression, InstanceElement, getRestriction, ListType, createRestriction, isServiceId } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { Field as SalesforceField } from 'jsforce'
 import { restoreValues, resolveValues, createRefToElmWithValue } from '@salto-io/adapter-utils'
@@ -411,7 +411,7 @@ describe('transformer', () => {
         salesforceIdField = _.cloneDeep(origSalesforceIdField)
         const fieldElement = getSObjectFieldElement(dummyElem, salesforceIdField,
           serviceIds, {})
-        expect((await fieldElement.getType()).annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+        expect(isServiceId((await fieldElement.getType())))
           .toEqual(true)
       })
     })
@@ -1134,8 +1134,7 @@ describe('transformer', () => {
   describe('type definitions', () => {
     it('should include apiName annotation with service_id type', async () => {
       await awu(Object.values(Types.getAllFieldTypes())).forEach(async type => {
-        expect((await type.getAnnotationTypes())[API_NAME]
-          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+        expect(isServiceId((await type.getAnnotationTypes())[API_NAME]))
           .toEqual(true)
       })
     })

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -411,7 +411,8 @@ describe('transformer', () => {
         salesforceIdField = _.cloneDeep(origSalesforceIdField)
         const fieldElement = getSObjectFieldElement(dummyElem, salesforceIdField,
           serviceIds, {})
-        expect(await fieldElement.getType()).toEqual(BuiltinTypes.SERVICE_ID)
+        expect((await fieldElement.getType()).annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+          .toEqual(true)
       })
     })
 
@@ -1133,7 +1134,9 @@ describe('transformer', () => {
   describe('type definitions', () => {
     it('should include apiName annotation with service_id type', async () => {
       await awu(Object.values(Types.getAllFieldTypes())).forEach(async type => {
-        expect((await type.getAnnotationTypes())[API_NAME]).toEqual(BuiltinTypes.SERVICE_ID)
+        expect((await type.getAnnotationTypes())[API_NAME]
+          .annotations?.[CORE_ANNOTATIONS.SERVICE_ID])
+          .toEqual(true)
       })
     })
   })


### PR DESCRIPTION
_Release Notes_: 
added boolean CORE_ANNOTATION "_service_id" which indicates wether field's type is service_id type
