### PR TITLE
changed fetch align to drop add changes if mergeable id is in common (Fixes SALTO-1430)

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -232,9 +232,21 @@ export const routeOverride = async (
 export const routeAlign = async (
   change: DetailedChange,
   primarySource: NaclFilesSource,
+  commonSource: NaclFilesSource
 ): Promise<RoutedChanges> => {
   // All add changes to the current active env specific folder
+  // unless it is an unmergeable id, and the mergeableID is in common
   if (change.action === 'add') {
+    const topLevelID = change.id.createTopLevelParentID().parent
+    const commonTopLevel = await commonSource.get(topLevelID)
+    const primaryTopLevel = await primarySource.get(topLevelID)
+    const { mergeableID } = getMergeableParentID(
+      change.id,
+      [commonTopLevel, primaryTopLevel].filter(values.isDefined)
+    )
+    if (values.isDefined(await commonSource.get(mergeableID))) {
+      return {}
+    }
     return { primarySource: [change] }
   }
   // We drop the common projection of the change
@@ -488,7 +500,7 @@ export const routeChanges = async (
   const routedChanges = await Promise.all(changes.map(c => {
     switch (mode) {
       case 'isolated': return routeIsolated(c, primarySource, commonSource, secondarySources)
-      case 'align': return routeAlign(c, primarySource)
+      case 'align': return routeAlign(c, primarySource, commonSource)
       case 'override': return routeOverride(c, primarySource, commonSource, secondarySources)
       default: return routeDefault(c, primarySource, commonSource, secondarySources)
     }

--- a/packages/workspace/test/workspace/multi_env/routers.test.ts
+++ b/packages/workspace/test/workspace/multi_env/routers.test.ts
@@ -46,6 +46,9 @@ const commonObj = new ObjectType({
   },
   annotations: {
     boolean: false,
+    arr: [
+      { a: 'a' },
+    ],
   },
   fields: {
     commonField,
@@ -65,6 +68,9 @@ const sharedObject = new ObjectType({
   },
   annotations: {
     boolean: false,
+    arr: [
+      { a: 'a' },
+    ],
   },
   fields: {
     envField,
@@ -405,7 +411,7 @@ describe('default fetch routing', () => {
 })
 
 describe('align fetch routing', () => {
-  it('should route add changes to common', async () => {
+  it('should route add changes to primary', async () => {
     const change: DetailedChange = {
       action: 'add',
       data: { after: newObj },
@@ -415,6 +421,18 @@ describe('align fetch routing', () => {
     expect(routedChanges.primarySource).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
     expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
+    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+  })
+
+  it('should drop add changes if the mergeable id is in common', async () => {
+    const change: DetailedChange = {
+      action: 'add',
+      data: { after: 'B' },
+      id: commonObj.elemID.createNestedID('attr', 'arr', '0', 'b'),
+    }
+    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'align')
+    expect(routedChanges.primarySource).toHaveLength(0)
+    expect(routedChanges.commonSource).toHaveLength(0)
     expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
   })
 


### PR DESCRIPTION
_changed fetch align to drop add changes if mergeable id is in common_

---

_Until this fix, the route align method would have passed all add changes to the primary source. This was based on an assumption that all of the changes that are produced by the plan are "mergeable". This assumption did not take into account add changes inside an array object in which the array did not change length. When this type of change was applied that an array which was in the common source - the result was an array with a lot of undefined items in the primary source. The fix is to route an add change to the primary source only if its mergeable id is not in common._

---
_Release Notes_: 
_Fixed add changes in common array can result in invalid nacls in the env folder when using fetch align_
