### PR TITLE
fix [SALTO-1410] - updateNaclFiles returning wrong number of changes

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -462,7 +462,8 @@ export const loadWorkspace = async (
         postChangeHash: loadedStateHash,
       } },
       validate })
-    return (Object.values(workspaceChanges).flat().length + stateOnlyChanges.length)
+    return (Object.values(workspaceChanges).map(changeSet => changeSet.changes)
+      .flat().length + stateOnlyChanges.length)
   }
   const setNaclFiles = async (naclFiles: NaclFile[], validate = true): Promise<EnvsChanges> => {
     const elementChanges = await (await getLoadedNaclFilesSource()).setNaclFiles(...naclFiles)


### PR DESCRIPTION
Fix issue where lazy element workspace would return wrong number of changes on updateNaclFiles in workspace

---



---
The number of changes printed in fetch will be correct