### PR TITLE
SALTO-1446: Fixed type names in SDF error response

### DIFF
--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -53,6 +53,11 @@ const { makeArray } = collections.array
 const { withLimitedConcurrency } = promises.array
 const log = logger(module)
 
+const FAILED_TYPE_NAME_TO_REAL_NAME: Record<string, string> = {
+  csvimport: 'savedcsvimport',
+  plugintypeimpl: 'pluginimplementation',
+}
+
 export type SdfClientOpts = {
   credentials: SdfCredentials
   config?: SdfClientConfig
@@ -501,14 +506,20 @@ export default class SdfClient {
       .filter(failedImport => {
         if (failedImport.customObject.result.message.includes('unexpected error')) {
           log.debug('Failed to fetch (%s) instance with id (%s) due to SDF unexpected error',
-            failedImport.customObject.type, failedImport.customObject.id)
+            SdfClient.fixTypeName(failedImport.customObject.type), failedImport.customObject.id)
           return true
         }
         return false
       })
-      .groupBy(failedImport => failedImport.customObject.type)
+      .groupBy(failedImport => SdfClient.fixTypeName(failedImport.customObject.type))
       .mapValues(failedImports => failedImports.map(failedImport => failedImport.customObject.id))
       .value()
+  }
+
+  private static fixTypeName(typeName: string): string {
+    // For some type names, SDF might return different names in its
+    // error response, so we replace it with the original name
+    return FAILED_TYPE_NAME_TO_REAL_NAME[typeName] ?? typeName
   }
 
   async listInstances(

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -568,20 +568,20 @@ describe('netsuite client', () => {
           return Promise.resolve({
             isSuccess: () => true,
             data: [
-              { type: 'addressForm', scriptId: 'a' },
-              { type: 'addressForm', scriptId: 'b' },
-              { type: 'addressForm', scriptId: 'c' },
-              { type: 'addressForm', scriptId: 'd' },
+              { type: 'savedcsvimport', scriptId: 'a' },
+              { type: 'savedcsvimport', scriptId: 'b' },
+              { type: 'savedcsvimport', scriptId: 'c' },
+              { type: 'savedcsvimport', scriptId: 'd' },
               { type: 'advancedpdftemplate', scriptId: 'a' },
             ],
           })
         }
         if (context.commandName === COMMANDS.IMPORT_OBJECTS) {
-          if (context.arguments.type === 'addressForm') {
+          if (context.arguments.type === 'savedcsvimport') {
             const conditionalFailedForm = {
               customObject: {
                 id: 'b',
-                type: 'addressForm',
+                type: 'csvimport',
                 result: {
                   code: 'FAILED',
                   message: 'An unexpected error has occurred',
@@ -593,7 +593,7 @@ describe('netsuite client', () => {
               {
                 customObject: {
                   id: 'c',
-                  type: 'addressForm',
+                  type: 'csvimport',
                   result: {
                     code: 'FAILED',
                     message: 'An unexpected error has occurred',
@@ -603,7 +603,7 @@ describe('netsuite client', () => {
               {
                 customObject: {
                   id: 'd',
-                  type: 'addressForm',
+                  type: 'csvimport',
                   result: {
                     code: 'FAILED',
                     message: 'You cannot download the XML file for this object because it is locked.',
@@ -644,11 +644,17 @@ describe('netsuite client', () => {
         return Promise.resolve({ isSuccess: () => true })
       })
 
+      const query = buildNetsuiteQuery({
+        types: {
+          savedcsvimport: ['.*'],
+          advancedpdftemplate: ['.*'],
+        },
+      })
       const {
         failedTypeToInstances,
-      } = await mockClient().getCustomObjects(typeNames, typeNamesQuery)
+      } = await mockClient().getCustomObjects(typeNames, query)
       expect(failedTypeToInstances).toEqual({
-        addressForm: ['c'],
+        savedcsvimport: ['c'],
         advancedpdftemplate: ['a'],
       })
     })


### PR DESCRIPTION
In case of an error in fetching instances in Netsuite, for some types (`savedcsvimport` and `pluginimplementation`) SDF would return different type names. This would cause Salto to add invalid type names to the skip list

---
_Release Notes_: 
Netsuite Adapter:
Fixed a bug where in some cases an invalid type name would be added to the configuration skip list