### PR TITLE
fixed merge errors are not removed when fixed

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -91,12 +91,13 @@ export const buildNewMergedElementsAndErrors = async ({
     const fullname = id.getFullName()
     if (!sieve.has(fullname)) {
       sieve.add(fullname)
-      const [before, mergedItem, mergeErrors] = await Promise.all([
+      const [before, beforeErrors, mergedItem, mergeErrors] = await Promise.all([
         currentElements.get(id),
+        currentErrors.get(fullname),
         newMergedElementsResult.merged.get(fullname),
         newMergedElementsResult.errors.get(fullname),
       ])
-      if (!isEqualElements(before, mergedItem) || !_.isEmpty(mergeErrors)) {
+      if (!isEqualElements(before, mergedItem) || !_.isEqual(beforeErrors, mergeErrors)) {
         if (mergedItem !== undefined) {
           await currentElements.set(mergedItem)
         } else if (before !== undefined) {
@@ -104,7 +105,9 @@ export const buildNewMergedElementsAndErrors = async ({
         }
         changes.push(toChange({ before, after: mergedItem }))
         if (mergeErrors !== undefined) {
-          await currentErrors.set(fullname, mergeErrors)
+          await currentErrors.set(fullname, mergeErrors ?? [])
+        } else {
+          await currentErrors.delete(fullname)
         }
       }
     }

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -718,6 +718,41 @@ describe('workspace', () => {
         ).list()).toArray()).toEqual([afterObj.elemID])
       })
     })
+
+    describe('when merge errors are fixed', () => {
+      it('should delete fixed merge errors', async () => {
+        const ws = await createWorkspace(naclFileStore)
+        await ws.setNaclFiles([
+          {
+            filename: 'mergeIssue.nacl',
+            buffer: `
+                type salto.dup {
+                  x = "x"
+                }
+
+                type salto.dup {
+                  x = "x"
+                }
+              `,
+          },
+        ])
+
+        expect((await ws.errors()).merge).toHaveLength(1)
+        expect((await ws.errors()).merge[0].message).toContain('duplicate annotation key x')
+        await ws.setNaclFiles([
+          {
+            filename: 'mergeIssue.nacl',
+            buffer: `
+                type salto.dup {
+                  x = "x"
+                }
+              `,
+          },
+        ])
+
+        expect((await ws.errors()).merge).toHaveLength(0)
+      })
+    })
   })
 
   describe('updateNaclFiles', () => {


### PR DESCRIPTION
_Fixed merge errors are not removed when fixed_

---

_This fixes a bug in which merge errors that were fixed by the user were not updated in the cache due to a faulty condition in the cache update logic. This PR fixes this logic._

---
_Release Notes_: 
_NA_
