### PR TITLE
Fix remove change to field with hidden annotations (fix SALTO-1451)

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -194,13 +194,13 @@ export const createMergeManager = async (flushables: Flushable[],
     const src1 = values.isDefined(cacheUpdate.src1Overrides)
       ? mapReadOnlyElementsSource(
         sources[cacheUpdate.src1Prefix],
-        async elem => cacheUpdate.src1Overrides?.[elem.elemID.getFullName()] ?? elem
+        async elem => elem && (cacheUpdate.src1Overrides?.[elem.elemID.getFullName()] ?? elem)
       )
       : sources[cacheUpdate.src1Prefix]
     const src2 = values.isDefined(cacheUpdate.src2Overrides)
       ? mapReadOnlyElementsSource(
         sources[cacheUpdate.src2Prefix],
-        async elem => cacheUpdate.src2Overrides?.[elem.elemID.getFullName()] ?? elem
+        async elem => elem && (cacheUpdate.src2Overrides?.[elem.elemID.getFullName()] ?? elem)
       ) : sources[cacheUpdate.src2Prefix]
     const src1Changes = possibleSrc1Changes ?? createEmptyChangeSet(
       await hashes.get(getSourceHashKey(cacheUpdate.src1Prefix))

--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -21,7 +21,7 @@ import { ThenableIterable } from '@salto-io/lowerdash/src/collections/asyncitera
 import _ from 'lodash'
 import AsyncLock from 'async-lock'
 import { MergeError, MergeResult } from '../../merger'
-import { ElementsSource } from '../elements_source'
+import { ElementsSource, mapReadOnlyElementsSource } from '../elements_source'
 import { RemoteMap, RemoteMapEntry, RemoteMapCreator } from '../remote_map'
 
 const { awu } = collections.asynciterable
@@ -58,6 +58,8 @@ export type CacheUpdate = {
 export type CacheChangeSetUpdate = {
   src1Changes?: ChangeSet<Change<Element>>
   src2Changes?: ChangeSet<Change<Element>>
+  src1Overrides?: Record<string, Element>
+  src2Overrides?: Record<string, Element>
   src1Prefix: string
   src2Prefix: string
   mergeFunc: (elements: AsyncIterable<Element>) => Promise<MergeResult>
@@ -189,8 +191,17 @@ export const createMergeManager = async (flushables: Flushable[],
     noErrorMergeIds: string[]
   }> => {
     const { src1Changes: possibleSrc1Changes, src2Changes: possibleSrc2Changes } = cacheUpdate
-    const src1 = sources[cacheUpdate.src1Prefix]
-    const src2 = sources[cacheUpdate.src2Prefix]
+    const src1 = values.isDefined(cacheUpdate.src1Overrides)
+      ? mapReadOnlyElementsSource(
+        sources[cacheUpdate.src1Prefix],
+        async elem => cacheUpdate.src1Overrides?.[elem.elemID.getFullName()] ?? elem
+      )
+      : sources[cacheUpdate.src1Prefix]
+    const src2 = values.isDefined(cacheUpdate.src2Overrides)
+      ? mapReadOnlyElementsSource(
+        sources[cacheUpdate.src2Prefix],
+        async elem => cacheUpdate.src2Overrides?.[elem.elemID.getFullName()] ?? elem
+      ) : sources[cacheUpdate.src2Prefix]
     const src1Changes = possibleSrc1Changes ?? createEmptyChangeSet(
       await hashes.get(getSourceHashKey(cacheUpdate.src1Prefix))
     )
@@ -239,7 +250,9 @@ export const createMergeManager = async (flushables: Flushable[],
         deleted1.forEach(d => potentialDeletedIds.add(d))
         deleted2.forEach(d => potentialDeletedIds.add(d))
         src1ElementsToMerge = await awu(await getElementsToMergeFromChanges(
-          src1Changes, src2ChangeIDs, src2,
+          src1Changes,
+          src2ChangeIDs,
+          src2,
         ))
         src2ElementsToMerge = await awu(await getElementsToMergeFromChanges(
           src2Changes, src1ChangeIDs, src1,

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -215,6 +215,23 @@ type salesforce.lead {
   'willbempty.nacl': 'type nonempty { a = 2 }',
   'renamed_type.nacl': `type salesforce.RenamedType1 {
   }`,
+  'fieldsWithHidden.nacl': `
+  type salesforce.FieldTypeWithHidden {
+    annotations {
+      salesforce.HiddenVal hiddenValAnno {
+      }
+      string visible {
+
+      }
+    }
+  }
+
+  type salesforce.ObjWithFieldTypeWithHidden {
+    salesforce.FieldTypeWithHidden fieldWithHidden {
+      visible = "YOU SEE ME"
+    }
+  }
+  `,
 }
 
 export const mockDirStore = (


### PR DESCRIPTION
_fixed removing fields with hidden annotation from the nacls does not remove the hidden annotations_

---

_When a change is made in the nacls, we complete the hidden parts from the state. When a field is removed - we need to make sure what we don't re-add the hidden field annotation. This fix fixes a bug in which the workspace element which is used as a reference was taken from the nacl version *before the change* with the fields. Causing the fields to be re added. The solution was to use the version of the field *after the change* in which the fields are already deleted._

---
_Release Notes_: 
_NA_
