### PR TITLE
Fix error on rename env (fix SALTO-1452)

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -773,9 +773,9 @@ export const loadWorkspace = async (
       await credentials.rename(envName, newEnvName)
 
       const environmentSource = enviormentsSources.sources[envName]
-      // ensure that the env is loaded
-      await environmentSource.naclFiles.load({})
       if (environmentSource) {
+        // ensure that the env is loaded
+        await environmentSource.naclFiles.load({})
         await environmentSource.naclFiles.rename(newEnvNaclPath || newEnvName)
         await environmentSource.state?.rename(newEnvName)
       }

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -771,7 +771,10 @@ export const loadWorkspace = async (
       }
       await config.setWorkspaceConfig(workspaceConfig)
       await credentials.rename(envName, newEnvName)
+
       const environmentSource = enviormentsSources.sources[envName]
+      // ensure that the env is loaded
+      await environmentSource.naclFiles.load({})
       if (environmentSource) {
         await environmentSource.naclFiles.rename(newEnvNaclPath || newEnvName)
         await environmentSource.state?.rename(newEnvName)

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2028,6 +2028,7 @@ describe('workspace', () => {
       const verifyRenameFiles = (): void => {
         expect(credSource.rename).toHaveBeenCalledTimes(1)
         expect(stateRename).toHaveBeenCalledTimes(1)
+        expect(naclFiles.load).toHaveBeenCalledTimes(1)
         expect(naclFiles.rename).toHaveBeenCalledTimes(1)
       }
 


### PR DESCRIPTION
_Fix error on rename env_

---

_The nacl files source throws an error if its member are accessed before its load method was invoked. This call was missing from the rename env method causing an error to be thrown. This fix adds the call._

---
_Release Notes_: 
_NA_
