### PR TITLE
resolve top level parent only when needed (fix SALTO-1458)

### DIFF
--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -325,7 +325,7 @@ const addPlanFunctions = (
     changeErrors,
   })
 
-const buildDiffGraph = async (
+const buildDiffGraph = (
   ...transforms: ReadonlyArray<PlanTransformer>
 ): Promise<DiffGraph<ChangeDataType>> => (
   transforms.reduce(

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -252,7 +252,9 @@ const addDifferentElements = (
     return 0
   }
   await awu(iterateTogether(await getFilteredElements(before), await getFilteredElements(after),
-    cmp)).map(handleSpecialIds).forEach(addElementsNodes)
+    cmp))
+    .map(handleSpecialIds)
+    .forEach(addElementsNodes)
   return outputGraph
 }, 'add nodes to graph with action %s for %d elements')
 
@@ -273,11 +275,11 @@ const resolveNodeElements = (
   })
 
   const resolvedBefore = _.keyBy(
-    await resolve(beforeItemsToResolve, before),
+    await resolve(beforeItemsToResolve, before, true),
     e => e.elemID.getFullName()
   ) as Record<string, ChangeDataType>
   const resolvedAfter = _.keyBy(
-    await resolve(afterItemsToResolve, after),
+    await resolve(afterItemsToResolve, after, true),
     e => e.elemID.getFullName()
   ) as Record<string, ChangeDataType>
 
@@ -323,7 +325,7 @@ const addPlanFunctions = (
     changeErrors,
   })
 
-const buildDiffGraph = (
+const buildDiffGraph = async (
   ...transforms: ReadonlyArray<PlanTransformer>
 ): Promise<DiffGraph<ChangeDataType>> => (
   transforms.reduce(

--- a/packages/workspace/test/core/expressions.test.ts
+++ b/packages/workspace/test/core/expressions.test.ts
@@ -440,7 +440,7 @@ describe('Test Salto Expressions', () => {
       expect(resolvedValueType).toEqual(refTargetInstObj)
     })
 
-    it('should not resolve the top level element in a reference when resolveRoot is true', async () => {
+    it('should not resolve the top level element in a reference when resolveRoot is false', async () => {
       const refTargetInstObj = new ObjectType({
         elemID: ElemID.fromFullName('salto.testObj'),
       })

--- a/packages/workspace/test/core/expressions.test.ts
+++ b/packages/workspace/test/core/expressions.test.ts
@@ -409,7 +409,7 @@ describe('Test Salto Expressions', () => {
       expect(resInst.refType.elemID).toBe(resObj.elemID)
     })
 
-    it('should resolve the top level element in a reference', async () => {
+    it('should resolve the top level element in a reference when resolveRoot is true', async () => {
       const refTargetInstObj = new ObjectType({
         elemID: ElemID.fromFullName('salto.testObj'),
       })
@@ -431,12 +431,41 @@ describe('Test Salto Expressions', () => {
           [
             refTargetInstObj, instanceToResolveObj, refTargetInst, instanceToResolve,
           ]
-        )
+        ),
+        true
       )).toArray()) as [InstanceElement]
       const resolvedRef = resovledElems[0].value.test as ReferenceExpression
       const resolvedValue = resolvedRef.topLevelParent as InstanceElement
       const resolvedValueType = await resolvedValue.getType() as ObjectType
       expect(resolvedValueType).toEqual(refTargetInstObj)
+    })
+
+    it('should not resolve the top level element in a reference when resolveRoot is true', async () => {
+      const refTargetInstObj = new ObjectType({
+        elemID: ElemID.fromFullName('salto.testObj'),
+      })
+      // We need to object types here since if we were to use the same type, it would have been
+      // resolved when `instanceToResolve` would have been resolved.
+      const instanceToResolveObj = new ObjectType({
+        elemID: ElemID.fromFullName('salto.testObj2'),
+      })
+      const refTargetInst = new InstanceElement('rrr', new ReferenceExpression(refTargetInstObj.elemID), {
+        test: 'okok',
+      })
+      const instanceToResolve = new InstanceElement('rrr', new ReferenceExpression(instanceToResolveObj.elemID), {
+        test: refTo(refTargetInst, 'test'),
+      })
+      const elems = [instanceToResolve]
+      const resovledElems = (await awu(await resolve(
+        elems,
+        createInMemoryElementSource(
+          [
+            refTargetInstObj, instanceToResolveObj, refTargetInst, instanceToResolve,
+          ]
+        ),
+      )).toArray()) as [InstanceElement]
+      const resolvedRef = resovledElems[0].value.test as ReferenceExpression
+      expect(resolvedRef.topLevelParent).not.toBeDefined()
     })
   })
 


### PR DESCRIPTION
_resolve top level parent only when needed_

---

_When passed to the adapter, resolved reference expression needs to have the optional top level parent attribute set with a resolved element id. (which used in the netsuite adapter). An old bug in the lazy element branch was caused by the fact that the top level parent was not resolved. The fix for that bug (which was to always resolve the top level parent) solved the issue, but introduced a very large performance penalty in the `getPlan` method. (specifically, in the `isEqualNode` method. This fix solves the issue by adding a resolve root boolean which is only used in the one place in which is needed. As a result, the performance of the `getPlan` method were greatly improved. _

---
_Release Notes_: 
_NA_
