### PR TITLE
reuse readonly main db connection (fixes SALTO-1453)

### DIFF
--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -173,6 +173,7 @@ AsyncIterable<remoteMap.RemoteMapEntry<string>[]> {
 
 const MAX_CONNECTIONS = 1000
 const persistentDBConnections: Record<string, Promise<rocksdb>> = {}
+const readonlyDBConnections: Record<string, Promise<rocksdb>> = {}
 const tmpDBConnections: Record<string, Record<string, Promise<rocksdb>>> = {}
 let currentConnectionsCount = 0
 
@@ -493,7 +494,7 @@ remoteMap.RemoteMapCreator => {
         tmpDB = await tmpConnection
         tmpDBConnections[location][tmpLocation] = tmpConnection
       }
-      const mainDBConnections = persistent ? persistentDBConnections : tmpDBConnections[location]
+      const mainDBConnections = persistent ? persistentDBConnections : readonlyDBConnections
       if (location in mainDBConnections) {
         persistentDB = await mainDBConnections[location]
         return
@@ -507,13 +508,8 @@ remoteMap.RemoteMapCreator => {
         const readOnly = !persistent
         return getOpenDBConnection(location, readOnly)
       })()
-      const r = Math.random()
-      console.log("111111", r)
       mainDBConnections[location] = connectionPromise
-      console.log("222222222", r)
       persistentDB = await connectionPromise
-      console.log("3333333", r)
-
     }
     await createDBConnections()
     return {

--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -487,14 +487,15 @@ remoteMap.RemoteMapCreator => {
       }
     }
     const createDBConnections = async (): Promise<void> => {
+      tmpDBConnections[location] = tmpDBConnections[location] ?? {}
       if (tmpDB === undefined) {
         const tmpConnection = getOpenDBConnection(tmpLocation, false)
         tmpDB = await tmpConnection
-        tmpDBConnections[location] = tmpDBConnections[location] ?? {}
         tmpDBConnections[location][tmpLocation] = tmpConnection
       }
-      if (location in persistentDBConnections) {
-        persistentDB = await persistentDBConnections[location]
+      const mainDBConnections = persistent ? persistentDBConnections : tmpDBConnections[location]
+      if (location in mainDBConnections) {
+        persistentDB = await mainDBConnections[location]
         return
       }
       if (currentConnectionsCount > MAX_CONNECTIONS) {
@@ -506,10 +507,13 @@ remoteMap.RemoteMapCreator => {
         const readOnly = !persistent
         return getOpenDBConnection(location, readOnly)
       })()
-      if (persistent) {
-        persistentDBConnections[location] = connectionPromise
-      }
+      const r = Math.random()
+      console.log("111111", r)
+      mainDBConnections[location] = connectionPromise
+      console.log("222222222", r)
       persistentDB = await connectionPromise
+      console.log("3333333", r)
+
     }
     await createDBConnections()
     return {


### PR DESCRIPTION
_reuse readonly main db connection_

---

_When two write connections are created in the same time for rocks db - an error will be thrown. The remote map implementation did not acquire main read connection in an atomic way. Since creating read connections involved creating a write connection to see if the db exists - a race condition could have resulted in the error_

---
_Release Notes_: 
_NA_
