### PR TITLE
 changed restore to apply the selectors to the plan (fix SALTO-1441)

### DIFF
--- a/packages/core/src/core/plan/plan_item.ts
+++ b/packages/core/src/core/plan/plan_item.ts
@@ -18,6 +18,10 @@ import wu from 'wu'
 import { NodeId, Group, ActionName } from '@salto-io/dag'
 import { Change, getChangeElement, DetailedChange } from '@salto-io/adapter-api'
 import { detailedCompare } from '@salto-io/adapter-utils'
+import { values, collections } from '@salto-io/lowerdash'
+
+const { awu } = collections.asynciterable
+type SetId = collections.set.SetId
 
 export type PlanItemId = NodeId
 export type PlanItem = Group<Change> & {
@@ -56,3 +60,14 @@ export const addPlanItemAccessors = (group: Group<Change>): PlanItem => Object.a
       .flatten()
   },
 })
+
+export const filterPlanItem = async (
+  planItem: PlanItem,
+  func: (change: Change) => Promise<Change | undefined>
+) : Promise<PlanItem> => {
+  const filteredItems = new Map(await awu(planItem.items.entries())
+    .map(async ([setID, change]) => [setID, await func(change)])
+    .filter(([_setID, change]) => values.isDefined(change))
+    .toArray() as Iterable<[SetId, Change]>)
+  return addPlanItemAccessors({ items: filteredItems, groupKey: planItem.groupKey })
+}


### PR DESCRIPTION

_ changed restore to apply the selectors to the plan instead of the entire workspace_

---

_The restore method applied its element selectors to the entire workspace. That resulted with invoking transform elements on the entire workspace and state, which was painfully slow (~70second for the workspace in the ticket). In order to solve it, we modified the method to apply the selectors to the result of the `getPlan` function by:
  - Adding a new method to filter plan item changes
  - Using this method to filter out the plan
  - Verifying that all of the specific element selectors were present by checking that the get function on the element sources returns a value (this method can handle exact selectors so there was no need for the previous complex sieve usage)

Since https://github.com/salto-io/salto/pull/2212 improves the speed of the getPlan command, the result was a x20 improvement on the workspace from the ticket, when both PRs are in place._

---
_Release Notes_: 
_NA_
