### PR TITLE
[SALTO-1375] create only one tmp DB per process

### DIFF
--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -252,6 +252,8 @@ remoteMap.RemoteMapCreator => {
       locationCaches.set(location, locationCache)
     }
   }
+  let persistentDB: rocksdb
+  let tmpDB: rocksdb
   return async <T, K extends string = string>(
     { namespace,
       batchInterval = 1000,
@@ -273,8 +275,6 @@ remoteMap.RemoteMapCreator => {
         `Invalid namespace: ${namespace}. Must include only alphanumeric characters or -`
       )
     }
-    let persistentDB: rocksdb
-    let tmpDB: rocksdb
 
     const uniqueId = uuidv4()
     const tmpLocation = path.join(locationTmpDir, uniqueId)


### PR DESCRIPTION
Fix issue where too many temp dbs would be created for each process
---

---
Some internal folders no user would look at will be cleaner