### PR TITLE
SALTO-1465: fixed upgrade from NetSuite without SuiteApp to with SuiteApp

### DIFF
--- a/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
+++ b/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
@@ -27,14 +27,16 @@ const filterCreator: FilterCreator = ({ client }): FilterWith<'onFetch'> => ({
     if (!client.isSuiteAppConfigured()) {
       return
     }
-    const sdfTypeNames = new Set(getMetadataTypes().map(e => e.elemID.getFullName()))
+    const sdfTypeNames = new Set(getMetadataTypes().map(e => e.elemID.getFullName().toLowerCase()))
     const supportedDataTypes = (await elementsComponents
       .filterTypes(
         NETSUITE,
-        elements.filter(isObjectType).filter(isDataObjectType),
+        elements
+          .filter(isObjectType)
+          .filter(isDataObjectType),
         SUPPORTED_TYPES
       ))
-      .filter(e => !sdfTypeNames.has(e.elemID.getFullName()))
+      .filter(e => !sdfTypeNames.has(e.elemID.getFullName().toLowerCase()))
 
     _.remove(elements, e => isObjectType(e) && isDataObjectType(e))
     elements.push(...supportedDataTypes)

--- a/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
@@ -19,18 +19,19 @@ import filterCreator from '../../src/filters/remove_unsupported_types'
 import { NETSUITE } from '../../src/constants'
 import NetsuiteClient from '../../src/client/client'
 import { FilterOpts } from '../../src/filter'
-import { file } from '../../src/types/file_cabinet_types'
+import { customrecordtype } from '../../src/types/custom_types/customrecordtype'
 
 describe('remove_unsupported_types', () => {
   let filterOpts: FilterOpts
   let elements: TypeElement[]
-  const sdfType = file
+  const sdfType = customrecordtype
   const supportedSoapType = new ObjectType({ elemID: new ElemID(NETSUITE, 'Subsidiary'), annotations: { source: 'soap' } })
   const unsupportedSoapType = new ObjectType({ elemID: new ElemID(NETSUITE, 'someType'), annotations: { source: 'soap' } })
+  const sdfSoapType = new ObjectType({ elemID: new ElemID(NETSUITE, 'CustomRecordType'), annotations: { source: 'soap' } })
   const isSuiteAppConfiguredMock = jest.fn()
 
   beforeEach(() => {
-    elements = [sdfType, supportedSoapType, unsupportedSoapType]
+    elements = [sdfType, supportedSoapType, unsupportedSoapType, sdfSoapType]
     isSuiteAppConfiguredMock.mockReset()
     isSuiteAppConfiguredMock.mockReturnValue(true)
     filterOpts = {
@@ -47,12 +48,12 @@ describe('remove_unsupported_types', () => {
 
   it('should remove the unsupported types', async () => {
     await filterCreator(filterOpts).onFetch?.(elements)
-    expect(elements.map(e => e.elemID.name)).toEqual(['file', 'Subsidiary'])
+    expect(elements.map(e => e.elemID.name)).toEqual(['customrecordtype', 'Subsidiary'])
   })
 
   it('should do nothing if suiteApp is not installed', async () => {
     isSuiteAppConfiguredMock.mockReturnValue(false)
     await filterCreator(filterOpts).onFetch?.(elements)
-    expect(elements.map(e => e.elemID.name)).toEqual(['file', 'Subsidiary', 'someType'])
+    expect(elements.map(e => e.elemID.name)).toEqual(['customrecordtype', 'Subsidiary', 'someType', 'CustomRecordType'])
   })
 })


### PR DESCRIPTION
Fixed upgrading from NetSuite without SuiteApp to NetSuite with SuiteApp
Due to a collision between SDF types to SOAP types, the fetch after the upgrade would throw an error. 

---
_Release Notes_: 
None