### PR TITLE
added a static file reviver (fix SALTO-1454)

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -203,29 +203,39 @@ export const loadWorkspace = async (
   }): Promise<WorkspaceState> => {
     const initState = async (): Promise<WorkspaceState> => {
       const states: Record<string, SingleState> = Object.fromEntries(await awu(envs())
-        .map(async envName => [envName, {
-          merged: new RemoteElementSource(
-            await remoteMapCreator<Element>({
-              namespace: getRemoteMapNamespace('merged', envName),
-              serialize: element => serialize([element], 'keepRef'),
-              // TODO: we might need to pass static file reviver to the deserialization func
-              deserialize: deserializeSingleElement,
+        .map(async envName => {
+          const envSrc = createNaclFilesSource(envName)
+          return [envName, {
+            merged: new RemoteElementSource(
+              await remoteMapCreator<Element>({
+                namespace: getRemoteMapNamespace('merged', envName),
+                serialize: element => serialize([element], 'keepRef'),
+                // TODO: we might need to pass static file reviver to the deserialization func
+                deserialize: s => deserializeSingleElement(
+                  s,
+                  async staticFile => await envSrc.getStaticFileByHash(
+                    staticFile.filepath,
+                    staticFile.encoding,
+                    staticFile.hash
+                  ) ?? staticFile
+                ),
+                persistent,
+              })
+            ),
+            errors: await remoteMapCreator<MergeError[]>({
+              namespace: getRemoteMapNamespace('errors', envName),
+              serialize: mergeErrors => serialize(mergeErrors, 'keepRef'),
+              deserialize: async data => deserializeMergeErrors(data),
               persistent,
-            })
-          ),
-          errors: await remoteMapCreator<MergeError[]>({
-            namespace: getRemoteMapNamespace('errors', envName),
-            serialize: mergeErrors => serialize(mergeErrors, 'keepRef'),
-            deserialize: async data => deserializeMergeErrors(data),
-            persistent,
-          }),
-          validationErrors: await remoteMapCreator<ValidationError[]>({
-            namespace: getRemoteMapNamespace('validationErrors', envName),
-            serialize: validationErrors => serialize(validationErrors, 'keepRef'),
-            deserialize: async data => deserializeValidationErrors(data),
-            persistent,
-          }),
-        }]).toArray())
+            }),
+            validationErrors: await remoteMapCreator<ValidationError[]>({
+              namespace: getRemoteMapNamespace('validationErrors', envName),
+              serialize: validationErrors => serialize(validationErrors, 'keepRef'),
+              deserialize: async data => deserializeValidationErrors(data),
+              persistent,
+            }),
+          }]
+        }).toArray())
       const sources: Record<string, ReadOnlyElementsSource> = {}
       await awu(envs()).forEach(async envName => {
         sources[MULTI_ENV_SOURCE_PREFIX + envName] = await naclFilesSource

--- a/packages/workspace/test/common/nacl_file_source.ts
+++ b/packages/workspace/test/common/nacl_file_source.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, Element, Change, isObjectType } from '@salto-io/adapter-api'
+import { ElemID, Element, Change, isObjectType, isStaticFile } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { resolvePath } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -22,6 +22,7 @@ import { Errors } from '../../src/workspace/errors'
 import { SourceRange } from '../../src/parser/internal/types'
 import { createInMemoryElementSource } from '../../src/workspace/elements_source'
 import { createAddChange } from '../../src/workspace/nacl_files/multi_env/projections'
+import { mockStaticFilesSource } from '../utils'
 
 const { awu } = collections.asynciterable
 type ThenableIterable<T> = collections.asynciterable.ThenableIterable<T>
@@ -32,6 +33,7 @@ export const createMockNaclFileSource = (
   errors: Errors = new Errors({ merge: [], parse: [], validation: [] }),
   sourceRanges?: SourceRange[],
   changes: ChangeSet<Change> = { changes: [], cacheValid: true },
+  staticFileSource = mockStaticFilesSource()
 ): NaclFilesSource => {
   const currentElements = elements
   const elementSource = createInMemoryElementSource(currentElements)
@@ -99,5 +101,11 @@ export const createMockNaclFileSource = (
         : []
       return [e.elemID.getFullName(), ...fieldNames]
     }))),
+    getStaticFileByHash: async (filePath, enc, hash) => {
+      const sfile = await staticFileSource.getStaticFile(filePath, enc)
+      return isStaticFile(sfile) && sfile.hash === hash
+        ? sfile
+        : undefined
+    },
   })
 }

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import path from 'path'
-import { Element, ElemID, BuiltinTypes, ObjectType, DetailedChange, Change, getChangeElement } from '@salto-io/adapter-api'
+import { Element, ElemID, BuiltinTypes, ObjectType, DetailedChange, Change, getChangeElement, StaticFile } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import * as utils from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -27,6 +27,8 @@ import { ValidationError } from '../../../src/validator'
 import { MergeError } from '../../../src/merger'
 import { expectToContainAllItems } from '../../common/helpers'
 import { InMemoryRemoteMap } from '../../../src/workspace/remote_map'
+import { mockStaticFilesSource } from '../../utils'
+import { MissingStaticFile } from '../../../src/workspace/static_files'
 
 const { awu } = collections.asynciterable
 jest.mock('@salto-io/adapter-utils', () => ({
@@ -154,17 +156,24 @@ const emptySource = createMockNaclFileSource(
   commonErrors,
   []
 )
+const commonSrcStaticFileSource = mockStaticFilesSource()
 const commonSource = createMockNaclFileSource(
   [commonObject, commonFragment],
   commonNaclFiles,
   commonErrors,
-  [commonSourceRange]
+  [commonSourceRange],
+  { changes: [], cacheValid: true },
+  commonSrcStaticFileSource
 )
+
+const envSrcStaticFileSource = mockStaticFilesSource()
 const envSource = createMockNaclFileSource(
   [envObject, envFragment],
   envNaclFiles,
   envErrors,
-  [envSourceRange]
+  [envSourceRange],
+  { changes: [], cacheValid: true },
+  envSrcStaticFileSource
 )
 const inactiveSource = createMockNaclFileSource(
   [inactiveObject, inactiveFragment],
@@ -890,6 +899,57 @@ describe('multi env source', () => {
         false
       )
       await expect(() => nonPSource.flush()).rejects.toThrow()
+    })
+  })
+
+  describe('getStaticFileByHash', () => {
+    const staticFile = new StaticFile({
+      content: Buffer.from(''),
+      filepath: 'aaa.txt',
+      encoding: 'utf-8',
+      hash: 'aaa',
+    })
+    it('should return the file it is present in the common source and the hashes match', async () => {
+      commonSrcStaticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(staticFile)
+      envSrcStaticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(new MissingStaticFile(''))
+      const src = multiEnvSource(
+        sources,
+        activePrefix,
+        commonPrefix,
+        () => Promise.resolve(new InMemoryRemoteMap()),
+        false
+      )
+      expect(await src.getStaticFileByHash(
+        staticFile.filepath, staticFile.encoding, staticFile.hash
+      )).toEqual(staticFile)
+    })
+    it('should return the file it is present in the env source and the hashes match', async () => {
+      commonSrcStaticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(new MissingStaticFile(''))
+      envSrcStaticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(staticFile)
+      const src = multiEnvSource(
+        sources,
+        activePrefix,
+        commonPrefix,
+        () => Promise.resolve(new InMemoryRemoteMap()),
+        false
+      )
+      expect(await src.getStaticFileByHash(
+        staticFile.filepath, staticFile.encoding, staticFile.hash
+      )).toEqual(staticFile)
+    })
+    it('should return undefined if the hahes do not match', async () => {
+      commonSrcStaticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(new MissingStaticFile(''))
+      envSrcStaticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(staticFile)
+      const src = multiEnvSource(
+        sources,
+        activePrefix,
+        commonPrefix,
+        () => Promise.resolve(new InMemoryRemoteMap()),
+        false
+      )
+      expect(await src.getStaticFileByHash(
+        staticFile.filepath, staticFile.encoding, 'nohash'
+      )).not.toBeDefined()
     })
   })
 })

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -19,7 +19,7 @@ import _ from 'lodash'
 import { DirectoryStore } from '../../../src/workspace/dir_store'
 
 import { naclFilesSource, NaclFilesSource } from '../../../src/workspace/nacl_files'
-import { StaticFilesSource } from '../../../src/workspace/static_files'
+import { StaticFilesSource, MissingStaticFile } from '../../../src/workspace/static_files'
 import { ParsedNaclFileCache, createParseResultCache } from '../../../src/workspace/nacl_files/parsed_nacl_files_cache'
 
 import { mockStaticFilesSource, persistentMockCreateRemoteMap } from '../../utils'
@@ -472,6 +472,55 @@ describe('Nacl Files Source', () => {
         false
       )
       await expect(nonPSrc.flush()).rejects.toThrow()
+    })
+  })
+
+  describe('getStaticFileByHash', () => {
+    const staticFileSource = mockStaticFilesSource()
+    const staticFile = new StaticFile({
+      content: Buffer.from(''),
+      filepath: 'aaa.txt',
+      encoding: 'utf-8',
+      hash: 'aaa',
+    })
+    it('should return the file it is present and the hashes match', async () => {
+      staticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(staticFile)
+      const src = await naclFilesSource(
+        '',
+        mockDirStore,
+        staticFileSource,
+        () => Promise.resolve(new InMemoryRemoteMap()),
+        false
+      )
+      expect(await src.getStaticFileByHash(
+        staticFile.filepath, staticFile.encoding, staticFile.hash
+      )).toEqual(staticFile)
+    })
+    it('should return undefined if the file is invalid', async () => {
+      staticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(new MissingStaticFile(''))
+      const src = await naclFilesSource(
+        '',
+        mockDirStore,
+        staticFileSource,
+        () => Promise.resolve(new InMemoryRemoteMap()),
+        false
+      )
+      expect(await src.getStaticFileByHash(
+        'nope.txt', staticFile.encoding, staticFile.hash
+      )).not.toBeDefined()
+    })
+    it('should return undefined if the hahes do not match', async () => {
+      staticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(staticFile)
+      const src = await naclFilesSource(
+        '',
+        mockDirStore,
+        staticFileSource,
+        () => Promise.resolve(new InMemoryRemoteMap()),
+        false
+      )
+      expect(await src.getStaticFileByHash(
+        staticFile.filepath, staticFile.encoding, 'otherhash'
+      )).not.toBeDefined()
     })
   })
 })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -96,7 +96,6 @@ const createState = (
   servicesUpdateDate: new InMemoryRemoteMap(),
   saltoMetadata: new InMemoryRemoteMap([{ key: 'version', value: '0.0.1' }]),
 }), persistent)
-
 const createWorkspace = async (
   dirStore?: DirectoryStore<string>,
   state?: State,


### PR DESCRIPTION
_added a static file reviver for workspace and multi env source_

---

_The workspace and multi env source did not have static file reviver, since they do not have a static file store (or information as to which source a specific static file belongs to).  This resulted in static files being loaded as simple static files, which prevented their content from being loaded, this in turn lead to deploy fails when attempting to deploy static files, since their data was missing.

In order to resolve this, we added a method that allows to get a static file from the file source by hash. Since the hash is a good identifier for content, and since it is present in the simple static file, this allows us to properly revive the static files without de-encapsulation

---
_Release Notes_: 
_NA_
