### PR TITLE
SALTO-1450 avoid failing move operations on missing ids

### DIFF
--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -261,7 +261,7 @@ ${Prompts.LIST_IDS(ids)}
   public static readonly SHOULD_MOVE_QUESTION = (to: string): string =>
     Prompts.SHOULD_RUN_ELEMENTS_OPERATION(`move to ${to}`)
 
-  public static readonly NO_ELEMENTS_MESSAGE = `Did not find any configuration elements that matches your criteria.
+  public static readonly NO_ELEMENTS_MESSAGE = `Did not find any configuration elements that match your criteria.
 Nothing to do.
 `
 

--- a/packages/core/src/core/diff.ts
+++ b/packages/core/src/core/diff.ts
@@ -61,10 +61,16 @@ export const createDiffChanges = async (
   elementSelectors: ElementSelector[] = [],
 ): Promise<DetailedChange[]> => {
   if (elementSelectors.length > 0) {
-    const toElementIdsFiltered = selectElementIdsByTraversal(elementSelectors,
-      toElements.map(element => ({ elemID: element.elemID, element })), true)
-    const fromElementIdsFiltered = selectElementIdsByTraversal(elementSelectors,
-      fromElements.map(element => ({ elemID: element.elemID, element })), true)
+    const toElementIdsFiltered = selectElementIdsByTraversal(
+      elementSelectors,
+      toElements.map(element => ({ elemID: element.elemID, element })),
+      true,
+    )
+    const fromElementIdsFiltered = selectElementIdsByTraversal(
+      elementSelectors,
+      fromElements.map(element => ({ elemID: element.elemID, element })),
+      true,
+    )
     const selectorsToVerify = new Set<string>(elementSelectors
       .map(sel => sel.origin).filter(sel => !sel.includes('*')))
     const toElementsFiltered = filterElementsByRelevance([...toElements],

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -73,8 +73,11 @@ type MultiEnvState = {
 type MultiEnvSource = Omit<NaclFilesSource, 'getAll'> & {
   getAll: (env?: string) => Promise<Element[]>
   promote: (ids: ElemID[]) => Promise<void>
-  getElementIdsBySelectors: (selectors: ElementSelector[],
-    commonOnly?: boolean, validateDeterminedSelectors?: boolean) => Promise<ElemID[]>
+  getElementIdsBySelectors: (
+    selectors: ElementSelector[],
+    commonOnly?: boolean,
+    validateDeterminedSelectors?: boolean,
+  ) => Promise<ElemID[]>
   demote: (ids: ElemID[]) => Promise<void>
   demoteAll: () => Promise<void>
   copyTo: (ids: ElemID[], targetEnvs?: string[]) => Promise<void>
@@ -233,10 +236,18 @@ const buildMultiEnvSource = (
   const getElementsFromSource = async (source: NaclFilesSource): Promise<ElementIDToValue[]> =>
     (await source.getAll()).map(elem => ({ elemID: elem.elemID, element: elem }))
 
-  const getElementIdsBySelectors = async (selectors: ElementSelector[],
-    commonOnly = false, validateDeterminedSelectors = false): Promise<ElemID[]> =>
-    selectElementIdsByTraversal(selectors, await getElementsFromSource(commonOnly
-      ? commonSource() : primarySource()), false, validateDeterminedSelectors)
+  const getElementIdsBySelectors = async (
+    selectors: ElementSelector[], commonOnly = false,
+  ): Promise<ElemID[]> =>
+    selectElementIdsByTraversal(
+      selectors,
+      await getElementsFromSource(
+        commonOnly
+          ? commonSource()
+          : primarySource()
+      ),
+      false,
+    )
 
   const promote = async (ids: ElemID[]): Promise<void> => {
     const routedChanges = await routePromote(

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -112,8 +112,9 @@ export type Workspace = {
   getSourceRanges: (elemID: ElemID) => Promise<SourceRange[]>
   getElementReferencedFiles: (id: ElemID) => Promise<string[]>
   getElementNaclFiles: (id: ElemID) => Promise<string[]>
-  getElementIdsBySelectors: (selectors: ElementSelector[],
-    commonOnly?: boolean) => Promise<ElemID[]>
+  getElementIdsBySelectors: (
+    selectors: ElementSelector[], commonOnly?: boolean,
+  ) => Promise<ElemID[]>
   getParsedNaclFile: (filename: string) => Promise<ParsedNaclFile | undefined>
   flush: () => Promise<void>
   clone: () => Promise<Workspace>
@@ -380,9 +381,9 @@ export const loadWorkspace = async (config: WorkspaceConfigSource, credentials: 
     getSourceMap: (filename: string) => naclFilesSource.getSourceMap(filename),
     getSourceRanges: (elemID: ElemID) => naclFilesSource.getSourceRanges(elemID),
     listNaclFiles: () => naclFilesSource.listNaclFiles(),
-    getElementIdsBySelectors: async (selectors: ElementSelector[],
-      commonOnly = false, validateElementIdsExist = false) => naclFilesSource
-      .getElementIdsBySelectors(selectors, commonOnly, validateElementIdsExist),
+    getElementIdsBySelectors: async (selectors: ElementSelector[], commonOnly = false) => (
+      naclFilesSource.getElementIdsBySelectors(selectors, commonOnly)
+    ),
     getElementReferencedFiles: id => naclFilesSource.getElementReferencedFiles(id),
     getElementNaclFiles: id => naclFilesSource.getElementNaclFiles(id),
     getTotalSize: () => naclFilesSource.getTotalSize(),

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -425,28 +425,19 @@ describe('select elements recursively', () => {
       }))))
     expect(elementIds).toEqual([ElemID.fromFullName('mockAdapter.test.instance.mockInstance.bool')])
   })
-  it('should just return element id if validateDeterminedSelectors is false', async () => {
-    const selectors = createElementSelectors([
-      'mockAdapter.test.instance.mockInstance.thispropertydoesntexist',
-    ]).validSelectors
-    const elementIds = (await selectElementIdsByTraversal(selectors,
-      [mockInstance, mockType].map(element => ({
-        elemID: element.elemID,
-        element,
-      }))))
-    expect(elementIds).toEqual([ElemID
-      .fromFullName('mockAdapter.test.instance.mockInstance.thispropertydoesntexist')])
-  })
-  it('should not return non-existant element id if validateDeterminedSelectors is true', async () => {
+  it('should not return non-existent element id', async () => {
     const selectors = createElementSelectors([
       'mockAdapter.test.instance.mockInstance.thispropertydoesntexist',
       'mockAdapter.test.field.strMap',
     ]).validSelectors
-    const elementIds = (await selectElementIdsByTraversal(selectors,
+    const elementIds = (await selectElementIdsByTraversal(
+      selectors,
       [mockInstance, mockType].map(element => ({
         elemID: element.elemID,
         element,
-      })), false, true))
+      })),
+      false,
+    ))
     expect(elementIds).toEqual([ElemID.fromFullName('mockAdapter.test.field.strMap')])
   })
 })

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -440,4 +440,15 @@ describe('select elements recursively', () => {
     ))
     expect(elementIds).toEqual([ElemID.fromFullName('mockAdapter.test.field.strMap')])
   })
+  it('should return empty list on empty selector list', async () => {
+    const elementIds = (await selectElementIdsByTraversal(
+      [],
+      [mockInstance, mockType].map(element => ({
+        elemID: element.elemID,
+        element,
+      })),
+      false,
+    ))
+    expect(elementIds).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
Until now, when explicit elem ids (without any wildcards) were passed to operations like `move-to-common` / `clone` / `move-to-envs` (and `diff`), we would fail if not all of them were found in the (env-specific part of the) selected env. 

We're changing this behavior to be the same as selectors with wildcards - the preview will show the full list of ids that were _found_, and any missing ids will be omitted silently.

---
_Release Notes_: 
Core: 
- Commands that accept selectors no longer throw an error when element ids that were specified exactly are not found. This impacts `move-to-common`, `clone`, `move-to-envs`, and `diff`.
