### PR TITLE
SALTO-1450 SALTO-1471 avoid failing move operations on missing ids

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -110,7 +110,7 @@ export class ReferenceExpression {
     if (this.resValue === undefined && elementsSource === undefined) {
       throw new Error(
         `Can not resolve value of reference with ElemID ${this.elemID.getFullName()} `
-        + 'without elementsSource cause value does not exist'
+        + 'without elementsSource because value does not exist'
       )
     }
     const value = (await elementsSource?.get(this.elemID)) ?? this.value

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -106,7 +106,7 @@ const moveElement = async (
 ): Promise<CliExitCode> => {
   try {
     const elemIds = await awu(
-      await workspace.getElementIdsBySelectors(elmSelectors, to === 'envs')
+      await workspace.getElementIdsBySelectors(elmSelectors, to === 'envs', true)
     ).toArray()
 
     if (!await shouldMoveElements(to, elemIds, cliOutput, force)) {
@@ -285,7 +285,7 @@ export const cloneAction: WorkspaceCommandAction<ElementCloneArgs> = async ({
 
   try {
     const elemIds = await awu(
-      await workspace.getElementIdsBySelectors(validSelectors)
+      await workspace.getElementIdsBySelectors(validSelectors, false, true)
     ).toArray()
     if (!await shouldCloneElements(toEnvs, elemIds, output, force ?? false)) {
       return CliExitCode.Success

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -265,7 +265,7 @@ ${Prompts.LIST_IDS(ids)}
   public static readonly SHOULD_MOVE_QUESTION = (to: string): string =>
     Prompts.SHOULD_RUN_ELEMENTS_OPERATION(`move to ${to}`)
 
-  public static readonly NO_ELEMENTS_MESSAGE = `Did not find any configuration elements that matches your criteria.
+  public static readonly NO_ELEMENTS_MESSAGE = `Did not find any configuration elements that match your criteria.
 Nothing to do.
 `
 

--- a/packages/core/src/core/diff.ts
+++ b/packages/core/src/core/diff.ts
@@ -98,33 +98,12 @@ const filterPlanItemsByRelevance = async (
     .toArray()
 }
 
-const verifyExactSelectorsExistance = async (
-  elementSelectors: ElementSelector[],
-  toElementsSrc: elementSource.ElementsSource,
-  fromElementsSrc: elementSource.ElementsSource,
-): Promise<void> => {
-  const selectorsToVerify = new Set<string>(elementSelectors
-    .map(sel => sel.origin).filter(sel => !sel.includes('*')))
-
-  const missingSelectors = await awu(selectorsToVerify.values())
-    .filter(async selector => {
-      const id = ElemID.fromFullName(selector)
-      return (await toElementsSrc.get(id) === undefined
-        && await fromElementsSrc.get(id) === undefined)
-    })
-    .toArray()
-  if (missingSelectors.length > 0) {
-    throw new Error(`ids not found: ${Array.from(missingSelectors)}`)
-  }
-}
-
 const getFilteredIds = async (
   elementSelectors: ElementSelector[],
   src: elementSource.ElementsSource
 ): Promise<ElemID[]> => {
   const elementIDs = awu(await src.list())
-  return awu(await selectElementIdsByTraversal(elementSelectors,
-    elementIDs, src, true)).toArray()
+  return awu(await selectElementIdsByTraversal(elementSelectors, elementIDs, src, true)).toArray()
 }
 
 export const createDiffChanges = async (
@@ -141,7 +120,6 @@ export const createDiffChanges = async (
   })
 
   if (elementSelectors.length > 0) {
-    await verifyExactSelectorsExistance(elementSelectors, toElementsSrc, fromElementsSrc)
     const toElementIdsFiltered = await getFilteredIds(elementSelectors, toElementsSrc)
     const fromElementIdsFiltered = await getFilteredIds(elementSelectors, fromElementsSrc)
     return filterPlanItemsByRelevance(

--- a/packages/core/src/core/diff.ts
+++ b/packages/core/src/core/diff.ts
@@ -101,10 +101,9 @@ const filterPlanItemsByRelevance = async (
 const getFilteredIds = async (
   elementSelectors: ElementSelector[],
   src: elementSource.ElementsSource
-): Promise<ElemID[]> => {
-  const elementIDs = awu(await src.list())
-  return awu(await selectElementIdsByTraversal(elementSelectors, elementIDs, src, true)).toArray()
-}
+): Promise<ElemID[]> => (
+  awu(await selectElementIdsByTraversal(elementSelectors, src, true)).toArray()
+)
 
 export const createDiffChanges = async (
   toElementsSrc: elementSource.ElementsSource,

--- a/packages/core/test/core/diff.test.ts
+++ b/packages/core/test/core/diff.test.ts
@@ -160,12 +160,14 @@ describe('diff', () => {
         singlePathObjMerged,
         multiPathInstMerged,
         singlePathInstMerged,
+        nestedType,
       ]
       singlePathInstMergedAfter.value.nested.str = 'modified'
       beforeElements = [
         multiPathObjMerged,
         singlePathInstMergedAfter,
         multiPathInstMerged,
+        nestedType,
       ]
     })
 
@@ -207,7 +209,7 @@ describe('diff', () => {
       beforeAll(async () => {
         nestedID = singlePathInstMerged.elemID
           .createNestedID('nested')
-          // .createNestedID('str') // TODO fix
+          .createNestedID('str')
         const selectors = [
           createElementSelector(singlePathObjMerged.elemID.getFullName()),
           createElementSelector(nestedID.getFullName()),
@@ -225,7 +227,7 @@ describe('diff', () => {
         expect(changes.find(c => c.id.isEqual(singlePathObjMerged.elemID))).toBeTruthy()
       })
       it('should create partial changes for elements that pass nested filters', () => {
-        expect(changes.find(c => c.id.isEqual(nestedID.createNestedID('str')))).toBeTruthy()
+        expect(changes.find(c => c.id.isEqual(nestedID))).toBeTruthy()
       })
     })
     describe('check diff handling of selectors', () => {

--- a/packages/core/test/core/diff.test.ts
+++ b/packages/core/test/core/diff.test.ts
@@ -207,7 +207,7 @@ describe('diff', () => {
       beforeAll(async () => {
         nestedID = singlePathInstMerged.elemID
           .createNestedID('nested')
-          .createNestedID('str')
+          // .createNestedID('str') // TODO fix
         const selectors = [
           createElementSelector(singlePathObjMerged.elemID.getFullName()),
           createElementSelector(nestedID.getFullName()),
@@ -225,7 +225,7 @@ describe('diff', () => {
         expect(changes.find(c => c.id.isEqual(singlePathObjMerged.elemID))).toBeTruthy()
       })
       it('should create partial changes for elements that pass nested filters', () => {
-        expect(changes.find(c => c.id.isEqual(nestedID))).toBeTruthy()
+        expect(changes.find(c => c.id.isEqual(nestedID.createNestedID('str')))).toBeTruthy()
       })
     })
     describe('check diff handling of selectors', () => {

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -292,18 +292,13 @@ const buildMultiEnvSource = (
     return buildRes.changes
   }
 
-  const getElementsFromSource = async (source: NaclFilesSource):
-    Promise<AsyncIterable<ElemID>> => awu((await source.list()))
-
   const getElementIdsBySelectors = async (
     selectors: ElementSelector[],
     commonOnly = false,
   ): Promise<AsyncIterable<ElemID>> => {
     const relevantSource = commonOnly ? commonSource() : primarySource()
-    const elementsFromSource = await getElementsFromSource(relevantSource)
     return selectElementIdsByTraversal(
       selectors,
-      elementsFromSource,
       relevantSource,
       true,
     )

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -84,8 +84,10 @@ export type EnvsChanges = Record<string, ChangeSet<Change>>
 export type MultiEnvSource = Omit<NaclFilesSource<EnvsChanges>, 'getAll' | 'getElementsSource'> & {
   getAll: (env?: string) => Promise<AsyncIterable<Element>>
   promote: (ids: ElemID[]) => Promise<EnvsChanges>
-  getElementIdsBySelectors: (selectors: ElementSelector[],
-    commonOnly?: boolean, validateDeterminedSelectors?: boolean) => Promise<AsyncIterable<ElemID>>
+  getElementIdsBySelectors: (
+    selectors: ElementSelector[],
+    commonOnly?: boolean,
+  ) => Promise<AsyncIterable<ElemID>>
   demote: (ids: ElemID[]) => Promise<EnvsChanges>
   demoteAll: () => Promise<EnvsChanges>
   copyTo: (ids: ElemID[], targetEnvs?: string[]) => Promise<EnvsChanges>
@@ -296,7 +298,6 @@ const buildMultiEnvSource = (
   const getElementIdsBySelectors = async (
     selectors: ElementSelector[],
     commonOnly = false,
-    validateDeterminedSelectors = false,
   ): Promise<AsyncIterable<ElemID>> => {
     const relevantSource = commonOnly ? commonSource() : primarySource()
     const elementsFromSource = await getElementsFromSource(relevantSource)
@@ -305,7 +306,6 @@ const buildMultiEnvSource = (
       elementsFromSource,
       relevantSource,
       false,
-      validateDeterminedSelectors,
     )
   }
 

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -305,7 +305,7 @@ const buildMultiEnvSource = (
       selectors,
       elementsFromSource,
       relevantSource,
-      false,
+      true,
     )
   }
 

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -87,6 +87,7 @@ export type MultiEnvSource = Omit<NaclFilesSource<EnvsChanges>, 'getAll' | 'getE
   getElementIdsBySelectors: (
     selectors: ElementSelector[],
     commonOnly?: boolean,
+    compact?: boolean,
   ) => Promise<AsyncIterable<ElemID>>
   demote: (ids: ElemID[]) => Promise<EnvsChanges>
   demoteAll: () => Promise<EnvsChanges>
@@ -295,12 +296,13 @@ const buildMultiEnvSource = (
   const getElementIdsBySelectors = async (
     selectors: ElementSelector[],
     commonOnly = false,
+    compact = false,
   ): Promise<AsyncIterable<ElemID>> => {
     const relevantSource = commonOnly ? commonSource() : primarySource()
     return selectElementIdsByTraversal(
       selectors,
       relevantSource,
-      true,
+      compact,
     )
   }
 

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -116,8 +116,10 @@ export type Workspace = {
   getSourceRanges: (elemID: ElemID) => Promise<SourceRange[]>
   getElementReferencedFiles: (id: ElemID) => Promise<string[]>
   getElementNaclFiles: (id: ElemID) => Promise<string[]>
-  getElementIdsBySelectors: (selectors: ElementSelector[],
-    commonOnly?: boolean) => Promise<AsyncIterable<ElemID>>
+  getElementIdsBySelectors: (
+    selectors: ElementSelector[],
+    commonOnly?: boolean,
+  ) => Promise<AsyncIterable<ElemID>>
   getParsedNaclFile: (filename: string) => Promise<ParsedNaclFile | undefined>
   flush: () => Promise<void>
   clone: () => Promise<Workspace>
@@ -637,8 +639,7 @@ export const loadWorkspace = async (
     listNaclFiles: async () => (
       (await getLoadedNaclFilesSource()).listNaclFiles()
     ),
-    getElementIdsBySelectors: async (selectors: ElementSelector[],
-      commonOnly = false) => (
+    getElementIdsBySelectors: async (selectors: ElementSelector[], commonOnly = false) => (
       (await getLoadedNaclFilesSource()).getElementIdsBySelectors(selectors, commonOnly)
     ),
     getElementReferencedFiles: async id => (

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -119,6 +119,7 @@ export type Workspace = {
   getElementIdsBySelectors: (
     selectors: ElementSelector[],
     commonOnly?: boolean,
+    compact?: boolean,
   ) => Promise<AsyncIterable<ElemID>>
   getParsedNaclFile: (filename: string) => Promise<ParsedNaclFile | undefined>
   flush: () => Promise<void>
@@ -639,8 +640,10 @@ export const loadWorkspace = async (
     listNaclFiles: async () => (
       (await getLoadedNaclFilesSource()).listNaclFiles()
     ),
-    getElementIdsBySelectors: async (selectors: ElementSelector[], commonOnly = false) => (
-      (await getLoadedNaclFilesSource()).getElementIdsBySelectors(selectors, commonOnly)
+    getElementIdsBySelectors: async (
+      selectors: ElementSelector[], commonOnly = false, compact = false,
+    ) => (
+      (await getLoadedNaclFilesSource()).getElementIdsBySelectors(selectors, commonOnly, compact)
     ),
     getElementReferencedFiles: async id => (
       (await getLoadedNaclFilesSource()).getElementReferencedFiles(id)

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -334,11 +334,9 @@ describe.skip('validation tests', () => {
 })
 describe('select elements recursively', () => {
   const testElements = [mockInstance, mockType]
-  const testElementIds = testElements.map(element => element.elemID)
   const testSelect = async (selectors: ElementSelector[], compact = false): Promise<ElemID[]> =>
     awu(await selectElementIdsByTraversal(
       selectors,
-      awu(testElementIds),
       createInMemoryElementSource(testElements),
       compact,
     )).toArray()
@@ -415,7 +413,6 @@ describe('select elements recursively', () => {
     ]).validSelectors
     const elementIds = await awu(await selectElementIdsByTraversal(
       selectors,
-      awu([mockInstance, mockType]).map(element => element.elemID),
       createInMemoryElementSource([mockInstance, mockType]),
       false,
     )).toArray()

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -335,14 +335,12 @@ describe.skip('validation tests', () => {
 describe('select elements recursively', () => {
   const testElements = [mockInstance, mockType]
   const testElementIds = testElements.map(element => element.elemID)
-  const testSelect = async (selectors: ElementSelector[],
-    compact = false, validateDeterminedSelectors = false): Promise<ElemID[]> =>
+  const testSelect = async (selectors: ElementSelector[], compact = false): Promise<ElemID[]> =>
     awu(await selectElementIdsByTraversal(
       selectors,
       awu(testElementIds),
       createInMemoryElementSource(testElements),
       compact,
-      validateDeterminedSelectors
     )).toArray()
   it('finds subElements one and two layers deep', async () => {
     const selectors = createElementSelectors([
@@ -410,27 +408,17 @@ describe('select elements recursively', () => {
     const elementIds = await testSelect(selectors, true)
     expect(elementIds).toEqual([ElemID.fromFullName('mockAdapter.test.instance.mockInstance.bool')])
   })
-  it('should just return element id if validateDeterminedSelectors is false', async () => {
-    const selectors = createElementSelectors([
-      'mockAdapter.test.instance.mockInstance.thispropertydoesntexist',
-    ]).validSelectors
-    const elementIds = await awu((await selectElementIdsByTraversal(
-      selectors,
-      awu([mockInstance, mockType]).map(element => (element.elemID)),
-      createInMemoryElementSource([mockInstance, mockType])
-    ))).toArray()
-    expect(elementIds).toEqual([ElemID
-      .fromFullName('mockAdapter.test.instance.mockInstance.thispropertydoesntexist')])
-  })
-  it('should not return non-existant element id if validateDeterminedSelectors is true', async () => {
+  it('should not return non-existent element id', async () => {
     const selectors = createElementSelectors([
       'mockAdapter.test.instance.mockInstance.thispropertydoesntexist',
       'mockAdapter.test.field.strMap',
     ]).validSelectors
-    const elementIds = await awu(await selectElementIdsByTraversal(selectors,
+    const elementIds = await awu(await selectElementIdsByTraversal(
+      selectors,
       awu([mockInstance, mockType]).map(element => element.elemID),
       createInMemoryElementSource([mockInstance, mockType]),
-      false, true)).toArray()
+      false,
+    )).toArray()
     expect(elementIds).toEqual([ElemID.fromFullName('mockAdapter.test.field.strMap')])
   })
 })

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -842,26 +842,74 @@ describe('multi env source', () => {
       )
     })
   })
+  describe('getElementIdsBySelectors', () => {
+    describe('commonOnly=false', () => {
+      it('should extract the proper ids with overlaps when compact=false', async () => {
+        const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
+        const res = await awu(await source.getElementIdsBySelectors(selectors)).toArray()
+        expect(res.map(id => id.getFullName()).sort()).toEqual([
+          envElemID,
+          envElemID.createNestedID('field', 'field'),
+          objectElemID,
+          objectElemID.createNestedID('field', 'envField'),
+        ].map(id => id.getFullName()))
+      })
+      it('should extract the proper ids without overlaps when compact=true', async () => {
+        const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
+        const res = await awu(
+          await source.getElementIdsBySelectors(selectors, false, true)
+        ).toArray()
+        expect(res.map(id => id.getFullName()).sort()).toEqual([
+          envElemID,
+          objectElemID,
+        ].map(id => id.getFullName()))
+      })
+    })
+    describe('commonOnly=true', () => {
+      it('should extract the proper ids with overlaps when compact=false', async () => {
+        const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
+        const res = await awu(await source.getElementIdsBySelectors(selectors, true)).toArray()
+        expect(res.map(id => id.getFullName()).sort()).toEqual([
+          commonObject.elemID,
+          commonObject.elemID.createNestedID('field', 'field'),
+          objectElemID,
+          objectElemID.createNestedID('field', 'commonField'),
+        ].map(id => id.getFullName()))
+      })
+      it('should extract the proper ids without overlaps when compact=true', async () => {
+        const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
+        const res = await awu(
+          await source.getElementIdsBySelectors(selectors, true, true)
+        ).toArray()
+        expect(res.map(id => id.getFullName()).sort()).toEqual([
+          commonObject.elemID,
+          objectElemID,
+        ].map(id => id.getFullName()))
+      })
+    })
+  })
   describe('promote', () => {
-    it('should route promote the proper ids without overlaps', async () => {
+    it('should route promote the proper ids', async () => {
       const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
       jest.spyOn(routers, 'routePromote').mockImplementationOnce(
         () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
       )
-      await source.promote(await awu(await source.getElementIdsBySelectors(selectors)).toArray())
+      await source.promote(
+        await awu(await source.getElementIdsBySelectors(selectors, false, true)).toArray()
+      )
       expect(routers.routePromote).toHaveBeenCalledWith(
         [envElemID, objectElemID], envSource, commonSource, { inactive: inactiveSource }
       )
     })
   })
   describe('demote', () => {
-    it('should route demote the proper ids without overlaps', async () => {
+    it('should route demote the proper ids', async () => {
       const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
       jest.spyOn(routers, 'routeDemote').mockImplementationOnce(
         () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
       )
       await source.demote(await awu(
-        await source.getElementIdsBySelectors(selectors, true)
+        await source.getElementIdsBySelectors(selectors, true, true)
       ).toArray())
       expect(routers.routeDemote).toHaveBeenCalledWith(
         [commonObject.elemID, objectElemID], envSource, commonSource, { inactive: inactiveSource }

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -843,8 +843,8 @@ describe('multi env source', () => {
     })
   })
   describe('promote', () => {
-    it('should route promote the proper ids', async () => {
-      const selectors = createElementSelectors(['salto.*']).validSelectors
+    it('should route promote the proper ids without overlaps', async () => {
+      const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
       jest.spyOn(routers, 'routePromote').mockImplementationOnce(
         () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
       )
@@ -855,13 +855,14 @@ describe('multi env source', () => {
     })
   })
   describe('demote', () => {
-    it('should route demote the proper ids', async () => {
-      const selectors = createElementSelectors(['salto.*']).validSelectors
+    it('should route demote the proper ids without overlaps', async () => {
+      const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
       jest.spyOn(routers, 'routeDemote').mockImplementationOnce(
         () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
       )
-      await source.demote(await awu(await source.getElementIdsBySelectors(selectors, true))
-        .toArray())
+      await source.demote(await awu(
+        await source.getElementIdsBySelectors(selectors, true)
+      ).toArray())
       expect(routers.routeDemote).toHaveBeenCalledWith(
         [commonObject.elemID, objectElemID], envSource, commonSource, { inactive: inactiveSource }
       )


### PR DESCRIPTION
Similar change to https://github.com/salto-io/salto/pull/2224 (adjusted to the new implementation) + additional unrelated fixes due to the changes in the branch (see SALTO-1471).

---

* I think there's still some remaining issue in how we load the referenced type's fields in `transformElements` - @roironn can you please check if it's something you're familiar with? (see the relevant comment)
* We should have better coverage of functions like `getElementIdsBySelectors` and not just as part of another test. I'll try to add a few tomorrow

---
_Release Notes_: 
None (assuming it will already be listed in the master release)
