### PR TITLE
SALTO-1438: fixed max-length validation when value is not a string

### DIFF
--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -377,7 +377,7 @@ Promise<{ elements: T[]; staticFiles: Record<string, StaticFile> }> => {
         elemID: reviveElemID(v.elemID),
         fieldName: v.fieldName,
         value: v.value,
-        maxLength: v.max_length,
+        maxLength: v.maxLength,
       })
     ),
   }

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -156,12 +156,12 @@ export class RegexMismatchValidationError extends ValidationError {
 }
 
 export class InvalidValueMaxLengthValidationError extends ValidationError {
-  readonly value: Value
+  readonly value: string
   readonly fieldName: string
   readonly maxLength: number
 
   constructor({ elemID, value, fieldName, maxLength }:
-    { elemID: ElemID; value: Value; fieldName: string; maxLength: number }) {
+    { elemID: ElemID; value: string; fieldName: string; maxLength: number }) {
     super({
       elemID,
       error: `Value "${value}" is too long for field.`
@@ -295,7 +295,7 @@ const validateAnnotationsValue = async (
 
     const validateMaxLengthLimit = (): ValidationError[] => {
       const maxLength = restrictions.max_length
-      if ((values.isDefined(maxLength) && (!_.isString(val) || (val.length > maxLength)))) {
+      if ((values.isDefined(maxLength) && _.isString(val) && val.length > maxLength)) {
         return [new InvalidValueMaxLengthValidationError(
           { elemID, value, fieldName: elemID.name, maxLength }
         )]

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -912,6 +912,20 @@ describe('Elements validation', () => {
           expect(errors[0]).toBeInstanceOf(InvalidValueMaxLengthValidationError)
         })
 
+        it('should not return validation error on max_length validation if value is not a string', async () => {
+          extInst.value.restrictStringLength = {}
+          const errors = await validateElements(
+            [extInst],
+            createInMemoryElementSource([
+              extInst,
+              extType,
+              ...await getFieldsAndAnnoTypes(extType),
+            ])
+          )
+          expect(errors).toHaveLength(1)
+          expect(errors[0]).not.toBeInstanceOf(InvalidValueMaxLengthValidationError)
+        })
+
         it('should succeed max_length validation on an instance through field annotation', async () => {
           extInst.value.restrictStringLength = 'a'
           const errors = await validateElements(


### PR DESCRIPTION
Fixed a bug where a value of a field with max_length annotation would have some value that is not a string, an invalid error message would be thrown

---
_Release Notes_: 
None