### PR TITLE
update workspace cache after merge state only (fix SALTO-1442)

### DIFF
--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -206,6 +206,11 @@ export const updateStateOnly = async (ws: Workspace,
   try {
     log.info('applying %d changes to state only', changes.length)
     await logWorkspaceUpdates(ws, changes)
+    await ws.updateNaclFiles(
+      changes.map(change => change.change),
+      'default',
+      true
+    )
     await ws.flush()
     return true
   } catch (e) {
@@ -234,7 +239,7 @@ export const updateWorkspace = async ({
     await logWorkspaceUpdates(workspace, changes)
     numberOfAppliedChanges = await workspace.updateNaclFiles(
       changes.map(c => c.change),
-      mode
+      mode,
     )
     const { status, errors } = await validateWorkspace(workspace)
     const formattedErrors = await formatWorkspaceErrors(workspace, errors)
@@ -269,7 +274,14 @@ export const applyChangesToWorkspace = async ({
   cliTelemetry.changesToApply(changesToApply.length, workspaceTags)
   const updatingWsEmitter = new StepEmitter<number>()
   applyProgress.emit('workspaceWillBeUpdated', updatingWsEmitter, changes.length, changesToApply.length)
-  const results = await updateWorkspace({ workspace, output, changes: changesToApply, mode, force })
+  const results = await updateWorkspace({
+    workspace,
+    output,
+    changes:
+    changesToApply,
+    mode,
+    force,
+  })
 
   if (results.success) {
     updatingWsEmitter.emit('completed', results.numberOfAppliedChanges)

--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -277,8 +277,7 @@ export const applyChangesToWorkspace = async ({
   const results = await updateWorkspace({
     workspace,
     output,
-    changes:
-    changesToApply,
+    changes: changesToApply,
     mode,
     force,
   })

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -273,7 +273,7 @@ describe('fetch command', () => {
           })
           it('should deploy all changes', () => {
             expect(workspace.updateNaclFiles).toHaveBeenCalledWith(
-              changes.map(change => change.change), 'default',
+              changes.map(change => change.change), 'default'
             )
           })
         })
@@ -299,7 +299,7 @@ describe('fetch command', () => {
           })
           it('should forward strict mode', () => {
             expect(workspace.updateNaclFiles).toHaveBeenCalledWith(
-              changes.map(change => change.change), 'isolated',
+              changes.map(change => change.change), 'isolated'
             )
           })
         })
@@ -325,7 +325,7 @@ describe('fetch command', () => {
           })
           it('should forward align mode', () => {
             expect(workspace.updateNaclFiles).toHaveBeenCalledWith(
-              changes.map(change => change.change), 'align',
+              changes.map(change => change.change), 'align'
             )
           })
         })
@@ -351,7 +351,7 @@ describe('fetch command', () => {
           })
           it('should forward override mode', () => {
             expect(workspace.updateNaclFiles).toHaveBeenCalledWith(
-              changes.map(change => change.change), 'override',
+              changes.map(change => change.change), 'override'
             )
           })
         })
@@ -394,8 +394,10 @@ describe('fetch command', () => {
             it('should return OK status when state is updated', () => {
               expect(result).toBe(CliExitCode.Success)
             })
-            it('should not apply any changes', async () => {
-              expect(workspace.updateNaclFiles).not.toHaveBeenCalled()
+            it('should not apply changes in stateOnlyMode', async () => {
+              expect(workspace.updateNaclFiles).toHaveBeenCalledWith(
+                changes.map(change => change.change), 'default', true
+              )
             })
           })
           describe('when state failed to update', () => {
@@ -421,9 +423,6 @@ describe('fetch command', () => {
             it('should return AppError status when state is updated', () => {
               expect(result).toBe(CliExitCode.AppError)
             })
-            it('should not apply any changes', async () => {
-              expect(workspace.updateNaclFiles).not.toHaveBeenCalled()
-            })
           })
         })
         describe('when initial workspace is empty', () => {
@@ -448,7 +447,7 @@ describe('fetch command', () => {
           })
           it('should deploy all changes', () => {
             expect(workspace.updateNaclFiles).toHaveBeenCalledWith(
-              changes.map(change => change.change), 'default',
+              changes.map(change => change.change), 'default'
             )
           })
         })
@@ -473,7 +472,8 @@ describe('fetch command', () => {
                 stateOnly: false,
                 regenerateSaltoIds: false,
               })
-              expect(workspace.updateNaclFiles).toHaveBeenCalledWith([changes[0].change], 'default')
+              expect(workspace.updateNaclFiles)
+                .toHaveBeenCalledWith([changes[0].change], 'default')
             })
 
             it('should exit if errors identified in workspace after update', async () => {
@@ -503,7 +503,8 @@ describe('fetch command', () => {
                 stateOnly: false,
                 regenerateSaltoIds: false,
               })
-              expect(workspace.updateNaclFiles).toHaveBeenCalledWith([changes[0].change], 'default')
+              expect(workspace.updateNaclFiles)
+                .toHaveBeenCalledWith([changes[0].change], 'default')
               expect(res).toBe(CliExitCode.AppError)
 
               abortIfErrorCallback.mockRestore()
@@ -532,7 +533,8 @@ describe('fetch command', () => {
                 stateOnly: false,
                 regenerateSaltoIds: false,
               })
-              expect(workspace.updateNaclFiles).toHaveBeenCalledWith([changes[0].change], 'default')
+              expect(workspace.updateNaclFiles)
+                .toHaveBeenCalledWith([changes[0].change], 'default')
               expect(res).toBe(CliExitCode.Success)
             })
           })

--- a/packages/netsuite-adapter/src/types/file_cabinet_types.ts
+++ b/packages/netsuite-adapter/src/types/file_cabinet_types.ts
@@ -52,7 +52,7 @@ export const file = new ObjectType({
       },
     },
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
+      refType: createRefToElmWithValue(BuiltinTypes.STRING),
       annotations: {
       },
     },

--- a/packages/netsuite-adapter/src/types/file_cabinet_types.ts
+++ b/packages/netsuite-adapter/src/types/file_cabinet_types.ts
@@ -52,7 +52,7 @@ export const file = new ObjectType({
       },
     },
     description: {
-      refType: createRefToElmWithValue(BuiltinTypes.STRING),
+      refType: createRefToElmWithValue(BuiltinTypes.SERVICE_ID),
       annotations: {
       },
     },


### PR DESCRIPTION
_update workspace cache after merge state only_

---

_The resolve command compares the workspace merged cache (which is a merge of the nacls and the hidden values from the state) with the state. When the state-only command was invoked, the workspace was not updated with the changes, resulting in the merged cache no accounting for the changed hidden value, So if an hidden value has changed during a state only fetch, it would have be shown as a diff that needs to be restored. (In SALTO-1442, the fields that showed up are last fetch time which are hidden, and change on every fetch). The solution is to update the workspace with the hidden parts of the fetch changes in state only mode._

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_
