### PR TITLE
SALTO-1299 added filter that hides read-only values on fetch, unless data flag 'showReadO…

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -52,6 +52,7 @@ import foreignKeyReferencesFilter from './filters/foreign_key_references'
 import valueSetFilter from './filters/value_set'
 import cpqLookupFieldsFilter from './filters/cpq/lookup_fields'
 import cpqCustomScriptFilter from './filters/cpq/custom_script'
+import hideReadOnlyValuesFilter from './filters/cpq/hide_read_only_values'
 import customFeedFilterFilter, { CUSTOM_FEED_FILTER_METADATA_TYPE } from './filters/custom_feed_filter'
 import extraDependenciesFilter from './filters/extra_dependencies'
 import staticResourceFileExtFilter from './filters/static_resource_file_ext'
@@ -113,6 +114,7 @@ export const DEFAULT_FILTERS = [
   profilePathsFilter,
   territoryFilter,
   elementsUrlFilter,
+  hideReadOnlyValuesFilter,
   // The following filters should remain last in order to make sure they fix all elements
   convertListsFilter,
   convertTypeFilter,

--- a/packages/salesforce-adapter/src/config_change.ts
+++ b/packages/salesforce-adapter/src/config_change.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { ListMetadataQuery, RetrieveResult } from 'jsforce-types'
 import { collections, values } from '@salto-io/lowerdash'
 import { Values, InstanceElement, ElemID } from '@salto-io/adapter-api'
-import { ConfigChangeSuggestion, configType, isDataManagementConfigSuggestions, isMetadataConfigSuggestions, SalesforceConfig } from './types'
+import { ConfigChangeSuggestion, configType, isDataManagementConfigSuggestions, isMetadataConfigSuggestions, SalesforceConfig, DataManagementConfig } from './types'
 import * as constants from './constants'
 
 const { isDefined } = values
@@ -131,7 +131,7 @@ export const getConfigFromConfigChanges = (
   const data = currentDataManagement === undefined ? undefined : _.pickBy({
     ...currentDataManagement,
     ...dataManagementOverrides,
-  }, isDefined)
+  }, isDefined) as DataManagementConfig | undefined
 
   return {
     config: new InstanceElement(

--- a/packages/salesforce-adapter/src/fetch_profile/data_management.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/data_management.ts
@@ -24,6 +24,7 @@ export type DataManagement = {
   isObjectMatch: (name: string) => boolean
   isReferenceAllowed: (name: string) => boolean
   getObjectIdsFields: (name: string) => string[]
+  showReadOnlyValues?: boolean
 }
 
 export const buildDataManagement = (params: DataManagementConfig): DataManagement => (
@@ -39,6 +40,7 @@ export const buildDataManagement = (params: DataManagementConfig): DataManagemen
         ?.find(override => new RegExp(`^${override.objectsRegex}$`).test(name))
       return matchedOverride?.idFields ?? params.saltoIDSettings.defaultIdFields
     },
+    showReadOnlyValues: params.showReadOnlyValues,
   }
 )
 

--- a/packages/salesforce-adapter/src/filters/cpq/hide_read_only_values.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/hide_read_only_values.ts
@@ -1,0 +1,44 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, CORE_ANNOTATIONS, isObjectType } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { FilterCreator } from '../../filter'
+import { isCustomObject } from '../../transformers/transformer'
+import { FIELD_ANNOTATIONS } from '../../constants'
+
+const { awu } = collections.asynciterable
+
+const filter: FilterCreator = ({ config }) => ({
+  onFetch: async (elements: Element[]) => {
+    if (config.fetchProfile.dataManagement?.showReadOnlyValues === true) {
+      // eslint-disable-next-line no-useless-return
+      return
+    }
+    await awu(elements).filter(isCustomObject)
+      .filter(isObjectType)
+      .forEach(type => {
+        Object.values(type.fields)
+          .forEach(field => {
+            if ((!field.annotations[FIELD_ANNOTATIONS.CREATABLE]
+            && !field.annotations[FIELD_ANNOTATIONS.UPDATEABLE])) {
+              field.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
+            }
+          })
+      })
+  },
+})
+
+export default filter

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -111,6 +111,7 @@ export type DataManagementConfig = {
   excludeObjects?: string[]
   allowReferenceTo?: string[]
   saltoIDSettings: SaltoIDSettings
+  showReadOnlyValues?: boolean
 }
 
 export type FetchParameters = {

--- a/packages/salesforce-adapter/test/filters/cpq/hide_read_only_values.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/hide_read_only_values.test.ts
@@ -1,0 +1,190 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ObjectType, ElemID, Element, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { createRefToElmWithValue } from '@salto-io/adapter-utils'
+import { buildDataManagement } from '../../../src/fetch_profile/data_management'
+import { SaltoIDSettings, DataManagementConfig } from '../../../src/types'
+import { FilterWith } from '../../../src/filter'
+import SalesforceClient from '../../../src/client/client'
+import { SALESFORCE, API_NAME, METADATA_TYPE, CUSTOM_OBJECT, CPQ_TESTED_OBJECT, FIELD_ANNOTATIONS } from '../../../src/constants'
+import { Types } from '../../../src/transformers/transformer'
+import filterCreator from '../../../src/filters/cpq/hide_read_only_values'
+import mockClient from '../../client'
+import { defaultFilterContext } from '../../utils'
+
+describe('hide read only values filter', () => {
+  let client: SalesforceClient
+  type FilterType = FilterWith<'onFetch' | 'onDeploy' | 'preDeploy'>
+  let filter: FilterType
+  let elements: Element[]
+
+  const mockCustomElemenID = new ElemID(SALESFORCE, CPQ_TESTED_OBJECT)
+  const mockNotCustomObject = new ObjectType({
+    elemID: mockCustomElemenID,
+    fields: {
+      readOnlyField: {
+        refType: createRefToElmWithValue(Types.primitiveDataTypes.Text),
+        annotations: {
+          [FIELD_ANNOTATIONS.CREATABLE]: false,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: false,
+        },
+      },
+      nonCreateableField: {
+        refType: createRefToElmWithValue(Types.primitiveDataTypes.Text),
+        annotations: {
+          [FIELD_ANNOTATIONS.CREATABLE]: false,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+        },
+      },
+      nonUpdateableField: {
+        refType: createRefToElmWithValue(Types.primitiveDataTypes.Text),
+        annotations: {
+          [FIELD_ANNOTATIONS.CREATABLE]: true,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: false,
+        },
+      },
+    },
+  })
+  const mockCustomObject = new ObjectType({
+    elemID: mockCustomElemenID,
+    fields: {
+      readOnlyField: {
+        refType: createRefToElmWithValue(Types.primitiveDataTypes.Text),
+        annotations: {
+          [FIELD_ANNOTATIONS.CREATABLE]: false,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: false,
+        },
+      },
+      nonCreateableField: {
+        refType: createRefToElmWithValue(Types.primitiveDataTypes.Text),
+        annotations: {
+          [FIELD_ANNOTATIONS.CREATABLE]: false,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+        },
+      },
+      nonUpdateableField: {
+        refType: createRefToElmWithValue(Types.primitiveDataTypes.Text),
+        annotations: {
+          [FIELD_ANNOTATIONS.CREATABLE]: true,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: false,
+        },
+      },
+    },
+    annotations: {
+      [API_NAME]: CPQ_TESTED_OBJECT,
+      [METADATA_TYPE]: CUSTOM_OBJECT,
+    },
+  })
+
+  describe('onFetch', () => {
+    beforeEach(async () => {
+      elements = [
+        mockCustomObject.clone(),
+        mockNotCustomObject.clone(),
+      ]
+    })
+    it('Should do nothing for not custom object type', async () => {
+      client = mockClient().client
+      const config = defaultFilterContext
+      filter = filterCreator({ client, config }) as FilterType
+      await filter.onFetch(elements)
+      const notCustomObjAfterFilter = elements[1] as ObjectType
+      expect(notCustomObjAfterFilter).toBeDefined()
+      expect(notCustomObjAfterFilter
+        .fields.readOnlyField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE])
+        .toBeUndefined()
+      expect(notCustomObjAfterFilter
+        .fields.nonCreateableField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE])
+        .toBeUndefined()
+      expect(notCustomObjAfterFilter
+        .fields.nonUpdateableField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE])
+        .toBeUndefined()
+    })
+    it('Should add "_hidden_value = true" to read only fields on custom object when showReadOnlyValue flag is undefined', async () => {
+      client = mockClient().client
+      const config = defaultFilterContext
+      filter = filterCreator({ client, config }) as FilterType
+      await filter.onFetch(elements)
+      const customObjAfterFilter = elements[0] as ObjectType
+      expect(customObjAfterFilter).toBeDefined()
+      expect(customObjAfterFilter.fields.readOnlyField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE])
+        .toBeTruthy()
+      expect(customObjAfterFilter
+        .fields.nonCreateableField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE])
+        .toBeUndefined()
+      expect(customObjAfterFilter
+        .fields.nonUpdateableField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE])
+        .toBeUndefined()
+    })
+    it('Should add "_hidden_value = true" to read only fields on custom object when showReadOnlyValue flag = false', async () => {
+      client = mockClient().client
+      const dataManagmentConfig = {
+        includeObjects: ['*'],
+        saltoIDSettings: {} as SaltoIDSettings,
+        showReadOnlyValues: false,
+      } as DataManagementConfig
+
+      const config = {
+        ..._.omit(defaultFilterContext, 'fetchProfile'),
+        fetchProfile: {
+          ...defaultFilterContext.fetchProfile,
+          dataManagement: buildDataManagement(dataManagmentConfig),
+        },
+      }
+      filter = filterCreator({ client, config }) as FilterType
+      await filter.onFetch(elements)
+      const customObjAfterFilter = elements[0] as ObjectType
+      expect(customObjAfterFilter).toBeDefined()
+      expect(customObjAfterFilter.fields.readOnlyField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE])
+        .toBeTruthy()
+      expect(customObjAfterFilter
+        .fields.nonCreateableField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE])
+        .toBeUndefined()
+      expect(customObjAfterFilter
+        .fields.nonUpdateableField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE])
+        .toBeUndefined()
+    })
+    it('Should do nothing to read only fields on custom object when showReadOnlyValue flag = true', async () => {
+      client = mockClient().client
+      const dataManagmentConfig = {
+        includeObjects: ['*'],
+        saltoIDSettings: {} as SaltoIDSettings,
+        showReadOnlyValues: true,
+      } as DataManagementConfig
+
+      const config = {
+        ..._.omit(defaultFilterContext, 'fetchProfile'),
+        fetchProfile: {
+          ...defaultFilterContext.fetchProfile,
+          dataManagement: buildDataManagement(dataManagmentConfig),
+        },
+      }
+      filter = filterCreator({ client, config }) as FilterType
+      await filter.onFetch(elements)
+      const customObjAfterFilter = elements[0] as ObjectType
+      expect(customObjAfterFilter).toBeDefined()
+      expect(customObjAfterFilter.fields.readOnlyField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE])
+        .toBeUndefined()
+      expect(customObjAfterFilter
+        .fields.nonCreateableField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE])
+        .toBeUndefined()
+      expect(customObjAfterFilter
+        .fields.nonUpdateableField.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE])
+        .toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
_Release Notes_: 
new filter that put '_hidden_value = true' annotation for all objectType's fields with annotations createable and updateable both equal false.
to turn off this filter the user should add a flag under data config 'showReadOnlyValues = true'. 
If such flag is undefined or equal to false, the filter will run on fetch operation.
