### PR TITLE
SAAS-2511: Retry failed promises

### DIFF
--- a/packages/lowerdash/src/retry/with_retry.ts
+++ b/packages/lowerdash/src/retry/with_retry.ts
@@ -39,7 +39,7 @@ const withRetry = async <TReturn = boolean>(
   const { strategy: retryStrategy, description } = { ...DEFAULT_OPTS, ...opts }
   let retry: RetryStrategy
   const attempt = async (): Promise<TReturn> => {
-    const result = await predicate()
+    const result = await predicate().catch(() => undefined)
     if (result) return result
     retry = retry ?? retryStrategy()
     const retryIn = retry()


### PR DESCRIPTION
Bug Fix\ feature request: make `lowerdash` implementation of `withRetry`, retry when promise fails

---
_Release Notes_: 
None