### PR TITLE
added state hash validity check on first ws build (SALTO-1480)

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -317,7 +317,7 @@ export const loadWorkspace = async (
       ): Promise<ChangeSet<Change<Element>>> => {
         const cacheValid = initBuild
           ? await stateToBuild.mergeManager.getHash(STATE_SOURCE_PREFIX + envName)
-            === await state(envName).getHash()
+            === await state(envName).getHash() && partialStateChanges.cacheValid
           : true
         // We identify a first nacl load when the state is empty, and all of the changes
         // are visible (which indicates a nacl load and not a first 'fetch' in which the

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -258,6 +258,8 @@ export const loadWorkspace = async (
       await initializedState.mergeManager.init()
       return initializedState
     }
+
+    const initBuild = workspaceState === undefined
     const stateToBuild = workspaceState !== undefined
       ? await workspaceState
       : await initState()
@@ -313,6 +315,10 @@ export const loadWorkspace = async (
       const completeStateOnlyChanges = async (
         partialStateChanges: ChangeSet<Change<Element>>
       ): Promise<ChangeSet<Change<Element>>> => {
+        const cacheValid = initBuild
+          ? await stateToBuild.mergeManager.getHash(STATE_SOURCE_PREFIX + envName)
+            === await state(envName).getHash()
+          : true
         // We identify a first nacl load when the state is empty, and all of the changes
         // are visible (which indicates a nacl load and not a first 'fetch' in which the
         // hidden changes won't be empty)
@@ -332,7 +338,7 @@ export const loadWorkspace = async (
           changes: partialStateChanges.changes
             .concat(initHiddenElementsChanges)
             .concat(stateRemovedElementChanges),
-          cacheValid: partialStateChanges.cacheValid,
+          cacheValid,
           preChangeHash: partialStateChanges.preChangeHash
             ?? await stateToBuild.mergeManager.getHash(STATE_SOURCE_PREFIX + envName),
           postChangeHash: await state(envName).getHash(),
@@ -355,9 +361,12 @@ export const loadWorkspace = async (
 
       const changeResult = await stateToBuild.mergeManager.mergeComponents({
         src1Changes: workspaceChanges[envName],
-        src2Changes: await completeStateOnlyChanges(stateOnlyChanges[envName]
-          ?? createEmptyChangeSet(await stateToBuild.mergeManager
-            .getHash(STATE_SOURCE_PREFIX + envName))),
+        src2Changes: await completeStateOnlyChanges(
+          stateOnlyChanges[envName]
+          ?? createEmptyChangeSet(
+            await state(envName).getHash()
+          )
+        ),
         src2Overrides: workspaceChangedElements,
         src1Prefix: MULTI_ENV_SOURCE_PREFIX + envName,
         src2Prefix: STATE_SOURCE_PREFIX + envName,


### PR DESCRIPTION
_added state hash validity check on first ws build_

---

_When building the workspace state, the salto state validity was always assumed. As a result, when the state file was changed out of band (for example, using a git checkout) changes in the state were ignored. The fix is to add a check for the state hash validity. (In the future we are planning on making the state non atomic - that is - allow iterative changes. When we'll do that we can also check for the changes midway) _

---
_Release Notes_: 
_NA_
