### PR TITLE
added an explicit check to ensure that a file was deleted (SALTO-1433)

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -532,10 +532,11 @@ const buildNaclFilesSource = (
     const modifiedNaclFiles: NaclFile[] = []
     if (!ignoreFileChanges) {
       const cacheFilenames = await currentState.parsedNaclFiles.list()
-      const naclFilenames = await naclFilesStore.list()
+      const naclFilenames = new Set(await naclFilesStore.list())
       const fileNames = new Set()
       await awu(cacheFilenames).forEach(async filename => {
-        const naclFile = await naclFilesStore.get(filename) ?? { filename, buffer: '' }
+        const naclFile = (naclFilenames.has(filename) && await naclFilesStore.get(filename))
+          || { filename, buffer: '' }
         const validCache = await currentState.parsedNaclFiles.hasValid(cacheResultKey(naclFile))
         if (!validCache) {
           modifiedNaclFiles.push(naclFile)


### PR DESCRIPTION
_added an explicit check to ensure that a file was deleted_

---
The path attribute that is created in the adapter is case sensitive. However, some filesystems are case insensitive. This can lead to some file overrides, so file changes are grouped based on their lower case value. The actual file name is not in lower case, and one of the possible filenames is used. This can result in the files being written to a different location than their filename attribute in the following way:
  - Two changes are create with the following pathes: [a, b, c.nacl] and [a, B, d.nacl].
  - The files will not be grouped together since the full filename is not the same in lower case.
  - When the first file is flushed, mkdir -p is invoked. 
  - When the second file is flushed - mkdir has no effect (it is case insensitive) so [a,B,d.nacl] will be saved as a/b/d.nacl (or the other way around depending on the flush order)
  - The cache key for [a,B,d.nacl], which was saved as a/b/d.nacl was `a/B/d.nacl`

This caused the following chain of events when the WS was loaded after that flush:
  - The newfile was detected a new file with no cache.
  - The cached file existence in the disk was verified using file.exists. Since file.exists is case insensitive - it returned true and the cache was considered to be valid.
  - Merge error

The solution is to explicitly check if the filenames are the same, and not to trust the file.exists call. 

---
_Release Notes_: 
_NA_
