### PR TITLE
fixed validation recurse into resolved references when type is UKNOWN (Fix SALTO-1461)

### DIFF
--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -470,7 +470,7 @@ const validateValue = async (
   }
 
   if (type === BuiltinTypes.UNKNOWN) {
-    if (!_.isObjectLike(value)) {
+    if (!_.isPlainObject(value)) {
       return []
     }
     return (await Promise.all(Object.keys(value).map(


### PR DESCRIPTION
_fixed validation recurse into resolved references when type is UKNOWN_

---

_The uknown section of the validator used `_.isObjectLike` which return true for classes in order to check if its needs to recurse into values. Changing it to `_.isPlainObject` solved the issue._

---
_Release Notes_: 
_NA_
