### PR TITLE
SALTO-1461: fixed workato validation error

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -82,7 +82,7 @@ export class ReferenceExpression {
   constructor(
     public readonly elemID: ElemID,
     private resValue?: Value,
-    public readonly topLevelParent?: Element
+    public topLevelParent?: Element
   ) {}
 
   /**
@@ -104,6 +104,10 @@ export class ReferenceExpression {
     return (this.resValue instanceof ReferenceExpression)
       ? this.resValue.value
       : this.resValue
+  }
+
+  set value(value: Value) {
+    this.resValue = value
   }
 
   async getResolvedValue(elementsSource?: ReadOnlyElementsSource): Promise<Value> {

--- a/packages/workspace/test/core/expressions.test.ts
+++ b/packages/workspace/test/core/expressions.test.ts
@@ -467,6 +467,30 @@ describe('Test Salto Expressions', () => {
       const resolvedRef = resovledElems[0].value.test as ReferenceExpression
       expect(resolvedRef.topLevelParent).not.toBeDefined()
     })
+
+    it('should resolve instance with references to itself', async () => {
+      const type = new ObjectType({ elemID: new ElemID('adapter', 'type') })
+      const instance = new InstanceElement(
+        'instance',
+        type,
+        {
+          a: {
+            ref: new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'instance', 'b')),
+          },
+          b: {
+            ref: new ReferenceExpression(new ElemID('adapter', 'type', 'instance', 'instance', 'c')),
+          },
+          c: 2,
+        },
+      )
+      const [resolvedInstance] = await resolve([instance], createInMemoryElementSource([
+        instance,
+        type,
+        ...await getFieldsAndAnnoTypes(type),
+      ])) as [InstanceElement]
+      expect(resolvedInstance.value.b.ref.value).toBe(2)
+      expect(resolvedInstance.value.a.ref.value.ref.value).toBe(2)
+    })
   })
 
   describe('Template Expression', () => {


### PR DESCRIPTION
Fix validation errors in workato

---
The issue was in `resolve`. When a value in an element would reference another value in the same element it would not be fully resolved due to the fact that transformValues creates deep copy of the values

---
_Release Notes_: 
None