### PR TITLE
Salto 1327 - Incorrect validation error on references with a required field

### DIFF
--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -68,7 +68,7 @@ const validateAnnotations = async (
   elementsSource: ReadOnlyElementsSource
 ):
 Promise<ValidationError[]> => {
-  if (isObjectType(type)) {
+  if (isObjectType(type) && !isReferenceExpression(value)) {
     return awu(Object.keys(type.fields)).flatMap(
       // eslint-disable-next-line no-use-before-define
       async k => validateFieldAnnotations(

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -697,7 +697,7 @@ describe('Elements validation', () => {
           )).toHaveLength(0)
         })
 
-        it('should not return validation errors even when the value is an ilegal reference', async () => {
+        it('should not return validation errors even when the value is an illegal reference', async () => {
           const refInst = new InstanceElement(
             'instWithRef',
             withSimpleTypeField,

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -55,9 +55,9 @@ describe('Elements validation', () => {
     },
   })
 
-  const hasSimpleTypeElemID = new ElemID('netsuite', 'hasSimple')
-  const hasSimpleTypeField = new ObjectType({
-    elemID: hasSimpleTypeElemID,
+  const withSimpleTypeElemID = new ElemID('netsuite', 'hasSimple')
+  const withSimpleTypeField = new ObjectType({
+    elemID: withSimpleTypeElemID,
     fields: {
       simple: { refType: createRefToElmWithValue(simpleType) },
     },
@@ -680,7 +680,7 @@ describe('Elements validation', () => {
         it('should not return validation errors when the value is a legal reference', async () => {
           const refInst = new InstanceElement(
             'instWithRef',
-            hasSimpleTypeField,
+            withSimpleTypeField,
             {
               simple: new ReferenceExpression(varInst.elemID, varInst),
             }
@@ -690,17 +690,17 @@ describe('Elements validation', () => {
             createInMemoryElementSource([
               refInst,
               simpleType,
-              hasSimpleTypeField,
+              withSimpleTypeField,
               varInst,
-              ...await getFieldsAndAnnoTypes(hasSimpleTypeField),
+              ...await getFieldsAndAnnoTypes(withSimpleTypeField),
             ])
           )).toHaveLength(0)
         })
 
-        it('should not return validation errors even when the value is a ilegal reference', async () => {
+        it('should not return validation errors even when the value is an ilegal reference', async () => {
           const refInst = new InstanceElement(
             'instWithRef',
-            hasSimpleTypeField,
+            withSimpleTypeField,
             {
               simple: new ReferenceExpression(illegalValueVarInst.elemID, illegalValueVarInst),
             }
@@ -710,9 +710,9 @@ describe('Elements validation', () => {
             createInMemoryElementSource([
               refInst,
               simpleType,
-              hasSimpleTypeField,
+              withSimpleTypeField,
               varInst,
-              ...await getFieldsAndAnnoTypes(hasSimpleTypeField),
+              ...await getFieldsAndAnnoTypes(withSimpleTypeField),
             ])
           )).toHaveLength(0)
         })

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -54,6 +54,15 @@ describe('Elements validation', () => {
       annostr: 'str',
     },
   })
+
+  const hasSimpleTypeElemID = new ElemID('netsuite', 'hasSimple')
+  const hasSimpleTypeField = new ObjectType({
+    elemID: hasSimpleTypeElemID,
+    fields: {
+      simple: { refType: createRefToElmWithValue(simpleType) },
+    },
+  })
+
   const restrictedType = new PrimitiveType({
     elemID: new ElemID('salto', 'restrictedType'),
     primitive: PrimitiveTypes.STRING,
@@ -666,6 +675,46 @@ describe('Elements validation', () => {
           expect(errors[0].message)
             .toMatch(`Field ${simpleType.fields.bool.name} is required but has no value`)
           expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('reqNested', '1', 'bool'))
+        })
+
+        it('should not return validation errors when the value is a legal reference', async () => {
+          const refInst = new InstanceElement(
+            'instWithRef',
+            hasSimpleTypeField,
+            {
+              simple: new ReferenceExpression(varInst.elemID, varInst),
+            }
+          )
+          expect(await validateElements(
+            [refInst],
+            createInMemoryElementSource([
+              refInst,
+              simpleType,
+              hasSimpleTypeField,
+              varInst,
+              ...await getFieldsAndAnnoTypes(hasSimpleTypeField),
+            ])
+          )).toHaveLength(0)
+        })
+
+        it('should not return validation errors even when the value is a ilegal reference', async () => {
+          const refInst = new InstanceElement(
+            'instWithRef',
+            hasSimpleTypeField,
+            {
+              simple: new ReferenceExpression(illegalValueVarInst.elemID, illegalValueVarInst),
+            }
+          )
+          expect(await validateElements(
+            [refInst],
+            createInMemoryElementSource([
+              refInst,
+              simpleType,
+              hasSimpleTypeField,
+              varInst,
+              ...await getFieldsAndAnnoTypes(hasSimpleTypeField),
+            ])
+          )).toHaveLength(0)
         })
       })
 


### PR DESCRIPTION

bug fix, when a value has a reference the validation won't continue validating that value

_Release Notes_: 
when a value has a reference the validation won't continue validating that value
