### PR TITLE
added an informative error for db locks when destroyed is called (SALTO-1483)

### DIFF
--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -231,8 +231,9 @@ export const cleanDatabases = async (): Promise<void> => {
     await awu(fs.readdirSync(tmpDir)).forEach(async tmpLoc => {
       try {
         await promisify(
-          getRemoteDbImpl().destroy.bind(getRemoteDbImpl(), 
-          path.join(tmpDir, tmpLoc)))()
+          getRemoteDbImpl().destroy.bind(getRemoteDbImpl(),
+            path.join(tmpDir, tmpLoc))
+        )()
       } catch (e) {
         if (isDBLockErr(e)) {
           throw new DBLockError()

--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -59,7 +59,8 @@ const isDBLockErr = (error: Error): boolean => (
 
 class DBLockError extends Error {
   constructor() {
-    super('Salto local database locked. Could another Salto process be open?')
+    super('Salto local database locked. Could another Salto process '
+    + 'or a process using Salto be open?')
   }
 }
 


### PR DESCRIPTION
__
added an informative error for db locks when destroyed is called
---

_Destroy can throw an error if another process is holding a write connection to the db. We wrapped this error with an informative wrapper_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_
