### PR TITLE
Fix default netsuite folders regexes

### DIFF
--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -147,9 +147,9 @@ export const fetchDefault: FetchParams = {
       name: '.*',
     }],
     fileCabinet: [
-      '^/SuiteScripts/.*',
-      '^/Templates/.*',
-      '^/SuiteBundles/.*',
+      '^/SuiteScripts(/.*)?',
+      '^/Templates(/.*)?',
+      '^/SuiteBundles(/.*)?',
     ],
   },
   [EXCLUDE]: {

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -147,9 +147,9 @@ export const fetchDefault: FetchParams = {
       name: '.*',
     }],
     fileCabinet: [
-      '^/SuiteScripts(/.*)?',
-      '^/Templates(/.*)?',
-      '^/SuiteBundles(/.*)?',
+      '^/SuiteScripts.*',
+      '^/Templates.*',
+      '^/SuiteBundles.*',
     ],
   },
   [EXCLUDE]: {


### PR DESCRIPTION
The current default file cabinet regexes in Netsuite wouldn't include the top folders, e.g. The folder `/SuiteScript` does not match the regex `^/SuiteScripts/.*`. This would cause the top folders instances to not be fetched.

---
_Release Notes_: 
None