### PR TITLE
fixed diff command ignores field annotation changes (SALTO-1484)

### DIFF
--- a/packages/core/src/core/diff.ts
+++ b/packages/core/src/core/diff.ts
@@ -44,7 +44,7 @@ const filterElementByRelevance = async (
   topLevelIds: Set<string>,
   elementsSource: ReadOnlyElementsSource
 ): Promise<Element | undefined> => {
-  if (topLevelIds.has(elem.elemID.getFullName())) {
+  if (topLevelIds.has(elem.elemID.createTopLevelParentID().parent.getFullName())) {
     return transformElement({
       element: elem,
       transformFunc: filterRelevantParts(relevantIds),

--- a/packages/core/test/core/diff.test.ts
+++ b/packages/core/test/core/diff.test.ts
@@ -281,8 +281,7 @@ describe('diff', () => {
           .sort()).toEqual([nestedID, simpleId].sort())
       })
 
-      // eslint-disable-next-line
-      it.skip('includes field inner annotations when the field is selected', async () => {
+      it('includes field inner annotations when the field is selected', async () => {
         const newSinglePathObjMerged = singlePathObjMerged.clone() as ObjectType
         newSinglePathObjMerged.fields.simple.annotations.description = 'new description'
         const simpleFieldId = newSinglePathObjMerged.elemID.createNestedID('field', 'simple')


### PR DESCRIPTION
_fixed diff command ignores field annotation changes when selectors are used_

---

_When a field selector was used, the diff command ignored changes in that field. This is due to an error which assumed that the change element is a top level element. Field is a legal change element, so the assumption did not hold. Fixed this by checking for the change top level element id._

---
_Release Notes_: 
_NA_
