### PR TITLE
Fix static file changes ignored in deploy (SALTO-1485)

### DIFF
--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -297,7 +297,7 @@ export const generateElements = async (
   ) || defaultObj
 
   const generateValue = async (ref: TypeElement, isHidden?: boolean): Promise<Value> => {
-    if (staticFileIds.has(ref.elemID.getFullName()) && isHidden !== true) {
+    if (staticFileIds.has(ref.elemID.getFullName()) && !isHidden) {
       const content = generateFileContent()
       return new StaticFile({
         content,
@@ -305,7 +305,7 @@ export const generateElements = async (
         filepath: [getName(), 'txt'].join('.'),
       })
     }
-    if (referenceFields.has(ref.elemID.getFullName()) && isHidden !== true) {
+    if (referenceFields.has(ref.elemID.getFullName()) && !isHidden) {
       return new ReferenceExpression(chooseObjIgnoreRank().elemID)
     }
     if (isPrimitiveType(ref)) {

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -19,6 +19,7 @@ import wu from 'wu'
 
 import { Element, ElemID, getChangeElement, Value,
   DetailedChange, Change, ChangeDataType, StaticFile } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
 import { promises, collections, values } from '@salto-io/lowerdash'
 import { applyInstanceDefaults } from '@salto-io/adapter-utils'
 import { RemoteMap, RemoteMapCreator, mapRemoteMapResult } from '../../remote_map'
@@ -34,6 +35,7 @@ import { Errors } from '../../errors'
 import { RemoteElementSource, ElementsSource } from '../../elements_source'
 import { serialize, deserializeSingleElement, deserializeMergeErrors } from '../../../serializer/elements'
 
+const log = logger(module)
 const { awu } = collections.asynciterable
 type ThenableIterable<T> = collections.asynciterable.ThenableIterable<T>
 const { series } = promises.array
@@ -81,7 +83,8 @@ type MultiEnvState = {
 
 export type EnvsChanges = Record<string, ChangeSet<Change>>
 
-export type MultiEnvSource = Omit<NaclFilesSource<EnvsChanges>, 'getAll' | 'getElementsSource'> & {
+export type MultiEnvSource = Omit<NaclFilesSource<EnvsChanges>
+  , 'getAll' | 'getElementsSource'> & {
   getAll: (env?: string) => Promise<AsyncIterable<Element>>
   promote: (ids: ElemID[]) => Promise<EnvsChanges>
   getElementIdsBySelectors: (
@@ -124,13 +127,19 @@ const buildMultiEnvSource = (
     [commonSourceName]: sources[commonSourceName],
   })
 
-  const getStaticFileByHash = (
+  const getStaticFile = async (
     filePath: string,
     encoding: BufferEncoding,
-    hash: string
-  ): Promise<StaticFile | undefined> => awu(Object.values(getActiveSources()))
-    .map(src => src.getStaticFileByHash(filePath, encoding, hash))
-    .find(values.isDefined)
+  ): Promise<StaticFile | undefined> => {
+    const sourcesFiles = (await Promise.all(Object.values(getActiveSources())
+      .map(src => src.getStaticFile(filePath, encoding))))
+      .filter(values.isDefined)
+    if (sourcesFiles.length > 1
+      && !_.every(sourcesFiles, sf => sf.hash === sourcesFiles[0].hash)) {
+      log.warn(`Found two different hashes for static file ${filePath}`)
+    }
+    return sourcesFiles[0]
+  }
 
   const buildStateForSingleEnv = async (
     envName: string,
@@ -140,10 +149,9 @@ const buildMultiEnvSource = (
       serialize: element => serialize([element], 'keepRef'),
       deserialize: s => deserializeSingleElement(
         s,
-        async staticFile => await getStaticFileByHash(
+        async staticFile => await getStaticFile(
           staticFile.filepath,
           staticFile.encoding,
-          staticFile.hash
         ) ?? staticFile
       ),
       persistent,
@@ -578,7 +586,7 @@ const buildMultiEnvSource = (
       const naclSource = env === undefined ? primarySource() : sources[env]
       return naclSource === undefined ? [] : naclSource.getSearchableNames()
     },
-    getStaticFileByHash,
+    getStaticFile,
   }
 }
 

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -136,7 +136,7 @@ const buildMultiEnvSource = (
       .filter(values.isDefined)
     if (sourcesFiles.length > 1
       && !_.every(sourcesFiles, sf => sf.hash === sourcesFiles[0].hash)) {
-      log.warn(`Found two different hashes for static file ${filePath}`)
+      log.warn(`Found different hashes for static file ${filePath}`)
     }
     return sourcesFiles[0]
   }

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -89,10 +89,9 @@ export type NaclFilesSource<Changes=ChangeSet<Change>> = Omit<ElementsSource, 'c
   getElementsSource: () => Promise<ElementsSource>
   load: (args: SourceLoadParams) => Promise<Changes>
   getSearchableNames(): Promise<string[]>
-  getStaticFileByHash: (
+  getStaticFile: (
     filePath: string,
     encoding: BufferEncoding,
-    hash: string
   ) => Promise<StaticFile | undefined>
 }
 
@@ -911,9 +910,9 @@ const buildNaclFilesSource = (
     },
     getSearchableNames: async (): Promise<string[]> =>
       (awu((await getState())?.searchableNamesIndex?.keys() ?? []).toArray()),
-    getStaticFileByHash: async (filePath, encoding, hash) => {
+    getStaticFile: async (filePath, encoding) => {
       const staticFile = await staticFilesSource.getStaticFile(filePath, encoding)
-      if (isStaticFile(staticFile) && staticFile.hash === hash) {
+      if (isStaticFile(staticFile)) {
         return staticFile
       }
       return undefined

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import path from 'path'
 import { Element, SaltoError, SaltoElementError, ElemID, InstanceElement, DetailedChange, Change,
   Value, isElement, isInstanceElement, toChange, isRemovalChange, getChangeElement,
-  ReadOnlyElementsSource, isAdditionOrModificationChange } from '@salto-io/adapter-api'
+  ReadOnlyElementsSource, isAdditionOrModificationChange, StaticFile } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { applyDetailedChanges, resolvePath, setPath } from '@salto-io/adapter-utils'
 import { collections, promises, values } from '@salto-io/lowerdash'
@@ -245,7 +245,10 @@ export const loadWorkspace = async (
                     staticFile.filepath,
                     staticFile.encoding,
                     staticFile.hash
-                  ) ?? staticFile
+                  ) ?? new StaticFile({
+                    filepath: staticFile.filepath,
+                    hash: '',
+                  })
                 ),
                 persistent,
               })
@@ -472,13 +475,10 @@ export const loadWorkspace = async (
     return naclFilesSource
   }
 
-  const elements = async (env?: string): Promise<ElementsSource> => {
-    // eslint-disable-next-line no-console
-    console.log(env)
-    // eslint-disable-next-line no-console
-    console.log(Object.keys(await (await getWorkspaceState()).states))
-    return (await getWorkspaceState()).states[env ?? currentEnv()].merged
-  }
+  const elements = async (
+    env?: string
+  ): Promise<ElementsSource> => (await getWorkspaceState())
+    .states[env ?? currentEnv()].merged
 
   const getStateOnlyChanges = async (
     hiddenChanges: DetailedChange[],

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import path from 'path'
 import { Element, SaltoError, SaltoElementError, ElemID, InstanceElement, DetailedChange, Change,
   Value, isElement, isInstanceElement, toChange, isRemovalChange, getChangeElement,
-  ReadOnlyElementsSource, isAdditionOrModificationChange, StaticFile } from '@salto-io/adapter-api'
+  ReadOnlyElementsSource, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { applyDetailedChanges, resolvePath, setPath } from '@salto-io/adapter-utils'
 import { collections, promises, values } from '@salto-io/lowerdash'
@@ -241,14 +241,10 @@ export const loadWorkspace = async (
                 // TODO: we might need to pass static file reviver to the deserialization func
                 deserialize: s => deserializeSingleElement(
                   s,
-                  async staticFile => await envSrc.getStaticFileByHash(
+                  async staticFile => await envSrc.getStaticFile(
                     staticFile.filepath,
                     staticFile.encoding,
-                    staticFile.hash
-                  ) ?? new StaticFile({
-                    filepath: staticFile.filepath,
-                    hash: '',
-                  })
+                  ) ?? staticFile
                 ),
                 persistent,
               })

--- a/packages/workspace/test/common/nacl_file_source.ts
+++ b/packages/workspace/test/common/nacl_file_source.ts
@@ -108,9 +108,9 @@ export const createMockNaclFileSource = (
         : []
       return [e.elemID.getFullName(), ...fieldNames]
     }))),
-    getStaticFileByHash: async (filePath, enc, hash) => {
+    getStaticFile: async (filePath, enc) => {
       const sfile = await staticFileSource.getStaticFile(filePath, enc)
-      return isStaticFile(sfile) && sfile.hash === hash
+      return isStaticFile(sfile)
         ? sfile
         : undefined
     },

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -968,8 +968,8 @@ describe('multi env source', () => {
         () => Promise.resolve(new InMemoryRemoteMap()),
         false
       )
-      expect(await src.getStaticFileByHash(
-        staticFile.filepath, staticFile.encoding, staticFile.hash
+      expect(await src.getStaticFile(
+        staticFile.filepath, staticFile.encoding
       )).toEqual(staticFile)
     })
     it('should return the file it is present in the env source and the hashes match', async () => {
@@ -982,23 +982,9 @@ describe('multi env source', () => {
         () => Promise.resolve(new InMemoryRemoteMap()),
         false
       )
-      expect(await src.getStaticFileByHash(
-        staticFile.filepath, staticFile.encoding, staticFile.hash
+      expect(await src.getStaticFile(
+        staticFile.filepath, staticFile.encoding
       )).toEqual(staticFile)
-    })
-    it('should return undefined if the hahes do not match', async () => {
-      commonSrcStaticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(new MissingStaticFile(''))
-      envSrcStaticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(staticFile)
-      const src = multiEnvSource(
-        sources,
-        activePrefix,
-        commonPrefix,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        false
-      )
-      expect(await src.getStaticFileByHash(
-        staticFile.filepath, staticFile.encoding, 'nohash'
-      )).not.toBeDefined()
     })
   })
 })

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -19,7 +19,7 @@ import _ from 'lodash'
 import { DirectoryStore } from '../../../src/workspace/dir_store'
 
 import { naclFilesSource, NaclFilesSource } from '../../../src/workspace/nacl_files'
-import { StaticFilesSource, MissingStaticFile } from '../../../src/workspace/static_files'
+import { StaticFilesSource } from '../../../src/workspace/static_files'
 import { ParsedNaclFileCache, createParseResultCache } from '../../../src/workspace/nacl_files/parsed_nacl_files_cache'
 
 import { mockStaticFilesSource, persistentMockCreateRemoteMap } from '../../utils'
@@ -491,35 +491,9 @@ describe('Nacl Files Source', () => {
         () => Promise.resolve(new InMemoryRemoteMap()),
         false
       )
-      expect(await src.getStaticFileByHash(
-        staticFile.filepath, staticFile.encoding, staticFile.hash
+      expect(await src.getStaticFile(
+        staticFile.filepath, staticFile.encoding
       )).toEqual(staticFile)
-    })
-    it('should return undefined if the file is invalid', async () => {
-      staticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(new MissingStaticFile(''))
-      const src = await naclFilesSource(
-        '',
-        mockDirStore,
-        staticFileSource,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        false
-      )
-      expect(await src.getStaticFileByHash(
-        'nope.txt', staticFile.encoding, staticFile.hash
-      )).not.toBeDefined()
-    })
-    it('should return undefined if the hahes do not match', async () => {
-      staticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(staticFile)
-      const src = await naclFilesSource(
-        '',
-        mockDirStore,
-        staticFileSource,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        false
-      )
-      expect(await src.getStaticFileByHash(
-        staticFile.filepath, staticFile.encoding, 'otherhash'
-      )).not.toBeDefined()
     })
   })
 })


### PR DESCRIPTION
_Fix static file changes ignored in deploy_

---

_The `getStaticFilesByHash` method used in the workspace element source deserialize function, used the cached static file hash in order to differentiate static files with the same path which exists in both the common and the primary source. This caused it to fail when a static file was changed (since the hash didn't match) causing the diff function to ignore the change. In order to resolve that, we removed the hash check, added a log warning if the file exists in both envs with different hashes, and created https://salto-io.atlassian.net/browse/SALTO-1062 for future handling._

---
_Release Notes_: 
_NA_
