### PR TITLE
Salto 1363 - Parser should create parse error when annotation values are added to an annotation type definition

### DIFF
--- a/packages/workspace/src/parser/internal/native/consumers/blocks.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/blocks.ts
@@ -60,7 +60,8 @@ export const recoverInvalidItemDefinition = (context: ParseContext): void => {
   // No need to consume if this is a CCURLY as it will be handled by the caller
 }
 
-export const consumeBlockBody = (context: ParseContext, idPrefix: ElemID, isAnnotationBlock?: boolean): ConsumerReturnType<{
+// (context: ParseContext, idPrefix: ElemID, isAnnotationBlock?: boolean): ConsumerReturnType
+export const consumeBlockBody = (context: ParseContext, idPrefix: ElemID): ConsumerReturnType<{
     attrs: Values
     fields: Record<string, {refType: ReferenceExpression; annotations? : Values}>
     annotationRefTypes: ReferenceMap
@@ -75,9 +76,7 @@ export const consumeBlockBody = (context: ParseContext, idPrefix: ElemID, isAnno
   while (context.lexer.peek() && context.lexer.peek()?.type !== TOKEN_TYPES.CCURLY) {
     const defTokens = consumeWords(context)
     if (isAttrDef(defTokens.value, context)) {
-      if (isAnnotationBlock) {
-        
-      }
+      // if (isAnnotationBlock) { }
       // Consume Attr!
       const key = defTokens.value[0]
       const attrID = attrIDPrefix.createNestedID(key)
@@ -96,7 +95,8 @@ export const consumeBlockBody = (context: ParseContext, idPrefix: ElemID, isAnno
       registerRange(context, attrID, { start: defTokens.range.start, end: consumedValue.range.end })
     } else if (isAnnotationBlockDef(idPrefix, defTokens.value, context)) {
       const annoBlockID = idPrefix.createNestedID('annotation')
-      const consumedBlock = consumeBlockBody(context, annoBlockID, true)
+      const consumedBlock = consumeBlockBody(context, annoBlockID)
+      // const consumedBlock = consumeBlockBody(context, annoBlockID, true)
       if (!_.isEmpty(consumedBlock.value.attrs)) {
         context.errors.push(invalidAttrDefinitionInAnnotationBlock({
           ...consumedBlock.range,

--- a/packages/workspace/src/parser/internal/native/consumers/blocks.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/blocks.ts
@@ -60,7 +60,7 @@ export const recoverInvalidItemDefinition = (context: ParseContext): void => {
   // No need to consume if this is a CCURLY as it will be handled by the caller
 }
 
-export const consumeBlockBody = (context: ParseContext, idPrefix: ElemID): ConsumerReturnType<{
+export const consumeBlockBody = (context: ParseContext, idPrefix: ElemID, isAnnotationBlock?: boolean): ConsumerReturnType<{
     attrs: Values
     fields: Record<string, {refType: ReferenceExpression; annotations? : Values}>
     annotationRefTypes: ReferenceMap
@@ -75,6 +75,9 @@ export const consumeBlockBody = (context: ParseContext, idPrefix: ElemID): Consu
   while (context.lexer.peek() && context.lexer.peek()?.type !== TOKEN_TYPES.CCURLY) {
     const defTokens = consumeWords(context)
     if (isAttrDef(defTokens.value, context)) {
+      if (isAnnotationBlock) {
+        
+      }
       // Consume Attr!
       const key = defTokens.value[0]
       const attrID = attrIDPrefix.createNestedID(key)
@@ -93,7 +96,7 @@ export const consumeBlockBody = (context: ParseContext, idPrefix: ElemID): Consu
       registerRange(context, attrID, { start: defTokens.range.start, end: consumedValue.range.end })
     } else if (isAnnotationBlockDef(idPrefix, defTokens.value, context)) {
       const annoBlockID = idPrefix.createNestedID('annotation')
-      const consumedBlock = consumeBlockBody(context, annoBlockID)
+      const consumedBlock = consumeBlockBody(context, annoBlockID, true)
       if (!_.isEmpty(consumedBlock.value.attrs)) {
         context.errors.push(invalidAttrDefinitionInAnnotationBlock({
           ...consumedBlock.range,

--- a/packages/workspace/src/parser/internal/native/errors.ts
+++ b/packages/workspace/src/parser/internal/native/errors.ts
@@ -91,6 +91,12 @@ export const multipleAnnotationBlocks = (range: SourceRange): ParseError => crea
   'Invalid annotations block, only one annotation block can be defined in a fragment.',
 )
 
+export const annotationInAnnotationBlocks = (range: SourceRange): ParseError => createError(
+  range,
+  'Invalid annotations block',
+  'Can not define an annotation values inside annotation type definitions',
+)
+
 export const multiplFieldDefinitions = (
   range: SourceRange,
   fieldName: string

--- a/packages/workspace/src/parser/internal/native/errors.ts
+++ b/packages/workspace/src/parser/internal/native/errors.ts
@@ -91,12 +91,6 @@ export const multipleAnnotationBlocks = (range: SourceRange): ParseError => crea
   'Invalid annotations block, only one annotation block can be defined in a fragment.',
 )
 
-export const annotationInAnnotationBlocks = (range: SourceRange): ParseError => createError(
-  range,
-  'Invalid annotations block',
-  'Can not define an annotation values inside annotation type definitions',
-)
-
 export const multiplFieldDefinitions = (
   range: SourceRange,
   fieldName: string

--- a/packages/workspace/test/parser/errors.test.ts
+++ b/packages/workspace/test/parser/errors.test.ts
@@ -462,6 +462,37 @@ describe('parsing errors', () => {
         expect(Object.keys(element.annotationRefTypes)).toEqual(['my'])
       })
     })
+    describe('when there annotation values inside annotation type definitions', () => {
+      const nacl = `
+      type baby.you {
+          annotations {
+            can.drive my {
+              car = "Yes"
+            }
+          }
+      }
+    `
+      let res: ParseResult
+      beforeAll(async () => {
+        res = await parse(Buffer.from(nacl), 'file.nacl', {})
+      })
+      it('should create an error', () => {
+        expect(res.errors).toHaveLength(1)
+        expect(res.errors[0].subject).toEqual({
+          start: { byte: 72, col: 26, line: 4 },
+          end: { byte: 113, col: 14, line: 6 },
+          filename: 'file.nacl',
+        })
+        expect(res.errors[0].message).toBe('Can not define an annotation values inside annotation type definitions')
+        expect(res.errors[0].summary).toBe('Invalid annotations block')
+      })
+      it('should still create the element properly', async () => {
+        expect(await awu(res.elements).toArray()).toHaveLength(1)
+        const element = (await awu(res.elements).toArray())[0] as ObjectType
+        expect(element.elemID.getFullName()).toEqual('baby.you')
+        expect(Object.keys(element.annotationRefTypes)).toEqual(['my'])
+      })
+    })
     describe('when there are duplicated annotation type blocks', () => {
       const nacl = `
       type baby.you {

--- a/packages/workspace/test/parser/errors.test.ts
+++ b/packages/workspace/test/parser/errors.test.ts
@@ -448,8 +448,8 @@ describe('parsing errors', () => {
       it('should create an error', () => {
         expect(res.errors).toHaveLength(1)
         expect(res.errors[0].subject).toEqual({
-          start: { byte: 45, col: 23, line: 3 },
-          end: { byte: 123, col: 12, line: 7 },
+          start: { byte: 100, col: 13, line: 6 },
+          end: { byte: 111, col: 24, line: 6 },
           filename: 'file.nacl',
         })
         expect(res.errors[0].message).toBe('Invalid annotations block, unexpected attribute definition.')
@@ -479,11 +479,11 @@ describe('parsing errors', () => {
       it('should create an error', () => {
         expect(res.errors).toHaveLength(1)
         expect(res.errors[0].subject).toEqual({
-          start: { byte: 72, col: 26, line: 4 },
-          end: { byte: 113, col: 14, line: 6 },
+          start: { byte: 88, col: 15, line: 5 },
+          end: { byte: 99, col: 26, line: 5 },
           filename: 'file.nacl',
         })
-        expect(res.errors[0].message).toBe('Can not define an annotation values inside annotation type definitions')
+        expect(res.errors[0].message).toBe('Invalid annotations block, unexpected attribute definition.')
         expect(res.errors[0].summary).toBe('Invalid annotations block')
       })
       it('should still create the element properly', async () => {


### PR DESCRIPTION

added a parse error for  annotation values inside annotation type definitions

_Release Notes_: 
added a parse error for  annotation values inside annotation type definitions
