### PR TITLE
SALTO-825: added change validator to prevent deployment of sub-instances

### DIFF
--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -22,6 +22,7 @@ import removeListItemValidator from './change_validators/remove_list_item'
 import instanceChangesValidator from './change_validators/instance_changes'
 import fileValidator from './change_validators/file_changes'
 import immutableChangesValidator from './change_validators/immutable_changes'
+import subInstancesValidator from './change_validators/subinstances'
 import { validateDependsOnInvalidElement } from './change_validators/dependencies'
 
 
@@ -32,6 +33,7 @@ const changeValidators: ChangeValidator[] = [
   immutableChangesValidator,
   removeListItemValidator,
   fileValidator,
+  subInstancesValidator,
 ]
 
 const nonSuiteAppValidators: ChangeValidator[] = [

--- a/packages/netsuite-adapter/src/change_validators/subinstances.ts
+++ b/packages/netsuite-adapter/src/change_validators/subinstances.ts
@@ -1,0 +1,33 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeValidator, isInstanceChange, isRemovalOrModificationChange,
+} from '@salto-io/adapter-api'
+
+const changeValidator: ChangeValidator = async changes => (
+  changes
+    .filter(isInstanceChange)
+    .map(change => (isRemovalOrModificationChange(change) ? change.data.before : change.data.after))
+    .filter(instance => instance.value.isSubInstance)
+    .map(({ elemID }) => ({
+      elemID,
+      severity: 'Error',
+      message: 'Sub-instances are read only',
+      detailedMessage: `Changing sub-instance (${elemID.getFullName()}) is not supported`,
+    }))
+)
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
@@ -62,7 +62,7 @@ const filterCreator = (): FilterWith<'onFetch' | 'preDeploy'> => ({
           const newInstance = new InstanceElement(
             instanceName,
             fieldType,
-            value,
+            { ...value, isSubInstance: true },
             [NETSUITE, RECORDS_PATH, fieldType.elemID.name, instanceName]
           )
           newInstancesMap[instanceName] = newInstance

--- a/packages/netsuite-adapter/test/change_validators/subinstances.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/subinstances.test.ts
@@ -19,15 +19,41 @@ import { NETSUITE } from '../../src/constants'
 
 
 describe('subInstances change validator', () => {
-  it('should have change error if a sub-instance has been modified', async () => {
-    const accountingPeriodType = new ObjectType({ elemID: new ElemID(NETSUITE, 'AccountingPeriod') })
-    const before = new InstanceElement('instance', accountingPeriodType, { isSubInstance: true })
+  describe('should have change error if a sub-instance has been modified', () => {
+    let accountingPeriodType: ObjectType
+    let accountingPeriodInstance: InstanceElement
 
-    const changeErrors = await subInstancesValidator(
-      [toChange({ before })]
-    )
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0].severity).toEqual('Error')
-    expect(changeErrors[0].elemID).toEqual(before.elemID)
+    beforeEach(() => {
+      accountingPeriodType = new ObjectType({ elemID: new ElemID(NETSUITE, 'AccountingPeriod') })
+      accountingPeriodInstance = new InstanceElement('instance', accountingPeriodType, { isSubInstance: true })
+    })
+    it('removal', async () => {
+      const changeErrors = await subInstancesValidator(
+        [toChange({ before: accountingPeriodInstance })]
+      )
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0].severity).toEqual('Error')
+      expect(changeErrors[0].elemID).toEqual(accountingPeriodInstance.elemID)
+    })
+
+    it('modification', async () => {
+      const after = accountingPeriodInstance.clone()
+      after.value.isSubInstance = false
+      const changeErrors = await subInstancesValidator(
+        [toChange({ before: accountingPeriodInstance, after })]
+      )
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0].severity).toEqual('Error')
+      expect(changeErrors[0].elemID).toEqual(accountingPeriodInstance.elemID)
+    })
+
+    it('addition', async () => {
+      const changeErrors = await subInstancesValidator(
+        [toChange({ after: accountingPeriodInstance })]
+      )
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0].severity).toEqual('Error')
+      expect(changeErrors[0].elemID).toEqual(accountingPeriodInstance.elemID)
+    })
   })
 })

--- a/packages/netsuite-adapter/test/change_validators/subinstances.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/subinstances.test.ts
@@ -1,0 +1,33 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import subInstancesValidator from '../../src/change_validators/subinstances'
+import { NETSUITE } from '../../src/constants'
+
+
+describe('subInstances change validator', () => {
+  it('should have change error if a sub-instance has been modified', async () => {
+    const accountingPeriodType = new ObjectType({ elemID: new ElemID(NETSUITE, 'AccountingPeriod') })
+    const before = new InstanceElement('instance', accountingPeriodType, { isSubInstance: true })
+
+    const changeErrors = await subInstancesValidator(
+      [toChange({ before })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].elemID).toEqual(before.elemID)
+  })
+})

--- a/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
@@ -61,6 +61,7 @@ describe('data_instances_internal_id', () => {
 
       await filterCreator().onFetch(elements)
       expect(elements[1].elemID.name).toBe('type_someList_1')
+      expect(elements[1].value.isSubInstance).toBeTruthy()
       expect((instance.value.someList[0] as ReferenceExpression).elemID.getFullName())
         .toBe(elements[1].elemID.getFullName())
       expect(elements.length).toBe(2)


### PR DESCRIPTION
When there is an object with an internal id inside a list, we extract it to a different instance and add a reference to it (because we don't support hidden values inside lists). This instances are not deployable so I added a change validate to verify the user does not edit them

---
_Release Notes_: 
None

---
_User Notifications_: 
None