### PR TITLE
Added missing naclCase to element path

### DIFF
--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -63,7 +63,9 @@ export const createInstanceElement = async (customizationInfo: CustomizationInfo
 
   const getInstancePath = (instanceName: string): string[] =>
     (isFolderCustomizationInfo(customizationInfo) || isFileCustomizationInfo(customizationInfo)
-      ? [NETSUITE, FILE_CABINET_PATH, ...customizationInfo.path.map(removeDotPrefix)]
+      ? [NETSUITE, FILE_CABINET_PATH, ...customizationInfo.path.map(
+        pathPart => pathNaclCase(naclCase(removeDotPrefix(pathPart)))
+      )]
       : [NETSUITE, RECORDS_PATH, type.elemID.name, instanceName])
 
   const transformPrimitive: TransformFunc = async ({ value, field }) => {

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -304,8 +304,8 @@ describe('Transformer', () => {
         const result = await createInstanceElement(fileCustomizationInfo, fileCabinetTypes[FILE],
           mockGetElemIdFunc)
         expect(result.path)
-          .toEqual([NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates',
-            'Inner EmailTemplates Folder', 'content.html'])
+          .toEqual([NETSUITE, FILE_CABINET_PATH, 'Templates', 'E_mail_Templates',
+            'Inner_EmailTemplates_Folder', 'content_html'])
       })
 
       it('should create instance path correctly for file instance when it has . prefix', async () => {
@@ -314,7 +314,7 @@ describe('Transformer', () => {
         const result = await createInstanceElement(fileCustomizationInfoWithDotPrefix,
           fileCabinetTypes[FILE], mockGetElemIdFunc)
         expect(result.path).toEqual(
-          [NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates', '_hiddenFolder', '_hiddenFile.xml']
+          [NETSUITE, FILE_CABINET_PATH, 'Templates', 'E_mail_Templates', '_hiddenFolder', '_hiddenFile_xml']
         )
       })
 
@@ -325,8 +325,8 @@ describe('Transformer', () => {
           mockGetElemIdFunc
         )
         expect(result.path)
-          .toEqual([NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates',
-            'Inner EmailTemplates Folder'])
+          .toEqual([NETSUITE, FILE_CABINET_PATH, 'Templates', 'E_mail_Templates',
+            'Inner_EmailTemplates_Folder'])
       })
 
       it('should create instance path correctly for folder instance when it has . prefix', async () => {
@@ -335,7 +335,7 @@ describe('Transformer', () => {
         const result = await createInstanceElement(folderCustomizationInfoWithDotPrefix,
           fileCabinetTypes[FOLDER], mockGetElemIdFunc)
         expect(result.path)
-          .toEqual([NETSUITE, FILE_CABINET_PATH, 'Templates', 'E-mail Templates', '_hiddenFolder'])
+          .toEqual([NETSUITE, FILE_CABINET_PATH, 'Templates', 'E_mail_Templates', '_hiddenFolder'])
       })
 
       it('should transform path field correctly', async () => {


### PR DESCRIPTION
This is causing a file with `?` in its path to be created in NetSuite demo account (https://salto-io.atlassian.net/browse/SAAS-2342)

---
_Release Notes_: 
Bugfix:
NetSuite Adapter:
Fixed escaping in file cabinet instances paths


---
_User Notifications_: 
None