### PR TITLE
fixed bug with double dependecies fields

### DIFF
--- a/packages/netsuite-adapter/src/filters/parse_saved_searchs.ts
+++ b/packages/netsuite-adapter/src/filters/parse_saved_searchs.ts
@@ -18,7 +18,7 @@ import { getChangeElement, InstanceElement, isInstanceChange, isInstanceElement,
 import _ from 'lodash'
 import { SAVED_SEARCH } from '../constants'
 import { FilterCreator } from '../filter'
-import { savedsearch, savedsearchInnerTypes } from '../saved_search_parsing/parsed_saved_search'
+import { savedsearch, savedsearchInnerTypes, savedSearchDependenciesElemID } from '../saved_search_parsing/parsed_saved_search'
 import { savedsearch as oldSavedSearch } from '../types/custom_types/savedsearch'
 import { parseDefinition } from '../saved_search_parsing/saved_search_parser'
 
@@ -49,6 +49,7 @@ const removeValuesFromInstance = (instance:InstanceElement): void => {
 const filterCreator: FilterCreator = ({ elementsSource }) => ({
   onFetch: async elements => {
     _.remove(elements, e => isObjectType(e) && e.elemID.name === SAVED_SEARCH)
+    _.remove(elements, e => isObjectType(e) && e.elemID.isEqual(savedSearchDependenciesElemID))
     const instances = _.remove(elements, e => isInstanceElement(e)
      && e.elemID.typeName === SAVED_SEARCH)
     elements.push(savedsearch)

--- a/packages/netsuite-adapter/src/saved_search_parsing/parsed_saved_search.ts
+++ b/packages/netsuite-adapter/src/saved_search_parsing/parsed_saved_search.ts
@@ -24,7 +24,7 @@ import * as constants from '../constants'
 export const savedsearchInnerTypes: ObjectType[] = []
 
 const savedSearchElemID = new ElemID(constants.NETSUITE, 'savedsearch')
-const savedSearchDependenciesElemID = new ElemID(constants.NETSUITE, 'savedsearch_dependencies')
+export const savedSearchDependenciesElemID = new ElemID(constants.NETSUITE, 'savedsearch_dependencies')
 const savedSearchFilterRecordElemID = new ElemID(constants.NETSUITE, 'savedsearch_filterRecord')
 const savedSearchAvailableFilterElemID = new ElemID(constants.NETSUITE, 'savedsearch_availableFilter')
 const savedSearchReturnFieldElemID = new ElemID(constants.NETSUITE, 'savedsearch_returnField')

--- a/packages/netsuite-adapter/test/filters/parse_saved_searches.test.ts
+++ b/packages/netsuite-adapter/test/filters/parse_saved_searches.test.ts
@@ -19,6 +19,7 @@ import filterCreator from '../../src/filters/parse_saved_searchs'
 import { customTypes } from '../../src/types'
 import NetsuiteClient from '../../src/client/client'
 import { SAVED_SEARCH } from '../../src/constants'
+import { savedSearchDependenciesElemID } from '../../src/saved_search_parsing/parsed_saved_search'
 
 jest.mock('../../src/saved_search_parsing/saved_search_parser', () => ({
   parseDefinition: jest.fn().mockResolvedValue({
@@ -55,13 +56,22 @@ describe('parse_saved_searches filter', () => {
     )
     sourceInstance.value.definition = 'testDefinition'
   })
-  it('test onFetch removes old object type', async () => {
+  it('test onFetch removes old saved search object type', async () => {
     const savedSearchObject = new ObjectType({ elemID: new ElemID('netsuite', SAVED_SEARCH), fields: {} })
     const elements = [savedSearchObject]
     await filterCreator(fetchOpts).onFetch?.(elements)
     expect(elements.filter(isObjectType)
       .filter(e => e.elemID.typeName === SAVED_SEARCH))
       .not.toEqual(savedSearchObject)
+  })
+  it('test onFetch removes doubled dependency object type', async () => {
+    const dependencyObjectType = new ObjectType({ elemID: savedSearchDependenciesElemID,
+      fields: {} })
+    const elements = [dependencyObjectType]
+    await filterCreator(fetchOpts).onFetch?.(elements)
+    expect(elements.filter(isObjectType)
+      .filter(e => e.elemID.typeName === SAVED_SEARCH))
+      .not.toEqual(dependencyObjectType)
   })
   it('test onFetch adds definition values', async () => {
     await filterCreator(fetchOpts).onFetch?.([instance])


### PR DESCRIPTION
fixed bug with double dependencies as object types.

---
the other option to fix this was not to create a new dependency in the new parsed saved search and use the old one but it is not exported and the code there is generated.

