### PR TITLE
SALTO-1449: Fix router moving annotations to values when wrapping instance additions

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/addition_wrapper.ts
+++ b/packages/workspace/src/workspace/nacl_files/addition_wrapper.ts
@@ -93,6 +93,7 @@ const createInstanceElementFromNestedAdditions = (
   commonInstance: InstanceElement,
   path?: string[]
 ): InstanceElement => {
+  // IDs inside instances can be of values or annotations, we need to keep them separate
   const value = {}
   const annotations = {}
   nestedValues.forEach(nestedValue => {

--- a/packages/workspace/src/workspace/nacl_files/addition_wrapper.ts
+++ b/packages/workspace/src/workspace/nacl_files/addition_wrapper.ts
@@ -94,15 +94,22 @@ const createInstanceElementFromNestedAdditions = (
   path?: string[]
 ): InstanceElement => {
   const value = {}
+  const annotations = {}
   nestedValues.forEach(nestedValue => {
     const inValuePath = nestedValue.id.createTopLevelParentID().path
-    _.set(value, inValuePath, nestedValue.value)
+    _.set(
+      nestedValue.id.isAttrID() ? annotations : value,
+      inValuePath,
+      nestedValue.value,
+    )
   })
+
   return new InstanceElement(
     commonInstance.elemID.name,
     commonInstance.refType,
     value,
-    path
+    path,
+    annotations,
   )
 }
 

--- a/packages/workspace/test/workspace/nacl_files/elements_cache.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/elements_cache.test.ts
@@ -39,7 +39,7 @@ describe('test cache manager', () => {
     )
   })
 
-  describe('On clear', async () => {
+  describe('On clear', () => {
     it('calls clear on each flushable', async () => {
       await manager.clear()
       await Promise.all(flushables.map(async flushable => {
@@ -47,7 +47,7 @@ describe('test cache manager', () => {
       }))
     })
   })
-  describe('On flush', async () => {
+  describe('On flush', () => {
     it('If flush was successful, doesnt clear on init', async () => {
       await manager.flush()
       await Promise.all(flushables.map(async flushable => {


### PR DESCRIPTION
When instance annotations were added and the router had to wrap them with a new instance
it would move the annotations to the instance values instead

---

This case was triggered by running fetch align and getting a new annotation.
This would create a change where the instance would have this annotation in its `.value` instead of in `.annotations`.
When this was stored in the nacl cache, the issue would persist and would cause trouble when trying to deploy that instance since the rest of the code is not built to handle the case where an annotation is placed in a value (and so, it treated that annotation as if it was part of the value, tried to deploy it, and crashed).

Note that a workaround for existing workspaces is to clear their nacl cache (that would force the parser to read the nacl file, and the parser would place the annotation correctly)

---
_Release Notes_: 
- Fix issue where salesforce metadata deployment would sometimes crash with the error "Maximum call stack size exceeded"

---
_User Notifications_: 
_None_
