### PR TITLE
Revert "SALTO-1308 Make Read-Only Field Annotations Hidden (#2194)"

### DIFF
--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -141,14 +141,6 @@ export const BuiltinTypes = {
       [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
     },
   }),
-  HIDDEN_BOOLEAN: new PrimitiveType({
-    elemID: new ElemID(GLOBAL_ADAPTER, 'hidden_boolean'),
-    primitive: PrimitiveTypes.BOOLEAN,
-    annotationRefsOrTypes: StandardCoreAnnotationTypes,
-    annotations: {
-      [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
-    },
-  }),
 }
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/packages/cli/e2e_test/salto.test.ts
+++ b/packages/cli/e2e_test/salto.test.ts
@@ -44,7 +44,6 @@ import {
 } from './helpers/workspace'
 import { instanceExists, objectExists, getSalesforceCredsInstance } from './helpers/salesforce'
 
-
 const { awu } = collections.asynciterable
 // let lastPlan: Plan
 let credsLease: CredsLease<UsernamePasswordCredentials>

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -59,7 +59,6 @@ export enum FIELD_TYPE_NAMES {
 export enum INTERNAL_FIELD_TYPE_NAMES {
   UNKNOWN = 'Unknown', // internal-only placeholder for fields whose type is unknown
   ANY = 'AnyType',
-  SERVICE_ID = 'ServiceId',
 }
 
 export type ALL_FIELD_TYPE_NAMES = FIELD_TYPE_NAMES | INTERNAL_FIELD_TYPE_NAMES

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -396,9 +396,9 @@ export class Types {
     [BUSINESS_STATUS]: Types.BusinessStatusType,
     [SECURITY_CLASSIFICATION]: Types.SecurityClassificationType,
     [COMPLIANCE_GROUP]: BuiltinTypes.STRING,
-    [FIELD_ANNOTATIONS.CREATABLE]: BuiltinTypes.HIDDEN_BOOLEAN,
-    [FIELD_ANNOTATIONS.UPDATEABLE]: BuiltinTypes.HIDDEN_BOOLEAN,
-    [FIELD_ANNOTATIONS.QUERYABLE]: BuiltinTypes.HIDDEN_BOOLEAN,
+    [FIELD_ANNOTATIONS.CREATABLE]: BuiltinTypes.BOOLEAN,
+    [FIELD_ANNOTATIONS.UPDATEABLE]: BuiltinTypes.BOOLEAN,
+    [FIELD_ANNOTATIONS.QUERYABLE]: BuiltinTypes.BOOLEAN,
     [INTERNAL_ID_ANNOTATION]: BuiltinTypes.HIDDEN_STRING,
     [FIELD_ANNOTATIONS.EXTERNAL_ID]: BuiltinTypes.BOOLEAN,
     [FIELD_ANNOTATIONS.TRACK_TRENDING]: BuiltinTypes.BOOLEAN,
@@ -628,14 +628,6 @@ export class Types {
     AnyType: new PrimitiveType({
       elemID: new ElemID(SALESFORCE, INTERNAL_FIELD_TYPE_NAMES.ANY),
       primitive: PrimitiveTypes.UNKNOWN,
-      annotationRefsOrTypes: {
-        ...Types.commonAnnotationTypes,
-      },
-    }),
-    ServiceId: new PrimitiveType({
-      elemID: new ElemID(SALESFORCE, 'serviceid'),
-      primitive: PrimitiveTypes.STRING,
-      annotations: { [CORE_ANNOTATIONS.SERVICE_ID]: true },
       annotationRefsOrTypes: {
         ...Types.commonAnnotationTypes,
       },
@@ -1157,7 +1149,7 @@ export const getSObjectFieldElement = (
     // returned from the API is string)
     naclFieldType = getFieldType(FIELD_TYPE_NAMES.AUTONUMBER)
   } else if (field.idLookup && field.type === 'id') {
-    naclFieldType = Types.primitiveDataTypes.ServiceId
+    naclFieldType = BuiltinTypes.SERVICE_ID
   } else if (field.type === 'string' && !field.compoundFieldName) { // string
     naclFieldType = getFieldType(FIELD_TYPE_NAMES.TEXT)
   } else if ((field.type === 'double' && !field.compoundFieldName)) {


### PR DESCRIPTION
This reverts commit SALTO-1308 which caused a bug when fetching on existing non empty workspace.
has been tested on a workspace after fetch with master version. second fetch worked fine.