### PR TITLE
SALTO-1495: Add support for annotation type changes in hidden values

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -522,7 +522,7 @@ export const loadWorkspace = async (
     const { visible: visibleChanges, hidden: hiddenChanges } = await handleHiddenChanges(
       changes,
       state(),
-      (await getLoadedNaclFilesSource()).getAll,
+      await getLoadedNaclFilesSource(),
     )
     const workspaceChanges = await ((await getLoadedNaclFilesSource())
       .updateNaclFiles(

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -173,6 +173,13 @@ type salesforce.HiddenToVisibleVal {
   }
 }
 
+type salesforce.HiddenToVisibleType is string {
+  ${CORE_ANNOTATIONS.HIDDEN_VALUE} = true
+}
+
+type salesforce.VisibleToHiddenType is string {
+}
+
 type salesforce.NestedHiddenVal {
   annotations {
     salesforce.HiddenVal hidden_val_anno {
@@ -226,9 +233,39 @@ type salesforce.lead {
     }
   }
 
+  type salesforce.FieldTypeWithChangingHidden {
+    annotations {
+      hidden_string hiddenSwitchType {
+      }
+      string visibleSwitchType {
+      }
+      salesforce.VisibleToHiddenType visibleChangeType {
+      }
+      salesforce.HiddenToVisibleType hiddenTypeChange {
+      }
+    }
+  }
+
   type salesforce.ObjWithFieldTypeWithHidden {
+    annotations {
+      hidden_string hiddenSwitchType {
+      }
+      string visibleSwitchType {
+      }
+      salesforce.VisibleToHiddenType visibleChangeType {
+      }
+      salesforce.HiddenToVisibleType hiddenTypeChange {
+      }
+    }
+    visibleSwitchType = "asd"
+    visibleChangeType = "asd"
+
     salesforce.FieldTypeWithHidden fieldWithHidden {
       visible = "YOU SEE ME"
+    }
+    salesforce.FieldTypeWithChangingHidden fieldWithChangingHidden {
+      visibleSwitchType = "asd"
+      visibleChangeType = "asd"
     }
   }
   `,

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -256,9 +256,12 @@ type salesforce.lead {
       }
       salesforce.HiddenToVisibleType hiddenTypeChange {
       }
+      salesforce.VisibleToHiddenType visibleChangeAndSwitchType {
+      }
     }
     visibleSwitchType = "asd"
     visibleChangeType = "asd"
+    visibleChangeAndSwitchType = "asd"
 
     salesforce.FieldTypeWithHidden fieldWithHidden {
       visible = "YOU SEE ME"

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -241,7 +241,7 @@ type salesforce.lead {
       }
       salesforce.VisibleToHiddenType visibleChangeType {
       }
-      salesforce.HiddenToVisibleType hiddenTypeChange {
+      salesforce.HiddenToVisibleType hiddenChangeType {
       }
     }
   }
@@ -254,7 +254,7 @@ type salesforce.lead {
       }
       salesforce.VisibleToHiddenType visibleChangeType {
       }
-      salesforce.HiddenToVisibleType hiddenTypeChange {
+      salesforce.HiddenToVisibleType hiddenChangeType {
       }
       salesforce.VisibleToHiddenType visibleChangeAndSwitchType {
       }

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -14,11 +14,10 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ObjectType, ElemID, BuiltinTypes, PrimitiveType, PrimitiveTypes, isObjectType, InstanceElement, isInstanceElement, CORE_ANNOTATIONS, DetailedChange, getChangeElement, Element, INSTANCE_ANNOTATIONS, ReferenceExpression } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, BuiltinTypes, PrimitiveType, PrimitiveTypes, isObjectType, InstanceElement, isInstanceElement, CORE_ANNOTATIONS, DetailedChange, getChangeElement, INSTANCE_ANNOTATIONS, ReferenceExpression } from '@salto-io/adapter-api'
 import { createRefToElmWithValue } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { mockState } from '../common/state'
-import { mockFunction } from '../common/helpers'
 import { MergeResult } from '../../src/merger'
 import { mergeWithHidden, handleHiddenChanges } from '../../src/workspace/hidden_values'
 import { createInMemoryElementSource } from '../../src/workspace/elements_source'
@@ -200,7 +199,7 @@ describe('handleHiddenChanges', () => {
         result = await handleHiddenChanges(
           [change],
           mockState(),
-          mockFunction<() => Promise<AsyncIterable<Element>>>().mockResolvedValue(awu([])),
+          createInMemoryElementSource(),
         )
         expect(result.visible).toHaveLength(1)
         expect(result.hidden).toHaveLength(1)
@@ -229,7 +228,7 @@ describe('handleHiddenChanges', () => {
         result = await handleHiddenChanges(
           [change],
           mockState([instanceType, instance]),
-          mockFunction<() => Promise<AsyncIterable<Element>>>().mockResolvedValue(awu([])),
+          createInMemoryElementSource(),
         )
       })
       it('should not have a visible change', () => {
@@ -259,7 +258,7 @@ describe('handleHiddenChanges', () => {
         const res = (await handleHiddenChanges(
           [change],
           mockState([instanceType, instance]),
-          mockFunction<() => Promise<AsyncIterable<Element>>>().mockResolvedValue(awu([])),
+          createInMemoryElementSource(),
         ))
         expect(res.visible).toHaveLength(1)
         expect(res.hidden).toHaveLength(1)
@@ -289,7 +288,7 @@ describe('handleHiddenChanges', () => {
       result = await handleHiddenChanges(
         [change],
         mockState([object]),
-        mockFunction<() => Promise<AsyncIterable<Element>>>().mockResolvedValue(awu([])),
+        createInMemoryElementSource(),
       )
     })
 
@@ -334,7 +333,7 @@ describe('handleHiddenChanges', () => {
         result = await handleHiddenChanges(
           [change],
           mockState([instance]),
-          mockFunction<() => Promise<AsyncIterable<Element>>>().mockResolvedValue(awu([])),
+          createInMemoryElementSource(),
         )
         expect(result.visible).toHaveLength(1)
         expect(result.hidden).toHaveLength(0)
@@ -360,7 +359,7 @@ describe('handleHiddenChanges', () => {
         result = await handleHiddenChanges(
           [change],
           mockState([instance]),
-          mockFunction<() => Promise<AsyncIterable<Element>>>().mockResolvedValue(awu([])),
+          createInMemoryElementSource(),
         )
         expect(result.visible).toHaveLength(1)
         expect(result.hidden).toHaveLength(0)
@@ -391,7 +390,7 @@ describe('handleHiddenChanges', () => {
       const result = await handleHiddenChanges(
         [change],
         mockState([]),
-        mockFunction<() => Promise<AsyncIterable<Element>>>().mockResolvedValue(awu([])),
+        createInMemoryElementSource(),
       )
       expect(result.visible.length).toBe(1)
       expect(result.hidden.length).toBe(0)
@@ -423,7 +422,7 @@ describe('handleHiddenChanges', () => {
       const result = await handleHiddenChanges(
         [change],
         mockState([stateInstance]),
-        mockFunction<() => Promise<AsyncIterable<Element>>>().mockResolvedValue(awu([])),
+        createInMemoryElementSource(),
       )
       expect(result.visible.length).toBe(1)
       expect(result.hidden.length).toBe(0)

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -974,6 +974,7 @@ describe('workspace', () => {
             visibleSwitchType: 'asd',
             visibleChangeType: 'asd',
             hiddenTypeChange: 'asd',
+            visibleChangeAndSwitchType: 'asd',
           },
         },
       },
@@ -982,12 +983,14 @@ describe('workspace', () => {
         visibleSwitchType: BuiltinTypes.HIDDEN_STRING,
         visibleChangeType: new ReferenceExpression(new ElemID('salesforce', 'VisibleToHiddenType')),
         hiddenTypeChange: new ReferenceExpression(new ElemID('salesforce', 'HiddenToVisibleType')),
+        visibleChangeAndSwitchType: BuiltinTypes.HIDDEN_STRING,
       },
       annotations: {
         hiddenSwitchType: 'asd',
         visibleSwitchType: 'asd',
         visibleChangeType: 'asd',
         hiddenTypeChange: 'asd',
+        visibleChangeAndSwitchType: 'asd',
       },
     })
 
@@ -1342,7 +1345,7 @@ describe('workspace', () => {
         },
       },
       { // Switch hidden annotation type to visible type for type annotation
-        id: new ElemID('salesforce', 'ObjWithFieldTypeWithHidden', 'annotation', 'visibleSwitchType'),
+        id: objWithFieldTypeWithHidden.elemID.createNestedID('annotation', 'visibleSwitchType'),
         action: 'modify',
         data: {
           before: createRefToElmWithValue(BuiltinTypes.STRING),
@@ -1350,11 +1353,19 @@ describe('workspace', () => {
         },
       },
       { // Switch hidden annotation type to visible type for type annotation
-        id: new ElemID('salesforce', 'ObjWithFieldTypeWithHidden', 'annotation', 'hiddenSwitchType'),
+        id: objWithFieldTypeWithHidden.elemID.createNestedID('annotation', 'hiddenSwitchType'),
         action: 'modify',
         data: {
           before: createRefToElmWithValue(BuiltinTypes.HIDDEN_STRING),
           after: createRefToElmWithValue(BuiltinTypes.STRING),
+        },
+      },
+      { // Switch visible annotation type to hidden when the same type changes to hidden as well
+        id: objWithFieldTypeWithHidden.elemID.createNestedID('annotation', 'visibleChangeAndSwitchType'),
+        action: 'modify',
+        data: {
+          before: new ReferenceExpression(new ElemID('salesforce', 'VisibleToHiddenType')),
+          after: createRefToElmWithValue(BuiltinTypes.HIDDEN_STRING),
         },
       },
       { // Change type with annotation value from visible to hidden

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -285,7 +285,7 @@ describe('workspace', () => {
 
   describe('getSearchableNames', () => {
     let workspace: Workspace
-    const TOTAL_NUM_ELEMENETS = 57
+    const TOTAL_NUM_ELEMENETS = 61
 
     it('should return names of top level elements and fields', async () => {
       workspace = await createWorkspace()
@@ -653,7 +653,7 @@ describe('workspace', () => {
 
     it('should return the correct changes', async () => {
       const primaryEnvChanges = changes.default.changes
-      expect(primaryEnvChanges).toHaveLength(25)
+      expect(primaryEnvChanges).toHaveLength(27)
       expect((primaryEnvChanges.find(c => c.action === 'add') as AdditionChange<Element>).data.after)
         .toEqual(newAddedObject)
       const multiLocChange = primaryEnvChanges
@@ -967,6 +967,27 @@ describe('workspace', () => {
             hiddenValAnno: 'YOU DO NOT SEE ME',
           },
         },
+        fieldWithChangingHidden: {
+          refType: new ReferenceExpression(new ElemID('salesforce', 'FieldTypeWithChangingHidden')),
+          annotations: {
+            hiddenSwitchType: 'asd',
+            visibleSwitchType: 'asd',
+            visibleChangeType: 'asd',
+            hiddenTypeChange: 'asd',
+          },
+        },
+      },
+      annotationRefsOrTypes: {
+        hiddenSwitchType: BuiltinTypes.STRING,
+        visibleSwitchType: BuiltinTypes.HIDDEN_STRING,
+        visibleChangeType: new ReferenceExpression(new ElemID('salesforce', 'VisibleToHiddenType')),
+        hiddenTypeChange: new ReferenceExpression(new ElemID('salesforce', 'HiddenToVisibleType')),
+      },
+      annotations: {
+        hiddenSwitchType: 'asd',
+        visibleSwitchType: 'asd',
+        visibleChangeType: 'asd',
+        hiddenTypeChange: 'asd',
       },
     })
 
@@ -1070,7 +1091,6 @@ describe('workspace', () => {
         id: new ElemID('salesforce', 'lead', 'attr', 'bobo'),
         action: 'add',
         data: { after: 'baba' },
-
       },
       {
         path: ['other', 'boo'],
@@ -1305,6 +1325,48 @@ describe('workspace', () => {
           before: objWithFieldTypeWithHidden.fields.fieldWithHidden,
         },
       },
+      { // Change visible annotation type to hidden type for field annotation
+        id: new ElemID('salesforce', 'FieldTypeWithChangingHidden', 'annotation', 'visibleSwitchType'),
+        action: 'modify',
+        data: {
+          before: createRefToElmWithValue(BuiltinTypes.STRING),
+          after: createRefToElmWithValue(BuiltinTypes.HIDDEN_STRING),
+        },
+      },
+      { // Change hidden annotation type to visible type for field annotation
+        id: new ElemID('salesforce', 'FieldTypeWithChangingHidden', 'annotation', 'hiddenSwitchType'),
+        action: 'modify',
+        data: {
+          before: createRefToElmWithValue(BuiltinTypes.HIDDEN_STRING),
+          after: createRefToElmWithValue(BuiltinTypes.STRING),
+        },
+      },
+      { // Switch hidden annotation type to visible type for type annotation
+        id: new ElemID('salesforce', 'ObjWithFieldTypeWithHidden', 'annotation', 'visibleSwitchType'),
+        action: 'modify',
+        data: {
+          before: createRefToElmWithValue(BuiltinTypes.STRING),
+          after: createRefToElmWithValue(BuiltinTypes.HIDDEN_STRING),
+        },
+      },
+      { // Switch hidden annotation type to visible type for type annotation
+        id: new ElemID('salesforce', 'ObjWithFieldTypeWithHidden', 'annotation', 'hiddenSwitchType'),
+        action: 'modify',
+        data: {
+          before: createRefToElmWithValue(BuiltinTypes.HIDDEN_STRING),
+          after: createRefToElmWithValue(BuiltinTypes.STRING),
+        },
+      },
+      { // Change type with annotation value from visible to hidden
+        id: new ElemID('salesforce', 'VisibleToHiddenType', 'attr', CORE_ANNOTATIONS.HIDDEN_VALUE),
+        action: 'add',
+        data: { after: true },
+      },
+      { // Change type with annotation value from hidden to visible
+        id: new ElemID('salesforce', 'HiddenToVisibleType', 'attr', CORE_ANNOTATIONS.HIDDEN_VALUE),
+        action: 'remove',
+        data: { before: true },
+      },
     ]
 
     let clonedChanges: DetailedChange[]
@@ -1328,10 +1390,6 @@ describe('workspace', () => {
     let elemMapWithHidden: Record<string, Element>
     let workspace: Workspace
     let updateNaclFileResults: UpdateNaclFilesResult
-    const expectedUpdateNaclFileResult: UpdateNaclFilesResult = {
-      naclFilesChangesCount: 20,
-      stateOnlyChangesCount: 15,
-    }
     const dirStore = mockDirStore()
 
     beforeAll(async () => {
@@ -1405,7 +1463,10 @@ describe('workspace', () => {
       // This is just meant to test that calculating number of changes works,
       // and could possibly change. If you get a failure here and the number
       // of changes you get seems ok, you can just change numExpectedChanges
-      expect(updateNaclFileResults).toEqual(expectedUpdateNaclFileResult)
+      expect(updateNaclFileResults).toEqual({
+        naclFilesChangesCount: 20,
+        stateOnlyChangesCount: 15,
+      })
     })
     it('should not cause parse errors', async () => {
       expect((await workspace.errors()).parse).toHaveLength(0)

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -973,7 +973,7 @@ describe('workspace', () => {
             hiddenSwitchType: 'asd',
             visibleSwitchType: 'asd',
             visibleChangeType: 'asd',
-            hiddenTypeChange: 'asd',
+            hiddenChangeType: 'asd',
             visibleChangeAndSwitchType: 'asd',
           },
         },
@@ -982,14 +982,14 @@ describe('workspace', () => {
         hiddenSwitchType: BuiltinTypes.STRING,
         visibleSwitchType: BuiltinTypes.HIDDEN_STRING,
         visibleChangeType: new ReferenceExpression(new ElemID('salesforce', 'VisibleToHiddenType')),
-        hiddenTypeChange: new ReferenceExpression(new ElemID('salesforce', 'HiddenToVisibleType')),
+        hiddenChangeType: new ReferenceExpression(new ElemID('salesforce', 'HiddenToVisibleType')),
         visibleChangeAndSwitchType: BuiltinTypes.HIDDEN_STRING,
       },
       annotations: {
         hiddenSwitchType: 'asd',
         visibleSwitchType: 'asd',
         visibleChangeType: 'asd',
-        hiddenTypeChange: 'asd',
+        hiddenChangeType: 'asd',
         visibleChangeAndSwitchType: 'asd',
       },
     })
@@ -1475,7 +1475,7 @@ describe('workspace', () => {
       // and could possibly change. If you get a failure here and the number
       // of changes you get seems ok, you can just change numExpectedChanges
       expect(updateNaclFileResults).toEqual({
-        naclFilesChangesCount: 20,
+        naclFilesChangesCount: 23,
         stateOnlyChangesCount: 15,
       })
     })
@@ -1723,6 +1723,36 @@ describe('workspace', () => {
       const elem = await workspace.getValue(objWithFieldTypeWithHidden.elemID) as ObjectType
       expect(elem).toBeDefined()
       expect(elem.fields.fieldWithHidden).toBeUndefined()
+    })
+
+    it('should hide annotation values when they switch type to hidden', () => {
+      const obj = elemMap[objWithFieldTypeWithHidden.elemID.getFullName()] as ObjectType
+      expect(obj).toBeDefined()
+      expect(obj.annotations).not.toHaveProperty('visibleSwitchType')
+      expect(obj.fields.fieldWithChangingHidden.annotations).not.toHaveProperty('visibleSwitchType')
+    })
+    it('should add annotation values when they switch type to visible', () => {
+      const obj = elemMap[objWithFieldTypeWithHidden.elemID.getFullName()] as ObjectType
+      expect(obj).toBeDefined()
+      expect(obj.annotations).toHaveProperty('hiddenSwitchType')
+      expect(obj.fields.fieldWithChangingHidden.annotations).toHaveProperty('hiddenSwitchType')
+    })
+    it('should hide annotation values when their type changes to hidden', () => {
+      const obj = elemMap[objWithFieldTypeWithHidden.elemID.getFullName()] as ObjectType
+      expect(obj).toBeDefined()
+      expect(obj.annotations).not.toHaveProperty('visibleChangeType')
+      expect(obj.fields.fieldWithChangingHidden.annotations).not.toHaveProperty('visibleChangeType')
+    })
+    it('should add annotation values when their type changes to visible', () => {
+      const obj = elemMap[objWithFieldTypeWithHidden.elemID.getFullName()] as ObjectType
+      expect(obj).toBeDefined()
+      expect(obj.annotations).toHaveProperty('hiddenChangeType')
+      expect(obj.fields.fieldWithChangingHidden.annotations).toHaveProperty('hiddenChangeType')
+    })
+    it('should hide annotation values when they switch type to hidden and the source type changes', () => {
+      const obj = elemMap[objWithFieldTypeWithHidden.elemID.getFullName()] as ObjectType
+      expect(obj).toBeDefined()
+      expect(obj.annotations).not.toHaveProperty('visibleChangeAndSwitchType')
     })
 
     describe('on secondary envs', () => {


### PR DESCRIPTION
- Add support for changing an annotation type from a hidden to a visible type (and vice versa)
- Fix handling of annotation types becoming hidden / visible

---
_Release Notes_: 
_None_ (this fixes an issue that could not happen in any released version of the code)

---
_User Notifications_: 
_None_
