### PR TITLE
SALTO-825: fixed required validation error in subinstances

### DIFF
--- a/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
@@ -17,7 +17,7 @@ import { BuiltinTypes, ElemID, InstanceElement, isInstanceElement, isObjectType,
 import { applyFunctionToChangeData, naclCase, TransformFunc, transformValues } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { isDataObjectType } from '../types'
+import { customTypes, isDataObjectType } from '../types'
 import { ACCOUNT_SPECIFIC_VALUE, NETSUITE, RECORDS_PATH } from '../constants'
 import { FilterWith } from '../filter'
 
@@ -38,6 +38,7 @@ const getSubInstanceName = (path: ElemID, internalId: string): string => {
 const filterCreator = (): FilterWith<'onFetch' | 'preDeploy'> => ({
   onFetch: async elements => {
     const newInstancesMap: Record<string, InstanceElement> = {}
+    const recordRefType = elements.filter(isObjectType).find(e => e.elemID.name === 'RecordRef')
 
     const transformIds: TransformFunc = async ({ value, field, path }) => {
       const fieldType = await field?.getType()
@@ -61,7 +62,12 @@ const filterCreator = (): FilterWith<'onFetch' | 'preDeploy'> => ({
         if (!(instanceName in newInstancesMap)) {
           const newInstance = new InstanceElement(
             instanceName,
-            fieldType,
+            // If the fieldType is an SDF type we replace it with RecordRef to avoid validation
+            // errors because SDF types has fields with a "required" annotation which might not
+            // be fulfilled
+            fieldType.elemID.name in customTypes
+              && recordRefType !== undefined
+              ? recordRefType : fieldType,
             { ...value, isSubInstance: true },
             [NETSUITE, RECORDS_PATH, fieldType.elemID.name, instanceName]
           )

--- a/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
@@ -16,6 +16,7 @@
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/data_instances_internal_id'
 import { ACCOUNT_SPECIFIC_VALUE, NETSUITE } from '../../src/constants'
+import { role } from '../../src/types/custom_types/role'
 
 describe('data_instances_internal_id', () => {
   const recordRefType = new ObjectType({
@@ -51,9 +52,18 @@ describe('data_instances_internal_id', () => {
     })
 
     it('should extract list items with internal id', async () => {
+      const SubsidiaryType = new ObjectType({
+        elemID: new ElemID(NETSUITE, 'Subsidiary'),
+        fields: {
+          internalId: {
+            refType: BuiltinTypes.STRING,
+            annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+          },
+        },
+      })
       const instance = new InstanceElement(
         'instance',
-        new ObjectType({ elemID: new ElemID(NETSUITE, 'type'), fields: { someList: { refType: new ListType(recordRefType) } }, annotations: { source: 'soap' } }),
+        new ObjectType({ elemID: new ElemID(NETSUITE, 'type'), fields: { someList: { refType: new ListType(SubsidiaryType) } }, annotations: { source: 'soap' } }),
         { someList: [{ internalId: '1' }, { internalId: '1' }] }
       )
 
@@ -61,10 +71,29 @@ describe('data_instances_internal_id', () => {
 
       await filterCreator().onFetch(elements)
       expect(elements[1].elemID.name).toBe('type_someList_1')
+      expect(elements[1].elemID.typeName).toBe('Subsidiary')
       expect(elements[1].value.isSubInstance).toBeTruthy()
       expect((instance.value.someList[0] as ReferenceExpression).elemID.getFullName())
         .toBe(elements[1].elemID.getFullName())
       expect(elements.length).toBe(2)
+    })
+
+    it('list item type should be record type if the original type is an SDF type', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        new ObjectType({ elemID: new ElemID(NETSUITE, 'type'), fields: { someList: { refType: new ListType(role) } }, annotations: { source: 'soap' } }),
+        { someList: [{ internalId: '1' }, { internalId: '1' }] }
+      )
+
+      const elements = [instance, recordRefType]
+
+      await filterCreator().onFetch(elements)
+      expect(elements[2].elemID.name).toBe('type_someList_1')
+      expect(elements[2].elemID.typeName).toBe('RecordRef')
+      expect((elements[2] as InstanceElement).value.isSubInstance).toBeTruthy()
+      expect((instance.value.someList[0] as ReferenceExpression).elemID.getFullName())
+        .toBe(elements[2].elemID.getFullName())
+      expect(elements.length).toBe(3)
     })
   })
 

--- a/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
@@ -88,12 +88,12 @@ describe('data_instances_internal_id', () => {
       const elements = [instance, recordRefType]
 
       await filterCreator().onFetch(elements)
+      expect(elements.length).toBe(3)
       expect(elements[2].elemID.name).toBe('type_someList_1')
       expect(elements[2].elemID.typeName).toBe('RecordRef')
       expect((elements[2] as InstanceElement).value.isSubInstance).toBeTruthy()
       expect((instance.value.someList[0] as ReferenceExpression).elemID.getFullName())
         .toBe(elements[2].elemID.getFullName())
-      expect(elements.length).toBe(3)
     })
   })
 


### PR DESCRIPTION
Sub-instances of SDF types might not have the required fields of the type. To avoid validation errors we use `RecordRef` types for sub-instances of SDF types

---
_Release Notes_: 
None

---
_User Notifications_: 
None