### PR TITLE
SALTO-825: fixed identifiers with parent

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
@@ -20,7 +20,7 @@ import {
 import { getParents } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { TYPE_TO_ID_FIELD_PATHS } from '../data_elements/multi_fields_identifiers'
+import { TYPE_TO_ID_FIELD_PATHS } from '../data_elements/types'
 import { isDataObjectType, isFileCabinetType } from '../types'
 
 const { awu } = collections.asynciterable

--- a/packages/netsuite-adapter/src/data_elements/data_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/data_elements.ts
@@ -101,7 +101,7 @@ const createInstances = async (
   const fixedValuesList = await awu(valuesList).map(async values => {
     const type = getType(values, typesMap)
     return {
-      record: await transformValues({
+      values: await transformValues({
         values,
         type,
         strict: false,
@@ -113,9 +113,9 @@ const createInstances = async (
 
   addIdentifierToValues(fixedValuesList)
 
-  return fixedValuesList.map(({ record, type }) => {
+  return fixedValuesList.map(({ values, type }) => {
     const serviceIdFieldName = getTypeIdentifier(type)
-    const identifierValue = record[serviceIdFieldName]
+    const identifierValue = values[serviceIdFieldName]
     const defaultName = naclCase(identifierValue)
 
     const name = elemIdGetter !== undefined ? elemIdGetter(
@@ -134,7 +134,7 @@ const createInstances = async (
     return new InstanceElement(
       name,
       type,
-      record,
+      values,
       [NETSUITE, RECORDS_PATH, type.elemID.name, pathNaclCase(name)],
     )
   })

--- a/packages/netsuite-adapter/src/data_elements/data_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/data_elements.ts
@@ -21,7 +21,7 @@ import { naclCase, pathNaclCase, transformValues } from '@salto-io/adapter-utils
 import { collections } from '@salto-io/lowerdash'
 import { NETSUITE, RECORDS_PATH } from '../constants'
 import { NetsuiteQuery } from '../query'
-import { TYPE_TO_IDENTIFIER } from './types'
+import { getTypeIdentifier, TYPE_TO_IDENTIFIER } from './types'
 import NetsuiteClient from '../client/client'
 import { castFieldValue } from './custom_fields'
 import { addIdentifierToValues, addIdentifierToType } from './multi_fields_identifiers'
@@ -59,16 +59,17 @@ export const getDataTypes = async (
   })
 
   types
-    .filter(type => TYPE_TO_IDENTIFIER[type.elemID.name] !== undefined)
+    .filter(type => getTypeIdentifier(type) !== undefined)
     .forEach(type => {
-      const field = type.fields[TYPE_TO_IDENTIFIER[type.elemID.name]]
+      const identifierField = getTypeIdentifier(type)
+      const field = type.fields[identifierField]
       if (field !== undefined) {
         field.refType = new ReferenceExpression(
           BuiltinTypes.SERVICE_ID.elemID,
           BuiltinTypes.SERVICE_ID
         )
       } else {
-        log.warn(`Identifier field ${TYPE_TO_IDENTIFIER[type.elemID.name]} does not exists on type ${type.elemID.getFullName()}`)
+        log.warn(`Identifier field ${identifierField} does not exists on type ${type.elemID.getFullName()}`)
       }
     })
   return types
@@ -92,44 +93,51 @@ const getType = (
   return typesMap[typeNames[0]]
 }
 
-const createInstance = async (
-  values: Values,
+const createInstances = async (
+  valuesList: Values[],
   typesMap: Record<string, ObjectType>,
   elemIdGetter?: ElemIdGetter,
-): Promise<InstanceElement> => {
-  const type = getType(values, typesMap)
-  const fixedValues = await transformValues({
-    values,
-    type,
-    strict: false,
-    transformFunc: async ({ value, field }) => castFieldValue(value, field),
-  }) ?? values
+): Promise<InstanceElement[]> => {
+  const fixedValuesList = await awu(valuesList).map(async values => {
+    const type = getType(values, typesMap)
+    return {
+      record: await transformValues({
+        values,
+        type,
+        strict: false,
+        transformFunc: async ({ value, field }) => castFieldValue(value, field),
+      }) ?? values,
+      type,
+    }
+  }).toArray()
 
-  addIdentifierToValues(fixedValues, type)
+  addIdentifierToValues(fixedValuesList)
 
-  const serviceIdFieldName = TYPE_TO_IDENTIFIER[type.elemID.name]
-  const identifierValue = fixedValues[serviceIdFieldName]
-  const defaultName = naclCase(identifierValue)
+  return fixedValuesList.map(({ record, type }) => {
+    const serviceIdFieldName = getTypeIdentifier(type)
+    const identifierValue = record[serviceIdFieldName]
+    const defaultName = naclCase(identifierValue)
 
-  const name = elemIdGetter !== undefined ? elemIdGetter(
-    NETSUITE,
-    {
-      [ADAPTER]: NETSUITE,
-      [serviceIdFieldName]: identifierValue,
-      [OBJECT_SERVICE_ID]: toServiceIdsString({
+    const name = elemIdGetter !== undefined ? elemIdGetter(
+      NETSUITE,
+      {
         [ADAPTER]: NETSUITE,
-        [OBJECT_NAME]: type.elemID.getFullName(),
-      }),
-    },
-    defaultName
-  ).name : defaultName
+        [serviceIdFieldName]: identifierValue,
+        [OBJECT_SERVICE_ID]: toServiceIdsString({
+          [ADAPTER]: NETSUITE,
+          [OBJECT_NAME]: type.elemID.getFullName(),
+        }),
+      },
+      defaultName
+    ).name : defaultName
 
-  return new InstanceElement(
-    name,
-    type,
-    fixedValues,
-    [NETSUITE, RECORDS_PATH, type.elemID.name, pathNaclCase(name)],
-  )
+    return new InstanceElement(
+      name,
+      type,
+      record,
+      [NETSUITE, RECORDS_PATH, type.elemID.name, pathNaclCase(name)],
+    )
+  })
 }
 
 export const getDataElements = async (
@@ -152,8 +160,11 @@ export const getDataElements = async (
     return types
   }
 
-  const instances = await Promise.all((await client.getAllRecords(availableTypesToFetch))
-    .map(record => createInstance(record, typesMap, elemIdGetter)))
+  const instances = await createInstances(
+    await client.getAllRecords(availableTypesToFetch),
+    typesMap,
+    elemIdGetter,
+  )
 
   return [
     ...types,
@@ -161,7 +172,7 @@ export const getDataElements = async (
       const type = await instance.getType()
       return query.isObjectMatch({
         type: type.elemID.name,
-        instanceId: instance.value[TYPE_TO_IDENTIFIER[type.elemID.name]],
+        instanceId: instance.value[getTypeIdentifier(type)],
       })
     }).toArray(),
   ]

--- a/packages/netsuite-adapter/src/data_elements/multi_fields_identifiers.ts
+++ b/packages/netsuite-adapter/src/data_elements/multi_fields_identifiers.ts
@@ -13,38 +13,80 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, Field, ObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, Field, ObjectType, Values } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
 import { values } from '@salto-io/lowerdash'
 import _ from 'lodash'
+import { getDataInstanceId } from '../elements_source_index/elements_source_index'
+import { IDENTIFIER_FIELD, TYPE_TO_IDENTIFIER, TYPE_TO_ID_FIELD_PATHS } from './types'
 
-// This is used for constructing a unique identifier for data types
-// field using multiple other fields
-export const TYPE_TO_ID_FIELD_PATHS: Record<string, string[][]> = {
-  AccountingPeriod: [['periodName'], ['fiscalCalendar', 'name']],
-  Nexus: [['country'], ['state', 'name']],
-  Account: [['acctName'], ['acctNumber']],
-}
+const log = logger(module)
 
-export const IDENTIFIER_FIELD = 'identifier'
 
 export const addIdentifierToType = (type: ObjectType): void => {
-  if (!(type.elemID.name in TYPE_TO_ID_FIELD_PATHS)) {
+  if (!(type.elemID.name in TYPE_TO_ID_FIELD_PATHS) && type.fields.parent === undefined) {
     return
   }
 
   type.fields[IDENTIFIER_FIELD] = new Field(type, IDENTIFIER_FIELD, BuiltinTypes.SERVICE_ID)
 }
 
-export const addIdentifierToValues = (
-  record: Record<string, unknown>,
+const getIdentifierWithoutParent = (
+  record: Values,
   type: ObjectType
-): void => {
+): string => {
   if (!(type.elemID.name in TYPE_TO_ID_FIELD_PATHS)) {
-    return
+    return record[TYPE_TO_IDENTIFIER[type.elemID.name]]
   }
 
-  record.identifier = TYPE_TO_ID_FIELD_PATHS[type.elemID.name]
+  return TYPE_TO_ID_FIELD_PATHS[type.elemID.name]
     .map(fieldPath => _.get(record, fieldPath))
     .filter(values.isDefined)
     .join('_')
+}
+
+const getFullIdentifier = (
+  record: Values,
+  type: ObjectType,
+  internalIdToExternalId: Record<string, Values>
+): string => {
+  const currentInstanceId = getIdentifierWithoutParent(record, type)
+  if (record.parent === undefined) {
+    return currentInstanceId
+  }
+
+  const parent = internalIdToExternalId[
+    getDataInstanceId(record.parent.attributes.internalId, type)
+  ]
+  if (parent === undefined) {
+    log.warn(`Could not find parent with id ${record.parent.attributes.internalId} of instance with id ${record.attributes.internalId} of type ${type.elemID.getFullName()}`)
+    return `${record.parent.attributes.internalId}_${currentInstanceId}`
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return `${getFullIdentifier(parent, type, internalIdToExternalId)}_${currentInstanceId}`
+}
+
+export const addIdentifierToValues = (
+  valuesList: { type: ObjectType; record: Values }[],
+): void => {
+  const valuesListWithIdentifier = valuesList.filter(
+    ({ type }) => type.fields[IDENTIFIER_FIELD] !== undefined
+  )
+
+  const internalIdToExternalId = _(valuesListWithIdentifier)
+    .keyBy(({ type, record }) => getDataInstanceId(record.attributes.internalId, type))
+    .mapValues(({ record }) => record)
+    .value()
+
+
+  const identifiers = valuesListWithIdentifier.map(({ record, type }) =>
+    getFullIdentifier(record, type, internalIdToExternalId))
+
+  // We first get all the identifiers and then set it in valuesListWithIdentifier
+  // because `getFullIdentifier` uses record to generate the id and editing before
+  // generating all the records can cause duplication in the identifier parts
+  valuesListWithIdentifier.forEach(({ record }, i) => {
+    record[IDENTIFIER_FIELD] = identifiers[i]
+  })
 }

--- a/packages/netsuite-adapter/src/data_elements/types.ts
+++ b/packages/netsuite-adapter/src/data_elements/types.ts
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { ObjectType } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { IDENTIFIER_FIELD, TYPE_TO_ID_FIELD_PATHS } from './multi_fields_identifiers'
 
 export const ITEM_TYPE_ID = '-10'
 export const TRANSACTION_TYPE_ID = '-30'
@@ -223,6 +223,16 @@ export const ITEM_TYPE_TO_SEARCH_STRING: Record<string, string> = {
   DownloadItem: '_downloadItem',
 }
 
+// This is used for constructing a unique identifier for data types
+// field using multiple other fields
+export const TYPE_TO_ID_FIELD_PATHS: Record<string, string[][]> = {
+  AccountingPeriod: [['periodName'], ['fiscalCalendar', 'name']],
+  Nexus: [['country'], ['state', 'name']],
+  Account: [['acctName'], ['acctNumber']],
+}
+
+export const IDENTIFIER_FIELD = 'identifier'
+
 export const TYPE_TO_IDENTIFIER: Record<string, string> = {
   Subsidiary: 'name',
   Department: 'name',
@@ -238,5 +248,11 @@ export const TYPE_TO_IDENTIFIER: Record<string, string> = {
   ...Object.fromEntries(Object.keys(ITEM_TYPE_TO_SEARCH_STRING).map(type => [type, 'itemId'])),
   ...Object.fromEntries(Object.keys(TYPE_TO_ID_FIELD_PATHS).map(type => [type, IDENTIFIER_FIELD])),
 }
+
+export const getTypeIdentifier = (type: ObjectType): string => (
+  type.fields[IDENTIFIER_FIELD] !== undefined
+    ? IDENTIFIER_FIELD
+    : TYPE_TO_IDENTIFIER[type.elemID.name]
+)
 
 export const SUPPORTED_TYPES = Object.keys(TYPES_TO_INTERNAL_ID)


### PR DESCRIPTION
Apparently, types with `parent` can have the same identifier if their parent is different. 
Fixed the identifiers to use the parent in the identifier. 

---
_Release Notes_: 
None

---
_User Notifications_: 
None
