### PR TITLE
SALTO-825: fixed partial fetch for data instances

### DIFF
--- a/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
@@ -50,8 +50,8 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource):
   }
 
   const updateInternalIdsIndex = async (element: InstanceElement): Promise<void> => {
-    const { internalId } = element.value
-    if (internalId === undefined) {
+    const { internalId, isSubInstance } = element.value
+    if (internalId === undefined || isSubInstance) {
       return
     }
 

--- a/packages/netsuite-adapter/src/filters/roles_internal_id.ts
+++ b/packages/netsuite-adapter/src/filters/roles_internal_id.ts
@@ -62,16 +62,17 @@ const getRoleAdditionInstances = (changes: Change[]): InstanceElement[] =>
  */
 const filterCreator: FilterCreator = ({ client }) => ({
   onFetch: async elements => {
-    if (!client.isSuiteAppConfigured()
-    || !elements.some(isRoleInstance)) {
-      return
-    }
     role.fields.internalId = new Field(
       role,
       'internalId',
       BuiltinTypes.STRING,
       { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
     )
+
+    if (!client.isSuiteAppConfigured()
+    || !elements.some(isRoleInstance)) {
+      return
+    }
 
     const scriptIdToInternalId = await getRolesScriptIdsToInternalIds(client)
 

--- a/packages/netsuite-adapter/test/elements_source_index.test.ts
+++ b/packages/netsuite-adapter/test/elements_source_index.test.ts
@@ -63,7 +63,11 @@ describe('createElementsSourceIndex', () => {
         'name',
         type,
         { internalId: '4', [LAST_FETCH_TIME]: '2021-02-22T18:55:17.949Z' },
-        [],
+      ),
+      new InstanceElement(
+        'name2',
+        type,
+        { internalId: '5', [LAST_FETCH_TIME]: '2021-02-22T18:55:17.949Z', isSubInstance: true },
       ),
       type,
     ]).getAll)
@@ -73,7 +77,7 @@ describe('createElementsSourceIndex', () => {
 
     const elementsSourceIndex = createElementsSourceIndex(elementsSource)
     const index = (await elementsSourceIndex.getIndexes()).internalIdsIndex
-    expect(index['someType-4']).toEqual({ lastFetchTime: new Date('2021-02-22T18:55:17.949Z'), elemID: new ElemID(NETSUITE, 'someType', 'instance', 'name') })
+    expect(index).toEqual({ 'someType-4': { lastFetchTime: new Date('2021-02-22T18:55:17.949Z'), elemID: new ElemID(NETSUITE, 'someType', 'instance', 'name') } })
   })
 
   it('should create the right custom fields index', async () => {

--- a/packages/netsuite-adapter/test/filters/roles_internal_ids.test.ts
+++ b/packages/netsuite-adapter/test/filters/roles_internal_ids.test.ts
@@ -21,6 +21,9 @@ import { FilterOpts } from '../../src/filter'
 
 describe('roles_internal_ids', () => {
   describe('on fetch', () => {
+    beforeEach(() => {
+      delete role.fields.internalId
+    })
     it('should add the internal id to roles instances', async () => {
       const instance = new InstanceElement(
         'role',
@@ -35,6 +38,7 @@ describe('roles_internal_ids', () => {
 
       await filterCreator({ client } as FilterOpts).onFetch?.([instance])
       expect(instance.value.internalId).toBe('1')
+      expect(role.fields.internalId).toBeDefined()
     })
 
     it('should do nothing if suiteapp is not configured', async () => {
@@ -51,6 +55,7 @@ describe('roles_internal_ids', () => {
 
       await filterCreator({ client } as FilterOpts).onFetch?.([instance])
       expect(instance.value.internalId).toBeUndefined()
+      expect(role.fields.internalId).toBeDefined()
     })
 
     it('should do nothing if query failed', async () => {
@@ -67,6 +72,7 @@ describe('roles_internal_ids', () => {
 
       await filterCreator({ client } as FilterOpts).onFetch?.([instance])
       expect(instance.value.internalId).toBeUndefined()
+      expect(role.fields.internalId).toBeDefined()
     })
 
     it('should do nothing if got invalid results', async () => {
@@ -83,6 +89,7 @@ describe('roles_internal_ids', () => {
 
       await filterCreator({ client } as FilterOpts).onFetch?.([instance])
       expect(instance.value.internalId).toBeUndefined()
+      expect(role.fields.internalId).toBeDefined()
     })
   })
 


### PR DESCRIPTION
Fixed two issues with partial fetch for data instances:
- If the partial fetch would not include `role`s the role internal id field would be deleted
- internalIdsIndex includes sub-instances that caused wrong references in the `data_instances_references` filter

---
_Release Notes_: 
None

---
_User Notifications_: 
None