### PR TITLE
SALTO - 1500 package change validator is not working on modification change

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/package.ts
+++ b/packages/salesforce-adapter/src/change_validators/package.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, getChangeElement, InstanceElement, isAdditionChange, isModificationChange, isRemovalChange, ChangeError, ChangeValidator, ActionName, isInstanceChange, isFieldChange, isObjectType } from '@salto-io/adapter-api'
+import { Element, getChangeElement, InstanceElement, isModificationChange, isRemovalChange, ChangeError, ChangeValidator, ActionName, isInstanceChange, isFieldChange, isObjectType } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { apiName, isCustomObject, metadataType } from '../transformers/transformer'
@@ -66,7 +66,6 @@ const isInstalledPackageVersionChange = async (
 
 const changeValidator: ChangeValidator = async changes => {
   const addRemoveErrors = await awu(changes)
-    .filter(change => isAdditionChange(change) || isRemovalChange(change))
     .filter(async change => await isCustomObject(getChangeElement(change)) || isFieldChange(change))
     .filter(change => hasNamespace(getChangeElement(change)))
     .map(change => packageChangeError(change.action, getChangeElement(change)))

--- a/packages/salesforce-adapter/test/change_validators/package.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/package.test.ts
@@ -19,6 +19,8 @@ import packageValidator, {
   PACKAGE_VERSION_FIELD_NAME,
 } from '../../src/change_validators/package'
 import { API_NAME, CUSTOM_OBJECT, INSTANCE_FULL_NAME_FIELD, METADATA_TYPE } from '../../src/constants'
+import { Types } from '../../src/transformers/transformer'
+import { createField } from '../utils'
 
 describe('package change validator', () => {
   let obj: ObjectType
@@ -156,6 +158,19 @@ describe('package change validator', () => {
   })
 
   describe('onUpdate', () => {
+    describe('modify field', () => {
+      it('should have change error when modifing a field type', async () => {
+        const beforeField = createField(obj, Types.primitiveDataTypes.Lookup, 'Standard')
+        const afterField = beforeField.clone()
+        afterField.annotations.modifyMe = 'modified'
+        afterField.refType = 
+        const changeErrors = await packageValidator([toChange({ beforeField, afterField })])
+        expect(changeErrors).toHaveLength(1)
+        expect(changeErrors[0].severity).toEqual('Error')
+        expect(changeErrors[0].elemID).toEqual(beforeField.elemID)
+      })
+    })
+
     describe('add field', () => {
       it('should have change error when adding a field with namespace to an object', async () => {
         const newField = addField('ObjectName__c.MyNamespace__FieldName__c')


### PR DESCRIPTION
removed the filter of modification change from package change validator to resolved this bug. 

---

_Release Notes_: 
Salto will now return an error when when modifying a managed object.

---
_User Notifications_: 
none