### PR TITLE
SALTO-825: fixed validation errors for skipped instances

### DIFF
--- a/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
@@ -17,7 +17,7 @@ import { BuiltinTypes, ElemID, InstanceElement, isInstanceElement, isObjectType,
 import { applyFunctionToChangeData, naclCase, TransformFunc, transformValues } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { customTypes, isDataObjectType } from '../types'
+import { isCustomType, isDataObjectType, isFileCabinetType } from '../types'
 import { ACCOUNT_SPECIFIC_VALUE, NETSUITE, RECORDS_PATH } from '../constants'
 import { FilterWith } from '../filter'
 
@@ -56,7 +56,9 @@ const filterCreator = (): FilterWith<'onFetch' | 'preDeploy'> => ({
       if (path !== undefined
         && value.internalId !== undefined
         && isObjectType(fieldType)
-        && isInsideList) {
+        && (isInsideList
+          || isCustomType(fieldType.elemID)
+          || isFileCabinetType(fieldType.elemID))) {
         const instanceName = getSubInstanceName(path, value.internalId)
 
         if (!(instanceName in newInstancesMap)) {
@@ -65,7 +67,7 @@ const filterCreator = (): FilterWith<'onFetch' | 'preDeploy'> => ({
             // If the fieldType is an SDF type we replace it with RecordRef to avoid validation
             // errors because SDF types has fields with a "required" annotation which might not
             // be fulfilled
-            fieldType.elemID.name in customTypes
+            (isCustomType(fieldType.elemID) || isFileCabinetType(fieldType.elemID))
               && recordRefType !== undefined
               ? recordRefType : fieldType,
             { ...value, isSubInstance: true },

--- a/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
@@ -78,21 +78,21 @@ describe('data_instances_internal_id', () => {
       expect(elements.length).toBe(2)
     })
 
-    it('list item type should be record type if the original type is an SDF type', async () => {
+    it('type should be record type if the original type is an SDF type', async () => {
       const instance = new InstanceElement(
         'instance',
-        new ObjectType({ elemID: new ElemID(NETSUITE, 'type'), fields: { someList: { refType: new ListType(role) } }, annotations: { source: 'soap' } }),
-        { someList: [{ internalId: '1' }, { internalId: '1' }] }
+        new ObjectType({ elemID: new ElemID(NETSUITE, 'type'), fields: { someValue: { refType: role } }, annotations: { source: 'soap' } }),
+        { someValue: { internalId: '1' } }
       )
 
       const elements = [instance, recordRefType]
 
       await filterCreator().onFetch(elements)
       expect(elements.length).toBe(3)
-      expect(elements[2].elemID.name).toBe('type_someList_1')
+      expect(elements[2].elemID.name).toBe('type_someValue_1')
       expect(elements[2].elemID.typeName).toBe('RecordRef')
       expect((elements[2] as InstanceElement).value.isSubInstance).toBeTruthy()
-      expect((instance.value.someList[0] as ReferenceExpression).elemID.getFullName())
+      expect((instance.value.someValue as ReferenceExpression).elemID.getFullName())
         .toBe(elements[2].elemID.getFullName())
     })
   })


### PR DESCRIPTION
Data instances can have references to SDF instances that have required fields. If the instance is skipped, we can create a reference to the instance so we leave the value as is. The problem is that the value might not have the required fields. To solve this, we extract the value to sub-instance of type `RecordRef` 

---
_Release Notes_: 
None

---
_User Notifications_: 
None