### PR TITLE
SALTO-1502 Sort the attributes field in Settings_Role to make it stable across fetches

### DIFF
--- a/packages/zuora-billing-adapter/src/adapter.ts
+++ b/packages/zuora-billing-adapter/src/adapter.ts
@@ -28,6 +28,7 @@ import fieldReferencesFilter from './filters/field_references'
 import objectDefsFilter from './filters/object_defs'
 import objectDefSplitFilter from './filters/object_def_split'
 import workflowAndTaskReferencesFilter from './filters/workflow_and_task_references'
+import unorderedListsFilter from './filters/unordered_lists'
 import changeValidator from './change_validator'
 import { ZUORA_BILLING, LIST_ALL_SETTINGS_TYPE, SETTINGS_TYPE_PREFIX, CUSTOM_OBJECT_DEFINITION_TYPE } from './constants'
 import { generateBillingSettingsTypes } from './transformers/billing_settings'
@@ -41,6 +42,9 @@ const log = logger(module)
 export const DEFAULT_FILTERS = [
   // objectDefsFilter should run before everything else
   objectDefsFilter,
+
+  // unorderedLists should run before references are created
+  unorderedListsFilter,
 
   workflowAndTaskReferencesFilter,
 

--- a/packages/zuora-billing-adapter/src/filters/unordered_lists.ts
+++ b/packages/zuora-billing-adapter/src/filters/unordered_lists.ts
@@ -1,0 +1,43 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  Element, isInstanceElement,
+} from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { SETTINGS_TYPE_PREFIX } from '../constants'
+
+/**
+ * Sort lists whose order changes between fetches, to avoid unneeded noise.
+ */
+const filterCreator: FilterCreator = () => ({
+  onFetch: async (elements: Element[]): Promise<void> => {
+    const roleInstances = (elements
+      .filter(isInstanceElement)
+      .filter(e => e.refType.elemID.name === `${SETTINGS_TYPE_PREFIX}Role`))
+
+    roleInstances.forEach(role => {
+      if (Array.isArray(role.value.attributes)) {
+        role.value.attributes = _.sortBy(
+          role.value.attributes,
+          attr => [attr.scope, attr.name, attr.activationLevel],
+        )
+      }
+    })
+  },
+})
+
+export default filterCreator

--- a/packages/zuora-billing-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/unordered_lists.test.ts
@@ -1,0 +1,97 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ObjectType, ElemID, InstanceElement, Element, isInstanceElement,
+} from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import ZuoraClient from '../../src/client/client'
+import { ZUORA_BILLING, SETTINGS_TYPE_PREFIX } from '../../src/constants'
+import filterCreator from '../../src/filters/unordered_lists'
+
+describe('Unordered lists filter', () => {
+  let client: ZuoraClient
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  let filter: FilterType
+
+  const generateElements = (): Element[] => {
+    const settingsRoleType = new ObjectType({
+      elemID: new ElemID(ZUORA_BILLING, `${SETTINGS_TYPE_PREFIX}Role`),
+    })
+    const withAttrs = new InstanceElement(
+      'normal',
+      settingsRoleType,
+      {
+        attributes: [
+          { scope: 'a', name: 'b' },
+          { scope: 'c', name: 'a', activationLevel: 'l1' },
+          { name: 'a', activationLevel: 'l1' },
+        ],
+      },
+    )
+    const empty = new InstanceElement(
+      'empty',
+      settingsRoleType,
+      {},
+    )
+    return [settingsRoleType, withAttrs, empty]
+  }
+
+  let elements: Element[]
+
+  beforeAll(async () => {
+    client = new ZuoraClient({
+      credentials: { baseURL: 'http://localhost', clientId: 'id', clientSecret: 'secret' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFunc: clientUtils.getWithCursorPagination,
+      }),
+      config: {
+        fetch: {
+          includeTypes: [],
+        },
+        apiDefinitions: {
+          swagger: { url: 'ignore' },
+          typeDefaults: {
+            transformation: {
+              idFields: ['name'],
+            },
+          },
+          types: {},
+        },
+      },
+    }) as FilterType
+
+    elements = generateElements()
+    await filter.onFetch(elements)
+  })
+
+  it('sort correctly even if fields are missing', async () => {
+    const instances = elements.filter(isInstanceElement)
+    expect(instances[0].value.attributes).toEqual([
+      { name: 'a', activationLevel: 'l1' },
+      { scope: 'a', name: 'b' },
+      { scope: 'c', name: 'a', activationLevel: 'l1' },
+    ])
+  })
+
+  it('do nothing when attributes are not specified', async () => {
+    const instances = elements.filter(isInstanceElement)
+    expect(instances[1].value.attributes).toBeUndefined()
+  })
+})


### PR DESCRIPTION
The field is an unsorted list, and its order changes on every fetch. Sorting it to avoid unnecessary noise in the nacls.

---
_Release Notes_: 
Zuora Billing:
 * Sort the Settings_Role.attributes field to avoid noise due to order changes returned from the API.
