### PR TITLE
fixed parser to support names starting with booleans

### DIFF
--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -47,7 +47,6 @@ export const rules: Record<string, moo.Rules> = {
     [TOKEN_TYPES.MULTILINE_START]: { match: /'''[ \t]*[(\r\n)(\n)]/, lineBreaks: true, push: 'multilineString' },
     [TOKEN_TYPES.DOUBLE_QUOTES]: { match: '"', push: 'string' },
     [TOKEN_TYPES.NUMBER]: /-?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+-]?\d+)?/,
-    [TOKEN_TYPES.BOOLEAN]: new RegExp(`${TRUE}|${FALSE}`),
     [TOKEN_TYPES.LEFT_PAREN]: '(',
     [TOKEN_TYPES.RIGHT_PAREN]: ')',
     [TOKEN_TYPES.ARR_OPEN]: '[',

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -778,6 +778,17 @@ each([true, false]).describe('Salto parser', (useLegacyParser: boolean) => {
     const result = await parse(Buffer.from(body), 'none', functions)
     expect(result.errors).not.toHaveLength(0)
   })
+
+  if (!useLegacyParser) {
+    it('should parse instance name that starts with boolean', async () => {
+      const body = `
+    salesforce.someType false_string {}
+    `
+      const result = await parse(Buffer.from(body), 'none', functions)
+      expect(result.errors).toHaveLength(0)
+    })
+  }
+
   describe('tokenizeContent', () => {
     it('seperate and token each part of a line correctly', () => {
       expect(Array.from(tokenizeContent('aaa   bbb ccc.ddd   "eee fff  ggg.hhh"'))).toEqual([


### PR DESCRIPTION
Fixed a bug where the parser throws an error for instance names starting with a boolean value (e.g., `false_name`)

---
_Release Notes_:
Fixed incorrect syntax errors for instance names starting with boolean values

---
_User Notifications_: 
None