### PR TITLE
SALTO-1509 - Change result type of workspace update NaCls

### DIFF
--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -234,13 +234,13 @@ export const updateWorkspace = async ({
   mode = 'default',
 }: UpdateWorkspaceParams): Promise<{ success: boolean; numberOfAppliedChanges: number }> => {
   let numberOfAppliedChanges = 0
-
   if (changes.length > 0) {
     await logWorkspaceUpdates(workspace, changes)
-    numberOfAppliedChanges = await workspace.updateNaclFiles(
+    const { naclFilesChangesCount, stateOnlyChangesCount } = await workspace.updateNaclFiles(
       changes.map(c => c.change),
       mode,
     )
+    numberOfAppliedChanges = naclFilesChangesCount + stateOnlyChangesCount
     const { status, errors } = await validateWorkspace(workspace)
     const formattedErrors = await formatWorkspaceErrors(workspace, errors)
     await printWorkspaceErrors(status, formattedErrors, output)

--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -236,11 +236,12 @@ export const updateWorkspace = async ({
   let numberOfAppliedChanges = 0
   if (changes.length > 0) {
     await logWorkspaceUpdates(workspace, changes)
-    const { naclFilesChangesCount, stateOnlyChangesCount } = await workspace.updateNaclFiles(
+    const updateNaclFilesResult = await workspace.updateNaclFiles(
       changes.map(c => c.change),
       mode,
     )
-    numberOfAppliedChanges = naclFilesChangesCount + stateOnlyChangesCount
+    numberOfAppliedChanges = updateNaclFilesResult.naclFilesChangesCount
+      + updateNaclFilesResult.stateOnlyChangesCount
     const { status, errors } = await validateWorkspace(workspace)
     const formattedErrors = await formatWorkspaceErrors(workspace, errors)
     await printWorkspaceErrors(status, formattedErrors, output)

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -183,7 +183,7 @@ describe('deploy command', () => {
         workspace.errors.mockResolvedValueOnce(
           mocks.mockErrors([{ severity: 'Error', message: '' }])
         )
-        return 0
+        return { naclFilesChangesCount: 0, stateOnlyChangesCount: 0 }
       })
       mockGetUserBooleanInput.mockReturnValue(true)
     })

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -486,7 +486,7 @@ describe('fetch command', () => {
                 workspace.errors.mockResolvedValue(
                   mocks.mockErrors([{ severity: 'Error', message: 'BLA Error' }])
                 )
-                return 0
+                return { naclFilesChangesCount: 0, stateOnlyChangesCount: 0 }
               })
 
               const res = await fetchCommand({
@@ -516,7 +516,7 @@ describe('fetch command', () => {
                 workspace.errors.mockResolvedValue(
                   mocks.mockErrors([{ severity: 'Warning', message: 'BLA Error' }])
                 )
-                return 0
+                return { naclFilesChangesCount: 0, stateOnlyChangesCount: 0 }
               })
 
               const res = await fetchCommand({

--- a/packages/cli/test/commands/restore.test.ts
+++ b/packages/cli/test/commands/restore.test.ts
@@ -87,7 +87,10 @@ describe('restore command', () => {
     let workspace: Workspace
     beforeEach(async () => {
       workspace = mocks.mockWorkspace({})
-      jest.spyOn(workspace, 'updateNaclFiles').mockResolvedValue(2)
+      jest.spyOn(workspace, 'updateNaclFiles').mockResolvedValue({
+        naclFilesChangesCount: 2,
+        stateOnlyChangesCount: 0,
+      })
 
       result = await action({
         ...cliCommandArgs,
@@ -204,7 +207,7 @@ describe('restore command', () => {
       workspace.errors.mockResolvedValue(
         mocks.mockErrors([{ severity: 'Error', message: 'some error ' }])
       )
-      return 0
+      return { naclFilesChangesCount: 0, stateOnlyChangesCount: 0 }
     })
     const result = await action({
       ...cliCommandArgs,

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -331,7 +331,10 @@ export const mockWorkspace = ({
     transformError: mockFunction<Workspace['transformError']>().mockImplementation(
       async error => ({ ...error, sourceFragments: [] })
     ),
-    updateNaclFiles: mockFunction<Workspace['updateNaclFiles']>(),
+    updateNaclFiles: mockFunction<Workspace['updateNaclFiles']>().mockResolvedValue({
+      naclFilesChangesCount: 0,
+      stateOnlyChangesCount: 0,
+    }),
     listNaclFiles: mockFunction<Workspace['listNaclFiles']>().mockResolvedValue([]),
     getTotalSize: mockFunction<Workspace['getTotalSize']>().mockResolvedValue(0),
     getNaclFile: mockFunction<Workspace['getNaclFile']>(),

--- a/packages/cli/test/workspace/workspace.test.ts
+++ b/packages/cli/test/workspace/workspace.test.ts
@@ -28,7 +28,10 @@ const mockWsFunctions = {
   envs: mockFunction<Workspace['envs']>().mockReturnValue(['default']),
   currentEnv: mockFunction<Workspace['currentEnv']>().mockReturnValue('default'),
   errors: mockFunction<Workspace['errors']>().mockResolvedValue(mockErrors([])),
-  updateNaclFiles: mockFunction<Workspace['updateNaclFiles']>(),
+  updateNaclFiles: mockFunction<Workspace['updateNaclFiles']>().mockResolvedValue({
+    naclFilesChangesCount: 0,
+    stateOnlyChangesCount: 0,
+  }),
   isEmpty: mockFunction<Workspace['isEmpty']>().mockResolvedValue(false),
   flush: mockFunction<Workspace['flush']>(),
   transformError: mockFunction<Workspace['transformError']>().mockImplementation(

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -83,6 +83,11 @@ export type UnresolvedElemIDs = {
   missing: ElemID[]
 }
 
+export type UpdateNaclFilesResult = {
+  naclFilesChangesCount: number
+  stateOnlyChangesCount: number
+}
+
 export type Workspace = {
   uid: string
   name: string
@@ -111,7 +116,7 @@ export type Workspace = {
     changes: DetailedChange[],
     mode?: RoutingMode,
     stateOnly? : boolean
-  ) => Promise<number>
+  ) => Promise<UpdateNaclFilesResult>
   listNaclFiles: () => Promise<string[]>
   getTotalSize: () => Promise<number>
   getNaclFile: (filename: string) => Promise<NaclFile | undefined>
@@ -513,7 +518,7 @@ export const loadWorkspace = async (
       mode?: RoutingMode
       validate?: boolean
       stateOnly?: boolean
-    }) : Promise<number> => {
+    }) : Promise<UpdateNaclFilesResult> => {
     const { visible: visibleChanges, hidden: hiddenChanges } = await handleHiddenChanges(
       changes,
       state(),
@@ -538,8 +543,12 @@ export const loadWorkspace = async (
         postChangeHash,
       } },
       validate })
-    return (Object.values(workspaceChanges).map(changeSet => changeSet.changes)
-      .flat().length + stateOnlyChanges.length)
+    return {
+      naclFilesChangesCount: Object.values(workspaceChanges)
+        .map(changeSet => changeSet.changes)
+        .flat().length,
+      stateOnlyChangesCount: stateOnlyChanges.length,
+    }
   }
   const setNaclFiles = async (naclFiles: NaclFile[], validate = true): Promise<EnvsChanges> => {
     const elementChanges = await (await getLoadedNaclFilesSource()).setNaclFiles(...naclFiles)


### PR DESCRIPTION
Change result of workspace `updateNaclFiles` to a type including:

- Number of NaCl updates
- Number of state only updates

Instead of a number represents the sum of all changes

---

This is required in order to determine if changes were applied in SAAS.
Specifically, it is required in scenarios like Fetch Align,
in order to determine if a user approval is required.

---

_Release Notes_: N/A

---

_User Notifications_: N/A
