### PR TITLE
SALTO-1149 move logic for extracting standalone fields to shared ducktype code

### DIFF
--- a/packages/adapter-components/src/elements/ducktype/index.ts
+++ b/packages/adapter-components/src/elements/ducktype/index.ts
@@ -14,5 +14,6 @@
 * limitations under the License.
 */
 export { toInstance } from './instance_elements'
+export { extractStandaloneFields } from './standalone_field_extractor'
 export { getAllElements, getTypeAndInstances } from './transformer'
 export { generateType, toNestedTypeName } from './type_elements'

--- a/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
+++ b/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
@@ -16,21 +16,18 @@
 import _ from 'lodash'
 import { InstanceElement, isObjectType, isInstanceElement, ReferenceExpression, ObjectType, Element } from '@salto-io/adapter-api'
 import { createRefToElmWithValue } from '@salto-io/adapter-utils'
-import { config as configUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { values as lowerdashValues, collections } from '@salto-io/lowerdash'
+import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
-import { WORKATO } from '../constants'
-import { FilterCreator } from '../filter'
-import { API_DEFINITIONS_CONFIG } from '../config'
+import { StandaloneFieldConfigType, TransformationConfig, TransformationDefaultConfig } from '../../config'
+import { generateType, toNestedTypeName } from './type_elements'
+import { toInstance } from './instance_elements'
 
 const log = logger(module)
-const { isDefined } = lowerdashValues
 const { awu } = collections.asynciterable
-const { generateType, toInstance, toNestedTypeName } = elementUtils.ducktype
 
 const convertStringToObject = (
   inst: InstanceElement,
-  standaloneFields: configUtils.StandaloneFieldConfigType[],
+  standaloneFields: StandaloneFieldConfigType[],
 ): void => {
   const fieldsByPath = _.keyBy(standaloneFields, ({ fieldName }) => fieldName)
   inst.value = _.mapValues(inst.value, (fieldValue, fieldName) => {
@@ -57,6 +54,7 @@ const convertStringToObject = (
 }
 
 const addFieldTypeAndInstances = async ({
+  adapterName,
   typeName,
   fieldName,
   type,
@@ -64,12 +62,13 @@ const addFieldTypeAndInstances = async ({
   transformationConfigByType,
   transformationDefaultConfig,
 }: {
+  adapterName: string
   typeName: string
   fieldName: string
   type: ObjectType
   instances: InstanceElement[]
-  transformationConfigByType: Record<string, configUtils.TransformationConfig>
-  transformationDefaultConfig: configUtils.TransformationDefaultConfig
+  transformationConfigByType: Record<string, TransformationConfig>
+  transformationDefaultConfig: TransformationDefaultConfig
 }): Promise<Element[]> => {
   if (type.fields[fieldName] === undefined) {
     log.info('type %s field %s does not exist (maybe it is not populated by any of the instances), not extracting field', type.elemID.name, fieldName)
@@ -83,7 +82,7 @@ const addFieldTypeAndInstances = async ({
 
   const elements: Element[] = []
   const fieldType = generateType({
-    adapterName: WORKATO,
+    adapterName,
     name: toNestedTypeName(typeName, fieldName),
     entries: instancesWithValues.map(inst => inst.value[fieldName]),
     hasDynamicFields: false,
@@ -115,22 +114,28 @@ const addFieldTypeAndInstances = async ({
   return elements
 }
 
-const extractFields = async ({
+/**
+ * Extract fields marked as standalone into their own instances, and convert the original
+ * value into a reference to the new instances.
+ *
+ * Note: modifies the elements array in-place.
+ */
+export const extractStandaloneFields = async ({
   elements,
   transformationConfigByType,
   transformationDefaultConfig,
+  adapterName,
 }: {
   elements: Element[]
-  transformationConfigByType: Record<string, configUtils.TransformationConfig>
-  transformationDefaultConfig: configUtils.TransformationDefaultConfig
-}): Promise<Element[]> => {
+  transformationConfigByType: Record<string, TransformationConfig>
+  transformationDefaultConfig: TransformationDefaultConfig
+  adapterName: string
+}): Promise<void> => {
   const allTypes = _.keyBy(elements.filter(isObjectType), e => e.elemID.name)
   const allInstancesbyType = _.groupBy(
     elements.filter(isInstanceElement),
     e => e.refType.elemID.getFullName()
   )
-
-  const newElements: Element[] = []
 
   const typesWithStandaloneFields = _.pickBy(
     _.mapValues(
@@ -138,7 +143,7 @@ const extractFields = async ({
       typeDef => typeDef.standaloneFields,
     ),
     standaloneFields => !_.isEmpty(standaloneFields),
-  ) as Record<string, configUtils.StandaloneFieldConfigType[]>
+  ) as Record<string, StandaloneFieldConfigType[]>
 
   await awu(Object.entries(typesWithStandaloneFields))
     .forEach(async ([typeName, standaloneFields]) => {
@@ -155,7 +160,8 @@ const extractFields = async ({
       // now extract the field data to its own type and instances, and replace the original
       // value with a reference to the newly-generate instance
       await awu(standaloneFields).forEach(async fieldDef => {
-        newElements.push(...await addFieldTypeAndInstances({
+        elements.push(...await addFieldTypeAndInstances({
+          adapterName,
           typeName,
           fieldName: fieldDef.fieldName,
           type,
@@ -165,29 +171,4 @@ const extractFields = async ({
         }))
       })
     })
-  return newElements
 }
-
-/**
- * Extract fields to their own types based on the configuration.
- * For each of these fields, extract the values into separate instances and convert the values
- * into reference expressions.
- */
-const filter: FilterCreator = ({ config }) => ({
-  onFetch: async elements => {
-    const transformationConfigByType = _.pickBy(
-      _.mapValues(config[API_DEFINITIONS_CONFIG].types, def => def.transformation),
-      isDefined,
-    )
-    const transformationDefaultConfig = config[API_DEFINITIONS_CONFIG].typeDefaults.transformation
-
-    const allNewElements = await extractFields({
-      elements,
-      transformationConfigByType,
-      transformationDefaultConfig,
-    })
-    elements.push(...allNewElements)
-  },
-})
-
-export default filter

--- a/packages/adapter-components/src/elements/index.ts
+++ b/packages/adapter-components/src/elements/index.ts
@@ -19,7 +19,7 @@ import * as soap from './soap'
 import * as subtypes from './subtypes'
 import { computeGetArgs, simpleGetArgs } from './request_parameters'
 import { RECORDS_PATH, TYPES_PATH, SUBTYPES_PATH } from './constants'
-import { returnFullEntry, FindNestedFieldFunc } from './field_finder'
+import { findDataField, returnFullEntry, FindNestedFieldFunc } from './field_finder'
 import { filterTypes } from './type_elements'
 
 export {
@@ -28,7 +28,7 @@ export {
   soap,
   subtypes,
   computeGetArgs, simpleGetArgs,
-  returnFullEntry, FindNestedFieldFunc,
+  findDataField, returnFullEntry, FindNestedFieldFunc,
   RECORDS_PATH, TYPES_PATH, SUBTYPES_PATH,
   filterTypes,
 }

--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -23,7 +23,6 @@ import { logger } from '@salto-io/logging'
 import WorkatoClient from './client/client'
 import { FilterCreator, Filter, filtersRunner } from './filter'
 import { WorkatoConfig } from './config'
-import extractFieldsFilter from './filters/extract_fields'
 import fieldReferencesFilter from './filters/field_references'
 import recipeCrossServiceReferencesFilter from './filters/cross_service/recipe_references'
 import { WORKATO } from './constants'
@@ -36,7 +35,6 @@ const { returnFullEntry, simpleGetArgs } = elementUtils
 const { getAllElements } = elementUtils.ducktype
 
 export const DEFAULT_FILTERS = [
-  extractFieldsFilter,
   fieldReferencesFilter,
   recipeCrossServiceReferencesFilter,
 ]


### PR DESCRIPTION
In preparation for the Zendesk adapter which will also use standalone fields, moving the logic from a workato-specific filter to the shared `ducktype` code (the `swagger` variant is already in `adapter-components`).

Note that there are some other improvements we can make in that logic - focused on just making it reusable for now to avoid code duplications.

---
_Release Notes_: 
None
