### PR TITLE
Added service url to dummy adapter element

### DIFF
--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -117,6 +117,7 @@ const defaultObj = new ObjectType({
   fields: {
     legit: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
   },
+  annotations: { [CORE_ANNOTATIONS.SERVICE_URL]: 'https://www.salto.io/' },
   path: [DUMMY_ADAPTER, 'Default', 'Default'],
 })
 


### PR DESCRIPTION
Added service URL for dummy adapter element.
This is done for writing an e2e in the SaaS to test the "show in service" functionality

---
_Release Notes_: 
None

---
_User Notifications_: 
None
