### PR TITLE
changed restore to only compare visible parts (SAAS-2639)

### DIFF
--- a/packages/core/src/core/diff.ts
+++ b/packages/core/src/core/diff.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { Element, DetailedChange, ElemID, ReadOnlyElementsSource, isAdditionChange, isRemovalChange, Change } from '@salto-io/adapter-api'
-import { ElementSelector, selectElementIdsByTraversal, elementSource } from '@salto-io/workspace'
+import { ElementSelector, selectElementIdsByTraversal } from '@salto-io/workspace'
 import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
 import wu from 'wu'
 import { collections } from '@salto-io/lowerdash'
@@ -58,8 +58,8 @@ const filterElementByRelevance = async (
 
 const filterPlanItemsByRelevance = async (
   plan: Plan,
-  toElementsSrc: elementSource.ElementsSource,
-  fromElementsSrc: elementSource.ElementsSource,
+  toElementsSrc: ReadOnlyElementsSource,
+  fromElementsSrc: ReadOnlyElementsSource,
   toElementIdsFiltered: ElemID[],
   fromElementIdsFiltered: ElemID[],
 ): Promise<DetailedChange[]> => {
@@ -100,14 +100,14 @@ const filterPlanItemsByRelevance = async (
 
 const getFilteredIds = async (
   elementSelectors: ElementSelector[],
-  src: elementSource.ElementsSource
+  src: ReadOnlyElementsSource
 ): Promise<ElemID[]> => (
   awu(await selectElementIdsByTraversal(elementSelectors, src, true)).toArray()
 )
 
 export const createDiffChanges = async (
-  toElementsSrc: elementSource.ElementsSource,
-  fromElementsSrc: elementSource.ElementsSource,
+  toElementsSrc: ReadOnlyElementsSource,
+  fromElementsSrc: ReadOnlyElementsSource,
   elementSelectors: ElementSelector[] = [],
   topLevelFilters: IDFilter[] = []
 ): Promise<DetailedChange[]> => {

--- a/packages/core/src/core/restore.ts
+++ b/packages/core/src/core/restore.ts
@@ -14,10 +14,10 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ElemID, DetailedChange } from '@salto-io/adapter-api'
+import { ElemID, DetailedChange, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { filterByID, applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { pathIndex, ElementSelector, elementSource, remoteMap } from '@salto-io/workspace'
+import { pathIndex, ElementSelector, remoteMap } from '@salto-io/workspace'
 import { createDiffChanges } from './diff'
 
 const { awu } = collections.asynciterable
@@ -47,8 +47,8 @@ const splitChangeByPath = async (
 }
 
 export const createRestoreChanges = async (
-  workspaceElements: elementSource.ElementsSource,
-  state: elementSource.ElementsSource,
+  workspaceElements: ReadOnlyElementsSource,
+  state: ReadOnlyElementsSource,
   index: remoteMap.RemoteMap<pathIndex.Path[]>,
   elementSelectors: ElementSelector[] = [],
   services?: readonly string[]

--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -14,10 +14,9 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ElemID, ElemIDTypes, Value, ElemIDType } from '@salto-io/adapter-api'
+import { ElemID, ElemIDTypes, Value, ElemIDType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { TransformFunc, transformElement } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { ElementsSource } from './elements_source'
 
 const { asynciterable } = collections
 const { awu } = asynciterable
@@ -193,7 +192,7 @@ const isElementPossiblyParentOfSearchedElement = (
 
 export const selectElementIdsByTraversal = async (
   selectors: ElementSelector[],
-  source: ElementsSource,
+  source: ReadOnlyElementsSource,
   compact = false,
 ): Promise<AsyncIterable<ElemID>> => {
   if (selectors.length === 0) {

--- a/packages/workspace/src/workspace/elements_source.ts
+++ b/packages/workspace/src/workspace/elements_source.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { Element, ElemID, Value, BuiltinTypesByFullName, ListType, MapType, isContainerType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
-import { collections } from '@salto-io/lowerdash'
+import { collections, values } from '@salto-io/lowerdash'
 import { resolvePath } from '@salto-io/adapter-utils'
 import { RemoteMap, InMemoryRemoteMap } from './remote_map'
 import { Keywords } from '../parser/language'
@@ -160,13 +160,14 @@ export const createInMemoryElementSource = (
 
 export const mapReadOnlyElementsSource = (
   source: ReadOnlyElementsSource,
-  func: (orig: Element) => Promise<Element>
+  func: (orig: Element) => Promise<Element | undefined>
 ): ReadOnlyElementsSource => ({
   get: async id => {
     const origValue = await source.get(id)
     return origValue !== undefined ? func(origValue) : undefined
   },
-  getAll: async () => awu(await source.getAll()).map(async element => func(element)),
+  getAll: async () => awu(await source.getAll()).map(async element => func(element))
+    .filter(values.isDefined),
   has: id => source.has(id),
   list: () => source.list(),
 })


### PR DESCRIPTION
_Changed restore to only compare visible parts_

---
When an element which contains a hidden value is fetched in state only mode, its hidden part will be returned from workspace.elements. As a result, restore create nested changes for an element which is not in the nacls. When this type of changes is applied to the workspace, parsing errors are created. The solution is to modify restore to only compare the visible part of the state, with the visible parts of the workspace.

---
_Release Notes_: 
_Fixed restoring an element with hidden values creates invalid nacl files._

---
_User Notifications_: 
_NA_
