### PR TITLE
SALTO-1149 adapter-components - support renaming types in ducktype adapters

### DIFF
--- a/packages/adapter-components/src/config/ducktype.ts
+++ b/packages/adapter-components/src/config/ducktype.ts
@@ -49,7 +49,7 @@ export const createDucktypeAdapterApiConfigType = ({
   const requestTypes = createRequestConfigs(adapter, additionalRequestFields)
   const transformationTypes = createTransformationConfigTypes(adapter, {
     hasDynamicFields: { refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN) },
-    sourceTypeName: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
+    sourceTypeName: { refType: BuiltinTypes.STRING },
     ...additionalTransformationFields,
   })
   return createAdapterApiConfigType({

--- a/packages/adapter-components/src/config/ducktype.ts
+++ b/packages/adapter-components/src/config/ducktype.ts
@@ -22,7 +22,7 @@ import { createRequestConfigs } from './request'
 type DuckTypeTransformationExtra = {
   // types that contain a single object with dynamic keys (map type)
   hasDynamicFields?: boolean
-  typeNameOverrideFrom?: string
+  sourceTypeName?: string
 }
 export type DuckTypeTransformationConfig = TransformationConfig & DuckTypeTransformationExtra
 export type DuckTypeTransformationDefaultConfig = (
@@ -49,7 +49,7 @@ export const createDucktypeAdapterApiConfigType = ({
   const requestTypes = createRequestConfigs(adapter, additionalRequestFields)
   const transformationTypes = createTransformationConfigTypes(adapter, {
     hasDynamicFields: { refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN) },
-    typeNameOverrideFrom: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
+    sourceTypeName: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
     ...additionalTransformationFields,
   })
   return createAdapterApiConfigType({

--- a/packages/adapter-components/src/config/ducktype.ts
+++ b/packages/adapter-components/src/config/ducktype.ts
@@ -22,6 +22,7 @@ import { createRequestConfigs } from './request'
 type DuckTypeTransformationExtra = {
   // types that contain a single object with dynamic keys (map type)
   hasDynamicFields?: boolean
+  typeNameOverrideFrom?: string
 }
 export type DuckTypeTransformationConfig = TransformationConfig & DuckTypeTransformationExtra
 export type DuckTypeTransformationDefaultConfig = (
@@ -48,6 +49,7 @@ export const createDucktypeAdapterApiConfigType = ({
   const requestTypes = createRequestConfigs(adapter, additionalRequestFields)
   const transformationTypes = createTransformationConfigTypes(adapter, {
     hasDynamicFields: { refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN) },
+    typeNameOverrideFrom: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
     ...additionalTransformationFields,
   })
   return createAdapterApiConfigType({

--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateFetchConfig as validateDuckTypeFetchConfig } from './ducktype'
+export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateFetchConfig as validateDuckTypeFetchConfig } from './ducktype'
 export { createRequestConfigs, validateRequestConfig, RequestConfig, RecurseIntoCondition, isRecurseIntoConditionByField } from './request'
 export { createAdapterApiConfigType, createUserFetchConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig } from './shared'
 export { createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig, validateFetchConfig as validateSwaggerFetchConfig } from './swagger'

--- a/packages/adapter-components/src/elements/ducktype/type_elements.ts
+++ b/packages/adapter-components/src/elements/ducktype/type_elements.ts
@@ -130,8 +130,8 @@ const generateTypeRenameConfig = (
 ): Record<string, string> => (
   Object.fromEntries(
     Object.entries(transformationConfigByType)
-      .map(([origTypeName, { typeNameOverrideFrom }]) => ([typeNameOverrideFrom, origTypeName]))
-      .filter(([typeNameOverrideFrom]) => typeNameOverrideFrom !== undefined)
+      .map(([origTypeName, { sourceTypeName }]) => ([sourceTypeName, origTypeName]))
+      .filter(([sourceTypeName]) => sourceTypeName !== undefined)
   )
 )
 

--- a/packages/adapter-components/src/elements/ducktype/type_elements.ts
+++ b/packages/adapter-components/src/elements/ducktype/type_elements.ts
@@ -19,7 +19,7 @@ import {
   FieldDefinition,
 } from '@salto-io/adapter-api'
 import { pathNaclCase, naclCase, createRefToElmWithValue } from '@salto-io/adapter-utils'
-import { TransformationConfig, TransformationDefaultConfig, getConfigWithDefault } from '../../config'
+import { DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, getConfigWithDefault } from '../../config'
 import { TYPES_PATH, SUBTYPES_PATH } from '../constants'
 import { hideFields } from '../type_elements'
 
@@ -47,13 +47,15 @@ const generateNestedType = ({
   transformationConfigByType,
   transformationDefaultConfig,
   hasDynamicFields,
+  typeNameOverrideConfig,
 }: {
   adapterName: string
   typeName: string
   parentName: string
   entries: Values[]
-  transformationConfigByType: Record<string, TransformationConfig>
-  transformationDefaultConfig: TransformationDefaultConfig
+  transformationConfigByType: Record<string, DuckTypeTransformationConfig>
+  transformationDefaultConfig: DuckTypeTransformationDefaultConfig
+  typeNameOverrideConfig: Record<string, string>
   hasDynamicFields: boolean
 }): NestedTypeWithNestedTypes => {
   const validEntries = entries.filter(entry => entry !== undefined && entry !== null)
@@ -69,6 +71,7 @@ const generateNestedType = ({
         hasDynamicFields,
         transformationConfigByType,
         transformationDefaultConfig,
+        typeNameOverrideConfig,
       })
       return {
         type: new ListType(nestedType.type),
@@ -88,6 +91,7 @@ const generateNestedType = ({
         transformationConfigByType,
         transformationDefaultConfig,
         isSubType: true,
+        typeNameOverrideConfig,
       })
     }
 
@@ -119,6 +123,19 @@ const generateNestedType = ({
 }
 
 /**
+ * Helper utility for generating the types to rename based on the ducktype transformation config
+ */
+const generateTypeRenameConfig = (
+  transformationConfigByType: Record<string, DuckTypeTransformationConfig>
+): Record<string, string> => (
+  Object.fromEntries(
+    Object.entries(transformationConfigByType)
+      .map(([origTypeName, { typeNameOverrideFrom }]) => ([typeNameOverrideFrom, origTypeName]))
+      .filter(([typeNameOverrideFrom]) => typeNameOverrideFrom !== undefined)
+  )
+)
+
+/**
  * Generate a synthetic type based on the list of all entries found for this type:
  * The type's fields are a superset of the fields that are found in at least one entry.
  *
@@ -138,17 +155,23 @@ export const generateType = ({
   hasDynamicFields,
   transformationConfigByType,
   transformationDefaultConfig,
+  typeNameOverrideConfig,
   isSubType = false,
 }: {
   adapterName: string
   name: string
   entries: Values[]
   hasDynamicFields: boolean
-  transformationConfigByType: Record<string, TransformationConfig>
-  transformationDefaultConfig: TransformationDefaultConfig
+  transformationConfigByType: Record<string, DuckTypeTransformationConfig>
+  transformationDefaultConfig: DuckTypeTransformationDefaultConfig
+  typeNameOverrideConfig?: Record<string, string>
   isSubType?: boolean
 }): ObjectTypeWithNestedTypes => {
-  const naclName = naclCase(name)
+  const typeRenameConfig = typeNameOverrideConfig ?? generateTypeRenameConfig(
+    transformationConfigByType
+  )
+  const typeName = typeRenameConfig[name] ?? name
+  const naclName = naclCase(typeName)
   const path = [
     adapterName, TYPES_PATH,
     ...(isSubType
@@ -172,11 +195,12 @@ export const generateType = ({
         refType: createRefToElmWithValue(new MapType(addNestedType(generateNestedType({
           adapterName,
           typeName: 'value',
-          parentName: name,
+          parentName: typeName,
           entries: entries.flatMap(Object.values).filter(entry => entry !== undefined),
           transformationConfigByType,
           transformationDefaultConfig,
           hasDynamicFields: false,
+          typeNameOverrideConfig: typeRenameConfig,
         })))),
       },
     }
@@ -188,11 +212,12 @@ export const generateType = ({
             refType: createRefToElmWithValue(addNestedType(generateNestedType({
               adapterName,
               typeName: fieldName,
-              parentName: name,
+              parentName: typeName,
               entries: entries.map(entry => entry[fieldName]).filter(entry => entry !== undefined),
               transformationConfigByType,
               transformationDefaultConfig,
               hasDynamicFields: false,
+              typeNameOverrideConfig: typeRenameConfig,
             }))),
           },
         ])
@@ -205,7 +230,7 @@ export const generateType = ({
   )
 
   if (Array.isArray(fieldsToHide)) {
-    hideFields(fieldsToHide, fields, name)
+    hideFields(fieldsToHide, fields, typeName)
   }
 
   const type = new ObjectType({

--- a/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
@@ -142,6 +142,116 @@ describe('ducktype_type_elements', () => {
         },
       }))).toBeTruthy()
     })
+    it('should generate types with correct names when typeNameOverrideFrom is used', () => {
+      const entries = [
+        {
+          id: 41619,
+          api_collection_id: 11815,
+          flow_id: 1381119,
+          flow_ids: [1381119, 1382229],
+          name: 'ab321',
+          method: 'GET',
+          url: 'https://some.url.com/a/bbb/user/{id}',
+          legacy_url: null,
+          base_path: '/a/bbb/user/{id}',
+          path: 'user/{id}',
+          active: false,
+          legacy: false,
+          created_at: '2020-12-21T16:08:03.762-08:00',
+          updated_at: '2020-12-21T16:08:03.762-08:00',
+        },
+        {
+          id: 54775,
+          api_collection_id: 22,
+          flow_id: 890,
+          flow_ids: [890, 980],
+          name: 'some other name',
+          field_with_complex_type: {
+            number: 53,
+            nested_type: {
+              val: 'agds',
+              another_val: 'dgadgasg',
+            },
+          },
+          field_with_complex_list_type: [{
+            number: 53,
+          }],
+        },
+        {
+          field_with_complex_type: {
+            number: 222,
+            nested_type: {
+              val: 'agds',
+              another_val: 7,
+              abc: 'abc',
+              unknown: null,
+            },
+          },
+        },
+      ]
+      const { type, nestedTypes } = generateType({
+        adapterName: ADAPTER_NAME,
+        name: 'typeName',
+        entries,
+        hasDynamicFields: false,
+        isSubType: false,
+        transformationConfigByType: {
+          renamedComplex: {
+            typeNameOverrideFrom: 'renamedTypeName__field_with_complex_type',
+          },
+          renamedTypeName: {
+            typeNameOverrideFrom: 'typeName',
+          },
+        },
+        transformationDefaultConfig: { idFields: [] },
+      })
+      expect(type.isEqual(new ObjectType({
+        elemID: new ElemID(ADAPTER_NAME, 'renamedTypeName'),
+        fields: {
+          id: { refType: createRefToElmWithValue(BuiltinTypes.NUMBER) },
+          api_collection_id: { refType: createRefToElmWithValue(BuiltinTypes.NUMBER) },
+          flow_id: { refType: createRefToElmWithValue(BuiltinTypes.NUMBER) },
+          flow_ids: { refType: createRefToElmWithValue(new ListType(BuiltinTypes.NUMBER)) },
+          name: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
+          method: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
+          url: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
+          legacy_url: { refType: createRefToElmWithValue(BuiltinTypes.UNKNOWN) },
+          base_path: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
+          path: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
+          active: { refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN) },
+          legacy: { refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN) },
+          created_at: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
+          updated_at: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
+          field_with_complex_type: { refType: createRefToElmWithValue(nestedTypes[0]) },
+          field_with_complex_list_type: {
+            refType: createRefToElmWithValue(new ListType(nestedTypes[2])),
+          },
+        },
+      }))).toBeTruthy()
+      expect(nestedTypes).toHaveLength(3)
+      expect(nestedTypes[0].isEqual(new ObjectType({
+        elemID: new ElemID(ADAPTER_NAME, 'renamedComplex'),
+        fields: {
+          number: { refType: createRefToElmWithValue(BuiltinTypes.NUMBER) },
+          nested_type: { refType: createRefToElmWithValue(nestedTypes[1]) },
+        },
+      }))).toBeTruthy()
+      expect(nestedTypes[1].isEqual(new ObjectType({
+        elemID: new ElemID(ADAPTER_NAME, 'renamedComplex__nested_type'),
+        fields: {
+          val: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
+          another_val: { refType: createRefToElmWithValue(BuiltinTypes.UNKNOWN) },
+          abc: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
+          unknown: { refType: createRefToElmWithValue(BuiltinTypes.UNKNOWN) },
+        },
+      }))).toBeTruthy()
+      expect(nestedTypes[2].isEqual(new ObjectType({
+        elemID: new ElemID(ADAPTER_NAME, 'renamedTypeName__field_with_complex_list_type'),
+        fields: {
+          number: { refType: createRefToElmWithValue(BuiltinTypes.NUMBER) },
+        },
+      }))).toBeTruthy()
+    })
     it('should annotate fields marked as fieldsToHide with _hidden_value', () => {
       const entries = [
         {

--- a/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
@@ -142,7 +142,7 @@ describe('ducktype_type_elements', () => {
         },
       }))).toBeTruthy()
     })
-    it('should generate types with correct names when typeNameOverrideFrom is used', () => {
+    it('should generate types with correct names when sourceTypeName is used', () => {
       const entries = [
         {
           id: 41619,
@@ -197,10 +197,10 @@ describe('ducktype_type_elements', () => {
         isSubType: false,
         transformationConfigByType: {
           renamedComplex: {
-            typeNameOverrideFrom: 'renamedTypeName__field_with_complex_type',
+            sourceTypeName: 'renamedTypeName__field_with_complex_type',
           },
           renamedTypeName: {
-            typeNameOverrideFrom: 'typeName',
+            sourceTypeName: 'typeName',
           },
         },
         transformationDefaultConfig: { idFields: [] },

--- a/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
@@ -208,23 +208,23 @@ describe('ducktype_type_elements', () => {
       expect(type.isEqual(new ObjectType({
         elemID: new ElemID(ADAPTER_NAME, 'renamedTypeName'),
         fields: {
-          id: { refType: createRefToElmWithValue(BuiltinTypes.NUMBER) },
-          api_collection_id: { refType: createRefToElmWithValue(BuiltinTypes.NUMBER) },
-          flow_id: { refType: createRefToElmWithValue(BuiltinTypes.NUMBER) },
-          flow_ids: { refType: createRefToElmWithValue(new ListType(BuiltinTypes.NUMBER)) },
-          name: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
-          method: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
-          url: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
-          legacy_url: { refType: createRefToElmWithValue(BuiltinTypes.UNKNOWN) },
-          base_path: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
-          path: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
-          active: { refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN) },
-          legacy: { refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN) },
-          created_at: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
-          updated_at: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
-          field_with_complex_type: { refType: createRefToElmWithValue(nestedTypes[0]) },
+          id: { refType: BuiltinTypes.NUMBER },
+          api_collection_id: { refType: BuiltinTypes.NUMBER },
+          flow_id: { refType: BuiltinTypes.NUMBER },
+          flow_ids: { refType: new ListType(BuiltinTypes.NUMBER) },
+          name: { refType: BuiltinTypes.STRING },
+          method: { refType: BuiltinTypes.STRING },
+          url: { refType: BuiltinTypes.STRING },
+          legacy_url: { refType: BuiltinTypes.UNKNOWN },
+          base_path: { refType: BuiltinTypes.STRING },
+          path: { refType: BuiltinTypes.STRING },
+          active: { refType: BuiltinTypes.BOOLEAN },
+          legacy: { refType: BuiltinTypes.BOOLEAN },
+          created_at: { refType: BuiltinTypes.STRING },
+          updated_at: { refType: BuiltinTypes.STRING },
+          field_with_complex_type: { refType: nestedTypes[0] },
           field_with_complex_list_type: {
-            refType: createRefToElmWithValue(new ListType(nestedTypes[2])),
+            refType: new ListType(nestedTypes[2]),
           },
         },
       }))).toBeTruthy()
@@ -232,23 +232,23 @@ describe('ducktype_type_elements', () => {
       expect(nestedTypes[0].isEqual(new ObjectType({
         elemID: new ElemID(ADAPTER_NAME, 'renamedComplex'),
         fields: {
-          number: { refType: createRefToElmWithValue(BuiltinTypes.NUMBER) },
-          nested_type: { refType: createRefToElmWithValue(nestedTypes[1]) },
+          number: { refType: BuiltinTypes.NUMBER },
+          nested_type: { refType: nestedTypes[1] },
         },
       }))).toBeTruthy()
       expect(nestedTypes[1].isEqual(new ObjectType({
         elemID: new ElemID(ADAPTER_NAME, 'renamedComplex__nested_type'),
         fields: {
-          val: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
-          another_val: { refType: createRefToElmWithValue(BuiltinTypes.UNKNOWN) },
-          abc: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
-          unknown: { refType: createRefToElmWithValue(BuiltinTypes.UNKNOWN) },
+          val: { refType: BuiltinTypes.STRING },
+          another_val: { refType: BuiltinTypes.UNKNOWN },
+          abc: { refType: BuiltinTypes.STRING },
+          unknown: { refType: BuiltinTypes.UNKNOWN },
         },
       }))).toBeTruthy()
       expect(nestedTypes[2].isEqual(new ObjectType({
         elemID: new ElemID(ADAPTER_NAME, 'renamedTypeName__field_with_complex_list_type'),
         fields: {
-          number: { refType: createRefToElmWithValue(BuiltinTypes.NUMBER) },
+          number: { refType: BuiltinTypes.NUMBER },
         },
       }))).toBeTruthy()
     })


### PR DESCRIPTION
Add a `typeNameOverrideFrom` config option to allow giving better names to nested types in ducktype adapters (will initially be used for Zendesk).


---
_Release Notes_: 
None

---
_User Notifications_: 
None