### PR TITLE
SALTO-1513 add salesforce.QuickAction.field.fieldOverrides to hardcoded_lists

### DIFF
--- a/packages/salesforce-adapter/src/filters/hardcoded_lists.json
+++ b/packages/salesforce-adapter/src/filters/hardcoded_lists.json
@@ -137,6 +137,7 @@
   "salesforce.Profile.field.pageAccesses",
   "salesforce.Profile.field.recordTypeVisibilities",
   "salesforce.Profile.field.userPermissions",
+  "salesforce.QuickAction.field.fieldOverrides",
   "salesforce.QuickActionLayout.field.quickActionLayoutColumns",
   "salesforce.QuickActionLayoutColumn.field.quickActionLayoutItems",
   "salesforce.QuickActionList.field.quickActionListItems",


### PR DESCRIPTION
Salesforce's `QuickAction.field.fieldOverrides` should be a list, so added to the `hardcoded_lists.json` file