### PR TITLE
SALTO-1515: return instance ElemID instead of Field in MultiDefaultsChangeValidator

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
+++ b/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
@@ -58,13 +58,17 @@ const formatContext = (context: Value): string => {
   return safeJsonStringify(context)
 }
 
-const createChangeError = (field: Field, contexts: string[], instanceName?: string):
-  ChangeError => ({
-  elemID: field.elemID,
-  severity: 'Warning',
-  message: `There cannot be more than one 'default' field set to 'true'. Field name: ${field.name} in${instanceName ? ` instance: ${instanceName}` : ''} type ${field.parent.elemID.name}.`,
-  detailedMessage: `There cannot be more than one 'default' ${field.name} in${instanceName ? ` instance: ${instanceName}` : ''} type ${field.parent.elemID.name}. The following ${fieldNameToInnerContextField[field.name] ?? LABEL}s are set to default: ${contexts}`,
-})
+const createChangeError = (field: Field, contexts: string[], instance?: InstanceElement):
+  ChangeError => {
+  const instanceName = instance?.elemID.name
+
+  return {
+    elemID: instance?.elemID ?? field.elemID,
+    severity: 'Warning',
+    message: `There cannot be more than one 'default' field set to 'true'. Field name: ${field.name} in${instanceName ? ` instance: ${instanceName}` : ''} type ${field.parent.elemID.name}.`,
+    detailedMessage: `There cannot be more than one 'default' ${field.name} in${instanceName ? ` instance: ${instanceName}` : ''} type ${field.parent.elemID.name}. The following ${fieldNameToInnerContextField[field.name] ?? LABEL}s are set to default: ${contexts}`,
+  }
+}
 
 const getPicklistMultipleDefaultsErrors = (field: FieldWithValueSet): ChangeError[] => {
   const contexts = field.annotations.valueSet
@@ -107,7 +111,7 @@ const getInstancesMultipleDefaultsErrors = async (
           createChangeError((
             await after.getType()).fields[fieldName],
           contexts,
-          after.elemID.name),
+          after),
         ] : []
     }).toArray()
 

--- a/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
+++ b/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
@@ -58,24 +58,31 @@ const formatContext = (context: Value): string => {
   return safeJsonStringify(context)
 }
 
-const createChangeError = (field: Field, contexts: string[], instance?: InstanceElement):
+const createInstanceChangeError = (field: Field, contexts: string[], instance: InstanceElement):
   ChangeError => {
-  const instanceName = instance?.elemID.name
-
+  const instanceName = instance.elemID.name
   return {
-    elemID: instance?.elemID ?? field.elemID,
+    elemID: instance.elemID,
     severity: 'Warning',
-    message: `There cannot be more than one 'default' field set to 'true'. Field name: ${field.name} in${instanceName ? ` instance: ${instanceName}` : ''} type ${field.parent.elemID.name}.`,
-    detailedMessage: `There cannot be more than one 'default' ${field.name} in${instanceName ? ` instance: ${instanceName}` : ''} type ${field.parent.elemID.name}. The following ${fieldNameToInnerContextField[field.name] ?? LABEL}s are set to default: ${contexts}`,
+    message: `There cannot be more than one 'default' field set to 'true'. Field name: ${field.name} in instance: ${instanceName} type ${field.parent.elemID.name}.`,
+    detailedMessage: `There cannot be more than one 'default' ${field.name} in instance: ${instanceName} type ${field.parent.elemID.name}. The following ${fieldNameToInnerContextField[field.name] ?? LABEL}s are set to default: ${contexts}`,
   }
 }
+
+const createFieldChangeError = (field: Field, contexts: string[]):
+  ChangeError => ({
+  elemID: field.elemID,
+  severity: 'Warning',
+  message: `There cannot be more than one 'default' field set to 'true'. Field name: ${field.name} in type ${field.parent.elemID.name}.`,
+  detailedMessage: `There cannot be more than one 'default' ${field.name} in type ${field.parent.elemID.name}. The following ${fieldNameToInnerContextField[field.name] ?? LABEL}s are set to default: ${contexts}`,
+})
 
 const getPicklistMultipleDefaultsErrors = (field: FieldWithValueSet): ChangeError[] => {
   const contexts = field.annotations.valueSet
     .filter(obj => obj.default)
     .map(obj => obj[LABEL])
     .map(formatContext)
-  return contexts.length > 1 ? [createChangeError(field, contexts)] : []
+  return contexts.length > 1 ? [createFieldChangeError(field, contexts)] : []
 }
 
 const getInstancesMultipleDefaultsErrors = async (
@@ -108,7 +115,7 @@ const getInstancesMultipleDefaultsErrors = async (
         .map(formatContext)
       return contexts.length > 1
         ? [
-          createChangeError((
+          createInstanceChangeError((
             await after.getType()).fields[fieldName],
           contexts,
           after),

--- a/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
@@ -179,12 +179,12 @@ describe('multiple defaults change validator', () => {
               label: 'lala',
             },
           ] }, type)
-        const changeField = createChangeField('customValue', type)
+        createChangeField('customValue', type)
         const afterInstance = createAfterInstance(beforeInstance)
         const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
         expect(changeErrors).toHaveLength(1)
         const [changeError] = changeErrors
-        expect(changeError.elemID).toEqual(changeField.elemID)
+        expect(changeError.elemID).toEqual(afterInstance.elemID)
         expect(changeError.severity).toEqual('Warning')
       })
       it('should not have error for <= 1 default values GlobalValueSet', async () => {
@@ -257,11 +257,11 @@ describe('multiple defaults change validator', () => {
           }, type)
 
           const afterInstance = createAfterInstance(beforeInstance)
-          const changeField = createChangeField('applicationVisibilities', type)
+          createChangeField('applicationVisibilities', type)
           const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
           expect(changeErrors).toHaveLength(1)
           const [changeError] = changeErrors
-          expect(changeError.elemID).toEqual(changeField.elemID)
+          expect(changeError.elemID).toEqual(afterInstance.elemID)
           expect(changeError.severity).toEqual('Warning')
         })
 
@@ -309,11 +309,11 @@ describe('multiple defaults change validator', () => {
           }, type)
 
           const afterInstance = createAfterInstance(beforeInstance)
-          const changeField = createChangeField('recordTypeVisibilities', type)
+          createChangeField('recordTypeVisibilities', type)
           const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
           expect(changeErrors).toHaveLength(1)
           const [changeError] = changeErrors
-          expect(changeError.elemID).toEqual(changeField.elemID)
+          expect(changeError.elemID).toEqual(afterInstance.elemID)
           expect(changeError.severity).toEqual('Warning')
         })
 
@@ -374,15 +374,15 @@ describe('multiple defaults change validator', () => {
           }, type)
 
           const afterInstance = createAfterInstance(beforeInstance)
-          const changeFieldRecordType = createChangeField('recordTypeVisibilities', type)
-          const changeFieldApplication = createChangeField('applicationVisibilities', type)
+          createChangeField('recordTypeVisibilities', type)
+          createChangeField('applicationVisibilities', type)
           const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
           const changeErrorsIds = changeErrors.map(error => safeJsonStringify(error.elemID))
           expect(changeErrors).toHaveLength(2)
 
           // doesn't work without the JsonStringify
-          expect(changeErrorsIds).toContain(safeJsonStringify(changeFieldRecordType.elemID))
-          expect(changeErrorsIds).toContain(safeJsonStringify(changeFieldApplication.elemID))
+          expect(changeErrorsIds).toContain(safeJsonStringify(afterInstance.elemID))
+          expect(changeErrorsIds).toContain(safeJsonStringify(afterInstance.elemID))
           changeErrors.forEach(error => {
             expect(error.severity).toEqual('Warning')
           })

--- a/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
@@ -29,16 +29,6 @@ describe('multiple defaults change validator', () => {
     after: Field | InstanceElement):
       Promise<ReadonlyArray<ChangeError>> =>
     multipleDefaultsValidator([toChange({ before, after })])
-  const createChangeField = (name: string, type: ObjectType): Field => (
-    new Field(type, name, new ListType(new ObjectType(
-      { elemID: new ElemID(SALESFORCE, 'valuesList'),
-        fields: {
-          fullName: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
-          default: { refType: createRefToElmWithValue(BuiltinTypes.BOOLEAN) },
-          label: { refType: createRefToElmWithValue(BuiltinTypes.STRING) },
-        } }
-    )))
-  )
   describe('in custom fields', () => {
     let obj: ObjectType
     beforeEach(() => {
@@ -179,7 +169,6 @@ describe('multiple defaults change validator', () => {
               label: 'lala',
             },
           ] }, type)
-        createChangeField('customValue', type)
         const afterInstance = createAfterInstance(beforeInstance)
         const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
         expect(changeErrors).toHaveLength(1)
@@ -257,7 +246,6 @@ describe('multiple defaults change validator', () => {
           }, type)
 
           const afterInstance = createAfterInstance(beforeInstance)
-          createChangeField('applicationVisibilities', type)
           const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
           expect(changeErrors).toHaveLength(1)
           const [changeError] = changeErrors
@@ -309,7 +297,6 @@ describe('multiple defaults change validator', () => {
           }, type)
 
           const afterInstance = createAfterInstance(beforeInstance)
-          createChangeField('recordTypeVisibilities', type)
           const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
           expect(changeErrors).toHaveLength(1)
           const [changeError] = changeErrors
@@ -374,8 +361,6 @@ describe('multiple defaults change validator', () => {
           }, type)
 
           const afterInstance = createAfterInstance(beforeInstance)
-          createChangeField('recordTypeVisibilities', type)
-          createChangeField('applicationVisibilities', type)
           const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
           const changeErrorsIds = changeErrors.map(error => safeJsonStringify(error.elemID))
           expect(changeErrors).toHaveLength(2)


### PR DESCRIPTION

---
_Release Notes_: 
multi defaults change validator will now yield instance element ids instead of the field.

---
_User Notifications_: 
None