### PR TITLE
SALTO-825: open data instances

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -209,7 +209,7 @@ describe('Netsuite adapter E2E with real account', () => {
     })
 
     const subsidiaryInstance = new InstanceElement(
-      naclCase(randomString),
+      naclCase(`Parent Company_${randomString}`),
       subsidiaryType,
       {
         name: randomString,
@@ -223,7 +223,6 @@ describe('Netsuite adapter E2E with real account', () => {
         },
       }
     )
-
     afterAll(async () => {
       const revertChanges: Map<ChangeId, Change<InstanceElement>> = new Map([
         ...withSuiteApp ? [subsidiaryInstance] : [],

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -61,7 +61,7 @@ import { createElementsSourceIndex } from './elements_source_index/elements_sour
 import { LazyElementsSourceIndexes } from './elements_source_index/types'
 import getChangeValidator from './change_validator'
 import { getChangeGroupIdsFunc } from './group_changes'
-import { getDataTypes } from './data_elements/data_elements'
+import { getDataElements } from './data_elements/data_elements'
 
 const { makeArray } = collections.array
 const { awu } = collections.asynciterable
@@ -197,10 +197,8 @@ export default class NetsuiteAdapter implements AdapterOperations {
 
     const isPartial = this.fetchTarget !== undefined
 
-    // TODO: Replace when data instances are ready
-    // const dataElementsPromise = await getDataElements(this.client, fetchQuery,
-    // this.getElemIdFunc)
-    const dataElementsPromise = await getDataTypes(this.client)
+    const dataElementsPromise = await getDataElements(this.client, fetchQuery,
+      this.getElemIdFunc)
 
     const getCustomObjectsResult = this.client.getCustomObjects(
       Object.keys(customTypes),

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -49,6 +49,7 @@ import rolesInternalId from './filters/roles_internal_id'
 import dataInstancesAttributes from './filters/data_instances_attributes'
 import dataInstancesNullFields from './filters/data_instances_null_fields'
 import dataInstancesDiff from './filters/data_instances_diff'
+import dataInstancesIdentifiers from './filters/data_instances_identifiers'
 import addInternalId from './filters/add_internal_ids'
 import { Filter, FilterCreator } from './filter'
 import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_USE_CHANGES_DETECTION } from './config'
@@ -107,6 +108,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     client,
     elementsSource,
     filtersCreators = [
+      dataInstancesIdentifiers,
       dataInstancesDiff,
       // addParentFolder must run before replaceInstanceReferencesFilter
       addParentFolder,

--- a/packages/netsuite-adapter/src/filters/data_instances_identifiers.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_identifiers.ts
@@ -1,0 +1,44 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, getChangeElement, InstanceElement, isInstanceChange } from '@salto-io/adapter-api'
+import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import { IDENTIFIER_FIELD } from '../data_elements/types'
+import { FilterWith } from '../filter'
+import { isDataObjectType } from '../types'
+
+const { awu } = collections.asynciterable
+
+const filterCreator = (): FilterWith<'preDeploy'> => ({
+  preDeploy: async changes => {
+    await awu(changes)
+      .filter(isInstanceChange)
+      .filter(async change => isDataObjectType(
+        await getChangeElement<InstanceElement>(change).getType()
+      ))
+      .forEach(async change => {
+        applyFunctionToChangeData<Change<InstanceElement>>(
+          change,
+          element => {
+            delete element.value[IDENTIFIER_FIELD]
+            return element
+          }
+        )
+      })
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/remove_redundant_fields.ts
+++ b/packages/netsuite-adapter/src/filters/remove_redundant_fields.ts
@@ -23,7 +23,7 @@ import { isDataObjectType } from '../types'
 const { awu } = collections.asynciterable
 
 const REDUNDANT_TYPES = ['NullField', 'CustomFieldList', 'CustomFieldRef']
-const REDUNDANT_FIELDS = ['lastModifiedDate', 'dateCreated']
+const REDUNDANT_FIELDS = ['lastModifiedDate', 'dateCreated', 'createdDate', 'daysOverdue']
 
 const filterCreator = (): FilterWith<'onFetch'> => ({
   onFetch: async elements => {

--- a/packages/netsuite-adapter/test/filters/data_instances_identifiers.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_identifiers.test.ts
@@ -1,0 +1,30 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/data_instances_identifiers'
+import { NETSUITE } from '../../src/constants'
+import { IDENTIFIER_FIELD } from '../../src/data_elements/types'
+
+describe('data_instances_identifiers', () => {
+  it('should remove identifier field', async () => {
+    const accountType = new ObjectType({ elemID: new ElemID(NETSUITE, 'Account'), annotations: { source: 'soap' } })
+    const accountInstance = new InstanceElement('instance', accountType, { [IDENTIFIER_FIELD]: 'someValue' })
+    await filterCreator().preDeploy?.([
+      toChange({ after: accountInstance }),
+    ])
+    expect(accountInstance.value[IDENTIFIER_FIELD]).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Open Netsuite data instances for users

---

This PR:
- uncomment the commented line that fetches data instances
- adds e2e for fetching and deploying data instances
- Fixed bug that when creating data instances we are sending the "identifier" value too
- removed redundant fields from fetch 

---
_Release Notes_: 
Netsuite Adapter:
Additional types were added for accounts with Salto SuiteApp configured (Subsidiary, Account, Location, Items, and more). The additional types support all deployment types (creation, modification, and deletions)

---
_User Notifications_: 
New instances of the new types will be fetched in the next fetch for users with Salto SuiteApp configured
