### PR TITLE
SALTO-1192: Fixed validation errors in workbook and translationcollection

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -51,6 +51,7 @@ import dataInstancesNullFields from './filters/data_instances_null_fields'
 import dataInstancesDiff from './filters/data_instances_diff'
 import dataInstancesIdentifiers from './filters/data_instances_identifiers'
 import addInternalId from './filters/add_internal_ids'
+import translationConverter from './filters/translation_converter'
 import { Filter, FilterCreator } from './filter'
 import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_WARN_STALE_DATA, DEFAULT_USE_CHANGES_DETECTION } from './config'
 import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery, QueryParams, convertToQueryParams } from './query'
@@ -132,6 +133,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       dataInstancesReferences,
       dataInstancesInternalId,
       addInternalId,
+      translationConverter,
     ],
     typesToSkip = [
       INTEGRATION, // The imported xml has no values, especially no SCRIPT_ID, for standard

--- a/packages/netsuite-adapter/src/filters/translation_converter.ts
+++ b/packages/netsuite-adapter/src/filters/translation_converter.ts
@@ -1,0 +1,133 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, Field, isInstanceElement, isInstanceChange, InstanceElement, Change, isField, ElemID, isObjectType } from '@salto-io/adapter-api'
+import { applyFunctionToChangeData, getPath, transformValues } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { FilterWith } from '../filter'
+import { workbook } from '../autogen/types/custom_types/workbook'
+import { translationcollection } from '../autogen/types/custom_types/translationcollection'
+import { dataset } from '../autogen/types/custom_types/dataset'
+import { ATTRIBUTE_PREFIX } from '../client/constants'
+import { getMetadataTypes } from '../types'
+import { NETSUITE } from '../constants'
+import { centercategory } from '../autogen/types/custom_types/centercategory'
+import { centertab } from '../autogen/types/custom_types/centertab'
+import { subtab } from '../autogen/types/custom_types/subtab'
+
+const { awu } = collections.asynciterable
+
+const log = logger(module)
+
+const FIELDS_TO_CONVERT = [
+  workbook.elemID.createNestedID('field', 'name'),
+  translationcollection.elemID.createNestedID('field', 'name'),
+  dataset.elemID.createNestedID('field', 'name'),
+  new ElemID(NETSUITE, 'centercategory_links_link', 'field', 'linklabel'),
+  centercategory.elemID.createNestedID('field', 'label'),
+  centertab.elemID.createNestedID('field', 'label'),
+  subtab.elemID.createNestedID('field', 'title'),
+]
+const REAL_VALUE_KEY = '#text'
+const TRANSLATE_KEY = 'translate'
+
+const getTranslateFieldName = (key: string): string => `${key}Translate`
+
+const filterCreator = (): FilterWith<'onFetch' | 'preDeploy'> => ({
+  onFetch: async elements => {
+    const types = _.keyBy(getMetadataTypes(), type => type.elemID.name)
+
+    FIELDS_TO_CONVERT.forEach(elemID => {
+      const type = types[elemID.typeName]
+
+      if (!isObjectType(type)) {
+        log.warn(`received non object type from ${elemID.getFullName()}`)
+        return
+      }
+      const path = getPath(type, elemID)
+      const field = path && _.get(type, path)
+      if (!isField(field)) {
+        log.warn(`Got a value that is not a field ${field} for elem ID ${elemID.getFullName()}`)
+        return
+      }
+      field.parent.fields[getTranslateFieldName(field.name)] = new Field(
+        type,
+        getTranslateFieldName(field.name),
+        BuiltinTypes.BOOLEAN
+      )
+    })
+
+    await awu(elements)
+      .filter(isInstanceElement)
+      .forEach(async instance => {
+        instance.value = await transformValues({
+          values: instance.value,
+          type: await instance.getType(),
+          strict: false,
+          pathID: instance.elemID,
+          transformFunc: ({ value }) => {
+            if (!_.isPlainObject(value)) {
+              return value
+            }
+            _(value)
+              .entries()
+              .filter(([_key, val]) => _.isPlainObject(val) && REAL_VALUE_KEY in val)
+              .forEach(([key, val]) => {
+                value[getTranslateFieldName(key)] = val[TRANSLATE_KEY] === 'T'
+                value[key] = val[REAL_VALUE_KEY]
+              })
+            return value
+          },
+        }) ?? instance.value
+      })
+  },
+
+  preDeploy: async changes =>
+    awu(changes)
+      .filter(isInstanceChange)
+      .forEach(async change =>
+        applyFunctionToChangeData<Change<InstanceElement>>(
+          change,
+          async instance => {
+            instance.value = await transformValues({
+              values: instance.value,
+              type: await instance.getType(),
+              strict: false,
+              pathID: instance.elemID,
+              transformFunc: ({ value }) => {
+                if (!_.isPlainObject(value)) {
+                  return value
+                }
+                _(value)
+                  .entries()
+                  .filter(([key]) => getTranslateFieldName(key) in value)
+                  .forEach(([key, val]) => {
+                    value[key] = {
+                      [REAL_VALUE_KEY]: val,
+                      [`${ATTRIBUTE_PREFIX}translate`]: value[getTranslateFieldName(key)] ? 'T' : 'F',
+                    }
+                    delete value[getTranslateFieldName(key)]
+                  })
+                return value
+              },
+            }) ?? instance.value
+            return instance
+          }
+        )),
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -202,7 +202,7 @@ export const toCustomizationInfo = async (
 ): Promise<CustomizationInfo> => {
   const transformPrimitive: TransformFunc = async ({ value, field }) => {
     const fieldType = await field?.getType()
-    if (!isPrimitiveType(fieldType)) {
+    if (!isPrimitiveType(fieldType) || (!isPrimitiveValue(value) && !Buffer.isBuffer(value))) {
       return value
     }
     if (fieldType.primitive === PrimitiveTypes.BOOLEAN) {

--- a/packages/netsuite-adapter/test/filters/translation_converter.test.ts
+++ b/packages/netsuite-adapter/test/filters/translation_converter.test.ts
@@ -1,0 +1,70 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, toChange } from '@salto-io/adapter-api'
+import { ATTRIBUTE_PREFIX } from '../../src/client/constants'
+import { translationcollection } from '../../src/autogen/types/custom_types/translationcollection'
+import filterCreator from '../../src/filters/translation_converter'
+
+
+describe('translation_converter filter', () => {
+  describe('onFetch', () => {
+    it('should add nameTranslate to type', async () => {
+      await filterCreator().onFetch([])
+      expect(translationcollection.fields.nameTranslate).toBeDefined()
+    })
+
+    it('should split name if it is an object', async () => {
+      const instance = new InstanceElement('instance', translationcollection, {
+        name: {
+          '#text': 'name',
+          translate: 'T',
+        },
+      })
+      await filterCreator().onFetch([instance])
+      expect(instance.value).toEqual({ name: 'name', nameTranslate: true })
+    })
+
+    it('should do nothing if name is a string', async () => {
+      const instance = new InstanceElement('instance', translationcollection, {
+        name: 'name',
+      })
+      await filterCreator().onFetch([instance])
+      expect(instance.value).toEqual({ name: 'name' })
+    })
+  })
+
+  describe('preDeploy', () => {
+    it('should combine name and translate', async () => {
+      const instance = new InstanceElement('instance', translationcollection, {
+        name: 'name',
+        nameTranslate: true,
+      })
+      await filterCreator().preDeploy([toChange({ after: instance })])
+      expect(instance.value).toEqual({ name: {
+        '#text': 'name',
+        [`${ATTRIBUTE_PREFIX}translate`]: 'T',
+      } })
+    })
+
+    it('should do nothing if nameTranslate is undefined', async () => {
+      const instance = new InstanceElement('instance', translationcollection, {
+        name: 'name',
+      })
+      await filterCreator().preDeploy([toChange({ after: instance })])
+      expect(instance.value).toEqual({ name: 'name' })
+    })
+  })
+})


### PR DESCRIPTION
Fixed validation error on the name value in translationcollection, workbook, and dataset types

---
_Release Notes_: 
Bugfixes:
Netsuite Adapter:
Fixed validation error of values that contain '#text' in them


---
_User Notifications_: 
new "translate fields" will be added to some of the types

Values of the form 
```
name = {
    '#text' = 'value'
    translate = 'T'
}
```
will be changed to
```
name = 'value'
nameTranslate = true
```
(This change will be omitted from the tracker)