### PR TITLE
SALTO-1149 make reference resolution context reusable in adapter-components

### DIFF
--- a/packages/adapter-components/src/references/context.ts
+++ b/packages/adapter-components/src/references/context.ts
@@ -31,13 +31,6 @@ export type ContextFunc = ({ instance, elemByElemID, field, fieldPath }: {
 
 const noop = (val: string): string => val
 
-export type ReferenceContextStrategyName = 'none'
-export const contextStrategyDefaultLookup: Record<
-  string, ContextFunc
-> = {
-  none: async () => undefined,
-}
-
 /**
  * Use the value of a neighbor field as the context for finding the referenced element.
  *

--- a/packages/adapter-components/src/references/context.ts
+++ b/packages/adapter-components/src/references/context.ts
@@ -1,0 +1,112 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { Element, Field, ReferenceExpression, InstanceElement, ElemID, getField, isReferenceExpression } from '@salto-io/adapter-api'
+import { resolvePath, GetLookupNameFunc } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { multiIndex } from '@salto-io/lowerdash'
+
+const log = logger(module)
+
+export type ContextValueMapperFunc = (val: string) => string | undefined
+export type ContextFunc = ({ instance, elemByElemID, field, fieldPath }: {
+  instance: InstanceElement
+  elemByElemID: multiIndex.Index<[string], Element>
+  field: Field
+  fieldPath?: ElemID
+}) => Promise<string | undefined>
+
+const noop = (val: string): string => val
+
+export type ReferenceContextStrategyName = 'none'
+export const contextStrategyDefaultLookup: Record<
+  string, ContextFunc
+> = {
+  none: async () => undefined,
+}
+
+/**
+ * Use the value of a neighbor field as the context for finding the referenced element.
+ *
+ * @param contextFieldName    The name of the neighboring field (same level)
+ * @param levelsUp            How many levels to go up in the instance's type definition before
+ *                            looking for the neighbor.
+ * @param contextValueMapper  An additional function to use to convert the value before the lookup
+ */
+export const neighborContextGetter = ({
+  contextFieldName,
+  levelsUp = 0,
+  contextValueMapper = noop,
+  getLookUpName,
+}: {
+  contextFieldName: string
+  levelsUp?: number
+  contextValueMapper?: ContextValueMapperFunc
+  getLookUpName: GetLookupNameFunc
+}): ContextFunc => (async ({ instance, elemByElemID, fieldPath }) => {
+  if (fieldPath === undefined || contextFieldName === undefined) {
+    return undefined
+  }
+
+  const resolveReference = async (
+    context: ReferenceExpression,
+    path?: ElemID
+  ): Promise<string | undefined> => {
+    const contextField = await getField(
+      await instance.getType(),
+      fieldPath.createTopLevelParentID().path
+    )
+    const refWithValue = new ReferenceExpression(
+      context.elemID,
+      context.value ?? elemByElemID.get(context.elemID.getFullName()),
+    )
+    return getLookUpName({ ref: refWithValue, field: contextField, path })
+  }
+
+  const getParent = (currentFieldPath: ElemID, numLevels = 0): ElemID => {
+    const getParentPath = (p: ElemID): ElemID => {
+      const isNum = (str: string | undefined): boolean => (
+        !_.isEmpty(str) && !Number.isNaN(_.toNumber(str))
+      )
+      let path = p
+      // ignore array indices
+      while (isNum(path.getFullNameParts().pop())) {
+        path = path.createParentID()
+      }
+      return path.createParentID()
+    }
+    if (numLevels <= 0) {
+      return getParentPath(currentFieldPath)
+    }
+    return getParent(getParentPath(currentFieldPath), numLevels - 1)
+  }
+
+  try {
+    const contextPath = getParent(fieldPath, levelsUp).createNestedID(contextFieldName)
+    const context = resolvePath(instance, contextPath)
+    const contextStr = (isReferenceExpression(context)
+      ? await resolveReference(context, contextPath)
+      : context)
+
+    if (!_.isString(contextStr)) {
+      return undefined
+    }
+    return contextValueMapper ? contextValueMapper(contextStr) : contextStr
+  } catch (e) {
+    log.error('could not resolve context for reference. error: %s, params: %s, stack: %s', e, { fieldPath, contextFieldName, levelsUp }, e.stack)
+    return undefined
+  }
+})

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -45,7 +45,7 @@ export const replaceReferenceValues = async <
     const findElem = (value: string, targetType?: string): Element | undefined => (
       targetType !== undefined
         // TODO make the field we're using to look up more explicit
-        ? elemLookupMaps.map(lookup => lookup.get(targetType, value)).find(isDefined)
+        ? elemLookupMaps.map(lookup => lookup.get(targetType, _.toString(value))).find(isDefined)
         : undefined
     )
 
@@ -76,10 +76,10 @@ export const replaceReferenceValues = async <
       if (elem === undefined) {
         return undefined
       }
-      const res = (await serializer.serialize({
+      const res = (_.toString(await serializer.serialize({
         ref: new ReferenceExpression(elem.elemID, elem),
         field,
-      }) === val) ? new ReferenceExpression(elem.elemID, elem) : undefined
+      })) === _.toString(val)) ? new ReferenceExpression(elem.elemID, elem) : undefined
       if (res !== undefined) {
         fieldsWithResolvedReferences.add(field.elemID.getFullName())
       }
@@ -146,7 +146,7 @@ export const addReferences = async <
   fieldsToGroupBy.forEach(fieldName => indexer.addIndex({
     name: `${fieldName}Lookup`,
     filter: e => isInstanceElement(e) && e.value[fieldName] !== undefined,
-    key: (inst: InstanceElement) => [inst.refType.elemID.name, inst.value[fieldName]],
+    key: (inst: InstanceElement) => [inst.refType.elemID.name, _.toString(inst.value[fieldName])],
   }))
   const { elemByElemID, ...fieldLookups } = await indexer.process(awu(elements))
 

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -13,47 +13,62 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Field, Element, isInstanceElement, Value, Values, ReferenceExpression, InstanceElement } from '@salto-io/adapter-api'
-import { TransformFunc, transformValues } from '@salto-io/adapter-utils'
 import _ from 'lodash'
+import { Field, Element, isInstanceElement, Value, Values, ReferenceExpression, InstanceElement, ElemID } from '@salto-io/adapter-api'
+import { TransformFunc, transformValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
+import { values as lowerDashValues, collections, multiIndex } from '@salto-io/lowerdash'
 import {
   ReferenceSerializationStrategy, ExtendedReferenceTargetDefinition, ReferenceResolverFinder,
   generateReferenceResolverFinder, FieldReferenceDefinition,
 } from './reference_mapping'
+import { ContextFunc, contextStrategyDefaultLookup } from './context'
 
 const { awu } = collections.asynciterable
 
 const log = logger(module)
 const { isDefined } = lowerDashValues
-type ElemLookupMapping = Record<string, Record<string, Element>>
 
-const replaceReferenceValues = async (
+export const replaceReferenceValues = async <
+  T extends string
+>(
   instance: InstanceElement,
-  resolverFinder: ReferenceResolverFinder,
-  elemLookupMaps: ElemLookupMapping[],
+  resolverFinder: ReferenceResolverFinder<T>,
+  elemLookupMaps: multiIndex.Index<[string, string], Element>[],
   fieldsWithResolvedReferences: Set<string>,
+  elemByElemID: multiIndex.Index<[string], Element>,
+  contextStrategyLookup: Record<T, ContextFunc> = contextStrategyDefaultLookup,
 ): Promise<Values> => {
-  const getRefElem = (
-    val: string | number, target: ExtendedReferenceTargetDefinition,
-  ): Element | undefined => {
+  const getRefElem = async (
+    val: string | number, target: ExtendedReferenceTargetDefinition<T>, field: Field, path?: ElemID
+  ): Promise<Element | undefined> => {
     const findElem = (value: string, targetType?: string): Element | undefined => (
       targetType !== undefined
         // TODO make the field we're using to look up more explicit
-        ? elemLookupMaps.map(lookup => lookup[targetType]?.[value]).find(isDefined)
+        ? elemLookupMaps.map(lookup => lookup.get(targetType, value)).find(isDefined)
         : undefined
     )
 
-    const elemParent = target.parent
-    const elemType = target.type
+    const parentContextFunc = contextStrategyLookup[target.parentContext ?? 'none' as T]
+    const typeContextFunc = contextStrategyLookup[target.typeContext ?? 'none' as T]
+    if (parentContextFunc === undefined || typeContextFunc === undefined) {
+      return undefined
+    }
+    const elemParent = target.parent ?? await parentContextFunc(
+      { instance, elemByElemID, field, fieldPath: path }
+    )
+    const elemType = target.type ?? await typeContextFunc({
+      instance, elemByElemID, field, fieldPath: path,
+    })
     return findElem(
       target.lookup(val, elemParent),
       elemType,
     )
   }
 
-  const replacePrimitive = async (val: string | number, field: Field): Promise<Value> => {
+  const replacePrimitive = async (
+    val: string | number, field: Field, path?: ElemID,
+  ): Promise<Value> => {
     const toValidatedReference = async (
       serializer: ReferenceSerializationStrategy,
       elem: Element | undefined,
@@ -71,25 +86,29 @@ const replaceReferenceValues = async (
       return res
     }
 
-    const reference = (await awu(resolverFinder(field))
+    const reference = await awu(await resolverFinder(field))
       .filter(refResolver => refResolver.target !== undefined)
       .map(async refResolver => toValidatedReference(
         refResolver.serializationStrategy,
-        getRefElem(val, refResolver.target as ExtendedReferenceTargetDefinition),
+        await getRefElem(
+          val,
+          refResolver.target as ExtendedReferenceTargetDefinition<T>,
+          field,
+          path,
+        ),
       ))
       .filter(isDefined)
-      .toArray())
-      .pop()
+      .peek()
 
     return reference ?? val
   }
 
-  const transformPrimitive: TransformFunc = async ({ value, field }) => (
+  const transformPrimitive: TransformFunc = async ({ value, field, path }) => (
     (
       field !== undefined
       && (_.isString(value) || _.isNumber(value))
     )
-      ? replacePrimitive(value, field)
+      ? replacePrimitive(value, field, path)
       : value
   )
 
@@ -104,44 +123,42 @@ const replaceReferenceValues = async (
   ) ?? instance.value
 }
 
-const mapFieldToElem = (
-  instances: InstanceElement[], fieldName: string,
-): Record<string, Element> => (
-  _(instances)
-    .filter(e => e.value[fieldName] !== undefined)
-    .map(e => [e.value[fieldName], e])
-    .fromPairs()
-    .value()
-)
-
-const groupByTypeAndField = (
-  instances: InstanceElement[], fieldName: string,
-): ElemLookupMapping => (
-  _(instances)
-    .groupBy(e => e.refType.elemID.name)
-    .mapValues(insts => mapFieldToElem(insts, fieldName))
-    .value()
-)
-
 /**
  * Convert field values into references, based on predefined rules.
  *
  */
-export const addReferences = async (
+export const addReferences = async <
+  T extends string
+>(
   elements: Element[],
-  defs: FieldReferenceDefinition[],
+  defs: FieldReferenceDefinition<T>[],
   fieldsToGroupBy: string[] = ['id'],
+  contextStrategyLookup?: Record<T, ContextFunc>,
 ): Promise<void> => {
-  const resolverFinder = generateReferenceResolverFinder(defs)
+  const resolverFinder = generateReferenceResolverFinder<T>(defs)
   const instances = elements.filter(isInstanceElement)
-  const lookups = fieldsToGroupBy.map(fieldName => groupByTypeAndField(instances, fieldName))
+
+  const indexer = multiIndex.buildMultiIndex<Element>().addIndex({
+    name: 'elemByElemID',
+    key: elem => [elem.elemID.getFullName()],
+  })
+
+  fieldsToGroupBy.forEach(fieldName => indexer.addIndex({
+    name: `${fieldName}Lookup`,
+    filter: e => isInstanceElement(e) && e.value[fieldName] !== undefined,
+    key: (inst: InstanceElement) => [inst.refType.elemID.name, inst.value[fieldName]],
+  }))
+  const { elemByElemID, ...fieldLookups } = await indexer.process(awu(elements))
+
   const fieldsWithResolvedReferences = new Set<string>()
   await awu(instances).forEach(async instance => {
     instance.value = await replaceReferenceValues(
       instance,
       resolverFinder,
-      lookups,
+      Object.values(fieldLookups),
       fieldsWithResolvedReferences,
+      elemByElemID,
+      contextStrategyLookup,
     )
   })
   log.debug('added references in the following fields: %s', [...fieldsWithResolvedReferences])

--- a/packages/adapter-components/src/references/index.ts
+++ b/packages/adapter-components/src/references/index.ts
@@ -13,6 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { neighborContextGetter, contextStrategyDefaultLookup, ContextFunc, ContextValueMapperFunc, ReferenceContextStrategyName } from './context'
+export { neighborContextGetter, ContextFunc, ContextValueMapperFunc } from './context'
 export { addReferences, replaceReferenceValues } from './field_references'
 export { FieldReferenceDefinition, ReferenceResolverFinder, ReferenceTargetDefinition, ExtendedReferenceTargetDefinition } from './reference_mapping'

--- a/packages/adapter-components/src/references/index.ts
+++ b/packages/adapter-components/src/references/index.ts
@@ -13,5 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { addReferences } from './field_references'
-export { FieldReferenceDefinition } from './reference_mapping'
+export { neighborContextGetter, contextStrategyDefaultLookup, ContextFunc, ContextValueMapperFunc, ReferenceContextStrategyName } from './context'
+export { addReferences, replaceReferenceValues } from './field_references'
+export { FieldReferenceDefinition, ReferenceResolverFinder, ReferenceTargetDefinition, ExtendedReferenceTargetDefinition } from './reference_mapping'

--- a/packages/adapter-components/src/references/reference_mapping.ts
+++ b/packages/adapter-components/src/references/reference_mapping.ts
@@ -16,6 +16,7 @@
 import _ from 'lodash'
 import { Field, Value, Element } from '@salto-io/adapter-api'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
+import { ReferenceContextStrategyName } from './context'
 
 export type ApiNameFunc = (elem: Element) => string
 type LookupFunc = (val: Value, context?: string) => string
@@ -43,16 +44,28 @@ const ReferenceSerializationStrategyLookup: Record<
   },
 }
 
-type ReferenceTargetDefinition = {
-  name?: string
+type PickOne<T, K extends keyof T> = Pick<T, K> & { [P in keyof Omit<T, K>]?: never };
+type MetadataTypeArgs<T extends string> = {
   type: string
-  parent?: string
+  typeContext: T
 }
-export type ExtendedReferenceTargetDefinition = ReferenceTargetDefinition & { lookup: LookupFunc }
+type MetadataParentArgs<T extends string> = {
+  parent?: string
+  parentContext?: T
+}
+export type ReferenceTargetDefinition<
+  T extends string
+> = {
+  name?: string
+} & (PickOne<MetadataTypeArgs<T>, 'type'> | PickOne<MetadataTypeArgs<T>, 'typeContext'>)
+  & (PickOne<MetadataParentArgs<T>, 'parent'> | PickOne<MetadataParentArgs<T>, 'parentContext'>)
+export type ExtendedReferenceTargetDefinition<
+  T extends string
+> = ReferenceTargetDefinition<T> & { lookup: LookupFunc }
 
 type SourceDef = {
   field: string | RegExp
-  parentTypes: string[]
+  parentTypes?: string[]
 }
 
 /**
@@ -67,22 +80,29 @@ type SourceDef = {
  * 1. An element matching the rule is found.
  * 2. Resolving the resulting reference expression back returns the original value.
  */
-export type FieldReferenceDefinition = {
+export type FieldReferenceDefinition<
+  T extends string = ReferenceContextStrategyName
+> = {
   src: SourceDef
   serializationStrategy?: ReferenceSerializationStrategyName
   // If target is missing, the definition is used for resolving
-  target?: ReferenceTargetDefinition
+  target?: ReferenceTargetDefinition<T>
 }
 
 // We can extract the api name from the elem id as long as we don't support renaming
 const apiName: ApiNameFunc = elem => elem.elemID.name
 
-export class FieldReferenceResolver {
+type FieldReferenceResolverDetails<T extends string> = {
+  serializationStrategy: ReferenceSerializationStrategy
+  target?: ExtendedReferenceTargetDefinition<T>
+}
+
+export class FieldReferenceResolver<T extends string> {
   src: SourceDef
   serializationStrategy: ReferenceSerializationStrategy
-  target?: ExtendedReferenceTargetDefinition
+  target?: ExtendedReferenceTargetDefinition<T>
 
-  constructor(def: FieldReferenceDefinition) {
+  constructor(def: FieldReferenceDefinition<T>) {
     this.src = def.src
     this.serializationStrategy = ReferenceSerializationStrategyLookup[
       def.serializationStrategy ?? 'fullValue'
@@ -92,28 +112,33 @@ export class FieldReferenceResolver {
       : undefined
   }
 
-  static create(def: FieldReferenceDefinition): FieldReferenceResolver {
-    return new FieldReferenceResolver(def)
+  static create<S extends string>(def: FieldReferenceDefinition<S>): FieldReferenceResolver<S> {
+    return new FieldReferenceResolver<S>(def)
   }
 
   match(field: Field): boolean {
     return (
       field.name === this.src.field
-      && this.src.parentTypes.includes(apiName(field.parent))
+      && (
+        this.src.parentTypes === undefined
+        || this.src.parentTypes.includes(apiName(field.parent))
+      )
     )
   }
 }
 
-export type ReferenceResolverFinder = (field: Field) => FieldReferenceResolver[]
+export type ReferenceResolverFinder<T extends string> = (
+  field: Field
+) => Promise<FieldReferenceResolverDetails<T>[]>
 
 /**
  * Generates a function that filters the relevant resolvers for a given field.
  */
-export const generateReferenceResolverFinder = (
-  defs: FieldReferenceDefinition[],
-): ReferenceResolverFinder => {
+export const generateReferenceResolverFinder = <
+  T extends string
+>(defs: FieldReferenceDefinition<T>[]): ReferenceResolverFinder<T> => {
   const referenceDefinitions = defs.map(
-    def => FieldReferenceResolver.create(def)
+    def => FieldReferenceResolver.create<T>(def)
   )
 
   const matchersByFieldName = _(referenceDefinitions)
@@ -121,7 +146,7 @@ export const generateReferenceResolverFinder = (
     .groupBy(def => def.src.field)
     .value()
 
-  return (field => (
+  return (async field => (
     (matchersByFieldName[field.name] ?? []).filter(resolver => resolver.match(field))
   ))
 }

--- a/packages/adapter-components/test/references/field_references.test.ts
+++ b/packages/adapter-components/test/references/field_references.test.ts
@@ -16,7 +16,7 @@
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, BuiltinTypes, isInstanceElement, ListType, createRefToElmWithValue } from '@salto-io/adapter-api'
 import { addReferences } from '../../src/references/field_references'
 import { FieldReferenceDefinition } from '../../src/references/reference_mapping'
-import { ContextValueMapperFunc, ContextFunc, neighborContextGetter, contextStrategyDefaultLookup } from '../../src/references'
+import { ContextValueMapperFunc, ContextFunc, neighborContextGetter } from '../../src/references'
 
 const ADAPTER_NAME = 'myAdapter'
 
@@ -183,7 +183,7 @@ describe('Field references', () => {
 
   describe('addReferences', () => {
     let elements: Element[]
-    const fieldNameToTypeMappingDefs: FieldReferenceDefinition<'none' | 'parentSubject' | 'parentValue' | 'neighborRef'>[] = [
+    const fieldNameToTypeMappingDefs: FieldReferenceDefinition<'parentSubject' | 'parentValue' | 'neighborRef'>[] = [
       {
         src: { field: 'api_client_id', parentTypes: ['api_access_profile'] },
         serializationStrategy: 'id',
@@ -229,7 +229,6 @@ describe('Field references', () => {
     beforeAll(async () => {
       elements = generateElements()
       await addReferences(elements, fieldNameToTypeMappingDefs, undefined, {
-        none: contextStrategyDefaultLookup.none,
         parentSubject: neighborContextFunc({ contextFieldName: 'subject', levelsUp: 1, contextValueMapper: val => val.replace('_id', '') }),
         parentValue: neighborContextFunc({ contextFieldName: 'value', levelsUp: 2, contextValueMapper: val => val.replace('_id', '') }),
         neighborRef: neighborContextFunc({ contextFieldName: 'ref' }),

--- a/packages/adapter-components/test/references/field_references.test.ts
+++ b/packages/adapter-components/test/references/field_references.test.ts
@@ -148,12 +148,12 @@ describe('Field references', () => {
     type1,
     new InstanceElement('brand1', brandType, { id: 1001 }),
     new InstanceElement('brand2', brandType, { id: 1002 }),
-    new InstanceElement('group3', groupType, { id: 2003 }),
-    new InstanceElement('group4', groupType, { id: 2004 }),
+    new InstanceElement('group3', groupType, { id: '2003' }),
+    new InstanceElement('group4', groupType, { id: '2004' }),
     new InstanceElement('inst1', type1, {
       subjectAndValues: [
         {
-          valueList: [{ value: 1001, bla: 'ignore' }],
+          valueList: [{ value: '1001', bla: 'ignore' }],
           subject: 'brand_id',
         },
         {

--- a/packages/lowerdash/src/types.ts
+++ b/packages/lowerdash/src/types.ts
@@ -83,3 +83,6 @@ export const isArrayOfType = <T>(
 ): array is T[] => (
     array.every(typeGuard)
   )
+
+export type AllowOnly<T, K extends keyof T> = Pick<T, K> & { [P in keyof Omit<T, K>]?: never };
+export type OneOf<T, K = keyof T> = K extends keyof T ? AllowOnly<T, K> : never

--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -218,7 +218,15 @@ describe('Salesforce adapter E2E with real account', () => {
             InstanceElement
           expect(innerMetadataInstance).toBeDefined()
           Object.entries(expectedValues)
-            .forEach(([key, val]) => expect(innerMetadataInstance.value[key]).toEqual(val))
+            .forEach(([key, val]) => {
+              if (isReferenceExpression(val)) {
+                expect(val.elemID.getFullName()).toEqual(
+                  innerMetadataInstance.value[key].elemID?.getFullName()
+                )
+              } else {
+                expect(innerMetadataInstance.value[key]).toEqual(val)
+              }
+            })
         }
 
         it('should fetch validation rules', async () => {

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -13,14 +13,14 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Field, Element, isInstanceElement, Value, Values, isReferenceExpression, isField, ReferenceExpression, InstanceElement, ElemID, getField, ReadOnlyElementsSource } from '@salto-io/adapter-api'
-import { TransformFunc, transformValues, resolvePath, getParents } from '@salto-io/adapter-utils'
-import _ from 'lodash'
+import { Element, isInstanceElement, isReferenceExpression, isField, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { references as referenceUtils } from '@salto-io/adapter-components'
+import { getParents } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { values as lowerDashValues, collections, multiIndex } from '@salto-io/lowerdash'
+import { collections, multiIndex } from '@salto-io/lowerdash'
 import { apiName, metadataType } from '../transformers/transformer'
 import { FilterCreator } from '../filter'
-import { ReferenceSerializationStrategy, ExtendedReferenceTargetDefinition, ReferenceResolverFinder, generateReferenceResolverFinder, ReferenceContextStrategyName, FieldReferenceDefinition, getLookUpName } from '../transformers/reference_mapping'
+import { generateReferenceResolverFinder, ReferenceContextStrategyName, FieldReferenceDefinition, getLookUpName } from '../transformers/reference_mapping'
 import {
   WORKFLOW_ACTION_ALERT_METADATA_TYPE, WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
   WORKFLOW_FLOW_ACTION_METADATA_TYPE, WORKFLOW_OUTBOUND_MESSAGE_METADATA_TYPE,
@@ -31,81 +31,10 @@ import { buildElementsSourceForFetch, extractFlatCustomObjectFields, hasApiName 
 
 const { awu } = collections.asynciterable
 const log = logger(module)
-const { isDefined } = lowerDashValues
 const { flatMapAsync } = collections.asynciterable
-type ContextValueMapperFunc = (val: string) => string | undefined
-type ContextFunc = ({ instance, elemByElemID, field, fieldPath }: {
-  instance: InstanceElement
-  elemByElemID: multiIndex.Index<[string], Element>
-  field: Field
-  fieldPath?: ElemID
-}) => Promise<string | undefined>
+const { neighborContextGetter, replaceReferenceValues } = referenceUtils
 
-const noop = (val: string): string => val
-
-/**
- * Use the value of a neighbor field as the context for finding the referenced element.
- *
- * @param contextFieldName    The name of the neighboring field (same level)
- * @param levelsUp            How many levels to go up in the instance's type definition before
- *                            looking for the neighbor.
- * @param contextValueMapper  An additional function to use to convert the value before the lookup
- */
-const neighborContextFunc = ({
-  contextFieldName,
-  levelsUp = 0,
-  contextValueMapper = noop,
-}: {
-  contextFieldName: string
-  levelsUp?: number
-  contextValueMapper?: ContextValueMapperFunc
-}): ContextFunc => (async ({ instance, elemByElemID, fieldPath }) => {
-  if (fieldPath === undefined || contextFieldName === undefined) {
-    return undefined
-  }
-
-  const resolveReference = async (
-    context: ReferenceExpression,
-    path?: ElemID
-  ): Promise<string | undefined> => {
-    const contextField = await getField(
-      await instance.getType(),
-      fieldPath.createTopLevelParentID().path
-    )
-    const refWithValue = new ReferenceExpression(
-      context.elemID,
-      context.value ?? elemByElemID.get(context.elemID.getFullName()),
-    )
-    return getLookUpName({ ref: refWithValue, field: contextField, path })
-  }
-
-  const getParent = (currentFieldPath: ElemID, numLevels = 0): ElemID => {
-    const getParentPath = (p: ElemID): ElemID => {
-      const isNum = (str: string | undefined): boolean => (
-        !_.isEmpty(str) && !Number.isNaN(_.toNumber(str))
-      )
-      let path = p
-      // ignore array indices
-      while (isNum(path.getFullNameParts().pop())) {
-        path = path.createParentID()
-      }
-      return path.createParentID()
-    }
-    if (numLevels <= 0) {
-      return getParentPath(currentFieldPath)
-    }
-    return getParent(getParentPath(currentFieldPath), numLevels - 1)
-  }
-
-  const contextPath = getParent(fieldPath, levelsUp).createNestedID(contextFieldName)
-  const context = resolvePath(instance, contextPath)
-  const contextStr = isReferenceExpression(context)
-    ? await resolveReference(context, contextPath)
-    : context
-  return contextValueMapper ? contextValueMapper(contextStr) : contextStr
-})
-
-const workflowActionMapper: ContextValueMapperFunc = (val: string) => {
+const workflowActionMapper: referenceUtils.ContextValueMapperFunc = (val: string) => {
   const typeMapping: Record<string, string> = {
     Alert: WORKFLOW_ACTION_ALERT_METADATA_TYPE,
     FieldUpdate: WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
@@ -116,7 +45,7 @@ const workflowActionMapper: ContextValueMapperFunc = (val: string) => {
   return typeMapping[val]
 }
 
-const flowActionCallMapper: ContextValueMapperFunc = (val: string) => {
+const flowActionCallMapper: referenceUtils.ContextValueMapperFunc = (val: string) => {
   const typeMapping: Record<string, string> = {
     apex: 'ApexClass',
     emailAlert: WORKFLOW_ACTION_ALERT_METADATA_TYPE,
@@ -125,8 +54,14 @@ const flowActionCallMapper: ContextValueMapperFunc = (val: string) => {
   return typeMapping[val]
 }
 
-const ContextStrategyLookup: Record<
-  ReferenceContextStrategyName, ContextFunc
+const neighborContextFunc = (args: {
+  contextFieldName: string
+  levelsUp?: number
+  contextValueMapper?: referenceUtils.ContextValueMapperFunc
+}): referenceUtils.ContextFunc => neighborContextGetter({ ...args, getLookUpName })
+
+const contextStrategyLookup: Record<
+  ReferenceContextStrategyName, referenceUtils.ContextFunc
 > = {
   none: async () => undefined,
   instanceParent: async ({ instance, elemByElemID }) => {
@@ -150,81 +85,6 @@ const ContextStrategyLookup: Record<
   neighborPicklistObjectLookup: neighborContextFunc({ contextFieldName: 'picklistObject' }),
 }
 
-const replaceReferenceValues = async (
-  instance: InstanceElement,
-  resolverFinder: ReferenceResolverFinder,
-  elemLookupMap: multiIndex.Index<[string, string], Element>,
-  fieldsWithResolvedReferences: Set<string>,
-  elemByElemID: multiIndex.Index<[string], Element>,
-): Promise<Values> => {
-  const getRefElem = async (
-    val: string, target: ExtendedReferenceTargetDefinition, field: Field, path?: ElemID
-  ): Promise<Element | undefined> => {
-    const findElem = (value: string, targetType?: string): Element | undefined => (
-      targetType !== undefined ? elemLookupMap.get(targetType, value) : undefined
-    )
-
-    const parentContextFunc = ContextStrategyLookup[target.parentContext ?? 'none']
-    const typeContextFunc = ContextStrategyLookup[target.typeContext ?? 'none']
-    if (parentContextFunc === undefined || typeContextFunc === undefined) {
-      return undefined
-    }
-    const elemParent = target.parent ?? await parentContextFunc(
-      { instance, elemByElemID, field, fieldPath: path }
-    )
-    const elemType = target.type ?? await typeContextFunc({
-      instance, elemByElemID, field, fieldPath: path,
-    })
-    return findElem(
-      target.lookup(val, elemParent),
-      elemType,
-    )
-  }
-
-  const replacePrimitive = async (val: string, field: Field, path?: ElemID): Promise<Value> => {
-    const toValidatedReference = async (
-      serializer: ReferenceSerializationStrategy,
-      elem: Element | undefined,
-    ): Promise<ReferenceExpression | undefined> => {
-      if (elem === undefined) {
-        return undefined
-      }
-      const res = (await serializer.serialize({
-        ref: new ReferenceExpression(elem.elemID, elem),
-        field,
-      }) === val) ? new ReferenceExpression(elem.elemID) : undefined
-      if (res !== undefined) {
-        fieldsWithResolvedReferences.add(field.elemID.getFullName())
-      }
-      return res
-    }
-
-    const reference = await awu(await resolverFinder(field))
-      .filter(refResolver => refResolver.target !== undefined)
-      .map(async refResolver => toValidatedReference(
-        refResolver.serializationStrategy,
-        await getRefElem(val, refResolver.target as ExtendedReferenceTargetDefinition, field, path),
-      ))
-      .filter(isDefined)
-      .peek()
-
-    return reference ?? val
-  }
-
-  const transformPrimitive: TransformFunc = ({ value, field, path }) => (
-    (!_.isUndefined(field) && _.isString(value)) ? replacePrimitive(value, field, path) : value
-  )
-
-  return await transformValues(
-    {
-      values: instance.value,
-      type: await instance.getType(),
-      transformFunc: transformPrimitive,
-      strict: false,
-      pathID: instance.elemID,
-    }
-  ) || instance.value
-}
 
 export const addReferences = async (
   elements: Element[],
@@ -259,9 +119,10 @@ export const addReferences = async (
       instance.value = await replaceReferenceValues(
         instance,
         resolverFinder,
-        elemLookup,
+        [elemLookup],
         fieldsWithResolvedReferences,
         elemByElemID,
+        contextStrategyLookup,
       )
     })
   log.debug('added references in the following fields: %s', [...fieldsWithResolvedReferences])

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -115,14 +115,14 @@ export const addReferences = async (
   await awu(elements)
     .filter(isInstanceElement)
     .forEach(async instance => {
-      instance.value = await replaceReferenceValues(
+      instance.value = await replaceReferenceValues({
         instance,
         resolverFinder,
-        { elemLookup },
+        elemLookupMaps: { elemLookup },
         fieldsWithResolvedReferences,
         elemByElemID,
         contextStrategyLookup,
-      )
+      })
     })
   log.debug('added references in the following fields: %s', [...fieldsWithResolvedReferences])
 }

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -63,7 +63,6 @@ const neighborContextFunc = (args: {
 const contextStrategyLookup: Record<
   ReferenceContextStrategyName, referenceUtils.ContextFunc
 > = {
-  none: async () => undefined,
   instanceParent: async ({ instance, elemByElemID }) => {
     const parentRef = getParents(instance)[0]
     const parent = isReferenceExpression(parentRef)
@@ -119,7 +118,7 @@ export const addReferences = async (
       instance.value = await replaceReferenceValues(
         instance,
         resolverFinder,
-        [elemLookup],
+        { elemLookup },
         fieldsWithResolvedReferences,
         elemByElemID,
         contextStrategyLookup,

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -92,7 +92,7 @@ const ReferenceSerializationStrategyLookup: Record<
 }
 
 export type ReferenceContextStrategyName = (
-  'none' | 'instanceParent' | 'neighborTypeWorkflow' | 'neighborCPQLookup' | 'neighborCPQRuleLookup'
+  'instanceParent' | 'neighborTypeWorkflow' | 'neighborCPQLookup' | 'neighborCPQRuleLookup'
   | 'neighborLookupValueTypeLookup' | 'neighborObjectLookup' | 'neighborPicklistObjectLookup'
   | 'neighborTypeLookup' | 'neighborActionTypeFlowLookup' | 'neighborActionTypeLookup' | 'parentObjectLookup'
   | 'parentInputObjectLookup' | 'parentOutputObjectLookup'

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { Field, isElement, Value, Element } from '@salto-io/adapter-api'
+import { references as referenceUtils } from '@salto-io/adapter-components'
 import { GetLookupNameFunc, GetLookupNameFuncArgs } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
@@ -97,21 +98,6 @@ export type ReferenceContextStrategyName = (
   | 'parentInputObjectLookup' | 'parentOutputObjectLookup'
 )
 
-type PickOne<T, K extends keyof T> = Pick<T, K> & { [P in keyof Omit<T, K>]?: never };
-type MetadataTypeArgs = {
-  type: string
-  typeContext: ReferenceContextStrategyName
-}
-type MetadataParentArgs = {
-  parent?: string
-  parentContext?: ReferenceContextStrategyName
-}
-type ReferenceTargetDefinition = {
-  name?: string
-} & (PickOne<MetadataTypeArgs, 'type'> | PickOne<MetadataTypeArgs, 'typeContext'>)
-  & (PickOne<MetadataParentArgs, 'parent'> | PickOne<MetadataParentArgs, 'parentContext'>)
-export type ExtendedReferenceTargetDefinition = ReferenceTargetDefinition & { lookup: LookupFunc }
-
 type SourceDef = {
   field: string | RegExp
   parentTypes: string[]
@@ -125,7 +111,7 @@ export type FieldReferenceDefinition = {
   src: SourceDef
   serializationStrategy?: ReferenceSerializationStrategyName
   // If target is missing, the definition is used for resolving
-  target?: ReferenceTargetDefinition
+  target?: referenceUtils.ReferenceTargetDefinition<ReferenceContextStrategyName>
 }
 
 /**
@@ -466,7 +452,7 @@ const matchApiName = async (elem: Element, types: string[]): Promise<boolean> =>
 export class FieldReferenceResolver {
   src: SourceDef
   serializationStrategy: ReferenceSerializationStrategy
-  target?: ExtendedReferenceTargetDefinition
+  target?: referenceUtils.ExtendedReferenceTargetDefinition<ReferenceContextStrategyName>
 
   constructor(def: FieldReferenceDefinition) {
     this.src = def.src

--- a/packages/salesforce-adapter/test/filters/cpq/fields_with_context_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/fields_with_context_references.test.ts
@@ -187,8 +187,11 @@ describe('fields with context references filter', () => {
           .toEqual(productRuleValues.SBQQ__LookupProductField__c)
       })
       it('Should replace value of field that exists in lookup object with reference', () => {
-        expect(productRule.value.SBQQ__LookupMessageField__c)
-          .toEqual(new ReferenceExpression(mockLookupDataObject.fields.message.elemID))
+        const value = productRule.value.SBQQ__LookupMessageField__c
+        expect(value)
+          .toBeInstanceOf(ReferenceExpression)
+        expect((value as ReferenceExpression).elemID.getFullName())
+          .toEqual(mockLookupDataObject.fields.message.elemID.getFullName())
       })
     })
 
@@ -207,8 +210,11 @@ describe('fields with context references filter', () => {
           .toEqual(productRuleValues.SBQQ__LookupProductField__c)
       })
       it('Should replace value of field that exists in lookup object with reference', () => {
-        expect(productRule.value.SBQQ__LookupMessageField__c)
-          .toEqual(new ReferenceExpression(mockLookupDataObject.fields.message.elemID))
+        const value = productRule.value.SBQQ__LookupMessageField__c
+        expect(value)
+          .toBeInstanceOf(ReferenceExpression)
+        expect((value as ReferenceExpression).elemID.getFullName())
+          .toEqual(mockLookupDataObject.fields.message.elemID.getFullName())
       })
     })
   })

--- a/packages/stripe-adapter/src/filters/field_references.ts
+++ b/packages/stripe-adapter/src/filters/field_references.ts
@@ -17,7 +17,7 @@ import { Element } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
 
-const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition[] = [
+const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition<never>[] = [
   {
     src: { field: 'product', parentTypes: ['plan', 'price'] },
     serializationStrategy: 'id',

--- a/packages/stripe-adapter/src/filters/field_references.ts
+++ b/packages/stripe-adapter/src/filters/field_references.ts
@@ -31,7 +31,7 @@ const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition<never>
  */
 const filter: FilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
-    await referenceUtils.addReferences(elements, fieldNameToTypeMappingDefs)
+    await referenceUtils.addReferences({ elements, defs: fieldNameToTypeMappingDefs })
   },
 })
 

--- a/packages/workato-adapter/src/filters/field_references.ts
+++ b/packages/workato-adapter/src/filters/field_references.ts
@@ -63,7 +63,7 @@ const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition<never>
  */
 const filter: FilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
-    await referenceUtils.addReferences(elements, fieldNameToTypeMappingDefs)
+    await referenceUtils.addReferences({ elements, defs: fieldNameToTypeMappingDefs })
   },
 })
 

--- a/packages/workato-adapter/src/filters/field_references.ts
+++ b/packages/workato-adapter/src/filters/field_references.ts
@@ -19,7 +19,7 @@ import { FilterCreator } from '../filter'
 
 const { toNestedTypeName } = elementUtils.ducktype
 
-const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition[] = [
+const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition<never>[] = [
   {
     src: { field: 'api_client_id', parentTypes: ['api_access_profile'] },
     serializationStrategy: 'id',

--- a/packages/zuora-billing-adapter/src/filters/field_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/field_references.ts
@@ -18,7 +18,7 @@ import { references as referenceUtils } from '@salto-io/adapter-components'
 import { WORKFLOW_TYPE, TASK_TYPE, SETTINGS_TYPE_PREFIX } from '../constants'
 import { FilterCreator } from '../filter'
 
-const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition[] = [
+const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition<never>[] = [
   {
     src: { field: 'source_workflow_id', parentTypes: ['Linkage'] },
     serializationStrategy: 'id',

--- a/packages/zuora-billing-adapter/src/filters/field_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/field_references.ts
@@ -52,7 +52,11 @@ const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition<never>
  */
 const filter: FilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
-    await referenceUtils.addReferences(elements, fieldNameToTypeMappingDefs, ['id', 'name'])
+    await referenceUtils.addReferences({
+      elements,
+      defs: fieldNameToTypeMappingDefs,
+      fieldsToGroupBy: ['id', 'name'],
+    })
   },
 })
 


### PR DESCRIPTION
We had a few advanced features in the Salesforce reference resolution engine that we will need in Zendesk as well, so moving them (with some small adjustments) to the new reusable reference engine in adapter-components.

---
_Release Notes_: 
None

---
_User Notifications_: 
None