### PR TITLE
revert plus escaping change to avoid changing elem ids

### DIFF
--- a/packages/adapter-utils/src/nacl_case_utils.ts
+++ b/packages/adapter-utils/src/nacl_case_utils.ts
@@ -57,7 +57,6 @@ const defaultNaclCaseMapping = {
   '~': 'zb',
   '$': 'zc',
   ',': 'zd',
-  '+': 'ze',
 } as Record<string, string>
 
 const suffixFromList = (specialCharsMappingList: string[]): string => {


### PR DESCRIPTION
revert the escaping change from https://github.com/salto-io/salto/pull/2180/files#diff-6769e54d872566aa16194498189ac5c0b1fa0c6834b09d029c12381884155ecdR60, since it was already escaped but just with a longer suffix, and we prefer to avoid the noise in the elem id changes in the read-only adapters.

---
_Release Notes_: 
None (not released yet)
