### PR TITLE
fixed salto creates wrong plan for removal changes (SALTO-1511)

### DIFF
--- a/packages/workspace/src/workspace/elements_source.ts
+++ b/packages/workspace/src/workspace/elements_source.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { Element, ElemID, Value, BuiltinTypesByFullName, ListType, MapType, isContainerType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
-import { collections } from '@salto-io/lowerdash'
+import { collections, values } from '@salto-io/lowerdash'
 import { resolvePath } from '@salto-io/adapter-utils'
 import { RemoteMap, InMemoryRemoteMap } from './remote_map'
 import { Keywords } from '../parser/language'
@@ -166,7 +166,9 @@ export const mapReadOnlyElementsSource = (
     const origValue = await source.get(id)
     return origValue !== undefined ? func(origValue) : undefined
   },
-  getAll: async () => awu(await source.getAll()).map(async element => func(element)),
+  getAll: async () => awu(await source.getAll())
+    .map(async element => func(element))
+    .filter(values.isDefined),
   has: id => source.has(id),
   list: () => source.list(),
 })

--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -270,11 +270,23 @@ export const createMergeManager = async (flushables: Flushable[],
         ))
       } else {
         log.warn(`Invalid data detected in local cache ${namespace}. Rebuilding cache.`)
+        const src1Overrides = cacheUpdate.src1Overrides ?? {}
+        const src2Overrides = cacheUpdate.src2Overrides ?? {}
         src1ElementsToMerge = (src1 && recoveryOperation === REBUILD_ON_RECOVERY)
-          ? (awu(await src1.getAll()).concat(await getContainerTypeChanges(src1Changes.changes)))
+          ? (awu(await src1.getAll())
+            .map(elem => (elem.elemID.getFullName() in src1Overrides
+              ? src1Overrides[elem.elemID.getFullName()]
+              : elem))
+            .filter(values.isDefined)
+            .concat(await getContainerTypeChanges(src1Changes.changes)))
           : []
         src2ElementsToMerge = (src2 && recoveryOperation === REBUILD_ON_RECOVERY)
-          ? (awu(await src2.getAll()).concat(await getContainerTypeChanges(src2Changes.changes)))
+          ? (awu(await src2.getAll())
+            .map(elem => (elem.elemID.getFullName() in src2Overrides
+              ? src2Overrides[elem.elemID.getFullName()]
+              : elem))
+            .filter(values.isDefined)
+            .concat(await getContainerTypeChanges(src2Changes.changes)))
           : []
       }
       return { src1ElementsToMerge, src2ElementsToMerge, potentialDeletedIds }

--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -252,6 +252,22 @@ export const createMergeManager = async (flushables: Flushable[],
         })
         return { changeIds, potentialDeletedIds }
       }
+
+      const getRecoveryElements = async (
+        src: ReadOnlyElementsSource,
+        srcOverrides: Record<string, Element>,
+        srcChanges: Change<Element>[]
+      ): Promise<AsyncIterable<Element>> => ((src && recoveryOperation === REBUILD_ON_RECOVERY)
+        ? (awu(await src.getAll())
+        // using the 'in' notation here since undefined for an existing key is different
+        // then an undefined key (overriding a key with undefined value)
+          .map(elem => (elem.elemID.getFullName() in srcOverrides
+            ? srcOverrides[elem.elemID.getFullName()]
+            : elem))
+          .filter(values.isDefined)
+          .concat(await getContainerTypeChanges(srcChanges)))
+        : awu([]))
+
       const potentialDeletedIds = new Set<string>()
       if (cacheValid) {
         const { changeIds: src1ChangeIDs,
@@ -272,22 +288,8 @@ export const createMergeManager = async (flushables: Flushable[],
         log.warn(`Invalid data detected in local cache ${namespace}. Rebuilding cache.`)
         const src1Overrides = cacheUpdate.src1Overrides ?? {}
         const src2Overrides = cacheUpdate.src2Overrides ?? {}
-        src1ElementsToMerge = (src1 && recoveryOperation === REBUILD_ON_RECOVERY)
-          ? (awu(await src1.getAll())
-            .map(elem => (elem.elemID.getFullName() in src1Overrides
-              ? src1Overrides[elem.elemID.getFullName()]
-              : elem))
-            .filter(values.isDefined)
-            .concat(await getContainerTypeChanges(src1Changes.changes)))
-          : []
-        src2ElementsToMerge = (src2 && recoveryOperation === REBUILD_ON_RECOVERY)
-          ? (awu(await src2.getAll())
-            .map(elem => (elem.elemID.getFullName() in src2Overrides
-              ? src2Overrides[elem.elemID.getFullName()]
-              : elem))
-            .filter(values.isDefined)
-            .concat(await getContainerTypeChanges(src2Changes.changes)))
-          : []
+        src1ElementsToMerge = await getRecoveryElements(src1, src1Overrides, src1Changes.changes)
+        src2ElementsToMerge = await getRecoveryElements(src2, src2Overrides, src2Changes.changes)
       }
       return { src1ElementsToMerge, src2ElementsToMerge, potentialDeletedIds }
     }

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -3359,3 +3359,30 @@ describe('isValidEnvName', () => {
     expect(isValidEnvName('100%')).toEqual(false)
   })
 })
+
+describe('update nacl files with invalid state cache', () => {
+  let workspace: Workspace
+  beforeAll(async () => {
+    const dirStore = mockDirStore()
+    const changes: DetailedChange[] = [
+      {
+        action: 'remove',
+        id: ElemID.fromFullName('salesforce.ObjWithFieldTypeWithHidden'),
+        data: {
+          before: new ObjectType({
+            elemID: ElemID.fromFullName('salesforce.ObjWithFieldTypeWithHidden'),
+          }),
+        },
+      },
+    ]
+    workspace = await createWorkspace(dirStore)
+    const state = workspace.state()
+    await state.setHash('XXX')
+    await workspace.updateNaclFiles(changes)
+  })
+
+  it('should not have the hidden parts of the removed element', async () => {
+    expect(await workspace.getValue(ElemID.fromFullName('salesforce.ObjWithFieldTypeWithHidden')))
+      .not.toBeDefined()
+  })
+})


### PR DESCRIPTION
_fixed salto creates wrong plan for removal changes_

---

_When a element is completely removed from the nacls, it should be completely removed from the workspace cache even if it has hidden parts which were not removed (since we consider such a removal as a signal that the entire element needs to be removed. There was a bug in the code, which ignored that condition when the state cache was invalid. This PR fixes this._

---
_Release Notes_: 
Fixed removing an object which was modified via a deploy result in wrong deployment plan.

---
_User Notifications_: 
_NA_
