### PR TITLE
adapter-components improvements - cursor pagination, standalone fields

### DIFF
--- a/packages/adapter-components/src/client/index.ts
+++ b/packages/adapter-components/src/client/index.ts
@@ -19,5 +19,5 @@ export { DEFAULT_RETRY_OPTS, RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS } from
 export { logDecorator, requiresLogin } from './decorators'
 export { AdapterHTTPClient, ClientOpts, HTTPClientInterface } from './http_client'
 export { APIConnection, ConnectionCreator, axiosConnection, createClientConnection, createRetryOptions, validateCredentials, UnauthorizedError, ResponseValue } from './http_connection'
-export { createPaginator, getWithCursorPagination, getWithPageOffsetPagination, getWithPageOffsetAndLastPagination, getWithOffsetAndLimit, traverseRequests, ClientGetWithPaginationParams, PaginationFunc, Paginator, GetAllItemsFunc } from './pagination'
+export { createPaginator, getWithCursorPagination, getWithPageOffsetPagination, getWithPageOffsetAndLastPagination, getWithOffsetAndLimit, traverseRequests, ClientGetWithPaginationParams, PaginationFunc, Paginator, GetAllItemsFunc, PathCheckerFunc } from './pagination'
 export { createRateLimitersFromConfig, throttle, BottleneckBuckets } from './rate_limit'

--- a/packages/adapter-components/src/client/pagination.ts
+++ b/packages/adapter-components/src/client/pagination.ts
@@ -178,8 +178,14 @@ export const getWithPageOffsetAndLastPagination: ((firstPage: number) => GetAllI
   }
 )
 
-export type PathCheckerFunc = (current: string, next: string) => boolean
-const defaultPathChecker: PathCheckerFunc = (current, next) => (current === next)
+/**
+ * Path checker for ensuring the next url's path is under the same endpoint as the one configured.
+ * Can be customized when the next url returned has different formatting, e.g. has a longer prefix
+ * (such as /api/v1/product vs /product).
+ * @return true if the configured endpoint can be used to get the next path, false otherwise.
+ */
+export type PathCheckerFunc = (endpointPath: string, nextPath: string) => boolean
+const defaultPathChecker: PathCheckerFunc = (endpointPath, nextPath) => (endpointPath === nextPath)
 
 /**
  * Make paginated requests using the specified paginationField, assuming the next page is specified

--- a/packages/adapter-components/test/client/pagination.test.ts
+++ b/packages/adapter-components/test/client/pagination.test.ts
@@ -594,7 +594,7 @@ describe('client_pagination', () => {
         status: 200,
         statusText: 'OK',
       }))
-      const result = (await toArrayAsync(await getWithCursorPagination({
+      const result = (await toArrayAsync(await getWithCursorPagination()({
         client,
         pageSize: 123,
         getParams: {
@@ -614,7 +614,7 @@ describe('client_pagination', () => {
         status: 200,
         statusText: 'OK',
       }))
-      const result = (await toArrayAsync(await getWithCursorPagination({
+      const result = (await toArrayAsync(await getWithCursorPagination()({
         client,
         pageSize: 123,
         getParams: {
@@ -646,7 +646,7 @@ describe('client_pagination', () => {
         status: 200,
         statusText: 'OK',
       }))
-      const result = (await toArrayAsync(await getWithCursorPagination({
+      const result = (await toArrayAsync(await getWithCursorPagination()({
         client,
         pageSize: 123,
         getParams: {
@@ -675,7 +675,7 @@ describe('client_pagination', () => {
         status: 200,
         statusText: 'OK',
       }))
-      const result = (await toArrayAsync(await getWithCursorPagination({
+      const result = (await toArrayAsync(await getWithCursorPagination()({
         client,
         pageSize: 123,
         getParams: {
@@ -702,7 +702,7 @@ describe('client_pagination', () => {
         status: 404,
         statusText: 'Not Found',
       }))
-      const result = (await toArrayAsync(await getWithCursorPagination({
+      const result = (await toArrayAsync(await getWithCursorPagination()({
         client,
         pageSize: 1,
         getParams: {
@@ -732,7 +732,7 @@ describe('client_pagination', () => {
         status: 404,
         statusText: 'Not Found',
       }))
-      await expect(toArrayAsync(await getWithCursorPagination({
+      await expect(toArrayAsync(await getWithCursorPagination()({
         client,
         pageSize: 1,
         getParams: {
@@ -743,6 +743,35 @@ describe('client_pagination', () => {
           },
         },
       }))).rejects.toThrow()
+    })
+
+    it('should check path based on path checker used by getWithCursorPagination', async () => {
+      client.getSinglePage.mockResolvedValueOnce(Promise.resolve({
+        data: {
+          products: ['a', 'b'],
+          nextPage: '/ep_suffix?page=p1',
+        },
+        status: 200,
+        statusText: 'OK',
+      })).mockResolvedValueOnce(Promise.resolve({
+        data: {
+          products: ['c', 'd'],
+        },
+        status: 200,
+        statusText: 'OK',
+      }))
+      const result = (await toArrayAsync(await getWithCursorPagination((current, next) => `${current}_suffix` === next)({
+        client,
+        pageSize: 123,
+        getParams: {
+          url: '/ep',
+          paginationField: 'nextPage',
+        },
+      }))).flat()
+      expect(result).toEqual([{ products: ['a', 'b'], nextPage: '/ep_suffix?page=p1' }, { products: ['c', 'd'] }])
+      expect(client.getSinglePage).toHaveBeenCalledTimes(2)
+      expect(client.getSinglePage).toHaveBeenCalledWith({ url: '/ep' })
+      expect(client.getSinglePage).toHaveBeenCalledWith({ url: '/ep', queryParams: { page: 'p1' } })
     })
   })
 

--- a/packages/stripe-adapter/src/adapter.ts
+++ b/packages/stripe-adapter/src/adapter.ts
@@ -59,7 +59,7 @@ export default class StripeAdapter implements AdapterOperations {
     this.client = client
     this.paginator = createPaginator({
       client: this.client,
-      paginationFunc: getWithCursorPagination,
+      paginationFunc: getWithCursorPagination(),
     })
     this.filtersRunner = filtersRunner(
       {

--- a/packages/stripe-adapter/test/adapter.test.ts
+++ b/packages/stripe-adapter/test/adapter.test.ts
@@ -186,7 +186,7 @@ describe('adapter', () => {
     })
   })
 
-  describe('endpoint overrides', () => {
+  describe('type overrides', () => {
     it('should fetch only the relevant types', async () => {
       const { elements } = await adapter.operations({
         credentials: new InstanceElement(

--- a/packages/stripe-adapter/test/filters/field_references.test.ts
+++ b/packages/stripe-adapter/test/filters/field_references.test.ts
@@ -33,7 +33,7 @@ describe('Field references filter', () => {
       client,
       paginator: clientUtils.createPaginator({
         client,
-        paginationFunc: clientUtils.getWithCursorPagination,
+        paginationFunc: clientUtils.getWithCursorPagination(),
       }),
       config: {
         [FETCH_CONFIG]: {

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -245,7 +245,7 @@ describe('adapter', () => {
       })
     })
 
-    describe('endpoint overrides', () => {
+    describe('type overrides', () => {
       it('should fetch only the relevant types', async () => {
         const { elements } = await adapter.operations({
           credentials: new InstanceElement(

--- a/packages/zuora-billing-adapter/src/client/pagination.ts
+++ b/packages/zuora-billing-adapter/src/client/pagination.ts
@@ -24,7 +24,7 @@ export const paginate: clientUtils.GetAllItemsFunc = async function *paginate({
 }) {
   if (getParams?.paginationField?.includes('next')) {
     // special handling for endpoints that use descending ids, like the recipes endpoint
-    yield* getWithCursorPagination({ client, pageSize, getParams })
+    yield* getWithCursorPagination()({ client, pageSize, getParams })
   } else {
     yield* getWithPageOffsetAndLastPagination(0)({ client, pageSize, getParams })
   }

--- a/packages/zuora-billing-adapter/test/filters/field_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/field_references.test.ts
@@ -33,7 +33,7 @@ describe('Field references filter', () => {
       client,
       paginator: clientUtils.createPaginator({
         client,
-        paginationFunc: clientUtils.getWithCursorPagination,
+        paginationFunc: clientUtils.getWithCursorPagination(),
       }),
       config: {
         fetch: {

--- a/packages/zuora-billing-adapter/test/filters/object_defs.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/object_defs.test.ts
@@ -305,7 +305,7 @@ describe('Object defs filter', () => {
       client,
       paginator: clientUtils.createPaginator({
         client,
-        paginationFunc: clientUtils.getWithCursorPagination,
+        paginationFunc: clientUtils.getWithCursorPagination(),
       }),
       config: {
         fetch: {

--- a/packages/zuora-billing-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/unordered_lists.test.ts
@@ -59,7 +59,7 @@ describe('Unordered lists filter', () => {
       client,
       paginator: clientUtils.createPaginator({
         client,
-        paginationFunc: clientUtils.getWithCursorPagination,
+        paginationFunc: clientUtils.getWithCursorPagination(),
       }),
       config: {
         fetch: {

--- a/packages/zuora-billing-adapter/test/filters/workflow_and_task_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/workflow_and_task_references.test.ts
@@ -244,7 +244,7 @@ describe('Workflow and task references filter', () => {
       client,
       paginator: clientUtils.createPaginator({
         client,
-        paginationFunc: clientUtils.getWithCursorPagination,
+        paginationFunc: clientUtils.getWithCursorPagination(),
       }),
       config: {
         fetch: {


### PR DESCRIPTION
A couple of additional infra improvements before the zendesk PR:
* Allow custom path validation on cursor pagination
* Support arrays of standalone fields in ducktype adapters


---
_Release Notes_: 
None

---
_User Notifications_: 
None