### PR TITLE
SALTO-1466 picklist promote

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -23,6 +23,7 @@ import customFieldTypeValidator from './change_validators/custom_field_type'
 import standardFieldLabelValidator from './change_validators/standard_field_label'
 import profileMapKeysValidator from './change_validators/profile_map_keys'
 import multipleDefaultsValidator from './change_validators/multiple_deafults'
+import picklistPromoteValidator from './change_validators/picklist_promote'
 
 const changeValidators: ChangeValidator[] = [
   packageValidator,
@@ -33,6 +34,7 @@ const changeValidators: ChangeValidator[] = [
   standardFieldLabelValidator,
   profileMapKeysValidator,
   multipleDefaultsValidator,
+  picklistPromoteValidator,
 ]
 
 export default createChangeValidator(changeValidators)

--- a/packages/salesforce-adapter/src/change_validators/picklist_promote.ts
+++ b/packages/salesforce-adapter/src/change_validators/picklist_promote.ts
@@ -49,19 +49,10 @@ const createChangeErrors = (pickListField: Field): ChangeError[] => {
  * Promoting picklist value-set to global is forbbiden
  */
 const changeValidator: ChangeValidator = async changes => {
-  
-  // validate that the changed picklist field has corresponding new global value set addition change
-  const valdiateCreatedGvsCreated = (change: Change): boolean => {
-    const ValueSetID = getChangeElement(change).annotations[VALUE_SET_FIELDS.VALUE_SET_NAME] as ReferenceExpression
-    const gvsFound = changes.filter(c => c.action === 'add'
-    && getChangeElement(c).elemID.getFullName() === ValueSetID.elemID.getFullName()).length !== 0
-    return gvsFound
-  }
 
   return awu(changes)
     .filter(isModificationChange)
     .filter(isGlobalPicklistChange)
-    .filter(valdiateCreatedGvsCreated)
     .map(getChangeElement)
     .flatMap(field => createChangeErrors(field as Field))
     .toArray()

--- a/packages/salesforce-adapter/src/change_validators/picklist_promote.ts
+++ b/packages/salesforce-adapter/src/change_validators/picklist_promote.ts
@@ -1,0 +1,70 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, ChangeError, Field, getAllChangeElements, isModificationChange, ChangeValidator,
+  getChangeElement, ReferenceExpression} from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { apiName, isCustom } from '../transformers/transformer'
+import { isPicklistField, isGlobalValueSetPicklistField } from '../filters/value_set'
+import { VALUE_SET_FIELDS } from '../constants'
+
+const { awu } = collections.asynciterable
+
+const isGlobalPicklistChange = async (change: Change): Promise<boolean> => {
+  const [before, after] = getAllChangeElements(change)
+  return isPicklistField(before) && isPicklistField(after) && isCustom(await apiName(before))
+  && !isGlobalValueSetPicklistField(before) && isGlobalValueSetPicklistField(after)
+}
+
+const createChangeErrors = (pickListField: Field): ChangeError[] => {
+  const gvsElemID = pickListField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME].elemID
+
+  return [{
+    elemID: pickListField.elemID,
+    severity: 'Error',
+    message: `You cannot promote a picklist value set to global one. Field: ${pickListField.name}`,
+    detailedMessage: 'You cannot promote a picklist value set to global one. Please promote via the service.',
+  },
+  {
+    elemID: gvsElemID,
+    severity: 'Error',
+    message: `You cannot create a global value set as a result of a picklist promote. Field: ${gvsElemID.name}`,
+    detailedMessage: 'You cannot promote a picklist value set to global one. Please promote via the service.',
+  }]
+}
+
+/**
+ * Promoting picklist value-set to global is forbbiden
+ */
+const changeValidator: ChangeValidator = async changes => {
+  
+  // validate that the changed picklist field has corresponding new global value set addition change
+  const valdiateCreatedGvsCreated = (change: Change): boolean => {
+    const ValueSetID = getChangeElement(change).annotations[VALUE_SET_FIELDS.VALUE_SET_NAME] as ReferenceExpression
+    const gvsFound = changes.filter(c => c.action === 'add'
+    && getChangeElement(c).elemID.getFullName() === ValueSetID.elemID.getFullName()).length !== 0
+    return gvsFound
+  }
+
+  return awu(changes)
+    .filter(isModificationChange)
+    .filter(isGlobalPicklistChange)
+    .filter(valdiateCreatedGvsCreated)
+    .map(getChangeElement)
+    .flatMap(field => createChangeErrors(field as Field))
+    .toArray()
+}
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/change_validators/picklist_promote.ts
+++ b/packages/salesforce-adapter/src/change_validators/picklist_promote.ts
@@ -14,11 +14,13 @@
 * limitations under the License.
 */
 import { Change, ChangeError, Field, getAllChangeElements, isModificationChange, ChangeValidator,
-  getChangeElement, ReferenceExpression} from '@salto-io/adapter-api'
+  getChangeElement, ReferenceExpression, SaltoErrorSeverity, ChangeDataType } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { apiName, isCustom } from '../transformers/transformer'
 import { isPicklistField, isGlobalValueSetPicklistField } from '../filters/value_set'
 import { VALUE_SET_FIELDS } from '../constants'
+import { isInstanceOfType } from '../filters/utils'
+import { GLOBAL_VALUE_SET } from '../filters/global_value_sets'
 
 const { awu } = collections.asynciterable
 
@@ -28,21 +30,42 @@ const isGlobalPicklistChange = async (change: Change): Promise<boolean> => {
   && !isGlobalValueSetPicklistField(before) && isGlobalValueSetPicklistField(after)
 }
 
-const createChangeErrors = (pickListField: Field): ChangeError[] => {
-  const gvsElemID = pickListField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME].elemID
-
-  return [{
+const createChangeErrors = (res: {pickListField: ChangeDataType, globalValueSetFound: boolean}): ChangeError[] => {
+  const {pickListField, globalValueSetFound} = res
+  const picklistErr = {
     elemID: pickListField.elemID,
-    severity: 'Error',
-    message: `You cannot promote a picklist value set to global one. Field: ${pickListField.name}`,
+    severity: 'Error' as SaltoErrorSeverity,
+    message: `You cannot promote a picklist value set to global one. Field: ${(pickListField as Field).name}`,
     detailedMessage: 'You cannot promote a picklist value set to global one. Please promote via the service.',
-  },
-  {
-    elemID: gvsElemID,
-    severity: 'Error',
-    message: `You cannot create a global value set as a result of a picklist promote. Field: ${gvsElemID.name}`,
-    detailedMessage: 'You cannot promote a picklist value set to global one. Please promote via the service.',
-  }]
+  }
+  // picklistField valueSetName annotation points to a valid GVS
+  if (globalValueSetFound) {
+    const gvsElemID = pickListField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME].value.elemID
+    const gvsErr = {
+      elemID: gvsElemID,
+      severity: 'Error' as SaltoErrorSeverity,
+      message: `You cannot create a global value set as a result of a picklist promote. Value list name: ${gvsElemID.name}`,
+      detailedMessage: 'You cannot create a global value set as a result of a picklist promote. Please promote via the service.',
+    }
+    return [picklistErr, gvsErr]
+  } else {
+    return [picklistErr]
+  }
+}
+
+// validate that the changed picklist field has corresponding new global value set addition change
+const valdiateCreatedGvsCreated = (changes: readonly Change[]) => {
+  return (change: Change): boolean => {
+    const referencedGvs = getChangeElement(change).annotations[VALUE_SET_FIELDS.VALUE_SET_NAME]
+    if (referencedGvs instanceof ReferenceExpression) {
+      const referencedValue = referencedGvs.value
+      if (isInstanceOfType(GLOBAL_VALUE_SET)(referencedValue)) {
+        return changes.filter(c => c.action === 'add'
+          && getChangeElement(c).elemID.getFullName() === referencedValue.elemID.getFullName()).length !== 0
+      }
+    }
+    return false
+  }
 }
 
 /**
@@ -50,12 +73,18 @@ const createChangeErrors = (pickListField: Field): ChangeError[] => {
  */
 const changeValidator: ChangeValidator = async changes => {
 
+  const gvsCreatedResolver = valdiateCreatedGvsCreated(changes)
+
   return awu(changes)
     .filter(isModificationChange)
     .filter(isGlobalPicklistChange)
-    .map(getChangeElement)
-    .flatMap(field => createChangeErrors(field as Field))
+    .map((change) => {
+      return { pickListField: getChangeElement(change), globalValueSetFound: gvsCreatedResolver(change) }
+    })
+    .flatMap(createChangeErrors)
     .toArray()
 }
+
+
 
 export default changeValidator

--- a/packages/salesforce-adapter/src/filters/value_set.ts
+++ b/packages/salesforce-adapter/src/filters/value_set.ts
@@ -40,7 +40,7 @@ export const isPicklistField = (changedElement: ChangeDataType): changedElement 
 export const isStandardValueSetPicklistField = (field: Field): boolean =>
   field.annotations[FIELD_ANNOTATIONS.VALUE_SET] instanceof ReferenceExpression
 
-const isGlobalValueSetPicklistField = (field: Field): boolean =>
+export const isGlobalValueSetPicklistField = (field: Field): boolean =>
   !_.isUndefined(field.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME])
 
 /**

--- a/packages/salesforce-adapter/test/change_validators/picklist_promote.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/picklist_promote.test.ts
@@ -14,8 +14,7 @@
 * limitations under the License.
 */
 import {
-  Change,
-  ElemID, Field, InstanceElement, ObjectType, ReferenceExpression, toChange,
+  Change, ElemID, Field, InstanceElement, ObjectType, ReferenceExpression, toChange,
 } from '@salto-io/adapter-api'
 import { Types } from '../../src/transformers/transformer'
 import picklistPromoteValidator from '../../src/change_validators/picklist_promote'
@@ -30,7 +29,6 @@ describe('picklist promote change validator', () => {
     const createGlobalValueSetInstanceElement = (): InstanceElement =>
       new InstanceElement('global_value_set_test', new ObjectType({
         elemID: new ElemID(constants.SALESFORCE, 'global_value_set'),
-        annotationRefsOrTypes: {},
         annotations: { [constants.METADATA_TYPE]: GLOBAL_VALUE_SET },
       }))
     const gvs: InstanceElement = createGlobalValueSetInstanceElement()

--- a/packages/salesforce-adapter/test/change_validators/picklist_promote.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/picklist_promote.test.ts
@@ -1,0 +1,103 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Change,
+  ElemID, Field, InstanceElement, ObjectType, ReferenceExpression, toChange,
+} from '@salto-io/adapter-api'
+import { Types } from '../../src/transformers/transformer'
+import picklistPromoteValidator from '../../src/change_validators/picklist_promote'
+import { API_NAME, VALUE_SET_FIELDS } from '../../src/constants'
+import { createField } from '../utils'
+import * as constants from '../../src/constants'
+import { GLOBAL_VALUE_SET } from '../../src/filters/global_value_sets'
+
+
+describe('picklist promote change validator', () => {
+  describe('onUpdate', () => {
+
+    const createGlobalValueSetInstanceElement = (): InstanceElement =>
+      new InstanceElement('global_value_set_test', new ObjectType({
+        elemID: new ElemID(constants.SALESFORCE, 'global_value_set'),
+        annotationRefsOrTypes: {},
+        annotations: { [constants.METADATA_TYPE]: GLOBAL_VALUE_SET },
+      }))
+
+    const pickListFieldName = 'pick__c'
+    let obj: ObjectType
+    let beforeField: Field
+    let afterField: Field
+    let gvs: InstanceElement
+    let pickListChange: Change
+    let gvsChange: Change
+    beforeEach(() => {
+      obj = new ObjectType({
+        elemID: new ElemID('salesforce', 'obj'),
+      })
+      beforeField = createField(obj, Types.primitiveDataTypes.Picklist, pickListFieldName)
+      beforeField.name = pickListFieldName
+      gvs = createGlobalValueSetInstanceElement()
+      afterField = createAfterField(beforeField)
+      pickListChange = toChange({ before: beforeField, after: afterField })
+      gvsChange = toChange({after: gvs})
+    })
+
+    const createAfterField = (beforeField: Field): Field => {
+      const afterField = beforeField.clone()
+      afterField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME] = new ReferenceExpression(new ElemID(''), gvs)
+      return afterField
+    }
+    
+    it('should have created 2 errors (for picklist & value-set)', async () => {
+      const changeErrors = await picklistPromoteValidator([pickListChange, gvsChange])
+      expect(changeErrors).toHaveLength(2)
+      const errorElemsNamesSet = new Set(changeErrors.map((changeErr) => changeErr.elemID.name))
+      expect(errorElemsNamesSet).toEqual(new Set(['pick__c', 'global_value_set_test']))
+    })
+
+    it('should have created just picklist error when value-set change doesn\'t exist', async () => {
+      const changeErrors = await picklistPromoteValidator([pickListChange])
+      expect(changeErrors).toHaveLength(1)
+      const errorElemsNamesSet = new Set(changeErrors.map((changeErr) => changeErr.elemID.name))
+      expect(new Set(['pick__c'])).toEqual(errorElemsNamesSet)
+    })
+
+    it('should have created just picklist error when extra change isn\'t reference', async () => {
+      afterField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME] = "some string"
+      const changeErrors = await picklistPromoteValidator([pickListChange, gvsChange])
+      expect(changeErrors).toHaveLength(1)
+      const errorElemsNamesSet = new Set(changeErrors.map((changeErr) => changeErr.elemID.name))
+      expect(new Set(['pick__c'])).toEqual(errorElemsNamesSet)
+    })
+
+    it('should not have errors for non-custom picklist', async () => {
+      beforeField.annotations[API_NAME] = 'pick'
+      const changeErrors = await picklistPromoteValidator([pickListChange, gvsChange])
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('should not have errors for already global value-set picklist field', async () => {
+      beforeField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME] = 'something'
+      const changeErrors = await picklistPromoteValidator([pickListChange, gvsChange])
+      expect(changeErrors).toHaveLength(0)
+    })
+    
+    it('should not have errors for moving to a non-global value-set change', async () => {
+      delete afterField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME]
+      const changeErrors = await picklistPromoteValidator([pickListChange])
+      expect(changeErrors).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
Adds a change validator to salesforce, prohibiting a picklist field to have a change of regular value-set to a global one (promotion). will add another change-error for the global value-set creation itself.

---

_Release Notes_: 

Salesforce adapter:
* Salto will now return an error when when attempting to promote a picklist value-set to a global one.
---
_User Notifications_: 
_NA_
