### PR TITLE
modify plan to add modify changes instead of merging remove and add changes (SALTO-1017)

### DIFF
--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -22,7 +22,7 @@ import {
   Value, isReferenceExpression, compareSpecialValues, BuiltinTypesByFullName, isAdditionChange,
   isModificationChange, isRemovalChange,
 } from '@salto-io/adapter-api'
-import { DataNodeMap, GroupedNodeMap, DiffNode, mergeNodesToModify, DiffGraph, Group } from '@salto-io/dag'
+import { DataNodeMap, GroupedNodeMap, DiffNode, DiffGraph, Group } from '@salto-io/dag'
 import { logger } from '@salto-io/logging'
 import { expressions, elementSource } from '@salto-io/workspace'
 import { collections, values } from '@salto-io/lowerdash'
@@ -167,21 +167,42 @@ const addDifferentElements = (
 ): PlanTransformer => graph => log.time(async () => {
   const outputGraph = graph.clone()
   const sieve = new Set<string>()
+
   const toChange = (
-    elem: ChangeDataType,
-    action: Change['action'] & ('add' | 'remove')
+    beforeElem?: ChangeDataType,
+    afterElem?: ChangeDataType
   ): DiffNode<ChangeDataType> => {
-    if (action === 'add') {
-      return { originalId: elem.elemID.getFullName(), action, data: { after: elem } }
+    if (beforeElem !== undefined && afterElem !== undefined) {
+      return {
+        originalId: beforeElem.elemID.getFullName(),
+        action: 'modify',
+        data: { before: beforeElem, after: afterElem },
+      }
     }
-    return { originalId: elem.elemID.getFullName(), action, data: { before: elem } }
+    if (beforeElem !== undefined) {
+      return {
+        originalId: beforeElem.elemID.getFullName(),
+        action: 'remove',
+        data: { before: beforeElem },
+      }
+    }
+    if (afterElem !== undefined) {
+      return {
+        originalId: afterElem.elemID.getFullName(),
+        action: 'add',
+        data: { after: afterElem },
+      }
+    }
+    throw new Error('either before or after needs to be defined')
   }
 
   const addElemToOutputGraph = (
-    elem: ChangeDataType,
-    action: Change['action'] & ('add' | 'remove')
+    beforeElem? : ChangeDataType,
+    afterElem?: ChangeDataType
   ): void => {
-    outputGraph.addNode(changeId(elem, action), [], toChange(elem, action))
+    const change = toChange(beforeElem, afterElem)
+    const elem = getChangeElement(change)
+    outputGraph.addNode(changeId(elem, change.action), [], change)
   }
 
   const addNodeIfDifferent = async (
@@ -194,12 +215,7 @@ const addDifferentElements = (
     if (!sieve.has(fullname)) {
       sieve.add(fullname)
       if (!await isEqualsNode(beforeNode, afterNode, before, after)) {
-        if (values.isDefined(beforeNode)) {
-          addElemToOutputGraph(beforeNode, 'remove')
-        }
-        if (values.isDefined(afterNode)) {
-          addElemToOutputGraph(afterNode, 'add')
-        }
+        addElemToOutputGraph(beforeNode, afterNode)
       }
     }
   }
@@ -265,7 +281,7 @@ const resolveNodeElements = (
 ): PlanTransformer => async graph => {
   const beforeItemsToResolve: ChangeDataType[] = []
   const afterItemsToResolve: ChangeDataType[] = []
-  graph.walkSync(id => {
+  wu(graph.keys()).forEach(id => {
     const change = graph.getData(id)
     if (change.action !== 'add') {
       beforeItemsToResolve.push(change.data.before)
@@ -284,7 +300,7 @@ const resolveNodeElements = (
     e => e.elemID.getFullName()
   ) as Record<string, ChangeDataType>
 
-  graph.walkSync(id => {
+  wu(graph.keys()).forEach(id => {
     const change = graph.getData(id)
     const resolvedChange = _.clone(change)
     if (isAdditionChange(resolvedChange)) {
@@ -341,24 +357,6 @@ export const defaultDependencyChangers = [
   addFieldToObjectDependency,
   addReferencesDependency,
 ]
-
-const addModifyNodes = (
-  addDependencies: PlanTransformer
-): PlanTransformer => {
-  const runMergeStep: PlanTransformer = async stepGraph => {
-    const mergedGraph = await addDependencies(stepGraph)
-    mergeNodesToModify(mergedGraph)
-    if (stepGraph.size !== mergedGraph.size) {
-      // Some of the nodes were merged, this may enable other nodes to be merged
-      // Note that with each iteration that changes the size we merge at least one node pair
-      // so if we have N node pairs this recursion will run at most N times
-      mergedGraph.clearEdges()
-      return runMergeStep(mergedGraph)
-    }
-    return mergedGraph
-  }
-  return runMergeStep
-}
 
 const removeRedundantFieldChanges = (
   graph: GroupedNodeMap<Change<ChangeDataType>>
@@ -417,7 +415,7 @@ export const getPlan = async ({
     const diffGraph = await buildDiffGraph(
       addDifferentElements(before, after, topLevelFilters, numBeforeElements + numAfterElements),
       resolveNodeElements(before, after),
-      addModifyNodes(addNodeDependencies(dependencyChangers)),
+      addNodeDependencies(dependencyChangers),
     )
     const filterResult = await filterInvalidChanges(
       before, after, diffGraph, changeValidators,

--- a/packages/dag/src/diff.ts
+++ b/packages/dag/src/diff.ts
@@ -13,7 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
 import wu from 'wu'
 import { collections } from '@salto-io/lowerdash'
 import { NodeId, DataNodeMap } from './nodemap'
@@ -77,87 +76,3 @@ export const removeEqualNodes = <T>(equals: NodeEqualityFunc<T>): DiffGraphTrans
     return outputGraph
   }
 )
-
-const mergeNodes = <T>(
-  target: DiffGraph<T>, oldIds: NodeId[], newId: NodeId, newData: DiffNode<T>
-): void => {
-  const deps = new Set<NodeId>(
-    wu.chain(...oldIds.map(id => target.get(id)))
-      // filter out old nodes from dependency list
-      .filter(id => !oldIds.includes(id))
-  )
-
-  target.addNode(newId, deps, newData)
-
-  // update reverse deps to new node
-  oldIds.forEach(id => {
-    target.deleteNode(id).forEach(affected => target.addEdge(affected, newId))
-  })
-}
-
-const tryCreateModificationNode = <T>(
-  target: DiffGraph<T>,
-  additionNodeId: NodeId,
-  removalNodeId: NodeId,
-): DiffGraph<T> => {
-  const edgeCausesCycle = (from: NodeId, to: NodeId): boolean => {
-    const fromDeps = target.get(from)
-    // no modification required, this is already checked
-    if (fromDeps.has(to)) return false
-    const toDeps = target.get(to)
-    const newEdges = new Map([
-      [from, new Set([...fromDeps, to])],
-      // Remove edge in the reverse direction to avoid a false positive cycle
-      [to, new Set(wu(toDeps).filter(dep => dep !== from))],
-    ])
-    return target.doesCreateCycle(newEdges, from)
-  }
-  // for cycle detection, merging the nodes is equivalent to adding edges in both directions
-  // (obviously not at the same time, because that would create a cycle)
-  if (edgeCausesCycle(additionNodeId, removalNodeId)
-      || edgeCausesCycle(removalNodeId, additionNodeId)) {
-    return target
-  }
-
-  const removalNode = target.getData(removalNodeId) as RemovalDiffNode<T>
-  const additionNode = target.getData(additionNodeId) as AdditionDiffNode<T>
-  const { originalId } = removalNode
-
-  const modificationNodeId = _.uniqueId()
-  const modificationNode: ModificationDiffNode<T> = {
-    action: 'modify',
-    originalId,
-    data: {
-      before: removalNode.data.before,
-      after: additionNode.data.after,
-    },
-  }
-
-  mergeNodes(target, [removalNodeId, additionNodeId], modificationNodeId, modificationNode)
-  return target
-}
-
-type Pair<T> = [T, T]
-const isPair = <T>(items: ReadonlyArray<T>): items is Pair<T> => (
-  items.length === 2
-)
-type SetIdPair = Pair<collections.set.SetId>
-
-export const mergeNodesToModify = <T>(target: DiffGraph<T>): void => {
-  const addBeforeRemove = (nodes: SetIdPair): SetIdPair => {
-    const [adds, removes] = _.partition(nodes, node => target.getData(node).action === 'add')
-    return [adds[0], removes[0]]
-  }
-
-  // Find all pairs of nodes pointing to the same original ID
-  const mergeCandidates = wu(
-    iterable.groupBy(target.keys(), id => target.getData(id).originalId).values()
-  ).filter(isPair)
-
-  mergeCandidates
-    .map(addBeforeRemove)
-    .reduce(
-      (graph, [add, remove]) => tryCreateModificationNode(graph, add, remove),
-      target,
-    )
-}

--- a/packages/dag/src/nodemap.ts
+++ b/packages/dag/src/nodemap.ts
@@ -230,8 +230,8 @@ export class AbstractNodeMap extends collections.map.DefaultMap<NodeId, Set<Node
     return wu(this.get(from)).some(d => this.hasCycle(d, new Set<NodeId>(visited)))
   }
 
-  *evaluationOrderGroups(): IterableIterator<Iterable<NodeId>> {
-    const dependencies = this.clone()
+  *evaluationOrderGroups(destructive = false): IterableIterator<Iterable<NodeId>> {
+    const dependencies = destructive ? this : this.clone()
     let nextNodes: Iterable<NodeId> = dependencies.keys()
 
     while (true) {
@@ -251,6 +251,17 @@ export class AbstractNodeMap extends collections.map.DefaultMap<NodeId, Set<Node
 
   evaluationOrder(): Iterable<NodeId> {
     return wu(this.evaluationOrderGroups()).flatten()
+  }
+
+  getCycles(): AbstractNodeMap {
+    const expensable = this.clone()
+    try {
+      wu(expensable.evaluationOrderGroups(true)).toArray()
+    } catch {
+      // The iteration will throw an error if cycles exists.
+      // We want to return them so we catch it.
+    }
+    return expensable
   }
 
   async walkAsyncDestructive(handler: AsyncNodeHandler): Promise<void> {

--- a/packages/dag/test/diff.test.ts
+++ b/packages/dag/test/diff.test.ts
@@ -13,10 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import wu from 'wu'
-import { collections } from '@salto-io/lowerdash'
 import { DataNodeMap } from '../src/nodemap'
-import { removeEqualNodes, DiffNode, DiffGraph, mergeNodesToModify, ModificationDiff } from '../src/diff'
+import { removeEqualNodes, DiffNode, DiffGraph } from '../src/diff'
 
 describe('DiffGraph functions', () => {
   const diffNode = <T>(
@@ -87,79 +85,6 @@ describe('DiffGraph functions', () => {
       })
       it('should not remove the nodes', () => {
         expect(subject.size).toBe(2)
-      })
-    })
-  })
-
-  describe('mergeNodesToModify', () => {
-    describe('when add and remove are not of the same id', () => {
-      beforeEach(async () => {
-        graph.addNode('remove', [], diffNode(1, 'remove', 'data'))
-        graph.addNode('add', [], diffNode(2, 'add', 'data'))
-
-        subject = graph.clone()
-        mergeNodesToModify(subject)
-      })
-      it('should not merge nodes', () => {
-        expect(subject.size).toBe(2)
-      })
-    })
-    describe('when add and remove are of the same id', () => {
-      describe('when add and remove can be merged with no cycle', () => {
-        beforeEach(async () => {
-          graph.addNode(1, [3], diffNode(1, 'remove', 'before'))
-          graph.addNode(2, [1, 4], diffNode(1, 'add', 'after'))
-          graph.addNode(3, [], diffNode(2, 'add', ''))
-          graph.addNode(4, [], diffNode(3, 'add', ''))
-          graph.addNode(5, [1], diffNode(4, 'add', ''))
-          graph.addNode(6, [2], diffNode(5, 'add', ''))
-
-          subject = graph.clone()
-          mergeNodesToModify(subject)
-        })
-        it('should merge the nodes', () => {
-          expect(subject.size).toBe(graph.size - 1)
-        })
-        describe('merged node', () => {
-          let mergedId: collections.set.SetId
-          let mergedNode: DiffNode<string>
-          let deps: Set<collections.set.SetId>
-          beforeEach(() => {
-            [mergedId] = wu(subject.keys()).filter(key => subject.getData(key).originalId === 1)
-            mergedNode = subject.getData(mergedId)
-            deps = subject.get(mergedId)
-          })
-          it('should have modification action', () => {
-            expect(mergedNode.action).toEqual('modify')
-          })
-          it('should have before and after data', () => {
-            expect((mergedNode as ModificationDiff<string>).data.before).toEqual('before')
-            expect((mergedNode as ModificationDiff<string>).data.after).toEqual('after')
-          })
-          it('should have the same original id', () => {
-            expect(mergedNode.originalId).toEqual(1)
-          })
-          it('should have the dependencies of both original nodes', () => {
-            expect(deps).toEqual(new Set([3, 4]))
-          })
-          it('should have the reverse dependencies of original nodes', () => {
-            expect(subject.get(5)).toContain(mergedId)
-            expect(subject.get(6)).toContain(mergedId)
-          })
-        })
-      })
-      describe('when merging add and remove would cause a cycle', () => {
-        beforeEach(async () => {
-          graph.addNode(1, [], diffNode(1, 'add', 'after'))
-          graph.addNode(2, [1, 3], diffNode(1, 'remove', 'before'))
-          graph.addNode(3, [1], diffNode(2, 'add', 'data'))
-
-          subject = graph.clone()
-          mergeNodesToModify(subject)
-        })
-        it('should not merge the nodes', () => {
-          expect(subject).toEqual(graph)
-        })
       })
     })
   })

--- a/packages/dag/test/nodemap.test.ts
+++ b/packages/dag/test/nodemap.test.ts
@@ -456,6 +456,33 @@ describe('NodeMap', () => {
       })
     })
   })
+  describe('get cycles', () => {
+    describe('for a graph with no cycles', () => {
+      beforeEach(() => {
+        subject.addNode(1, [3])
+        subject.addNode(2, [3])
+        subject.addNode(3, [])
+      })
+      it('should return an empty map', () => {
+        expect(subject.getCycles().size).toEqual(0)
+      })
+    })
+
+    describe('for a graph with cycles', () => {
+      beforeEach(() => {
+        subject.addNode(1, [6])
+        subject.addNode(2, [3])
+        subject.addNode(3, [4])
+        subject.addNode(4, [2])
+        subject.addNode(5, [6])
+        subject.addNode(6, [])
+      })
+
+      it('should return the cycles', () => {
+        expect([...subject.getCycles().keys()]).toEqual([2, 3, 4])
+      })
+    })
+  })
 
   describe('evaluationOrder', () => {
     let res: NodeId[]


### PR DESCRIPTION
_modify plan to add modify changes instead of merging remove and add changes_

---
Currently, the plan fails due to circular dependencies in a few cases in which there is no real limitation on the deployment plan. This PR address to such issues:
1) Cycles that are created by modify changes
2) Cycles that are created by by dependencies between changes which are in the same changes group (and are therefor, by definition, handles by the service.

To fix this this PR:
1.  Reverted the behaviour of adding modify changes as add+remove changes and merging them only if they do not create a cycle (as we realised they *never* create a cycle) 
2. Removed evaluation order calls on the single change diff graph (since it is not grouped, and can therefor contain cycles which causes the call to throw an error) 
3. Fixed a bug in the graph grouping function which caused it create a graph without cycles even if such cycles exists.
4. Added a method in the node map to return the cycles instead of throwing an error in order to throw a proper error in the group graph function (up until now, such error would only have been thrown *post* iteration. Since the iteration can be mutable (for example, a deploy) its a good idea to fail fast on this one :)) 

---
_Release Notes_: 
_Fixed Salto fails to deploy changes due to false dependencies cycles_

---
_User Notifications_: 
_NA_
