### PR TITLE
fixed restore create multiple remove changes for object with multiple path hints (SALTO-1532)

### DIFF
--- a/packages/core/src/core/restore.ts
+++ b/packages/core/src/core/restore.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ElemID, DetailedChange } from '@salto-io/adapter-api'
+import { ElemID, DetailedChange, isRemovalChange } from '@salto-io/adapter-api'
 import { filterByID, applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { pathIndex, ElementSelector, elementSource, remoteMap } from '@salto-io/workspace'
@@ -27,7 +27,7 @@ const splitChangeByPath = async (
   index: pathIndex.PathIndex
 ): Promise<DetailedChange[]> => {
   const changeHints = await pathIndex.getFromPathIndex(change.id, index)
-  if (_.isEmpty(changeHints)) {
+  if (_.isEmpty(changeHints) || isRemovalChange(change)) {
     return [change]
   }
   return Promise.all(changeHints.map(async hint => {

--- a/packages/core/test/core/restore.test.ts
+++ b/packages/core/test/core/restore.test.ts
@@ -208,4 +208,18 @@ describe('restore', () => {
       })
     })
   })
+
+  describe('with remove changes for elements with multiple path hints', () => {
+    let changes: DetailedChange[]
+    beforeAll(async () => {
+      changes = await createRestoreChanges(
+        createElementSource([multiPathObjMerged]),
+        createElementSource([]),
+        index
+      )
+    })
+    it('should return only on change (avoid spliting by path hint)', () => {
+      expect(changes).toHaveLength(1)
+    })
+  })
 })


### PR DESCRIPTION
_fixed restore create multiple remove changes for object with multiple path hints_

---

When an element exists in the state but not in the workspace, a remove change is created by restore for the element. If the element has multiple entries in the path index, the split change by path hint method would have generated multiple remove changes. When identical remove changes are applied to the update nacl files bad things can happen. (In this bug case, the field was removed multiple time which caused the buffer manipulation to create a broken nack)

---
_Release Notes_: 
_Fixed restore can create bad nacls_

---
_User Notifications_: 
_NA_
