### PR TITLE
Salto 1460 - LightningPage should have parent relation to the CustomObject

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -321,6 +321,7 @@ export const SETTINGS_METADATA_TYPE = 'Settings'
 export const TERRITORY2_TYPE = 'Territory2'
 export const TERRITORY2_MODEL_TYPE = 'Territory2Model'
 export const TERRITORY2_RULE_TYPE = 'Territory2Rule'
+export const LIGHTNING_PAGE_TYPE = 'LightningPage'
 
 // Retrieve constants
 export const RETRIEVE_LOAD_OF_METADATA_ERROR_REGEX = /Load of metadata from db failed for metadata of type:(?<type>\w+) and file name:(?<instance>\w+).$/

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -322,6 +322,7 @@ export const TERRITORY2_TYPE = 'Territory2'
 export const TERRITORY2_MODEL_TYPE = 'Territory2Model'
 export const TERRITORY2_RULE_TYPE = 'Territory2Rule'
 export const LIGHTNING_PAGE_TYPE = 'LightningPage'
+export const FLEXI_PAGE_TYPE = 'FlexiPage'
 
 // Retrieve constants
 export const RETRIEVE_LOAD_OF_METADATA_ERROR_REGEX = /Load of metadata from db failed for metadata of type:(?<type>\w+) and file name:(?<instance>\w+).$/

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -595,7 +595,7 @@ const fixDependentInstancesPathAndSetParent = async (
 
   const getDependentobjectID = async (
     instance: InstanceElement
-  ): Promise<string> => {
+  ): Promise<string | undefined> => {
     switch (await metadataType(instance)) {
       case LEAD_CONVERT_SETTINGS_METADATA_TYPE:
         return 'Lead'
@@ -603,7 +603,7 @@ const fixDependentInstancesPathAndSetParent = async (
         if (hasSobjectField(instance)) {
           return instance.value.sobjectType
         }
-        return ''
+        return undefined
       default:
         return parentApiName(instance)
     }
@@ -612,8 +612,11 @@ const fixDependentInstancesPathAndSetParent = async (
   const getDependentCustomObj = async (
     instance: InstanceElement
   ): Promise<ObjectType | undefined> => {
-    const objectID = apiNameToCustomObject.get(await getDependentobjectID(instance))
-    const object = objectID !== undefined ? await referenceElements.get(objectID) : undefined
+    const dependentobjID = await getDependentobjectID(instance)
+    const objectID = dependentobjID !== undefined
+      ? apiNameToCustomObject.get(dependentobjID) : undefined
+    const object = objectID !== undefined
+      ? await referenceElements.get(objectID) : undefined
     return isObjectType(object) ? object : undefined
   }
 

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -598,19 +598,21 @@ const fixDependentInstancesPathAndSetParent = async (
   const hasSobjectField = (instance: InstanceElement): boolean =>
     isDefined(instance.value.sobjectType)
 
+  const getCustomObjectParent = async (
+    instance: InstanceElement
+  ): Promise<ObjectType | undefined> => {
+    if (await hasCustomObjectParent(instance)) {
+      return getDependentCustomObj(instance)
+    } if (instance.elemID.typeName === LIGHTNING_PAGE_TYPE && hasSobjectField(instance)) {
+      return findObjectType(elements, new ElemID('salesforce', instance.value.sobjectType))
+    }
+    return undefined
+  }
+
   await awu(elements)
     .filter(isInstanceElement)
     .forEach(async instance => {
-      let customObj
-      if (await hasCustomObjectParent(instance)) {
-        customObj = await getDependentCustomObj(instance)
-      } else if (instance.elemID.typeName === LIGHTNING_PAGE_TYPE && hasSobjectField(instance)) {
-        customObj = findObjectType(elements, new ElemID('salesforce', instance.value.sobjectType))
-        // eslint-disable-next-line no-console
-        console.log(instance)
-      } else {
-        return
-      }
+      const customObj = await getCustomObjectParent(instance)
       if (_.isUndefined(customObj)) {
         return
       }

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -595,24 +595,24 @@ const fixDependentInstancesPathAndSetParent = async (
 
   const getDependentobjectID = async (
     instance: InstanceElement
-  ): Promise<ElemID | undefined> => {
+  ): Promise<string> => {
     switch (await metadataType(instance)) {
       case LEAD_CONVERT_SETTINGS_METADATA_TYPE:
-        return apiNameToCustomObject.get('Lead')
-      case FLEXI_PAGE_TYPE || LIGHTNING_PAGE_TYPE:
+        return 'Lead'
+      case FLEXI_PAGE_TYPE:
         if (hasSobjectField(instance)) {
-          return apiNameToCustomObject.get(instance.value.sobjectType)
+          return instance.value.sobjectType
         }
-        return undefined
+        return ''
       default:
-        return apiNameToCustomObject.get(await parentApiName(instance))
+        return parentApiName(instance)
     }
   }
 
   const getDependentCustomObj = async (
     instance: InstanceElement
   ): Promise<ObjectType | undefined> => {
-    const objectID = await getDependentobjectID(instance)
+    const objectID = apiNameToCustomObject.get(await getDependentobjectID(instance))
     const object = objectID !== undefined ? await referenceElements.get(objectID) : undefined
     return isObjectType(object) ? object : undefined
   }

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
-import { collections, strings, multiIndex, promises, values as valuesIsDefiend } from '@salto-io/lowerdash'
+import { collections, strings, multiIndex, promises, values as lowerdashValues } from '@salto-io/lowerdash'
 import {
   ADAPTER, Element, Field, ObjectType, TypeElement, isObjectType, isInstanceElement, ElemID,
   BuiltinTypes, CORE_ANNOTATIONS, TypeMap, InstanceElement, Values, ReadOnlyElementsSource,
@@ -37,6 +37,7 @@ import {
   VALIDATION_RULES_METADATA_TYPE, BUSINESS_PROCESS_METADATA_TYPE, RECORD_TYPE_METADATA_TYPE,
   WEBLINK_METADATA_TYPE, INTERNAL_FIELD_TYPE_NAMES, CUSTOM_FIELD, NAME_FIELDS,
   COMPOUND_FIELD_TYPE_NAMES, INTERNAL_ID_ANNOTATION, INTERNAL_ID_FIELD, LIGHTNING_PAGE_TYPE,
+  FLEXI_PAGE_TYPE,
 } from '../constants'
 import { FilterCreator } from '../filter'
 import {
@@ -68,7 +69,7 @@ const { makeArray } = collections.array
 const { awu, groupByAsync, keyByAsync } = collections.asynciterable
 const { removeAsync } = promises.array
 const { mapValuesAsync, mapKeysAsync } = promises.object
-const { isDefined } = valuesIsDefiend
+const { isDefined } = lowerdashValues
 
 
 export const INSTANCE_REQUIRED_FIELD = 'required'
@@ -549,11 +550,15 @@ const workflowDependentMetadataTypes = new Set(Object.values(WORKFLOW_FIELD_TO_T
 const dependentMetadataTypes = new Set([CUSTOM_TAB_METADATA_TYPE, DUPLICATE_RULE_METADATA_TYPE,
   QUICK_ACTION_METADATA_TYPE, LEAD_CONVERT_SETTINGS_METADATA_TYPE,
   ASSIGNMENT_RULES_METADATA_TYPE, CUSTOM_OBJECT_TRANSLATION_METADATA_TYPE, SHARING_RULES_TYPE,
+  LIGHTNING_PAGE_TYPE, FLEXI_PAGE_TYPE,
   ...workflowDependentMetadataTypes.values(),
 ])
 
 const hasCustomObjectParent = async (instance: InstanceElement): Promise<boolean> =>
   dependentMetadataTypes.has(await metadataType(instance))
+
+const shouldAddElemName = async (instance: InstanceElement): Promise<boolean> =>
+  (await apiNameParts(instance)).length > 1 || await metadataType(instance) === FLEXI_PAGE_TYPE
 
 const fixDependentInstancesPathAndSetParent = async (
   elements: Element[],
@@ -573,7 +578,7 @@ const fixDependentInstancesPathAndSetParent = async (
             )
           )]
         : [pathNaclCase(instance.elemID.typeName)]),
-      ...((await apiNameParts(instance)).length > 1
+      ...(await shouldAddElemName(instance)
         ? [pathNaclCase(instance.elemID.name)] : []),
     ]
   }
@@ -585,34 +590,38 @@ const fixDependentInstancesPathAndSetParent = async (
     map: obj => obj.elemID,
   })
 
+  const hasSobjectField = (instance: InstanceElement): boolean =>
+    isDefined(instance.value.sobjectType)
+
+  const getDependentobjectID = async (
+    instance: InstanceElement
+  ): Promise<ElemID | undefined> => {
+    switch (await metadataType(instance)) {
+      case LEAD_CONVERT_SETTINGS_METADATA_TYPE:
+        return apiNameToCustomObject.get('Lead')
+      case FLEXI_PAGE_TYPE || LIGHTNING_PAGE_TYPE:
+        if (hasSobjectField(instance)) {
+          return apiNameToCustomObject.get(instance.value.sobjectType)
+        }
+        return undefined
+      default:
+        return apiNameToCustomObject.get(await parentApiName(instance))
+    }
+  }
+
   const getDependentCustomObj = async (
     instance: InstanceElement
   ): Promise<ObjectType | undefined> => {
-    const objectID = await metadataType(instance) === LEAD_CONVERT_SETTINGS_METADATA_TYPE
-      ? apiNameToCustomObject.get('Lead')
-      : apiNameToCustomObject.get(await parentApiName(instance))
+    const objectID = await getDependentobjectID(instance)
     const object = objectID !== undefined ? await referenceElements.get(objectID) : undefined
     return isObjectType(object) ? object : undefined
   }
 
-  const hasSobjectField = (instance: InstanceElement): boolean =>
-    isDefined(instance.value.sobjectType)
-
-  const getCustomObjectParent = async (
-    instance: InstanceElement
-  ): Promise<ObjectType | undefined> => {
-    if (await hasCustomObjectParent(instance)) {
-      return getDependentCustomObj(instance)
-    } if (instance.elemID.typeName === LIGHTNING_PAGE_TYPE && hasSobjectField(instance)) {
-      return findObjectType(elements, new ElemID('salesforce', instance.value.sobjectType))
-    }
-    return undefined
-  }
-
   await awu(elements)
     .filter(isInstanceElement)
+    .filter(hasCustomObjectParent)
     .forEach(async instance => {
-      const customObj = await getCustomObjectParent(instance)
+      const customObj = await getDependentCustomObj(instance)
       if (_.isUndefined(customObj)) {
         return
       }

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -30,7 +30,7 @@ import {
   CUSTOM_OBJECT, INSTANCE_FULL_NAME_FIELD, LABEL, NAMESPACE_SEPARATOR,
   API_NAME, FORMULA, LOOKUP_FILTER_FIELDS, CUSTOM_SETTINGS_TYPE,
   FIELD_DEPENDENCY_FIELDS, VALUE_SETTINGS_FIELDS, VALUE_SET_FIELDS,
-  CUSTOM_VALUE, VALUE_SET_DEFINITION_FIELDS,
+  CUSTOM_VALUE, VALUE_SET_DEFINITION_FIELDS, LIGHTNING_PAGE_TYPE,
   OBJECTS_PATH, INSTALLED_PACKAGES_PATH, TYPES_PATH, RECORDS_PATH,
   ASSIGNMENT_RULES_METADATA_TYPE, LEAD_CONVERT_SETTINGS_METADATA_TYPE, QUICK_ACTION_METADATA_TYPE,
   CUSTOM_TAB_METADATA_TYPE, CUSTOM_OBJECT_TRANSLATION_METADATA_TYPE, SHARING_RULES_TYPE,
@@ -1259,9 +1259,13 @@ describe('Custom Objects filter', () => {
           it('should change path of nested instances listed in nestedMetadatatypeToReplaceDirName', async () => {
             mockSingleSObject('Lead', [], false, true, false, 'Instance Label')
             result.push(customObjectInstance)
+            // eslint-disable-next-line no-console
+            console.log(customObjectInstance)
             await filter.onFetch(result)
             const [leadWebLink] = result.filter(o => o.elemID.name === 'Lead_WebLinkFullName')
             const leadWebLinkInstance = (leadWebLink as InstanceElement)
+            // eslint-disable-next-line no-console
+            console.log(leadWebLinkInstance)
             expect(leadWebLinkInstance.path).toEqual([SALESFORCE, OBJECTS_PATH, 'Lead', 'ButtonsLinksAndActions',
               leadWebLinkInstance.elemID.name])
           })
@@ -1446,6 +1450,31 @@ describe('Custom Objects filter', () => {
           it('should add PARENT annotation to quickAction instance', async () => {
             expect(quickActionInstance.annotations[CORE_ANNOTATIONS.PARENT])
               .toContainEqual(new ReferenceExpression(leadType.elemID))
+          })
+        })
+
+        describe('LightningPage', () => {
+          const recordPageType = new ObjectType({
+            elemID: new ElemID(SALESFORCE, LIGHTNING_PAGE_TYPE),
+            annotations: { [METADATA_TYPE]: LIGHTNING_PAGE_TYPE },
+          })
+          const recordPageInstance = new InstanceElement('LightningPageTest',
+            recordPageType,
+            { [INSTANCE_FULL_NAME_FIELD]: LIGHTNING_PAGE_TYPE,
+              sobjectType: 'Lead' })
+          // eslint-disable-next-line no-console
+          // console.log(recordPageInstance)
+          beforeEach(async () => {
+            await filter.onFetch([leadType, recordPageType, recordPageInstance])
+          })
+          it('should add PARENT annotation to Lightning page instance with sobjectType', async () => {
+            expect(recordPageInstance.annotations[CORE_ANNOTATIONS.PARENT])
+              .toContainEqual(new ReferenceExpression(leadType.elemID))
+          })
+
+          it('should change the path of Lightning page instance with sobjectType', async () => {
+            expect(recordPageInstance.path)
+              .toEqual([SALESFORCE, OBJECTS_PATH, 'Lead', LIGHTNING_PAGE_TYPE])
           })
         })
 

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -34,6 +34,7 @@ import {
   OBJECTS_PATH, INSTALLED_PACKAGES_PATH, TYPES_PATH, RECORDS_PATH,
   ASSIGNMENT_RULES_METADATA_TYPE, LEAD_CONVERT_SETTINGS_METADATA_TYPE, QUICK_ACTION_METADATA_TYPE,
   CUSTOM_TAB_METADATA_TYPE, CUSTOM_OBJECT_TRANSLATION_METADATA_TYPE, SHARING_RULES_TYPE,
+  FLEXI_PAGE_TYPE,
 } from '../../src/constants'
 import mockAdapter from '../adapter'
 import { findElements, createValueSetEntry, defaultFilterContext } from '../utils'
@@ -1259,13 +1260,9 @@ describe('Custom Objects filter', () => {
           it('should change path of nested instances listed in nestedMetadatatypeToReplaceDirName', async () => {
             mockSingleSObject('Lead', [], false, true, false, 'Instance Label')
             result.push(customObjectInstance)
-            // eslint-disable-next-line no-console
-            console.log(customObjectInstance)
             await filter.onFetch(result)
             const [leadWebLink] = result.filter(o => o.elemID.name === 'Lead_WebLinkFullName')
             const leadWebLinkInstance = (leadWebLink as InstanceElement)
-            // eslint-disable-next-line no-console
-            console.log(leadWebLinkInstance)
             expect(leadWebLinkInstance.path).toEqual([SALESFORCE, OBJECTS_PATH, 'Lead', 'ButtonsLinksAndActions',
               leadWebLinkInstance.elemID.name])
           })
@@ -1456,14 +1453,12 @@ describe('Custom Objects filter', () => {
         describe('LightningPage', () => {
           const recordPageType = new ObjectType({
             elemID: new ElemID(SALESFORCE, LIGHTNING_PAGE_TYPE),
-            annotations: { [METADATA_TYPE]: LIGHTNING_PAGE_TYPE },
+            annotations: { [METADATA_TYPE]: FLEXI_PAGE_TYPE },
           })
           const recordPageInstance = new InstanceElement('LightningPageTest',
             recordPageType,
             { [INSTANCE_FULL_NAME_FIELD]: LIGHTNING_PAGE_TYPE,
               sobjectType: 'Lead' })
-          // eslint-disable-next-line no-console
-          // console.log(recordPageInstance)
           beforeEach(async () => {
             await filter.onFetch([leadType, recordPageType, recordPageInstance])
           })
@@ -1474,7 +1469,7 @@ describe('Custom Objects filter', () => {
 
           it('should change the path of Lightning page instance with sobjectType', async () => {
             expect(recordPageInstance.path)
-              .toEqual([SALESFORCE, OBJECTS_PATH, 'Lead', LIGHTNING_PAGE_TYPE])
+              .toEqual([SALESFORCE, OBJECTS_PATH, 'Lead', LIGHTNING_PAGE_TYPE, 'LightningPageTest'])
           })
         })
 


### PR DESCRIPTION
added a parent relation to LightningPage that has a source object type and changed their path

---
_Release Notes_: 
 LightningPage will now have parent relation to the CustomObject