### PR TITLE
SALTO-1540: Support validating required values inside maps

### DIFF
--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -69,13 +69,14 @@ const validateAnnotations = async (
   elementsSource: ReadOnlyElementsSource
 ):
 Promise<ValidationError[]> => {
-  if (isObjectType(type) && !isReferenceExpression(value)) {
-    return awu(Object.keys(type.fields)).flatMap(
+  if ((isObjectType(type) || isMapType(type)) && !isReferenceExpression(value)) {
+    const objType = toObjectType(type, value)
+    return awu(Object.keys(objType.fields)).flatMap(
       // eslint-disable-next-line no-use-before-define
       async k => validateFieldAnnotations(
         elemID.createNestedID(k),
         value[k],
-        type.fields[k],
+        objType.fields[k],
         elementsSource,
       )
     ).toArray()

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -676,6 +676,35 @@ describe('Elements validation', () => {
           expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('reqNested', '1', 'bool'))
         })
 
+        it('should return error when element inside a map is missing a required field', async () => {
+          extType.fields.reqNested.refType = createRefToElmWithValue(
+            new MapType(await extType.fields.reqNested.getType())
+          )
+          extInst.refType = createRefToElmWithValue(extType)
+          extInst.value.reqNested = {
+            a: {
+              str: 'str',
+              num: 1,
+              bool: true,
+            },
+            b: {
+              str: 'str',
+            },
+          }
+
+          const errors = await validateElements(
+            [extInst],
+            createInMemoryElementSource([
+              extInst, extType, ...await getFieldsAndAnnoTypes(extType),
+            ])
+          )
+          expect(errors).toHaveLength(1)
+          expect(errors[0].message).toMatch(
+            `Field ${simpleType.fields.bool.name} is required but has no value`
+          )
+          expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('reqNested', 'b', 'bool'))
+        })
+
         it('should not return validation errors when the value is a legal reference', async () => {
           const refInst = new InstanceElement(
             'instWithRef',

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -1440,7 +1440,7 @@ describe('Elements validation', () => {
 
       it('should return error on inconsistent object map values', async () => {
         extInst.value.mapOfObject.invalid1 = 'aaa'
-        extInst.value.mapOfObject.invalid2 = { str: 2 }
+        extInst.value.mapOfObject.invalid2 = { str: 2, bool: true }
         const errors = await validateElements(
           [extInst],
           createInMemoryElementSource([
@@ -1449,11 +1449,23 @@ describe('Elements validation', () => {
             ...await getFieldsAndAnnoTypes(nestedType),
           ])
         )
-        expect(errors).toHaveLength(2)
-        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('mapOfObject', 'invalid1'))
-        expect(errors[1].elemID).toEqual(extInst.elemID.createNestedID('mapOfObject', 'invalid2', 'str'))
-        expect(errors[0].message).toMatch(new RegExp('Invalid value type for salto.simple$'))
-        expect(errors[1].message).toMatch(new RegExp('Invalid value type for string$'))
+        expect(errors).toHaveLength(4)
+        expect(errors).toContainEqual(expect.objectContaining({
+          elemID: extInst.elemID.createNestedID('mapOfObject', 'invalid1'),
+          error: 'Invalid value type for salto.simple',
+        }))
+        expect(errors).toContainEqual(expect.objectContaining({
+          elemID: extInst.elemID.createNestedID('mapOfObject', 'invalid1', 'bool'),
+          error: 'Field bool is required but has no value',
+        }))
+        expect(errors).toContainEqual(expect.objectContaining({
+          elemID: extInst.elemID.createNestedID('mapOfObject', 'invalid2', 'str'),
+          error: 'Invalid value type for string',
+        }))
+        expect(errors).toContainEqual(expect.objectContaining({
+          elemID: extInst.elemID.createNestedID('mapOfObject', 'invalid2', 'str'),
+          error: 'Value is not valid for field str expected one of: "str"',
+        }))
       })
 
       it('should not return error for list/object mismatch with empty array', async () => {


### PR DESCRIPTION
This fixes the validator code to emit a validation warning when a required value
is missing inside a map. before this it only worked in lists and objects.

---
_Release Notes_: 
- Fixed issue where we would not get validator errors when a required value was missing in a map

---
_User Notifications_: 
_None_
