### PR TITLE
SAAS-2785 Avoid failing deploy on invalid profile map structure

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/profile_map_keys.ts
+++ b/packages/salesforce-adapter/src/change_validators/profile_map_keys.ts
@@ -45,8 +45,8 @@ const getMapKeyErrors = async (
           errors.push({
             elemID: path,
             severity: 'Error',
-            message: `Unpexpected structure in profile ${after.value.fullName} field ${fieldName}: Nested value '${mapDef.key}' not found`,
-            detailedMessage: `Nested value '${mapDef.key}' not found in field '${fieldName}'`,
+            message: `Nested value '${mapDef.key}' not found in field '${fieldName}`,
+            detailedMessage: `Profile ${after.value.fullName} field ${fieldName}: Nested value '${mapDef.key}' not found`,
           })
           return undefined
         }

--- a/packages/salesforce-adapter/src/change_validators/profile_map_keys.ts
+++ b/packages/salesforce-adapter/src/change_validators/profile_map_keys.ts
@@ -41,6 +41,16 @@ const getMapKeyErrors = async (
     const mapDef = PROFILE_MAP_FIELD_DEF[fieldName]
     const findInvalidPaths: TransformFunc = async ({ value, path, field }) => {
       if (isObjectType(await field?.getType()) && path !== undefined) {
+        if (value[mapDef.key] === undefined) {
+          errors.push({
+            elemID: path,
+            severity: 'Error',
+            message: `Unpexpected structure in profile ${after.value.fullName} field ${fieldName}: Nested value '${mapDef.key}' not found`,
+            detailedMessage: `Profile ${after.value.fullName} field ${fieldName}: Nested value '${mapDef.key}' not found`,
+          })
+          return undefined
+        }
+
         // we reached the map's inner value
         const expectedPath = defaultMapper(value[mapDef.key]).slice(0, mapDef.nested ? 2 : 1)
         const pathParts = path.getFullNameParts().filter(part => !isNum(part))

--- a/packages/salesforce-adapter/src/change_validators/profile_map_keys.ts
+++ b/packages/salesforce-adapter/src/change_validators/profile_map_keys.ts
@@ -46,7 +46,7 @@ const getMapKeyErrors = async (
             elemID: path,
             severity: 'Error',
             message: `Unpexpected structure in profile ${after.value.fullName} field ${fieldName}: Nested value '${mapDef.key}' not found`,
-            detailedMessage: `Profile ${after.value.fullName} field ${fieldName}: Nested value '${mapDef.key}' not found`,
+            detailedMessage: `Nested value '${mapDef.key}' not found in field '${fieldName}'`,
           })
           return undefined
         }

--- a/packages/salesforce-adapter/test/change_validators/profile_map_keys.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/profile_map_keys.test.ts
@@ -162,7 +162,7 @@ describe('profile map keys change validator', () => {
     expect(changeErrors).toHaveLength(1)
     expect(changeErrors[0].severity).toEqual('Error')
     expect(changeErrors[0].elemID).toEqual(afterProfileInstance.elemID.createNestedID('fieldPermissions', 'Account', 'Contact'))
-    expect(changeErrors[0].detailedMessage).toEqual('Nested value \'field\' not found in field \'fieldPermissions\'')
+    expect(changeErrors[0].detailedMessage).toEqual('Profile Admin field fieldPermissions: Nested value \'field\' not found')
   })
 
   it('should not validate map keys on delete', async () => {

--- a/packages/salesforce-adapter/test/change_validators/profile_map_keys.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/profile_map_keys.test.ts
@@ -162,7 +162,7 @@ describe('profile map keys change validator', () => {
     expect(changeErrors).toHaveLength(1)
     expect(changeErrors[0].severity).toEqual('Error')
     expect(changeErrors[0].elemID).toEqual(afterProfileInstance.elemID.createNestedID('fieldPermissions', 'Account', 'Contact'))
-    expect(changeErrors[0].detailedMessage).toEqual('Profile Admin field fieldPermissions: Nested value \'field\' not found')
+    expect(changeErrors[0].detailedMessage).toEqual('Nested value \'field\' not found in field \'fieldPermissions\'')
   })
 
   it('should not validate map keys on delete', async () => {

--- a/packages/salesforce-adapter/test/change_validators/profile_map_keys.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/profile_map_keys.test.ts
@@ -127,6 +127,44 @@ describe('profile map keys change validator', () => {
     expect(changeErrors[3].detailedMessage).toEqual('Profile Admin field layoutAssignments: Incorrect map key Account_Account_Layout@bs, should be new_account_layout_name@s')
   })
 
+  it('should have error on invalid nacl structure', async () => {
+    const afterProfileObj = generateProfileType(true)
+    const afterProfileInstance = new InstanceElement(
+      'Admin',
+      afterProfileObj,
+      {
+        [INSTANCE_FULL_NAME_FIELD]: 'Admin',
+        applicationVisibilities: {
+          app1: { application: 'app1', default: true, visible: false },
+          app2: { application: 'app2', default: true, visible: false },
+        },
+        fieldPermissions: {
+          Account: {
+            AccountNumber: {
+              field: 'Account.AccountNumber',
+              editable: true,
+              readable: true,
+            },
+            Contact: {
+              // invalid
+              HasOptedOutOfEmail: {
+                field: 'Contact.HasOptedOutOfEmail',
+                editable: true,
+                readable: true,
+              },
+            },
+          },
+        },
+      },
+    )
+
+    const changeErrors = await runChangeValidator(profileInstance, afterProfileInstance)
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].elemID).toEqual(afterProfileInstance.elemID.createNestedID('fieldPermissions', 'Account', 'Contact'))
+    expect(changeErrors[0].detailedMessage).toEqual('Profile Admin field fieldPermissions: Nested value \'field\' not found')
+  })
+
   it('should not validate map keys on delete', async () => {
     breakInstanceMaps(profileInstance)
 


### PR DESCRIPTION
Avoid crashing in the change validator when the structure is not as expected.

---
_Release Notes_: 
Salesforce Adapter:
* Omit profiles with invalid structure instead of failing deploy.

---
_User Notifications_: 
None