### PR TITLE
SAAS-2785 Mark map key fields as required

### DIFF
--- a/packages/salesforce-adapter/test/filters/convert_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_maps.test.ts
@@ -92,6 +92,12 @@ describe('ProfileMaps filter', () => {
         expect(isMapType(fieldType)).toBeTruthy()
         expect(isListType((fieldType as MapType).getInnerType())).toBeFalsy()
       })
+      it('should mark the fields that are used for keys as _required=true', async () => {
+        expect(profileObj).toEqual(generateProfileType(true))
+        const fieldType = await profileObj.fields.applicationVisibilities.getType()
+        expect(isMapType(fieldType)).toBeTruthy()
+        expect(isListType((fieldType as MapType).getInnerType())).toBeFalsy()
+      })
       it('should convert instance values to maps', () => {
         expect((instances[0] as InstanceElement).value).toEqual({
           applicationVisibilities: {

--- a/packages/salesforce-adapter/test/utils.ts
+++ b/packages/salesforce-adapter/test/utils.ts
@@ -194,6 +194,13 @@ export const generateProfileType = (useMaps = false, preDeploy = false): ObjectT
     ? ProfileFieldLevelSecurity
     : new ListType(ProfileFieldLevelSecurity)
 
+  if (useMaps || preDeploy) {
+    // mark key fields as _required=true
+    ProfileApplicationVisibility.fields.application.annotations[CORE_ANNOTATIONS.REQUIRED] = true
+    ProfileLayoutAssignment.fields.layout.annotations[CORE_ANNOTATIONS.REQUIRED] = true
+    ProfileFieldLevelSecurity.fields.field.annotations[CORE_ANNOTATIONS.REQUIRED] = true
+  }
+
   return new ObjectType({
     elemID: new ElemID(constants.SALESFORCE, constants.PROFILE_METADATA_TYPE),
     fields: {


### PR DESCRIPTION
Mark fields used as map keys in profile subtypes as `_required = true` - if they do not exist, deploying the profile will fail when the maps are converted back before deploy.

---
_Release Notes_: 
Salesforce adapter:
* Marking a few fields in types related to profiles and business hours as `_required=true`.

---
_User Notifications_: 
Salesforce adapter:
A `_required=true` annotation was added under the following salesforce fields:
* `BusinessHoursEntry.name`
* `ProfileApexClassAccess.apexClass`
* `ProfileApexPageAccess.apexPage`
* `ProfileApplicationVisibility.application`
* `ProfileCategoryGroupVisibility.dataCategoryGroup`
* `ProfileCustomMetadataTypeAccess.name`
* `ProfileCustomPermissions.name`
* `ProfileCustomSettingAccess.name`
* `ProfileExternalDataSourceAccess.externalDataSource`
* `ProfileFieldLevelSecurity.field`
* `ProfileFlowAccess.flow`
* `ProfileLayoutAssignment.layout`
* `ProfileObjectPermissions.object`
* `ProfileRecordTypeVisibility.recordType`
* `ProfileUserPermission.name`
