### PR TITLE
update workspace on fetch even if no changes were made (fix SALTO-1543)

### DIFF
--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -234,25 +234,23 @@ export const updateWorkspace = async ({
   mode = 'default',
 }: UpdateWorkspaceParams): Promise<{ success: boolean; numberOfAppliedChanges: number }> => {
   let numberOfAppliedChanges = 0
-  if (changes.length > 0) {
-    await logWorkspaceUpdates(workspace, changes)
-    const updateNaclFilesResult = await workspace.updateNaclFiles(
-      changes.map(c => c.change),
-      mode,
-    )
-    numberOfAppliedChanges = updateNaclFilesResult.naclFilesChangesCount
-      + updateNaclFilesResult.stateOnlyChangesCount
-    const { status, errors } = await validateWorkspace(workspace)
-    const formattedErrors = await formatWorkspaceErrors(workspace, errors)
-    await printWorkspaceErrors(status, formattedErrors, output)
-    if (status === 'Error') {
-      log.warn(formattedErrors)
-      const shouldAbort = force || await shouldAbortWorkspaceInCaseOfValidationError(errors.length)
-      if (!shouldAbort) {
-        await workspace.flush()
-      }
-      return { success: false, numberOfAppliedChanges: 0 }
+  await logWorkspaceUpdates(workspace, changes)
+  const updateNaclFilesResult = await workspace.updateNaclFiles(
+    changes.map(c => c.change),
+    mode,
+  )
+  numberOfAppliedChanges = updateNaclFilesResult.naclFilesChangesCount
+    + updateNaclFilesResult.stateOnlyChangesCount
+  const { status, errors } = await validateWorkspace(workspace)
+  const formattedErrors = await formatWorkspaceErrors(workspace, errors)
+  await printWorkspaceErrors(status, formattedErrors, output)
+  if (status === 'Error') {
+    log.warn(formattedErrors)
+    const shouldAbort = force || await shouldAbortWorkspaceInCaseOfValidationError(errors.length)
+    if (!shouldAbort) {
+      await workspace.flush()
     }
+    return { success: false, numberOfAppliedChanges: 0 }
   }
   await workspace.flush()
   log.debug('finished updating workspace')

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -188,7 +188,7 @@ describe('fetch command', () => {
           })
         })
         it('should not update workspace', () => {
-          expect(workspace.updateNaclFiles).not.toHaveBeenCalled()
+          expect(workspace.updateNaclFiles).toHaveBeenCalledWith([], 'default')
           expect(telemetry.getEventsMap()[eventsNames.changes]).toHaveLength(1)
           expect(telemetry.getEventsMap()[eventsNames.changes][0].value).toEqual(0)
         })

--- a/packages/cli/test/workspace/workspace.test.ts
+++ b/packages/cli/test/workspace/workspace.test.ts
@@ -155,8 +155,8 @@ describe('workspace', () => {
   })
 
   describe('applyChangesToWorkspace', () => {
-    const approveChangesCallback = jest.fn().mockResolvedValue(true)
     const changes = dummyChanges.map(change => ({ change, serviceChange: change }))
+    const approveChangesCallback = jest.fn().mockResolvedValue(changes)
     beforeEach(() => {
       approveChangesCallback.mockClear()
     })


### PR DESCRIPTION
_update workspace on fetch even if no changes were made_

---
This fix solves an issue in which the workspace update method was not invoked by the cli if no changes were fetched during the fetch. This has caused state corruption since the state is set in the `core` method, and failing to update the workspace cases the hashes to go out of sync. 

---
_Release Notes_: 
_NA_

---
_User Notifications_: 
_NA_
