### PR TITLE
SALTO-1531: add data instance support in safe deploy change validator in Netsuite

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/safe_deploy.ts
+++ b/packages/netsuite-adapter/src/change_validators/safe_deploy.ts
@@ -43,7 +43,7 @@ export type QueryChangeValidator = (
 
 const { awu } = collections.asynciterable
 
-const getIdentifingValue = async (instance: InstanceElement): Promise<string> => (
+const getIdentifyingValue = async (instance: InstanceElement): Promise<string> => (
   instance.value[SCRIPT_ID] ?? instance.value[getTypeIdentifier(await instance.getType())]
 )
 const getIdentifingValuesByType = async (
@@ -52,7 +52,7 @@ const getIdentifingValuesByType = async (
   Object.fromEntries(await awu(Object.entries(instancesByType))
     .map(async ([type, instances]) => [
       type,
-      await awu(instances).map(inst => getIdentifingValue(inst)).toArray(),
+      await awu(instances).map(inst => getIdentifyingValue(inst)).toArray(),
     ])
     .toArray())
 )


### PR DESCRIPTION
Include data instances in safe deploy change validator, in order to warn the user if an instance was changed in the service since the last fetch.
---

originally we only supported custom types and fileCabinet types.

---
_Release Notes_: 
Netsuite Adapter: When attempting to deploy a data instance which has changed in the service since the last fetch, a warning will be shown (previously supported only custom types and file cabinet types).
---
_User Notifications_: 
None
