### PR TITLE
SALTO-1508 standard picklist fix

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/picklist_promote.ts
+++ b/packages/salesforce-adapter/src/change_validators/picklist_promote.ts
@@ -17,7 +17,7 @@ import { Change, ChangeError, Field, getAllChangeElements, isModificationChange,
   getChangeElement, isFieldChange, ModificationChange, ElemID, isReferenceExpression } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { apiName, isCustom } from '../transformers/transformer'
-import { isPicklistField, isGlobalValueSetPicklistField } from '../filters/value_set'
+import { isPicklistField, hasValueSetNameAnnotation } from '../filters/value_set'
 import { VALUE_SET_FIELDS } from '../constants'
 import { isInstanceOfType } from '../filters/utils'
 import { GLOBAL_VALUE_SET } from '../filters/global_value_sets'
@@ -27,7 +27,7 @@ const { awu } = collections.asynciterable
 const isGlobalPicklistChange = async (change: Change): Promise<boolean> => {
   const [before, after] = getAllChangeElements(change)
   return isPicklistField(before) && isPicklistField(after) && isCustom(await apiName(before))
-  && !isGlobalValueSetPicklistField(before) && isGlobalValueSetPicklistField(after)
+  && !hasValueSetNameAnnotation(before) && hasValueSetNameAnnotation(after)
 }
 
 const createChangeErrors = ({ pickListField, gvsElemID }:

--- a/packages/salesforce-adapter/src/change_validators/picklist_standard_field.ts
+++ b/packages/salesforce-adapter/src/change_validators/picklist_standard_field.ts
@@ -25,15 +25,15 @@ import { VALUE_SET_FIELDS } from '../constants'
 
 const { awu } = collections.asynciterable
 
-const isStandardValueSet = async (plField: Field): Promise<boolean> => {
+const isStandardValueSet = async (picklistField: Field): Promise<boolean> => {
   const standardVSchecker = isInstanceOfType(STANDARD_VALUE_SET)
-  return isValueSetReference(plField)
-  && standardVSchecker(plField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME].value)
+  return isValueSetReference(picklistField)
+    && standardVSchecker(picklistField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME].value)
 }
 
 const shouldCreateChangeError = async (changeElement: ChangeDataType): Promise<boolean> =>
   isPicklistField(changeElement) && !isCustom(await apiName(changeElement))
-  && !(await isStandardValueSet(changeElement))
+    && !(await isStandardValueSet(changeElement))
 
 const createChangeError = (field: Field): ChangeError =>
   ({

--- a/packages/salesforce-adapter/src/change_validators/picklist_standard_field.ts
+++ b/packages/salesforce-adapter/src/change_validators/picklist_standard_field.ts
@@ -18,13 +18,18 @@ import {
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { apiName, isCustom } from '../transformers/transformer'
-import { isPicklistField, isStandardValueSetPicklistField } from '../filters/value_set'
+import { isPicklistField, isValueSetReference } from '../filters/value_set'
+import { VALUE_SET_FIELDS } from '../constants'
 
 const { awu } = collections.asynciterable
 
+const isStandardValueSet = (plField: Field): boolean =>
+  isValueSetReference(plField)
+  && plField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME].elemID.typeName === 'StandardValueSet'
+
 const shouldCreateChangeError = async (changeElement: ChangeDataType): Promise<boolean> =>
   isPicklistField(changeElement) && !isCustom(await apiName(changeElement))
-  && !isStandardValueSetPicklistField(changeElement)
+  && !isStandardValueSet(changeElement)
 
 const createChangeError = (field: Field): ChangeError =>
   ({

--- a/packages/salesforce-adapter/src/change_validators/picklist_standard_field.ts
+++ b/packages/salesforce-adapter/src/change_validators/picklist_standard_field.ts
@@ -14,22 +14,24 @@
 * limitations under the License.
 */
 import {
-  ChangeDataType, ChangeError, Field, getChangeElement, isModificationChange, ChangeValidator,
+  ChangeDataType, ChangeError, Field, getChangeElement, isModificationChange, ChangeValidator 
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { apiName, isCustom } from '../transformers/transformer'
 import { isPicklistField, isValueSetReference } from '../filters/value_set'
+import { STANDARD_VALUE_SET } from '../filters/standard_value_sets'
+import { isInstanceOfType } from '../filters/utils'
 import { VALUE_SET_FIELDS } from '../constants'
 
 const { awu } = collections.asynciterable
 
-const isStandardValueSet = (plField: Field): boolean =>
+const isStandardValueSet = async (plField: Field): Promise<boolean> =>
   isValueSetReference(plField)
-  && plField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME].elemID.typeName === 'StandardValueSet'
+  && await (isInstanceOfType(STANDARD_VALUE_SET)(plField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME].value))
 
 const shouldCreateChangeError = async (changeElement: ChangeDataType): Promise<boolean> =>
   isPicklistField(changeElement) && !isCustom(await apiName(changeElement))
-  && !isStandardValueSet(changeElement)
+  && !(await isStandardValueSet(changeElement))
 
 const createChangeError = (field: Field): ChangeError =>
   ({

--- a/packages/salesforce-adapter/src/change_validators/picklist_standard_field.ts
+++ b/packages/salesforce-adapter/src/change_validators/picklist_standard_field.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  ChangeDataType, ChangeError, Field, getChangeElement, isModificationChange, ChangeValidator 
+  ChangeDataType, ChangeError, Field, getChangeElement, isModificationChange, ChangeValidator,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { apiName, isCustom } from '../transformers/transformer'
@@ -25,9 +25,11 @@ import { VALUE_SET_FIELDS } from '../constants'
 
 const { awu } = collections.asynciterable
 
-const isStandardValueSet = async (plField: Field): Promise<boolean> =>
-  isValueSetReference(plField)
-  && await (isInstanceOfType(STANDARD_VALUE_SET)(plField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME].value))
+const isStandardValueSet = async (plField: Field): Promise<boolean> => {
+  const standardVSchecker = isInstanceOfType(STANDARD_VALUE_SET)
+  return isValueSetReference(plField)
+  && standardVSchecker(plField.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME].value)
+}
 
 const shouldCreateChangeError = async (changeElement: ChangeDataType): Promise<boolean> =>
   isPicklistField(changeElement) && !isCustom(await apiName(changeElement))

--- a/packages/salesforce-adapter/src/filters/value_set.ts
+++ b/packages/salesforce-adapter/src/filters/value_set.ts
@@ -16,8 +16,8 @@
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import {
-  Field, getChangeElement, isField, isModificationChange, ChangeDataType, ReferenceExpression,
-  InstanceElement, isInstanceChange, ModificationChange, isFieldChange,
+  Field, getChangeElement, isField, isModificationChange, ChangeDataType,
+  InstanceElement, isInstanceChange, ModificationChange, isFieldChange, isReferenceExpression,
 } from '@salto-io/adapter-api'
 
 import { FilterWith } from '../filter'
@@ -38,7 +38,7 @@ export const isPicklistField = (changedElement: ChangeDataType): changedElement 
     ]).includes(changedElement.refType.elemID.getFullName())
 
 export const isValueSetReference = (field: Field): boolean =>
-  field.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME] instanceof ReferenceExpression
+  isReferenceExpression(field.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME])
 
 export const hasValueSetNameAnnotation = (field: Field): boolean =>
   !_.isUndefined(field.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME])

--- a/packages/salesforce-adapter/src/filters/value_set.ts
+++ b/packages/salesforce-adapter/src/filters/value_set.ts
@@ -37,10 +37,10 @@ export const isPicklistField = (changedElement: ChangeDataType): changedElement 
       Types.primitiveDataTypes.MultiselectPicklist.elemID.getFullName(),
     ]).includes(changedElement.refType.elemID.getFullName())
 
-export const isStandardValueSetPicklistField = (field: Field): boolean =>
-  field.annotations[FIELD_ANNOTATIONS.VALUE_SET] instanceof ReferenceExpression
+export const isValueSetReference = (field: Field): boolean =>
+  field.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME] instanceof ReferenceExpression
 
-export const isGlobalValueSetPicklistField = (field: Field): boolean =>
+export const hasValueSetNameAnnotation = (field: Field): boolean =>
   !_.isUndefined(field.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME])
 
 /**
@@ -98,8 +98,7 @@ const filterCreator = (): FilterWith<'onDeploy'> => ({
         const field = getChangeElement(change)
         return (
           isRestrictedPicklistField(field)
-          && !isGlobalValueSetPicklistField(field)
-          && !isStandardValueSetPicklistField(field)
+          && !isValueSetReference(field)
         )
       })
       .forEach(change => {


### PR DESCRIPTION
Fix  standard picklist change-validator that reports false-positive on errors.
Change includes referring to the correct value-set annotation (valueSetName instead of valueSet) and checking that the referred value set is indeed standard (standardValueSet).

---

_Release Notes_: 

Salesforce adapter:
_NA_

---

_User Notifications_: 
_NA_
