### PR TITLE
SALTO-1533: Avoid sharing filter context between deploy calls

### DIFF
--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -13,7 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Stream } from 'stream'
 import {
   MetadataObject, DescribeValueTypeResult, MetadataInfo, SaveResult, UpsertResult,
   ListMetadataQuery, FileProperties, DescribeSObjectResult, BulkOptions, BulkLoadOperation,
@@ -43,7 +42,7 @@ export interface Metadata {
   retrieve(request: RetrieveRequest,
     callback?: Callback<RetrieveResult>): RetrieveResultLocator<RetrieveResult>
   deploy(
-    zipInput: Stream | Buffer | string, options: DeployOptions
+    zipInput: Buffer | string | NodeJS.ReadableStream, options: DeployOptions
   ): DeployResultLocator<DeployResult>
 }
 

--- a/packages/salesforce-adapter/test/connection.ts
+++ b/packages/salesforce-adapter/test/connection.ts
@@ -162,7 +162,7 @@ type GetDeployResultParams = {
   ignoreWarnings?: boolean
   checkOnly?: boolean
 }
-export const mockDeployResult = ({
+export const mockDeployResultComplete = ({
   success = true,
   componentSuccess = [],
   componentFailure = [],
@@ -170,31 +170,35 @@ export const mockDeployResult = ({
   ignoreWarnings = true,
   rollbackOnError = true,
   checkOnly = false,
-}: GetDeployResultParams): DeployResultLocator<DeployResult> => ({
-  complete: jest.fn().mockResolvedValue({
-    id: _.uniqueId(),
-    checkOnly,
-    completedDate: '2020-05-01T14:31:36.000Z',
-    createdDate: '2020-05-01T14:21:36.000Z',
-    done: true,
-    details: [{
-      componentFailures: componentFailure.map(mockDeployMessage),
-      componentSuccesses: componentSuccess.map(mockDeployMessage),
-      runTestResult: mockRunTestResult(runTestResult),
-    }],
-    ignoreWarnings,
-    lastModifiedDate: '2020-05-01T14:31:36.000Z',
-    numberComponentErrors: componentFailure.length,
-    numberComponentsDeployed: componentSuccess.length,
-    numberComponentsTotal: componentFailure.length + componentSuccess.length,
-    numberTestErrors: 0,
-    numberTestsCompleted: 0,
-    numberTestsTotal: 0,
-    rollbackOnError,
-    startDate: '2020-05-01T14:21:36.000Z',
-    status: success ? 'Succeeded' : 'Failed',
-    success,
-  } as DeployResult),
+}: GetDeployResultParams): DeployResult => ({
+  id: _.uniqueId(),
+  checkOnly,
+  completedDate: '2020-05-01T14:31:36.000Z',
+  createdDate: '2020-05-01T14:21:36.000Z',
+  done: true,
+  details: [{
+    componentFailures: componentFailure.map(mockDeployMessage),
+    componentSuccesses: componentSuccess.map(mockDeployMessage),
+    runTestResult: mockRunTestResult(runTestResult),
+  }],
+  ignoreWarnings,
+  lastModifiedDate: '2020-05-01T14:31:36.000Z',
+  numberComponentErrors: componentFailure.length,
+  numberComponentsDeployed: componentSuccess.length,
+  numberComponentsTotal: componentFailure.length + componentSuccess.length,
+  numberTestErrors: 0,
+  numberTestsCompleted: 0,
+  numberTestsTotal: 0,
+  rollbackOnError,
+  startDate: '2020-05-01T14:21:36.000Z',
+  status: success ? 'Succeeded' : 'Failed',
+  success,
+})
+
+export const mockDeployResult = (
+  params: GetDeployResultParams
+): DeployResultLocator<DeployResult> => ({
+  complete: jest.fn().mockResolvedValue(mockDeployResultComplete(params)),
 }) as unknown as DeployResultLocator<DeployResult>
 
 export const mockQueryResult = (

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -26,7 +26,7 @@ type ObjectTypeCtorParam = ConstructorParameters<typeof ObjectType>[0]
 type CreateMetadataObjectTypeParams = Omit<ObjectTypeCtorParam, 'elemID'> & {
   annotations: MetadataTypeAnnotations
 }
-const createMetadataObjectType = (
+export const createMetadataObjectType = (
   params: CreateMetadataObjectTypeParams
 ): MetadataObjectType => new ObjectType({
   elemID: new ElemID(SALESFORCE, params.annotations.metadataType),


### PR DESCRIPTION
This changes the usage pattern of the filters runner such that it will not allow
filters to accidentally share context between preDeploy and onDeploy of different
deploy calls

---

The problematic scenario was where two (or more) concurrent `adapter.deploy` calls were made, this could lead to the same filter instance getting called with `preDeploy` for deploy A, then `preDeploy` for deploy B before returning to `onDeploy` of deploy A.
for stateful filters this caused an issue since they rely on their state in `onDeploy` to match what they saw in `preDeploy`.

Changing the usage pattern such that every `adapter.deploy` call creates a new set of filter instances resolves this issue

---
_Release Notes_: 
Salesforce adapter:
- Fixed an issue where the workspace state was not properly updated after a `deploy` call that involved both metadata and data records

---
_User Notifications_: 
None
