### PR TITLE
SALTO-1550 throw more indicative error when field is missing

### DIFF
--- a/packages/core/test/core/plan/plan_item.test.ts
+++ b/packages/core/test/core/plan/plan_item.test.ts
@@ -228,9 +228,9 @@ describe('PlanItem', () => {
       expect(getChangeElement(modified as Change).annotations.str).toEqual('modified!')
     })
     it('should filter out changes where before and after were set as undefined', () => {
-      const droped = wu(modifiedPlanItem.changes())
+      const dropped = wu(modifiedPlanItem.changes())
         .find(change => getChangeElement(change).elemID.getFullName() === 'salto.filter')
-      expect(droped).not.toBeDefined()
+      expect(dropped).not.toBeDefined()
     })
     it('should keep changes that were not modified by the callback', () => {
       const kept = wu(modifiedPlanItem.changes())

--- a/packages/workspace/src/workspace/nacl_files/addition_wrapper.ts
+++ b/packages/workspace/src/workspace/nacl_files/addition_wrapper.ts
@@ -14,14 +14,11 @@
 * limitations under the License.
 */
 import { AdditionDiff } from '@salto-io/dag'
-import { logger } from '@salto-io/logging'
 import {
   Element, ElemID, ObjectType, InstanceElement, Value,
   isObjectType, isInstanceElement, PrimitiveType, isField, FieldDefinition, Field,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
-
-const log = logger(module)
 
 export type DetailedAddition = AdditionDiff<Value> & {
   id: ElemID
@@ -59,7 +56,6 @@ const createObjectTypeFromNestedAdditions = (
         const fieldName = nestedValue.id.createTopLevelParentID().path[0]
         const field = commonObjectType.fields[fieldName]
         if (field === undefined) {
-          log.error('field %s was not found in common object type %s', fieldName, commonObjectType.elemID.getFullName())
           throw new Error(`field ${fieldName} was not found in common object type ${commonObjectType.elemID.getFullName()}`)
         }
         return { ...prev,

--- a/packages/workspace/test/workspace/nacl_files/addition_wrapper.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/addition_wrapper.test.ts
@@ -1,0 +1,42 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, BuiltinTypes } from '@salto-io/adapter-api'
+import { wrapNestedValues } from '../../../src/workspace/nacl_files/addition_wrapper'
+
+describe('addition wrapper', () => {
+  describe('wrapNestedValues', () => {
+    let obj: ObjectType
+
+    beforeEach(() => {
+      obj = new ObjectType({
+        elemID: new ElemID('salto', 'obj'),
+        fields: {
+          abc: { refType: BuiltinTypes.STRING },
+        },
+      })
+    })
+
+    it('should return the expected value when adding to an existing field', () => {
+      const newObj = wrapNestedValues([{ id: new ElemID('salto', 'obj', 'field', 'abc', 'anno1'), value: 'def' }], obj) as ObjectType
+      expect(newObj).toBeInstanceOf(ObjectType)
+      expect(newObj.fields.abc.annotations).toEqual({ anno1: 'def' })
+    })
+
+    it('should throw an error when attempting to add to a nonexistent field', () => {
+      expect(() => wrapNestedValues([{ id: new ElemID('salto', 'obj', 'field', 'invalid', 'anno1'), value: 'def' }], obj)).toThrow(new Error('field invalid was not found in common object type salto.obj'))
+    })
+  })
+})


### PR DESCRIPTION
This was a side-effect of another bug, but we should have details about the specific field that failed if we're already getting to this scenario.

---
_Release Notes_: 
None

---
_User Notifications_: 
None