### PR TITLE
SALTO-1549: Fixed data_types_custom_fields when custom field is removed from a type

### DIFF
--- a/packages/netsuite-adapter/src/filters/data_types_custom_fields.ts
+++ b/packages/netsuite-adapter/src/filters/data_types_custom_fields.ts
@@ -124,10 +124,16 @@ const filterCreator: FilterCreator = ({ isPartial, elementsSourceIndex }) => ({
     const nameToType = _.keyBy(dataTypes, e => e.elemID.name)
 
     if (isPartial) {
+      const fetchedIds = new Set(elements
+        .filter(isInstanceElement)
+        .map(instance => instance.elemID.getFullName()))
+
       Object.entries((await elementsSourceIndex.getIndexes()).customFieldsIndex)
         .filter(([type]) => type in nameToType)
         .forEach(([type, fields]) => {
-          fields.forEach(field => addFieldToType(nameToType[type], field, nameToType))
+          fields
+            .filter(field => !fetchedIds.has(field.elemID.getFullName()))
+            .forEach(field => addFieldToType(nameToType[type], field, nameToType))
         })
     }
 


### PR DESCRIPTION
Fixed a bug that when using partial fetch, a removal of a custom field from a type would be updated in the field instance (e.g., entitycustomfield) but not updated in the relevant type

---
_Release Notes_: 
None

---
_User Notifications_: 
None