### PR TITLE
Salto 1535 - Add explicit references in Flow

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -352,7 +352,7 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     })
   )),
   {
-    src: { field: 'field', parentTypes: ['FlowRecordFilter', 'FlowInputFieldAssignment'] },
+    src: { field: 'field', parentTypes: ['FlowRecordFilter', 'FlowInputFieldAssignment', 'FlowOutputFieldAssignment'] },
     serializationStrategy: 'relativeApiName',
     target: { parentContext: 'parentObjectLookup', type: CUSTOM_FIELD },
   },

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -132,6 +132,10 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
   {
+    src: { field: 'flowName', parentTypes: ['FlowSubflow'] },
+    target: { type: 'Flow' },
+  },
+  {
     src: { field: 'letterhead', parentTypes: ['EmailTemplate'] },
     target: { type: 'Letterhead' },
   },


### PR DESCRIPTION
added a reference to flowName in subflows field of Flow
added a reference to field in outputAssignments field of FlowRecordLookup

---
_Release Notes_: 
subflows flowName and  outputAssignments field  will now contain reference
