### PR TITLE
Replaced no-unused-expressions with typescript-eslint version

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -148,6 +148,8 @@ module.exports = {
                 message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
             },
         ],
+        'no-unused-expressions': 'off',
+        '@typescript-eslint/no-unused-expressions': ['error'],
     },
     overrides: [
         {

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -472,7 +472,6 @@ const updateSuiteAppTypes = (
   configToUpdate: InstanceElement,
 ): boolean => {
   let didUpdate = false
-  // eslint-disable-next-line no-unused-expressions
   configToUpdate.value?.[FETCH]?.[EXCLUDE]?.types?.forEach((excludeItem: FetchTypeQueryParams) => {
     if (excludeItem.name !== undefined) {
       const fixedName = strings.lowerCaseFirstLetter(excludeItem.name)

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -700,7 +700,7 @@ describe('Adapter', () => {
           getElemIdFunc: mockGetElemIdFunc,
         })
 
-        // eslint-disable-next-line no-unused-expressions
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         adapter.deployModifiers
 
         expect(getChangeValidatorMock).toHaveBeenCalledWith({
@@ -726,7 +726,7 @@ describe('Adapter', () => {
           getElemIdFunc: mockGetElemIdFunc,
         })
 
-        // eslint-disable-next-line no-unused-expressions
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         adapter.deployModifiers
 
         expect(getChangeValidatorMock).toHaveBeenCalledWith({
@@ -752,7 +752,7 @@ describe('Adapter', () => {
           getElemIdFunc: mockGetElemIdFunc,
         })
 
-        // eslint-disable-next-line no-unused-expressions
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         adapter.deployModifiers
 
         expect(getChangeValidatorMock).toHaveBeenCalledWith({

--- a/packages/salesforce-adapter/test/deprecated_config.test.ts
+++ b/packages/salesforce-adapter/test/deprecated_config.test.ts
@@ -148,7 +148,6 @@ describe('deprecated config', () => {
       configWithOldOptions.metadataTypesSkippedList = ['a', 'b']
 
       const expectedConfig = _.cloneDeep(currentConfig)
-      // eslint-disable-next-line no-unused-expressions
       expectedConfig.fetch?.metadata?.exclude?.push(...[{ metadataType: 'a' }, { metadataType: 'b' }])
 
       const config = updateDeprecatedConfiguration(new InstanceElement(
@@ -165,7 +164,6 @@ describe('deprecated config', () => {
       configWithOldOptions.instancesRegexSkippedList = ['a', 'a.b', 'a.b.c', PACKAGES_INSTANCES_REGEX]
 
       const expectedConfig = _.cloneDeep(currentConfig)
-      // eslint-disable-next-line no-unused-expressions
       expectedConfig.fetch?.metadata?.exclude?.push(...[
         { name: '.*a.*' },
         { metadataType: '.*a', name: 'b.*' },


### PR DESCRIPTION
Replaced eslint rule with its matched typescript-eslint version

---
_Release Notes_: 
None

---
_User Notifications_: 
None