### PR TITLE
SALTO-1562 - Ignore InstanceNotLeasedError on renew added to persistent-pool

### DIFF
--- a/packages/persistent-pool/package.json
+++ b/packages/persistent-pool/package.json
@@ -27,6 +27,7 @@
     "lint-fix": "yarn lint --fix"
   },
   "dependencies": {
+    "@salto-io/logging": "0.3.0",
     "@salto-io/lowerdash": "0.3.0",
     "aws-sdk": "^2.863.0",
     "uuid": "^3.3.3"

--- a/packages/persistent-pool/src/lib/renewed_lease.ts
+++ b/packages/persistent-pool/src/lib/renewed_lease.ts
@@ -14,7 +14,10 @@
 * limitations under the License.
 */
 import { types } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
 import { Pool, LeaseUpdateOpts, Lease, InstanceId, InstanceNotLeasedError } from '../types'
+
+const log = logger(module)
 
 const poolFuncs: (keyof Pool)[] = ['lease', 'return']
 const isPool = (
@@ -64,8 +67,7 @@ export default class RenewedLease<T> extends types.Bean<RenewedLeaseOpts<T>>
       if (!(e instanceof InstanceNotLeasedError)) {
         throw e
       }
-      // eslint-disable-next-line no-console
-      console.log(e)
+      log.warn('lease returned by unknown entity, stops renew interval')
     }
   }
 

--- a/packages/persistent-pool/test/lib/renewed_lease.test.ts
+++ b/packages/persistent-pool/test/lib/renewed_lease.test.ts
@@ -124,6 +124,12 @@ describe('RenewedLease', () => {
       pool.updateTimeout.mockRejectedValueOnce(instanceNotLeasedError)
       expect(setTimeout).not.toHaveBeenCalled()
     })
+    it('when renew throws unknown error should stop silently', () => {
+      jest.clearAllMocks()
+      const instanceNotLeasedError = new InstanceNotLeasedError({ id: '1', typeName: '1', clientId: '1' })
+      pool.updateTimeout.mockRejectedValueOnce(instanceNotLeasedError)
+      expect(setTimeout).not.toHaveBeenCalled()
+    })
   })
 
   describe('poolOrFactory', () => {

--- a/packages/persistent-pool/test/lib/renewed_lease.test.ts
+++ b/packages/persistent-pool/test/lib/renewed_lease.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { RenewedLease, Pool, Lease, LeaseUpdateOpts } from '../../src/index'
+import { RenewedLease, Pool, Lease, LeaseUpdateOpts, InstanceNotLeasedError } from '../../src/index'
 import { MockObj, createMockPool } from '../mock_repo'
 
 jest.useFakeTimers()
@@ -117,6 +117,12 @@ describe('RenewedLease', () => {
           })
         })
       })
+    })
+    it('when renew throws InstanceNotLeasedError should stop silently', () => {
+      jest.clearAllMocks()
+      const instanceNotLeasedError = new InstanceNotLeasedError({ id: '1', typeName: '1', clientId: '1' })
+      pool.updateTimeout.mockRejectedValueOnce(instanceNotLeasedError)
+      expect(setTimeout).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/persistent-pool/test/lib/renewed_lease.test.ts
+++ b/packages/persistent-pool/test/lib/renewed_lease.test.ts
@@ -126,7 +126,7 @@ describe('RenewedLease', () => {
     })
     it('when renew throws unknown error should stop silently', () => {
       jest.clearAllMocks()
-      const instanceNotLeasedError = new InstanceNotLeasedError({ id: '1', typeName: '1', clientId: '1' })
+      const instanceNotLeasedError = new Error()
       pool.updateTimeout.mockRejectedValueOnce(instanceNotLeasedError)
       expect(setTimeout).not.toHaveBeenCalled()
     })

--- a/packages/persistent-pool/tsconfig.json
+++ b/packages/persistent-pool/tsconfig.json
@@ -24,6 +24,7 @@
     "index.ts", "../lowerdash/test/retry/wait_for.test.ts"
   ],
   "references": [
+    { "path": "../logging" },
     { "path": "../lowerdash" },
   ]
 }


### PR DESCRIPTION
_Ignore InstanceNotLeasedError on renew added to persistent-pool_

---

_Meant mainly for SaaS UI e2e_

---
