### PR TITLE
SALTO-1552: SDF client now support fetching instances of SuiteApps

### DIFF
--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -55,6 +55,7 @@ netsuite {
 | fetchTypeTimeoutInMinutes      | 4                       | The max number of minutes a single SDF command can run
 | maxItemsInImportObjectsRequest | 40                      | Limits the max number of requested items a single import-objects request
 | sdfConcurrencyLimit            | 4                       | Limits the max number of concurrent SDF API calls. The number should not exceed the concurrency limit enforced by the upstream service.
+| installedSuiteApps             | []                      | The SuiteApps ids to deploy and fetch elements from
 
 ### Salto SuiteApp client configuration options
 

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -30,7 +30,7 @@ import {
   customTypes, getMetadataTypes, fileCabinetTypes,
 } from './types'
 import { TYPES_TO_SKIP, FILE_PATHS_REGEX_SKIP_LIST,
-  INTEGRATION, FETCH_TARGET, SKIP_LIST, LAST_FETCH_TIME, USE_CHANGES_DETECTION, FETCH, INCLUDE, EXCLUDE, DEPLOY, DEPLOY_REFERENCED_ELEMENTS, WARN_STALE_DATA } from './constants'
+  INTEGRATION, FETCH_TARGET, SKIP_LIST, LAST_FETCH_TIME, USE_CHANGES_DETECTION, FETCH, INCLUDE, EXCLUDE, DEPLOY, DEPLOY_REFERENCED_ELEMENTS, WARN_STALE_DATA, APPLICATION_ID } from './constants'
 import replaceInstanceReferencesFilter from './filters/instance_references'
 import parseSavedSearch from './filters/parse_saved_searchs'
 import convertLists from './filters/convert_lists'
@@ -219,7 +219,11 @@ export default class NetsuiteAdapter implements AdapterOperations {
           BuiltinTypes.STRING,
           { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
         )
-      })
+      });
+
+    [...Object.values(customTypes), ...Object.values(fileCabinetTypes)].forEach(type => {
+      type.fields[APPLICATION_ID] = new Field(type, APPLICATION_ID, BuiltinTypes.STRING)
+    })
 
     const customizationInfos = [...customObjects, ...fileCabinetContent]
     const instances = await awu(customizationInfos).map(customizationInfo => {

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -51,6 +51,7 @@ import dataInstancesNullFields from './filters/data_instances_null_fields'
 import dataInstancesDiff from './filters/data_instances_diff'
 import dataInstancesIdentifiers from './filters/data_instances_identifiers'
 import addInternalId from './filters/add_internal_ids'
+import accountSpecificValues from './filters/account_specific_values'
 import translationConverter from './filters/translation_converter'
 import { Filter, FilterCreator } from './filter'
 import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_WARN_STALE_DATA, DEFAULT_USE_CHANGES_DETECTION } from './config'
@@ -134,6 +135,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       dataInstancesInternalId,
       addInternalId,
       translationConverter,
+      accountSpecificValues,
     ],
     typesToSkip = [
       INTEGRATION, // The imported xml has no values, especially no SCRIPT_ID, for standard

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -46,6 +46,8 @@ const log = logger(module)
 const { makeArray } = collections.array
 
 const configID = new ElemID(NETSUITE)
+// Taken from https://github.com/salto-io/netsuite-suitecloud-sdk/blob/e009e0eefcd918635353d093be6a6c2222d223b8/packages/node-cli/src/validation/InteractiveAnswersValidator.js#L27
+const SUITEAPP_ID_FORMAT_REGEX = /^[a-z0-9]+(\.[a-z0-9]+){2}$/
 
 // The SuiteApp fields are commented out until we will be ready to expose them to the user
 export const defaultCredentialsType = new ObjectType({
@@ -81,8 +83,14 @@ export const defaultCredentialsType = new ObjectType({
 })
 
 const validateInstalledSuiteApps = (installedSuiteApps: unknown): void => {
-  if (!Array.isArray(installedSuiteApps) || installedSuiteApps.some(suiteApp => typeof suiteApp !== 'string')) {
+  if (!Array.isArray(installedSuiteApps)
+    || installedSuiteApps.some(suiteApp => typeof suiteApp !== 'string')) {
     throw Error(`received an invalid ${INSTALLED_SUITEAPPS} value: ${installedSuiteApps}`)
+  }
+
+  const invalidValues = installedSuiteApps.filter(id => !SUITEAPP_ID_FORMAT_REGEX.test(id))
+  if (invalidValues.length !== 0) {
+    throw Error(`${INSTALLED_SUITEAPPS} values should contain only lowercase characters or numbers and exactly two dots (such as com.saltoio.salto). The following values are invalid: ${invalidValues.join(', ')}`)
   }
 }
 

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -33,6 +33,7 @@ import {
   EXCLUDE,
   DEPLOY,
   DEPLOY_REFERENCED_ELEMENTS,
+  INSTALLED_SUITEAPPS,
 } from './constants'
 import { validateFetchParameters, convertToQueryParams } from './query'
 import { Credentials, toCredentialsAccountId } from './client/credentials'
@@ -79,6 +80,11 @@ export const defaultCredentialsType = new ObjectType({
   annotations: {},
 })
 
+const validateInstalledSuiteApps = (installedSuiteApps: unknown): void => {
+  if (!Array.isArray(installedSuiteApps) || installedSuiteApps.some(suiteApp => typeof suiteApp !== 'string')) {
+    throw Error(`received an invalid ${INSTALLED_SUITEAPPS} value: ${installedSuiteApps}`)
+  }
+}
 
 const getFilePathRegexSkipList = (config: Readonly<InstanceElement> |
   undefined): string[] | undefined => config?.value?.[FILE_PATHS_REGEX_SKIP_LIST]
@@ -125,6 +131,10 @@ const validateConfig = (config: Readonly<InstanceElement> | undefined):
 
   if (deployParams !== undefined) {
     validateDeployParams(deployParams)
+  }
+
+  if (clientConfig?.[INSTALLED_SUITEAPPS] !== undefined) {
+    validateInstalledSuiteApps(clientConfig[INSTALLED_SUITEAPPS])
   }
 }
 

--- a/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
@@ -20,6 +20,7 @@ import {
 import { getParents } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
+import { APPLICATION_ID } from '../constants'
 import { TYPE_TO_ID_FIELD_PATHS } from '../data_elements/types'
 import { isDataObjectType, isFileCabinetType } from '../types'
 
@@ -63,6 +64,12 @@ const changeValidator: ChangeValidator = async changes => (
         )) {
         modifiedImmutableFields.push(
           after.elemID.createNestedID(CORE_ANNOTATIONS.PARENT).getFullName()
+        )
+      }
+
+      if (before.value[APPLICATION_ID] !== after.value[APPLICATION_ID]) {
+        modifiedImmutableFields.push(
+          after.elemID.createNestedID(APPLICATION_ID).getFullName()
         )
       }
       return modifiedImmutableFields.map(modifiedField => ({

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -13,9 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { collections, decorators, promises, values } from '@salto-io/lowerdash'
+import { collections, decorators, objects, promises, values } from '@salto-io/lowerdash'
 import { Values, AccountId } from '@salto-io/adapter-api'
-import { mkdirp, readDir, readFile, writeFile, rm } from '@salto-io/file'
+import { mkdirp, readDir, readFile, writeFile, rm, rename } from '@salto-io/file'
 import { logger } from '@salto-io/logging'
 import {
   CommandsMetadataService, CommandActionExecutor, CLIConfigurationService, NodeConsoleLogger,
@@ -31,6 +31,7 @@ import uuidv4 from 'uuid/v4'
 import AsyncLock from 'async-lock'
 import wu from 'wu'
 import {
+  APPLICATION_ID,
   FILE_CABINET_PATH_SEPARATOR,
 } from '../constants'
 import {
@@ -156,6 +157,7 @@ type Project = {
   projectPath: string
   executor: CommandActionExecutor
   authId: string
+  type: 'AccountCustomization' | 'SuiteApp'
 }
 
 type ObjectsChunk = {
@@ -174,6 +176,7 @@ export default class SdfClient {
   private readonly globalLimiter: Bottleneck
   private readonly setupAccountLock: AsyncLock
   private readonly baseCommandExecutor: CommandActionExecutor
+  private readonly installedSuiteApps: string[]
 
   constructor({
     credentials,
@@ -192,6 +195,7 @@ export default class SdfClient {
     const commandTimeoutInMinutes = config?.fetchTypeTimeoutInMinutes
       ?? DEFAULT_COMMAND_TIMEOUT_IN_MINUTES
     SdkProperties.setCommandTimeout(commandTimeoutInMinutes * MINUTE_IN_MILLISECONDS)
+    this.installedSuiteApps = config?.installedSuiteApps ?? []
   }
 
   @SdfClient.logDecorator
@@ -228,17 +232,32 @@ export default class SdfClient {
     }
   )
 
-  private async createProject(projectName: string): Promise<void> {
+  private async createProject(projectName: string, suiteAppId: string | undefined): Promise<void> {
+    const projectPath = osPath.join(baseExecutionPath, projectName)
+    const args: Record<string, unknown> = {
+      projectname: projectName,
+    }
+    if (suiteAppId !== undefined) {
+      args.type = 'SUITEAPP'
+      const splitIndex = suiteAppId.lastIndexOf('.')
+      args.publisherid = suiteAppId.slice(0, splitIndex)
+      args.projectid = suiteAppId.slice(splitIndex + 1)
+      args.projectversion = '1.0.0'
+      args.overwrite = true
+      args.parentdirectory = osPath.join(baseExecutionPath, suiteAppId)
+    } else {
+      args.type = 'ACCOUNTCUSTOMIZATION'
+      args.parentdirectory = projectPath
+    }
     const actionResult = await this.baseCommandExecutor.executeAction({
       commandName: COMMANDS.CREATE_PROJECT,
       runInInteractiveMode: false,
-      arguments: {
-        projectname: projectName,
-        type: 'ACCOUNTCUSTOMIZATION',
-        parentdirectory: osPath.join(baseExecutionPath, projectName),
-      },
+      arguments: args,
     })
     SdfClient.verifySuccessfulAction(actionResult, COMMANDS.CREATE_PROJECT)
+    if (suiteAppId !== undefined) {
+      await rename(osPath.join(baseExecutionPath, suiteAppId), projectPath)
+    }
   }
 
   private static verifySuccessfulAction(actionResult: ActionResult, commandName: string):
@@ -302,15 +321,15 @@ export default class SdfClient {
     })
   }
 
-  private async initProject(): Promise<Project> {
+  private async initProject(suiteAppId?: string): Promise<Project> {
     const authId = uuidv4()
     const projectName = `TempSdfProject-${authId}`
-    await this.createProject(projectName)
+    await this.createProject(projectName, suiteAppId)
     const projectPath = SdfClient.getProjectPath(projectName)
     const executor = SdfClient
       .initCommandActionExecutor(projectPath)
     await this.setupAccount(executor, authId)
-    return { projectName, projectPath, executor, authId }
+    return { projectName, projectPath, executor, authId, type: suiteAppId !== undefined ? 'SuiteApp' : 'AccountCustomization' }
   }
 
   private static async deleteProject(projectName: string): Promise<void> {
@@ -345,50 +364,82 @@ export default class SdfClient {
       return { elements: [], failedToFetchAllAtOnce: false, failedTypeToInstances: {} }
     }
 
-    const { executor, projectName, authId } = await this.initProject()
-    const { failedToFetchAllAtOnce, failedTypeToInstances } = await this.importObjects(
-      executor, typeNames, query
-    )
-    const objectsDirPath = SdfClient.getObjectsDirPath(projectName)
-    const filenames = await readDir(objectsDirPath)
-    const scriptIdToFiles = _.groupBy(filenames, filename => filename.split(FILE_SEPARATOR)[0])
+    log.debug(`Running getCustomObjects with the following suiteApps ids: ${this.installedSuiteApps.join(', ')}`)
+    const importResult = await Promise.all(
+      [undefined, ...this.installedSuiteApps]
+        .map(async suiteAppId => {
+          const { executor, projectName, authId } = await this.initProject()
+          const { failedTypeToInstances, failedToFetchAllAtOnce } = await this.importObjects(
+            executor,
+            typeNames,
+            query,
+            suiteAppId,
+          )
+          const objectsDirPath = SdfClient.getObjectsDirPath(projectName)
+          const filenames = await readDir(objectsDirPath)
+          const scriptIdToFiles = _.groupBy(
+            filenames,
+            filename => filename.split(FILE_SEPARATOR)[0]
+          )
 
-    const transformCustomObject = async (
-      scriptId: string, objectFileNames: string[]
-    ): Promise<CustomTypeInfo> => {
-      const [[additionalFilename], [contentFilename]] = _.partition(objectFileNames,
-        filename => filename.includes(ADDITIONAL_FILE_PATTERN))
-      const xmlContent = readFile(osPath.resolve(objectsDirPath, contentFilename))
-      if (_.isUndefined(additionalFilename)) {
-        return convertToCustomTypeInfo((await xmlContent).toString(), scriptId)
-      }
-      const additionalFileContent = readFile(osPath.resolve(objectsDirPath, additionalFilename))
-      return convertToTemplateCustomTypeInfo((await xmlContent).toString(), scriptId,
-        additionalFilename.split(FILE_SEPARATOR)[2], await additionalFileContent)
-    }
+          const transformCustomObject = async (
+            scriptId: string, objectFileNames: string[]
+          ): Promise<CustomTypeInfo> => {
+            const [[additionalFilename], [contentFilename]] = _.partition(objectFileNames,
+              filename => filename.includes(ADDITIONAL_FILE_PATTERN))
+            const xmlContent = readFile(osPath.resolve(objectsDirPath, contentFilename))
+            if (_.isUndefined(additionalFilename)) {
+              return convertToCustomTypeInfo((await xmlContent).toString(), scriptId)
+            }
+            const additionalFileContent = readFile(
+              osPath.resolve(objectsDirPath, additionalFilename)
+            )
+            return convertToTemplateCustomTypeInfo((await xmlContent).toString(), scriptId,
+              additionalFilename.split(FILE_SEPARATOR)[2], await additionalFileContent)
+          }
 
-    const elements = await withLimitedConcurrency(
-      Object.entries(scriptIdToFiles).map(([scriptId, objectFileNames]) =>
-        () => transformCustomObject(scriptId, objectFileNames)),
-      READ_CONCURRENCY
+          const elements = await withLimitedConcurrency(
+            Object.entries(scriptIdToFiles).map(([scriptId, objectFileNames]) =>
+              () => transformCustomObject(scriptId, objectFileNames)),
+            READ_CONCURRENCY
+          )
+
+          if (suiteAppId !== undefined) {
+            elements.forEach(e => { e.values[APPLICATION_ID] = suiteAppId })
+          }
+          await this.projectCleanup(projectName, authId)
+
+          return { elements, failedToFetchAllAtOnce, failedTypeToInstances }
+        })
     )
-    await this.projectCleanup(projectName, authId)
+
+    const failedTypeToInstances = objects.concatObjects(
+      importResult.map(res => res.failedTypeToInstances)
+    )
+
+    const elements = importResult.flatMap(res => res.elements)
+    const failedToFetchAllAtOnce = importResult.some(res => res.failedToFetchAllAtOnce)
+
     return { elements, failedToFetchAllAtOnce, failedTypeToInstances }
   }
 
   private async importObjects(
     executor: CommandActionExecutor,
     typeNames: string[],
-    query: NetsuiteQuery
-  ): Promise<{ failedToFetchAllAtOnce: boolean; failedTypeToInstances: NetsuiteQueryParameters['types'] }> {
+    query: NetsuiteQuery,
+    suiteAppId: string | undefined,
+  ): Promise<{
+    failedToFetchAllAtOnce: boolean
+    failedTypeToInstances: NetsuiteQueryParameters['types']
+  }> {
     const importAllAtOnce = async (): Promise<NetsuiteQueryParameters['types'] | undefined> => {
-      log.debug('Fetching all custom objects at once')
+      log.debug(`Fetching all custom objects at once with suiteApp: ${suiteAppId}`)
       try {
         // When fetchAllAtOnce we use the below heuristic in order to define a proper timeout,
         // instead of adding another configuration value
-        return await this.runImportObjectsCommand(executor, ALL, ALL)
+        return await this.runImportObjectsCommand(executor, ALL, ALL, suiteAppId)
       } catch (e) {
-        log.warn('Attempt to fetch all custom objects has failed')
+        log.warn(`Attempt to fetch all custom objects has failed with suiteApp: ${suiteAppId}`)
         log.warn(e)
         return undefined
       }
@@ -400,14 +451,20 @@ export default class SdfClient {
         return { failedToFetchAllAtOnce: false, failedTypeToInstances }
       }
     }
-    const failedTypeToInstances = await this.importObjectsInChunks(executor, typeNames, query)
+    const failedTypeToInstances = await this.importObjectsInChunks(
+      executor,
+      typeNames,
+      query,
+      suiteAppId,
+    )
     return { failedToFetchAllAtOnce: this.fetchAllTypesAtOnce, failedTypeToInstances }
   }
 
   private async importObjectsInChunks(
     executor: CommandActionExecutor,
     typeNames: string[],
-    query: NetsuiteQuery
+    query: NetsuiteQuery,
+    suiteAppId: string | undefined,
   ): Promise<NetsuiteQueryParameters['types']> {
     const importObjectsChunk = async (
       { type, ids, index, total }: ObjectsChunk, retry = true
@@ -415,29 +472,29 @@ export default class SdfClient {
       const retryFetchFailedInstances = async (
         failedInstancesIds: string[]
       ): Promise<NetsuiteQueryParameters['types']> => {
-        log.debug('Retrying to fetch failed instances of chunk %d/%d of type %s: %o',
-          index, total, type, failedInstancesIds)
+        log.debug('Retrying to fetch failed instances with suiteApp: %s of chunk %d/%d of type %s: %o',
+          suiteAppId, index, total, type, failedInstancesIds)
         const failedTypeToInstancesAfterRetry = await this.runImportObjectsCommand(
-          executor, type, failedInstancesIds.join(' ')
+          executor, type, failedInstancesIds.join(' '), suiteAppId
         )
-        log.debug('Retried to fetch %d failed instances of chunk %d/%d of type: %s.',
-          failedInstancesIds.length, index, total, type)
+        log.debug('Retried to fetch %d failed instances with suiteApp: %s of chunk %d/%d of type: %s.',
+          suiteAppId, failedInstancesIds.length, index, total, type)
         return failedTypeToInstancesAfterRetry
       }
 
       try {
-        log.debug('Starting to fetch chunk %d/%d with %d objects of type: %s', index, total, ids.length, type)
+        log.debug('Starting to fetch chunk %d/%d with %d objects of type: %s with SuiteApp %s', index, total, ids.length, type, suiteAppId)
         let failedTypeToInstances = await this.runImportObjectsCommand(
-          executor, type, ids.join(' ')
+          executor, type, ids.join(' '), suiteAppId
         )
         if (failedTypeToInstances[type]?.length > 0) {
           failedTypeToInstances = await retryFetchFailedInstances(failedTypeToInstances[type])
         }
-        log.debug('Fetched chunk %d/%d with %d objects of type: %s. failedTypeToInstances: %o',
-          index, total, ids.length, type, failedTypeToInstances)
+        log.debug('Fetched chunk %d/%d with %d objects of type: %s with suiteApp: %s. failedTypeToInstances: %o',
+          index, total, ids.length, type, suiteAppId, failedTypeToInstances)
         return failedTypeToInstances
       } catch (e) {
-        log.warn('Failed to fetch chunk %d/%d with %d objects of type: %s', index, total, ids.length, type)
+        log.warn('Failed to fetch chunk %d/%d with %d objects of type: %s with suiteApp: %s', index, total, ids.length, type, suiteAppId)
         log.warn(e)
         if (!retry) {
           throw e
@@ -458,7 +515,8 @@ export default class SdfClient {
 
     const instancesIds = (await this.listInstances(
       executor,
-      typeNames.filter(query.isTypeMatch)
+      typeNames.filter(query.isTypeMatch),
+      suiteAppId,
     )).filter(query.isObjectMatch)
 
     const instancesIdsByType = _.groupBy(instancesIds, id => id.type)
@@ -489,6 +547,7 @@ export default class SdfClient {
     executor: CommandActionExecutor,
     type: string,
     scriptIds: string,
+    suiteAppId: string | undefined,
   ): Promise<NetsuiteQueryParameters['types']> {
     const actionResult = await this.executeProjectAction(
       COMMANDS.IMPORT_OBJECTS,
@@ -498,6 +557,7 @@ export default class SdfClient {
         scriptid: scriptIds,
         maxItemsInImportObjectsRequest: this.maxItemsInImportObjectsRequest,
         excludefiles: true,
+        appid: suiteAppId,
       },
       executor,
     )
@@ -525,11 +585,13 @@ export default class SdfClient {
   async listInstances(
     executor: CommandActionExecutor,
     types: string[],
+    suiteAppId: string | undefined
   ): Promise<ObjectID[]> {
     const results = await this.executeProjectAction(
       COMMANDS.LIST_OBJECTS,
       {
         type: types.join(' '),
+        appid: suiteAppId,
       },
       executor,
     )
@@ -663,8 +725,8 @@ export default class SdfClient {
   }
 
   @SdfClient.logDecorator
-  async deploy(customizationInfos: CustomizationInfo[]): Promise<void> {
-    const project = await this.initProject()
+  async deploy(customizationInfos: CustomizationInfo[], suiteAppId?: string): Promise<void> {
+    const project = await this.initProject(suiteAppId)
     const objectsDirPath = SdfClient.getObjectsDirPath(project.projectName)
     const fileCabinetDirPath = SdfClient.getFileCabinetDirPath(project.projectName)
     await Promise.all(customizationInfos.map(async customizationInfo => {
@@ -692,12 +754,14 @@ export default class SdfClient {
     await writeFile(manifestPath, fixedManifestContent)
   }
 
-  private async runDeployCommands({ executor, projectPath }: Project): Promise<void> {
+  private async runDeployCommands({ executor, projectPath, type }: Project): Promise<void> {
     await this.executeProjectAction(COMMANDS.ADD_PROJECT_DEPENDENCIES, {}, executor)
     await SdfClient.cleanInvalidDependencies(projectPath)
     await this.executeProjectAction(
       COMMANDS.DEPLOY_PROJECT,
-      { accountspecificvalues: 'WARNING' },
+      // SuiteApp project type can't contain account specific values
+      // and thus the flag is not supported
+      type === 'AccountCustomization' ? { accountspecificvalues: 'WARNING' } : {},
       executor
     )
   }

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -26,6 +26,7 @@ import {
   CLIENT_CONFIG, MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST, FETCH_TARGET, SKIP_LIST,
   SUITEAPP_CONCURRENCY_LIMIT, SUITEAPP_CLIENT_CONFIG, USE_CHANGES_DETECTION,
   CONCURRENCY_LIMIT, FETCH, INCLUDE, EXCLUDE, DEPLOY, DATASET, WORKBOOK, WARN_STALE_DATA,
+  INSTALLED_SUITEAPPS,
 } from './constants'
 import { NetsuiteQueryParameters, FetchParams, convertToQueryParams, QueryParams, FetchTypeQueryParams } from './query'
 import { TYPES_TO_INTERNAL_ID } from './data_elements/types'
@@ -79,6 +80,10 @@ const clientConfigType = new ObjectType({
           max: 50,
         }),
       },
+    },
+
+    [INSTALLED_SUITEAPPS]: {
+      refType: new ListType(BuiltinTypes.STRING),
     },
   },
 })
@@ -260,6 +265,7 @@ export type SdfClientConfig = {
   [MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST]?: number
   [FETCH_TYPE_TIMEOUT_IN_MINUTES]?: number
   [SDF_CONCURRENCY_LIMIT]?: number
+  [INSTALLED_SUITEAPPS]?: string[]
 }
 
 export type SuiteAppClientConfig = {

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -47,6 +47,7 @@ export const PATH = 'path'
 export const PERMITTED_ROLE = 'permittedrole'
 export const RECORD_TYPE = 'recordType'
 export const LAST_FETCH_TIME = '_lastfetchtime'
+export const APPLICATION_ID = 'application_id'
 
 // Field Annotations
 export const IS_ATTRIBUTE = 'isAttribute'
@@ -79,6 +80,7 @@ export const FETCH = 'fetch'
 export const INCLUDE = 'include'
 export const EXCLUDE = 'exclude'
 export const DEPLOY = 'deploy'
+export const INSTALLED_SUITEAPPS = 'installedSuiteApps'
 
 export const CAPTURE = 'capture'
 // e.g. '[scriptid=customworkflow1]' & '[scriptid=customworkflow1.workflowstate17.workflowaction33]'

--- a/packages/netsuite-adapter/src/filters/account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/account_specific_values.ts
@@ -1,0 +1,57 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { isInstanceElement } from '@salto-io/adapter-api'
+import { applyFunctionToChangeData, transformValues } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
+import { isCustomType } from '../types'
+import { FilterWith } from '../filter'
+import { ACCOUNT_SPECIFIC_VALUE, APPLICATION_ID } from '../constants'
+
+const { awu } = collections.asynciterable
+
+
+const filterCreator = (): FilterWith<'preDeploy'> => ({
+  preDeploy: async changes => {
+    await awu(changes)
+      .forEach(async change =>
+        applyFunctionToChangeData(
+          change,
+          async element => {
+            if (!isInstanceElement(element)
+              || !isCustomType((await element.getType()).elemID)
+              // instances that are not from a suite app are handled
+              // using the accountspecificvalues flag
+              || element.value[APPLICATION_ID] === undefined) {
+              return element
+            }
+
+            element.value = await transformValues({
+              values: element.value,
+              type: await element.getType(),
+              strict: false,
+              pathID: element.elemID,
+              transformFunc: async ({ value }) =>
+                (_.isString(value) && value.includes(ACCOUNT_SPECIFIC_VALUE) ? undefined : value),
+            }) ?? element.value
+
+            return element
+          }
+        ))
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -16,7 +16,8 @@
 import {
   ElemID, Field, InstanceElement, isPrimitiveType, ObjectType, PrimitiveType,
   PrimitiveTypes, Values, isObjectType, isPrimitiveValue, StaticFile, ElemIdGetter,
-  ADAPTER, OBJECT_SERVICE_ID, OBJECT_NAME, toServiceIdsString, ServiceIds, isInstanceElement,
+  ADAPTER, OBJECT_SERVICE_ID, OBJECT_NAME, toServiceIdsString, ServiceIds,
+  isInstanceElement,
 } from '@salto-io/adapter-api'
 import { MapKeyFunc, mapKeysRecursive, TransformFunc, transformValues, GetLookupNameFunc, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -25,6 +26,7 @@ import {
   ADDRESS_FORM, ENTRY_FORM, TRANSACTION_FORM, IS_ATTRIBUTE, NETSUITE, RECORDS_PATH,
   SCRIPT_ID, ADDITIONAL_FILE_SUFFIX, FILE, FILE_CABINET_PATH, PATH, FILE_CABINET_PATH_SEPARATOR,
   LAST_FETCH_TIME,
+  APPLICATION_ID,
 } from './constants'
 import { fieldTypes } from './types/field_types'
 import { customTypes, fileCabinetTypes, isCustomType, isFileCabinetType } from './types'
@@ -249,7 +251,8 @@ export const toCustomizationInfo = async (
     return { typeName, values, path } as FolderCustomizationInfo
   }
 
-  delete instance.value[LAST_FETCH_TIME]
+  delete values[LAST_FETCH_TIME]
+  delete values[APPLICATION_ID]
 
   const scriptId = instance.value[SCRIPT_ID]
   // Template Custom Type

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -529,7 +529,7 @@ describe('Adapter', () => {
         const expectedResolvedInstance = instance.clone()
         expectedResolvedInstance.value.description = 'description value'
         expect(client.deploy)
-          .toHaveBeenCalledWith([await toCustomizationInfo(expectedResolvedInstance)])
+          .toHaveBeenCalledWith([await toCustomizationInfo(expectedResolvedInstance)], undefined)
         expect(post.isEqual(instance)).toBe(true)
       })
 
@@ -538,7 +538,10 @@ describe('Adapter', () => {
         expect(result.errors).toHaveLength(0)
         expect(result.appliedChanges).toHaveLength(1)
         const post = getChangeElement(result.appliedChanges[0]) as InstanceElement
-        expect(client.deploy).toHaveBeenCalledWith([await toCustomizationInfo(fileInstance)])
+        expect(client.deploy).toHaveBeenCalledWith(
+          [await toCustomizationInfo(fileInstance)],
+          undefined,
+        )
         expect(post.isEqual(fileInstance)).toBe(true)
       })
 
@@ -547,7 +550,10 @@ describe('Adapter', () => {
         expect(result.errors).toHaveLength(0)
         expect(result.appliedChanges).toHaveLength(1)
         const post = getChangeElement(result.appliedChanges[0]) as InstanceElement
-        expect(client.deploy).toHaveBeenCalledWith([await toCustomizationInfo(folderInstance)])
+        expect(client.deploy).toHaveBeenCalledWith(
+          [await toCustomizationInfo(folderInstance)],
+          undefined,
+        )
         expect(post.isEqual(folderInstance)).toBe(true)
       })
 
@@ -563,7 +569,7 @@ describe('Adapter', () => {
         })
         expect(client.deploy).toHaveBeenCalledWith(expect.arrayContaining(
           [await toCustomizationInfo(folderInstance), await toCustomizationInfo(fileInstance)]
-        ))
+        ), undefined)
         expect(result.errors).toHaveLength(0)
         expect(result.appliedChanges).toHaveLength(2)
       })
@@ -582,7 +588,7 @@ describe('Adapter', () => {
         })
         expect(client.deploy).toHaveBeenCalledWith(expect.arrayContaining(
           [await toCustomizationInfo(folderInstance), await toCustomizationInfo(fileInstance)]
-        ))
+        ), undefined)
         expect(result.errors).toHaveLength(1)
         expect(result.errors).toEqual([clientError])
         expect(result.appliedChanges).toHaveLength(0)
@@ -608,7 +614,10 @@ describe('Adapter', () => {
         const expectedResolvedInstance = instance.clone()
         expectedResolvedInstance.value.description = 'description value'
         expect(client.deploy)
-          .toHaveBeenCalledWith([await toCustomizationInfo(expectedResolvedInstance)])
+          .toHaveBeenCalledWith(
+            [await toCustomizationInfo(expectedResolvedInstance)],
+            undefined,
+          )
         expect(post).toEqual(instance)
       })
 
@@ -617,7 +626,10 @@ describe('Adapter', () => {
         expect(result.errors).toHaveLength(0)
         expect(result.appliedChanges).toHaveLength(1)
         const post = getChangeElement(result.appliedChanges[0]) as InstanceElement
-        expect(client.deploy).toHaveBeenCalledWith([await toCustomizationInfo(fileInstance)])
+        expect(client.deploy).toHaveBeenCalledWith(
+          [await toCustomizationInfo(fileInstance)],
+          undefined,
+        )
         expect(post).toEqual(fileInstance)
       })
 
@@ -626,7 +638,10 @@ describe('Adapter', () => {
         expect(result.errors).toHaveLength(0)
         expect(result.appliedChanges).toHaveLength(1)
         const post = getChangeElement(result.appliedChanges[0]) as InstanceElement
-        expect(client.deploy).toHaveBeenCalledWith([await toCustomizationInfo(folderInstance)])
+        expect(client.deploy).toHaveBeenCalledWith(
+          [await toCustomizationInfo(folderInstance)],
+          undefined,
+        )
         expect(post).toEqual(folderInstance)
       })
 
@@ -644,7 +659,7 @@ describe('Adapter', () => {
         const expectedResolvedAfter = after.clone()
         expectedResolvedAfter.value.description = 'edited description value'
         expect(client.deploy)
-          .toHaveBeenCalledWith([await toCustomizationInfo(expectedResolvedAfter)])
+          .toHaveBeenCalledWith([await toCustomizationInfo(expectedResolvedAfter)], undefined)
         expect(post).toEqual(after)
       })
     })

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -34,6 +34,7 @@ import {
   DEPLOY,
   DEPLOY_REFERENCED_ELEMENTS,
   WARN_STALE_DATA,
+  INSTALLED_SUITEAPPS,
 } from '../src/constants'
 import { mockGetElemIdFunc } from './utils'
 import SuiteAppClient from '../src/client/suiteapp_client/suiteapp_client'
@@ -421,6 +422,68 @@ describe('NetsuiteAdapter creator', () => {
             elementsSource: buildElementsSourceFromElements([]),
           })
         ).toThrow()
+      })
+    })
+
+    describe('installedSuiteApps', () => {
+      it('should throw an error when installedSuiteApps is not a list', () => {
+        const invalidConfig = new InstanceElement(
+          ElemID.CONFIG_NAME,
+          adapter.configType as ObjectType,
+          {
+            [CLIENT_CONFIG]: {
+              [INSTALLED_SUITEAPPS]: 2,
+            },
+          }
+        )
+        expect(
+          () => adapter.operations({
+            credentials,
+            config: invalidConfig,
+            getElemIdFunc: mockGetElemIdFunc,
+            elementsSource: buildElementsSourceFromElements([]),
+          })
+        ).toThrow()
+      })
+
+      it('should throw an error when installedSuiteApps has an item that is not a string', () => {
+        const invalidConfig = new InstanceElement(
+          ElemID.CONFIG_NAME,
+          adapter.configType as ObjectType,
+          {
+            [CLIENT_CONFIG]: {
+              [INSTALLED_SUITEAPPS]: ['a', 2],
+            },
+          }
+        )
+        expect(
+          () => adapter.operations({
+            credentials,
+            config: invalidConfig,
+            getElemIdFunc: mockGetElemIdFunc,
+            elementsSource: buildElementsSourceFromElements([]),
+          })
+        ).toThrow()
+      })
+
+      it('should not throw an error when installedSuiteApps is valid', () => {
+        const validConfig = new InstanceElement(
+          ElemID.CONFIG_NAME,
+          adapter.configType as ObjectType,
+          {
+            [CLIENT_CONFIG]: {
+              [INSTALLED_SUITEAPPS]: ['a', 'b'],
+            },
+          }
+        )
+        expect(
+          () => adapter.operations({
+            credentials,
+            config: validConfig,
+            getElemIdFunc: mockGetElemIdFunc,
+            elementsSource: buildElementsSourceFromElements([]),
+          })
+        ).not.toThrow()
       })
     })
   })

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -452,7 +452,27 @@ describe('NetsuiteAdapter creator', () => {
           adapter.configType as ObjectType,
           {
             [CLIENT_CONFIG]: {
-              [INSTALLED_SUITEAPPS]: ['a', 2],
+              [INSTALLED_SUITEAPPS]: ['a.b.c', 2],
+            },
+          }
+        )
+        expect(
+          () => adapter.operations({
+            credentials,
+            config: invalidConfig,
+            getElemIdFunc: mockGetElemIdFunc,
+            elementsSource: buildElementsSourceFromElements([]),
+          })
+        ).toThrow()
+      })
+
+      it('should throw an error when installedSuiteApps has an item that is not a valid id', () => {
+        const invalidConfig = new InstanceElement(
+          ElemID.CONFIG_NAME,
+          adapter.configType as ObjectType,
+          {
+            [CLIENT_CONFIG]: {
+              [INSTALLED_SUITEAPPS]: ['a', 'a.b.c'],
             },
           }
         )
@@ -472,7 +492,7 @@ describe('NetsuiteAdapter creator', () => {
           adapter.configType as ObjectType,
           {
             [CLIENT_CONFIG]: {
-              [INSTALLED_SUITEAPPS]: ['a', 'b'],
+              [INSTALLED_SUITEAPPS]: ['a.b.c', 'b.c.d'],
             },
           }
         )

--- a/packages/netsuite-adapter/test/change_validators/immutable_changes.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/immutable_changes.test.ts
@@ -17,6 +17,7 @@ import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, Re
 import immutableChangesValidator from '../../src/change_validators/immutable_changes'
 import { customTypes, fileCabinetTypes } from '../../src/types'
 import { ENTITY_CUSTOM_FIELD, FILE, NETSUITE, PATH, SCRIPT_ID } from '../../src/constants'
+import { addressForm } from '../../src/autogen/types/custom_types/addressForm'
 
 
 describe('customization type change validator', () => {
@@ -127,6 +128,18 @@ describe('customization type change validator', () => {
     })
     const before = new InstanceElement('instance', accountingPeriodType, { fiscalCalendar: { name: 'a' } })
     const after = new InstanceElement('instance', accountingPeriodType, { fiscalCalendar: { name: 'b' } })
+
+    const changeErrors = await immutableChangesValidator(
+      [toChange({ before, after })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].elemID).toEqual(after.elemID)
+  })
+
+  it('should have change error if application_id was modified', async () => {
+    const before = new InstanceElement('instance', addressForm, { application_id: 'a' })
+    const after = new InstanceElement('instance', addressForm, { application_id: 'b' })
 
     const changeErrors = await immutableChangesValidator(
       [toChange({ before, after })]

--- a/packages/netsuite-adapter/test/filters/account_specific_value.test.ts
+++ b/packages/netsuite-adapter/test/filters/account_specific_value.test.ts
@@ -1,0 +1,40 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { getChangeElement, InstanceElement, toChange } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/account_specific_values'
+import { ACCOUNT_SPECIFIC_VALUE, APPLICATION_ID } from '../../src/constants'
+import { addressForm } from '../../src/autogen/types/custom_types/addressForm'
+
+describe('account_specific_values filter', () => {
+  it('should remove account specific values', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      addressForm,
+      {
+        [APPLICATION_ID]: 'a.b.c',
+        a: 2,
+        b: ACCOUNT_SPECIFIC_VALUE,
+        c: {
+          d: `${ACCOUNT_SPECIFIC_VALUE}|${ACCOUNT_SPECIFIC_VALUE}`,
+          e: 3,
+        },
+      }
+    )
+    const change = toChange({ after: instance })
+    await filterCreator().preDeploy([change])
+    expect(getChangeElement(change).value).toEqual({ a: 2, c: { e: 3 }, [APPLICATION_ID]: 'a.b.c' })
+  })
+})


### PR DESCRIPTION
Add support for fetching and deploying instances from SuiteApps installed on the account

---

For fetching the instances, I pass `appid` to the `object:import` command
For deploying, I create a SuiteApp type sdf project and run `project:deploy`

---
_Release Notes_: 
Netsuite Adapter:
Netsuite adapter now supports fetching and deploying instances (not locked) from SuiteApps installed in the account using the `client.installedSuiteApps` configuration option
Some types in NetSuite will have an additional `application_id` field after the next fetch

---
_User Notifications_: 
None