### PR TITLE
WIP - Salto-1455 cpq deploy retries

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -178,7 +178,7 @@ salesforce {
 | [deploy](#client-deploy-options)                              | `{}` (no overrides)      | Deploy options
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [maxConcurrentApiRequests](#rate-limit-configuration-options) | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
-| [dataRetry](#client-data-retry-options) | `{}` (no overrides)      | Configuration for retrying on specific errors regarding data objects (for CPQ)
+| [dataRetry](#client-data-retry-options) | `{}` (no overrides)      | Configuration for retrying on specific errors regarding data objects (for custom object instances)
 
 #### Client polling options
 
@@ -223,7 +223,7 @@ For more details see the DeployOptions section in the [salesforce documentation 
 
 | Name                                                        | Default when undefined                           | Description
 | ------------------------------------------------------------| -------------------------------------------------| -----------
-| maxRetries                                                    | `3`                                              | Max retries to fetch data instances
-| delayMillis                                                        | `1000`                                | Time (in millis) between each retry
+| maxAttempts                                                    | `3`                                              | Max attempts to deploy data instances
+| retryDelay                                                        | `1000`                                | Delay (in millis) between each retry
 | retryableFailures                                                        | `FIELD_CUSTOM_VALIDATION_EXCEPTION, UNABLE_TO_LOCK_ROW`                                | Error messages for which to retry
 | 

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -178,6 +178,7 @@ salesforce {
 | [deploy](#client-deploy-options)                              | `{}` (no overrides)      | Deploy options
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [maxConcurrentApiRequests](#rate-limit-configuration-options) | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
+| [dataRetry](#client-data-retry-options) | `{}` (no overrides)      | Configuration for retrying on specific errors regarding data objects (for CPQ)
 
 #### Client polling options
 
@@ -217,3 +218,12 @@ For more details see the DeployOptions section in the [salesforce documentation 
 | list                                                        | `-1` (unlimited)                                 | Max number of concurrent list requests
 | query                                                       | `4`                                              | Max number of concurrent SOQL query requests
 | total                                                       | `-1` (unlimited)                                 | Shared limit for read, retrieve and list
+
+### Client data retry options
+
+| Name                                                        | Default when undefined                           | Description
+| ------------------------------------------------------------| -------------------------------------------------| -----------
+| maxRetries                                                    | `3`                                              | Max retries to fetch data instances
+| delayMillis                                                        | `1000`                                | Time (in millis) between each retry
+| retryableFailures                                                        | `FIELD_CUSTOM_VALIDATION_EXCEPTION, UNABLE_TO_LOCK_ROW`                                | Error messages for which to retry
+| 

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -64,7 +64,7 @@ import valueToStaticFileFilter from './filters/value_to_static_file'
 import convertMapsFilter from './filters/convert_maps'
 import elementsUrlFilter from './filters/elements_url'
 import territoryFilter from './filters/territory'
-import { FetchElements, SalesforceConfig } from './types'
+import { CustomObjectsDeployRetryOptions, FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges } from './config_change'
 import { FilterCreator, Filter, FilterResult } from './filter'
 import { addDefaults } from './filters/utils'
@@ -230,6 +230,7 @@ export const allSystemFields = [
 
 export default class SalesforceAdapter implements AdapterOperations {
   private maxItemsInRetrieveRequest: number
+  private customObjectsDeployOptions: CustomObjectsDeployRetryOptions
   private metadataToRetrieve: string[]
   private metadataTypesOfInstancesFetchedInFilters: string[]
   private nestedMetadataTypes: Record<string, NestedMetadataTypeInfo>
@@ -294,6 +295,8 @@ export default class SalesforceAdapter implements AdapterOperations {
     config,
   }: SalesforceAdapterParams) {
     this.maxItemsInRetrieveRequest = config.maxItemsInRetrieveRequest ?? maxItemsInRetrieveRequest
+    this.customObjectsDeployOptions = config.customObjectsDeployRetryOptions
+    ?? constants.DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRTY_OPTIONS
     this.metadataToRetrieve = metadataToRetrieve
     this.userConfig = config
     this.metadataTypesOfInstancesFetchedInFilters = metadataTypesOfInstancesFetchedInFilters
@@ -379,7 +382,8 @@ export default class SalesforceAdapter implements AdapterOperations {
 
     const result = await isCustomObjectInstanceChanges(resolvedChanges)
       ? await deployCustomObjectInstancesGroup(
-        resolvedChanges as Change<InstanceElement>[], this.client, this.fetchProfile.dataManagement,
+        resolvedChanges as Change<InstanceElement>[], this.client,
+        this.customObjectsDeployOptions, this.fetchProfile.dataManagement,
       )
       : await deployMetadata(resolvedChanges, this.client,
         this.nestedMetadataTypes, this.userConfig.client?.deploy?.deleteBeforeUpdate)

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -64,7 +64,7 @@ import valueToStaticFileFilter from './filters/value_to_static_file'
 import convertMapsFilter from './filters/convert_maps'
 import elementsUrlFilter from './filters/elements_url'
 import territoryFilter from './filters/territory'
-import { CustomObjectsDeployRetryOptions, FetchElements, SalesforceConfig } from './types'
+import { FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges } from './config_change'
 import { FilterCreator, Filter, FilterResult } from './filter'
 import { addDefaults } from './filters/utils'
@@ -230,7 +230,6 @@ export const allSystemFields = [
 
 export default class SalesforceAdapter implements AdapterOperations {
   private maxItemsInRetrieveRequest: number
-  private customObjectsDeployOptions: CustomObjectsDeployRetryOptions
   private metadataToRetrieve: string[]
   private metadataTypesOfInstancesFetchedInFilters: string[]
   private nestedMetadataTypes: Record<string, NestedMetadataTypeInfo>
@@ -295,8 +294,6 @@ export default class SalesforceAdapter implements AdapterOperations {
     config,
   }: SalesforceAdapterParams) {
     this.maxItemsInRetrieveRequest = config.maxItemsInRetrieveRequest ?? maxItemsInRetrieveRequest
-    this.customObjectsDeployOptions = config.customObjectsDeployRetryOptions
-    ?? constants.DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRTY_OPTIONS
     this.metadataToRetrieve = metadataToRetrieve
     this.userConfig = config
     this.metadataTypesOfInstancesFetchedInFilters = metadataTypesOfInstancesFetchedInFilters
@@ -382,8 +379,9 @@ export default class SalesforceAdapter implements AdapterOperations {
 
     const result = await isCustomObjectInstanceChanges(resolvedChanges)
       ? await deployCustomObjectInstancesGroup(
-        resolvedChanges as Change<InstanceElement>[], this.client,
-        this.customObjectsDeployOptions, this.fetchProfile.dataManagement,
+        resolvedChanges as Change<InstanceElement>[],
+        this.client,
+        this.fetchProfile.dataManagement
       )
       : await deployMetadata(resolvedChanges, this.client,
         this.nestedMetadataTypes, this.userConfig.client?.deploy?.deleteBeforeUpdate)

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -23,7 +23,8 @@ import SalesforceAdapter from './adapter'
 import { configType, usernamePasswordCredentialsType, oauthRequestParameters,
   isAccessTokenConfig, SalesforceConfig, accessTokenCredentialsType,
   UsernamePasswordCredentials, Credentials, OauthAccessTokenCredentials, CLIENT_CONFIG,
-  SalesforceClientConfig, RetryStrategyName, FETCH_CONFIG, MAX_ITEMS_IN_RETRIEVE_REQUEST, USE_OLD_PROFILES } from './types'
+  SalesforceClientConfig, RetryStrategyName, FETCH_CONFIG, MAX_ITEMS_IN_RETRIEVE_REQUEST,
+  USE_OLD_PROFILES, CUSTOM_OBJECTS_DEPLOY_RETRY_OPTIONS } from './types'
 import { validateFetchParameters } from './fetch_profile/fetch_profile'
 import { ConfigValidationError } from './config_validation'
 import { updateDeprecatedConfiguration } from './deprecated_config'
@@ -76,6 +77,7 @@ SalesforceConfig => {
     maxItemsInRetrieveRequest: config?.value?.[MAX_ITEMS_IN_RETRIEVE_REQUEST],
     useOldProfiles: config?.value?.[USE_OLD_PROFILES],
     client: config?.value?.[CLIENT_CONFIG],
+    customObjectsDeployRetryOptions: config?.value?.[CUSTOM_OBJECTS_DEPLOY_RETRY_OPTIONS],
   }
   Object.keys(config?.value ?? {})
     .filter(k => !Object.keys(adapterConfig).includes(k))

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -24,7 +24,7 @@ import { configType, usernamePasswordCredentialsType, oauthRequestParameters,
   isAccessTokenConfig, SalesforceConfig, accessTokenCredentialsType,
   UsernamePasswordCredentials, Credentials, OauthAccessTokenCredentials, CLIENT_CONFIG,
   SalesforceClientConfig, RetryStrategyName, FETCH_CONFIG, MAX_ITEMS_IN_RETRIEVE_REQUEST,
-  USE_OLD_PROFILES, CUSTOM_OBJECTS_DEPLOY_RETRY_OPTIONS } from './types'
+  USE_OLD_PROFILES } from './types'
 import { validateFetchParameters } from './fetch_profile/fetch_profile'
 import { ConfigValidationError } from './config_validation'
 import { updateDeprecatedConfiguration } from './deprecated_config'
@@ -77,7 +77,6 @@ SalesforceConfig => {
     maxItemsInRetrieveRequest: config?.value?.[MAX_ITEMS_IN_RETRIEVE_REQUEST],
     useOldProfiles: config?.value?.[USE_OLD_PROFILES],
     client: config?.value?.[CLIENT_CONFIG],
-    customObjectsDeployRetryOptions: config?.value?.[CUSTOM_OBJECTS_DEPLOY_RETRY_OPTIONS],
   }
   Object.keys(config?.value ?? {})
     .filter(k => !Object.keys(adapterConfig).includes(k))

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -29,12 +29,11 @@ import { flatValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { Options, RequestCallback } from 'request'
 import { AccountId, Value } from '@salto-io/adapter-api'
-import { CUSTOM_OBJECT_ID_FIELD, DEFAULT_MAX_CONCURRENT_API_REQUESTS } from '../constants'
+import { CUSTOM_OBJECT_ID_FIELD, DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRTY_OPTIONS, DEFAULT_MAX_CONCURRENT_API_REQUESTS } from '../constants'
 import { CompleteSaveResult, SfError, SalesforceRecord } from './types'
-import {
-  UsernamePasswordCredentials, OauthAccessTokenCredentials, Credentials,
+import { UsernamePasswordCredentials, OauthAccessTokenCredentials, Credentials,
   SalesforceClientConfig, ClientRateLimitConfig, ClientRetryConfig, ClientPollingConfig,
-} from '../types'
+  CustomObjectsDeployRetryConfig } from '../types'
 import Connection from './jsforce'
 
 const { makeArray } = collections.array
@@ -314,6 +313,7 @@ export default class SalesforceClient {
   private readonly credentials: Credentials
   private readonly config?: SalesforceClientConfig
   readonly rateLimiters: Record<RateLimitBucketName, Bottleneck>
+  readonly dataRetry: CustomObjectsDeployRetryConfig
   readonly clientName: string
 
   constructor(
@@ -329,6 +329,7 @@ export default class SalesforceClient {
     this.rateLimiters = createRateLimitersFromConfig(
       _.defaults({}, config?.maxConcurrentApiRequests, DEFAULT_MAX_CONCURRENT_API_REQUESTS)
     )
+    this.dataRetry = config?.dataRetry ?? DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRTY_OPTIONS
     this.clientName = 'SFDC'
   }
 

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -290,8 +290,8 @@ export const DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST = 2500
 export const DEFAULT_USE_OLD_PROFILES = false
 export const MAX_QUERY_LENGTH = 2000
 export const DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRTY_OPTIONS = {
-  maxRetries: 3,
-  delayMillis: 1000,
+  maxAttempts: 3,
+  retryDelay: 1000,
   retryableFailures: [
     'FIELD_CUSTOM_VALIDATION_EXCEPTION',
     'UNABLE_TO_LOCK_ROW',

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -293,8 +293,8 @@ export const DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRTY_OPTIONS = {
   maxRetries: 3,
   delayMillis: 1000,
   retryableFailures: [
-    'FIELD_CUSTOM_VALIDATION_EXCEPTION:You must specify either field or tested variable.',
-    'UNABLE_TO_LOCK_ROW:unable to obtain exclusive access to this record.',
+    'FIELD_CUSTOM_VALIDATION_EXCEPTION',
+    'UNABLE_TO_LOCK_ROW',
   ],
 }
 

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -289,6 +289,14 @@ export const DEFAULT_MAX_CONCURRENT_API_REQUESTS = {
 export const DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST = 2500
 export const DEFAULT_USE_OLD_PROFILES = false
 export const MAX_QUERY_LENGTH = 2000
+export const DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRTY_OPTIONS = {
+  maxRetries: 3,
+  delayMillis: 1000,
+  retryableFailures: [
+    'FIELD_CUSTOM_VALIDATION_EXCEPTION:You must specify either field or tested variable.',
+    'UNABLE_TO_LOCK_ROW:unable to obtain exclusive access to this record.',
+  ],
+}
 
 // Metadata types
 export const TOPICS_FOR_OBJECTS_METADATA_TYPE = 'TopicsForObjects'

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -170,8 +170,8 @@ export type ClientRetryConfig = Partial<{
 }>
 
 export type CustomObjectsDeployRetryConfig = {
-  maxRetries: number
-  delayMillis: number
+  maxAttempts: number
+  retryDelay: number
   retryableFailures: string[]
 }
 

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -23,6 +23,7 @@ import { SALESFORCE } from './constants'
 
 export const CLIENT_CONFIG = 'client'
 export const MAX_ITEMS_IN_RETRIEVE_REQUEST = 'maxItemsInRetrieveRequest'
+export const CUSTOM_OBJECTS_DEPLOY_RETRY_OPTIONS = 'customObjectsDeployRetryOptions'
 export const USE_OLD_PROFILES = 'useOldProfiles'
 export const FETCH_CONFIG = 'fetch'
 export const METADATA_CONFIG = 'metadata'
@@ -175,9 +176,16 @@ export type SalesforceClientConfig = Partial<{
   retry: ClientRetryConfig
 }>
 
+export type CustomObjectsDeployRetryOptions = {
+  maxRetries: number
+  delayMillis: number
+  retryableFailures: string[]
+}
+
 export type SalesforceConfig = {
   [FETCH_CONFIG]?: FetchParameters
   [MAX_ITEMS_IN_RETRIEVE_REQUEST]?: number
+  [CUSTOM_OBJECTS_DEPLOY_RETRY_OPTIONS]?: CustomObjectsDeployRetryOptions
   [USE_OLD_PROFILES]?: boolean
   [CLIENT_CONFIG]?: SalesforceClientConfig
 }

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -169,23 +169,23 @@ export type ClientRetryConfig = Partial<{
   retryStrategy: RetryStrategy
 }>
 
-export type SalesforceClientConfig = Partial<{
-  polling: ClientPollingConfig
-  deploy: ClientDeployConfig
-  maxConcurrentApiRequests: ClientRateLimitConfig
-  retry: ClientRetryConfig
-}>
-
-export type CustomObjectsDeployRetryOptions = {
+export type CustomObjectsDeployRetryConfig = {
   maxRetries: number
   delayMillis: number
   retryableFailures: string[]
 }
 
+export type SalesforceClientConfig = Partial<{
+  polling: ClientPollingConfig
+  deploy: ClientDeployConfig
+  maxConcurrentApiRequests: ClientRateLimitConfig
+  retry: ClientRetryConfig
+  dataRetry: CustomObjectsDeployRetryConfig
+}>
+
 export type SalesforceConfig = {
   [FETCH_CONFIG]?: FetchParameters
   [MAX_ITEMS_IN_RETRIEVE_REQUEST]?: number
-  [CUSTOM_OBJECTS_DEPLOY_RETRY_OPTIONS]?: CustomObjectsDeployRetryOptions
   [USE_OLD_PROFILES]?: boolean
   [CLIENT_CONFIG]?: SalesforceClientConfig
 }

--- a/packages/salesforce-adapter/test/client.ts
+++ b/packages/salesforce-adapter/test/client.ts
@@ -36,8 +36,8 @@ const mockClient = (): { connection: MockInterface<Connection>; client: Salesfor
         list: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
       },
       dataRetry: {
-        maxRetries: 3,
-        delayMillis: 1000,
+        maxAttempts: 3,
+        retryDelay: 1000,
         retryableFailures: ['err1', 'err2'],
       },
     },

--- a/packages/salesforce-adapter/test/client.ts
+++ b/packages/salesforce-adapter/test/client.ts
@@ -35,6 +35,11 @@ const mockClient = (): { connection: MockInterface<Connection>; client: Salesfor
         read: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
         list: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
       },
+      dataRetry: {
+        maxRetries: 3,
+        delayMillis: 1000,
+        retryableFailures: ['err1', 'err2'],
+      },
     },
   })
 

--- a/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
@@ -1,0 +1,132 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { BulkLoadOperation } from 'jsforce-types'
+import { SalesforceRecord } from '../src/client/types'
+import { CrudFn, retryFlow } from '../src/custom_object_instances_deploy'
+import { instancesToCreateRecords } from '../src/transformers/transformer'
+import mockClient from './client'
+
+describe('Custom Object Deploy', () => {
+  describe('retry mechanism', () => {
+    const { client } = mockClient()
+    const inst1 = new InstanceElement('inst1', new ObjectType({ elemID: new ElemID('', 'test') }))
+    const inst2 = new InstanceElement('inst2', new ObjectType({ elemID: new ElemID('', 'test') }))
+    const instanceElements = [inst1, inst2]
+    const retryArgs = { maxRetries: 3, delayMillis: 1000, retryableFailures: ['err1', 'err2'] }
+    const clientBulkOpSpy = jest.spyOn(client, 'bulkLoadOperation')
+    const clientOp: CrudFn = async ({ typeName, instances, client: sfClient }) => {
+      const results = await sfClient.bulkLoadOperation(
+        typeName,
+        'insert',
+        await instancesToCreateRecords(instances)
+      )
+      return instances.map((instance, index) =>
+        ({ instance, result: results[index] }))
+    }
+
+    beforeEach(() => {
+      clientBulkOpSpy.mockReset()
+    })
+
+    it('should not retry on only successes', async () => {
+      clientBulkOpSpy.mockResolvedValue(
+        [
+          {
+            id: '1',
+            success: true,
+          },
+          {
+            id: '2',
+            success: true,
+          },
+        ]
+      )
+      const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retryArgs)
+      expect(res).toEqual({ successInstances: [inst1, inst2], errorMessages: [] })
+      expect(clientBulkOpSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not retry on non-recoverable error(s)', async () => {
+      clientBulkOpSpy.mockResolvedValue(
+        [
+          {
+            id: '1',
+            success: true,
+          },
+          {
+            id: '2',
+            success: false,
+            errors: ['err555'],
+          },
+        ]
+      )
+      const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retryArgs)
+      expect(res).toEqual({ successInstances: [inst1], errorMessages: ['inst2:\n    \terr555'] })
+      expect(clientBulkOpSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not retry on partially recoverable error(s)', async () => {
+      clientBulkOpSpy.mockResolvedValue(
+        [
+          {
+            id: '1',
+            success: true,
+          },
+          {
+            id: '2',
+            success: false,
+            errors: ['err1', 'bla bla bla'],
+          },
+        ]
+      )
+      const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retryArgs)
+      expect(res).toEqual({ successInstances: [inst1], errorMessages: ['inst2:\n    \terr1\n\tbla bla bla'] })
+      expect(clientBulkOpSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should retry on recoverable error(s)', async () => {
+      clientBulkOpSpy.mockImplementation(
+        async (_1: string,
+          _2: BulkLoadOperation,
+          records: SalesforceRecord[]) => {
+          if (records.length > 1) {
+            return [
+              {
+                id: '1',
+                success: true,
+              },
+              {
+                id: '2',
+                success: false,
+                errors: ['err1'],
+              },
+            ]
+          }
+          return [{
+            id: '2',
+            success: false,
+            errors: ['err1 bla bla bla'],
+          }]
+        }
+
+      )
+      const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retryArgs)
+      expect(res).toEqual({ successInstances: [inst1], errorMessages: ['inst2:\n    \terr1'] })
+      expect(clientBulkOpSpy).toHaveBeenCalledTimes(4)
+    })
+  })
+})


### PR DESCRIPTION
Add retry mechanism to custom objects deploy flow. supports custom retry options via config to customise max-retries, delay between each retry and which salesforce error messages are retryable.

---

_Release Notes_: 

Salesforce adapter:
_NA_

---

_User Notifications_: 
_NA_