### PR TITLE
SALTO-1565 remove "override" and "isolated" modes from documentation

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -327,7 +327,7 @@ Update the workspace configuration elements from the upstream services
 * `--state-only, --st` : Update just the state file and not the NaCLs [boolean] [default: false]
 * `--services, -s` :     Specific services to perform this action for (default=all) [array]
 * `--env, -e` :          The name of the environment to use
-* `--mode, -m <mode>` :  Choose a fetch mode. Options - [default, align, override, isolated]
+* `--mode, -m <mode>` :  Choose a fetch mode. Options - [default, align]
 
 ### **salto deploy**
 
@@ -357,7 +357,7 @@ Update the workspace configuration elements from the state file
 * `--list-planned-changes, -l` : Print a summary of the expected changes [boolean] [default: false]
 * `--services, -s` :             Specific services to perform this action for (default=all) [array]
 * `--env, -e` :                  The name of the environment to use [string]
-* `--mode, -m <mode>` :          Choose a restore mode. Options - [default, align, override, isolated]
+* `--mode, -m <mode>` :          Choose a restore mode. Options - [default, align]
 
 ### **salto service \<command>**
 

--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -303,8 +303,9 @@ const fetchDef = createWorkspaceCommand({
         name: 'mode',
         alias: 'm',
         required: false,
-        description: 'Choose a fetch mode. Options - [default, align, override, isolated]',
+        description: 'Choose a fetch mode. Options - [default, align]',
         type: 'string',
+        // 'override' and 'isolated' are undocumented
         choices: ['default', 'align', 'override', 'isolated'],
         default: 'default',
       },

--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -211,8 +211,9 @@ const restoreDef = createWorkspaceCommand({
         name: 'mode',
         alias: 'm',
         required: false,
-        description: 'Choose a restore mode. Options - [default, align, override, isolated]',
+        description: 'Choose a restore mode. Options - [default, align]',
         type: 'string',
+        // 'override' and 'isolated' are undocumented
         choices: ['default', 'align', 'override', 'isolated'],
         default: 'default',
       },


### PR DESCRIPTION
These modes remain in code but are not recommended, so we're removing them from the docs.

---
_Release Notes_: 
None

---
_User Notifications_: 
None