### PR TITLE
SALTO-1555: added support for splitting the adapter configuration to multiple files

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -105,7 +105,7 @@ export type Adapter = {
   validateCredentials: (config: Readonly<InstanceElement>) => Promise<AccountId>
   authenticationMethods: AdapterAuthentication
   configType?: ObjectType
-  getInitialConfig?: () => Promise<InstanceElement[]>
+  getDefaultConfig?: () => Promise<InstanceElement[]>
   install?: () => Promise<AdapterInstallResult>
 }
 

--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -26,7 +26,7 @@ import { ChangeGroup, ChangeGroupIdFunction } from './change_group'
 export interface FetchResult {
   elements: Element[]
   errors?: SaltoError[]
-  updatedConfig?: { config: InstanceElement; message: string }
+  updatedConfig?: { config: InstanceElement[]; message: string }
   isPartial?: boolean
 }
 
@@ -105,6 +105,7 @@ export type Adapter = {
   validateCredentials: (config: Readonly<InstanceElement>) => Promise<AccountId>
   authenticationMethods: AdapterAuthentication
   configType?: ObjectType
+  getInitialConfig?: () => Promise<InstanceElement[]>
   install?: () => Promise<AdapterInstallResult>
 }
 

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -337,9 +337,7 @@ Promise<CliExitCode> => {
 
   try {
     await maybeIsolateExistingEnv(args.output, workspace, force, yesAll)
-    const workspaceConfig = await localWorkspaceConfigSource(
-      args.workspacePath, undefined, configOverrides
-    )
+    const workspaceConfig = await localWorkspaceConfigSource(args.workspacePath)
     const rmcToEnvSource = async (remoteMapCreator: rm.RemoteMapCreator):
     Promise<EnvironmentSource> =>
       createEnvironmentSource({

--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -156,7 +156,7 @@ export const fetchCommand = async (
           planItem,
         )
         if (shouldWriteToConfig) {
-          await workspace.updateServiceConfig(adapterName, fetchResult.updatedConfigs[adapterName])
+          await workspace.updateServiceConfig(adapterName, fetchResult.updatedConfig[adapterName])
         }
         return !shouldWriteToConfig
       })

--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -156,7 +156,7 @@ export const fetchCommand = async (
           planItem,
         )
         if (shouldWriteToConfig) {
-          await workspace.updateServiceConfig(adapterName, newConfig)
+          await workspace.updateServiceConfig(adapterName, fetchResult.updatedConfigs[adapterName])
         }
         return !shouldWriteToConfig
       })

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -206,6 +206,7 @@ describe('fetch command', () => {
             {
               changes: [],
               configChanges: plan,
+              updatedConfigs: { [newConfig.elemID.adapter]: [newConfig] },
               mergeErrors: [],
               success: true,
             }
@@ -231,7 +232,7 @@ describe('fetch command', () => {
           mockShouldUpdateConfig.mockResolvedValueOnce(Promise.resolve(true))
           result = await fetchCommand(fetchArgs)
           expect(result).toBe(CliExitCode.Success)
-          expect(fetchArgs.workspace.updateServiceConfig).toHaveBeenCalledWith('salesforce', newConfig)
+          expect(fetchArgs.workspace.updateServiceConfig).toHaveBeenCalledWith('salesforce', [newConfig])
         })
 
         it('should not write config when abort was requested', async () => {
@@ -557,6 +558,7 @@ describe('fetch command', () => {
                 },
               },
             ],
+            updatedConfigs: {},
             success: true,
           }
         )

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -206,7 +206,7 @@ describe('fetch command', () => {
             {
               changes: [],
               configChanges: plan,
-              updatedConfigs: { [newConfig.elemID.adapter]: [newConfig] },
+              updatedConfig: { [newConfig.elemID.adapter]: [newConfig] },
               mergeErrors: [],
               success: true,
             }
@@ -558,7 +558,7 @@ describe('fetch command', () => {
                 },
               },
             ],
-            updatedConfigs: {},
+            updatedConfig: {},
             success: true,
           }
         )

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -301,6 +301,7 @@ export const mockWorkspace = ({
     services: mockFunction<Workspace['services']>().mockReturnValue(services),
     servicesCredentials: mockFunction<Workspace['servicesCredentials']>().mockResolvedValue({}),
     serviceConfig: mockFunction<Workspace['serviceConfig']>().mockResolvedValue(undefined),
+    serviceConfigPaths: mockFunction<Workspace['serviceConfigPaths']>().mockResolvedValue([]),
     isEmpty: mockFunction<Workspace['isEmpty']>().mockResolvedValue(false),
     hasElementsInServices: mockFunction<Workspace['hasElementsInServices']>().mockResolvedValue(true),
     hasElementsInEnv: mockFunction<Workspace['hasElementsInEnv']>().mockResolvedValue(false),

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -28,6 +28,9 @@ export {
   WorkspaceConfigSource as LocalWorkspaceConfigSource,
 } from './src/local-workspace/workspace_config'
 export {
+  adaptersConfigSource as localAdaptersConfigSource,
+} from './src/local-workspace/adapters_config'
+export {
   SALTO_HOME_VAR,
   AppConfig,
   configFromDisk,

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -17,7 +17,7 @@ export { Plan, PlanItem } from './src/core/plan'
 export { FetchChange, FetchProgressEvents, StepEmitter, FetchChangeMetadata } from './src/core/fetch'
 export * from './src/api'
 export { ItemStatus } from './src/core/deploy'
-export { getAdaptersCredentialsTypes } from './src/core/adapters/adapters'
+export { getAdaptersCredentialsTypes, getInitialAdapterConfig } from './src/core/adapters/adapters'
 export { createDiffChanges } from './src/core/diff'
 export {
   loadLocalWorkspace, initLocalWorkspace, loadLocalElementsSources, getNaclFilesSourceParams,

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -17,7 +17,7 @@ export { Plan, PlanItem } from './src/core/plan'
 export { FetchChange, FetchProgressEvents, StepEmitter, FetchChangeMetadata } from './src/core/fetch'
 export * from './src/api'
 export { ItemStatus } from './src/core/deploy'
-export { getAdaptersCredentialsTypes, getInitialAdapterConfig } from './src/core/adapters/adapters'
+export { getAdaptersCredentialsTypes, getDefaultAdapterConfig } from './src/core/adapters/adapters'
 export { createDiffChanges } from './src/core/diff'
 export {
   loadLocalWorkspace, initLocalWorkspace, loadLocalElementsSources, getNaclFilesSourceParams,

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -17,7 +17,7 @@ export { Plan, PlanItem } from './src/core/plan'
 export { FetchChange, FetchProgressEvents, StepEmitter, FetchChangeMetadata } from './src/core/fetch'
 export * from './src/api'
 export { ItemStatus } from './src/core/deploy'
-export { getAdaptersCredentialsTypes, getDefaultAdapterConfig } from './src/core/adapters/adapters'
+export { getAdaptersCredentialsTypes } from './src/core/adapters/adapters'
 export { createDiffChanges } from './src/core/diff'
 export {
   loadLocalWorkspace, initLocalWorkspace, loadLocalElementsSources, getNaclFilesSourceParams,

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -27,7 +27,7 @@ import { EOL } from 'os'
 import { deployActions, DeployError, ItemStatus } from './core/deploy'
 import {
   adapterCreators, getAdaptersCredentialsTypes, getAdapters, getAdapterDependencyChangers,
-  initAdapters, getAdaptersCreatorConfigs, getInitialAdapterConfig,
+  initAdapters, getAdaptersCreatorConfigs, getDefaultAdapterConfig,
 } from './core/adapters'
 import { getPlan, Plan, PlanItem } from './core/plan'
 import {
@@ -175,7 +175,7 @@ export type FetchResult = {
   fetchErrors: SaltoError[]
   success: boolean
   configChanges?: Plan
-  updatedConfigs : Record<string, InstanceElement[]>
+  updatedConfig : Record<string, InstanceElement[]>
   adapterNameToConfigMessage?: Record<string, string>
 }
 export type FetchFunc = (
@@ -217,7 +217,7 @@ export const fetch: FetchFunc = async (
     progressEmitter.emit('adaptersDidInitialize')
   }
   const {
-    changes, elements, mergeErrors, errors, updatedConfigs,
+    changes, elements, mergeErrors, errors, updatedConfig,
     configChanges, adapterNameToConfigMessage, unmergedElements,
   } = await fetchChanges(
     adapters,
@@ -239,7 +239,7 @@ export const fetch: FetchFunc = async (
     mergeErrors,
     success: true,
     configChanges,
-    updatedConfigs,
+    updatedConfig,
     adapterNameToConfigMessage,
   }
 }
@@ -326,7 +326,7 @@ export const addAdapter = async (
   await workspace.addService(adapterName)
 
   if (_.isUndefined((await workspace.serviceConfig(adapterName)))) {
-    const defaultConfig = await getInitialAdapterConfig(adapterName)
+    const defaultConfig = await getDefaultAdapterConfig(adapterName)
     if (!_.isUndefined(defaultConfig)) {
       await workspace.updateServiceConfig(adapterName, defaultConfig)
     }

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -26,8 +26,8 @@ import { Workspace, ElementSelector, elementSource } from '@salto-io/workspace'
 import { EOL } from 'os'
 import { deployActions, DeployError, ItemStatus } from './core/deploy'
 import {
-  adapterCreators, getAdaptersCredentialsTypes, getAdapters,
-  getAdapterDependencyChangers, getDefaultAdapterConfig, initAdapters, getAdaptersCreatorConfigs,
+  adapterCreators, getAdaptersCredentialsTypes, getAdapters, getAdapterDependencyChangers,
+  initAdapters, getAdaptersCreatorConfigs, getInitialAdapterConfig,
 } from './core/adapters'
 import { getPlan, Plan, PlanItem } from './core/plan'
 import {
@@ -175,6 +175,7 @@ export type FetchResult = {
   fetchErrors: SaltoError[]
   success: boolean
   configChanges?: Plan
+  updatedConfigs : Record<string, InstanceElement[]>
   adapterNameToConfigMessage?: Record<string, string>
 }
 export type FetchFunc = (
@@ -216,7 +217,7 @@ export const fetch: FetchFunc = async (
     progressEmitter.emit('adaptersDidInitialize')
   }
   const {
-    changes, elements, mergeErrors, errors,
+    changes, elements, mergeErrors, errors, updatedConfigs,
     configChanges, adapterNameToConfigMessage, unmergedElements,
   } = await fetchChanges(
     adapters,
@@ -238,6 +239,7 @@ export const fetch: FetchFunc = async (
     mergeErrors,
     success: true,
     configChanges,
+    updatedConfigs,
     adapterNameToConfigMessage,
   }
 }
@@ -324,7 +326,7 @@ export const addAdapter = async (
   await workspace.addService(adapterName)
 
   if (_.isUndefined((await workspace.serviceConfig(adapterName)))) {
-    const defaultConfig = await getDefaultAdapterConfig(adapterName)
+    const defaultConfig = await getInitialAdapterConfig(adapterName)
     if (!_.isUndefined(defaultConfig)) {
       await workspace.updateServiceConfig(adapterName, defaultConfig)
     }

--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -64,6 +64,18 @@ export const getDefaultAdapterConfig = async (
   return configType ? createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType) : undefined
 }
 
+export const getInitialAdapterConfig = async (
+  adapterName: string
+): Promise<InstanceElement[] | undefined> => {
+  const { getInitialConfig } = adapterCreators[adapterName]
+  if (getInitialConfig !== undefined) {
+    return getInitialConfig()
+  }
+
+  const defaultConf = await getDefaultAdapterConfig(adapterName)
+  return defaultConf && [defaultConf]
+}
+
 const filterElementsSourceAdapter = (
   elementsSource: ReadOnlyElementsSource,
   adapter: string

--- a/packages/core/src/core/clean.ts
+++ b/packages/core/src/core/clean.ts
@@ -18,7 +18,7 @@ import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { Workspace, WorkspaceComponents } from '@salto-io/workspace'
 import { cleanDatabases } from '../local-workspace/remote_map'
-import { getDefaultAdapterConfig } from './adapters'
+import { getInitialAdapterConfig } from './adapters'
 
 const { awu } = collections.asynciterable
 
@@ -31,7 +31,7 @@ export const cleanWorkspace = async (
   await workspace.clear(_.omit(cleanArgs, 'serviceConfig'))
   if (cleanArgs.serviceConfig === true) {
     await awu(workspace.services()).forEach(async service => {
-      const defaultConfig = await getDefaultAdapterConfig(service)
+      const defaultConfig = await getInitialAdapterConfig(service)
       if (defaultConfig === undefined) {
         // some services, like hubspot, don't have configs to restore
         log.info('Cannot restore config for service %s', service)

--- a/packages/core/src/core/clean.ts
+++ b/packages/core/src/core/clean.ts
@@ -18,7 +18,7 @@ import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { Workspace, WorkspaceComponents } from '@salto-io/workspace'
 import { cleanDatabases } from '../local-workspace/remote_map'
-import { getInitialAdapterConfig } from './adapters'
+import { getDefaultAdapterConfig } from './adapters'
 
 const { awu } = collections.asynciterable
 
@@ -31,7 +31,7 @@ export const cleanWorkspace = async (
   await workspace.clear(_.omit(cleanArgs, 'serviceConfig'))
   if (cleanArgs.serviceConfig === true) {
     await awu(workspace.services()).forEach(async service => {
-      const defaultConfig = await getInitialAdapterConfig(service)
+      const defaultConfig = await getDefaultAdapterConfig(service)
       if (defaultConfig === undefined) {
         // some services, like hubspot, don't have configs to restore
         log.info('Cannot restore config for service %s', service)

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -602,7 +602,7 @@ export const fetchChanges = async (
   const configs = await awu(configsMerge.merged.values()).toArray()
 
   await awu(await configsMerge.errors.entries()).forEach(error => {
-    log.warn(`Got merge errors for config element ${error.key}: ${error.value.map(err => err.message).join(', ')}`)
+    throw new Error(`Got merge errors for config element ${error.key}: ${error.value.map(err => err.message).join(', ')}`)
   })
 
   const updatedConfigNames = new Set(configs.map(c => c.elemID.getFullName()))

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -600,9 +600,12 @@ export const fetchChanges = async (
 
   const configsMerge = await mergeElements(awu(updatedConfig.flatMap(c => c.config)))
 
-  const [error] = await awu(await configsMerge.errors.entries()).toArray()
-  if (error !== undefined) {
-    throw new Error(`Received configuration merge error: ${error.key}: ${error.value.map(err => err.message).join(', ')}`)
+  const errorMessages = await awu(await configsMerge.errors.entries())
+    .flatMap(err => err.value)
+    .map(err => err.message)
+    .toArray()
+  if (errorMessages.length !== 0) {
+    throw new Error(`Received configuration merge errors: ${errorMessages.join(', ')}`)
   }
 
   const configs = await awu(configsMerge.merged.values()).toArray()

--- a/packages/core/src/local-workspace/adapters_config.ts
+++ b/packages/core/src/local-workspace/adapters_config.ts
@@ -44,8 +44,7 @@ const createNaclSource = async (
   })
 
   const naclStaticFilesStore = localDirectoryStore({
-    baseDir,
-    name: 'salto.config',
+    baseDir: path.join(baseDir, 'salto.config', 'adapters'),
     nameSuffix: 'static-resources',
   })
 
@@ -55,7 +54,7 @@ const createNaclSource = async (
   )
 
   const source = await nacl.naclFilesSource(
-    'config',
+    'salto.config/adapters',
     naclFilesStore,
     staticFileSource,
     remoteMapCreator,

--- a/packages/core/src/local-workspace/adapters_config.ts
+++ b/packages/core/src/local-workspace/adapters_config.ts
@@ -157,5 +157,6 @@ export const adaptersConfigSource = async (
       }
       await naclSource.flush()
     },
+    source: naclSource,
   }
 }

--- a/packages/core/src/local-workspace/adapters_config.ts
+++ b/packages/core/src/local-workspace/adapters_config.ts
@@ -82,6 +82,10 @@ export const adaptersConfigSource = async (
 
   const setUnsafe = async (configs: Readonly<InstanceElement> | Readonly<InstanceElement>[]):
   Promise<void> => {
+    // This functions first remove the existing configuration and then add the new configuration
+    // instead of creating a "modify" change to the configuration so the config element will
+    // be splitted exactly like the new configuration and not like the old one
+
     const configsArr = collections.array.makeArray(configs)
     await Promise.all(_(configsArr)
       .map(conf => conf.elemID)

--- a/packages/core/src/local-workspace/adapters_config.ts
+++ b/packages/core/src/local-workspace/adapters_config.ts
@@ -1,0 +1,159 @@
+
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import path from 'path'
+import { workspaceConfigSource as wcs,
+  nacl, staticFiles, parser, merger, adaptersConfigSource as acs, remoteMap } from '@salto-io/workspace'
+import { DetailedChange, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { applyDetailedChanges, detailedCompare } from '@salto-io/adapter-utils'
+import { localDirectoryStore } from './dir_store'
+import { buildLocalStaticFilesCache } from './static_files_cache'
+
+const { awu } = collections.asynciterable
+
+export type WorkspaceConfigSource = wcs.WorkspaceConfigSource & {
+  localStorage: string
+}
+
+const createNaclSource = async (
+  baseDir: string,
+  localStorage: string,
+  remoteMapCreator: remoteMap.RemoteMapCreator
+)
+  : Promise<nacl.NaclFilesSource> => {
+  const naclFilesStore = localDirectoryStore({
+    baseDir: path.join(baseDir, 'salto.config', 'adapters'),
+    encoding: 'utf8',
+    fileFilter: `*${nacl.FILE_EXTENSION}`,
+  })
+
+  const naclStaticFilesStore = localDirectoryStore({
+    baseDir,
+    name: 'salto.config',
+    nameSuffix: 'static-resources',
+  })
+
+  const staticFileSource = staticFiles.buildStaticFilesSource(
+    naclStaticFilesStore,
+    buildLocalStaticFilesCache(localStorage, 'config-cache'),
+  )
+
+  const source = await nacl.naclFilesSource(
+    'config',
+    naclFilesStore,
+    staticFileSource,
+    remoteMapCreator,
+    true,
+  )
+  await source.load({})
+  return source
+}
+
+export const adaptersConfigSource = async (
+  baseDir: string,
+  localStorage: string,
+  remoteMapCreator: remoteMap.RemoteMapCreator,
+  configOverrides: DetailedChange[] = [],
+): Promise<acs.AdaptersConfigSource> => {
+  const configOverridesById = _.groupBy(configOverrides, change => change.id.adapter)
+
+  const applyConfigOverrides = (conf: InstanceElement): void => {
+    const overridesForInstance = configOverridesById[conf.elemID.adapter] ?? []
+    applyDetailedChanges(conf, overridesForInstance)
+  }
+
+  const naclSource = await createNaclSource(baseDir, localStorage, remoteMapCreator)
+
+  const setUnsafe = async (configs: Readonly<InstanceElement> | Readonly<InstanceElement>[]):
+  Promise<void> => {
+    const currentPaths = await naclSource.getElementNaclFiles(
+      collections.array.makeArray(configs)[0].elemID
+    )
+    const pathToInstances = _.groupBy(collections.array.makeArray(configs), conf => (conf.path !== undefined ? `${conf.path.join('/')}.nacl` : `${conf.elemID.adapter}.nacl`))
+    await Promise.all(Object.entries(pathToInstances)
+      .map(async ([confPath, confs]) => {
+        await naclSource.setNaclFiles({
+          filename: confPath,
+          buffer: await parser.dumpElements(confs),
+        })
+      }))
+    await Promise.all(currentPaths
+      .filter(confPath => !Object.keys(pathToInstances).includes(confPath))
+      .map(async confPath => {
+        await naclSource.setNaclFiles({ filename: confPath, buffer: '' })
+      }))
+    await naclSource.flush()
+  }
+
+  const getConfigWithoutOverrides = (adapter: string): Promise<InstanceElement | undefined> => naclSource.get(new ElemID(adapter, ElemID.CONFIG_NAME, 'instance'))
+
+  const validateConfigChanges = (configChanges: DetailedChange[]): void => {
+    const updatedOverriddenIds = configOverrides.filter(
+      overiddeChange => configChanges.some(
+        updateChange => updateChange.id.isParentOf(overiddeChange.id)
+          || overiddeChange.id.isParentOf(updateChange.id)
+          || overiddeChange.id.isEqual(updateChange.id)
+      )
+    )
+
+    if (updatedOverriddenIds.length !== 0) {
+      throw new Error(`cannot update fields that were overridden by the user: ${updatedOverriddenIds.map(change => change.id.getFullName())}`)
+    }
+  }
+
+  return {
+    getAdapter: async (adapter, defaultValue) => {
+      const conf = (await getConfigWithoutOverrides(adapter) ?? defaultValue)?.clone()
+      if (conf === undefined) {
+        return undefined
+      }
+      applyConfigOverrides(conf)
+      return conf
+    },
+
+    setAdapter: async (adapter, configs) => {
+      const currConfWithoutOverrides = await getConfigWithoutOverrides(adapter)
+      // Could happen at the initialization of a service.
+      if (currConfWithoutOverrides === undefined) {
+        await setUnsafe(configs)
+        return
+      }
+      const currConf = currConfWithoutOverrides.clone()
+      applyConfigOverrides(currConf)
+
+      const [mergeConfig] = await awu(
+        await (
+          await merger.mergeElements(awu(collections.array.makeArray(configs)).map(e => e.clone()))
+        ).merged.values()
+      ).toArray() as [InstanceElement]
+
+      const configChanges = await detailedCompare(currConf, mergeConfig)
+
+      validateConfigChanges(configChanges)
+
+      await setUnsafe(configs)
+      const overridesForInstance = configOverridesById[adapter]
+      if (overridesForInstance !== undefined) {
+        const reversedOverrides = await detailedCompare(currConf, currConfWithoutOverrides)
+        await naclSource.updateNaclFiles(reversedOverrides)
+        await applyDetailedChanges(mergeConfig, reversedOverrides)
+      }
+      await naclSource.flush()
+    },
+  }
+}

--- a/packages/core/src/local-workspace/adapters_config.ts
+++ b/packages/core/src/local-workspace/adapters_config.ts
@@ -33,7 +33,8 @@ export type WorkspaceConfigSource = wcs.WorkspaceConfigSource & {
 const createNaclSource = async (
   baseDir: string,
   localStorage: string,
-  remoteMapCreator: remoteMap.RemoteMapCreator
+  remoteMapCreator: remoteMap.RemoteMapCreator,
+  persistent: boolean,
 )
   : Promise<nacl.NaclFilesSource> => {
   const naclFilesStore = localDirectoryStore({
@@ -58,7 +59,7 @@ const createNaclSource = async (
     naclFilesStore,
     staticFileSource,
     remoteMapCreator,
-    true,
+    persistent,
   )
   await source.load({})
   return source
@@ -68,6 +69,7 @@ export const adaptersConfigSource = async (
   baseDir: string,
   localStorage: string,
   remoteMapCreator: remoteMap.RemoteMapCreator,
+  persistent: boolean,
   configOverrides: DetailedChange[] = [],
 ): Promise<acs.AdaptersConfigSource> => {
   const configOverridesById = _.groupBy(configOverrides, change => change.id.adapter)
@@ -77,7 +79,7 @@ export const adaptersConfigSource = async (
     applyDetailedChanges(conf, overridesForInstance)
   }
 
-  const naclSource = await createNaclSource(baseDir, localStorage, remoteMapCreator)
+  const naclSource = await createNaclSource(baseDir, localStorage, remoteMapCreator, persistent)
 
   const setUnsafe = async (configs: Readonly<InstanceElement> | Readonly<InstanceElement>[]):
   Promise<void> => {

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -37,6 +37,7 @@ export const STATES_DIR_NAME = 'states'
 export const CREDENTIALS_CONFIG_PATH = 'credentials'
 export const CACHE_DIR_NAME = 'cache'
 export const STATIC_RESOURCES_FOLDER = 'static-resources'
+const PERSISTENT_MODE = true
 
 export class NotAnEmptyWorkspaceError extends Error {
   constructor(exsitingPathes: string[]) {
@@ -272,14 +273,19 @@ Promise<Workspace> => {
 
   const workspaceConfig = await workspaceConfigSource(baseDir, localStorage)
   const remoteMapCreator = createRemoteMapCreator(path.join(localStorage, CACHE_DIR_NAME))
-  const adaptersConfig = await adaptersConfigSource(baseDir, localStorage, remoteMapCreator, true)
+  const adaptersConfig = await adaptersConfigSource(
+    baseDir,
+    localStorage,
+    remoteMapCreator,
+    PERSISTENT_MODE
+  )
   const credentials = credentialsSource(localStorage)
   const elemSources = await loadLocalElementsSources(
     path.resolve(baseDir),
     localStorage,
     [envName],
     remoteMapCreator,
-    true
+    PERSISTENT_MODE
   )
 
   return initWorkspace(

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -27,6 +27,7 @@ import { localState } from './state'
 import { workspaceConfigSource } from './workspace_config'
 import { buildLocalStaticFilesCache } from './static_files_cache'
 import { createRemoteMapCreator } from './remote_map'
+import { adaptersConfigSource } from './adapters_config'
 
 const { configSource } = cs
 const { FILE_EXTENSION, naclFilesSource, ENVS_PREFIX } = nacl
@@ -193,11 +194,18 @@ export const loadLocalWorkspace = async (
   if (_.isUndefined(baseDir)) {
     throw new NotAWorkspaceError()
   }
-  const workspaceConfig = await workspaceConfigSource(baseDir, undefined, configOverrides)
-  const envs = (await workspaceConfig.getWorkspaceConfig()).envs.map(e => e.name)
-  const credentials = credentialsSource(workspaceConfig.localStorage)
+  const workspaceConfig = await workspaceConfigSource(baseDir, undefined)
   const cacheDirName = path.join(workspaceConfig.localStorage, CACHE_DIR_NAME)
   const remoteMapCreator = createRemoteMapCreator(cacheDirName)
+  const adaptersConfig = await adaptersConfigSource(
+    baseDir,
+    workspaceConfig.localStorage,
+    remoteMapCreator,
+    configOverrides
+  )
+  const envs = (await workspaceConfig.getWorkspaceConfig()).envs.map(e => e.name)
+  const credentials = credentialsSource(workspaceConfig.localStorage)
+
   const elemSources = await loadLocalElementsSources(
     baseDir,
     workspaceConfig.localStorage,
@@ -207,6 +215,7 @@ export const loadLocalWorkspace = async (
   )
   const ws = await loadWorkspace(
     workspaceConfig,
+    adaptersConfig,
     credentials,
     elemSources,
     remoteMapCreator,
@@ -261,8 +270,9 @@ Promise<Workspace> => {
   }
 
   const workspaceConfig = await workspaceConfigSource(baseDir, localStorage)
-  const credentials = credentialsSource(localStorage)
   const remoteMapCreator = createRemoteMapCreator(path.join(localStorage, CACHE_DIR_NAME))
+  const adaptersConfig = await adaptersConfigSource(baseDir, localStorage, remoteMapCreator)
+  const credentials = credentialsSource(localStorage)
   const elemSources = await loadLocalElementsSources(
     path.resolve(baseDir),
     localStorage,
@@ -276,6 +286,7 @@ Promise<Workspace> => {
     uid,
     envName,
     workspaceConfig,
+    adaptersConfig,
     credentials,
     elemSources,
     remoteMapCreator

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -201,7 +201,8 @@ export const loadLocalWorkspace = async (
     baseDir,
     workspaceConfig.localStorage,
     remoteMapCreator,
-    configOverrides
+    persistent,
+    configOverrides,
   )
   const envs = (await workspaceConfig.getWorkspaceConfig()).envs.map(e => e.name)
   const credentials = credentialsSource(workspaceConfig.localStorage)
@@ -271,7 +272,7 @@ Promise<Workspace> => {
 
   const workspaceConfig = await workspaceConfigSource(baseDir, localStorage)
   const remoteMapCreator = createRemoteMapCreator(path.join(localStorage, CACHE_DIR_NAME))
-  const adaptersConfig = await adaptersConfigSource(baseDir, localStorage, remoteMapCreator)
+  const adaptersConfig = await adaptersConfigSource(baseDir, localStorage, remoteMapCreator, true)
   const credentials = credentialsSource(localStorage)
   const elemSources = await loadLocalElementsSources(
     path.resolve(baseDir),

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -37,7 +37,6 @@ export const STATES_DIR_NAME = 'states'
 export const CREDENTIALS_CONFIG_PATH = 'credentials'
 export const CACHE_DIR_NAME = 'cache'
 export const STATIC_RESOURCES_FOLDER = 'static-resources'
-const PERSISTENT_MODE = true
 
 export class NotAnEmptyWorkspaceError extends Error {
   constructor(exsitingPathes: string[]) {
@@ -273,11 +272,13 @@ Promise<Workspace> => {
 
   const workspaceConfig = await workspaceConfigSource(baseDir, localStorage)
   const remoteMapCreator = createRemoteMapCreator(path.join(localStorage, CACHE_DIR_NAME))
+  const persistentMode = true
+
   const adaptersConfig = await adaptersConfigSource(
     baseDir,
     localStorage,
     remoteMapCreator,
-    PERSISTENT_MODE
+    persistentMode
   )
   const credentials = credentialsSource(localStorage)
   const elemSources = await loadLocalElementsSources(
@@ -285,7 +286,7 @@ Promise<Workspace> => {
     localStorage,
     [envName],
     remoteMapCreator,
-    PERSISTENT_MODE
+    persistentMode
   )
 
   return initWorkspace(

--- a/packages/core/src/local-workspace/workspace_config.ts
+++ b/packages/core/src/local-workspace/workspace_config.ts
@@ -17,24 +17,23 @@ import _ from 'lodash'
 import path from 'path'
 import { workspaceConfigSource as wcs,
   WorkspaceConfig, configSource } from '@salto-io/workspace'
-import { DetailedChange } from '@salto-io/adapter-api'
 import { localDirectoryStore } from './dir_store'
 import { getSaltoHome, CONFIG_DIR_NAME } from '../app_config'
 import { WORKSPACE_CONFIG_NAME, ENVS_CONFIG_NAME, EnvsConfig,
   USER_CONFIG_NAME, UserDataConfig, WorkspaceMetadataConfig, envsConfigInstance,
-  userDataConfigInstance, workspaceMetadataConfigInstance, ADAPTERS_CONFIG_NAME } from './workspace_config_types'
+  userDataConfigInstance, workspaceMetadataConfigInstance } from './workspace_config_types'
 import { NoWorkspaceConfig, NoEnvsConfig } from './errors'
+
 
 export type WorkspaceConfigSource = wcs.WorkspaceConfigSource & {
   localStorage: string
 }
 
 export const workspaceConfigSource = async (
-  baseDir: string, localStorage?: string, configOverrides?: DetailedChange[]
+  baseDir: string, localStorage?: string
 ): Promise<WorkspaceConfigSource> => {
   const repoCs = configSource.configSource(
     localDirectoryStore({ baseDir, name: CONFIG_DIR_NAME, encoding: 'utf8' }),
-    configOverrides,
   )
   const workspaceConf = (await repoCs.get(WORKSPACE_CONFIG_NAME))?.value
 
@@ -46,8 +45,8 @@ export const workspaceConfigSource = async (
   || path.join(getSaltoHome(), `${workspaceConf?.name}-${workspaceConf?.uid}`)
   const localCs = configSource.configSource(
     localDirectoryStore({ baseDir: computedLocalStorage, name: '', encoding: 'utf8' }),
-    configOverrides,
   )
+
   return {
     localStorage: computedLocalStorage,
     getWorkspaceConfig: async (): Promise<WorkspaceConfig> => {
@@ -80,11 +79,5 @@ export const workspaceConfigSource = async (
       await repoCs.set(WORKSPACE_CONFIG_NAME, workspaceMetadata)
       await localCs.set(USER_CONFIG_NAME, userData)
     },
-    getAdapter: (adapter, defaultValue) => (
-      repoCs.get(path.join(ADAPTERS_CONFIG_NAME, adapter), defaultValue)
-    ),
-    setAdapter: (adapter, config) => (
-      repoCs.set(path.join(ADAPTERS_CONFIG_NAME, adapter), config)
-    ),
   }
 }

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -117,7 +117,7 @@ describe('api.ts', () => {
         changes: [],
         errors: [],
         configChanges: mockPlan.createPlan([[]]),
-        updatedConfigs: {},
+        updatedConfig: {},
         unmergedElements: fetchedElements,
         elements: fetchedElements,
         mergeErrors: [],

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -117,6 +117,7 @@ describe('api.ts', () => {
         changes: [],
         errors: [],
         configChanges: mockPlan.createPlan([[]]),
+        updatedConfigs: {},
         unmergedElements: fetchedElements,
         elements: fetchedElements,
         mergeErrors: [],

--- a/packages/core/test/common/nacl_file_source.ts
+++ b/packages/core/test/common/nacl_file_source.ts
@@ -1,0 +1,50 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { mockFunction, MockInterface } from '@salto-io/test-utils'
+import { nacl } from '@salto-io/workspace'
+
+
+export const createMockNaclFileSource = (): MockInterface<nacl.NaclFilesSource> => ({
+  list: mockFunction<nacl.NaclFilesSource['list']>(),
+  isEmpty: mockFunction<nacl.NaclFilesSource['isEmpty']>(),
+  get: mockFunction<nacl.NaclFilesSource['get']>(),
+  has: mockFunction<nacl.NaclFilesSource['has']>(),
+  set: mockFunction<nacl.NaclFilesSource['set']>(),
+  setAll: mockFunction<nacl.NaclFilesSource['setAll']>(),
+  delete: mockFunction<nacl.NaclFilesSource['delete']>(),
+  deleteAll: mockFunction<nacl.NaclFilesSource['deleteAll']>(),
+  getAll: mockFunction<nacl.NaclFilesSource['getAll']>(),
+  getElementsSource: mockFunction<nacl.NaclFilesSource['getElementsSource']>(),
+  clear: mockFunction<nacl.NaclFilesSource['clear']>(),
+  rename: mockFunction<nacl.NaclFilesSource['rename']>(),
+  flush: mockFunction<nacl.NaclFilesSource['flush']>(),
+  updateNaclFiles: mockFunction<nacl.NaclFilesSource['updateNaclFiles']>(),
+  listNaclFiles: mockFunction<nacl.NaclFilesSource['listNaclFiles']>(),
+  getTotalSize: mockFunction<nacl.NaclFilesSource['getTotalSize']>(),
+  getNaclFile: mockFunction<nacl.NaclFilesSource['getNaclFile']>(),
+  setNaclFiles: mockFunction<nacl.NaclFilesSource['setNaclFiles']>(),
+  removeNaclFiles: mockFunction<nacl.NaclFilesSource['removeNaclFiles']>(),
+  getSourceMap: mockFunction<nacl.NaclFilesSource['getSourceMap']>(),
+  getSourceRanges: mockFunction<nacl.NaclFilesSource['getSourceRanges']>(),
+  getErrors: mockFunction<nacl.NaclFilesSource['getErrors']>(),
+  getParsedNaclFile: mockFunction<nacl.NaclFilesSource['getParsedNaclFile']>(),
+  getElementNaclFiles: mockFunction<nacl.NaclFilesSource['getElementNaclFiles']>(),
+  clone: mockFunction<nacl.NaclFilesSource['clone']>(),
+  getElementReferencedFiles: mockFunction<nacl.NaclFilesSource['getElementReferencedFiles']>(),
+  load: mockFunction<nacl.NaclFilesSource['load']>(),
+  getSearchableNames: mockFunction<nacl.NaclFilesSource['getSearchableNames']>(),
+  getStaticFile: mockFunction<nacl.NaclFilesSource['getStaticFile']>(),
+})

--- a/packages/core/test/core/adapters/adapters.test.ts
+++ b/packages/core/test/core/adapters/adapters.test.ts
@@ -21,7 +21,7 @@ import { adapter } from '@salto-io/salesforce-adapter'
 import _ from 'lodash'
 import {
   initAdapters, getAdaptersCredentialsTypes, getAdaptersCreatorConfigs,
-  getInitialAdapterConfig,
+  getDefaultAdapterConfig,
 } from '../../../src/core/adapters'
 
 jest.mock('@salto-io/workspace', () => ({
@@ -60,7 +60,7 @@ describe('adapters.ts', () => {
     })
   })
 
-  describe('getInitialAdapterConfig', () => {
+  describe('getDefaultAdapterConfig', () => {
     let realAdapter: Adapter
     beforeEach(() => {
       realAdapter = _.clone(adapter)
@@ -68,14 +68,14 @@ describe('adapters.ts', () => {
     afterEach(() => {
       _.assign(adapter, realAdapter)
     })
-    it('should call createDefaultInstanceFromType when getInitialConfig is undefined', async () => {
-      await getInitialAdapterConfig('salesforce')
+    it('should call createDefaultInstanceFromType when getDefaultConfig is undefined', async () => {
+      await getDefaultAdapterConfig('salesforce')
       expect(utils.createDefaultInstanceFromType).toHaveBeenCalled()
     })
-    it('should use getInitialConfig when defined', async () => {
-      adapter.getInitialConfig = jest.fn()
-      await getInitialAdapterConfig('salesforce')
-      expect(adapter.getInitialConfig).toHaveBeenCalled()
+    it('should use getDefaultConfig when defined', async () => {
+      adapter.getDefaultConfig = jest.fn()
+      await getDefaultAdapterConfig('salesforce')
+      expect(adapter.getDefaultConfig).toHaveBeenCalled()
     })
   })
 

--- a/packages/core/test/core/adapters/adapters.test.ts
+++ b/packages/core/test/core/adapters/adapters.test.ts
@@ -13,14 +13,16 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, ElemID, AdapterAuthentication, ObjectType } from '@salto-io/adapter-api'
+import { InstanceElement, ElemID, AdapterAuthentication, ObjectType, Adapter } from '@salto-io/adapter-api'
 import * as utils from '@salto-io/adapter-utils'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { adapter } from '@salto-io/salesforce-adapter'
+import _ from 'lodash'
 import {
   initAdapters, getAdaptersCredentialsTypes, getAdaptersCreatorConfigs,
   getDefaultAdapterConfig,
+  getInitialAdapterConfig,
 } from '../../../src/core/adapters'
 
 jest.mock('@salto-io/workspace', () => ({
@@ -62,6 +64,25 @@ describe('adapters.ts', () => {
   describe('getDefaultAdapterConfig', () => {
     it('should call createDefaultInstanceFromType', async () => {
       await getDefaultAdapterConfig('salesforce')
+      expect(utils.createDefaultInstanceFromType).toHaveBeenCalled()
+    })
+  })
+
+  describe('getInitialAdapterConfig', () => {
+    let realAdapter: Adapter
+    beforeEach(() => {
+      realAdapter = _.clone(adapter)
+    })
+    afterEach(() => {
+      _.assign(adapter, realAdapter)
+    })
+    it('should use getInitialConfig when defined', async () => {
+      adapter.getInitialConfig = jest.fn()
+      await getInitialAdapterConfig('salesforce')
+      expect(adapter.getInitialConfig).toHaveBeenCalled()
+    })
+    it('should call createDefaultInstanceFromType when getInitialConfig is undefined', async () => {
+      await getInitialAdapterConfig('salesforce')
       expect(utils.createDefaultInstanceFromType).toHaveBeenCalled()
     })
   })

--- a/packages/core/test/core/adapters/adapters.test.ts
+++ b/packages/core/test/core/adapters/adapters.test.ts
@@ -15,13 +15,12 @@
 */
 import { InstanceElement, ElemID, AdapterAuthentication, ObjectType, Adapter } from '@salto-io/adapter-api'
 import * as utils from '@salto-io/adapter-utils'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { buildElementsSourceFromElements, createDefaultInstanceFromType } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { adapter } from '@salto-io/salesforce-adapter'
 import _ from 'lodash'
 import {
   initAdapters, getAdaptersCredentialsTypes, getAdaptersCreatorConfigs,
-  getDefaultAdapterConfig,
   getInitialAdapterConfig,
 } from '../../../src/core/adapters'
 
@@ -61,13 +60,6 @@ describe('adapters.ts', () => {
     })
   })
 
-  describe('getDefaultAdapterConfig', () => {
-    it('should call createDefaultInstanceFromType', async () => {
-      await getDefaultAdapterConfig('salesforce')
-      expect(utils.createDefaultInstanceFromType).toHaveBeenCalled()
-    })
-  })
-
   describe('getInitialAdapterConfig', () => {
     let realAdapter: Adapter
     beforeEach(() => {
@@ -76,14 +68,14 @@ describe('adapters.ts', () => {
     afterEach(() => {
       _.assign(adapter, realAdapter)
     })
+    it('should call createDefaultInstanceFromType when getInitialConfig is undefined', async () => {
+      await getInitialAdapterConfig('salesforce')
+      expect(utils.createDefaultInstanceFromType).toHaveBeenCalled()
+    })
     it('should use getInitialConfig when defined', async () => {
       adapter.getInitialConfig = jest.fn()
       await getInitialAdapterConfig('salesforce')
       expect(adapter.getInitialConfig).toHaveBeenCalled()
-    })
-    it('should call createDefaultInstanceFromType when getInitialConfig is undefined', async () => {
-      await getInitialAdapterConfig('salesforce')
-      expect(utils.createDefaultInstanceFromType).toHaveBeenCalled()
     })
   })
 
@@ -100,7 +92,10 @@ describe('adapters.ts', () => {
       expect(result[serviceName]).toEqual(
         expect.objectContaining({
           credentials: sfConfig,
-          config: await getDefaultAdapterConfig(serviceName),
+          config: await createDefaultInstanceFromType(
+            ElemID.CONFIG_NAME,
+            adapter.configType as ObjectType
+          ),
           getElemIdFunc: undefined,
         })
       )

--- a/packages/core/test/core/clean.test.ts
+++ b/packages/core/test/core/clean.test.ts
@@ -20,7 +20,7 @@ import { mockWorkspace } from '../common/workspace'
 
 jest.mock('../../src/core/adapters', () => ({
   ...jest.requireActual<{}>('../../src/core/adapters'),
-  getDefaultAdapterConfig: jest.fn(service => ({ service, aaa: 'aaa' })),
+  getInitialAdapterConfig: jest.fn(service => ({ service, aaa: 'aaa' })),
 }))
 
 describe('clean', () => {
@@ -50,8 +50,8 @@ describe('clean', () => {
       staticResources: false,
       credentials: true,
     })
-    expect(adapters.getDefaultAdapterConfig).toHaveBeenCalledWith('salesforce')
-    expect(adapters.getDefaultAdapterConfig).toHaveBeenCalledWith('netsuite')
+    expect(adapters.getInitialAdapterConfig).toHaveBeenCalledWith('salesforce')
+    expect(adapters.getInitialAdapterConfig).toHaveBeenCalledWith('netsuite')
     expect(workspace.updateServiceConfig).toHaveBeenCalledWith('salesforce', { service: 'salesforce', aaa: 'aaa' })
     expect(workspace.updateServiceConfig).toHaveBeenCalledWith('netsuite', { service: 'netsuite', aaa: 'aaa' })
     expect(workspace.flush).toHaveBeenCalled()
@@ -73,13 +73,13 @@ describe('clean', () => {
       staticResources: true,
       credentials: false,
     })
-    expect(adapters.getDefaultAdapterConfig).not.toHaveBeenCalled()
+    expect(adapters.getInitialAdapterConfig).not.toHaveBeenCalled()
     expect(workspace.updateServiceConfig).not.toHaveBeenCalled()
     expect(workspace.flush).toHaveBeenCalled()
   })
 
-  it('should finish even if some serviec configs cannot be restored', async () => {
-    jest.spyOn(adapters, 'getDefaultAdapterConfig')
+  it('should finish even if some service configs cannot be restored', async () => {
+    jest.spyOn(adapters, 'getInitialAdapterConfig')
       .mockImplementationOnce(async () => undefined)
       .mockImplementationOnce(async () => undefined)
     await cleanWorkspace(workspace, {
@@ -90,8 +90,8 @@ describe('clean', () => {
       credentials: true,
       serviceConfig: true,
     })
-    expect(adapters.getDefaultAdapterConfig).toHaveBeenCalledWith('salesforce')
-    expect(adapters.getDefaultAdapterConfig).toHaveBeenCalledWith('netsuite')
+    expect(adapters.getInitialAdapterConfig).toHaveBeenCalledWith('salesforce')
+    expect(adapters.getInitialAdapterConfig).toHaveBeenCalledWith('netsuite')
     expect(workspace.updateServiceConfig).not.toHaveBeenCalled()
     expect(workspace.flush).toHaveBeenCalled()
   })

--- a/packages/core/test/core/clean.test.ts
+++ b/packages/core/test/core/clean.test.ts
@@ -20,7 +20,7 @@ import { mockWorkspace } from '../common/workspace'
 
 jest.mock('../../src/core/adapters', () => ({
   ...jest.requireActual<{}>('../../src/core/adapters'),
-  getInitialAdapterConfig: jest.fn(service => ({ service, aaa: 'aaa' })),
+  getDefaultAdapterConfig: jest.fn(service => ({ service, aaa: 'aaa' })),
 }))
 
 describe('clean', () => {
@@ -50,8 +50,8 @@ describe('clean', () => {
       staticResources: false,
       credentials: true,
     })
-    expect(adapters.getInitialAdapterConfig).toHaveBeenCalledWith('salesforce')
-    expect(adapters.getInitialAdapterConfig).toHaveBeenCalledWith('netsuite')
+    expect(adapters.getDefaultAdapterConfig).toHaveBeenCalledWith('salesforce')
+    expect(adapters.getDefaultAdapterConfig).toHaveBeenCalledWith('netsuite')
     expect(workspace.updateServiceConfig).toHaveBeenCalledWith('salesforce', { service: 'salesforce', aaa: 'aaa' })
     expect(workspace.updateServiceConfig).toHaveBeenCalledWith('netsuite', { service: 'netsuite', aaa: 'aaa' })
     expect(workspace.flush).toHaveBeenCalled()
@@ -73,13 +73,13 @@ describe('clean', () => {
       staticResources: true,
       credentials: false,
     })
-    expect(adapters.getInitialAdapterConfig).not.toHaveBeenCalled()
+    expect(adapters.getDefaultAdapterConfig).not.toHaveBeenCalled()
     expect(workspace.updateServiceConfig).not.toHaveBeenCalled()
     expect(workspace.flush).toHaveBeenCalled()
   })
 
   it('should finish even if some service configs cannot be restored', async () => {
-    jest.spyOn(adapters, 'getInitialAdapterConfig')
+    jest.spyOn(adapters, 'getDefaultAdapterConfig')
       .mockImplementationOnce(async () => undefined)
       .mockImplementationOnce(async () => undefined)
     await cleanWorkspace(workspace, {
@@ -90,8 +90,8 @@ describe('clean', () => {
       credentials: true,
       serviceConfig: true,
     })
-    expect(adapters.getInitialAdapterConfig).toHaveBeenCalledWith('salesforce')
-    expect(adapters.getInitialAdapterConfig).toHaveBeenCalledWith('netsuite')
+    expect(adapters.getDefaultAdapterConfig).toHaveBeenCalledWith('salesforce')
+    expect(adapters.getDefaultAdapterConfig).toHaveBeenCalledWith('netsuite')
     expect(workspace.updateServiceConfig).not.toHaveBeenCalled()
     expect(workspace.flush).toHaveBeenCalled()
   })

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -319,7 +319,7 @@ describe('fetch', () => {
 
       beforeEach(() => {
         mockAdapters.dummy.fetch.mockResolvedValueOnce(
-          { elements: [], updatedConfig: { config: configInstance, message: 'test' } }
+          { elements: [], updatedConfig: { config: [configInstance], message: 'test' } }
         )
       })
       it('should return config change plan when there is no current config', async () => {

--- a/packages/core/test/workspace/local/adapters_config.test.ts
+++ b/packages/core/test/workspace/local/adapters_config.test.ts
@@ -132,7 +132,7 @@ describe('adapters local config', () => {
         data: { after: 2 },
       },
     ]
-    configSource = await adaptersConfigSource('bla', 'somePath', undefined as unknown as remoteMap.RemoteMapCreator, configOverrides)
+    configSource = await adaptersConfigSource('bla', 'somePath', undefined as unknown as remoteMap.RemoteMapCreator, true, configOverrides)
   })
 
 

--- a/packages/core/test/workspace/local/adapters_config.test.ts
+++ b/packages/core/test/workspace/local/adapters_config.test.ts
@@ -126,10 +126,10 @@ describe('adapters local config', () => {
       new ObjectType({
         elemID: new ElemID('salesforce', ElemID.CONFIG_NAME),
       }),
-      { value: { inner1: undefined, inner2: 2 } }
+      { value: { inner1: undefined, inner2: 2, inner3: [] } }
     ))
     const receivedChange = mockNaclFilesSource.updateNaclFiles.mock.calls[1][0][0]
-    expect(getChangeElement(receivedChange).value).toEqual({ value: { inner2: 2 } })
+    expect(getChangeElement(receivedChange).value).toEqual({ value: { inner2: 2, inner3: [] } })
     expect(mockNaclFilesSource.flush).toHaveBeenCalled()
   })
 

--- a/packages/core/test/workspace/local/adapters_config.test.ts
+++ b/packages/core/test/workspace/local/adapters_config.test.ts
@@ -1,0 +1,201 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Values, InstanceElement, ObjectType, ElemID, DetailedChange } from '@salto-io/adapter-api'
+import { adaptersConfigSource as acs, dirStore, nacl, remoteMap } from '@salto-io/workspace'
+import { getSaltoHome } from '../../../src/app_config'
+import * as mockDirStore from '../../../src/local-workspace/dir_store'
+import { WORKSPACE_CONFIG_NAME, ENVS_CONFIG_NAME, USER_CONFIG_NAME } from '../../../src/local-workspace/workspace_config_types'
+import { adaptersConfigSource } from '../../../src/local-workspace/adapters_config'
+
+jest.mock('@salto-io/workspace', () => {
+  const actual = jest.requireActual('@salto-io/workspace')
+  return {
+    ...actual,
+    nacl: {
+      ...actual.nacl,
+      naclFilesSource: jest.fn(),
+    },
+  }
+})
+jest.mock('../../../src/local-workspace/dir_store')
+describe('adapters local config', () => {
+  const SALESFORCE = 'adapters/salesforce'
+  const mockDirStoreInstance = (obj: Values): dirStore.DirectoryStore<string> => ({
+    get: jest.fn().mockImplementation(
+      (name: string) => {
+        if (!Object.keys(obj).includes(name)) return undefined
+        return ({
+          buffer: obj[Object.keys(obj).filter(key => name.startsWith(key))[0]],
+          filename: '',
+        })
+      }
+    ),
+    set: jest.fn(),
+    flush: jest.fn(),
+    list: jest.fn(),
+    delete: jest.fn(),
+    renameFile: jest.fn(),
+    mtimestamp: jest.fn(),
+    getFiles: jest.fn(),
+    clone: jest.fn(),
+  } as unknown as dirStore.DirectoryStore<string>)
+
+  const loadMock = jest.fn()
+  const getMock = jest.fn()
+  const setNaclFilesMock = jest.fn()
+  const updateNaclFilesMock = jest.fn()
+  const flushMock = jest.fn()
+  const getElementNaclFilesMock = jest.fn();
+  (nacl.naclFilesSource as jest.Mock).mockResolvedValue({
+    load: loadMock,
+    get: getMock,
+    setNaclFiles: setNaclFilesMock,
+    updateNaclFiles: updateNaclFilesMock,
+    flush: flushMock,
+    getElementNaclFiles: getElementNaclFilesMock,
+  } as unknown as nacl.NaclFilesSource)
+
+  const repoDirStore = mockDirStoreInstance({
+    [`${WORKSPACE_CONFIG_NAME}.nacl`]: `
+    workspace {
+    uid = "98bb902f-a144-42da-9672-f36e312e8e09"
+    name = "test"
+  }
+  `,
+    [`${ENVS_CONFIG_NAME}.nacl`]: `
+  envs {
+    envs = [
+      {
+        name = "default"
+      },
+      {
+        name = "env2"
+      },
+    ]
+  }`,
+  })
+  const prefDirStore = mockDirStoreInstance({
+    [`${USER_CONFIG_NAME}.nacl`]: `
+  workspaceUser {
+    currentEnv = "default"
+  }
+  `,
+  })
+  let configSource: acs.AdaptersConfigSource
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    const mockCreateDirStore = mockDirStore.localDirectoryStore as jest.Mock
+    getMock.mockResolvedValue(new InstanceElement(
+      ElemID.CONFIG_NAME,
+      new ObjectType({ elemID: new ElemID(SALESFORCE, ElemID.CONFIG_NAME) }),
+      {
+        metadataTypesSkippedList: [
+          'Report',
+          'ReportType',
+          'ReportFolder',
+          'Dashboard',
+          'DashboardFolder',
+          'EmailTemplate',
+        ],
+        instancesRegexSkippedList: [
+          '^ConnectedApp.CPQIntegrationUserApp$',
+        ],
+        maxItemsInRetrieveRequest: 2500,
+        client: {
+          maxConcurrentApiRequests: {
+            retrieve: 3,
+          },
+        },
+      }
+    ))
+    getElementNaclFilesMock.mockResolvedValue([])
+    mockCreateDirStore.mockImplementation(params =>
+      (params.baseDir.startsWith(getSaltoHome()) ? prefDirStore : repoDirStore))
+
+    const configOverrides: DetailedChange[] = [
+      {
+        id: new ElemID(SALESFORCE, ElemID.CONFIG_NAME, 'instance', ElemID.CONFIG_NAME, 'overridden'),
+        action: 'add',
+        data: { after: 2 },
+      },
+    ]
+    configSource = await adaptersConfigSource('bla', 'somePath', undefined as unknown as remoteMap.RemoteMapCreator, configOverrides)
+  })
+
+
+  it('should look for adapter in nacl files source', async () => {
+    await configSource.getAdapter('salesforce')
+    expect(getMock).toHaveBeenCalled()
+  })
+
+  it('should return undefined when there is not configuration', async () => {
+    getMock.mockReturnValue(undefined)
+    expect(await configSource.getAdapter('salesforce')).toBeUndefined()
+  })
+  it('should set adapter in nacl files source with the default path', async () => {
+    await configSource.setAdapter('salesforce', new InstanceElement(
+      'adapter/salesforce',
+      new ObjectType({
+        elemID: new ElemID('salesforce'),
+      })
+    ))
+    expect(setNaclFilesMock).toHaveBeenCalledWith(expect.objectContaining({ filename: 'salesforce.nacl' }))
+    expect(flushMock).toHaveBeenCalled()
+  })
+
+  it('should set adapter in nacl files source with the config path', async () => {
+    await configSource.setAdapter('salesforce', new InstanceElement(
+      'adapter/salesforce',
+      new ObjectType({
+        elemID: new ElemID('salesforce'),
+      }),
+      {},
+      ['dir', 'file']
+    ))
+    expect(setNaclFilesMock).toHaveBeenCalledWith(expect.objectContaining({ filename: 'dir/file.nacl' }))
+    expect(flushMock).toHaveBeenCalled()
+  })
+
+  describe('configOverrides', () => {
+    it('should apply config overrides', async () => {
+      expect((await configSource.getAdapter(SALESFORCE))?.value.overridden).toBe(2)
+    })
+
+    it('update to an overridden field should throw an exception', async () => {
+      const conf = await configSource.getAdapter(SALESFORCE) as InstanceElement
+      conf.value.overridden = 3
+      await expect(configSource.setAdapter(SALESFORCE, conf)).rejects.toThrow()
+      expect(updateNaclFilesMock).not.toHaveBeenCalled()
+      expect(flushMock).not.toHaveBeenCalled()
+    })
+
+    it('update a none overridden field should not throw an exception', async () => {
+      const conf = await configSource.getAdapter(SALESFORCE) as InstanceElement
+      conf.value.other = 3
+      await configSource.setAdapter(SALESFORCE, conf)
+      expect(updateNaclFilesMock).toHaveBeenCalled()
+      expect(flushMock).toHaveBeenCalled()
+    })
+
+    it('should not call updateNaclFiles when there is no configuration', async () => {
+      const conf = await configSource.getAdapter(SALESFORCE) as InstanceElement
+      getMock.mockResolvedValue(undefined)
+      await configSource.setAdapter(SALESFORCE, conf)
+      expect(updateNaclFilesMock).not.toHaveBeenCalled()
+      expect(flushMock).toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/test/workspace/local/adapters_config.test.ts
+++ b/packages/core/test/workspace/local/adapters_config.test.ts
@@ -55,14 +55,14 @@ describe('adapters local config', () => {
 
   const loadMock = jest.fn()
   const getMock = jest.fn()
-  const setNaclFilesMock = jest.fn()
+  const removeNaclFilesMock = jest.fn()
   const updateNaclFilesMock = jest.fn()
   const flushMock = jest.fn()
   const getElementNaclFilesMock = jest.fn();
   (nacl.naclFilesSource as jest.Mock).mockResolvedValue({
     load: loadMock,
     get: getMock,
-    setNaclFiles: setNaclFilesMock,
+    removeNaclFiles: removeNaclFilesMock,
     updateNaclFiles: updateNaclFilesMock,
     flush: flushMock,
     getElementNaclFiles: getElementNaclFilesMock,
@@ -152,7 +152,7 @@ describe('adapters local config', () => {
         elemID: new ElemID('salesforce'),
       })
     ))
-    expect(setNaclFilesMock).toHaveBeenCalledWith(expect.objectContaining({ filename: 'salesforce.nacl' }))
+    expect(updateNaclFilesMock).toHaveBeenCalledWith([expect.objectContaining({ path: ['salesforce'] })])
     expect(flushMock).toHaveBeenCalled()
   })
 
@@ -165,7 +165,7 @@ describe('adapters local config', () => {
       {},
       ['dir', 'file']
     ))
-    expect(setNaclFilesMock).toHaveBeenCalledWith(expect.objectContaining({ filename: 'dir/file.nacl' }))
+    expect(updateNaclFilesMock).toHaveBeenCalledWith([expect.objectContaining({ path: ['dir', 'file'] })])
     expect(flushMock).toHaveBeenCalled()
   })
 
@@ -190,11 +190,11 @@ describe('adapters local config', () => {
       expect(flushMock).toHaveBeenCalled()
     })
 
-    it('should not call updateNaclFiles when there is no configuration', async () => {
+    it('should call updateNaclFiles only once when there is no configuration', async () => {
       const conf = await configSource.getAdapter(SALESFORCE) as InstanceElement
       getMock.mockResolvedValue(undefined)
       await configSource.setAdapter(SALESFORCE, conf)
-      expect(updateNaclFilesMock).not.toHaveBeenCalled()
+      expect(updateNaclFilesMock).toHaveBeenCalledTimes(1)
       expect(flushMock).toHaveBeenCalled()
     })
   })

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -224,6 +224,8 @@ Promise<Workspace> => {
       currentEnv: 'default',
     })),
     setWorkspaceConfig: jest.fn(),
+  }
+  const mockAdaptersConf = {
     getAdapter: jest.fn(),
     setAdapter: jest.fn(),
   }
@@ -233,7 +235,13 @@ Promise<Workspace> => {
     delete: jest.fn(),
     rename: jest.fn(),
   }
-  return loadWorkspace(mockConfSource, mockCredentialsSource, elementsSources, mockCreateRemoteMap)
+  return loadWorkspace(
+    mockConfSource,
+    mockAdaptersConf,
+    mockCredentialsSource,
+    elementsSources,
+    mockCreateRemoteMap,
+  )
 }
 
 export const mockWorkspace = async (naclFiles: string[] = [], staticFileNames: string[] = []):

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -228,6 +228,7 @@ Promise<Workspace> => {
   const mockAdaptersConf = {
     getAdapter: jest.fn(),
     setAdapter: jest.fn(),
+    getNaclPaths: jest.fn(),
   }
   const mockCredentialsSource = {
     get: jest.fn(),

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -228,7 +228,7 @@ Promise<Workspace> => {
   const mockAdaptersConf = {
     getAdapter: jest.fn(),
     setAdapter: jest.fn(),
-    getNaclPaths: jest.fn(),
+    getElementNaclFiles: jest.fn(),
   }
   const mockCredentialsSource = {
     get: jest.fn(),

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -461,7 +461,7 @@ describe('Netsuite adapter E2E with real account', () => {
 
       it('should fetch account successfully', async () => {
         expect(fetchResult.elements.length).toBeGreaterThan(getMetadataTypes().length)
-        validateConfigSuggestions(fetchResult.updatedConfig?.config)
+        validateConfigSuggestions(fetchResult.updatedConfig?.config[0])
       })
 
       it('should fetch the created entityCustomField and its special chars', async () => {

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -278,10 +278,12 @@ export default class NetsuiteAdapter implements AdapterOperations {
 
     const isPartial = this.fetchTarget !== undefined
 
-    const { failedToFetchAllAtOnce,
+    const {
+      failedToFetchAllAtOnce,
       failedFilePaths,
       failedTypeToInstances,
-      elements } = await this.fetchByQuery(fetchQuery, progressReporter, this.useChangesDetection)
+      elements,
+    } = await this.fetchByQuery(fetchQuery, progressReporter, this.useChangesDetection)
 
     const updatedConfig = getConfigFromConfigChanges(
       failedToFetchAllAtOnce, failedFilePaths, failedTypeToInstances, this.userConfig

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -353,9 +353,9 @@ export const combineQueryParams = (
     .groupBy(type => type.name)
     .map((types, name) => ({
       name,
-      ids: types.some(type => type.ids === undefined)
-        ? undefined
-        : _.uniq(types.flatMap(type => type.ids as string[])),
+      ...types.some(type => type.ids === undefined)
+        ? {}
+        : { ids: _.uniq(types.flatMap(type => type.ids as string[])) },
     }))
     .value()
   return {
@@ -528,7 +528,7 @@ export const getConfigFromConfigChanges = (
   failedFilePaths: NetsuiteQueryParameters['filePaths'],
   failedTypeToInstances: NetsuiteQueryParameters['types'],
   currentConfig: NetsuiteConfig
-): { config: InstanceElement; message: string } | undefined => {
+): { config: InstanceElement[]; message: string } | undefined => {
   const conf = new InstanceElement(
     ElemID.CONFIG_NAME,
     configType,
@@ -561,5 +561,5 @@ export const getConfigFromConfigChanges = (
       : undefined,
   ].filter(values.isDefined).join(' In addition, ')
 
-  return message !== '' ? { config: conf, message } : undefined
+  return message !== '' ? { config: [conf], message } : undefined
 }

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -447,10 +447,10 @@ describe('Adapter', () => {
         })
       const getConfigFromConfigChangesMock = getConfigFromConfigChanges as jest.Mock
       const updatedConfig = new InstanceElement(ElemID.CONFIG_NAME, configType)
-      getConfigFromConfigChangesMock.mockReturnValue({ config: updatedConfig, message: '' })
+      getConfigFromConfigChangesMock.mockReturnValue({ config: [updatedConfig], message: '' })
       const fetchResult = await netsuiteAdapter.fetch(mockFetchOpts)
       expect(getConfigFromConfigChanges).toHaveBeenCalledWith(false, ['/path/to/file'], {}, config)
-      expect(fetchResult.updatedConfig?.config.isEqual(updatedConfig)).toBe(true)
+      expect(fetchResult.updatedConfig?.config[0].isEqual(updatedConfig)).toBe(true)
     })
 
     it('should call getConfigFromConfigChanges with failedTypeToInstances', async () => {
@@ -463,11 +463,11 @@ describe('Adapter', () => {
         })
       const getConfigFromConfigChangesMock = getConfigFromConfigChanges as jest.Mock
       const updatedConfig = new InstanceElement(ElemID.CONFIG_NAME, configType)
-      getConfigFromConfigChangesMock.mockReturnValue({ config: updatedConfig, message: '' })
+      getConfigFromConfigChangesMock.mockReturnValue({ config: [updatedConfig], message: '' })
       const fetchResult = await netsuiteAdapter.fetch(mockFetchOpts)
       expect(getConfigFromConfigChanges)
         .toHaveBeenCalledWith(false, [], failedTypeToInstances, config)
-      expect(fetchResult.updatedConfig?.config.isEqual(updatedConfig)).toBe(true)
+      expect(fetchResult.updatedConfig?.config[0].isEqual(updatedConfig)).toBe(true)
     })
 
     it('should call getConfigFromConfigChanges with false for fetchAllAtOnce', async () => {
@@ -479,10 +479,10 @@ describe('Adapter', () => {
         })
       const getConfigFromConfigChangesMock = getConfigFromConfigChanges as jest.Mock
       const updatedConfig = new InstanceElement(ElemID.CONFIG_NAME, configType)
-      getConfigFromConfigChangesMock.mockReturnValue({ config: updatedConfig, message: '' })
+      getConfigFromConfigChangesMock.mockReturnValue({ config: [updatedConfig], message: '' })
       const fetchResult = await netsuiteAdapter.fetch(mockFetchOpts)
       expect(getConfigFromConfigChangesMock).toHaveBeenCalledWith(true, [], {}, config)
-      expect(fetchResult.updatedConfig?.config.isEqual(updatedConfig)).toBe(true)
+      expect(fetchResult.updatedConfig?.config[0].isEqual(updatedConfig)).toBe(true)
     })
   })
 

--- a/packages/netsuite-adapter/test/config.test.ts
+++ b/packages/netsuite-adapter/test/config.test.ts
@@ -72,7 +72,7 @@ describe('config', () => {
 
   it('should return updated currentConfig with defined values when having suggestions and the currentConfig is empty', () => {
     const configFromConfigChanges = getConfigFromConfigChanges(true,
-      [newFailedFilePath], suggestedSkipListTypes, {})?.config as InstanceElement
+      [newFailedFilePath], suggestedSkipListTypes, {})?.config[0] as InstanceElement
     expect(configFromConfigChanges.isEqual(new InstanceElement(
       ElemID.CONFIG_NAME,
       configType,
@@ -103,7 +103,7 @@ describe('config', () => {
     const configChange = getConfigFromConfigChanges(
       true, [newFailedFilePath], suggestedSkipListTypes, currentConfigWithFetch
     )
-    expect(configChange?.config
+    expect(configChange?.config[0]
       .isEqual(new InstanceElement(
         ElemID.CONFIG_NAME,
         configType,
@@ -141,7 +141,7 @@ describe('config', () => {
       [FILE_PATHS_REGEX_SKIP_LIST]: ['someRegex1', '^someRegex2', 'someRegex3$', '^someRegex4$'],
     }
     const configChange = getConfigFromConfigChanges(false, [], {}, config)
-    expect(configChange?.config
+    expect(configChange?.config[0]
       .isEqual(new InstanceElement(
         ElemID.CONFIG_NAME,
         configType,
@@ -164,12 +164,12 @@ describe('config', () => {
       [DEPLOY_REFERENCED_ELEMENTS]: true,
     }
     const configChange = getConfigFromConfigChanges(false, [], {}, config)
-    expect(configChange?.config
+    expect(configChange?.config[0]
       .isEqual(new InstanceElement(
         ElemID.CONFIG_NAME,
         configType,
         {
-          [FETCH]: configChange?.config.value[FETCH],
+          [FETCH]: configChange?.config[0].value[FETCH],
           [CLIENT_CONFIG]: {
             [FETCH_TYPE_TIMEOUT_IN_MINUTES]: 15,
             [MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST]: 10,
@@ -190,8 +190,8 @@ describe('config', () => {
       [DEPLOY_REFERENCED_ELEMENTS]: false,
     }
     const configChange = getConfigFromConfigChanges(false, [], {}, config)
-    expect(configChange?.config?.value[DEPLOY_REFERENCED_ELEMENTS]).toBe(undefined)
-    expect(configChange?.config?.value[DEPLOY]).toBe(undefined)
+    expect(configChange?.config?.[0].value[DEPLOY_REFERENCED_ELEMENTS]).toBe(undefined)
+    expect(configChange?.config?.[0].value[DEPLOY]).toBe(undefined)
     expect(configChange?.message).toBe(UPDATE_DEPLOY_CONFIG)
   })
 
@@ -208,7 +208,7 @@ describe('config', () => {
     }
 
     const configChange = getConfigFromConfigChanges(false, [], {}, config)
-    expect(configChange?.config
+    expect(configChange?.config[0]
       .isEqual(new InstanceElement(
         ElemID.CONFIG_NAME,
         configType,
@@ -244,7 +244,7 @@ describe('config', () => {
     const conf = { ...currentConfigWithFetch,
       [SKIP_LIST]: currentConfigWithSkipList[SKIP_LIST] }
     const configChange = getConfigFromConfigChanges(false, [], {}, conf)
-    expect(configChange?.config
+    expect(configChange?.config[0]
       .isEqual(new InstanceElement(
         ElemID.CONFIG_NAME,
         configType,
@@ -280,7 +280,7 @@ describe('config', () => {
       },
     }
     const configChange = getConfigFromConfigChanges(false, [], {}, conf)
-    expect(configChange?.config?.value).toEqual({
+    expect(configChange?.config?.[0].value).toEqual({
       [FETCH]: {
         [EXCLUDE]: {
           types: [{

--- a/packages/netsuite-adapter/test/config.test.ts
+++ b/packages/netsuite-adapter/test/config.test.ts
@@ -164,6 +164,7 @@ describe('config', () => {
       [DEPLOY_REFERENCED_ELEMENTS]: true,
     }
     const configChange = getConfigFromConfigChanges(false, [], {}, config)
+    expect(configChange?.config).toHaveLength(1)
     expect(configChange?.config[0]
       .isEqual(new InstanceElement(
         ElemID.CONFIG_NAME,

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -28,9 +28,9 @@ import { configType, usernamePasswordCredentialsType, oauthRequestParameters,
 import { validateFetchParameters } from './fetch_profile/fetch_profile'
 import { ConfigValidationError } from './config_validation'
 import { updateDeprecatedConfiguration } from './deprecated_config'
-import { ConfigChange } from './config_change'
 import changeValidator from './change_validator'
 import { getChangeGroupIds } from './group_changes'
+import { ConfigChange } from './config_change'
 
 const log = logger(module)
 
@@ -120,7 +120,7 @@ In Addition, ${configFromFetch.message}`,
 export const adapter: Adapter = {
   operations: context => {
     const updatedConfig = context.config && updateDeprecatedConfiguration(context.config)
-    const config = adapterConfigFromConfig(updatedConfig?.config ?? context.config)
+    const config = adapterConfigFromConfig(updatedConfig?.config[0] ?? context.config)
     const credentials = credentialsFromConfig(context.credentials)
     const salesforceAdapter = new SalesforceAdapter({
       client: new SalesforceClient({ credentials, config: config[CLIENT_CONFIG] }),
@@ -132,7 +132,10 @@ export const adapter: Adapter = {
     return {
       fetch: async opts => {
         const fetchResults = await salesforceAdapter.fetch(opts)
-        fetchResults.updatedConfig = getConfigChange(fetchResults.updatedConfig, updatedConfig)
+        fetchResults.updatedConfig = getConfigChange(
+          fetchResults.updatedConfig,
+          updatedConfig,
+        )
         return fetchResults
       },
 

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -120,7 +120,7 @@ In Addition, ${configFromFetch.message}`,
 export const adapter: Adapter = {
   operations: context => {
     const updatedConfig = context.config && updateDeprecatedConfiguration(context.config)
-    const config = adapterConfigFromConfig(updatedConfig?.config[0] ?? context.config)
+    const config = adapterConfigFromConfig(updatedConfig?.config ?? context.config)
     const credentials = credentialsFromConfig(context.credentials)
     const salesforceAdapter = new SalesforceAdapter({
       client: new SalesforceClient({ credentials, config: config[CLIENT_CONFIG] }),
@@ -134,7 +134,10 @@ export const adapter: Adapter = {
         const fetchResults = await salesforceAdapter.fetch(opts)
         fetchResults.updatedConfig = getConfigChange(
           fetchResults.updatedConfig,
-          updatedConfig,
+          updatedConfig && {
+            config: [updatedConfig.config],
+            message: updatedConfig.message,
+          },
         )
         return fetchResults
       },

--- a/packages/salesforce-adapter/src/config_change.ts
+++ b/packages/salesforce-adapter/src/config_change.ts
@@ -88,7 +88,7 @@ export const createRetrieveConfigChange = (result: RetrieveResult): ConfigChange
     ))
 
 export type ConfigChange = {
-  config: InstanceElement
+  config: InstanceElement[]
   message: string
 }
 
@@ -134,7 +134,7 @@ export const getConfigFromConfigChanges = (
   }, isDefined) as DataManagementConfig | undefined
 
   return {
-    config: new InstanceElement(
+    config: [new InstanceElement(
       ElemID.CONFIG_NAME,
       configType,
       _.pickBy({
@@ -156,7 +156,7 @@ export const getConfigFromConfigChanges = (
         useOldProfiles: currentConfig.useOldProfiles,
         client: currentConfig.client,
       }, isDefined)
-    ),
+    )],
     message: getConfigChangeMessage(configChanges),
   }
 }

--- a/packages/salesforce-adapter/src/deprecated_config.ts
+++ b/packages/salesforce-adapter/src/deprecated_config.ts
@@ -158,7 +158,7 @@ const convertDeprecatedFetchParameters = (
 
 export const updateDeprecatedConfiguration = (configuration: Readonly<InstanceElement> | undefined):
 {
-  config: [InstanceElement]
+  config: InstanceElement
   message: string
 } | undefined => {
   if (configuration === undefined
@@ -176,5 +176,5 @@ export const updateDeprecatedConfiguration = (configuration: Readonly<InstanceEl
       updatedConf.value
     ),
   }
-  return { config: [updatedConf], message: DEPRECATED_OPTIONS_MESSAGE }
+  return { config: updatedConf, message: DEPRECATED_OPTIONS_MESSAGE }
 }

--- a/packages/salesforce-adapter/src/deprecated_config.ts
+++ b/packages/salesforce-adapter/src/deprecated_config.ts
@@ -18,7 +18,6 @@ import { InstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections, values } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { ConfigChange } from './config_change'
 import { ConfigValidationError, validateRegularExpressions } from './config_validation'
 import { validateDataManagementConfig } from './fetch_profile/data_management'
 import { DataManagementConfig, DATA_CONFIGURATION, DATA_MANAGEMENT, DeprecatedFetchParameters, DeprecatedMetadataParams, FetchParameters, FETCH_CONFIG, INSTANCES_REGEX_SKIPPED_LIST, INSTANCE_SUFFIXES, MetadataParams, METADATA_CONFIG, METADATA_TYPES_SKIPPED_LIST } from './types'
@@ -158,7 +157,10 @@ const convertDeprecatedFetchParameters = (
 }
 
 export const updateDeprecatedConfiguration = (configuration: Readonly<InstanceElement> | undefined):
-ConfigChange | undefined => {
+{
+  config: [InstanceElement]
+  message: string
+} | undefined => {
   if (configuration === undefined
     || DEPRECATED_FIELDS.every(field => configuration.value[field] === undefined)) {
     return undefined
@@ -174,5 +176,5 @@ ConfigChange | undefined => {
       updatedConf.value
     ),
   }
-  return { config: updatedConf, message: DEPRECATED_OPTIONS_MESSAGE }
+  return { config: [updatedConf], message: DEPRECATED_OPTIONS_MESSAGE }
 }

--- a/packages/salesforce-adapter/test/adapter.creator.test.ts
+++ b/packages/salesforce-adapter/test/adapter.creator.test.ts
@@ -622,19 +622,19 @@ describe('SalesforceAdapter creator', () => {
       const configFromFetch = config.clone()
       const updatedConfig = getConfigChange(
         {
-          config,
+          config: [config],
           message: `Salto failed to fetch some items from salesforce.
 
 In order to complete the fetch operation, Salto needs to stop managing these items by applying the following configuration change:`,
         },
         {
-          config: configFromFetch,
+          config: [configFromFetch],
           message: 'The configuration options "metadataTypesSkippedList", "instancesRegexSkippedList" and "dataManagement" are deprecated. The following changes will update the deprecated options to the "fetch" configuration option.',
         },
       )
 
       it('return fetch configuration', () => {
-        expect(updatedConfig?.config).toBe(config)
+        expect(updatedConfig?.config[0]).toBe(config)
       })
       it('return combined message', () => {
         expect(updatedConfig?.message).toBe(`The configuration options "metadataTypesSkippedList", "instancesRegexSkippedList" and "dataManagement" are deprecated. The following changes will update the deprecated options to the "fetch" configuration option.
@@ -646,7 +646,7 @@ In order to complete the fetch operation, Salto needs to stop managing these ite
 
     describe('only configWithoutDeprecated is defined', () => {
       const configChange = {
-        config,
+        config: [config],
         message: 'The configuration options "metadataTypesSkippedList", "instancesRegexSkippedList" and "dataManagement" are deprecated. The following changes will update the deprecated options to the "fetch" configuration option.',
       }
       const updatedConfig = getConfigChange(
@@ -660,7 +660,7 @@ In order to complete the fetch operation, Salto needs to stop managing these ite
 
     describe('only fetchConfiguration is defined', () => {
       const configChange = {
-        config,
+        config: [config],
         message: `Salto failed to fetch some items from salesforce.
 
 In order to complete the fetch operation, Salto needs to stop managing these items by applying the following configuration change:`,

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -949,7 +949,7 @@ public class MyClass${index} {
       it('should return correct config when orig config has values', async () => {
         mockFailures(connection)
         result = await adapter.fetch(mockFetchOpts)
-        config = result?.updatedConfig?.config as InstanceElement
+        config = result?.updatedConfig?.config[0] as InstanceElement
         expect(config).toBeDefined()
         expect(config.value).toEqual(
           {
@@ -978,7 +978,7 @@ public class MyClass${index} {
         mockFailures(connectionMock)
 
         result = await adapterMock.fetch(mockFetchOpts)
-        config = result?.updatedConfig?.config as InstanceElement
+        config = result?.updatedConfig?.config[0] as InstanceElement
         expect(config.value).toEqual(
           {
             fetch: {

--- a/packages/salesforce-adapter/test/config_change.test.ts
+++ b/packages/salesforce-adapter/test/config_change.test.ts
@@ -16,7 +16,7 @@
 import { InstanceElement } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { ConfigChangeSuggestion, SalesforceConfig } from '../src/types'
-import { getConfigFromConfigChanges, getConfigChangeMessage } from '../src/config_change'
+import { getConfigFromConfigChanges, getConfigChangeMessage, ConfigChange } from '../src/config_change'
 
 describe('Config Changes', () => {
   const includedObjectName = '.*Object.*'
@@ -77,7 +77,7 @@ describe('Config Changes', () => {
 
   describe('getConfigFromConfigChanges - dataManagement suggestions', () => {
     describe('when suggestion is about an object that appears in includeObjects', () => {
-      let newConfig: { config: InstanceElement; message: string } | undefined
+      let newConfig: ConfigChange | undefined
       beforeAll(() => {
         const suggestToRemoveObject = {
           type: 'dataObjectsExclude',
@@ -91,18 +91,18 @@ describe('Config Changes', () => {
 
       it('should create an instance with values same as original config besides excludeObjects', () => {
         expect(newConfig).toBeDefined()
-        expect(newConfig?.config?.value.fetch.metadata)
+        expect(newConfig?.config?.[0].value.fetch.metadata)
           .toEqual(currentConfig.fetch?.metadata)
 
         const currentConfigClone = _.cloneDeep(currentConfig)
         delete currentConfigClone.fetch?.data?.excludeObjects
 
-        expect(newConfig?.config?.value.fetch.data)
+        expect(newConfig?.config?.[0].value.fetch.data)
           .toMatchObject(currentConfigClone.fetch?.data ?? {})
       })
 
       it('should add the object name to excludeObjects', () => {
-        expect(newConfig?.config?.value.fetch.data.excludeObjects)
+        expect(newConfig?.config?.[0].value.fetch.data.excludeObjects)
           .toContain(includedObjectName)
       })
 
@@ -118,7 +118,7 @@ In order to complete the fetch operation, Salto needs to stop managing these ite
     })
 
     describe('when suggestion is about an object that appears in allowReferenceTo', () => {
-      let newConfig: InstanceElement | undefined
+      let newConfig: InstanceElement[] | undefined
       beforeAll(() => {
         const suggestToRemoveObject = {
           type: 'dataObjectsExclude',
@@ -129,17 +129,17 @@ In order to complete the fetch operation, Salto needs to stop managing these ite
 
       it('should create an instance with values same as original config besides excludeObjects and allowReferenceTo', () => {
         expect(newConfig).toBeDefined()
-        expect(newConfig?.value.fetch.metadata)
+        expect(newConfig?.[0].value.fetch.metadata)
           .toEqual(currentConfig.fetch?.metadata)
-        expect(newConfig?.value.fetch.data.saltoIDSettings)
+        expect(newConfig?.[0].value.fetch.data.saltoIDSettings)
           .toMatchObject(currentConfig.fetch?.data?.saltoIDSettings ?? {})
-        expect(newConfig?.value.fetch.data.includeObjects)
+        expect(newConfig?.[0].value.fetch.data.includeObjects)
           .toEqual(currentConfig.fetch?.data?.includeObjects)
       })
 
       it('should add the object name to excludeObjects and remove it from allowReferenceTo', () => {
-        expect(newConfig?.value.fetch.data.excludeObjects).toContain(refToObjectName)
-        expect(newConfig?.value.fetch.data.allowReferenceTo).not.toContain(refToObjectName)
+        expect(newConfig?.[0].value.fetch.data.excludeObjects).toContain(refToObjectName)
+        expect(newConfig?.[0].value.fetch.data.allowReferenceTo).not.toContain(refToObjectName)
       })
 
       it('should not change the currentConfig', () => {

--- a/packages/salesforce-adapter/test/config_change.test.ts
+++ b/packages/salesforce-adapter/test/config_change.test.ts
@@ -89,6 +89,10 @@ describe('Config Changes', () => {
         )
       })
 
+      it('should create one config instance', () => {
+        expect(newConfig?.config).toHaveLength(1)
+      })
+
       it('should create an instance with values same as original config besides excludeObjects', () => {
         expect(newConfig).toBeDefined()
         expect(newConfig?.config?.[0].value.fetch.metadata)

--- a/packages/salesforce-adapter/test/deprecated_config.test.ts
+++ b/packages/salesforce-adapter/test/deprecated_config.test.ts
@@ -95,7 +95,7 @@ describe('deprecated config', () => {
         configType,
         configWithOldOptions
       ))
-      expect(config?.config.value).toEqual(updatedConfig)
+      expect(config?.config[0].value).toEqual(updatedConfig)
       expect(config?.message).toBe(DEPRECATED_OPTIONS_MESSAGE)
     })
 
@@ -139,7 +139,7 @@ describe('deprecated config', () => {
       ))
       // _.isEqual is used instead of '.toEqual' because '.toEqual'
       // will return true of objects like {a: undefined} and {}
-      expect(_.isEqual(config?.config.value, updatedConfig)).toBeTruthy()
+      expect(_.isEqual(config?.config[0].value, updatedConfig)).toBeTruthy()
       expect(config?.message).toBe(DEPRECATED_OPTIONS_MESSAGE)
     })
 
@@ -155,7 +155,7 @@ describe('deprecated config', () => {
         configType,
         configWithOldOptions
       ))
-      expect(config?.config.value).toEqual(expectedConfig)
+      expect(config?.config[0].value).toEqual(expectedConfig)
       expect(config?.message).toBe(DEPRECATED_OPTIONS_MESSAGE)
     })
 
@@ -182,7 +182,7 @@ describe('deprecated config', () => {
         configType,
         configWithOldOptions
       ))
-      expect(config?.config.value).toEqual(expectedConfig)
+      expect(config?.config[0].value).toEqual(expectedConfig)
       expect(config?.message).toBe(DEPRECATED_OPTIONS_MESSAGE)
     })
   })

--- a/packages/salesforce-adapter/test/deprecated_config.test.ts
+++ b/packages/salesforce-adapter/test/deprecated_config.test.ts
@@ -95,7 +95,7 @@ describe('deprecated config', () => {
         configType,
         configWithOldOptions
       ))
-      expect(config?.config[0].value).toEqual(updatedConfig)
+      expect(config?.config.value).toEqual(updatedConfig)
       expect(config?.message).toBe(DEPRECATED_OPTIONS_MESSAGE)
     })
 
@@ -139,7 +139,7 @@ describe('deprecated config', () => {
       ))
       // _.isEqual is used instead of '.toEqual' because '.toEqual'
       // will return true of objects like {a: undefined} and {}
-      expect(_.isEqual(config?.config[0].value, updatedConfig)).toBeTruthy()
+      expect(_.isEqual(config?.config.value, updatedConfig)).toBeTruthy()
       expect(config?.message).toBe(DEPRECATED_OPTIONS_MESSAGE)
     })
 
@@ -155,7 +155,7 @@ describe('deprecated config', () => {
         configType,
         configWithOldOptions
       ))
-      expect(config?.config[0].value).toEqual(expectedConfig)
+      expect(config?.config.value).toEqual(expectedConfig)
       expect(config?.message).toBe(DEPRECATED_OPTIONS_MESSAGE)
     })
 
@@ -182,7 +182,7 @@ describe('deprecated config', () => {
         configType,
         configWithOldOptions
       ))
-      expect(config?.config[0].value).toEqual(expectedConfig)
+      expect(config?.config.value).toEqual(expectedConfig)
       expect(config?.message).toBe(DEPRECATED_OPTIONS_MESSAGE)
     })
   })

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -21,6 +21,7 @@ import { Workspace, SourceFragment, StateRecency, loadWorkspace, isValidEnvName,
 import * as hiddenValues from './src/workspace/hidden_values'
 import * as configSource from './src/workspace/config_source'
 import * as workspaceConfigSource from './src/workspace/workspace_config_source'
+import * as adaptersConfigSource from './src/workspace/adapters_config_source'
 import { WorkspaceConfig, EnvConfig } from './src/workspace/config/workspace_config_types'
 import * as state from './src/workspace/state'
 import * as dirStore from './src/workspace/dir_store'
@@ -67,6 +68,7 @@ export {
   COMMON_ENV_PREFIX,
   state,
   workspaceConfigSource,
+  adaptersConfigSource,
   WorkspaceComponents,
   validator,
   createElementSelector,

--- a/packages/workspace/src/merger/index.ts
+++ b/packages/workspace/src/merger/index.ts
@@ -97,3 +97,24 @@ export const mergeElements = async (
 
   return { merged, errors }
 }
+
+export const mergeSingleElement = async <T extends Element>(elementParts: T[]): Promise<T> => {
+  const mergeRes = await mergeElements(awu(elementParts))
+
+  if (mergeRes !== undefined) {
+    const [error] = await awu(await mergeRes.errors.entries()).toArray()
+    if (error !== undefined) {
+      throw new Error(`Received merge errors: ${error.key}: ${error.value.map(err => err.message).join(', ')}`)
+    }
+  }
+
+  const mergedElements = mergeRes
+        && (await awu(mergeRes.merged.values()).toArray())
+
+  if (mergedElements !== undefined && mergedElements.length !== 1) {
+    throw new Error(`Received invalid number of merged elements when expected one: ${mergedElements.map(e => e.elemID.getFullName()).join(', ')}`)
+  }
+
+  // A merge of elements of type T should result an element of type T
+  return mergedElements[0] as T
+}

--- a/packages/workspace/src/merger/index.ts
+++ b/packages/workspace/src/merger/index.ts
@@ -101,6 +101,13 @@ export const mergeElements = async (
 export const mergeSingleElement = async <T extends Element>(elementParts: T[]): Promise<T> => {
   const mergeRes = await mergeElements(awu(elementParts))
 
+  const errorMessages = await awu(await mergeRes.errors.entries())
+    .flatMap(err => err.value)
+    .map(err => err.message)
+    .toArray()
+  if (errorMessages.length !== 0) {
+    throw new Error(`Received merge errors: ${errorMessages.join(', ')}`)
+  }
   const [error] = await awu(await mergeRes.errors.entries()).toArray()
   if (error !== undefined) {
     throw new Error(`Received merge errors: ${error.key}: ${error.value.map(err => err.message).join(', ')}`)

--- a/packages/workspace/src/merger/index.ts
+++ b/packages/workspace/src/merger/index.ts
@@ -101,17 +101,14 @@ export const mergeElements = async (
 export const mergeSingleElement = async <T extends Element>(elementParts: T[]): Promise<T> => {
   const mergeRes = await mergeElements(awu(elementParts))
 
-  if (mergeRes !== undefined) {
-    const [error] = await awu(await mergeRes.errors.entries()).toArray()
-    if (error !== undefined) {
-      throw new Error(`Received merge errors: ${error.key}: ${error.value.map(err => err.message).join(', ')}`)
-    }
+  const [error] = await awu(await mergeRes.errors.entries()).toArray()
+  if (error !== undefined) {
+    throw new Error(`Received merge errors: ${error.key}: ${error.value.map(err => err.message).join(', ')}`)
   }
 
-  const mergedElements = mergeRes
-        && (await awu(mergeRes.merged.values()).toArray())
+  const mergedElements = await awu(mergeRes.merged.values()).toArray()
 
-  if (mergedElements !== undefined && mergedElements.length !== 1) {
+  if (mergedElements.length !== 1) {
     throw new Error(`Received invalid number of merged elements when expected one: ${mergedElements.map(e => e.elemID.getFullName()).join(', ')}`)
   }
 

--- a/packages/workspace/src/parser/dump.ts
+++ b/packages/workspace/src/parser/dump.ts
@@ -107,7 +107,10 @@ const dumpAnnotationTypesBlock = (annotationRefTypes: ReferenceMap): DumpedHclBl
       .map(([key, ref]) => dumpAnnotationTypeBlock(key, ref)),
   }])
 
-const dumpElementBlock = async (elem: Element, functions: Functions): Promise<DumpedHclBlock> => {
+const dumpElementBlock = async (
+  elem: Readonly<Element>,
+  functions: Functions
+): Promise<DumpedHclBlock> => {
   if (isField(elem)) {
     return dumpFieldBlock(elem, functions)
   }
@@ -160,7 +163,7 @@ const wrapBlocks = (blocks: DumpedHclBlock[]): DumpedHclBlock => ({
 })
 
 export const dumpElements = async (
-  elements: Element[], functions: Functions = {}, indentationLevel = 0
+  elements: Readonly<Element>[], functions: Functions = {}, indentationLevel = 0
 ): Promise<string> =>
   hclDump(
     wrapBlocks(await awu(elements).map(e => dumpElementBlock(e, functions)).toArray()),

--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -13,9 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { WorkspaceConfig } from './config/workspace_config_types'
+import { InstanceElement } from '@salto-io/adapter-api'
 
-export type WorkspaceConfigSource = {
-  getWorkspaceConfig(): Promise<WorkspaceConfig>
-  setWorkspaceConfig(config: WorkspaceConfig): Promise<void>
+export type AdaptersConfigSource = {
+  getAdapter(adapter: string, defaultValue?: InstanceElement): Promise<InstanceElement | undefined>
+  setAdapter(
+    adapter: string,
+    config: Readonly<InstanceElement> | Readonly<InstanceElement>[]
+  ): Promise<void>
 }

--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -21,5 +21,5 @@ export type AdaptersConfigSource = {
     adapter: string,
     config: Readonly<InstanceElement> | Readonly<InstanceElement>[]
   ): Promise<void>
-  getNaclPaths(adapter: string): Promise<string[]>
+  getElementNaclFiles(adapter: string): Promise<string[]>
 }

--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 import { InstanceElement } from '@salto-io/adapter-api'
-import { NaclFilesSource } from './nacl_files'
 
 export type AdaptersConfigSource = {
   getAdapter(adapter: string, defaultValue?: InstanceElement): Promise<InstanceElement | undefined>
@@ -22,5 +21,5 @@ export type AdaptersConfigSource = {
     adapter: string,
     config: Readonly<InstanceElement> | Readonly<InstanceElement>[]
   ): Promise<void>
-  readonly source: NaclFilesSource
+  getNaclPaths(adapter: string): Promise<string[]>
 }

--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { InstanceElement } from '@salto-io/adapter-api'
+import { NaclFilesSource } from './nacl_files'
 
 export type AdaptersConfigSource = {
   getAdapter(adapter: string, defaultValue?: InstanceElement): Promise<InstanceElement | undefined>
@@ -21,4 +22,5 @@ export type AdaptersConfigSource = {
     adapter: string,
     config: Readonly<InstanceElement> | Readonly<InstanceElement>[]
   ): Promise<void>
+  readonly source: NaclFilesSource
 }

--- a/packages/workspace/src/workspace/config_source.ts
+++ b/packages/workspace/src/workspace/config_source.ts
@@ -14,8 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { applyDetailedChanges, detailedCompare } from '@salto-io/adapter-utils'
-import { InstanceElement, DetailedChange, isInstanceElement } from '@salto-io/adapter-api'
+import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { parse, dumpElements } from '../parser'
@@ -41,97 +40,41 @@ class ConfigParseError extends Error {
 
 export const configSource = (
   dirStore: DirectoryStore<string>,
-  configOverrides: DetailedChange[] = [],
 ): ConfigSource => {
   const filename = (name: string): string =>
     (name.endsWith(FILE_EXTENSION) ? name : name.concat(FILE_EXTENSION))
 
-  const configOverridesById = _.groupBy(configOverrides, change => change.id.adapter)
-
-  const getConfigWithoutOverrides = async (name: string):
-    Promise<InstanceElement | undefined> => {
-    const naclFile = await dirStore.get(filename(name))
-    if (_.isUndefined(naclFile)) {
-      log.warn('Could not find file %s for configuration %s', filename(name), name)
-      return undefined
-    }
-    const parseResult = await parse(Buffer.from(naclFile.buffer), naclFile.filename)
-    if (!_.isEmpty(parseResult.errors)) {
-      log.error('failed to parse %s due to %o', name, parseResult.errors)
-      throw new ConfigParseError(name)
-    }
-    const elements = await awu(parseResult.elements).toArray()
-    if (elements.length > 1) {
-      log.warn('%s has more than a single element in the config file; returning the first element',
-        name)
-    }
-    const configInstance = elements.find(isInstanceElement)
-    if (configInstance === undefined) {
-      log.warn(
-        'failed to find config instance for %s, found the following elements: %s',
-        name,
-        elements.map(elem => elem.elemID.getFullName()).join(','),
-      )
-      return undefined
-    }
-    return configInstance
-  }
-
-  const applyConfigOverrides = (conf: InstanceElement): void => {
-    const overridesForInstance = configOverridesById[conf.elemID.adapter] ?? []
-    applyDetailedChanges(conf, overridesForInstance)
-  }
-
-  const setUnsafe = async (name: string, config: InstanceElement): Promise<void> => {
-    await dirStore.set({ filename: filename(name), buffer: await dumpElements([config]) })
-    await dirStore.flush()
-  }
-
-  const validateConfigChanges = (configChanges: DetailedChange[]): void => {
-    const updatedOverriddenIds = configOverrides.filter(
-      overiddeChange => configChanges.some(
-        updateChange => updateChange.id.isParentOf(overiddeChange.id)
-          || overiddeChange.id.isParentOf(updateChange.id)
-          || overiddeChange.id.isEqual(updateChange.id)
-      )
-    )
-
-    if (updatedOverriddenIds.length !== 0) {
-      throw new Error(`cannot update fields that were overriden by the user: ${updatedOverriddenIds.map(change => change.id.getFullName())}`)
-    }
-  }
-
   return {
     get: async (name, defaultValue) => {
-      const conf = await getConfigWithoutOverrides(name) ?? defaultValue
-      if (conf === undefined) {
-        return undefined
+      const naclFile = await dirStore.get(filename(name))
+      if (_.isUndefined(naclFile)) {
+        log.warn('Could not find file %s for configuration %s', filename(name), name)
+        return defaultValue
       }
-      applyConfigOverrides(conf)
-      return conf
+      const parseResult = await parse(Buffer.from(naclFile.buffer), naclFile.filename)
+      if (!_.isEmpty(parseResult.errors)) {
+        log.error('failed to parse %s due to %o', name, parseResult.errors)
+        throw new ConfigParseError(name)
+      }
+      const elements = await awu(parseResult.elements).toArray()
+      if (elements.length > 1) {
+        log.warn('%s has more than a single element in the config file; returning the first element',
+          name)
+      }
+      const configInstance = elements.find(isInstanceElement)
+      if (configInstance === undefined) {
+        log.warn(
+          'failed to find config instance for %s, found the following elements: %s',
+          name,
+          elements.map(elem => elem.elemID.getFullName()).join(','),
+        )
+        return defaultValue
+      }
+      return configInstance
     },
     set: async (name: string, config: InstanceElement): Promise<void> => {
-      const currConfWithoutOverrides = await getConfigWithoutOverrides(name)
-      // Could happen at the initialization of a service.
-      if (currConfWithoutOverrides === undefined) {
-        await setUnsafe(name, config)
-        return
-      }
-      const currConf = currConfWithoutOverrides.clone()
-      applyConfigOverrides(currConf)
-
-      const configChanges = await detailedCompare(currConf, config)
-
-      validateConfigChanges(configChanges)
-
-      // currConfWithoutOverrides might have a different id than config.
-      // In order to apply the changes on currConfWithoutOverrides we need it
-      // to have the same id prefix as the changes.
-      const configToUpdate = config.clone()
-      configToUpdate.value = currConfWithoutOverrides.value
-      applyDetailedChanges(configToUpdate, configChanges)
-
-      await setUnsafe(name, configToUpdate)
+      await dirStore.set({ filename: filename(name), buffer: await dumpElements([config]) })
+      await dirStore.flush()
     },
 
     delete: async (name: string): Promise<void> => {

--- a/packages/workspace/src/workspace/elements_source.ts
+++ b/packages/workspace/src/workspace/elements_source.ts
@@ -31,7 +31,7 @@ export interface ElementsSource {
   flush(): Promise<void>
   clear(): Promise<void>
   rename(name: string): Promise<void>
-  set(element: Element): Promise<void>
+  set(element: Readonly<Element>): Promise<void>
   setAll(elements: ThenableIterable<Element>): Promise<void>
   delete(id: ElemID): Promise<void>
   deleteAll(ids: ThenableIterable<ElemID>): Promise<void>

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import path from 'path'
 import { Element, SaltoError, SaltoElementError, ElemID, InstanceElement, DetailedChange, Change,
   Value, isElement, isInstanceElement, toChange, isRemovalChange, getChangeElement,
-  ReadOnlyElementsSource, isAdditionOrModificationChange } from '@salto-io/adapter-api'
+  ReadOnlyElementsSource, isAdditionOrModificationChange, ElemID } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { applyDetailedChanges, resolvePath, setPath } from '@salto-io/adapter-utils'
 import { collections, promises, values } from '@salto-io/lowerdash'
@@ -114,7 +114,7 @@ export type Workspace = {
     Promise<Readonly<Record<string, InstanceElement>>>
   serviceConfig: (name: string, defaultValue?: InstanceElement) =>
     Promise<InstanceElement | undefined>
-
+  serviceConfigPaths: (name: string) => Promise<string[]>
   isEmpty(naclFilesOnly?: boolean): Promise<boolean>
   hasElementsInServices(serviceNames: string[]): Promise<boolean>
   hasElementsInEnv(envName: string): Promise<boolean>
@@ -694,6 +694,7 @@ export const loadWorkspace = async (
       pickServices(names).map(async service => [service, await credentials.get(credsPath(service))])
     )),
     serviceConfig: (name, defaultValue) => adaptersConfig.getAdapter(name, defaultValue),
+    serviceConfigPaths: name => adaptersConfig.source.getElementNaclFiles(new ElemID(name, ElemID.CONFIG_NAME, 'instance', ElemID.CONFIG_NAME)),
     isEmpty: async (naclFilesOnly = false): Promise<boolean> => {
       const isNaclFilesSourceEmpty = !naclFilesSource
         || await (await getLoadedNaclFilesSource()).isEmpty()

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import path from 'path'
 import { Element, SaltoError, SaltoElementError, ElemID, InstanceElement, DetailedChange, Change,
   Value, isElement, isInstanceElement, toChange, isRemovalChange, getChangeElement,
-  ReadOnlyElementsSource, isAdditionOrModificationChange, ElemID } from '@salto-io/adapter-api'
+  ReadOnlyElementsSource, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { applyDetailedChanges, resolvePath, setPath } from '@salto-io/adapter-utils'
 import { collections, promises, values } from '@salto-io/lowerdash'
@@ -694,7 +694,7 @@ export const loadWorkspace = async (
       pickServices(names).map(async service => [service, await credentials.get(credsPath(service))])
     )),
     serviceConfig: (name, defaultValue) => adaptersConfig.getAdapter(name, defaultValue),
-    serviceConfigPaths: name => adaptersConfig.source.getElementNaclFiles(new ElemID(name, ElemID.CONFIG_NAME, 'instance', ElemID.CONFIG_NAME)),
+    serviceConfigPaths: adaptersConfig.getNaclPaths,
     isEmpty: async (naclFilesOnly = false): Promise<boolean> => {
       const isNaclFilesSourceEmpty = !naclFilesSource
         || await (await getLoadedNaclFilesSource()).isEmpty()

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -694,7 +694,7 @@ export const loadWorkspace = async (
       pickServices(names).map(async service => [service, await credentials.get(credsPath(service))])
     )),
     serviceConfig: (name, defaultValue) => adaptersConfig.getAdapter(name, defaultValue),
-    serviceConfigPaths: adaptersConfig.getNaclPaths,
+    serviceConfigPaths: adaptersConfig.getElementNaclFiles,
     isEmpty: async (naclFilesOnly = false): Promise<boolean> => {
       const isNaclFilesSourceEmpty = !naclFilesSource
         || await (await getLoadedNaclFilesSource()).isEmpty()

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -86,6 +86,7 @@ const mockWorkspaceConfigSource = (conf?: Values,
 const mockAdaptersConfigSource = (): AdaptersConfigSource => ({
   getAdapter: jest.fn(),
   setAdapter: jest.fn(),
+  getNaclPaths: jest.fn(),
 })
 
 const mockCredentialsSource = (): ConfigSource => ({

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -86,7 +86,7 @@ const mockWorkspaceConfigSource = (conf?: Values,
 const mockAdaptersConfigSource = (): AdaptersConfigSource => ({
   getAdapter: jest.fn(),
   setAdapter: jest.fn(),
-  getNaclPaths: jest.fn(),
+  getElementNaclFiles: jest.fn(),
 })
 
 const mockCredentialsSource = (): ConfigSource => ({


### PR DESCRIPTION
Added support for splitting the adapter configurations into multiple files

---
_Release Notes_: 
None

---
_User Notifications_: 
None