### PR TITLE
SALTO-1224/nacl detailed change

### DIFF
--- a/packages/adapter-api/src/change.ts
+++ b/packages/adapter-api/src/change.ts
@@ -99,11 +99,6 @@ export type AuditInformation = {
   createdAt?: string
  }
 
-export type AuditDetailedChange =
-DetailedChange & {
-    audit?: AuditInformation
-}
-
 export type ChangeParams<T> = { before?: T; after?: T }
 
 type ChangeParamType<T> = T extends ChangeParams<infer U> ? U : never

--- a/packages/adapter-api/src/change.ts
+++ b/packages/adapter-api/src/change.ts
@@ -92,6 +92,18 @@ export type DetailedChange<T = ChangeDataType | Values | Value> =
     path?: ReadonlyArray<string>
   }
 
+export type AuditInformation = {
+  changedBy?: string
+  changedAt?: string
+  createdBy?: string
+  createdAt?: string
+ }
+
+export type AuditDetailedChange =
+DetailedChange & {
+    audit?: AuditInformation
+}
+
 export type ChangeParams<T> = { before?: T; after?: T }
 
 type ChangeParamType<T> = T extends ChangeParams<infer U> ? U : never

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -137,7 +137,7 @@ export const toChangesWithPath = (
   })
 
 const getAuditInformationFromElement = (element: Element): AuditInformation => {
-  if (!element.annotations) {
+  if (!element || !element.annotations) {
     return {}
   }
   return { changedBy: element.annotations?.[CORE_ANNOTATIONS.CHANGED_BY],

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -165,9 +165,9 @@ const toFetchChanges = (
   return async (serviceChange: DetailedChange) => {
     const pendingChange = getMatchingChange(serviceChange.id, pendingChanges)
     const change = getMatchingChange(serviceChange.id, workspaceToServiceChanges)
-    const audit = change ? getAuditInformationFromElement(
+    const audit = change === undefined ? {} : getAuditInformationFromElement(
       await mergedServiceElements.get(change?.id.createBaseID().parent)
-    ) : {}
+    )
     if (change !== undefined && !change.id.isEqual(serviceChange.id)) {
       // temporary log - should be replaced by SALTO-1364
       log.warn('service %s change for id %s was replaced by containing %s change for id %s',

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -28,7 +28,7 @@ import {
 } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { merger, elementSource } from '@salto-io/workspace'
-import { collections, promises, types } from '@salto-io/lowerdash'
+import { collections, promises, types, values } from '@salto-io/lowerdash'
 import { StepEvents } from './deploy'
 import { getPlan, Plan } from './plan'
 import { AdapterEvents, createAdapterProgressReporter } from './adapters/progress'
@@ -37,6 +37,7 @@ import { IDFilter } from './plan/plan'
 const { awu, groupByAsync } = collections.asynciterable
 const { mergeElements } = merger
 const log = logger(module)
+const { isDefined } = values
 
 export type FetchChange = {
   // The actual change to apply to the workspace
@@ -140,10 +141,10 @@ const getAuditInformationFromElement = (element: Element): AuditInformation => {
   if (!element || !element.annotations) {
     return {}
   }
-  return { changedBy: element.annotations?.[CORE_ANNOTATIONS.CHANGED_BY],
-    changedAt: element.annotations?.[CORE_ANNOTATIONS.CHANGED_AT],
-    createdBy: element.annotations?.[CORE_ANNOTATIONS.CREATED_BY],
-    createdAt: element.annotations?.[CORE_ANNOTATIONS.CREATED_AT] }
+  return _.pickBy({ changedAt: element.annotations?.[CORE_ANNOTATIONS.CHANGED_AT],
+    changedBy: element.annotations?.[CORE_ANNOTATIONS.CHANGED_BY],
+    createdAt: element.annotations?.[CORE_ANNOTATIONS.CREATED_AT],
+    createdBy: element.annotations?.[CORE_ANNOTATIONS.CREATED_BY] }, isDefined)
 }
 
 type FetchChangeConvertor = (change: DetailedChange) => Promise<FetchChange[]>

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -50,13 +50,23 @@ export type FetchChange = {
   audit?: AuditInformation
 }
 
+const getAuditInformationFromElement = (element: Element | undefined): AuditInformation => {
+  if (!element) {
+    return {}
+  }
+  return _.pickBy({ changedAt: element.annotations?.[CORE_ANNOTATIONS.CHANGED_AT],
+    changedBy: element.annotations?.[CORE_ANNOTATIONS.CHANGED_BY],
+    createdAt: element.annotations?.[CORE_ANNOTATIONS.CREATED_AT],
+    createdBy: element.annotations?.[CORE_ANNOTATIONS.CREATED_BY] }, isDefined)
+}
+
 export const toAddFetchChange = (elem: Element): FetchChange => {
   const change: DetailedChange = {
     id: elem.elemID,
     action: 'add',
     data: { after: elem },
   }
-  return { change, serviceChange: change }
+  return { change, serviceChange: change, audit: getAuditInformationFromElement(elem) }
 }
 
 
@@ -136,16 +146,6 @@ export const toChangesWithPath = (
     // Replace merged element with original elements that have a path hint
     return originalElements.map(elem => _.merge({}, change, { change: { data: { after: elem } } }))
   })
-
-const getAuditInformationFromElement = (element: Element): AuditInformation => {
-  if (!element || !element.annotations) {
-    return {}
-  }
-  return _.pickBy({ changedAt: element.annotations?.[CORE_ANNOTATIONS.CHANGED_AT],
-    changedBy: element.annotations?.[CORE_ANNOTATIONS.CHANGED_BY],
-    createdAt: element.annotations?.[CORE_ANNOTATIONS.CREATED_AT],
-    createdBy: element.annotations?.[CORE_ANNOTATIONS.CREATED_BY] }, isDefined)
-}
 
 type FetchChangeConvertor = (change: DetailedChange) => Promise<FetchChange[]>
 const toFetchChanges = (

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -447,12 +447,14 @@ describe('fetch', () => {
       beforeEach(async () => {
         // the (changed) service instance
         const hiddenInstanceFromService = hiddenInstance.clone()
+        const typeWithFieldAndAnnotations = typeWithField.clone()
+        typeWithFieldAndAnnotations.annotations = { [CORE_ANNOTATIONS.CHANGED_AT]: 'test' }
         hiddenInstanceFromService.value.hidden = hiddenChangedVal
         hiddenInstanceFromService.value.hiddenValue = hiddenValueChangedVal
         hiddenInstanceFromService.value.notHidden = 'notHiddenChanged'
 
         mockAdapters.dummy.fetch.mockResolvedValueOnce(
-          Promise.resolve({ elements: [typeWithFieldChange, hiddenInstanceFromService] })
+          Promise.resolve({ elements: [typeWithFieldAndAnnotations, hiddenInstanceFromService] })
         )
 
         const result = await fetchChanges(
@@ -469,8 +471,11 @@ describe('fetch', () => {
         changes.forEach(c => expect(c.pendingChange).toBeUndefined())
       })
 
-      it('shouldn not remove hidden values from changes', () => {
-        // changes.forEach(c => expect(isModificationChange(c.change)).toEqual(true))
+      it('should return the change with audit information', () => {
+        expect(changes.some(c => c.audit?.changedAt === 'test')).toBeTruthy()
+      })
+
+      it('shouldn\'t not remove hidden values from changes', () => {
         expect(changes.some(c => (getChangeElement(c.change)) === hiddenChangedVal))
           .toBeTruthy()
         expect(changes.some(c => (getChangeElement(c.change)) === hiddenValueChangedVal))

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -475,7 +475,7 @@ describe('fetch', () => {
         expect(changes.some(c => c.audit?.changedAt === 'test')).toBeTruthy()
       })
 
-      it('shouldn\'t not remove hidden values from changes', () => {
+      it('should not remove hidden values from changes', () => {
         expect(changes.some(c => (getChangeElement(c.change)) === hiddenChangedVal))
           .toBeTruthy()
         expect(changes.some(c => (getChangeElement(c.change)) === hiddenValueChangedVal))


### PR DESCRIPTION
add audit information to FetchChange type in order to read them in saas.

---

the type AuditDetailedChange will be used in saas so its not redundent

---
_Release Notes_: 

---
_User Notifications_: 
