### PR TITLE
SALTO-1389: Add E2E tests for safe deploy feature

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -330,23 +330,26 @@ describe('Netsuite adapter E2E with real account', () => {
     })
 
     describe('safe deploy change validator', () => {
+      let beforeInstance: InstanceElement
+      let afterInstance: InstanceElement
+      let serviceInstance: InstanceElement
+      beforeAll(() => {
+        beforeInstance = entityCustomFieldToCreate.clone()
+        afterInstance = beforeInstance.clone()
+        serviceInstance = beforeInstance.clone()
+
+        beforeInstance.value.label = 'before label'
+        afterInstance.value.label = 'after label'
+        serviceInstance.value.label = `service label - ${randomString}`
+      })
+
       describe('with warnOnStaleWorkspaceData=true flag', () => {
-        let beforeInstance: InstanceElement
-        let afterInstance: InstanceElement
-        let serviceInstance: InstanceElement
         beforeAll(async () => {
           const adapterAttr = realAdapter(
             { credentials: credentialsLease.value, withSuiteApp },
             { deploy: { [WARN_STALE_DATA]: true } },
           )
           adapter = adapterAttr.adapter
-          beforeInstance = entityCustomFieldToCreate.clone()
-          afterInstance = beforeInstance.clone()
-          serviceInstance = beforeInstance.clone()
-
-          beforeInstance.value.label = 'before label'
-          afterInstance.value.label = 'after label'
-          serviceInstance.value.label = `service label - ${randomString}`
 
           const additionChanges = [toChange({ after: serviceInstance })]
           const additionResult = await adapter.deploy({ changeGroup: { groupID: 'SDF', changes: additionChanges } })
@@ -371,22 +374,12 @@ describe('Netsuite adapter E2E with real account', () => {
       })
 
       describe('with warnOnStaleWorkspaceData=false flag', () => {
-        let beforeInstance: InstanceElement
-        let afterInstance: InstanceElement
-        let serviceInstance: InstanceElement
         beforeAll(async () => {
           const adapterAttr = realAdapter(
             { credentials: credentialsLease.value, withSuiteApp },
             { deploy: { [WARN_STALE_DATA]: false } },
           )
           adapter = adapterAttr.adapter
-          beforeInstance = entityCustomFieldToCreate.clone()
-          afterInstance = beforeInstance.clone()
-          serviceInstance = beforeInstance.clone()
-
-          beforeInstance.value.label = 'before label'
-          afterInstance.value.label = 'after label'
-          serviceInstance.value.label = `service label - ${randomString}`
 
           const additionChanges = [toChange({ after: serviceInstance })]
           const additionResult = await adapter.deploy({ changeGroup: { groupID: 'SDF', changes: additionChanges } })

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -340,7 +340,7 @@ describe('Netsuite adapter E2E with real account', () => {
             { deploy: { [WARN_STALE_DATA]: true } },
           )
           adapter = adapterAttr.adapter
-          beforeInstance = entityCustomFieldToCreate
+          beforeInstance = entityCustomFieldToCreate.clone()
           afterInstance = beforeInstance.clone()
           serviceInstance = beforeInstance.clone()
 
@@ -388,7 +388,7 @@ describe('Netsuite adapter E2E with real account', () => {
             { deploy: { warnOnStaleWorkspaceData: false } },
           )
           adapter = adapterAttr.adapter
-          beforeInstance = entityCustomFieldToCreate
+          beforeInstance = entityCustomFieldToCreate.clone()
           afterInstance = beforeInstance.clone()
           serviceInstance = beforeInstance.clone()
 

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -332,15 +332,12 @@ describe('Netsuite adapter E2E with real account', () => {
     describe('safe deploy change validator', () => {
       let beforeInstance: InstanceElement
       let afterInstance: InstanceElement
-      let serviceInstance: InstanceElement
       beforeAll(() => {
         beforeInstance = entityCustomFieldToCreate.clone()
         afterInstance = beforeInstance.clone()
-        serviceInstance = beforeInstance.clone()
 
         beforeInstance.value.label = 'before label'
         afterInstance.value.label = 'after label'
-        serviceInstance.value.label = `service label - ${randomString}`
       })
 
       describe('with warnOnStaleWorkspaceData=true flag', () => {
@@ -350,12 +347,6 @@ describe('Netsuite adapter E2E with real account', () => {
             { deploy: { [WARN_STALE_DATA]: true } },
           )
           adapter = adapterAttr.adapter
-
-          const additionChanges = [toChange({ after: serviceInstance })]
-          const additionResult = await adapter.deploy({ changeGroup: { groupID: 'SDF', changes: additionChanges } })
-          // check that that test setup is successfull
-          expect(additionResult.errors.length).toBe(0)
-          expect(additionResult.appliedChanges.length).toBe(1)
         })
 
         it('should have warning when applying change validator', async () => {
@@ -380,12 +371,6 @@ describe('Netsuite adapter E2E with real account', () => {
             { deploy: { [WARN_STALE_DATA]: false } },
           )
           adapter = adapterAttr.adapter
-
-          const additionChanges = [toChange({ after: serviceInstance })]
-          const additionResult = await adapter.deploy({ changeGroup: { groupID: 'SDF', changes: additionChanges } })
-          // check that that test setup is successfull
-          expect(additionResult.errors.length).toBe(0)
-          expect(additionResult.appliedChanges.length).toBe(1)
         })
 
         it('should have no warning when applying change validator', async () => {

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -355,7 +355,7 @@ describe('Netsuite adapter E2E with real account', () => {
           expect(additionResult.appliedChanges.length).toBe(1)
         })
 
-        it('should have warning when attempting to deploy', async () => {
+        it('should have warning when applying change validator', async () => {
           const modificationChanges = [toChange({ before: beforeInstance, after: afterInstance })]
           const changeErrors: ReadonlyArray<ChangeError> = await awu([
             adapter.deployModifiers?.changeValidator,
@@ -403,7 +403,7 @@ describe('Netsuite adapter E2E with real account', () => {
           expect(additionResult.appliedChanges.length).toBe(1)
         })
 
-        it('should have not warning when attempting to deploy', async () => {
+        it('should have no warning when applying change validator', async () => {
           const modificationChanges = [toChange({ before: beforeInstance, after: afterInstance })]
           const changeErrors: ReadonlyArray<ChangeError> = await awu([
             adapter.deployModifiers?.changeValidator,

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -368,14 +368,6 @@ describe('Netsuite adapter E2E with real account', () => {
           const changeError = changeErrors.find(e => e.message === 'Continuing the deploy proccess will override changes made in the service to this element.')
           expect(changeError).toBeDefined()
         })
-
-        afterAll(async () => {
-          const removalChange = [toChange({ before: serviceInstance })]
-          const additionResult = await adapter.deploy({ changeGroup: { groupID: 'SDF', changes: removalChange } })
-          // check that that test cleanup is successfull
-          expect(additionResult.errors.length).toBe(0)
-          expect(additionResult.appliedChanges.length).toBe(1)
-        })
       })
 
       describe('with warnOnStaleWorkspaceData=false flag', () => {
@@ -385,7 +377,7 @@ describe('Netsuite adapter E2E with real account', () => {
         beforeAll(async () => {
           const adapterAttr = realAdapter(
             { credentials: credentialsLease.value, withSuiteApp },
-            { deploy: { warnOnStaleWorkspaceData: false } },
+            { deploy: { [WARN_STALE_DATA]: false } },
           )
           adapter = adapterAttr.adapter
           beforeInstance = entityCustomFieldToCreate.clone()
@@ -412,14 +404,6 @@ describe('Netsuite adapter E2E with real account', () => {
             .flatMap(validator => validator(modificationChanges))
             .toArray()
           expect(changeErrors.length).toBe(0)
-        })
-
-        afterAll(async () => {
-          const removalChange = [toChange({ before: serviceInstance })]
-          const additionResult = await adapter.deploy({ changeGroup: { groupID: 'SDF', changes: removalChange } })
-          // check that that test cleanup is successfull
-          expect(additionResult.errors.length).toBe(0)
-          expect(additionResult.appliedChanges.length).toBe(1)
         })
       })
     })

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -346,7 +346,7 @@ describe('Netsuite adapter E2E with real account', () => {
 
           beforeInstance.value.label = 'before label'
           afterInstance.value.label = 'after label'
-          serviceInstance.value.label = 'service label'
+          serviceInstance.value.label = `service label - ${randomString}`
 
           const additionChanges = [toChange({ after: serviceInstance })]
           const additionResult = await adapter.deploy({ changeGroup: { groupID: 'SDF', changes: additionChanges } })
@@ -394,7 +394,7 @@ describe('Netsuite adapter E2E with real account', () => {
 
           beforeInstance.value.label = 'before label'
           afterInstance.value.label = 'after label'
-          serviceInstance.value.label = 'service label'
+          serviceInstance.value.label = `service label - ${randomString}`
 
           const additionChanges = [toChange({ after: serviceInstance })]
           const additionResult = await adapter.deploy({ changeGroup: { groupID: 'SDF', changes: additionChanges } })


### PR DESCRIPTION
add e2e tests for safe deploy change validator.

---
Test description:
adding a new instance to the service, then run change validator on changes that should cause the safe deploy validator to throw warning (the validator does a three-way comparison)
---
_Release Notes_: 
None
---
_User Notifications_: 
None
