### PR TITLE
fixed elements without hidden elements to not return elements and tic files that were changed during the load (fix SAAS-2745)

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -670,7 +670,8 @@ export const loadWorkspace = async (
     if (includeHidden) {
       return elements(env)
     }
-    return ((await getLoadedNaclFilesSource())).getElementsSource(env)
+    await getWorkspaceState()
+    return (naclFileSources[env ?? currentEnv()]).getElementsSource()
   }
   const pickServices = (names?: ReadonlyArray<string>): ReadonlyArray<string> =>
     (_.isUndefined(names) ? services() : services().filter(s => names.includes(s)))


### PR DESCRIPTION
When getting elements without hidden types, the workspace attempted to complete this from a multienv source that into which the load source were not applied, resulting in missing file changes.

This resulted in `ws.elements(false)` calls to ignore changes in static files (SALTO-2745)

---


---
_Release Notes_: 
_Fixed diff command ignores static files changes_

