### PR TITLE
SALTO-925 - CPQ mapping references 

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -382,6 +382,23 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { parentContext: 'neighborCPQRuleLookup', type: CUSTOM_FIELD },
   },
   {
+<<<<<<< HEAD
+=======
+    src: { field: 'errorDisplayField', parentTypes: ['ValidationRule'] },
+    serializationStrategy: 'relativeApiName',
+    target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
+  },
+  {
+    src: { field: 'picklist', parentTypes: ['RecordTypePicklistValue'] },
+    serializationStrategy: 'relativeApiName',
+    target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
+  },
+  {
+    src: { field: 'page', parentTypes: ['WebLink'] },
+    target: { type: 'ApexPage' },
+  },
+  {
+>>>>>>> 21f71519... added refs rules
     src: { field: CPQ_LOOKUP_PRODUCT_FIELD, parentTypes: [CPQ_PRODUCT_RULE, CPQ_PRICE_RULE] },
     serializationStrategy: 'relativeApiName',
     target: { parentContext: 'neighborCPQLookup', type: CUSTOM_FIELD },

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -382,8 +382,6 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { parentContext: 'neighborCPQRuleLookup', type: CUSTOM_FIELD },
   },
   {
-<<<<<<< HEAD
-=======
     src: { field: 'errorDisplayField', parentTypes: ['ValidationRule'] },
     serializationStrategy: 'relativeApiName',
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
@@ -398,7 +396,6 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { type: 'ApexPage' },
   },
   {
->>>>>>> 21f71519... added refs rules
     src: { field: CPQ_LOOKUP_PRODUCT_FIELD, parentTypes: [CPQ_PRODUCT_RULE, CPQ_PRICE_RULE] },
     serializationStrategy: 'relativeApiName',
     target: { parentContext: 'neighborCPQLookup', type: CUSTOM_FIELD },


### PR DESCRIPTION
added Reference to cpq fields : 
errorDisplayField under ValidationRule
picklist under RecordTypePicklistValue
page under WebLink

---
_User Notifications_: 
on Salesforce adapter the following fields will be converted to a Reference expressions:
ValidationRule.errorDisplayField, RecordTypePicklistValue.picklist, WebLink.page.
