### PR TITLE
SALTO-1364: Allow fetch conflict logic to group related conflicts

### DIFF
--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -116,7 +116,7 @@ export const getApprovedChanges = async (
   const shouldApproveAll = (answers: inquirer.Answers): boolean => (
     _.values(answers).some(answer => answer === 'all')
   )
-  const isConflict = (change: FetchChange): boolean => change.pendingChange !== undefined
+  const isConflict = (change: FetchChange): boolean => !_.isEmpty(change.pendingChanges)
   const shouldAskForApproval = (change: FetchChange): boolean => isConflict(change)
 
   const [askForApproval, autoApproved] = _.partition(changes, shouldAskForApproval)

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -395,11 +395,13 @@ export const formatFetchChangeForApproval = async (
   idx: number,
   totalChanges: number
 ): Promise<string> => {
-  const formattedChange = await formatDetailedChanges([[change.serviceChange]], true)
-  const formattedConflict = change.pendingChange === undefined ? [] : [
-    header(Prompts.FETCH_CONFLICTING_CHANGE),
-    body(await formatDetailedChanges([[change.pendingChange]], true)),
-  ]
+  const formattedChange = await formatDetailedChanges([change.serviceChanges], true)
+  const formattedConflict = change.pendingChanges === undefined || _.isEmpty(change.pendingChanges)
+    ? []
+    : [
+      header(Prompts.FETCH_CONFLICTING_CHANGE),
+      body(await formatDetailedChanges([change.pendingChanges], true)),
+    ]
   return [
     header(Prompts.FETCH_CHANGE_HEADER(idx + 1, totalChanges)),
     body(formattedChange),

--- a/packages/cli/test/callbacks.test.ts
+++ b/packages/cli/test/callbacks.test.ts
@@ -42,7 +42,7 @@ describe('callbacks', () => {
   })
 
   describe('getApprovedChanges', () => {
-    const fetchChanges = dummyChanges.map(c => ({ change: c, serviceChange: c }))
+    const fetchChanges = dummyChanges.map(c => ({ change: c, serviceChanges: [c] }))
     it('should return all non conflict changes', async () => {
       const approved = await getApprovedChanges(fetchChanges)
       expect(approved).toHaveLength(fetchChanges.length)

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -243,7 +243,7 @@ describe('fetch command', () => {
       })
       describe('with upstream changes', () => {
         const changes = mocks.dummyChanges.map(
-          (change: DetailedChange): FetchChange => ({ change, serviceChange: change })
+          (change: DetailedChange): FetchChange => ({ change, serviceChanges: [change] })
         )
         const mockFetchWithChanges = jest.fn().mockResolvedValue(
           {

--- a/packages/cli/test/commands/restore.test.ts
+++ b/packages/cli/test/commands/restore.test.ts
@@ -51,7 +51,7 @@ describe('restore command', () => {
     mockRestore = restore as typeof mockRestore
     mockRestore.mockReset()
     mockRestore.mockResolvedValue(
-      mocks.dummyChanges.map(change => ({ change, serviceChange: change }))
+      mocks.dummyChanges.map(change => ({ change, serviceChanges: [change] }))
     )
   })
 

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -314,7 +314,7 @@ describe('formatter', () => {
   describe('formatFetchChangeForApproval', () => {
     const change = detailedChange('modify', ['object', 'field', 'value'], 'old', 'new')
     describe('without conflict', () => {
-      const changeWithoutConflict = { change, serviceChange: change }
+      const changeWithoutConflict = { change, serviceChanges: [change] }
       let output: string
       beforeAll(async () => {
         output = await formatFetchChangeForApproval(changeWithoutConflict, 0, 3)
@@ -329,8 +329,8 @@ describe('formatter', () => {
     describe('with conflict', () => {
       const fetchChange: FetchChange = {
         change: detailedChange('modify', ['object', 'field', 'value'], 'local', 'new'),
-        serviceChange: change,
-        pendingChange: detailedChange('modify', ['object', 'field', 'value'], 'old', 'local'),
+        serviceChanges: [change],
+        pendingChanges: [detailedChange('modify', ['object', 'field', 'value'], 'old', 'local')],
       }
       let output: string
       beforeAll(async () => {

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -618,7 +618,7 @@ export const deploy = async (
 
   return {
     success: true,
-    changes: dummyChanges.map(c => ({ change: c, serviceChange: c })),
+    changes: dummyChanges.map(c => ({ change: c, serviceChanges: [c] })),
     errors: [],
   }
 }

--- a/packages/cli/test/workspace/workspace.test.ts
+++ b/packages/cli/test/workspace/workspace.test.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import { FetchChange } from '@salto-io/core'
 import { Workspace, state } from '@salto-io/workspace'
 import { mockFunction } from '@salto-io/test-utils'
 import { EventEmitter } from 'pietile-eventemitter'
@@ -104,7 +105,7 @@ describe('workspace', () => {
       const result = await updateWorkspace({
         workspace: mockWs,
         output: cliOutput,
-        changes: dummyChanges.map(change => ({ change, serviceChange: change })),
+        changes: dummyChanges.map(change => ({ change, serviceChanges: [change] })),
       })
       expect(result).toBeTruthy()
       expect(mockWs.updateNaclFiles).toHaveBeenCalledWith(dummyChanges, 'default')
@@ -117,7 +118,7 @@ describe('workspace', () => {
       const result = await updateWorkspace({
         workspace: mockWs,
         output: cliOutput,
-        changes: changes.map(change => ({ change, serviceChange: change })),
+        changes: changes.map(change => ({ change, serviceChanges: [change] })),
       })
       expect(result).toBeTruthy()
       expect(mockWs.updateNaclFiles).toHaveBeenCalledWith(changes, 'default')
@@ -131,7 +132,7 @@ describe('workspace', () => {
       const result = await updateWorkspace({
         workspace: mockWs,
         output: cliOutput,
-        changes: dummyChanges.map(change => ({ change, serviceChange: change })),
+        changes: dummyChanges.map(change => ({ change, serviceChanges: [change] })),
       })
       expect(result.success).toBe(false)
       expect(mockWs.updateNaclFiles).toHaveBeenCalledWith(dummyChanges, 'default')
@@ -155,10 +156,14 @@ describe('workspace', () => {
   })
 
   describe('applyChangesToWorkspace', () => {
-    const changes = dummyChanges.map(change => ({ change, serviceChange: change }))
-    const approveChangesCallback = jest.fn().mockResolvedValue(changes)
+    type ApproveChangesCB = Parameters<typeof applyChangesToWorkspace>[0]['approveChangesCallback']
+
+    let changes: FetchChange[]
+    let approveChangesCallback: jest.MockedFunction<ApproveChangesCB>
+
     beforeEach(() => {
-      approveChangesCallback.mockClear()
+      changes = dummyChanges.map(change => ({ change, serviceChanges: [change] }))
+      approveChangesCallback = mockFunction<ApproveChangesCB>().mockResolvedValue(changes)
     })
     it('should apply changes and return true', async () => {
       const res = await applyChangesToWorkspace({

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -155,7 +155,7 @@ export const deploy = async (
     await workspace.elements(),
     changedElements,
     [id => changedElements.has(id)]
-  )).map(change => ({ change, serviceChange: change }))
+  )).map(change => ({ change, serviceChanges: [change] }))
     .flatMap(toChangesWithPath(
       async name => collections.array.makeArray(await changedElements.get(name))
     )).toArray()
@@ -242,7 +242,7 @@ export const fetch: FetchFunc = async (
   }
 }
 
-export type LocalChange = Omit<FetchChange, 'pendingChange'>
+export type LocalChange = Omit<FetchChange, 'pendingChanges'>
 
 export const restore = async (
   workspace: Workspace,
@@ -258,7 +258,7 @@ export const restore = async (
     elementSelectors,
     fetchServices
   )
-  return changes.map(change => ({ change, serviceChange: change }))
+  return changes.map(change => ({ change, serviceChanges: [change] }))
 }
 
 export const diff = async (
@@ -285,7 +285,7 @@ export const diff = async (
     [shouldElementBeIncluded(diffServices)]
   )
 
-  return diffChanges.map(change => ({ change, serviceChange: change }))
+  return diffChanges.map(change => ({ change, serviceChanges: [change] }))
 }
 
 class AdapterInstallError extends Error {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -438,7 +438,7 @@ describe('api.ts', () => {
       })
       const changes = await api.restore(ws)
       expect(changes).toHaveLength(1)
-      expect(_.keys(changes[0])).toEqual(['change', 'serviceChange'])
+      expect(_.keys(changes[0])).toEqual(['change', 'serviceChanges'])
     })
   })
 

--- a/packages/lowerdash/src/collections/tree_map.ts
+++ b/packages/lowerdash/src/collections/tree_map.ts
@@ -33,7 +33,6 @@ export class TreeMap<T> implements Map<string, T[]> {
     data: TreeMapEntry<S>,
     path: string[],
     createIfMissing = false,
-    returnPartial = false
   ): TreeMapEntry<S> | undefined => {
     if (_.isEmpty(path)) {
       return data
@@ -43,9 +42,9 @@ export class TreeMap<T> implements Map<string, T[]> {
       data.children[key] = { children: {}, value: [] }
     }
     if (Object.prototype.hasOwnProperty.call(data.children, key)) {
-      return TreeMap.getFromPath(data.children[key], restOfPath, createIfMissing, returnPartial)
+      return TreeMap.getFromPath(data.children[key], restOfPath, createIfMissing)
     }
-    return returnPartial ? data : undefined
+    return undefined
   }
 
   protected static mergeEntries = <S>(src: TreeMapEntry<S>, target: TreeMapEntry<S>): void => {
@@ -164,6 +163,15 @@ export class TreeMap<T> implements Map<string, T[]> {
     callbackfn: (value: T[], key: string, map: Map<string, T[]>) => void,
   ): void {
     this.iterEntry(this.data).forEach(([key, value]) => callbackfn(value, key, this))
+  }
+
+  valuesWithPrefix(prefix: string): IterableIterator<T[]> {
+    const path = prefix.split(this.separator)
+    const prefixSubtree = TreeMap.getFromPath(this.data, path)
+    if (prefixSubtree === undefined) {
+      return wu([])
+    }
+    return this.iterEntry(prefixSubtree, path).map(([_key, values]) => values)
   }
 }
 

--- a/packages/lowerdash/test/collections/tree_map.test.ts
+++ b/packages/lowerdash/test/collections/tree_map.test.ts
@@ -230,4 +230,33 @@ describe('tree map', () => {
     const newSourceMap = new TreeMap()
     expect(newSourceMap).toBeInstanceOf(TreeMap)
   })
+
+  describe('valuesWithPrefix', () => {
+    let tree: TreeMap<string>
+    beforeEach(() => {
+      tree = new TreeMap(baseEntries, separator)
+    })
+    describe('when iterating a prefix that exists', () => {
+      let iteratedValues: string[][]
+      beforeEach(() => {
+        iteratedValues = [...tree.valuesWithPrefix('salesforce|test')]
+      })
+      it('should iterate all values with the given prefix', () => {
+        expect(iteratedValues).toEqual(
+          baseEntries
+            .filter(([key]) => key.startsWith('salesforce|test'))
+            .map(([_key, value]) => value)
+        )
+      })
+    })
+    describe('when iterating a prefix that does not exist', () => {
+      let iteratedValues: string[][]
+      beforeEach(() => {
+        iteratedValues = [...tree.valuesWithPrefix('salesforce|test|no|such|prefix')]
+      })
+      it('should return an empty iterator', () => {
+        expect(iteratedValues).toHaveLength(0)
+      })
+    })
+  })
 })

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -55,7 +55,7 @@ const { awu } = collections.asynciterable
 const { makeArray } = collections.array
 
 describe('transformer', () => {
-  describe('getAuditAnnotations', () => {
+  describe('getAuthorAnnotations', () => {
     const newChangeDateFileProperties = mockFileProperties({ lastModifiedDate: 'date that is new',
       type: 'test',
       fullName: 'test',


### PR DESCRIPTION
This change allows the fetch conflict code to detect a conflict between one service change
and multiple pending changes (or vice-versa), grouping them into a single fetch change.

---

This can happen for example when a field is removed in the nacl and has several annotations change in the service - the conflict in this case is between the single removal change of the entire field, and multiple annotation changes.

The same can happen in the other direction, when there are multiple annotation changes in the nacl but the field is deleted in the service.

---
_Release Notes_: 
Core
- Fixed fetch conflict detection code issue that would cause invalid nacls to appear after fetch in case of conflicting changes

---
_User Notifications_: 
_None_