### PR TITLE
SALTO-1389: Add e2e tests for static resources for safe deploy change validator

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -330,58 +330,116 @@ describe('Netsuite adapter E2E with real account', () => {
     })
 
     describe('safe deploy change validator', () => {
-      let beforeInstance: InstanceElement
-      let afterInstance: InstanceElement
-      beforeAll(() => {
-        beforeInstance = entityCustomFieldToCreate.clone()
-        afterInstance = beforeInstance.clone()
+      describe('on custom type instances', () => {
+        let beforeInstance: InstanceElement
+        let afterInstance: InstanceElement
+        beforeAll(() => {
+          beforeInstance = entityCustomFieldToCreate.clone()
+          afterInstance = beforeInstance.clone()
 
-        beforeInstance.value.label = 'before label'
-        afterInstance.value.label = 'after label'
+          beforeInstance.value.label = 'before label'
+          afterInstance.value.label = 'after label'
+        })
+
+        describe('with warnOnStaleWorkspaceData=true flag', () => {
+          beforeAll(async () => {
+            const adapterAttr = realAdapter(
+              { credentials: credentialsLease.value, withSuiteApp },
+              { deploy: { [WARN_STALE_DATA]: true } },
+            )
+            adapter = adapterAttr.adapter
+          })
+
+          it('should have warning when applying change validator', async () => {
+            const modificationChanges = [toChange({ before: beforeInstance, after: afterInstance })]
+            const changeErrors: ReadonlyArray<ChangeError> = await awu([
+              adapter.deployModifiers?.changeValidator,
+            ])
+              .filter(values.isDefined)
+              .flatMap(validator => validator(modificationChanges))
+              .toArray()
+
+            expect(changeErrors.length).toBe(1)
+            const changeError = changeErrors.find(e => e.message === 'Continuing the deploy proccess will override changes made in the service to this element.')
+            expect(changeError).toBeDefined()
+          })
+        })
+
+        describe('with warnOnStaleWorkspaceData=false flag', () => {
+          beforeAll(async () => {
+            const adapterAttr = realAdapter(
+              { credentials: credentialsLease.value, withSuiteApp },
+              { deploy: { [WARN_STALE_DATA]: false } },
+            )
+            adapter = adapterAttr.adapter
+          })
+
+          it('should have no warning when applying change validator', async () => {
+            const modificationChanges = [toChange({ before: beforeInstance, after: afterInstance })]
+            const changeErrors: ReadonlyArray<ChangeError> = await awu([
+              adapter.deployModifiers?.changeValidator,
+            ])
+              .filter(values.isDefined)
+              .flatMap(validator => validator(modificationChanges))
+              .toArray()
+            expect(changeErrors.length).toBe(0)
+          })
+        })
       })
+      describe('on static resources', () => {
+        let beforeInstance: InstanceElement
+        let afterInstance: InstanceElement
+        beforeAll(() => {
+          beforeInstance = fileToCreate.clone()
+          afterInstance = beforeInstance.clone()
 
-      describe('with warnOnStaleWorkspaceData=true flag', () => {
-        beforeAll(async () => {
-          const adapterAttr = realAdapter(
-            { credentials: credentialsLease.value, withSuiteApp },
-            { deploy: { [WARN_STALE_DATA]: true } },
-          )
-          adapter = adapterAttr.adapter
+          beforeInstance.value.content = 'before content'
+          afterInstance.value.content = 'after content'
         })
 
-        it('should have warning when applying change validator', async () => {
-          const modificationChanges = [toChange({ before: beforeInstance, after: afterInstance })]
-          const changeErrors: ReadonlyArray<ChangeError> = await awu([
-            adapter.deployModifiers?.changeValidator,
-          ])
-            .filter(values.isDefined)
-            .flatMap(validator => validator(modificationChanges))
-            .toArray()
+        describe('with warnOnStaleWorkspaceData=true flag', () => {
+          beforeAll(async () => {
+            const adapterAttr = realAdapter(
+              { credentials: credentialsLease.value, withSuiteApp },
+              { deploy: { [WARN_STALE_DATA]: true } },
+            )
+            adapter = adapterAttr.adapter
+          })
 
-          expect(changeErrors.length).toBe(1)
-          const changeError = changeErrors.find(e => e.message === 'Continuing the deploy proccess will override changes made in the service to this element.')
-          expect(changeError).toBeDefined()
+          it('should have warning when applying change validator', async () => {
+            const modificationChanges = [toChange({ before: beforeInstance, after: afterInstance })]
+            const changeErrors: ReadonlyArray<ChangeError> = await awu([
+              adapter.deployModifiers?.changeValidator,
+            ])
+              .filter(values.isDefined)
+              .flatMap(validator => validator(modificationChanges))
+              .toArray()
+
+            expect(changeErrors.length).toBe(1)
+            const changeError = changeErrors.find(e => e.message === 'Continuing the deploy proccess will override changes made in the service to this element.')
+            expect(changeError).toBeDefined()
+          })
         })
-      })
 
-      describe('with warnOnStaleWorkspaceData=false flag', () => {
-        beforeAll(async () => {
-          const adapterAttr = realAdapter(
-            { credentials: credentialsLease.value, withSuiteApp },
-            { deploy: { [WARN_STALE_DATA]: false } },
-          )
-          adapter = adapterAttr.adapter
-        })
+        describe('with warnOnStaleWorkspaceData=false flag', () => {
+          beforeAll(async () => {
+            const adapterAttr = realAdapter(
+              { credentials: credentialsLease.value, withSuiteApp },
+              { deploy: { [WARN_STALE_DATA]: false } },
+            )
+            adapter = adapterAttr.adapter
+          })
 
-        it('should have no warning when applying change validator', async () => {
-          const modificationChanges = [toChange({ before: beforeInstance, after: afterInstance })]
-          const changeErrors: ReadonlyArray<ChangeError> = await awu([
-            adapter.deployModifiers?.changeValidator,
-          ])
-            .filter(values.isDefined)
-            .flatMap(validator => validator(modificationChanges))
-            .toArray()
-          expect(changeErrors.length).toBe(0)
+          it('should have no warning when applying change validator', async () => {
+            const modificationChanges = [toChange({ before: beforeInstance, after: afterInstance })]
+            const changeErrors: ReadonlyArray<ChangeError> = await awu([
+              adapter.deployModifiers?.changeValidator,
+            ])
+              .filter(values.isDefined)
+              .flatMap(validator => validator(modificationChanges))
+              .toArray()
+            expect(changeErrors.length).toBe(0)
+          })
         })
       })
     })

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -32,7 +32,8 @@ import {
   CUSTOM_RECORD_TYPE, EMAIL_TEMPLATE, ENTITY_CUSTOM_FIELD, FETCH_ALL_TYPES_AT_ONCE,
   FILE, FILE_CABINET_PATH_SEPARATOR, FOLDER, NETSUITE, PATH, ROLE, SCRIPT_ID,
   SKIP_LIST,
-  TRANSACTION_COLUMN_CUSTOM_FIELD, WARN_STALE_DATA, WORKFLOW,
+  TRANSACTION_COLUMN_CUSTOM_FIELD,
+  WARN_STALE_DATA, WORKFLOW,
 } from '../src/constants'
 import { mockDefaultValues } from './mock_elements'
 import { Credentials } from '../src/client/credentials'
@@ -143,7 +144,8 @@ describe('Netsuite adapter E2E with real account', () => {
             content: new StaticFile({
               filepath: 'somePath',
               content: Buffer.from('aaa'),
-            }) }
+            }),
+          }
           : {}),
       }
     )
@@ -399,8 +401,8 @@ describe('Netsuite adapter E2E with real account', () => {
           beforeInstance = fileToCreate.clone()
           afterInstance = beforeInstance.clone()
 
-          beforeInstance.value.content.content = Buffer.from('before content')
-          afterInstance.value.content.content = Buffer.from('after content')
+          beforeInstance.value.content = 'before content'
+          afterInstance.value.content = 'after content'
         })
 
         describe('with warnOnStaleWorkspaceData=true flag', () => {
@@ -547,7 +549,7 @@ describe('Netsuite adapter E2E with real account', () => {
         const contentStaticFile = content as StaticFile
         expect(contentStaticFile.content).toBeDefined()
         expect((contentStaticFile.content as Buffer).toString())
-          .toEqual(fileToCreate.value.content)
+          .toEqual(withSuiteApp ? fileToCreate.value.content.content : fileToCreate.value.content)
       })
 
       it('should fetch the modified folder', async () => {

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -139,10 +139,7 @@ describe('Netsuite adapter E2E with real account', () => {
       FILE,
       {
         description: randomString,
-        ...(withSuiteApp
-          ? { [PATH]: '/Images/InnerFolder/e2eTest.js',
-            content: 'aaa' }
-          : {}),
+        ...(withSuiteApp ? { [PATH]: '/Images/InnerFolder/e2eTest.js' } : {}),
       }
     )
 
@@ -397,8 +394,8 @@ describe('Netsuite adapter E2E with real account', () => {
           beforeInstance = fileToCreate.clone()
           afterInstance = beforeInstance.clone()
 
-          beforeInstance.value.content = 'before content'
-          afterInstance.value.content = 'after content'
+          beforeInstance.value.content = new StaticFile({ filepath: 'somePath', content: Buffer.from('before') })
+          afterInstance.value.content = new StaticFile({ filepath: 'somePath', content: Buffer.from('after') })
         })
 
         describe('with warnOnStaleWorkspaceData=true flag', () => {

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -138,7 +138,13 @@ describe('Netsuite adapter E2E with real account', () => {
       FILE,
       {
         description: randomString,
-        ...(withSuiteApp ? { [PATH]: '/Images/InnerFolder/e2eTest.js' } : {}),
+        ...(withSuiteApp
+          ? { [PATH]: '/Images/InnerFolder/e2eTest.js',
+            content: new StaticFile({
+              filepath: 'somePath',
+              content: Buffer.from('aaa'),
+            }) }
+          : {}),
       }
     )
 
@@ -393,8 +399,8 @@ describe('Netsuite adapter E2E with real account', () => {
           beforeInstance = fileToCreate.clone()
           afterInstance = beforeInstance.clone()
 
-          beforeInstance.value.content = 'before content'
-          afterInstance.value.content = 'after content'
+          beforeInstance.value.content = Buffer.from('before content')
+          afterInstance.value.content = Buffer.from('after content')
         })
 
         describe('with warnOnStaleWorkspaceData=true flag', () => {

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -399,8 +399,8 @@ describe('Netsuite adapter E2E with real account', () => {
           beforeInstance = fileToCreate.clone()
           afterInstance = beforeInstance.clone()
 
-          beforeInstance.value.content = Buffer.from('before content')
-          afterInstance.value.content = Buffer.from('after content')
+          beforeInstance.value.content.content = Buffer.from('before content')
+          afterInstance.value.content.content = Buffer.from('after content')
         })
 
         describe('with warnOnStaleWorkspaceData=true flag', () => {

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -141,11 +141,7 @@ describe('Netsuite adapter E2E with real account', () => {
         description: randomString,
         ...(withSuiteApp
           ? { [PATH]: '/Images/InnerFolder/e2eTest.js',
-            content: new StaticFile({
-              filepath: 'somePath',
-              content: Buffer.from('aaa'),
-            }),
-          }
+            content: 'aaa' }
           : {}),
       }
     )
@@ -549,7 +545,7 @@ describe('Netsuite adapter E2E with real account', () => {
         const contentStaticFile = content as StaticFile
         expect(contentStaticFile.content).toBeDefined()
         expect((contentStaticFile.content as Buffer).toString())
-          .toEqual(withSuiteApp ? fileToCreate.value.content.content : fileToCreate.value.content)
+          .toEqual(fileToCreate.value.content)
       })
 
       it('should fetch the modified folder', async () => {


### PR DESCRIPTION
Add the static-resources use-case to the NS E2E tests (put the previous tests under the `on custom type instances` describe).
---
_Release Notes_: 
None
---
_User Notifications_: 
None
