### PR TITLE
added no-hoist rule for rocks db deps (fix SALTO-1574)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
       "packages/*"
     ],
     "nohoist": [
-      "salto-vscode/**"
+      "salto-vscode/**",
+      "**/@salto-io/rocksdb/**"
     ]
   },
   "resolutions": {


### PR DESCRIPTION
_Added no-hoist rule for rocks db deps_

---

_The lib was missing in the executable since it was hoisted instead of being placed inside the rocks db lib. Still need to investigate what triggered the hoisting in main._

---
_Release Notes_: 
_NA_

---
_User Notifications_: 
_NA_
