### PR TITLE
changed workspace to deserialize deleted static files as MissingStaticFile (Fix Salto-1572)

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -34,6 +34,7 @@ import { createMergeManager, ElementMergeManager, ChangeSet, MergedRecoveryMode,
 import { Errors } from '../../errors'
 import { RemoteElementSource, ElementsSource } from '../../elements_source'
 import { serialize, deserializeSingleElement, deserializeMergeErrors } from '../../../serializer/elements'
+import { MissingStaticFile } from '../../static_files'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
@@ -132,7 +133,7 @@ const buildMultiEnvSource = (
   const getStaticFile = async (
     filePath: string,
     encoding: BufferEncoding,
-  ): Promise<StaticFile | undefined> => {
+  ): Promise<StaticFile> => {
     const sourcesFiles = (await Promise.all(Object.values(getActiveSources())
       .map(src => src.getStaticFile(filePath, encoding))))
       .filter(values.isDefined)
@@ -140,7 +141,7 @@ const buildMultiEnvSource = (
       && !_.every(sourcesFiles, sf => sf.hash === sourcesFiles[0].hash)) {
       log.warn(`Found different hashes for static file ${filePath}`)
     }
-    return sourcesFiles[0]
+    return sourcesFiles[0] ?? new MissingStaticFile(filePath)
   }
 
   const buildStateForSingleEnv = async (

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -39,6 +39,7 @@ import { RemoteElementSource, ElementsSource, mapReadOnlyElementsSource } from '
 import { createMergeManager, ElementMergeManager, ChangeSet, createEmptyChangeSet, MergedRecoveryMode } from './nacl_files/elements_cache'
 import { RemoteMap, RemoteMapCreator } from './remote_map'
 import { serialize, deserializeMergeErrors, deserializeSingleElement, deserializeValidationErrors } from '../serializer/elements'
+import { MissingStaticFile } from './static_files'
 
 const log = logger(module)
 
@@ -263,7 +264,7 @@ export const loadWorkspace = async (
                   async staticFile => await envSrc.getStaticFile(
                     staticFile.filepath,
                     staticFile.encoding,
-                  ) ?? staticFile
+                  ) ?? new MissingStaticFile(staticFile.filepath)
                 ),
                 persistent,
               })

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -39,7 +39,6 @@ import { RemoteElementSource, ElementsSource, mapReadOnlyElementsSource } from '
 import { createMergeManager, ElementMergeManager, ChangeSet, createEmptyChangeSet, MergedRecoveryMode } from './nacl_files/elements_cache'
 import { RemoteMap, RemoteMapCreator } from './remote_map'
 import { serialize, deserializeMergeErrors, deserializeSingleElement, deserializeValidationErrors } from '../serializer/elements'
-import { MissingStaticFile } from './static_files'
 
 const log = logger(module)
 
@@ -264,7 +263,7 @@ export const loadWorkspace = async (
                   async staticFile => await envSrc.getStaticFile(
                     staticFile.filepath,
                     staticFile.encoding,
-                  ) ?? new MissingStaticFile(staticFile.filepath)
+                  ) ?? staticFile
                 ),
                 persistent,
               })

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -1012,5 +1012,19 @@ describe('multi env source', () => {
         staticFile.filepath, staticFile.encoding
       )).toEqual(staticFile)
     })
+    it('should return missingStaticFile if the file is not present in any of the sources', async () => {
+      commonSrcStaticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(new MissingStaticFile(''))
+      envSrcStaticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(new MissingStaticFile(''))
+      const src = multiEnvSource(
+        sources,
+        activePrefix,
+        commonPrefix,
+        () => Promise.resolve(new InMemoryRemoteMap()),
+        false
+      )
+      expect(await src.getStaticFile(
+        staticFile.filepath, staticFile.encoding
+      )).toEqual(new MissingStaticFile(staticFile.filepath))
+    })
   })
 })


### PR DESCRIPTION
_changed workspace to deserialize deleted static files as MissingStaticFile_

---

_The fallback for a missing static file in the workspace deserializer was to return the original static file object instead of the lazystaticfile. This cause deletion of static files to be ignored. This change accounts for such cases._

---
_Release Notes_: 
_Fixed static files deletions are ignored in a deploy_

---
_User Notifications_: 
_NA_
