### PR TITLE
Revert "SALTO:1224/nacl detailed change (#2372)"

### DIFF
--- a/packages/cli/test/callbacks.test.ts
+++ b/packages/cli/test/callbacks.test.ts
@@ -42,7 +42,7 @@ describe('callbacks', () => {
   })
 
   describe('getApprovedChanges', () => {
-    const fetchChanges = dummyChanges.map(c => ({ change: c, serviceChange: c, audit: {} }))
+    const fetchChanges = dummyChanges.map(c => ({ change: c, serviceChange: c }))
     it('should return all non conflict changes', async () => {
       const approved = await getApprovedChanges(fetchChanges)
       expect(approved).toHaveLength(fetchChanges.length)

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -243,7 +243,7 @@ describe('fetch command', () => {
       })
       describe('with upstream changes', () => {
         const changes = mocks.dummyChanges.map(
-          (change: DetailedChange): FetchChange => ({ change, serviceChange: change, audit: {} })
+          (change: DetailedChange): FetchChange => ({ change, serviceChange: change })
         )
         const mockFetchWithChanges = jest.fn().mockResolvedValue(
           {

--- a/packages/cli/test/commands/restore.test.ts
+++ b/packages/cli/test/commands/restore.test.ts
@@ -51,7 +51,7 @@ describe('restore command', () => {
     mockRestore = restore as typeof mockRestore
     mockRestore.mockReset()
     mockRestore.mockResolvedValue(
-      mocks.dummyChanges.map(change => ({ change, serviceChange: change, audit: {} }))
+      mocks.dummyChanges.map(change => ({ change, serviceChange: change }))
     )
   })
 

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -314,7 +314,7 @@ describe('formatter', () => {
   describe('formatFetchChangeForApproval', () => {
     const change = detailedChange('modify', ['object', 'field', 'value'], 'old', 'new')
     describe('without conflict', () => {
-      const changeWithoutConflict = { change, serviceChange: change, audit: {} }
+      const changeWithoutConflict = { change, serviceChange: change }
       let output: string
       beforeAll(async () => {
         output = await formatFetchChangeForApproval(changeWithoutConflict, 0, 3)
@@ -330,7 +330,6 @@ describe('formatter', () => {
       const fetchChange: FetchChange = {
         change: detailedChange('modify', ['object', 'field', 'value'], 'local', 'new'),
         serviceChange: change,
-        audit: {},
         pendingChange: detailedChange('modify', ['object', 'field', 'value'], 'old', 'local'),
       }
       let output: string

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -618,7 +618,7 @@ export const deploy = async (
 
   return {
     success: true,
-    changes: dummyChanges.map(c => ({ change: c, serviceChange: c, audit: {} })),
+    changes: dummyChanges.map(c => ({ change: c, serviceChange: c })),
     errors: [],
   }
 }

--- a/packages/cli/test/workspace/workspace.test.ts
+++ b/packages/cli/test/workspace/workspace.test.ts
@@ -104,7 +104,7 @@ describe('workspace', () => {
       const result = await updateWorkspace({
         workspace: mockWs,
         output: cliOutput,
-        changes: dummyChanges.map(change => ({ change, serviceChange: change, audit: {} })),
+        changes: dummyChanges.map(change => ({ change, serviceChange: change })),
       })
       expect(result).toBeTruthy()
       expect(mockWs.updateNaclFiles).toHaveBeenCalledWith(dummyChanges, 'default')
@@ -117,7 +117,7 @@ describe('workspace', () => {
       const result = await updateWorkspace({
         workspace: mockWs,
         output: cliOutput,
-        changes: changes.map(change => ({ change, serviceChange: change, audit: {} })),
+        changes: changes.map(change => ({ change, serviceChange: change })),
       })
       expect(result).toBeTruthy()
       expect(mockWs.updateNaclFiles).toHaveBeenCalledWith(changes, 'default')
@@ -131,7 +131,7 @@ describe('workspace', () => {
       const result = await updateWorkspace({
         workspace: mockWs,
         output: cliOutput,
-        changes: dummyChanges.map(change => ({ change, serviceChange: change, audit: {} })),
+        changes: dummyChanges.map(change => ({ change, serviceChange: change })),
       })
       expect(result.success).toBe(false)
       expect(mockWs.updateNaclFiles).toHaveBeenCalledWith(dummyChanges, 'default')
@@ -155,7 +155,7 @@ describe('workspace', () => {
   })
 
   describe('applyChangesToWorkspace', () => {
-    const changes = dummyChanges.map(change => ({ change, serviceChange: change, audit: {} }))
+    const changes = dummyChanges.map(change => ({ change, serviceChange: change }))
     const approveChangesCallback = jest.fn().mockResolvedValue(changes)
     beforeEach(() => {
       approveChangesCallback.mockClear()

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -16,7 +16,7 @@
 import {
   Adapter, InstanceElement, ObjectType, ElemID, AccountId, getChangeElement, isField,
   Change, ChangeDataType, isFieldChange, AdapterFailureInstallResult, isAdapterSuccessInstallResult,
-  AdapterSuccessInstallResult, AdapterAuthentication, SaltoError, DetailedChange, AuditInformation,
+  AdapterSuccessInstallResult, AdapterAuthentication, SaltoError,
 } from '@salto-io/adapter-api'
 import { EventEmitter } from 'pietile-eventemitter'
 import { logger } from '@salto-io/logging'
@@ -38,7 +38,6 @@ import {
   getDetailedChanges,
   MergeErrorWithElements,
   toChangesWithPath,
-  getAuditInformationFromElement,
 } from './core/fetch'
 import { defaultDependencyChangers } from './core/plan/plan'
 import { createRestoreChanges } from './core/restore'
@@ -52,9 +51,6 @@ const log = logger(module)
 
 const getAdapterFromLoginConfig = (loginConfig: Readonly<InstanceElement>): Adapter =>
   adapterCreators[loginConfig.elemID.adapter]
-
-const getAuditInformationForDetailedChange = (change: DetailedChange): AuditInformation =>
-  getAuditInformationFromElement(getChangeElement(change))
 
 export const verifyCredentials = async (
   loginConfig: Readonly<InstanceElement>
@@ -158,9 +154,7 @@ export const deploy = async (
     await workspace.elements(),
     changedElements,
     [id => changedElements.has(id)]
-  )).map(change => ({ change,
-    serviceChange: change,
-    audit: getAuditInformationForDetailedChange(change) }))
+  )).map(change => ({ change, serviceChange: change }))
     .flatMap(toChangesWithPath(
       async name => collections.array.makeArray(await changedElements.get(name))
     )).toArray()
@@ -263,9 +257,7 @@ export const restore = async (
     elementSelectors,
     fetchServices
   )
-  return changes.map(change => ({ change,
-    serviceChange: change,
-    audit: getAuditInformationForDetailedChange(change) }))
+  return changes.map(change => ({ change, serviceChange: change }))
 }
 
 export const diff = async (
@@ -292,9 +284,7 @@ export const diff = async (
     [shouldElementBeIncluded(diffServices)]
   )
 
-  return diffChanges.map(change => ({ change,
-    serviceChange: change,
-    audit: getAuditInformationForDetailedChange(change) }))
+  return diffChanges.map(change => ({ change, serviceChange: change }))
 }
 
 class AdapterInstallError extends Error {

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -47,10 +47,10 @@ export type FetchChange = {
   // The change between the working copy and the state
   pendingChange?: DetailedChange
   // The change audit information from the service.
-  audit: AuditInformation
+  audit?: AuditInformation
 }
 
-export const getAuditInformationFromElement = (element: Element | undefined): AuditInformation => {
+const getAuditInformationFromElement = (element: Element | undefined): AuditInformation => {
   if (!element) {
     return {}
   }
@@ -144,9 +144,7 @@ export const toChangesWithPath = (
       return [change]
     }
     // Replace merged element with original elements that have a path hint
-    return originalElements.map(elem =>
-      _.merge({}, change, { change: { data: { after: elem } } },
-        { audit: getAuditInformationFromElement(elem) }))
+    return originalElements.map(elem => _.merge({}, change, { change: { data: { after: elem } } }))
   })
 
 type FetchChangeConvertor = (change: DetailedChange) => Promise<FetchChange[]>

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -438,7 +438,7 @@ describe('api.ts', () => {
       })
       const changes = await api.restore(ws)
       expect(changes).toHaveLength(1)
-      expect(_.keys(changes[0])).toEqual(['change', 'serviceChange', 'audit'])
+      expect(_.keys(changes[0])).toEqual(['change', 'serviceChange'])
     })
   })
 


### PR DESCRIPTION
This reverts commit 9f6de667ccf26f8ebf6e90a340bd668c0618c864.

revert changes in last last pr about making audit information mandatory

---

---
_Release Notes_: 


---
_User Notifications_: 
