### PR TITLE
add log when creating rocksdb if not exist

### DIFF
--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -318,6 +318,7 @@ const createDBIfNotExist = async (loc: string): Promise<void> => {
   } catch (e) {
     if (newDb.status === 'new') {
       await withCreatorLock(async () => {
+        log.info('DB does not exist. Creating on %s', loc)
         await promisify(newDb.open.bind(newDb))()
         await promisify(newDb.close.bind(newDb))()
       })

--- a/packages/dag/src/nodemap.ts
+++ b/packages/dag/src/nodemap.ts
@@ -352,7 +352,7 @@ export class DataNodeMap<T> extends AbstractNodeMap {
       const reason = this.has(id) ? 'Node has no data' : 'Node does not exist'
       throw new Error(`Cannot get data of "${id}": ${reason}`)
     }
-    return this.nodeData.get(id) as T
+    return result as T
   }
 
   setData(id: NodeId, data: T): void {


### PR DESCRIPTION
_add log when creating rocksdb if not exist_

---
In addition, remove unneeded `get` method on the graph
