### PR TITLE
SALTO-1434 - Add a warning message for unrestored static files

### DIFF
--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -444,6 +444,8 @@ export const formatFetchFinish = (): string => [
 export const formatStepStart = (text: string, indentLevel?: number): string => indent(`${chalk.yellow('>>>')} ${text}`, indentLevel ?? 1)
 export const formatStepCompleted = (text: string, indentLevel?: number): string => indent(`${chalk.green('vvv')} ${text}`, indentLevel ?? 1)
 export const formatStepFailed = (text: string, indentLevel?: number): string => indent(`${error('xxx')} ${text}`, indentLevel ?? 1)
+export const formatShowWarning = (text: string, indentLevel?: number): string => indent(`${chalk.red('!!!')} ${text}`, indentLevel ?? 1)
+export const formatListRecord = (text: string, indentLevel?: number): string => indent(`○ ${text}`, indentLevel ?? 2)
 
 export const formatMergeErrors = (mergeErrors: FetchResult['mergeErrors']): string =>
   `${Prompts.FETCH_MERGE_ERRORS}\n${mergeErrors.map(

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -197,6 +197,8 @@ ${Prompts.SERVICE_ADD_HELP}`
   public static readonly RESTORE_CALC_DIFF_FINISH = 'Finished calculating the difference between state and NaCL files.'
   public static readonly RESTORE_CALC_DIFF_FAIL = 'Calculating diff failed!'
   public static readonly RESTORE_UPDATE_WORKSPACE_SUCCESS = 'Applied changes'
+  public static readonly STATIC_RESOURCES_NOT_SUPPORTED = `Static resources are not supported for this operation as their content is not kept in the state file.
+  Therefore, the following files will not be restored:`
   public static readonly RESTORE_SUCCESS_FINISHED = 'Done! Your NaCL files are now updated with the latest changes.'
   public static readonly RESTORE_UPDATE_WORKSPACE_FAIL = 'Failed to apply changes to your NaCL files.'
   public static readonly INVALID_FILTERS = (

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -21,6 +21,7 @@ import {
   ObjectType, CORE_ANNOTATIONS, SaltoError, Values, ListType, DetailedChange,
   AdapterAuthentication, OAuthRequestParameters, OauthAccessTokenResponse,
   createRefToElmWithValue,
+  StaticFile,
 } from '@salto-io/adapter-api'
 import {
   Plan, PlanItem, EVENT_TYPES, DeployResult,
@@ -621,4 +622,30 @@ export const deploy = async (
     changes: dummyChanges.map(c => ({ change: c, serviceChanges: [c] })),
     errors: [],
   }
+}
+
+export const staticFileChange = (action: 'add' | 'modify' | 'remove'): DetailedChange => {
+  const id = new ElemID('salesforce')
+  const path = ['salesforce', 'Records', 'advancedpdftemplate', 'custtmpl_103_t2257860_156']
+  const beforeFile = new StaticFile({
+    filepath: 'salesforce/advancedpdftemplate/custtmpl_103_t2257860_156.xml',
+    encoding: 'binary',
+    hash: '5fa14331d637ce9b056be8abe433d43d',
+  })
+  const afterFile = new StaticFile({
+    filepath: 'salesforce/advancedpdftemplate/custtmpl_103_t2257860_156.xml',
+    encoding: 'binary',
+    hash: '81511e24c8023d819040a196fbaf8ee7',
+  })
+
+  if (action === 'add') {
+    const data = { after: afterFile }
+    return { id, action, data, path }
+  }
+  if (action === 'modify') {
+    const data = { before: beforeFile, after: afterFile }
+    return { id, action, data, path }
+  }
+  const data = { before: beforeFile }
+  return { id, action, data, path }
 }


### PR DESCRIPTION
Salto restore does not restore static resources, hence a suitable message has been added to the cli help and when running restore. The last one also prints the changed static files.