### PR TITLE
SALTO:1224/rename audit information

### DIFF
--- a/packages/adapter-api/src/change.ts
+++ b/packages/adapter-api/src/change.ts
@@ -92,11 +92,6 @@ export type DetailedChange<T = ChangeDataType | Values | Value> =
     path?: ReadonlyArray<string>
   }
 
-export type ChangeAuthorInformation = {
-  changedBy?: string
-  changedAt?: string
- }
-
 export type ChangeParams<T> = { before?: T; after?: T }
 
 type ChangeParamType<T> = T extends ChangeParams<infer U> ? U : never

--- a/packages/adapter-api/src/change.ts
+++ b/packages/adapter-api/src/change.ts
@@ -92,11 +92,9 @@ export type DetailedChange<T = ChangeDataType | Values | Value> =
     path?: ReadonlyArray<string>
   }
 
-export type AuditInformation = {
+export type ChangeAuthorInformation = {
   changedBy?: string
   changedAt?: string
-  createdBy?: string
-  createdAt?: string
  }
 
 export type ChangeParams<T> = { before?: T; after?: T }

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -20,8 +20,7 @@ import {
   Element, ElemID, AdapterOperations, Values, ServiceIds, ObjectType,
   toServiceIdsString, Field, OBJECT_SERVICE_ID, InstanceElement, isInstanceElement, isObjectType,
   ADAPTER, FIELD_NAME, INSTANCE_NAME, OBJECT_NAME, ElemIdGetter, DetailedChange, SaltoError,
-  ProgressReporter, ReadOnlyElementsSource, TypeMap, isServiceId, ChangeAuthorInformation,
-  CORE_ANNOTATIONS,
+  ProgressReporter, ReadOnlyElementsSource, TypeMap, isServiceId, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import {
   applyInstancesDefaults, resolvePath, flattenElementStr,
@@ -39,6 +38,10 @@ const { mergeElements } = merger
 const log = logger(module)
 const { isDefined } = values
 
+type ChangeAuthorInformation = {
+  changedBy?: string
+  changedAt?: string
+ }
 type FetchChangeMetadata = ChangeAuthorInformation
 
 export type FetchChange = {

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -52,7 +52,7 @@ export type FetchChange = {
   metadata?: FetchChangeMetadata
 }
 
-const getLastModifierInformationFromElement = (
+const getAuthorInformationFromElement = (
   element: Element | undefined
 ): ChangeAuthorInformation => {
   if (!element) {
@@ -63,7 +63,7 @@ const getLastModifierInformationFromElement = (
 }
 
 const getFetchChangeMetadata = (changedElement: Element): FetchChangeMetadata =>
-  getLastModifierInformationFromElement(changedElement)
+  getAuthorInformationFromElement(changedElement)
 
 export const toAddFetchChange = (elem: Element): FetchChange => {
   const change: DetailedChange = {

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -42,7 +42,7 @@ type ChangeAuthorInformation = {
   changedBy?: string
   changedAt?: string
  }
-type FetchChangeMetadata = ChangeAuthorInformation
+export type FetchChangeMetadata = ChangeAuthorInformation
 
 export type FetchChange = {
   // The actual change to apply to the workspace

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -65,7 +65,7 @@ const getAuthorInformationFromElement = (
     changedBy: element.annotations?.[CORE_ANNOTATIONS.CHANGED_BY] }, isDefined)
 }
 
-const getFetchChangeMetadata = (changedElement: Element): FetchChangeMetadata =>
+const getFetchChangeMetadata = (changedElement: Element | undefined): FetchChangeMetadata =>
   getAuthorInformationFromElement(changedElement)
 
 export const toAddFetchChange = (elem: Element): FetchChange => {

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -471,8 +471,8 @@ describe('fetch', () => {
         changes.forEach(c => expect(c.pendingChange).toBeUndefined())
       })
 
-      it('should return the change with audit information', () => {
-        expect(changes.some(c => c.audit?.changedAt === 'test')).toBeTruthy()
+      it('should return the change with metadata', () => {
+        expect(changes.some(c => c.metadata?.changedAt === 'test')).toBeTruthy()
       })
 
       it('should not remove hidden values from changes', () => {

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -146,7 +146,7 @@ salesforce {
 | elementsUrls                                                | true                                             | Populate URLs for your salesforce configuration elements and enable quick navigation from Salto to the corresponding salesforce screen
 | addMissingIds                                               | true                                             | Populate Salesforce internal ids for a few types that require special handling
 | profilePaths                                                | true                                             | Update file names for profiles whose API name is different from their display name
-| auditInformation                                            | true                                             | Populate Salesforce audit information about who and when last changed Salesforce configuration elements.
+| authorInformation                                            | true                                            | Populate Salesforce author information about who and when last changed Salesforce configuration elements.
 ### Data management configuration options
 
 | Name                                                        | Default when undefined                           | Description

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -30,7 +30,7 @@ import layoutFilter from './filters/layouts'
 import customObjectsFilter, { NESTED_INSTANCE_VALUE_TO_TYPE_NAME } from './filters/custom_objects'
 import customSettingsFilter from './filters/custom_settings_filter'
 import customObjectsSplitFilter from './filters/custom_object_split'
-import auditInformationFilter from './filters/audit_information'
+import authorInformationFilter from './filters/author_information'
 import profileInstanceSplitFilter from './filters/profile_instance_split'
 import customObjectsInstancesFilter from './filters/custom_objects_instances'
 import profilePermissionsFilter from './filters/profile_permissions'
@@ -115,7 +115,7 @@ export const DEFAULT_FILTERS = [
   profilePathsFilter,
   territoryFilter,
   elementsUrlFilter,
-  auditInformationFilter,
+  authorInformationFilter,
   hideReadOnlyValuesFilter,
   // The following filters should remain last in order to make sure they fix all elements
   convertListsFilter,

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -23,7 +23,7 @@ import { FetchElements, ConfigChangeSuggestion } from './types'
 import { METADATA_CONTENT_FIELD, NAMESPACE_SEPARATOR, INTERNAL_ID_FIELD, DEFAULT_NAMESPACE } from './constants'
 import SalesforceClient, { ErrorFilter } from './client/client'
 import { createListMetadataObjectsConfigChange, createRetrieveConfigChange, createSkippedListConfigChange } from './config_change'
-import { apiName, createInstanceElement, MetadataObjectType, createMetadataTypeElements, getAuditAnnotations } from './transformers/transformer'
+import { apiName, createInstanceElement, MetadataObjectType, createMetadataTypeElements, getAuthorAnnotations } from './transformers/transformer'
 import { fromRetrieveResult, toRetrieveRequest, getManifestTypeName } from './transformers/xml_transformer'
 import { MetadataQuery } from './fetch_profile/metadata_query'
 
@@ -110,7 +110,7 @@ const getInstanceFromMetadataInformation = (metadata: MetadataInfo,
     ? { ...metadata, [INTERNAL_ID_FIELD]: filePropertiesMap[metadata.fullName]?.id } : metadata
   return createInstanceElement(newMetadata, metadataType,
     filePropertiesMap[newMetadata.fullName]?.namespacePrefix,
-    getAuditAnnotations(filePropertiesMap[newMetadata.fullName]))
+    getAuthorAnnotations(filePropertiesMap[newMetadata.fullName]))
 }
 
 export const fetchMetadataInstances = async ({
@@ -264,7 +264,7 @@ export const retrieveMetadataInstances = async ({
     )
     return allValues.map(({ file, values }) => (
       createInstanceElement(values, typesByName[file.type], file.namespacePrefix,
-        getAuditAnnotations(file))
+        getAuthorAnnotations(file))
     ))
   }
 

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1381,7 +1381,7 @@ export const createInstanceElement = (
   ) as MetadataInstanceElement
 }
 
-export const getAuditAnnotations = (fileProperties: FileProperties): Record<string, string> => {
+export const getAuthorAnnotations = (fileProperties: FileProperties): Record<string, string> => {
   const annotations = {
     [CORE_ANNOTATIONS.CREATED_BY]: fileProperties?.createdByName,
     [CORE_ANNOTATIONS.CREATED_AT]: fileProperties?.createdDate,

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -61,7 +61,7 @@ export type OptionalFeatures = {
   elementsUrls?: boolean
   profilePaths?: boolean
   addMissingIds?: boolean
-  auditInformation?: boolean
+  authorInformation?: boolean
 }
 
 type ObjectIdSettings = {
@@ -396,7 +396,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     elementsUrls: { refType: BuiltinTypes.BOOLEAN },
     profilePaths: { refType: BuiltinTypes.BOOLEAN },
     addMissingIds: { refType: BuiltinTypes.BOOLEAN },
-    auditInformation: { refType: BuiltinTypes.BOOLEAN },
+    authorInformation: { refType: BuiltinTypes.BOOLEAN },
   },
 })
 

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -336,7 +336,7 @@ describe('SalesforceAdapter fetch', () => {
         expect(flow.value.bla.bla3).toBe(true)
       })
 
-      it('should add audit annotations to metadata instance', async () => {
+      it('should add author annotations to metadata instance', async () => {
         mockFlowType()
         const { elements: result } = await adapter.fetch(mockFetchOpts)
         const flow = findElements(result, 'Flow', 'FlowInstance').pop() as InstanceElement

--- a/packages/salesforce-adapter/test/filters/author_information.test.ts
+++ b/packages/salesforce-adapter/test/filters/author_information.test.ts
@@ -24,12 +24,12 @@ import mockClient from '../client'
 import Connection from '../../src/client/jsforce'
 import SalesforceClient from '../../src/client/client'
 import { Filter, FilterResult } from '../../src/filter'
-import auditInformation, { WARNING_MESSAGE } from '../../src/filters/audit_information'
+import authorInformation, { WARNING_MESSAGE } from '../../src/filters/author_information'
 import { defaultFilterContext } from '../utils'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 import { API_NAME, CUSTOM_FIELD, CUSTOM_OBJECT, METADATA_TYPE } from '../../src/constants'
 
-describe('audit information test', () => {
+describe('author information test', () => {
   let filter: Filter
   let client: SalesforceClient
   let connection: MockInterface<Connection>
@@ -73,7 +73,7 @@ describe('audit information test', () => {
       StringField__c: { refType: new ReferenceExpression(primNum.elemID, primNum) },
     },
   })
-  // In order to test an object without audit information in server.
+  // In order to test an object without author information in server.
 
   beforeEach(() => {
     ({ connection, client } = mockClient())
@@ -88,7 +88,7 @@ describe('audit information test', () => {
         }
         return []
       })
-    filter = auditInformation({ client, config: defaultFilterContext })
+    filter = authorInformation({ client, config: defaultFilterContext })
     customObject = new ObjectType({
       elemID: new ElemID('salesforce', 'Custom__c'),
       annotations: { metadataType: CUSTOM_OBJECT, [API_NAME]: 'Custom__c' },
@@ -97,7 +97,7 @@ describe('audit information test', () => {
       },
     })
   })
-  it('should add audit annotations to custom object', async () => {
+  it('should add author annotations to custom object', async () => {
     await filter.onFetch?.([customObject, objectWithoutInformation])
     checkElementAnnotations(customObject, objectProperties)
     checkElementAnnotations(customObject.fields.StringField__c, fieldProperties)
@@ -144,11 +144,11 @@ describe('audit information test', () => {
   })
   describe('when feature is disabled', () => {
     it('should not add any annotations', async () => {
-      filter = auditInformation({
+      filter = authorInformation({
         client,
         config: {
           ...defaultFilterContext,
-          fetchProfile: buildFetchProfile({ optionalFeatures: { auditInformation: false } }),
+          fetchProfile: buildFetchProfile({ optionalFeatures: { authorInformation: false } }),
         },
       })
       await filter.onFetch?.([customObject])

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -25,7 +25,7 @@ import {
   getValueTypeFieldElement, createMetadataTypeElements, MetadataObjectType,
   METADATA_TYPES_TO_RENAME, instancesToDeleteRecords, instancesToCreateRecords,
   isMetadataObjectType, isMetadataInstanceElement, toDeployableInstance, transformPrimitive,
-  getAuditAnnotations,
+  getAuthorAnnotations,
 } from '../../src/transformers/transformer'
 import { getLookUpName } from '../../src/transformers/reference_mapping'
 import {
@@ -66,11 +66,11 @@ describe('transformer', () => {
         fullName: 'test' }
     )
     it('get annotations with up to date change time will return full annotations', () => {
-      expect(getAuditAnnotations(newChangeDateFileProperties)[CORE_ANNOTATIONS.CHANGED_BY])
+      expect(getAuthorAnnotations(newChangeDateFileProperties)[CORE_ANNOTATIONS.CHANGED_BY])
         .toEqual('changed_name')
     })
     it('file properties with old change will return no user name in changedBy', () => {
-      expect(getAuditAnnotations(oldChangeDateFileProperties)[CORE_ANNOTATIONS.CHANGED_BY])
+      expect(getAuthorAnnotations(oldChangeDateFileProperties)[CORE_ANNOTATIONS.CHANGED_BY])
         .not
         .toBeDefined()
     })


### PR DESCRIPTION
renaming all of audit information changes to author information after a discussion about naming
Implementing author information behind FetchChangeMetadata to support future metadata information on fetch changes

---

---
_Release Notes_: 

The optional flag auditInformation has been renamed to authorInformation
Reminder - This his feature is true by default but can be turned off by adding
```
optionalFeatures = {
      authorInformation = true
      // formerly auditInformation = true 
    }
```
to each adapter configuration Nacl file inside the fetch scope.

---
_User Notifications_: 
