### PR TITLE
SALTO-1580: Avoid throwing exception in a valid case when routing changes

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -33,7 +33,7 @@ type InitArgs = {
 export const action: CommandDefAction<InitArgs> = async (
   { input: { workspaceName, envName }, cliTelemetry, output, workspacePath },
 ): Promise<CliExitCode> => {
-  log.debug('running env init command on \'%s\'', workspaceName)
+  log.debug('running workspace init command on \'%s\'', workspaceName)
   cliTelemetry.start()
   try {
     const baseDir = path.resolve(workspacePath)
@@ -52,7 +52,7 @@ export const action: CommandDefAction<InitArgs> = async (
     outputLine(Prompts.initCompleted(), output)
   } catch (e) {
     errorOutputLine(Prompts.initFailed(e.message), output)
-    log.error('%s %s', e, e.stack)
+    log.error('workspace init failed with error %s %s', e, e.stack)
     cliTelemetry.failure()
     cliTelemetry.stacktrace(e)
     return CliExitCode.AppError

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -52,6 +52,7 @@ export const action: CommandDefAction<InitArgs> = async (
     outputLine(Prompts.initCompleted(), output)
   } catch (e) {
     errorOutputLine(Prompts.initFailed(e.message), output)
+    log.error('%s %s', e, e.stack)
     cliTelemetry.failure()
     cliTelemetry.stacktrace(e)
     return CliExitCode.AppError

--- a/packages/workspace/src/workspace/nacl_files/addition_wrapper.ts
+++ b/packages/workspace/src/workspace/nacl_files/addition_wrapper.ts
@@ -35,7 +35,6 @@ const addToField = (
   commonField: Field,
   currentField?: FieldDefinition
 ): Record<string, FieldDefinition> => {
-  if (isField(nestedValue.value)) return { [nestedValue.value.name]: nestedValue.value }
   const { name } = commonField
   const { path } = nestedValue.id.createTopLevelParentID()
   const annotations = { ...currentField?.annotations }
@@ -53,6 +52,16 @@ const createObjectTypeFromNestedAdditions = (
   new ObjectType(nestedValues.reduce((prev, nestedValue) => {
     switch (nestedValue.id.idType) {
       case 'field': {
+        const { value } = nestedValue
+        if (isField(value)) {
+          return {
+            ...prev,
+            fields: {
+              ...prev.fields,
+              [value.name]: value,
+            },
+          }
+        }
         const fieldName = nestedValue.id.createTopLevelParentID().path[0]
         const field = commonObjectType.fields[fieldName]
         if (field === undefined) {


### PR DESCRIPTION
- The code in addition wrapper would handle a case where a full field was added but the exception was thrown before the code that handled that case
- Also added a full error log when init fails (unrelated)

---
_Release Notes_: 
- Fixed issue where fetch in isolated mode would fail in specific scenarios

---
_User Notifications_: 
_None_