### PR TITLE
Do salesforce oauth with refresh tokens

### DIFF
--- a/packages/adapter-api/src/authentication_types.ts
+++ b/packages/adapter-api/src/authentication_types.ts
@@ -18,7 +18,7 @@ import { Values } from './values'
 
 export type OAuthRequestParameters = {
   url: string
-  accessTokenField: string
+  oauthRequiredFields: string[]
 }
 
 export type AuthMethod = {
@@ -26,8 +26,7 @@ export type AuthMethod = {
 }
 
 export type OauthAccessTokenResponse = {
-  instanceUrl: string
-  accessToken: string
+  fields: Record<string, string>
 }
 
 export type OAuthMethod = AuthMethod & {

--- a/packages/cli/e2e_test/helpers/salesforce.ts
+++ b/packages/cli/e2e_test/helpers/salesforce.ts
@@ -76,8 +76,11 @@ export const getSalesforceCredsInstance = (creds: UsernamePasswordCredentials): 
 export const getSalesforceOAuthCreds = (creds: OauthAccessTokenCredentials): InstanceElement => {
   const configValues = {
     accessToken: creds.accessToken,
+    refreshToken: creds.refreshToken,
     instanceUrl: creds.instanceUrl,
     isSandbox: creds.isSandbox,
+    clientId: creds.clientId,
+    clientSecret: creds.clientSecret,
     authType: 'oauth',
   }
 

--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -148,7 +148,7 @@ export const getApprovedChanges = async (
 
 // TODO: SALTO-770 CLI should mask secret credentials based on adapter definition
 const isPasswordInputType = (fieldName: string): boolean =>
-  ['token', 'password', 'tokenId', 'tokenSecret', 'consumerKey', 'suiteAppTokenId', 'suiteAppTokenSecret', 'clientSecret'].includes(fieldName)
+  ['token', 'password', 'tokenId', 'tokenSecret', 'consumerKey', 'consumerSecret', 'suiteAppTokenId', 'suiteAppTokenSecret', 'clientSecret'].includes(fieldName)
 
 export const getFieldInputType = (fieldType: TypeElement, fieldName: string): string => {
   if (!isPrimitiveType(fieldType) || fieldType.primitive === PrimitiveTypes.UNKNOWN) {

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -50,7 +50,7 @@ const getOauthConfig = async (
   const oauthParameters = oauthMethod.createOAuthRequest(newConfig)
   const credentials = oauthMethod.createFromOauthResponse(newConfig.value,
     await processOauthCredentials(newConfig.value.port,
-      oauthParameters.accessTokenField, oauthParameters.url, output))
+      oauthParameters.oauthRequiredFields, oauthParameters.url, output))
   return new InstanceElement(ElemID.CONFIG_NAME, oauthMethod.credentialsType, credentials)
 }
 

--- a/packages/cli/test/cli_oauth_authenticator.test.ts
+++ b/packages/cli/test/cli_oauth_authenticator.test.ts
@@ -26,7 +26,7 @@ describe('When using the cli oauth authenticates', () => {
   let returnPromise: Promise<OauthAccessTokenResponse>
   beforeEach(async () => {
     mockWriteStream = new MockWriteStream()
-    returnPromise = cliOauthAuthenticator.processOauthCredentials(8080, 'access_token_field', 'testUrl', {
+    returnPromise = cliOauthAuthenticator.processOauthCredentials(8080, ['access_token_field', 'instance_url'], 'testUrl', {
       stdout: mockWriteStream,
       stderr: new MockWriteStream(),
     })
@@ -53,8 +53,8 @@ describe('When using the cli oauth authenticates', () => {
       expect(response.text).toContain('Done configuring Salto')
     })
     const retVal = await returnPromise
-    expect(retVal.accessToken).toEqual('accessTokenThing2')
-    expect(retVal.instanceUrl).toEqual('testInstanceUrl2')
+    expect(retVal.fields.accessTokenField).toEqual('accessTokenThing2')
+    expect(retVal.fields.instanceUrl).toEqual('testInstanceUrl2')
   })
 })
 
@@ -62,7 +62,7 @@ describe('when oauth output is badly shapen', () => {
   let returnPromise: Promise<OauthAccessTokenResponse>
   beforeEach(async () => {
     mockWriteStream = new MockWriteStream()
-    returnPromise = cliOauthAuthenticator.processOauthCredentials(8081, 'testAccessTokenField', 'testUrl',
+    returnPromise = cliOauthAuthenticator.processOauthCredentials(8081, ['testAccessTokenField'], 'testUrl',
       {
         stdout: mockWriteStream,
         stderr: new MockWriteStream(),

--- a/packages/cli/test/commands/service.test.ts
+++ b/packages/cli/test/commands/service.test.ts
@@ -27,8 +27,10 @@ import { CliExitCode } from '../../src/types'
 
 jest.mock('../../src/cli_oauth_authenticator', () => ({
   processOauthCredentials: jest.fn().mockResolvedValue({
-    instanceUrl: 'someInstanceUrl',
-    accessToken: 'accessToken',
+    fields: {
+      instanceUrl: 'someInstanceUrl',
+      accessToken: 'accessToken',
+    },
   }),
 }))
 jest.mock('@salto-io/core', () => ({
@@ -42,7 +44,8 @@ jest.mock('@salto-io/core', () => ({
       newAdapter: mocks.mockCredentialsType('newAdapter'),
       hubspot: mocks.mockCredentialsType('hubspot'),
       '': mocks.mockCredentialsType(''),
-      oauthAdapter: mocks.mockOauthCredentialsType('oauthAdapter', { url: '', accessTokenField: '' }),
+      oauthAdapter: mocks.mockOauthCredentialsType('oauthAdapter', { url: '',
+        oauthRequiredFields: [''] }),
     }
   }),
   addAdapter: jest.fn().mockImplementation((
@@ -69,7 +72,8 @@ jest.mock('@salto-io/core', () => ({
       } else if (serviceName === 'oauthAdapter') {
         loginStatuses[serviceName] = {
           isLoggedIn: true,
-          configTypeOptions: mocks.mockOauthCredentialsType(serviceName, { url: '', accessTokenField: '' }),
+          configTypeOptions: mocks.mockOauthCredentialsType(serviceName, { url: '',
+            oauthRequiredFields: [''] }),
         }
       } else {
         loginStatuses[serviceName] = {

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -377,6 +377,7 @@ export const mockOauthCredentialsType = (adapterName: string,
     credentialsType: new ObjectType({
       elemID: new ElemID(adapterName),
       fields: {
+        refreshToken: { refType: BuiltinTypes.STRING },
         accessToken: { refType: BuiltinTypes.STRING },
         instanceUrl: { refType: BuiltinTypes.STRING },
       },
@@ -393,8 +394,8 @@ export const mockOauthCredentialsType = (adapterName: string,
     createFromOauthResponse: jest.fn().mockImplementation((oldConfig: Values,
       response: OauthAccessTokenResponse) => ({
       isSandbox: oldConfig.isSandbox,
-      accessToken: response.accessToken,
-      instanceUrl: response.instanceUrl,
+      accessToken: response.fields.accessToken,
+      instanceUrl: response.fields.instanceUrl,
     })),
   }
   return baseType

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -144,26 +144,28 @@ export const createRequestModuleFunction = (retryOptions: RequestRetryOptions) =
       return callback(err, response, body)
     })
 
-const oauthConnection = (
-  instanceUrl: string,
-  accessToken: string,
-  refreshToken: string,
-  retryOptions: RequestRetryOptions,
-  clientId: string,
-  clientSecret: string,
-  isSandbox: boolean,
-): Connection =>
+type OauthConnectionParams = {
+  instanceUrl: string
+  accessToken: string
+  refreshToken: string
+  retryOptions: RequestRetryOptions
+  clientId: string
+  clientSecret: string
+  isSandbox: boolean
+}
+
+const oauthConnection = (params: OauthConnectionParams): Connection =>
   new RealConnection({
     oauth2: {
-      clientId,
-      clientSecret,
-      loginUrl: isSandbox ? 'https://test.salesforce.com' : 'https://login.salesforce.com/',
+      clientId: params.clientId,
+      clientSecret: params.clientSecret,
+      loginUrl: params.isSandbox ? 'https://test.salesforce.com' : 'https://login.salesforce.com',
     },
     version: API_VERSION,
-    instanceUrl,
-    accessToken,
-    refreshToken,
-    requestModule: createRequestModuleFunction(retryOptions),
+    instanceUrl: params.instanceUrl,
+    accessToken: params.accessToken,
+    refreshToken: params.refreshToken,
+    requestModule: createRequestModuleFunction(params.retryOptions),
   })
 
 const realConnection = (
@@ -253,8 +255,15 @@ const createConnectionFromCredentials = (
   options: RequestRetryOptions,
 ): Connection => {
   if (creds instanceof OauthAccessTokenCredentials) {
-    return oauthConnection(creds.instanceUrl, creds.accessToken, creds.refreshToken, options,
-      creds.clientId, creds.clientSecret, creds.isSandbox)
+    return oauthConnection({
+      instanceUrl: creds.instanceUrl,
+      accessToken: creds.accessToken,
+      refreshToken: creds.refreshToken,
+      retryOptions: options,
+      clientId: creds.clientId,
+      clientSecret: creds.clientSecret,
+      isSandbox: creds.isSandbox,
+    })
   }
   return realConnection(creds.isSandbox, options)
 }

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -147,15 +147,24 @@ export const createRequestModuleFunction = (retryOptions: RequestRetryOptions) =
 const oauthConnection = (
   instanceUrl: string,
   accessToken: string,
+  refreshToken: string,
   retryOptions: RequestRetryOptions,
-): Connection => (
+  clientId: string,
+  clientSecret: string,
+  isSandbox: boolean,
+): Connection =>
   new RealConnection({
+    oauth2: {
+      clientId,
+      clientSecret,
+      loginUrl: isSandbox ? 'https://test.salesforce.com' : 'https://login.salesforce.com/',
+    },
     version: API_VERSION,
     instanceUrl,
     accessToken,
+    refreshToken,
     requestModule: createRequestModuleFunction(retryOptions),
   })
-)
 
 const realConnection = (
   isSandbox: boolean,
@@ -244,7 +253,8 @@ const createConnectionFromCredentials = (
   options: RequestRetryOptions,
 ): Connection => {
   if (creds instanceof OauthAccessTokenCredentials) {
-    return oauthConnection(creds.instanceUrl, creds.accessToken, options)
+    return oauthConnection(creds.instanceUrl, creds.accessToken, creds.refreshToken, options,
+      creds.clientId, creds.clientSecret, creds.isSandbox)
   }
   return realConnection(creds.isSandbox, options)
 }

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -238,6 +238,10 @@ export const oauthRequestParameters = new ObjectType({
       refType: BuiltinTypes.STRING,
       annotations: { message: 'Consumer key for a connected app, whose redirect URI is http://localhost:port' },
     },
+    consumerSecret: {
+      refType: BuiltinTypes.STRING,
+      annotations: { message: 'Consumer secret for a connected app, whose redirect URI is http://localhost:port' },
+    },
     port: {
       refType: BuiltinTypes.NUMBER,
       annotations: { message: 'Port provided in the redirect URI' },
@@ -268,19 +272,28 @@ export class UsernamePasswordCredentials {
 }
 
 export class OauthAccessTokenCredentials {
-  constructor({ instanceUrl, accessToken, isSandbox }: {
+  constructor({ instanceUrl, accessToken, refreshToken, isSandbox, clientId, clientSecret }: {
     instanceUrl: string
     accessToken: string
+    refreshToken: string
+    clientId: string
+    clientSecret: string
     isSandbox: boolean
   }) {
     this.instanceUrl = instanceUrl
     this.accessToken = accessToken
+    this.refreshToken = refreshToken
     this.isSandbox = isSandbox
+    this.clientId = clientId
+    this.clientSecret = clientSecret
   }
 
   instanceUrl: string
   accessToken: string
+  refreshToken: string
   isSandbox: boolean
+  clientId: string
+  clientSecret: string
 }
 
 export type Credentials = UsernamePasswordCredentials | OauthAccessTokenCredentials

--- a/packages/salesforce-adapter/test/adapter.creator.test.ts
+++ b/packages/salesforce-adapter/test/adapter.creator.test.ts
@@ -38,15 +38,19 @@ describe('SalesforceAdapter creator', () => {
       authType: 'basic',
     }
   )
+  const oauthConfigObj = {
+    refreshToken: 'refreshToken',
+    accessToken: 'accessToken',
+    clientId: 'id',
+    clientSecret: 'secret',
+    instanceUrl: 'instance_url',
+    isSandbox: false,
+    authType: 'oauth',
+  }
   const oauthCredentials = new InstanceElement(
     ElemID.CONFIG_NAME,
     accessTokenCredentialsType,
-    {
-      accessToken: 'accessToken',
-      instanceUrl: 'instanceUrl',
-      isSandbox: false,
-      authType: 'oauth',
-    }
+    oauthConfigObj,
   )
   const config = new InstanceElement(
     ElemID.CONFIG_NAME,
@@ -94,9 +98,12 @@ describe('SalesforceAdapter creator', () => {
 
     it('should call validateCredentials with the correct credentials', () => {
       expect(validateCredentials).toHaveBeenCalledWith(new OauthAccessTokenCredentials({
-        accessToken: 'accessToken',
-        instanceUrl: 'instanceUrl',
-        isSandbox: false,
+        refreshToken: oauthConfigObj.refreshToken,
+        accessToken: oauthConfigObj.accessToken,
+        instanceUrl: oauthConfigObj.instanceUrl,
+        isSandbox: oauthConfigObj.isSandbox,
+        clientSecret: oauthConfigObj.clientSecret,
+        clientId: oauthConfigObj.clientId,
       }))
     })
   })
@@ -114,16 +121,24 @@ describe('SalesforceAdapter creator', () => {
     })
     it('creates the right object from the response', () => {
       const creds = (adapter.authenticationMethods.oauth as OAuthMethod).createFromOauthResponse(
-        { isSandbox: false },
         {
-          accessToken: 'testAccessToken',
-          instanceUrl: 'testInstanceUrl',
-        }
+          isSandbox: false,
+          consumerKey: oauthConfigObj.clientId,
+          consumerSecret: oauthConfigObj.clientSecret,
+        },
+        { fields: {
+          refreshToken: oauthConfigObj.refreshToken,
+          accessToken: oauthConfigObj.accessToken,
+          instanceUrl: oauthConfigObj.instanceUrl,
+        } },
       )
       expect(creds).toEqual({
         isSandbox: false,
-        accessToken: 'testAccessToken',
-        instanceUrl: 'testInstanceUrl',
+        accessToken: oauthConfigObj.accessToken,
+        instanceUrl: oauthConfigObj.instanceUrl,
+        clientSecret: oauthConfigObj.clientSecret,
+        clientId: oauthConfigObj.clientId,
+        refreshToken: oauthConfigObj.refreshToken,
       })
     })
   })

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -446,6 +446,9 @@ describe('salesforce client', () => {
       isSandbox: false,
       instanceUrl: 'testInstanceUrl',
       accessToken: 'testAccessToken',
+      refreshToken: 'testRefreshToken',
+      clientSecret: 'secret',
+      clientId: 'clientId',
     })
     it('should return empty orgId for oauth credentials', async () => {
       const { orgId, remainingDailyRequests } = await getConnectionDetails(oauthCredentials,


### PR DESCRIPTION
This is needed because access tokens only last for ~2 days

---
_Release Notes_: 
OSS oauth will now require consumer secret as well as consumer id (from salesforce connected app). Apps already configured through oauth will need to be reconfigured.

---
_User Notifications_: 
No changes
