### PR TITLE
SALTO-1237: added link value to files in the file cabinet

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -113,7 +113,6 @@ export default class SoapClient {
       },
       'q1:name': path.basename(file.path),
       'q1:attachFrom': '_computer',
-      'q1:content': file.content.toString('base64'),
       'q1:folder': {
         attributes: {
           internalId: file.folder.toString(),
@@ -124,6 +123,9 @@ export default class SoapClient {
       'q1:isInactive': file.isInactive,
       'q1:isOnline': file.isOnline,
       'q1:hideInBundle': file.hideInBundle,
+      ...'content' in file
+        ? { 'q1:content': file.content.toString('base64') }
+        : { 'q1:url': file.url },
     }
   }
 

--- a/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
@@ -191,9 +191,12 @@ export type FileDetails = {
   isInactive: boolean
   isOnline: boolean
   hideInBundle: boolean
-  content: Buffer
   description: string
-}
+} & ({
+  content: Buffer
+} | {
+  url: string
+})
 
 export type FolderDetails = {
   type: 'folder'

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -268,7 +268,7 @@ Promise<FileResult[]> => {
     ] = _.partition(filesCustomizations, file => file.values.link === undefined)
 
     const fileChunks = chunks.weightedChunks(
-      filesCustomizationWithoutContent.filter(file => file.values.link === undefined),
+      filesCustomizationWithoutContent,
       FILES_CHUNK_SIZE,
       file => file.size
     )

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -106,7 +106,7 @@ export const createInstanceElement = async (customizationInfo: CustomizationInfo
   if (isFolderCustomizationInfo(customizationInfo) || isFileCustomizationInfo(customizationInfo)) {
     valuesWithTransformedAttrs[PATH] = FILE_CABINET_PATH_SEPARATOR
       + customizationInfo.path.join(FILE_CABINET_PATH_SEPARATOR)
-    if (isFileCustomizationInfo(customizationInfo)) {
+    if (isFileCustomizationInfo(customizationInfo) && customizationInfo.fileContent !== undefined) {
       valuesWithTransformedAttrs[(fileContentField as Field).name] = new StaticFile({
         filepath: `${NETSUITE}/${FILE_CABINET_PATH}/${customizationInfo.path.map(removeDotPrefix).join('/')}`,
         content: customizationInfo.fileContent,
@@ -116,7 +116,8 @@ export const createInstanceElement = async (customizationInfo: CustomizationInfo
 
   const instanceName = getInstanceName(valuesWithTransformedAttrs)
   const instanceFileName = pathNaclCase(instanceName)
-  if (fileContentField && isTemplateCustomTypeInfo(customizationInfo)) {
+  if (fileContentField && isTemplateCustomTypeInfo(customizationInfo)
+    && customizationInfo.fileContent !== undefined) {
     valuesWithTransformedAttrs[fileContentField.name] = new StaticFile({
       filepath: `${NETSUITE}/${type.elemID.name}/${instanceFileName}.${customizationInfo.fileExtension}`,
       content: customizationInfo.fileContent,

--- a/packages/netsuite-adapter/src/types/file_cabinet_types.ts
+++ b/packages/netsuite-adapter/src/types/file_cabinet_types.ts
@@ -40,6 +40,11 @@ export const file = new ObjectType({
       annotations: {
       },
     },
+    link: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+      },
+    },
     availablewithoutlogin: {
       refType: BuiltinTypes.BOOLEAN,
       annotations: {

--- a/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
@@ -48,6 +48,20 @@ describe('suiteapp_file_cabinet', () => {
     isonline: 'T',
     name: 'file2',
     description: 'desc2',
+  },
+  {
+    addtimestamptourl: 'T',
+    bundleable: 'T',
+    filesize: '20',
+    folder: '4',
+    hideinbundle: 'T',
+    id: '6',
+    isinactive: 'T',
+    isonline: 'T',
+    name: 'file6',
+    description: 'desc3',
+    islink: 'T',
+    url: 'someUrl',
   }]
 
   const foldersQueryResponse = [{
@@ -137,6 +151,20 @@ describe('suiteapp_file_cabinet', () => {
         internalId: '2',
       },
     },
+    {
+      path: ['folder5', 'folder4', 'file6'],
+      typeName: 'file',
+      values: {
+        availablewithoutlogin: 'T',
+        isinactive: 'T',
+        bundleable: 'T',
+        description: 'desc3',
+        generateurltimestamp: 'T',
+        hideinbundle: 'T',
+        internalId: '6',
+        link: 'someUrl',
+      },
+    },
   ]
 
   const filesContent: Record<string, Buffer> = {
@@ -216,10 +244,10 @@ describe('suiteapp_file_cabinet', () => {
           filesize: (10 * 1024 * 1024).toString(),
           folder: '4',
           hideinbundle: 'T',
-          id: '6',
+          id: '7',
           isinactive: 'F',
           isonline: 'T',
-          name: 'file6',
+          name: 'file7',
         },
       ]
 
@@ -239,9 +267,9 @@ describe('suiteapp_file_cabinet', () => {
       const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient)
         .importFileCabinet(query)
       expect(elements).toEqual([
-        ...expectedResults,
+        ...expectedResults.filter(res => !('link' in res.values)),
         {
-          path: ['folder5', 'folder4', 'file6'],
+          path: ['folder5', 'folder4', 'file7'],
           typeName: 'file',
           fileContent: Buffer.from('someContent'),
           values: {
@@ -251,11 +279,12 @@ describe('suiteapp_file_cabinet', () => {
             description: '',
             generateurltimestamp: 'T',
             hideinbundle: 'T',
-            internalId: '6',
+            internalId: '7',
           },
         },
+        ...expectedResults.filter(res => 'link' in res.values),
       ])
-      expect(mockSuiteAppClient.readLargeFile).toHaveBeenCalledWith(6)
+      expect(mockSuiteAppClient.readLargeFile).toHaveBeenCalledWith(7)
       expect(mockSuiteAppClient.readLargeFile).toHaveBeenCalledTimes(1)
     })
 
@@ -298,7 +327,12 @@ describe('suiteapp_file_cabinet', () => {
       mockQuery.isFileMatch.mockImplementation(path => path !== '/folder5/folder4' && path !== '/folder5/folder3/file1')
       const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient)
         .importFileCabinet(query)
-      expect(elements).toEqual([expectedResults[0], expectedResults[2], expectedResults[4]])
+      expect(elements).toEqual([
+        expectedResults[0],
+        expectedResults[2],
+        expectedResults[4],
+        expectedResults[5],
+      ])
     })
 
     it('should not run queries of no files are matched', async () => {


### PR DESCRIPTION
Some files in the file cabinet are not files that were uploaded to the account but links to URLs outside of Netsuite.
This PR changed those file instances to not contain `content` value and contain a `link` value instead

I will remove this changed from the tracker in a SaaS PR

---
_Release Notes_: 
Netsuite Adapter:
Files in the file cabinet that are links will no longer have a "content" value but will have a "link" value to the linked URL

---
_User Notifications_: 
None