### PR TITLE
SALTO-1319: jira adapter - add references for values with self links

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -22,6 +22,7 @@ import JiraClient from './client/client'
 import changeValidator from './change_validator'
 import { JiraConfig, getApiDefinitions } from './config'
 import { FilterCreator, Filter, filtersRunner } from './filter'
+import referenceBySelfLinkFilter from './filters/references_by_self_link'
 import { JIRA } from './constants'
 import { pageByOffsetWithoutScopes } from './client/pagination'
 
@@ -30,6 +31,7 @@ const { createPaginator } = clientUtils
 const log = logger(module)
 
 export const DEFAULT_FILTERS = [
+  referenceBySelfLinkFilter,
 ]
 
 export interface JiraAdapterParams {

--- a/packages/jira-adapter/src/filters/references_by_self_link.ts
+++ b/packages/jira-adapter/src/filters/references_by_self_link.ts
@@ -1,0 +1,112 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { Element, isInstanceElement, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { multiIndex, collections } from '@salto-io/lowerdash'
+import { transformValues, TransformFunc } from '@salto-io/adapter-utils'
+import { elements as elementUtils } from '@salto-io/adapter-components'
+import { FilterCreator } from '../filter'
+
+const { awu } = collections.asynciterable
+const { ADDITIONAL_PROPERTIES_FIELD } = elementUtils.swagger
+
+const isPlainObject = (obj: unknown): obj is Record<string, unknown> => _.isPlainObject(obj)
+
+type ObjectWithSelfLink = { self: string } | { [ADDITIONAL_PROPERTIES_FIELD]: { self: string } }
+
+function getSelfLink(obj: ObjectWithSelfLink): string
+function getSelfLink(obj: unknown): string | undefined
+function getSelfLink(obj: unknown): string | undefined {
+  if (!isPlainObject(obj)) {
+    return undefined
+  }
+  if (_.isString(obj.self)) {
+    return obj.self
+  }
+  return getSelfLink(obj[ADDITIONAL_PROPERTIES_FIELD])
+}
+
+
+const hasSelfLink = (obj: unknown): obj is ObjectWithSelfLink => getSelfLink(obj) !== undefined
+
+type InstanceElementWithSelfLink = InstanceElement & {
+  value: InstanceElement['value'] & ObjectWithSelfLink
+}
+const isInstanceElementWithSelfLink = (elem: Element): elem is InstanceElementWithSelfLink => (
+  isInstanceElement(elem) && hasSelfLink(elem.value)
+)
+
+const getRelativeSelfLink = (fullLink: string): string => {
+  const selfLink = new URL(fullLink)
+  // We take only the part of the link after the api version
+  // we expect the pathname to be in the form of "/<rest or agile>/api/<version number>/..."
+  return selfLink.pathname.split('/').slice(4).join('/')
+}
+
+const transformSelfLinkToReference = (
+  elementsBySelfLink: multiIndex.Index<[string], InstanceElementWithSelfLink>
+): TransformFunc => ({ value, path }) => {
+  if (path && path.isTopLevel()) {
+    // Skip the top level value as we should not replace the instance content
+    // we a reference to itself
+    return value
+  }
+  if (hasSelfLink(value)) {
+    const target = elementsBySelfLink.get(getRelativeSelfLink(getSelfLink(value)))
+    if (target !== undefined) {
+      return new ReferenceExpression(target.elemID, target)
+    }
+  }
+  return value
+}
+
+/**
+ * Adds references from every nested element that contains a "self" link
+ * to a top level element with the same self link
+ */
+const filter: FilterCreator = () => ({
+  onFetch: async (elements: Element[]) => {
+    const elementsBySelfLink = await multiIndex.keyByAsync({
+      iter: awu(elements).filter(isInstanceElementWithSelfLink),
+      key: inst => [getRelativeSelfLink(getSelfLink(inst.value))],
+    })
+    await awu(elements).filter(isInstanceElement).forEach(async inst => {
+      inst.value = await transformValues({
+        values: inst.value,
+        type: await inst.getType(),
+        pathID: inst.elemID,
+        transformFunc: transformSelfLinkToReference(elementsBySelfLink),
+      }) ?? inst.value
+    })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/test/filters/references_by_self_link.test.ts
+++ b/packages/jira-adapter/test/filters/references_by_self_link.test.ts
@@ -1,0 +1,80 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import referenceBySelfLinkFilter from '../../src/filters/references_by_self_link'
+import { mockInstances, mockTypes } from '../mock_elements'
+import { mockClient, getDefaultAdapterConfig } from '../utils'
+
+describe('referenceBySelfLinkFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  beforeEach(async () => {
+    const { client, paginator } = mockClient()
+    filter = await referenceBySelfLinkFilter({
+      client,
+      paginator,
+      config: await getDefaultAdapterConfig(),
+    }) as typeof filter
+  })
+
+  describe('when an instance has a reference by self link', () => {
+    let source: InstanceElement
+    let target: InstanceElement
+    beforeEach(async () => {
+      source = new InstanceElement(
+        'my_board',
+        mockTypes.Board,
+        {
+          self: 'https://ori-salto-test.atlassian.net/rest/api/2/board/1',
+          location: {
+            // note the link is using a different API version - this is on purpose
+            self: 'https://ori-salto-test.atlassian.net/rest/api/2/project/10000',
+          },
+        }
+      )
+      target = mockInstances.Project.clone()
+      await filter.onFetch([source, target])
+    })
+    it('should create a reference', () => {
+      expect(source.value.location).toBeInstanceOf(ReferenceExpression)
+      expect(source.value.location.elemID).toEqual(target.elemID)
+    })
+  })
+  describe('with reference in additional properties', () => {
+    let source: InstanceElement
+    let target: InstanceElement
+    beforeEach(async () => {
+      source = mockInstances.Board.clone()
+      target = mockInstances.Project.clone()
+      await filter.onFetch([source, target])
+    })
+    it('should create a reference', () => {
+      expect(source.value.location).toBeInstanceOf(ReferenceExpression)
+      expect(source.value.location.elemID).toEqual(target.elemID)
+    })
+  })
+  describe('with link to a target that does not exist', () => {
+    let source: InstanceElement
+    beforeEach(async () => {
+      source = mockInstances.Board.clone()
+      await filter.onFetch([source])
+    })
+    it('should not create a reference', () => {
+      expect(source.value.location).not.toBeInstanceOf(ReferenceExpression)
+      expect(source.value.location).toEqual(mockInstances.Board.value.location)
+    })
+  })
+})

--- a/packages/jira-adapter/test/mock_elements.ts
+++ b/packages/jira-adapter/test/mock_elements.ts
@@ -1,0 +1,72 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ObjectType, ElemID, BuiltinTypes, MapType, InstanceElement } from '@salto-io/adapter-api'
+import { elements as elementsUtils } from '@salto-io/adapter-components'
+import { JIRA } from '../src/constants'
+
+const { ADDITIONAL_PROPERTIES_FIELD } = elementsUtils.swagger
+
+const boardLocationType = new ObjectType({
+  elemID: new ElemID(JIRA, 'Board_location'),
+  fields: {
+    projectId: { refType: BuiltinTypes.NUMBER },
+    [ADDITIONAL_PROPERTIES_FIELD]: { refType: new MapType(BuiltinTypes.UNKNOWN) },
+  },
+})
+
+const boardType = new ObjectType({
+  elemID: new ElemID(JIRA, 'Board'),
+  fields: {
+    self: { refType: BuiltinTypes.STRING },
+    location: { refType: boardLocationType },
+  },
+})
+
+const projectType = new ObjectType({
+  elemID: new ElemID(JIRA, 'Project'),
+  fields: {
+    self: { refType: BuiltinTypes.STRING },
+  },
+})
+
+export const mockTypes = {
+  Board: boardType,
+  Project: projectType,
+}
+
+export const mockInstances = {
+  Board: new InstanceElement(
+    'my_board',
+    mockTypes.Board,
+    {
+      self: 'https://test.atlassian.net/rest/agile/1.0/board/1',
+      location: {
+        projectId: 10000,
+        [ADDITIONAL_PROPERTIES_FIELD]: {
+          self: 'https://ori-salto-test.atlassian.net/rest/api/2/project/10000',
+        },
+      },
+    }
+  ),
+  Project: new InstanceElement(
+    'my_project',
+    mockTypes.Project,
+    {
+      self: 'https://ori-salto-test.atlassian.net/rest/api/3/project/10000',
+    }
+  ),
+}

--- a/packages/lowerdash/src/multi_index.ts
+++ b/packages/lowerdash/src/multi_index.ts
@@ -138,8 +138,8 @@ type KeyByAsyncParams<
 export const keyByAsync = async <
   Key extends KeyType,
   InputType,
-  FilteredType extends InputType,
-  ResultType
+  FilteredType extends InputType = InputType,
+  ResultType = InputType
 >(
   { iter, key, map, filter }: KeyByAsyncParams<Key, InputType, FilteredType, ResultType>
 ): Promise<Index<Key, ResultType>> => {

--- a/packages/lowerdash/src/multi_index.ts
+++ b/packages/lowerdash/src/multi_index.ts
@@ -29,7 +29,7 @@ export type Index<Key extends KeyType, T> = {
 type IndexFunction<
   InputType = unknown,
   FilteredType extends InputType = InputType,
-  ResultType = InputType,
+  ResultType = FilteredType,
   Key extends KeyType = KeyType,
   IndexName extends string = string,
 > = {
@@ -44,7 +44,7 @@ type MultiIndexBuilder<InputType, Result extends object = {}> = {
     IndexName extends string,
     Key extends KeyType,
     FilteredType extends InputType = InputType,
-    ResultType = InputType
+    ResultType = FilteredType
   >(
     f: IndexFunction<InputType, FilteredType, ResultType, Key, IndexName>
   ) => MultiIndexBuilder<InputType, Result & { [name in IndexName]: Index<Key, ResultType> }>
@@ -139,7 +139,7 @@ export const keyByAsync = async <
   Key extends KeyType,
   InputType,
   FilteredType extends InputType = InputType,
-  ResultType = InputType
+  ResultType = FilteredType
 >(
   { iter, key, map, filter }: KeyByAsyncParams<Key, InputType, FilteredType, ResultType>
 ): Promise<Index<Key, ResultType>> => {


### PR DESCRIPTION
Add filter that creates references for all instances in JIRA that reference each other using a "self" link

---

See the tests for an example of what these self links look like in the service
Some examples can also be found in the example JIRA workspace [here](https://github.com/salto-io/adapter-sample-jira-workspace/blob/main/jira/Records/Board/Engineering.nacl#L38-L45)

---
_Release Notes_: 
_None_ (JIRA adapter is not officially released yet)

---
_User Notifications_: 
Technically this would change any JIRA workspace by creating a bunch of references, but since the JIRA adapter is not officially released this should not matter as there should be no maintained JIRA workspaces
