### PR TITLE
SALTO-1584 stop pagination on empty page

### DIFF
--- a/packages/adapter-components/src/client/index.ts
+++ b/packages/adapter-components/src/client/index.ts
@@ -19,5 +19,5 @@ export { DEFAULT_RETRY_OPTS, RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS } from
 export { logDecorator, requiresLogin } from './decorators'
 export { AdapterHTTPClient, ClientOpts, HTTPClientInterface } from './http_client'
 export { APIConnection, ConnectionCreator, axiosConnection, createClientConnection, createRetryOptions, validateCredentials, UnauthorizedError, ResponseValue } from './http_connection'
-export { createPaginator, getWithCursorPagination, getWithPageOffsetPagination, getWithPageOffsetAndLastPagination, getWithOffsetAndLimit, traverseRequests, ClientGetWithPaginationParams, PaginationFunc, Paginator, GetAllItemsFunc, PathCheckerFunc } from './pagination'
+export { createPaginator, getWithCursorPagination, getWithPageOffsetPagination, getWithPageOffsetAndLastPagination, getWithOffsetAndLimit, traverseRequests, ClientGetWithPaginationParams, PaginationFunc, Paginator, GetAllItemsFunc, PathCheckerFunc, PageEntriesExtractor } from './pagination'
 export { createRateLimitersFromConfig, throttle, BottleneckBuckets } from './rate_limit'

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -18,7 +18,7 @@ import { Element, Values } from '@salto-io/adapter-api'
 import { naclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
-import { Paginator } from '../../client'
+import { Paginator, ResponseValue } from '../../client'
 import { generateType } from './type_elements'
 import { toInstance } from './instance_elements'
 import { TypeConfig, getConfigWithDefault } from '../../config'
@@ -82,7 +82,9 @@ export const getTypeAndInstances = async ({
   const getEntries = async (): Promise<Values[]> => {
     const getArgs = computeGetArgs(requestWithDefaults, contextElements)
     return (await Promise.all(
-      getArgs.map(async args => (await toArrayAsync(await paginator(args))).flat())
+      getArgs.map(async args => (await toArrayAsync(
+        await paginator(args, page => makeArray(page) as ResponseValue[])
+      )).flat())
     )).flat()
   }
 

--- a/packages/adapter-components/test/client/pagination.test.ts
+++ b/packages/adapter-components/test/client/pagination.test.ts
@@ -15,9 +15,12 @@
 */
 import { collections } from '@salto-io/lowerdash'
 import { MockInterface, mockFunction } from '@salto-io/test-utils'
-import { getWithCursorPagination, getWithPageOffsetPagination, getWithPageOffsetAndLastPagination, getWithOffsetAndLimit, HTTPClientInterface, createPaginator, GetAllItemsFunc, ResponseValue } from '../../src/client'
+import { getWithCursorPagination, getWithPageOffsetPagination, getWithPageOffsetAndLastPagination, getWithOffsetAndLimit, HTTPClientInterface, createPaginator, GetAllItemsFunc, ResponseValue, PageEntriesExtractor } from '../../src/client'
 
 const { toArrayAsync } = collections.asynciterable
+const { makeArray } = collections.array
+
+const extractPageEntries: PageEntriesExtractor = page => makeArray(page) as ResponseValue[]
 
 describe('client_pagination', () => {
   describe('getWithPageOffsetPagination', () => {
@@ -44,6 +47,7 @@ describe('client_pagination', () => {
         getParams: {
           url: '/ep',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(1)
@@ -68,6 +72,7 @@ describe('client_pagination', () => {
             arg2: 'val2',
           },
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(1)
@@ -117,6 +122,7 @@ describe('client_pagination', () => {
             parentId: (entry => entry.id as string),
           },
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([
         { a: 'a1', id: 123 },
@@ -146,6 +152,7 @@ describe('client_pagination', () => {
           url: '/ep',
           paginationField: 'page',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(1)
@@ -194,6 +201,7 @@ describe('client_pagination', () => {
           url: '/ep',
           paginationField: 'page',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a1' }, { a: 'a2', b: 'b2' }, { a: 'a3' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(4)
@@ -245,6 +253,7 @@ describe('client_pagination', () => {
           url: '/ep',
           paginationField: 'page.pageNum',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a1' }, { a: 'a2', b: 'b2' }, { a: 'a3' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(4)
@@ -278,6 +287,7 @@ describe('client_pagination', () => {
             arg1: 'val1',
           },
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a1' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(2)
@@ -310,6 +320,7 @@ describe('client_pagination', () => {
         getParams: {
           url: '/ep',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(1)
@@ -334,6 +345,7 @@ describe('client_pagination', () => {
             arg2: 'val2',
           },
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(1)
@@ -383,6 +395,7 @@ describe('client_pagination', () => {
             parentId: (entry => entry.id as string),
           },
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([
         { a: 'a1', id: 123 },
@@ -413,6 +426,7 @@ describe('client_pagination', () => {
           url: '/ep',
           paginationField: 'page',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(1)
@@ -433,6 +447,7 @@ describe('client_pagination', () => {
           url: '/ep',
           paginationField: 'page',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(1)
@@ -482,6 +497,7 @@ describe('client_pagination', () => {
           url: '/ep',
           paginationField: 'page',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a1' }, { a: 'a2', b: 'b2' }, { a: 'a3' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(4)
@@ -534,6 +550,7 @@ describe('client_pagination', () => {
           url: '/ep',
           paginationField: 'page.pageNum',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a1' }, { a: 'a2', b: 'b2' }, { a: 'a3' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(4)
@@ -568,6 +585,7 @@ describe('client_pagination', () => {
             arg1: 'val1',
           },
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a1' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(2)
@@ -600,6 +618,7 @@ describe('client_pagination', () => {
         getParams: {
           url: '/ep',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ products: ['a', 'b'] }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(1)
@@ -625,6 +644,7 @@ describe('client_pagination', () => {
             arg2: 'val2',
           },
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(1)
@@ -653,6 +673,7 @@ describe('client_pagination', () => {
           url: '/ep',
           paginationField: 'nextPage',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ products: ['a', 'b'], nextPage: '/ep?page=p1' }, { products: ['c', 'd'] }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(2)
@@ -682,6 +703,7 @@ describe('client_pagination', () => {
           url: '/ep',
           paginationField: 'nextPage.url',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ products: ['a', 'b'], nextPage: { url: '/ep?page=p1' } }, { products: ['c', 'd'] }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(2)
@@ -712,6 +734,7 @@ describe('client_pagination', () => {
             arg1: 'val1',
           },
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ products: ['a', 'b'], nextPage: '/ep?page=p1' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(2)
@@ -742,6 +765,7 @@ describe('client_pagination', () => {
             arg1: 'val1',
           },
         },
+        extractPageEntries,
       }))).rejects.toThrow()
     })
 
@@ -767,6 +791,7 @@ describe('client_pagination', () => {
           url: '/ep',
           paginationField: 'nextPage',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ products: ['a', 'b'], nextPage: '/ep_suffix?page=p1' }, { products: ['c', 'd'] }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(2)
@@ -788,7 +813,7 @@ describe('client_pagination', () => {
       beforeEach(async () => {
         client.getSinglePage.mockResolvedValue({ status: 200, statusText: 'OK', data: { page: 1 } })
         results = await toArrayAsync(
-          getWithOffsetAndLimit({ client, pageSize: 2, getParams: { url: '/ep' } })
+          getWithOffsetAndLimit({ client, pageSize: 2, getParams: { url: '/ep' }, extractPageEntries })
         )
       })
       it('should query a single page', () => {
@@ -813,7 +838,7 @@ describe('client_pagination', () => {
         let results: ResponseValue[][]
         beforeEach(async () => {
           results = await toArrayAsync(getWithOffsetAndLimit(
-            { client, pageSize: 2, getParams: { url: '/ep', paginationField: 'startAt' } }
+            { client, pageSize: 2, getParams: { url: '/ep', paginationField: 'startAt' }, extractPageEntries }
           ))
         })
         it('should query until isLast is true', () => {
@@ -825,7 +850,7 @@ describe('client_pagination', () => {
       describe('when response is not a valid page', () => {
         let resultIter: AsyncIterable<ResponseValue[]>
         beforeEach(async () => {
-          resultIter = getWithOffsetAndLimit({ client, pageSize: 2, getParams: { url: '/ep', paginationField: 'wrong' } })
+          resultIter = getWithOffsetAndLimit({ client, pageSize: 2, getParams: { url: '/ep', paginationField: 'wrong' }, extractPageEntries })
         })
         it('should throw error', async () => {
           await expect(toArrayAsync(resultIter)).rejects.toThrow()
@@ -850,7 +875,7 @@ describe('client_pagination', () => {
         let results: ResponseValue[][]
         beforeEach(async () => {
           results = await toArrayAsync(getWithOffsetAndLimit(
-            { client, pageSize: 2, getParams: { url: '/ep', paginationField: 'pagination.startAt' } }
+            { client, pageSize: 2, getParams: { url: '/ep', paginationField: 'pagination.startAt' }, extractPageEntries }
           ))
         })
         it('should query until isLast is true', () => {
@@ -872,12 +897,13 @@ describe('client_pagination', () => {
       const paginationFunc: GetAllItemsFunc = mockFunction<GetAllItemsFunc>()
       const paginator = createPaginator({ client, paginationFunc })
       const params = { url: 'url', queryParams: { a: 'b' }, paginationField: 'abc' }
-      paginator(params)
+      paginator(params, extractPageEntries)
       expect(paginationFunc).toHaveBeenCalledTimes(1)
       expect(paginationFunc).toHaveBeenLastCalledWith({
         client,
         pageSize: 3,
         getParams: params,
+        extractPageEntries,
       })
     })
   })

--- a/packages/adapter-components/test/elements/ducktype/transformer.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/transformer.test.ts
@@ -94,7 +94,7 @@ describe('ducktype_transformer', () => {
         'something.myType.instance.bla',
       ])
       expect(mockPaginator).toHaveBeenCalledTimes(1)
-      expect(mockPaginator).toHaveBeenCalledWith({ url: 'url', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined })
+      expect(mockPaginator).toHaveBeenCalledWith({ url: 'url', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
       expect(typeElements.generateType).toHaveBeenCalledTimes(1)
       expect(typeElements.generateType).toHaveBeenCalledWith({
         adapterName: 'something',
@@ -163,7 +163,7 @@ describe('ducktype_transformer', () => {
         'something.myType.instance.bla',
       ])
       expect(mockPaginator).toHaveBeenCalledTimes(1)
-      expect(mockPaginator).toHaveBeenCalledWith({ url: 'url', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined })
+      expect(mockPaginator).toHaveBeenCalledWith({ url: 'url', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
       expect(typeElements.generateType).toHaveBeenCalledTimes(1)
       expect(typeElements.generateType).toHaveBeenCalledWith({
         adapterName: 'something',
@@ -246,7 +246,7 @@ describe('ducktype_transformer', () => {
         'something.myType__some_nested.instance.bla',
       ])
       expect(mockPaginator).toHaveBeenCalledTimes(1)
-      expect(mockPaginator).toHaveBeenCalledWith({ url: 'url', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined })
+      expect(mockPaginator).toHaveBeenCalledWith({ url: 'url', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
       expect(typeElements.generateType).toHaveBeenCalledTimes(1)
       expect(typeElements.generateType).toHaveBeenCalledWith({
         adapterName: 'something',

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -67,7 +67,7 @@ describe('swagger_instance_elements', () => {
 
     beforeEach(() => {
       mockPaginator = mockFunction<Paginator>().mockImplementation(
-        async function *getAll(getParams) {
+        async function *getAll(getParams, extractPageEntries) {
           if (getParams.url === '/pet') {
             yield [
               {
@@ -89,7 +89,7 @@ describe('swagger_instance_elements', () => {
                 food1: { id: 'f1' },
                 food2: { id: 'f2' },
               },
-            ]
+            ].flatMap(extractPageEntries)
             yield [
               {
                 id: 'mouse',
@@ -100,12 +100,12 @@ describe('swagger_instance_elements', () => {
                 food1: { id: 'f1' },
                 food2: { id: 'f2' },
               },
-            ]
+            ].flatMap(extractPageEntries)
           }
           if (getParams.url === '/owner') {
             yield [
               { name: 'owner2' },
-            ]
+            ].flatMap(extractPageEntries)
           }
         }
       )
@@ -159,8 +159,8 @@ describe('swagger_instance_elements', () => {
         `${ADAPTER_NAME}.Pet.instance.mouse`,
       ])
       expect(mockPaginator).toHaveBeenCalledTimes(2)
-      expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet', queryParams: { a: 'b' }, recursiveQueryParams: undefined, paginationField: undefined })
-      expect(mockPaginator).toHaveBeenCalledWith({ url: '/owner', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined })
+      expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet', queryParams: { a: 'b' }, recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
+      expect(mockPaginator).toHaveBeenCalledWith({ url: '/owner', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
 
       const ownerInst = res.find(e => e.elemID.name === 'owner2')
       expect(ownerInst?.isEqual(new InstanceElement(
@@ -244,8 +244,8 @@ describe('swagger_instance_elements', () => {
         `${ADAPTER_NAME}.Pet.instance.mouse`,
       ])
       expect(mockPaginator).toHaveBeenCalledTimes(2)
-      expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet', queryParams: { a: 'b' }, recursiveQueryParams: undefined, paginationField: 'abc' })
-      expect(mockPaginator).toHaveBeenCalledWith({ url: '/owner', queryParams: undefined, recursiveQueryParams: undefined, paginationField: 'abc' })
+      expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet', queryParams: { a: 'b' }, recursiveQueryParams: undefined, paginationField: 'abc' }, expect.anything())
+      expect(mockPaginator).toHaveBeenCalledWith({ url: '/owner', queryParams: undefined, recursiveQueryParams: undefined, paginationField: 'abc' }, expect.anything())
     })
 
     it('should extract standalone fields', async () => {
@@ -302,8 +302,8 @@ describe('swagger_instance_elements', () => {
         `${ADAPTER_NAME}.Owner.instance.mouse__o3`,
       ])
       expect(mockPaginator).toHaveBeenCalledTimes(2)
-      expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet', queryParams: { a: 'b' }, recursiveQueryParams: undefined, paginationField: undefined })
-      expect(mockPaginator).toHaveBeenCalledWith({ url: '/owner', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined })
+      expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet', queryParams: { a: 'b' }, recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
+      expect(mockPaginator).toHaveBeenCalledWith({ url: '/owner', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
 
       const primaryOInst = res.find(e => e.elemID.name === 'dog__primary') as InstanceElement
       const dogO1Inst = res.find(e => e.elemID.name === 'dog__o1') as InstanceElement
@@ -461,8 +461,8 @@ describe('swagger_instance_elements', () => {
         `${ADAPTER_NAME}.Pet.instance.mouse`,
       ])
       expect(mockPaginator).toHaveBeenCalledTimes(2)
-      expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet', queryParams: { a: 'b' }, recursiveQueryParams: undefined, paginationField: undefined })
-      expect(mockPaginator).toHaveBeenCalledWith({ url: '/owner', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined })
+      expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet', queryParams: { a: 'b' }, recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
+      expect(mockPaginator).toHaveBeenCalledWith({ url: '/owner', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
 
       const petInst = res.find(e => e.elemID.name === 'dog') as InstanceElement
       expect(petInst).toBeInstanceOf(InstanceElement)
@@ -542,8 +542,8 @@ describe('swagger_instance_elements', () => {
         `${ADAPTER_NAME}.Owner.instance.o3`,
       ])
       expect(mockPaginator).toHaveBeenCalledTimes(2)
-      expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet', queryParams: { a: 'b' }, recursiveQueryParams: undefined, paginationField: undefined })
-      expect(mockPaginator).toHaveBeenCalledWith({ url: '/owner', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined })
+      expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet', queryParams: { a: 'b' }, recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
+      expect(mockPaginator).toHaveBeenCalledWith({ url: '/owner', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
 
       const dogO1Inst = res.find(e => e.elemID.name === 'o1') as InstanceElement
       expect(dogO1Inst).toBeInstanceOf(InstanceElement)
@@ -600,7 +600,9 @@ describe('swagger_instance_elements', () => {
         },
       })
 
-      mockPaginator = mockFunction<Paginator>().mockImplementationOnce(async function *get() {
+      mockPaginator = mockFunction<Paginator>().mockImplementationOnce(async function *get(
+        _args, extractPageEntries,
+      ) {
         yield [
           {
             id: 'dog',
@@ -621,7 +623,7 @@ describe('swagger_instance_elements', () => {
             food1: { id: 'f1' },
             food2: { id: 'f2' },
           },
-        ]
+        ].flatMap(extractPageEntries)
         yield [
           {
             id: 'mouse',
@@ -632,7 +634,7 @@ describe('swagger_instance_elements', () => {
             food1: { id: 'f1' },
             food2: { id: 'f2' },
           },
-        ]
+        ].flatMap(extractPageEntries)
         yield [
           {
             id: '33',
@@ -643,7 +645,7 @@ describe('swagger_instance_elements', () => {
             food1: { id: 'f1' },
             food2: { id: 'f2' },
           },
-        ]
+        ].flatMap(extractPageEntries)
       })
       const res = await getAllInstances({
         paginator: mockPaginator,
@@ -677,7 +679,7 @@ describe('swagger_instance_elements', () => {
         `${ADAPTER_NAME}.Pet.instance.33@`, // digit-only ids should be escaped
       ])
       expect(mockPaginator).toHaveBeenCalledTimes(1)
-      expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet_list', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined })
+      expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet_list', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
 
       const petInst = res.find(e => e.elemID.name === 'dog')
       expect(petInst?.isEqual(new InstanceElement(
@@ -735,7 +737,9 @@ describe('swagger_instance_elements', () => {
         AllCustomObjects,
       }
 
-      mockPaginator = mockFunction<Paginator>().mockImplementationOnce(async function *get() {
+      mockPaginator = mockFunction<Paginator>().mockImplementationOnce(async function *get(
+        _args, extractPageEntries,
+      ) {
         yield [
           {
             definitions: {
@@ -756,7 +760,7 @@ describe('swagger_instance_elements', () => {
               },
             },
           },
-        ]
+        ].flatMap(extractPageEntries)
       })
       const res = await getAllInstances({
         paginator: mockPaginator,
@@ -789,7 +793,7 @@ describe('swagger_instance_elements', () => {
         `${ADAPTER_NAME}.CustomObjectDefinition.instance.Food`,
       ])
       expect(mockPaginator).toHaveBeenCalledTimes(1)
-      expect(mockPaginator).toHaveBeenCalledWith({ url: '/custom_objects', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined })
+      expect(mockPaginator).toHaveBeenCalledWith({ url: '/custom_objects', queryParams: undefined, recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
 
       const petInst = res.find(e => e.elemID.name === 'Pet') as InstanceElement
       expect(petInst).toBeInstanceOf(InstanceElement)
@@ -913,17 +917,17 @@ describe('swagger_instance_elements', () => {
         })
       })
       it('should get inner types recursively for instances that match the condition', () => {
-        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/dog/owner' }))
-        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/fish/owner' }))
-        expect(mockPaginator).not.toHaveBeenCalledWith(expect.objectContaining({ url: expect.stringContaining('/pet/cat/') }))
+        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/dog/owner' }), expect.anything())
+        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/fish/owner' }), expect.anything())
+        expect(mockPaginator).not.toHaveBeenCalledWith(expect.objectContaining({ url: expect.stringContaining('/pet/cat/') }), expect.anything())
       })
       it('should get inner types for instances based on context from previous requests', () => {
-        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/dog/owner/o1/nicknames' }))
-        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/dog/owner/o2/nicknames' }))
-        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/dog/owner/o1/info' }))
-        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/dog/owner/o2/info' }))
-        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/fish/owner/o1/info' }))
-        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/fish/owner/o2/info' }))
+        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/dog/owner/o1/nicknames' }), expect.anything())
+        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/dog/owner/o2/nicknames' }), expect.anything())
+        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/dog/owner/o1/info' }), expect.anything())
+        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/dog/owner/o2/info' }), expect.anything())
+        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/fish/owner/o1/info' }), expect.anything())
+        expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/fish/owner/o2/info' }), expect.anything())
 
         expect(mockPaginator).not.toHaveBeenCalledWith(
           expect.objectContaining({ url: expect.stringMatching(/\/pet\/fish\/owner\/.*\/nicknames/) })

--- a/packages/jira-adapter/test/client/pagination.test.ts
+++ b/packages/jira-adapter/test/client/pagination.test.ts
@@ -21,6 +21,10 @@ import JiraClient from '../../src/client/client'
 import { pageByOffsetWithoutScopes } from '../../src/client/pagination'
 
 const { toArrayAsync } = collections.asynciterable
+const { makeArray } = collections.array
+
+const extractPageEntries: clientUtils.PageEntriesExtractor = page =>
+  makeArray(page) as clientUtils.ResponseValue[]
 
 describe('pageByOffsetWithoutScopes', () => {
   let client: JiraClient
@@ -46,7 +50,7 @@ describe('pageByOffsetWithoutScopes', () => {
       )
       responses = await toArrayAsync(
         pageByOffsetWithoutScopes(
-          { client, getParams: { url: 'http://myjira.net/thing' }, pageSize: 1 }
+          { client, getParams: { url: 'http://myjira.net/thing' }, pageSize: 1, extractPageEntries }
         )
       )
     })
@@ -74,6 +78,7 @@ describe('pageByOffsetWithoutScopes', () => {
           client,
           getParams: { url: 'http://myjira.net/thing/1', paginationField: 'startAt' },
           pageSize: 1,
+          extractPageEntries,
         })
       )
     })
@@ -90,6 +95,7 @@ describe('pageByOffsetWithoutScopes', () => {
         client,
         getParams: { url: 'http://myjira.net/thing/1', paginationField: 'startAt' },
         pageSize: 1,
+        extractPageEntries,
       })
     })
     it('should throw the error', async () => {

--- a/packages/workato-adapter/src/client/pagination.ts
+++ b/packages/workato-adapter/src/client/pagination.ts
@@ -54,15 +54,11 @@ export const getMinSinceIdPagination: clientUtils.GetAllItemsFunc = async functi
   yield* traverseRequests(nextPage)(args)
 }
 
-export const paginate: clientUtils.GetAllItemsFunc = async function *paginate({
-  client,
-  pageSize,
-  getParams,
-}) {
-  if (getParams?.paginationField === 'since_id') {
+export const paginate: clientUtils.GetAllItemsFunc = async function *paginate(args) {
+  if (args.getParams?.paginationField === 'since_id') {
     // special handling for endpoints that use descending ids, like the recipes endpoint
-    yield* getMinSinceIdPagination({ client, pageSize, getParams })
+    yield* getMinSinceIdPagination(args)
   } else {
-    yield* getWithPageOffsetPagination(1)({ client, pageSize, getParams })
+    yield* getWithPageOffsetPagination(1)(args)
   }
 }

--- a/packages/workato-adapter/test/client/pagination.test.ts
+++ b/packages/workato-adapter/test/client/pagination.test.ts
@@ -19,6 +19,10 @@ import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import { getMinSinceIdPagination } from '../../src/client/pagination'
 
 const { toArrayAsync } = collections.asynciterable
+const { makeArray } = collections.array
+
+const extractPageEntries: clientUtils.PageEntriesExtractor = page =>
+  makeArray(page) as clientUtils.ResponseValue[]
 
 describe('client_pagination', () => {
   describe('getMinSinceIdPagination', () => {
@@ -45,6 +49,7 @@ describe('client_pagination', () => {
         getParams: {
           url: '/ep',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(1)
@@ -69,6 +74,7 @@ describe('client_pagination', () => {
             arg2: 'val2',
           },
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(1)
@@ -118,6 +124,7 @@ describe('client_pagination', () => {
             parentId: (entry => entry.id as string),
           },
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([
         { a: 'a1', id: 123 },
@@ -145,6 +152,7 @@ describe('client_pagination', () => {
           url: '/ep',
           paginationField: 'page',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([])
       expect(client.getSinglePage).toHaveBeenCalledTimes(1)
@@ -194,6 +202,7 @@ describe('client_pagination', () => {
           url: '/ep',
           paginationField: 'since_id',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a1', id: 150 }, { a: 'a2', b: 'b2', id: 140 }, { a: 'a3', id: 130 }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(4)
@@ -231,6 +240,7 @@ describe('client_pagination', () => {
             arg1: 'val1',
           },
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a1', id: 150 }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(2)
@@ -282,6 +292,7 @@ describe('client_pagination', () => {
           url: '/ep',
           paginationField: 'since_id',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a1', id: 150 }, { a: 'a2', b: 'b2', id: 140 }, { a: 'a3', id: 140 }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(3)
@@ -319,6 +330,7 @@ describe('client_pagination', () => {
           url: '/ep',
           paginationField: 'since_id',
         },
+        extractPageEntries,
       }))).flat()
       expect(result).toEqual([{ a: 'a1', id: 150 }, { a: 'a2', b: 'b2', id: '140' }])
       expect(client.getSinglePage).toHaveBeenCalledTimes(2)

--- a/packages/zuora-billing-adapter/src/client/pagination.ts
+++ b/packages/zuora-billing-adapter/src/client/pagination.ts
@@ -17,15 +17,11 @@ import { client as clientUtils } from '@salto-io/adapter-components'
 
 const { getWithPageOffsetAndLastPagination, getWithCursorPagination } = clientUtils
 
-export const paginate: clientUtils.GetAllItemsFunc = async function *paginate({
-  client,
-  pageSize,
-  getParams,
-}) {
-  if (getParams?.paginationField?.includes('next')) {
+export const paginate: clientUtils.GetAllItemsFunc = async function *paginate(args) {
+  if (args.getParams?.paginationField?.includes('next')) {
     // special handling for endpoints that use descending ids, like the recipes endpoint
-    yield* getWithCursorPagination()({ client, pageSize, getParams })
+    yield* getWithCursorPagination()(args)
   } else {
-    yield* getWithPageOffsetAndLastPagination(0)({ client, pageSize, getParams })
+    yield* getWithPageOffsetAndLastPagination(0)(args)
   }
 }


### PR DESCRIPTION
Stop attempting to go to the next page if the current page has empty results. 

---

This required moving the entry-extraction logic into the pagination logic (which I think is a good thing).

---
_Release Notes_: 
None

---
_User Notifications_: 
None