### PR TITLE
SALTO-1583: new instances are not added on second first fetch if their type is also added

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -194,10 +194,6 @@ const toFetchChanges = (
         return undefined
       }
 
-      // Find all changes that relate to the current ID and mark them as handled
-      const relatedChanges = [...serviceAndPendingChanges.valuesWithPrefix(id)].flat()
-      relatedChanges.forEach(change => handledChangeIDs.add(change.change.id.getFullName()))
-
       const wsChange = workspaceToServiceChanges[id]
       if (wsChange === undefined) {
         // If we get here it means there is a difference between the service and the state
@@ -208,6 +204,13 @@ const toFetchChanges = (
         log.debug('service change on %s already updated in workspace', id)
         return undefined
       }
+
+      // Find all changes that relate to the current ID and mark them as handled
+      const relatedChanges = [...serviceAndPendingChanges.valuesWithPrefix(id)]
+        .flat()
+        .filter(change =>
+          wsChange.id.isEqual(change.change.id) || wsChange.id.isParentOf(change.change.id))
+      relatedChanges.forEach(change => handledChangeIDs.add(change.change.id.getFullName()))
 
       const [serviceChanges, pendingChanges] = _.partition(
         relatedChanges,

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -533,6 +533,29 @@ describe('fetch', () => {
       })
     })
 
+    describe('when the adapter returns elements that includes type and its instances', () => {
+      const inst = new InstanceElement('inst', newTypeBase)
+      beforeEach(async () => {
+        mockAdapters.dummy.fetch.mockResolvedValueOnce(
+          Promise.resolve({ elements: [newTypeBase, inst, typeWithHiddenField] })
+        )
+        const result = await fetchChanges(
+          mockAdapters,
+          createElementSource([typeWithHiddenField]),
+          createElementSource([]),
+          [],
+        )
+        changes = [...result.changes]
+      })
+      it('should return changes for both elements', () => {
+        expect(changes).toHaveLength(2)
+      })
+      it('should return correct changes', () => {
+        expect(changes[0].change).toMatchObject({ action: 'add', id: newTypeBase.elemID })
+        expect(changes[1].change).toMatchObject({ action: 'add', id: inst.elemID })
+      })
+    })
+
     describe('when the adapter returns elements that should be split', () => {
       beforeEach(async () => {
         mockAdapters.dummy.fetch.mockResolvedValueOnce(


### PR DESCRIPTION
_new instances do not add up on non first fetch if their type is also being added_

---

_Additional context for reviewer_
- the issue introduced in https://github.com/salto-io/salto/pull/2374
- please add the release note only if it existed in the previous version

---
_Release Notes_: 
fixed a bug that caused new instances to not be fetched after a type is removed from the skip list

