### PR TITLE
Added ability to fetch from another workspace to the cli

### DIFF
--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -251,9 +251,9 @@ export const action: WorkspaceCommandAction<FetchArgs> = async ({
 }): Promise<CliExitCode> => {
   const { force, stateOnly, services, mode, regenerateSaltoIds, fromWorkspace, fromEnv } = input
   if (
-    [fromEnv, fromWorkspace].some(values.isDefined) 
+    [fromEnv, fromWorkspace].some(values.isDefined)
     && ![fromEnv, fromWorkspace].every(values.isDefined)
-  ) { 
+  ) {
     errorOutputLine('The fromEnv and fromWorkspace arguments must both be provided.', output)
     outputLine(EOL, output)
     return CliExitCode.UserInputError

--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -65,12 +65,13 @@ const createFetchFromWorkspaceCommand = (
   otherWorkspacePath: string,
   env? : string
 ): FetchFunc => async (workspace, progressEmitter, services) => {
+  let otherWorkspace: Workspace
   try {
-    const otherWorkspace = await loadLocalWorkspace(otherWorkspacePath, [], false)
-    return await fetchFromWorkspaceFunc(workspace, otherWorkspace, progressEmitter, services, env)
+    otherWorkspace = await loadLocalWorkspace(otherWorkspacePath, [], false)
   } catch (err) {
     throw new Error(`Failed to load source workspace: ${err.message ?? err}`)
   }
+  return await fetchFromWorkspaceFunc({workspace, otherWorkspace, progressEmitter, services, env})
 }
 
 export const fetchCommand = async (

--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { EOL } from 'os'
 import _ from 'lodash'
 import wu from 'wu'
 import { getChangeElement, isInstanceElement, AdapterOperationName, Progress } from '@salto-io/adapter-api'
@@ -71,7 +72,7 @@ const createFetchFromWorkspaceCommand = (
   } catch (err) {
     throw new Error(`Failed to load source workspace: ${err.message ?? err}`)
   }
-  return await fetchFromWorkspaceFunc({workspace, otherWorkspace, progressEmitter, services, env})
+  return fetchFromWorkspaceFunc({ workspace, otherWorkspace, progressEmitter, services, env })
 }
 
 export const fetchCommand = async (
@@ -249,6 +250,11 @@ export const action: WorkspaceCommandAction<FetchArgs> = async ({
   workspace,
 }): Promise<CliExitCode> => {
   const { force, stateOnly, services, mode, regenerateSaltoIds, fromWorkspace, fromEnv } = input
+  if (fromEnv !== undefined && fromWorkspace === undefined) {
+    errorOutputLine('The fromEnv argument can only be used when a fromWorkspace argument is provided', output)
+    outputLine(EOL, output)
+    return CliExitCode.UserInputError
+  }
   const { shouldCalcTotalSize } = config
   await validateAndSetEnv(workspace, input, output)
   const activeServices = getAndValidateActiveServices(workspace, services)

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -15,7 +15,8 @@
 */
 import { EventEmitter } from 'pietile-eventemitter'
 import { InstanceElement, DetailedChange } from '@salto-io/adapter-api'
-import { fetch, FetchChange, FetchProgressEvents, StepEmitter, FetchFunc } from '@salto-io/core'
+import { fetch, fetchFromWorkspace, FetchChange, FetchProgressEvents, StepEmitter, FetchFunc,
+  loadLocalWorkspace } from '@salto-io/core'
 import { Workspace } from '@salto-io/workspace'
 import { mockFunction } from '@salto-io/test-utils'
 import { CliExitCode, CliTelemetry, CliError } from '../../src/types'
@@ -42,6 +43,12 @@ jest.mock('@salto-io/core', () => ({
     mergeErrors: [],
     success: true,
   })),
+  fetchFromWorkspace: jest.fn().mockImplementation(() => Promise.resolve({
+    changes: [],
+    mergeErrors: [],
+    success: true,
+  })),
+  loadLocalWorkspace: jest.fn().mockImplementation(() => mocks.mockWorkspace({})),
 }))
 describe('fetch command', () => {
   const services = ['salesforce']
@@ -821,6 +828,85 @@ describe('fetch command', () => {
         },
         workspace: mocks.mockWorkspace({}),
       })).rejects.toThrow(new CliError(CliExitCode.AppError))
+    })
+  })
+
+  describe('fetch from workspace', () => {
+    let mockFetchFromWorkspace: jest.Mock
+    let mockLoadLocalWorkspace: jest.Mock
+
+    beforeAll(() => {
+      mockFetchFromWorkspace = fetchFromWorkspace as jest.Mock
+      mockLoadLocalWorkspace = loadLocalWorkspace as jest.Mock
+    })
+
+    beforeEach(() => {
+      mockFetchFromWorkspace.mockClear()
+      mockLoadLocalWorkspace.mockClear()
+    })
+
+    it('should invoke the fetch from workspace method', async () => {
+      const workspace = mocks.mockWorkspace({ uid: 'target' })
+      const sourceWS = mocks.mockWorkspace({ uid: 'source' })
+      const sourcePath = 'path/to/source'
+      const env = 'sourceEnv'
+      mockLoadLocalWorkspace.mockResolvedValueOnce(sourceWS)
+      await action({
+        ...cliCommandArgs,
+        input: {
+          force: true,
+          mode: 'default',
+          services,
+          stateOnly: false,
+          regenerateSaltoIds: false,
+          fromEnv: env,
+          fromWorkspace: sourcePath,
+        },
+        workspace,
+      })
+      expect(mockLoadLocalWorkspace).toHaveBeenCalledWith(sourcePath, [], false)
+      expect(mockFetchFromWorkspace).toHaveBeenCalled()
+      const usedArgs = mockFetchFromWorkspace.mock.calls[0][0]
+      expect(usedArgs.workspace).toEqual(workspace)
+      expect(usedArgs.otherWorkspace).toEqual(sourceWS)
+      expect(usedArgs.services).toEqual(services)
+      expect(usedArgs.env).toEqual(env)
+    })
+
+    it('should throw an informative error if the workspace failed to load', async () => {
+      const errMsg = 'All your base are belong to us'
+      mockLoadLocalWorkspace.mockRejectedValueOnce(errMsg)
+      const workspace = mocks.mockWorkspace({ uid: 'target' })
+      await expect(() => action({
+        ...cliCommandArgs,
+        input: {
+          force: true,
+          mode: 'default',
+          services,
+          stateOnly: false,
+          regenerateSaltoIds: false,
+          fromEnv: 'what*env*er',
+          fromWorkspace: 'where*env*er',
+        },
+        workspace,
+      })).rejects.toThrow(`Failed to load source workspace: ${errMsg}`)
+    })
+
+    it('should return user input error if the from env argument is provided without the from workspace argument', async () => {
+      const workspace = mocks.mockWorkspace({ uid: 'target' })
+      const retValue = await action({
+        ...cliCommandArgs,
+        input: {
+          force: true,
+          mode: 'default',
+          services,
+          stateOnly: false,
+          regenerateSaltoIds: false,
+          fromEnv: 'what*env*er',
+        },
+        workspace,
+      })
+      expect(retValue).toEqual(CliExitCode.UserInputError)
     })
   })
 })

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -908,5 +908,22 @@ describe('fetch command', () => {
       })
       expect(retValue).toEqual(CliExitCode.UserInputError)
     })
+
+    it('should return user input error if the from fromWorkspace argument is provided without the from fromEnv argument', async () => {
+      const workspace = mocks.mockWorkspace({ uid: 'target' })
+      const retValue = await action({
+        ...cliCommandArgs,
+        input: {
+          force: true,
+          mode: 'default',
+          services,
+          stateOnly: false,
+          regenerateSaltoIds: false,
+          fromWorkspace: 'path/to/nowhere',
+        },
+        workspace,
+      })
+      expect(retValue).toEqual(CliExitCode.UserInputError)
+    })
   })
 })

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -186,13 +186,14 @@ export type FetchFunc = (
   ignoreStateElemIdMapping?: boolean,
 ) => Promise<FetchResult>
 
-export type FetchFromWorkspaceFunc = (
+export type FetchFromWorkspaceFuncParams = {
   workspace: Workspace,
   otherWorkspace: Workspace,
   progressEmitter?: EventEmitter<FetchProgressEvents>,
   services?: string[],
   env?: string
-) => Promise<FetchResult>
+}
+export type FetchFromWorkspaceFunc = (args: FetchFromWorkspaceFuncParams) => Promise<FetchResult>
 
 const updateStateWithFetchResults = async (
   workspace: Workspace,
@@ -256,14 +257,14 @@ export const fetch: FetchFunc = async (
   }
 }
 
-export const fetchFromWorkspace: FetchFromWorkspaceFunc = async (
+export const fetchFromWorkspace: FetchFromWorkspaceFunc = async ({
   workspace,
   otherWorkspace,
-  progressEmitter?,
-  services?,
-  env?,
-) => {
-  log.debug('fetch starting..')
+  progressEmitter,
+  services,
+  env,
+}: FetchFromWorkspaceFuncParams) => {
+  log.debug('fetch starting from workspace..')
   const fetchServices = services ?? workspace.services()
     .filter(service => otherWorkspace.services(env).includes(service))
 
@@ -285,7 +286,7 @@ export const fetchFromWorkspace: FetchFromWorkspaceFunc = async (
     env
   )
 
-  log.debug(`${elements.length} elements were fetched [mergedErrors=${mergeErrors.length}]`)
+  log.debug(`${elements.length} elements were fetched from a remote workspace [mergedErrors=${mergeErrors.length}]`)
   await updateStateWithFetchResults(workspace, elements, unmergedElements, fetchServices)
   return {
     changes,

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -16,7 +16,7 @@
 import {
   Adapter, InstanceElement, ObjectType, ElemID, AccountId, getChangeElement, isField,
   Change, ChangeDataType, isFieldChange, AdapterFailureInstallResult, isAdapterSuccessInstallResult,
-  AdapterSuccessInstallResult, AdapterAuthentication, SaltoError,
+  AdapterSuccessInstallResult, AdapterAuthentication, SaltoError, Element,
 } from '@salto-io/adapter-api'
 import { EventEmitter } from 'pietile-eventemitter'
 import { logger } from '@salto-io/logging'
@@ -27,17 +27,18 @@ import { EOL } from 'os'
 import { deployActions, DeployError, ItemStatus } from './core/deploy'
 import {
   adapterCreators, getAdaptersCredentialsTypes, getAdapters, getAdapterDependencyChangers,
-  initAdapters, getAdaptersCreatorConfigs, getDefaultAdapterConfig,
+  initAdapters, getDefaultAdapterConfig,
 } from './core/adapters'
 import { getPlan, Plan, PlanItem } from './core/plan'
 import {
-  createElemIdGetter,
   FetchChange,
   fetchChanges,
   FetchProgressEvents,
   getDetailedChanges,
   MergeErrorWithElements,
   toChangesWithPath,
+  fetchChangesFromWorkspace,
+  getFetchAdapterAndServicesSetup,
 } from './core/fetch'
 import { defaultDependencyChangers } from './core/plan/plan'
 import { createRestoreChanges } from './core/restore'
@@ -185,6 +186,31 @@ export type FetchFunc = (
   ignoreStateElemIdMapping?: boolean,
 ) => Promise<FetchResult>
 
+export type FetchFromWorkspaceFunc = (
+  workspace: Workspace,
+  otherWorkspace: Workspace,
+  progressEmitter?: EventEmitter<FetchProgressEvents>,
+  services?: string[],
+  env?: string
+) => Promise<FetchResult>
+
+const updateStateWithFetchResults = async (
+  workspace: Workspace,
+  mergedElements: Element[],
+  unmergedElements: Element[],
+  fetchedServices: string[]
+): Promise<void> => {
+  const fetchElementsFilter = shouldElementBeIncluded(fetchedServices)
+  const stateElementsNotCoveredByFetch = await awu(await workspace.state().getAll())
+    .filter(element => !fetchElementsFilter(element.elemID)).toArray()
+  await workspace.state()
+    .override(awu(mergedElements)
+      .concat(stateElementsNotCoveredByFetch), fetchedServices)
+  await workspace.state().updatePathIndex(unmergedElements,
+    (await workspace.state().existingServices()).filter(key => !fetchedServices.includes(key)))
+  log.debug(`finish to override state with ${mergedElements.length} elements`)
+}
+
 export const fetch: FetchFunc = async (
   workspace,
   progressEmitter?,
@@ -192,25 +218,16 @@ export const fetch: FetchFunc = async (
   ignoreStateElemIdMapping?,
 ) => {
   log.debug('fetch starting..')
-
   const fetchServices = services ?? workspace.services()
-  const fetchElementsFilter = shouldElementBeIncluded(fetchServices)
-  const stateElementsNotCoveredByFetch = await awu(await workspace.state().getAll())
-    .filter(element => !fetchElementsFilter(element.elemID)).toArray()
-
-  const adaptersCreatorConfigs = await getAdaptersCreatorConfigs(
+  const {
+    currentConfigs,
+    adaptersCreatorConfigs,
+  } = await getFetchAdapterAndServicesSetup(
+    workspace,
     fetchServices,
-    await workspace.servicesCredentials(services),
-    workspace.serviceConfig.bind(workspace),
-    await workspace.elements(),
-    ignoreStateElemIdMapping ? undefined : await createElemIdGetter(
-      await (await workspace.elements()).getAll(),
-      workspace.state()
-    )
+    ignoreStateElemIdMapping
   )
-  const currentConfigs = Object.values(adaptersCreatorConfigs)
-    .map(creatorConfig => creatorConfig.config)
-    .filter(config => !_.isUndefined(config)) as InstanceElement[]
+
   const adapters = initAdapters(adaptersCreatorConfigs)
 
   if (progressEmitter) {
@@ -227,12 +244,7 @@ export const fetch: FetchFunc = async (
     progressEmitter,
   )
   log.debug(`${elements.length} elements were fetched [mergedErrors=${mergeErrors.length}]`)
-  await workspace.state()
-    .override(awu(elements)
-      .concat(stateElementsNotCoveredByFetch), fetchServices)
-  await workspace.state().updatePathIndex(unmergedElements,
-    (await workspace.state().existingServices()).filter(key => !fetchServices.includes(key)))
-  log.debug(`finish to override state with ${elements.length} elements`)
+  await updateStateWithFetchResults(workspace, elements, unmergedElements, fetchServices)
   return {
     changes,
     fetchErrors: errors,
@@ -241,6 +253,49 @@ export const fetch: FetchFunc = async (
     configChanges,
     updatedConfig,
     adapterNameToConfigMessage,
+  }
+}
+
+export const fetchFromWorkspace: FetchFromWorkspaceFunc = async (
+  workspace,
+  otherWorkspace,
+  progressEmitter?,
+  services?,
+  env?,
+) => {
+  log.debug('fetch starting..')
+  const fetchServices = services ?? workspace.services()
+    .filter(service => otherWorkspace.services(env).includes(service))
+
+  const { currentConfigs } = await getFetchAdapterAndServicesSetup(
+    workspace,
+    fetchServices,
+  )
+
+  const {
+    changes, elements, mergeErrors, errors,
+    configChanges, adapterNameToConfigMessage, unmergedElements,
+  } = await fetchChangesFromWorkspace(
+    otherWorkspace,
+    fetchServices,
+    await workspace.elements(),
+    workspace.state(),
+    currentConfigs,
+    progressEmitter,
+    env
+  )
+
+  log.debug(`${elements.length} elements were fetched [mergedErrors=${mergeErrors.length}]`)
+  await updateStateWithFetchResults(workspace, elements, unmergedElements, fetchServices)
+  return {
+    changes,
+    fetchErrors: errors,
+    mergeErrors,
+    success: true,
+    updatedConfig: {},
+    configChanges,
+    adapterNameToConfigMessage,
+    progressEmitter,
   }
 }
 

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -191,7 +191,7 @@ export type FetchFromWorkspaceFuncParams = {
   otherWorkspace: Workspace
   progressEmitter?: EventEmitter<FetchProgressEvents>
   services?: string[]
-  env?: string
+  env: string
 }
 export type FetchFromWorkspaceFunc = (args: FetchFromWorkspaceFuncParams) => Promise<FetchResult>
 
@@ -266,7 +266,6 @@ export const fetchFromWorkspace: FetchFromWorkspaceFunc = async ({
 }: FetchFromWorkspaceFuncParams) => {
   log.debug('fetch starting from workspace..')
   const fetchServices = services ?? workspace.services()
-    .filter(service => otherWorkspace.services(env).includes(service))
 
   const { currentConfigs } = await getFetchAdapterAndServicesSetup(
     workspace,
@@ -282,8 +281,8 @@ export const fetchFromWorkspace: FetchFromWorkspaceFunc = async ({
     await workspace.elements(),
     workspace.state(),
     currentConfigs,
+    env,
     progressEmitter,
-    env
   )
 
   log.debug(`${elements.length} elements were fetched from a remote workspace [mergedErrors=${mergeErrors.length}]`)

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -187,10 +187,10 @@ export type FetchFunc = (
 ) => Promise<FetchResult>
 
 export type FetchFromWorkspaceFuncParams = {
-  workspace: Workspace,
-  otherWorkspace: Workspace,
-  progressEmitter?: EventEmitter<FetchProgressEvents>,
-  services?: string[],
+  workspace: Workspace
+  otherWorkspace: Workspace
+  progressEmitter?: EventEmitter<FetchProgressEvents>
+  services?: string[]
   env?: string
 }
 export type FetchFromWorkspaceFunc = (args: FetchFromWorkspaceFuncParams) => Promise<FetchResult>

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -679,8 +679,8 @@ const createEmptyFetchChangeDueToError = (errMsg: string): FetchChangesResult =>
   updatedConfig: {},
   errors: [{
     message: errMsg,
-    severity: 'Error'
-  }]
+    severity: 'Error',
+  }],
 })
 export const fetchChangesFromWorkspace = async (
   otherWorkspace: Workspace,
@@ -731,8 +731,8 @@ export const fetchChangesFromWorkspace = async (
   const fullElements = await awu(
     await (await otherWorkspace.elements(true, env)).getAll()
   )
-  .filter(elem => fetchServices.includes(elem.elemID.adapter))
-  .toArray()
+    .filter(elem => fetchServices.includes(elem.elemID.adapter))
+    .toArray()
 
   const otherPathIndex = await otherWorkspace.state(env).getPathIndex()
   const unmergedElements = await awu(fullElements).map(

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -21,17 +21,19 @@ import {
   toServiceIdsString, Field, OBJECT_SERVICE_ID, InstanceElement, isInstanceElement, isObjectType,
   ADAPTER, FIELD_NAME, INSTANCE_NAME, OBJECT_NAME, ElemIdGetter, DetailedChange, SaltoError,
   ProgressReporter, ReadOnlyElementsSource, TypeMap, isServiceId, CORE_ANNOTATIONS,
+  AdapterOperationsContext,
 } from '@salto-io/adapter-api'
 import {
   applyInstancesDefaults, resolvePath, flattenElementStr,
 } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { merger, elementSource } from '@salto-io/workspace'
+import { merger, elementSource, Workspace, pathIndex } from '@salto-io/workspace'
 import { collections, promises, types, values } from '@salto-io/lowerdash'
 import { StepEvents } from './deploy'
 import { getPlan, Plan } from './plan'
 import { AdapterEvents, createAdapterProgressReporter } from './adapters/progress'
 import { IDFilter } from './plan/plan'
+import { getAdaptersCreatorConfigs } from './adapters'
 
 const { awu, groupByAsync } = collections.asynciterable
 const { mergeElements } = merger
@@ -358,7 +360,7 @@ const fetchAndProcessMergeErrors = async (
     serviceElements: Element[]
     errors: SaltoError[]
     processErrorsResult: ProcessMergeErrorsResult
-    updatedConfig: UpdatedConfig[]
+    updatedConfigs: UpdatedConfig[]
     partiallyFetchedAdapters: Set<string>
   }> => {
   try {
@@ -392,7 +394,7 @@ const fetchAndProcessMergeErrors = async (
 
     const serviceElements = _.flatten(fetchResults.map(res => res.elements))
     const fetchErrors = fetchResults.flatMap(res => res.errors)
-    const updatedConfig = fetchResults
+    const updatedConfigs = fetchResults
       .map(res => res.updatedConfig)
       .filter(values.isDefined) as UpdatedConfig[]
 
@@ -447,7 +449,7 @@ const fetchAndProcessMergeErrors = async (
       serviceElements: validServiceElements,
       errors: fetchErrors,
       processErrorsResult,
-      updatedConfig,
+      updatedConfigs,
       partiallyFetchedAdapters,
     }
   } catch (error) {
@@ -529,7 +531,6 @@ const calcFetchChanges = async (
   // Merge pending changes and service changes into one tree so we can find conflicts between them
   serviceChanges.merge(pendingChanges)
   const fetchChanges = toFetchChanges(serviceChanges, workspaceToServiceChanges)
-
   const serviceElementsMap = _.groupBy(
     serviceElements,
     e => e.elemID.getFullName()
@@ -541,35 +542,25 @@ const calcFetchChanges = async (
     .toArray()
 }
 
-export const fetchChanges = async (
-  adapters: Record<string, AdapterOperations>,
-  workspaceElements: elementSource.ElementsSource,
-  stateElements: elementSource.ElementsSource,
-  currentConfigs: InstanceElement[],
+type CreateFetchChangesParams = {
+  adapterNames: string[]
+  workspaceElements: elementSource.ElementsSource
+  stateElements: elementSource.ElementsSource
+  unmergedElements: Element[]
+  processErrorsResult: ProcessMergeErrorsResult
+  currentConfigs: InstanceElement[]
+  getChangesEmitter: StepEmitter
+  partiallyFetchedAdapters?: Set<string>
+  updatedConfigs?: UpdatedConfig[]
+  errors?: SaltoError[]
   progressEmitter?: EventEmitter<FetchProgressEvents>
+}
+const createFetchChanges = async ({
+  adapterNames, workspaceElements, stateElements, unmergedElements,
+  processErrorsResult, currentConfigs, getChangesEmitter, partiallyFetchedAdapters = new Set(),
+  updatedConfigs = [], errors = [], progressEmitter,
+}: CreateFetchChangesParams
 ): Promise<FetchChangesResult> => {
-  const adapterNames = _.keys(adapters)
-  const getChangesEmitter = new StepEmitter()
-  if (progressEmitter) {
-    progressEmitter.emit('changesWillBeFetched', getChangesEmitter, adapterNames)
-  }
-  const {
-    serviceElements, errors, processErrorsResult, updatedConfig, partiallyFetchedAdapters,
-  } = await fetchAndProcessMergeErrors(
-    adapters,
-    stateElements,
-    getChangesEmitter,
-    progressEmitter
-  )
-
-  const adaptersFirstFetchPartial = await getAdaptersFirstFetchPartial(
-    stateElements,
-    partiallyFetchedAdapters
-  )
-  adaptersFirstFetchPartial.forEach(
-    adapter => log.warn('Received partial results from %s before full fetch', adapter)
-  )
-
   const calculateDiffEmitter = new StepEmitter()
   if (progressEmitter) {
     getChangesEmitter.emit('completed')
@@ -580,9 +571,9 @@ export const fetchChanges = async (
     .filter(e => !e.isConfig())
     .isEmpty()
   const changes = isFirstFetch
-    ? serviceElements.map(toAddFetchChange)
+    ? unmergedElements.map(toAddFetchChange)
     : await calcFetchChanges(
-      serviceElements,
+      unmergedElements,
       elementSource.createInMemoryElementSource(processErrorsResult.keptElements),
       // When we init a new env, state will be empty. We fallback to the workspace
       // elements since they should be considered a part of the env and the diff
@@ -592,13 +583,12 @@ export const fetchChanges = async (
       partiallyFetchedAdapters,
       new Set(adapterNames)
     )
-
   log.debug('finished to calculate fetch changes')
   if (progressEmitter) {
     calculateDiffEmitter.emit('completed')
   }
 
-  const configsMerge = await mergeElements(awu(updatedConfig.flatMap(c => c.config)))
+  const configsMerge = await mergeElements(awu(updatedConfigs.flatMap(c => c.config)))
 
   const errorMessages = await awu(await configsMerge.errors.entries())
     .flatMap(err => err.value)
@@ -617,7 +607,7 @@ export const fetchChanges = async (
     after: elementSource.createInMemoryElementSource(configs),
   })
 
-  const adapterNameToConfig = _.keyBy(updatedConfig, config => config.config[0].elemID.adapter)
+  const adapterNameToConfig = _.keyBy(updatedConfigs, config => config.config[0].elemID.adapter)
   const adapterNameToConfigMessage = _.mapValues(adapterNameToConfig, config => config.message)
 
   const elements = partiallyFetchedAdapters.size !== 0
@@ -631,12 +621,121 @@ export const fetchChanges = async (
     changes,
     elements,
     errors,
-    unmergedElements: serviceElements,
+    unmergedElements,
     mergeErrors: processErrorsResult.errorsWithDroppedElements,
     configChanges,
     updatedConfig: _.mapValues(adapterNameToConfig, config => config.config),
     adapterNameToConfigMessage,
   }
+}
+export const fetchChanges = async (
+  adapters: Record<string, AdapterOperations>,
+  workspaceElements: elementSource.ElementsSource,
+  stateElements: elementSource.ElementsSource,
+  currentConfigs: InstanceElement[],
+  progressEmitter?: EventEmitter<FetchProgressEvents>
+): Promise<FetchChangesResult> => {
+  const adapterNames = _.keys(adapters)
+  const getChangesEmitter = new StepEmitter()
+  if (progressEmitter) {
+    progressEmitter.emit('changesWillBeFetched', getChangesEmitter, adapterNames)
+  }
+  const {
+    serviceElements, errors, processErrorsResult, updatedConfigs, partiallyFetchedAdapters,
+  } = await fetchAndProcessMergeErrors(
+    adapters,
+    stateElements,
+    getChangesEmitter,
+    progressEmitter
+  )
+
+  const adaptersFirstFetchPartial = await getAdaptersFirstFetchPartial(
+    stateElements,
+    partiallyFetchedAdapters
+  )
+  adaptersFirstFetchPartial.forEach(
+    adapter => log.warn('Received partial results from %s before full fetch', adapter)
+  )
+
+  return createFetchChanges({
+    unmergedElements: serviceElements,
+    adapterNames: Object.keys(adapters),
+    workspaceElements,
+    stateElements,
+    currentConfigs,
+    getChangesEmitter,
+    progressEmitter,
+    processErrorsResult,
+    errors,
+    updatedConfigs,
+    partiallyFetchedAdapters,
+  })
+}
+
+export const fetchChangesFromWorkspace = async (
+  otherWorkspace: Workspace,
+  fetchServices: string[],
+  workspaceElements: elementSource.ElementsSource,
+  stateElements: elementSource.ElementsSource,
+  currentConfigs: InstanceElement[],
+  progressEmitter?: EventEmitter<FetchProgressEvents>,
+  env?: string
+): Promise<FetchChangesResult> => {
+  const getDifferentConfigs = async (): Promise<InstanceElement[]> => (
+    awu(currentConfigs).filter(async config => {
+      const otherConfig = await otherWorkspace.serviceConfig(config.elemID.adapter)
+      return !otherConfig || !otherConfig.isEqual(config)
+    }).toArray()
+  )
+
+  if (env && !otherWorkspace.envs().includes(env)) {
+    throw new Error('Source env does not exist in the source workspace.')
+  }
+
+  const otherServices = otherWorkspace.services(env)
+  const missingServices = fetchServices.filter(service => !otherServices.includes(service))
+
+  if (missingServices.length > 0) {
+    throw new Error(`Source env does not contain the following services: ${missingServices.join(',')}`)
+  }
+
+  if (await otherWorkspace.hasErrors(env)) {
+    throw new Error('Can not fetch from a workspace with errors.')
+  }
+
+  const differentConfig = await getDifferentConfigs()
+  if (!_.isEmpty(differentConfig)) {
+    throw new Error(`Can not fetch from a workspace. Found different configs for ${
+      differentConfig.map(config => config.elemID.adapter).join(', ')
+    }`)
+  }
+
+  const adapterNames = currentConfigs.map(config => config.elemID.adapter)
+  const getChangesEmitter = new StepEmitter()
+  if (progressEmitter) {
+    progressEmitter.emit('changesWillBeFetched', getChangesEmitter, adapterNames)
+  }
+
+  const fullElements = await awu(
+    await (await otherWorkspace.elements(true, env)).getAll()
+  ).toArray()
+  const otherPathIndex = await otherWorkspace.state(env).getPathIndex()
+  const unmergedElements = await awu(fullElements).map(
+    elem => pathIndex.splitElementByPath(elem, otherPathIndex)
+  ).flat().toArray()
+
+  return createFetchChanges({
+    adapterNames,
+    currentConfigs,
+    getChangesEmitter,
+    processErrorsResult: {
+      keptElements: fullElements,
+      errorsWithDroppedElements: [],
+    },
+    stateElements,
+    workspaceElements,
+    unmergedElements,
+  })
 }
 
 const id = (elemID: ElemID): string => elemID.getFullName()
@@ -732,4 +831,29 @@ export const createElemIdGetter = async (
 
   return (adapterName: string, serviceIds: ServiceIds, name: string): ElemID =>
     serviceIdToStateElemId[toServiceIdsString(serviceIds)] || new ElemID(adapterName, name)
+}
+
+export const getFetchAdapterAndServicesSetup = async (
+  workspace: Workspace,
+  fetchServices: string[],
+  ignoreStateElemIdMapping?: boolean
+): Promise<{
+  adaptersCreatorConfigs: Record<string, AdapterOperationsContext>
+  currentConfigs: InstanceElement[]
+}> => {
+  const adaptersCreatorConfigs = await getAdaptersCreatorConfigs(
+    fetchServices,
+    await workspace.servicesCredentials(fetchServices),
+    workspace.serviceConfig.bind(workspace),
+    await workspace.elements(),
+    ignoreStateElemIdMapping ? undefined : await createElemIdGetter(
+      await (await workspace.elements()).getAll(),
+      workspace.state()
+    )
+  )
+  const currentConfigs = Object.values(adaptersCreatorConfigs)
+    .map(creatorConfig => creatorConfig.config)
+    .filter(config => !_.isUndefined(config)) as InstanceElement[]
+
+  return { adaptersCreatorConfigs, currentConfigs }
 }

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -501,7 +501,7 @@ describe('api.ts', () => {
         ws = mockWorkspace({ elements: workspaceElements, stateElements })
         ows = mockWorkspace({})
         mockFetchChangesFromWorkspace.mockClear()
-        await api.fetchFromWorkspace({otherWorkspace: ws, workspace : ows, services: SERVICES})
+        await api.fetchFromWorkspace({ otherWorkspace: ws, workspace: ows, services: SERVICES })
       })
 
       it('should call fetch changes from workspace', () => {
@@ -516,7 +516,11 @@ describe('api.ts', () => {
         ws = mockWorkspace({})
         ows = mockWorkspace({})
         mockFetchChangesFromWorkspace.mockClear()
-        await api.fetchFromWorkspace({otherWorkspace: ws, workspace : ows, services: [mockService]})
+        await api.fetchFromWorkspace({
+          otherWorkspace: ws,
+          workspace: ows,
+          services: [mockService],
+        })
       })
 
       it('should call fetch changes with first service only', () => {
@@ -530,10 +534,10 @@ describe('api.ts', () => {
 
 
       beforeAll(async () => {
-        ws = mockWorkspace({services: ['salto', 'salesforce']})
-        ows = mockWorkspace({services: ['salto', 'netsuite']})
+        ws = mockWorkspace({ services: ['salto', 'salesforce'] })
+        ows = mockWorkspace({ services: ['salto', 'netsuite'] })
         mockFetchChangesFromWorkspace.mockClear()
-        await api.fetchFromWorkspace({otherWorkspace: ws, workspace : ows})
+        await api.fetchFromWorkspace({ otherWorkspace: ws, workspace: ows })
       })
 
       it('should use services that are in both workspace as default', () => {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -501,7 +501,12 @@ describe('api.ts', () => {
         ws = mockWorkspace({ elements: workspaceElements, stateElements })
         ows = mockWorkspace({})
         mockFetchChangesFromWorkspace.mockClear()
-        await api.fetchFromWorkspace({ otherWorkspace: ws, workspace: ows, services: SERVICES })
+        await api.fetchFromWorkspace({
+          otherWorkspace: ws,
+          workspace: ows,
+          services: SERVICES,
+          env: 'default',
+        })
       })
 
       it('should call fetch changes from workspace', () => {
@@ -520,6 +525,7 @@ describe('api.ts', () => {
           otherWorkspace: ws,
           workspace: ows,
           services: [mockService],
+          env: 'default',
         })
       })
 
@@ -537,12 +543,16 @@ describe('api.ts', () => {
         ws = mockWorkspace({ services: ['salto', 'salesforce'] })
         ows = mockWorkspace({ services: ['salto', 'netsuite'] })
         mockFetchChangesFromWorkspace.mockClear()
-        await api.fetchFromWorkspace({ otherWorkspace: ws, workspace: ows })
+        await api.fetchFromWorkspace({
+          otherWorkspace: ws,
+          workspace: ows,
+          env: 'default',
+        })
       })
 
-      it('should use services that are in both workspace as default', () => {
+      it('should use services that are in the current workspace as defaults', () => {
         const servicesUsed = mockFetchChangesFromWorkspace.mock.calls[0][1]
-        expect(servicesUsed).toEqual(['salto'])
+        expect(servicesUsed).toEqual(['salto', 'netsuite'])
       })
     })
   })

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -487,6 +487,7 @@ describe('api.ts', () => {
         unmergedElements: fetchedElements,
         elements: fetchedElements,
         mergeErrors: [],
+        updatedConfig: {},
         adapterNameToConfigMessage: {},
       })
     })

--- a/packages/core/test/common/workspace.ts
+++ b/packages/core/test/common/workspace.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, Element, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, Element, ElemID, InstanceElement, ObjectType, SaltoError } from '@salto-io/adapter-api'
 import * as workspace from '@salto-io/workspace'
 import { elementSource } from '@salto-io/workspace'
 import { mockState } from './state'
@@ -65,12 +65,16 @@ export const mockWorkspace = ({
   index = [],
   stateElements = undefined,
   services = SERVICES,
+  errors = [],
+  serviceConfigs = {}
 }: {
   elements?: Element[]
   name?: string
   index?: workspace.remoteMap.RemoteMapEntry<workspace.pathIndex.Path[]>[]
   stateElements?: Element[]
-  services?: string[]
+  services?: string[],
+  errors?: SaltoError[],
+  serviceConfigs?: Record<string, InstanceElement>
 }): workspace.Workspace => {
   const state = mockState(SERVICES, stateElements || elements, index)
   return {
@@ -88,11 +92,12 @@ export const mockWorkspace = ({
       [mockService]: mockConfigInstance,
       [emptyMockService]: mockEmptyConfigInstance,
     }),
-    serviceConfig: jest.fn().mockResolvedValue(undefined),
-    getWorkspaceErrors: jest.fn().mockResolvedValue([]),
+    serviceConfig: (serviceName: string) => serviceConfigs[serviceName],
+    getWorkspaceErrors: jest.fn().mockResolvedValue(errors),
     addService: jest.fn(),
     updateServiceCredentials: jest.fn(),
     updateServiceConfig: jest.fn(),
     clear: jest.fn(),
+    hasErrors: () => errors.length > 0,
   } as unknown as workspace.Workspace
 }

--- a/packages/core/test/common/workspace.ts
+++ b/packages/core/test/common/workspace.ts
@@ -66,14 +66,14 @@ export const mockWorkspace = ({
   stateElements = undefined,
   services = SERVICES,
   errors = [],
-  serviceConfigs = {}
+  serviceConfigs = {},
 }: {
   elements?: Element[]
   name?: string
   index?: workspace.remoteMap.RemoteMapEntry<workspace.pathIndex.Path[]>[]
   stateElements?: Element[]
-  services?: string[],
-  errors?: SaltoError[],
+  services?: string[]
+  errors?: SaltoError[]
   serviceConfigs?: Record<string, InstanceElement>
 }): workspace.Workspace => {
   const state = mockState(SERVICES, stateElements || elements, index)

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -1135,7 +1135,6 @@ describe('fetch from workspace', () => {
         createInMemoryElementSource([]),
         createInMemoryElementSource([]),
         [],
-        undefined,
         'nonexisiting'
       )
       expect([...fetchRes.changes]).toHaveLength(0)
@@ -1156,7 +1155,8 @@ describe('fetch from workspace', () => {
         ['salto', 'salesforce'],
         createInMemoryElementSource([]),
         createInMemoryElementSource([]),
-        []
+        [],
+        'default'
       )
       expect([...fetchRes.changes]).toHaveLength(0)
       expect(fetchRes.elements).toHaveLength(0)
@@ -1177,7 +1177,8 @@ describe('fetch from workspace', () => {
         ['salto'],
         createInMemoryElementSource([]),
         createInMemoryElementSource([]),
-        []
+        [],
+        'default'
       )
       expect([...fetchRes.changes]).toHaveLength(0)
       expect(fetchRes.elements).toHaveLength(0)
@@ -1219,7 +1220,8 @@ describe('fetch from workspace', () => {
         ['salto'],
         createInMemoryElementSource([]),
         createInMemoryElementSource([]),
-        currentServiceConfigs
+        currentServiceConfigs,
+        'default'
       )
 
       expect([...fetchRes.changes]).toHaveLength(0)
@@ -1321,7 +1323,8 @@ describe('fetch from workspace', () => {
         ['salto'],
         createInMemoryElementSource([existingElement]),
         createInMemoryElementSource([existingElement]),
-        configs
+        configs,
+        'default'
       )
     })
 

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -20,17 +20,21 @@ import {
   PrimitiveType, PrimitiveTypes, ADAPTER, OBJECT_SERVICE_ID, InstanceElement, CORE_ANNOTATIONS,
   ListType, FieldDefinition, FIELD_NAME, INSTANCE_NAME, OBJECT_NAME, ReferenceExpression,
   ReadOnlyElementsSource,
+  TypeReference,
+  createRefToElmWithValue,
 } from '@salto-io/adapter-api'
 import * as utils from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { elementSource } from '@salto-io/workspace'
+import { elementSource, pathIndex } from '@salto-io/workspace'
 import { mockFunction } from '@salto-io/test-utils'
+import { mockWorkspace } from '../common/workspace'
 import {
   fetchChanges, FetchChange, generateServiceIdToStateElemId,
-  FetchChangesResult, FetchProgressEvents, getAdaptersFirstFetchPartial,
+  FetchChangesResult, FetchProgressEvents, getAdaptersFirstFetchPartial, fetchChangesFromWorkspace,
 } from '../../src/core/fetch'
 import { getPlan, Plan } from '../../src/core/plan'
 import { createElementSource } from '../common/helpers'
+import { InMemoryRemoteMap } from '@salto-io/workspace/dist/src/workspace/remote_map'
 
 const { createInMemoryElementSource } = elementSource
 const { awu } = collections.asynciterable
@@ -329,8 +333,9 @@ describe('fetch', () => {
           createElementSource([]),
           [],
         )
+        expect(fetchChangesResult.configChanges).toBeDefined()
         verifyPlan(
-          fetchChangesResult.configChanges,
+          fetchChangesResult.configChanges as Plan,
           await getPlan({
             before: createElementSource([]),
             after: createElementSource([configInstance]),
@@ -346,8 +351,9 @@ describe('fetch', () => {
           createElementSource([]),
           [currentInstanceConfig],
         )
+        expect(fetchChangesResult.configChanges).toBeDefined()
         verifyPlan(
-          fetchChangesResult.configChanges,
+          fetchChangesResult.configChanges as Plan,
           await getPlan({
             before: createElementSource([currentInstanceConfig]),
             after: createElementSource([configInstance]),
@@ -363,9 +369,10 @@ describe('fetch', () => {
           createElementSource([]),
           [configInstance],
         )
-        expect([...fetchChangesResult.configChanges.itemsByEvalOrder()]).toHaveLength(0)
+        expect([...fetchChangesResult.configChanges?.itemsByEvalOrder() ?? []]).toHaveLength(0)
       })
     })
+
     describe('when merge elements returns errors', () => {
       const dupTypeID = new ElemID('dummy', 'dup')
       const dupTypeBase = new ObjectType({
@@ -1112,6 +1119,249 @@ describe('fetch', () => {
         })
         expect(adapters.dummy3.postFetch).not.toHaveBeenCalled()
       })
+    })
+  })
+})
+
+describe('fetch from workspace', () => {
+  describe('workspace mismatch errors', () => {
+    it('should fail when attempting to fetch an env not present in the source workspace', async () => {
+      const sourceWS = mockWorkspace({
+        services: ['salto']
+      })
+
+      const fetchRes = await fetchChangesFromWorkspace(
+        sourceWS,
+        ['salto'],
+        createInMemoryElementSource([]),
+        createInMemoryElementSource([]),
+        [],
+        undefined,
+        'nonexisiting'
+      )
+      expect([...fetchRes.changes]).toHaveLength(0)
+      expect(fetchRes.elements).toHaveLength(0)
+      expect(fetchRes.unmergedElements).toHaveLength(0)
+      expect(fetchRes.errors).toHaveLength(1)
+      expect(fetchRes.errors[0].message).toBe('nonexisiting env does not exist in the source workspace.')
+      expect(fetchRes.errors[0].severity).toBe('Error')
+    })
+
+    it('should fail when attempting to fetch a service not present in the source workspace', async () => {
+      const sourceWS = mockWorkspace({
+        services: ['salto']
+      })
+
+      const fetchRes = await fetchChangesFromWorkspace(
+        sourceWS,
+        ['salto', 'salesforce'],
+        createInMemoryElementSource([]),
+        createInMemoryElementSource([]),
+        []
+      )
+      expect([...fetchRes.changes]).toHaveLength(0)
+      expect(fetchRes.elements).toHaveLength(0)
+      expect(fetchRes.unmergedElements).toHaveLength(0)
+      expect(fetchRes.errors).toHaveLength(1)
+      expect(fetchRes.errors[0].message).toBe('Source env does not contain the following services: salesforce')
+      expect(fetchRes.errors[0].severity).toBe('Error')
+    })
+
+    it('should fail if the source workspace has errors', async () => {
+      const sourceWS = mockWorkspace({
+        services: ['salto'],
+        errors: [{'message' : 'A glitch', 'severity': 'Error'}]
+      })
+
+      const fetchRes = await fetchChangesFromWorkspace(
+        sourceWS,
+        ['salto'],
+        createInMemoryElementSource([]),
+        createInMemoryElementSource([]),
+        []
+      )
+      expect([...fetchRes.changes]).toHaveLength(0)
+      expect(fetchRes.elements).toHaveLength(0)
+      expect(fetchRes.unmergedElements).toHaveLength(0)
+      expect(fetchRes.errors).toHaveLength(1)
+      expect(fetchRes.errors[0].message).toBe('Can not fetch from a workspace with errors.')
+      expect(fetchRes.errors[0].severity).toBe('Error')
+    })
+
+    it('should fail if there is a mismatch in the adapter configs', async () => {
+      const currentServiceConfigs = [
+        new InstanceElement(
+          'salto_config',
+          new TypeReference(ElemID.fromFullName('salto_config')),
+          {
+            key: 'value'
+          }
+        ),
+        new InstanceElement(
+          'salto_config2',
+          new TypeReference(ElemID.fromFullName('salto_config2')),
+          {
+            key: 'value2'
+          }
+        )
+      ]
+
+      const sourceServiceConfigs = {
+        salto_config : currentServiceConfigs[0].clone(),
+        salto_config2: currentServiceConfigs[1].clone()
+      }
+      sourceServiceConfigs.salto_config2.value.key = 'otherValue'
+      const sourceWS = mockWorkspace({
+        serviceConfigs : sourceServiceConfigs
+      })
+      
+      const fetchRes = await fetchChangesFromWorkspace(
+        sourceWS,
+        ['salto'],
+        createInMemoryElementSource([]),
+        createInMemoryElementSource([]),
+        currentServiceConfigs
+      )
+
+      expect([...fetchRes.changes]).toHaveLength(0)
+      expect(fetchRes.elements).toHaveLength(0)
+      expect(fetchRes.unmergedElements).toHaveLength(0)
+      expect(fetchRes.errors).toHaveLength(1)
+      expect(fetchRes.errors[0].message).toBe('Can not fetch from a workspace. Found different configs for salto_config2')
+      expect(fetchRes.errors[0].severity).toBe('Error')
+    })
+  })
+
+  describe('fetch changes from workspace', () => {
+    const objElemId = new ElemID('salto', 'obj')
+    const objFragStdFields = new ObjectType({
+      elemID: objElemId,
+      fields : {
+        stdField: {
+          refType: createRefToElmWithValue(BuiltinTypes.STRING),
+          annotations : {
+            'test' : 'test'
+          }
+        }
+      },
+      path: ['salto', 'obj', 'standardFields']
+    })
+    const objFragCustomFields = new ObjectType({
+      elemID: objElemId,
+      fields : {
+        customField: {
+          refType: createRefToElmWithValue(BuiltinTypes.NUMBER),
+          annotations : {
+            'test' : 'test'
+          }
+        }
+      },
+      path: ['salto', 'obj', 'customFields']
+    })
+    const objFragAnnotations = new ObjectType({
+      elemID: objElemId,
+      annotationRefsOrTypes: {
+        anno : createRefToElmWithValue(BuiltinTypes.STRING)
+      },
+      annotations : {
+        anno: 'Anno!!!! Anno!!!! Annnooooooooooo!!!!!!!!'
+      },
+      path: ['salto', 'obj', 'annotations']
+    })
+
+     const objFull = new ObjectType({
+      elemID: objElemId,
+      fields : {
+        stdField: {
+          refType: createRefToElmWithValue(BuiltinTypes.STRING),
+          annotations : {
+            'test' : 'test'
+          }
+        },
+        customField: {
+          refType: createRefToElmWithValue(BuiltinTypes.NUMBER),
+          annotations : {
+            'test' : 'test'
+          }
+        }
+      },
+      annotationRefsOrTypes: {
+        anno : createRefToElmWithValue(BuiltinTypes.STRING)
+      },
+      annotations : {
+        anno: 'Anno!!!! Anno!!!! Annnooooooooooo!!!!!!!!'
+      },
+    })
+    const otherAdapterElem = new ObjectType({
+      elemID: new ElemID('other', 'obj'),
+      path: ['other', 'obj', 'all']
+    })
+    const existingElement = new ObjectType({
+      elemID: new ElemID('salto', 'existing'),
+      path: ['salto', 'existing', 'all']
+    })
+    const mergedElements = [objFull, existingElement, otherAdapterElem]
+    const unmergedElements = [
+      objFragStdFields, objFragCustomFields, 
+      objFragAnnotations, existingElement, otherAdapterElem
+    ]
+    const pi = new InMemoryRemoteMap<pathIndex.Path[]>()
+    let fetchRes: FetchChangesResult
+
+    beforeEach(async () => {
+      await pathIndex.overridePathIndex(pi, unmergedElements)
+      const configs = [
+        new InstanceElement('_config', new ReferenceExpression(new ElemID('salto')))
+      ]
+      fetchRes = await fetchChangesFromWorkspace(
+        mockWorkspace({
+          elements: mergedElements, 
+          index: await awu(pi.entries()).toArray(),
+          serviceConfigs: {salto: configs[0]}
+        }),
+        ['salto'],
+        createInMemoryElementSource([existingElement]),
+        createInMemoryElementSource([existingElement]),
+        configs
+      )
+    })
+
+
+    
+    it('should return all merged elements of the fetched services', () => {
+      const elemIDSorter = (a: Element, b: Element): number => {
+        if (a.elemID.getFullName() > b.elemID.getFullName()) {
+          return -1
+        }
+        if (a.elemID.getFullName() < b.elemID.getFullName()) {
+          return 1
+        }
+        return 0
+      }
+
+      const allMerged = [...fetchRes.elements]
+      expect(allMerged.sort(elemIDSorter)).toEqual(mergedElements
+        .filter(e => e.elemID.adapter === 'salto')
+        .sort(elemIDSorter))
+    })
+
+    it('should return all unmerged elements fragments with the same pathes as the source pathes', () => {
+      const unmerged = [...fetchRes.unmergedElements]
+      const expectedFrags = unmergedElements.filter(e => e.elemID.adapter === 'salto')
+      expect(unmerged).toHaveLength(expectedFrags.length)
+      expectedFrags
+        .forEach(frag => expect(unmerged.filter(e => e.isEqual(frag))).toHaveLength(1))
+    })
+
+    it('should create changes based on the current elements', () => {
+      const changes = [...fetchRes.changes]
+      const unmergedDiffElement = unmergedElements
+        .filter(elem => elem.elemID.getFullName() === 'salto.obj')
+      expect(changes).toHaveLength(unmergedDiffElement.length)
+      const changesElements = changes
+        .map(change => getChangeElement(change.change))
+      unmergedDiffElement
+        .forEach(frag => expect(changesElements.filter(e => e.isEqual(frag))).toHaveLength(1))
     })
   })
 })

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -25,7 +25,7 @@ import {
 } from '@salto-io/adapter-api'
 import * as utils from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { elementSource, pathIndex } from '@salto-io/workspace'
+import { elementSource, pathIndex, remoteMap } from '@salto-io/workspace'
 import { mockFunction } from '@salto-io/test-utils'
 import { mockWorkspace } from '../common/workspace'
 import {
@@ -34,7 +34,6 @@ import {
 } from '../../src/core/fetch'
 import { getPlan, Plan } from '../../src/core/plan'
 import { createElementSource } from '../common/helpers'
-import { InMemoryRemoteMap } from '@salto-io/workspace/dist/src/workspace/remote_map'
 
 const { createInMemoryElementSource } = elementSource
 const { awu } = collections.asynciterable
@@ -1127,7 +1126,7 @@ describe('fetch from workspace', () => {
   describe('workspace mismatch errors', () => {
     it('should fail when attempting to fetch an env not present in the source workspace', async () => {
       const sourceWS = mockWorkspace({
-        services: ['salto']
+        services: ['salto'],
       })
 
       const fetchRes = await fetchChangesFromWorkspace(
@@ -1149,7 +1148,7 @@ describe('fetch from workspace', () => {
 
     it('should fail when attempting to fetch a service not present in the source workspace', async () => {
       const sourceWS = mockWorkspace({
-        services: ['salto']
+        services: ['salto'],
       })
 
       const fetchRes = await fetchChangesFromWorkspace(
@@ -1170,7 +1169,7 @@ describe('fetch from workspace', () => {
     it('should fail if the source workspace has errors', async () => {
       const sourceWS = mockWorkspace({
         services: ['salto'],
-        errors: [{'message' : 'A glitch', 'severity': 'Error'}]
+        errors: [{ message: 'A glitch', severity: 'Error' }],
       })
 
       const fetchRes = await fetchChangesFromWorkspace(
@@ -1194,27 +1193,27 @@ describe('fetch from workspace', () => {
           'salto_config',
           new TypeReference(ElemID.fromFullName('salto_config')),
           {
-            key: 'value'
+            key: 'value',
           }
         ),
         new InstanceElement(
           'salto_config2',
           new TypeReference(ElemID.fromFullName('salto_config2')),
           {
-            key: 'value2'
+            key: 'value2',
           }
-        )
+        ),
       ]
 
       const sourceServiceConfigs = {
-        salto_config : currentServiceConfigs[0].clone(),
-        salto_config2: currentServiceConfigs[1].clone()
+        salto_config: currentServiceConfigs[0].clone(),
+        salto_config2: currentServiceConfigs[1].clone(),
       }
       sourceServiceConfigs.salto_config2.value.key = 'otherValue'
       const sourceWS = mockWorkspace({
-        serviceConfigs : sourceServiceConfigs
+        serviceConfigs: sourceServiceConfigs,
       })
-      
+
       const fetchRes = await fetchChangesFromWorkspace(
         sourceWS,
         ['salto'],
@@ -1236,88 +1235,88 @@ describe('fetch from workspace', () => {
     const objElemId = new ElemID('salto', 'obj')
     const objFragStdFields = new ObjectType({
       elemID: objElemId,
-      fields : {
+      fields: {
         stdField: {
           refType: createRefToElmWithValue(BuiltinTypes.STRING),
-          annotations : {
-            'test' : 'test'
-          }
-        }
+          annotations: {
+            test: 'test',
+          },
+        },
       },
-      path: ['salto', 'obj', 'standardFields']
+      path: ['salto', 'obj', 'standardFields'],
     })
     const objFragCustomFields = new ObjectType({
       elemID: objElemId,
-      fields : {
+      fields: {
         customField: {
           refType: createRefToElmWithValue(BuiltinTypes.NUMBER),
-          annotations : {
-            'test' : 'test'
-          }
-        }
+          annotations: {
+            test: 'test',
+          },
+        },
       },
-      path: ['salto', 'obj', 'customFields']
+      path: ['salto', 'obj', 'customFields'],
     })
     const objFragAnnotations = new ObjectType({
       elemID: objElemId,
       annotationRefsOrTypes: {
-        anno : createRefToElmWithValue(BuiltinTypes.STRING)
+        anno: createRefToElmWithValue(BuiltinTypes.STRING),
       },
-      annotations : {
-        anno: 'Anno!!!! Anno!!!! Annnooooooooooo!!!!!!!!'
+      annotations: {
+        anno: 'Anno!!!! Anno!!!! Annnooooooooooo!!!!!!!!',
       },
-      path: ['salto', 'obj', 'annotations']
+      path: ['salto', 'obj', 'annotations'],
     })
 
-     const objFull = new ObjectType({
+    const objFull = new ObjectType({
       elemID: objElemId,
-      fields : {
+      fields: {
         stdField: {
           refType: createRefToElmWithValue(BuiltinTypes.STRING),
-          annotations : {
-            'test' : 'test'
-          }
+          annotations: {
+            test: 'test',
+          },
         },
         customField: {
           refType: createRefToElmWithValue(BuiltinTypes.NUMBER),
-          annotations : {
-            'test' : 'test'
-          }
-        }
+          annotations: {
+            test: 'test',
+          },
+        },
       },
       annotationRefsOrTypes: {
-        anno : createRefToElmWithValue(BuiltinTypes.STRING)
+        anno: createRefToElmWithValue(BuiltinTypes.STRING),
       },
-      annotations : {
-        anno: 'Anno!!!! Anno!!!! Annnooooooooooo!!!!!!!!'
+      annotations: {
+        anno: 'Anno!!!! Anno!!!! Annnooooooooooo!!!!!!!!',
       },
     })
     const otherAdapterElem = new ObjectType({
       elemID: new ElemID('other', 'obj'),
-      path: ['other', 'obj', 'all']
+      path: ['other', 'obj', 'all'],
     })
     const existingElement = new ObjectType({
       elemID: new ElemID('salto', 'existing'),
-      path: ['salto', 'existing', 'all']
+      path: ['salto', 'existing', 'all'],
     })
     const mergedElements = [objFull, existingElement, otherAdapterElem]
     const unmergedElements = [
-      objFragStdFields, objFragCustomFields, 
-      objFragAnnotations, existingElement, otherAdapterElem
+      objFragStdFields, objFragCustomFields,
+      objFragAnnotations, existingElement, otherAdapterElem,
     ]
-    const pi = new InMemoryRemoteMap<pathIndex.Path[]>()
+    const pi = new remoteMap.InMemoryRemoteMap<pathIndex.Path[]>()
     let fetchRes: FetchChangesResult
 
     beforeEach(async () => {
       await pathIndex.overridePathIndex(pi, unmergedElements)
       const configs = [
-        new InstanceElement('_config', new ReferenceExpression(new ElemID('salto')))
+        new InstanceElement('_config', new ReferenceExpression(new ElemID('salto'))),
       ]
       fetchRes = await fetchChangesFromWorkspace(
         mockWorkspace({
-          elements: mergedElements, 
+          elements: mergedElements,
           index: await awu(pi.entries()).toArray(),
-          serviceConfigs: {salto: configs[0]}
+          serviceConfigs: { salto: configs[0] },
         }),
         ['salto'],
         createInMemoryElementSource([existingElement]),
@@ -1327,7 +1326,6 @@ describe('fetch from workspace', () => {
     })
 
 
-    
     it('should return all merged elements of the fetched services', () => {
       const elemIDSorter = (a: Element, b: Element): number => {
         if (a.elemID.getFullName() > b.elemID.getFullName()) {

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
 import { ElemID, Element, Value, Field, isObjectType, isInstanceElement,
   ObjectType, InstanceElement } from '@salto-io/adapter-api'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { safeJsonStringify, filterByID } from '@salto-io/adapter-utils'
 import { RemoteMapEntry, RemoteMap } from './remote_map'
 
 const { awu } = collections.asynciterable
@@ -221,4 +221,34 @@ export const getFromPathIndex = async (
     idParts.pop()
   } while (idParts.length > 0 && key !== topLevelKey)
   return []
+}
+
+export const splitElementByPath = async (
+  element: Element,
+  index: PathIndex
+): Promise<Element[]> => {
+  const setPath = (origElement: Element, path: Path): Element => {
+    const clonedElement = origElement.clone()
+    clonedElement.path = path
+    return clonedElement
+  }
+
+  const changeHints = await getFromPathIndex(element.elemID, index)
+  if (changeHints.length <= 1) {
+    return [setPath(element, changeHints[0])]
+  }
+
+  return (await Promise.all(changeHints.map(async hint => {
+    const filterByPathHint = async (id: ElemID): Promise<boolean> => {
+      const idHints = await getFromPathIndex(id, index)
+      return idHints.some(idHint => _.isEqual(idHint, hint))
+    }
+    const filteredElement = await filterByID(
+      element.elemID,
+      element,
+      filterByPathHint
+    )
+
+    return filteredElement ? setPath(filteredElement, hint) : undefined
+  }))).filter(values.isDefined)
 }

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -225,9 +225,9 @@ export const loadWorkspace = async (
     workspaceConfig.envs
   const services = (env?: string): string[] => {
     const envConf = env
-      ? makeArray(workspaceConfig.envs).find(e => e.name === currentEnv()) as EnvConfig
+      ? makeArray(workspaceConfig.envs).find(e => e.name === env)
       : currentEnvConf()
-    return envConf ? makeArray(envConf.services) : []
+    return makeArray(envConf?.services)
   }
   const state = (envName?: string): State => (
     enviormentsSources.sources[envName ?? currentEnv()].state as State
@@ -650,15 +650,16 @@ export const loadWorkspace = async (
     return { ...error, sourceFragments: [] }
   }
 
-  const errors = async (env: string = currentEnv()): Promise<Errors> => {
+  const errors = async (env?: string): Promise<Errors> => {
+    const envToUse = env ?? currentEnv()
     const currentState = await getWorkspaceState()
     const loadNaclFileSource = getOrCreateNaclFilesSource(env)
     // It is important to make sure these are obtain using Promise.all in order to allow
     // the SaaS UI to debouce the DB accesses.
     const [errorsFromSource, validationErrors, mergeErrors] = await Promise.all([
       loadNaclFileSource.getErrors(),
-      awu(currentState.states[env].validationErrors.values()).flat().toArray(),
-      awu(currentState.states[env].errors.values()).flat().toArray(),
+      awu(currentState.states[envToUse].validationErrors.values()).flat().toArray(),
+      awu(currentState.states[envToUse].errors.values()).flat().toArray(),
     ])
     _(validationErrors)
       .groupBy(error => error.constructor.name)

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -109,7 +109,7 @@ export type Workspace = {
   state: (envName?: string) => State
   envs: () => ReadonlyArray<string>
   currentEnv: () => string
-  services: () => string[]
+  services: (env?: string) => string[]
   servicesCredentials: (names?: ReadonlyArray<string>) =>
     Promise<Readonly<Record<string, InstanceElement>>>
   serviceConfig: (name: string, defaultValue?: InstanceElement) =>
@@ -120,7 +120,7 @@ export type Workspace = {
   hasElementsInEnv(envName: string): Promise<boolean>
   envOfFile(filename: string): string
   getSourceFragment(sourceRange: SourceRange): Promise<SourceFragment>
-  hasErrors(): Promise<boolean>
+  hasErrors(env?: string): Promise<boolean>
   errors(): Promise<Readonly<Errors>>
   transformToWorkspaceError<T extends SaltoElementError>(saltoElemErr: T):
     Promise<Readonly<WorkspaceError<T>>>
@@ -223,7 +223,12 @@ export const loadWorkspace = async (
     makeArray(workspaceConfig.envs).find(e => e.name === currentEnv()) as EnvConfig
   const currentEnvsConf = (): EnvConfig[] =>
     workspaceConfig.envs
-  const services = (): string[] => makeArray(currentEnvConf().services)
+  const services = (env?: string): string[] => {
+    const envConf = env
+      ? makeArray(workspaceConfig.envs).find(e => e.name === currentEnv()) as EnvConfig
+      : currentEnvConf()
+    return envConf ? makeArray(envConf.services) : []
+  }
   const state = (envName?: string): State => (
     enviormentsSources.sources[envName ?? currentEnv()].state as State
   )
@@ -645,15 +650,15 @@ export const loadWorkspace = async (
     return { ...error, sourceFragments: [] }
   }
 
-  const errors = async (): Promise<Errors> => {
+  const errors = async (env: string = currentEnv()): Promise<Errors> => {
     const currentState = await getWorkspaceState()
-    const loadNaclFileSource = await getLoadedNaclFilesSource()
+    const loadNaclFileSource = getOrCreateNaclFilesSource(env)
     // It is important to make sure these are obtain using Promise.all in order to allow
     // the SaaS UI to debouce the DB accesses.
     const [errorsFromSource, validationErrors, mergeErrors] = await Promise.all([
       loadNaclFileSource.getErrors(),
-      awu(currentState.states[currentEnv()].validationErrors.values()).flat().toArray(),
-      awu(currentState.states[currentEnv()].errors.values()).flat().toArray(),
+      awu(currentState.states[env].validationErrors.values()).flat().toArray(),
+      awu(currentState.states[env].errors.values()).flat().toArray(),
     ])
     _(validationErrors)
       .groupBy(error => error.constructor.name)
@@ -689,7 +694,7 @@ export const loadWorkspace = async (
     currentEnv,
     services,
     errors,
-    hasErrors: async () => (await errors()).hasErrors(),
+    hasErrors: async (env?: string) => (await errors(env)).hasErrors(),
     servicesCredentials: async (names?: ReadonlyArray<string>) => _.fromPairs(await Promise.all(
       pickServices(names).map(async service => [service, await credentials.get(credsPath(service))])
     )),


### PR DESCRIPTION
_Added ability to fetch from another workspace to the cli_

This PR includes:
1. Adding a core functionality to fetch from another workspace
2. Adding an argument to the fetch command that enables it to use the new function using a workspace

Future SaaS implementation will work in a similar way with a workspace that uses remote maps utilizing the existing wslc API
---

Still need to add all of the tests, but figured I'll create this PR for early review. Tested manually for the following scenarios:
1. Simple fetch from another workspace (with all types of changes)
2. Iterative fetches after fetching the source workspace to detect changes
3. Both of the above but from the source workspace non active env
4. Both of the above but the source workspace has errors
5. Missing services in the source workspace
6. Missing env in the source workspace
7. Invalid source workspace path

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
