### PR TITLE
Clarify move-to-common and move-to-envs docs

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -386,8 +386,8 @@ Manage the workspace environments
 Manage the workspace configuration elements
 
 **Commands:**
-* `move-to-common <elementSelector...>` :  Move configuration elements to the common configuration
-* `move-to-envs <elementSelector...>` :    Move configuration elements to the env-specific configuration
+* `move-to-common <elementSelector...>` :  Move env-specific configuration elements to the common configuration
+* `move-to-envs <elementSelector...>` :    Move common configuration elements to env-specific configurations
 * `clone <elementSelector...>` :           Clone elements from one env-specific configuration to others
 * `list-unresolved` :                      Lists unresolved references to configuration elements
 

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -159,7 +159,7 @@ export const moveToCommonAction: WorkspaceCommandAction<ElementMoveToCommonArgs>
 const moveToCommonDef = createWorkspaceCommand({
   properties: {
     name: 'move-to-common',
-    description: 'Move configuration elements to the common configuration',
+    description: 'Move env-specific configuration elements to the common configuration',
     positionalOptions: [
       {
         name: 'elementSelector',
@@ -213,7 +213,7 @@ export const moveToEnvsAction: WorkspaceCommandAction<ElementMoveToEnvsArgs> = a
 const moveToEnvsDef = createWorkspaceCommand({
   properties: {
     name: 'move-to-envs',
-    description: 'Move configuration elements to the env-specific configuration',
+    description: 'Move common configuration elements to env-specific configurations',
     positionalOptions: [
       {
         name: 'elementSelector',


### PR DESCRIPTION
Improved the documentation and CLI help for element move-to-common and move-to-envs to clearly indicate source and destination configurations.

---
_Release Notes_: 
Better documentation for element move-to-common and move-to-envs commands.
