### PR TITLE
SALTO-1601 fix workato id uniqueness for api endpoints

### DIFF
--- a/packages/workato-adapter/src/config.ts
+++ b/packages/workato-adapter/src/config.ts
@@ -99,6 +99,9 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       url: '/api_endpoints',
       paginationField: 'page',
     },
+    transformation: {
+      idFields: ['name', 'base_path'],
+    },
   },
   // eslint-disable-next-line camelcase
   api_client: {

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -82,7 +82,7 @@ describe('adapter', () => {
           'workato.api_collection',
           'workato.api_collection.instance.test1',
           'workato.api_endpoint',
-          'workato.api_endpoint.instance.ep321',
+          'workato.api_endpoint.instance.ep321__somedomainname_test1_v10_user__id_@uddbdd_00123_00125',
           'workato.connection',
           'workato.connection.instance.HTTP_connection_1@s',
           'workato.connection.instance.My_Gmail_connection@s',


### PR DESCRIPTION
API endpoint names are not unique - but the path they define is.
Keeping the name as part of the id as well to make the element easier to find (we can change that when we add aliases).


---
_Release Notes_: 
Workato adapter:
* Fix id definiton for API endpoints, to avoid omitting elements when multiple endpoints use the same name.

---
_User Notifications_: 
None (won't impact existing workspaces)