### PR TITLE
Change merge errors log level

### DIFF
--- a/packages/workspace/src/merger/index.ts
+++ b/packages/workspace/src/merger/index.ts
@@ -90,7 +90,7 @@ export const mergeElements = async (
   log.debug(`merged ${elementsCounter} elements to ${mergedCounter} elements [errors=${
     errorsCounter}]`)
   if (errorsCounter > 0) {
-    log.debug(`All merge errors:\n${(await awu(errors.values())
+    log.warn(`All merge errors:\n${(await awu(errors.values())
       .flatMap(elemErrs => elemErrs.map(e => e.message)).toArray())
       .join('\n')}`)
   }


### PR DESCRIPTION
Changed merge errors log level from debug to warning to make it easier to spot on datadog

---
_Release Notes_: 
None

---
_User Notifications_: 
None