### PR TITLE
SAAS-3034: added retries to suiteapp soap requests

### DIFF
--- a/packages/netsuite-adapter/test/client/soap_client.test.ts
+++ b/packages/netsuite-adapter/test/client/soap_client.test.ts
@@ -69,6 +69,28 @@ describe('soap_client', () => {
       fn => fn(),
     )
   })
+
+
+  describe('retries', () => {
+    it('when succeeds within the permitted retries should return the results', async () => {
+      getAsyncMock.mockRejectedValueOnce(new Error())
+      getAsyncMock.mockResolvedValueOnce([{
+        readResponse: {
+          record: {
+            content: 'ZGVtbw==',
+          },
+          status: { attributes: { isSuccess: 'true' } },
+        },
+      }])
+      expect(await client.readFile(1)).toEqual(Buffer.from('demo'))
+      expect(getAsyncMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('when still failing after the permitted retries should throw', async () => {
+      getAsyncMock.mockRejectedValue(new Error())
+      await expect(client.readFile(1)).rejects.toThrow()
+    })
+  })
   it('client should be cached', async () => {
     getAsyncMock.mockResolvedValue([{
       readResponse: {


### PR DESCRIPTION
Added retries to the SuiteApp Soap operation

---

We saw when fetching from Varonis account the following error https://salto-io.atlassian.net/browse/SAAS-3034 . I think it comes from the SuiteApp Soap operation so I added a retry

---
_Release Notes_:
Bugfix: 
Netsuite Adapter:
Added retry for soap requests operations for connection errors

---
_User Notifications_: 
None