### PR TITLE
SAAS-2711: split getUsageInFile to saas usage

### DIFF
--- a/packages/lang-server/src/usage.ts
+++ b/packages/lang-server/src/usage.ts
@@ -99,15 +99,21 @@ export const getReferencingFiles = async (
   }
 }
 
+export const getUsageOfElements = async (
+  elements: AsyncIterable<Element>,
+  id: ElemID,
+): Promise<ElemID[]> =>
+  awu(elements)
+    .flatMap(async e => getElemIDUsages(e, id))
+    .map(fullname => ElemID.fromFullName(fullname))
+    .toArray()
+
 export const getUsageInFile = async (
   workspace: EditorWorkspace,
   filename: string,
   id: ElemID
 ): Promise<ElemID[]> =>
-  awu(await workspace.getElements(filename))
-    .flatMap(async e => getElemIDUsages(e, id))
-    .map(fullname => ElemID.fromFullName(fullname))
-    .toArray()
+  getUsageOfElements(awu(await workspace.getElements(filename)), id)
 
 export const getWorkspaceReferences = async (
   workspace: EditorWorkspace,


### PR DESCRIPTION
_split getUsageInFile to saas usage_

---

https://salto-io.atlassian.net/browse/SAAS-2711
---
_Release Notes_: 
_None_

---
