### PR TITLE
SALTO-1586 handles different cases of envs.nacl

### DIFF
--- a/packages/cli/src/commands/common/env.ts
+++ b/packages/cli/src/commands/common/env.ts
@@ -40,5 +40,8 @@ export const validateAndSetEnv = async (
       throw new CliError(CliExitCode.UserInputError)
     }
     await workspace.setCurrentEnv(envArg.env, false)
+  } else if (workspace.currentEnv() === undefined) {
+    errorOutputLine('No environment is currently set', cliOutput)
+    throw new CliError(CliExitCode.UserInputError)
   }
 }

--- a/packages/cli/src/commands/common/services.ts
+++ b/packages/cli/src/commands/common/services.ts
@@ -35,7 +35,7 @@ export const getAndValidateActiveServices = (
 ): string[] => {
   const workspaceServices = workspace.services()
   if (workspaceServices.length === 0) {
-    throw new Error(`No services are configured for env=${workspace.currentEnv()}. Use 'salto service add'.`)
+    throw new Error('No services are configured for the current env. Use \'salto service add\'.')
   }
   if (inputServices === undefined) {
     return [...workspaceServices]

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -587,9 +587,10 @@ export const formatAddServiceFailed = (serviceName: string, errorMessage: string
 ].join('\n')
 
 export const formatEnvListItem = (envNames: ReadonlyArray<string>, currentEnv?: string): string => (
-  envNames
-    .map(name => `${name === currentEnv ? '*' : ' '} ${name}`)
-    .join('\n')
+  envNames.length > 0
+    ? envNames.map(name => `${name === currentEnv ? '*' : ' '} ${name}`).join('\n')
+    : `${Prompts.NO_ENVS}.
+${Prompts.ENV_CREATE_HELP}`
 )
 
 export const formatCurrentEnv = (envName?: string): string => (

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -69,6 +69,7 @@ export default class Prompts {
   }
 
   private static readonly SERVICE_ADD_HELP = 'Use `salto service add <service-name>` to add services to the environment'
+  public static readonly ENV_CREATE_HELP = 'Use `salto env create <envName>` to create an environment'
 
   public static initCompleted(): string {
     return `Initiated empty workspace
@@ -159,6 +160,7 @@ The steps are: I. Fetching configs, II. Calculating difference and III. Applying
   public static readonly SERVICE_NAME_NOT_VALID = (serviceName: string, supportedServiceAdapters:string[]): string => `${serviceName} is not a valid service name, available service names are:\n${supportedServiceAdapters.join('\n')}`
   public static readonly WORKING_ON_ENV = 'The active environment is'
   public static readonly NO_CURRENT_ENV = 'No active environment is currently set'
+  public static readonly NO_ENVS = 'There are no environments in this workspace'
   public static readonly SET_ENV = 'Active environment is set to'
   public static readonly DELETED_ENV = (envName: string): string => `Deleted environment - ${envName}`
   public static readonly CREATED_ENV = (envName: string): string =>

--- a/packages/cli/test/commands/commons.test.ts
+++ b/packages/cli/test/commands/commons.test.ts
@@ -16,6 +16,7 @@
 import { DetailedChange, ElemID, Value } from '@salto-io/adapter-api'
 import * as mocks from '../mocks'
 import { getAndValidateActiveServices } from '../../src/commands/common/services'
+import { validateAndSetEnv, EnvArg } from '../../src/commands/common/env'
 import { getConfigOverrideChanges } from '../../src/commands/common/config_override'
 
 describe('Commands commons tests', () => {
@@ -44,6 +45,14 @@ describe('Commands commons tests', () => {
 
     it('Should throw an error if input services were provided', () => {
       expect(() => getAndValidateActiveServices(mockWorkspace, ['wtfService'])).toThrow()
+    })
+  })
+  describe('validateAndSetEnv with workspace with no current environment', () => {
+    const mockWorkspace = mocks.mockWorkspace({ envs: [] })
+    const envArg: EnvArg = {}
+    const cliArgs = mocks.mockCliArgs()
+    it('Should throw an error if no environment is currently set', async () => {
+      await expect(validateAndSetEnv(mockWorkspace, envArg, cliArgs.output)).rejects.toThrow()
     })
   })
   describe('getConfigOverrideChanges', () => {

--- a/packages/core/src/local-workspace/errors.ts
+++ b/packages/core/src/local-workspace/errors.ts
@@ -26,3 +26,9 @@ export class NoEnvsConfig extends Error {
     super('cannot find envs config')
   }
 }
+
+export class EnvsConfigError extends Error {
+  constructor() {
+    super('envs config contains errors')
+  }
+}

--- a/packages/core/src/local-workspace/workspace_config.ts
+++ b/packages/core/src/local-workspace/workspace_config.ts
@@ -22,7 +22,7 @@ import { getSaltoHome, CONFIG_DIR_NAME } from '../app_config'
 import { WORKSPACE_CONFIG_NAME, ENVS_CONFIG_NAME, EnvsConfig,
   USER_CONFIG_NAME, UserDataConfig, WorkspaceMetadataConfig, envsConfigInstance,
   userDataConfigInstance, workspaceMetadataConfigInstance } from './workspace_config_types'
-import { NoWorkspaceConfig, NoEnvsConfig } from './errors'
+import { NoWorkspaceConfig, NoEnvsConfig, EnvsConfigError } from './errors'
 
 
 export type WorkspaceConfigSource = wcs.WorkspaceConfigSource & {
@@ -60,6 +60,9 @@ export const workspaceConfigSource = async (
       }
       if (_.isUndefined(envs)) {
         throw new NoEnvsConfig()
+      }
+      if (envs.envs === undefined || envs.envs.map(e => Boolean(e.name)).includes(false)) {
+        throw new EnvsConfigError()
       }
       return {
         ...envs,

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -211,11 +211,8 @@ export const loadWorkspace = async (
   const workspaceConfig = await config.getWorkspaceConfig()
   log.debug('Loading workspace with id: %s', workspaceConfig.uid)
 
-  if (_.isEmpty(workspaceConfig.envs)) {
-    throw new Error('Workspace with no environments is illegal')
-  }
   const envs = (): ReadonlyArray<string> => workspaceConfig.envs.map(e => e.name)
-  const currentEnv = (): string => workspaceConfig.currentEnv ?? workspaceConfig.envs[0].name
+  const currentEnv = (): string => workspaceConfig.currentEnv ?? workspaceConfig.envs[0]?.name
   const getRemoteMapNamespace = (
     namespace: string, env?: string
   ): string => `workspace-${env || currentEnv()}-${namespace}`
@@ -685,7 +682,7 @@ export const loadWorkspace = async (
   }
   const pickServices = (names?: ReadonlyArray<string>): ReadonlyArray<string> =>
     (_.isUndefined(names) ? services() : services().filter(s => names.includes(s)))
-  const credsPath = (service: string): string => path.join(currentEnv(), service)
+  const credsPath = (service: string): string => path.join(currentEnv() ?? '', service)
   return {
     uid: workspaceConfig.uid,
     name: workspaceConfig.name,

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -154,15 +154,16 @@ const getElemMap = async (
 
 describe('workspace', () => {
   describe('loadWorkspace', () => {
-    it('should fail if envs is empty', async () => {
+    it('should return envs=[] currentEnv=undefined', async () => {
       const noWorkspaceConfig = {
         getWorkspaceConfig: jest.fn().mockImplementation(() => ({ envs: [] })),
         setWorkspaceConfig: jest.fn(),
         getAdapter: jest.fn(),
         setAdapter: jest.fn(),
       }
-      await expect(createWorkspace(undefined, undefined, noWorkspaceConfig)).rejects
-        .toThrow(new Error('Workspace with no environments is illegal'))
+      const workspace = await createWorkspace(undefined, undefined, noWorkspaceConfig)
+      expect(workspace.envs()).toEqual([])
+      expect(workspace.currentEnv()).toBeUndefined()
     })
   })
   describe('elements', () => {


### PR DESCRIPTION
handles case of envs.nacl:
- if envs.nacl is missing- throws NoEnvsConfig
- if envs.nacl is missing 'envs' keyword or 'name' keyword for any env object- throws EnvsConfigError
- if envs list is empty- 'salto env list' and 'salto env create' would work, but some other commands would fail because there's no current env that is set.