### PR TITLE
SALTO-1635 - Added layout to exclude list.

### DIFF
--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -464,6 +464,10 @@ export const configType = new ObjectType({
                 name: '^(AddressCountryCode)|(AddressStateCode)$',
                 namespace: '',
               },
+              {
+                metadataType: 'Layout',
+                name: 'CollaborationGroup-Group Layout',
+              },
             ],
           },
           [SHOULD_FETCH_ALL_CUSTOM_SETTINGS]: false,


### PR DESCRIPTION
Excluding Layout (CollaborationGroup-Group Layout) that causes additions & removals noises in SalesForce adapter.

---
_Release Notes_: 
Salesforce Adapter:
- Added CollaborationGroup-Group Layout to default exclude list for new workspaces
---
_User Notifications_: 
_None_
