### PR TITLE
SALTO-1658 Fix Zuora settings payment gateway cards fields

### DIFF
--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -36,7 +36,7 @@ type TypeAdderType = (
   schema: SchemaOrReference,
   origTypeName: string,
   endpointName?: string,
-) => PrimitiveType | ObjectType
+) => PrimitiveType | ObjectType | ListType
 
 /**
  * Helper function for creating type elements for the given swagger definitions.
@@ -233,6 +233,13 @@ const typeAdder = ({
     )
 
     if (isObjectSchema(schema)) {
+      // top-level schemas are still created as object types
+      if (isArraySchemaObject(schema) && endpointName === undefined) {
+        return new ListType(addType(
+          schema.items,
+          typeName,
+        ))
+      }
       return toObjectType(
         schema,
         typeName,

--- a/packages/adapter-components/test/elements/swagger/petstore_openapi.v3.json
+++ b/packages/adapter-components/test/elements/swagger/petstore_openapi.v3.json
@@ -1087,7 +1087,10 @@
               "brand": {
                 "type": "string"
               },
-              "additionalProperties": {
+              "storage": {
+                "$ref": "#/components/schemas/FoodStorageType"
+              },
+                "additionalProperties": {
                 "$ref": "#/components/schemas/Category"
               }
             }
@@ -1123,6 +1126,12 @@
             "$ref": "#/components/schemas/Category"
           }
         ]
+      },
+      "FoodStorageType": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       },
       "User": {
         "allOf": [

--- a/packages/adapter-components/test/elements/swagger/petstore_openapi.v3.json
+++ b/packages/adapter-components/test/elements/swagger/petstore_openapi.v3.json
@@ -1090,7 +1090,7 @@
               "storage": {
                 "$ref": "#/components/schemas/FoodStorageType"
               },
-                "additionalProperties": {
+              "additionalProperties": {
                 "$ref": "#/components/schemas/Category"
               }
             }

--- a/packages/adapter-components/test/elements/swagger/petstore_openapi.v3.yaml
+++ b/packages/adapter-components/test/elements/swagger/petstore_openapi.v3.yaml
@@ -708,6 +708,8 @@ components:
             format: int64
           brand:
             type: string
+          storage:
+            $ref: '#/components/schemas/FoodStorageType'
           additionalProperties:
             $ref: '#/components/schemas/Category'
     FoodAndCategory:
@@ -722,6 +724,10 @@ components:
       oneOf:
       - $ref: '#/components/schemas/Food'
       - $ref: '#/components/schemas/Category'
+    FoodStorageType:
+      type: array
+      items:
+        type: string
     User:
       allOf:
       - type: object

--- a/packages/adapter-components/test/elements/swagger/petstore_swagger.v2.json
+++ b/packages/adapter-components/test/elements/swagger/petstore_swagger.v2.json
@@ -961,6 +961,9 @@
             "brand": {
               "type": "string"
             },
+            "storage": {
+              "$ref": "#/definitions/FoodStorageType",
+            },
             "additionalProperties": {
               "$ref": "#/definitions/Category"
             }
@@ -984,6 +987,12 @@
       ],
       "xml": {
         "name": "FoodAndCategory"
+      }
+    },
+    "FoodStorageType": {
+      "type": "array",
+      "items": {
+        "type": "string"
       }
     },
     "User": {

--- a/packages/adapter-components/test/elements/swagger/petstore_swagger.v2.yaml
+++ b/packages/adapter-components/test/elements/swagger/petstore_swagger.v2.yaml
@@ -657,6 +657,8 @@ definitions:
           format: int64
         brand:
           type: string
+        storage:
+          $ref: '#/definitions/FoodStorageType'
         additionalProperties:
           $ref: '#/definitions/Category'
       type: object
@@ -669,6 +671,10 @@ definitions:
     - $ref: '#/definitions/Category'
     xml:
       name: FoodAndCategory
+  FoodStorageType:
+    type: array
+    items:
+      type: string
   User:
     type: object
     allOf:

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -106,6 +106,7 @@ describe('swagger_type_elements', () => {
         expect(_.mapValues(food.fields, f => f.refType.elemID.getFullName())).toEqual({
           brand: 'string',
           id: 'number',
+          storage: 'List<string>',
           additionalProperties: 'Map<unknown>',
         })
 


### PR DESCRIPTION
Fix issue where if the swagger had a reference to a list instead of a list of references, we would create an intermediate object with an `items` field even in cases where we shouldn't. This impacted a few Zuora-Settings fields that had an unnecessary reference to a list of strings

---
_Release Notes_: 
Zuora-Billing adapter:
* Fix incorrect type for `cards` fields for Payment Gateways

---
_User Notifications_: 
Zuora-Billing:
* A few changes related to `Settings_Gateway` type and instances