### PR TITLE
add arm64 rocksdb prebuilds

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "@salto-io/logging": "0.3.3",
     "@salto-io/lowerdash": "0.3.3",
     "@salto-io/netsuite-adapter": "0.3.3",
-    "@salto-io/rocksdb": "5.1.1-salto-15",
+    "@salto-io/rocksdb": "5.1.1-salto-16",
     "@salto-io/salesforce-adapter": "0.3.3",
     "@salto-io/stripe-adapter": "0.3.3",
     "@salto-io/workato-adapter": "0.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1630,10 +1630,10 @@
     node-watch "0.7.1"
     xml2js "0.4.23"
 
-"@salto-io/rocksdb@5.1.1-salto-15":
-  version "5.1.1-salto-15"
-  resolved "https://registry.yarnpkg.com/@salto-io/rocksdb/-/rocksdb-5.1.1-salto-15.tgz#132c132ef147aba6c233fdee8b9410f478b8fe90"
-  integrity sha512-5fv4mwR2HBq9JcQCYDqj6TyUsclZ+lzSbmgrWckO7A7RW+yr8m0HvVaMAEf1JhGg90ZSpEoNGrMgCW1u1VBgdQ==
+"@salto-io/rocksdb@5.1.1-salto-16":
+  version "5.1.1-salto-16"
+  resolved "https://registry.yarnpkg.com/@salto-io/rocksdb/-/rocksdb-5.1.1-salto-16.tgz#49e15d82dde9cb1fed49da4bd43941005921d11e"
+  integrity sha512-059tSVGH6sSOY9hrYrAdp8jfcK3ZrkpMjcNVKpHgXiEXYyCytqdSeCWxngUoOUDyO4RTQ5mFPczEYsp13P+Dzw==
   dependencies:
     abstract-leveldown "^7.0.0"
     napi-macros "^2.0.0"


### PR DESCRIPTION
_add arm64 rocksdb prebuilds_

---

_Added prebuilds for arm64 - needed inorder to run salto in dev mode (when you don't use the binary)_

---