### PR TITLE
SALTO-1658 Fix Zuora settings gateway id fields

### DIFF
--- a/packages/zuora-billing-adapter/src/adapter.ts
+++ b/packages/zuora-billing-adapter/src/adapter.ts
@@ -22,7 +22,7 @@ import { client as clientUtils, config as configUtils, elements as elementUtils 
 import { logDuration } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import ZuoraClient from './client/client'
-import { ZuoraConfig, API_DEFINITIONS_CONFIG, FETCH_CONFIG, ZuoraApiConfig } from './config'
+import { ZuoraConfig, API_DEFINITIONS_CONFIG, FETCH_CONFIG, ZuoraApiConfig, getUpdatedConfig } from './config'
 import { FilterCreator, Filter, filtersRunner } from './filter'
 import fieldReferencesFilter from './filters/field_references'
 import objectDefsFilter from './filters/object_defs'
@@ -216,6 +216,11 @@ export default class ZuoraAdapter implements AdapterOperations {
     progressReporter.reportProgress({ message: 'Running filters for additional information' })
 
     await this.createFiltersRunner().onFetch(elements)
+
+    const updatedConfig = getUpdatedConfig(this.userConfig)
+    if (updatedConfig !== undefined) {
+      return { elements, updatedConfig }
+    }
     return { elements }
   }
 

--- a/packages/zuora-billing-adapter/src/config.ts
+++ b/packages/zuora-billing-adapter/src/config.ts
@@ -13,7 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, CORE_ANNOTATIONS, ListType, BuiltinTypes } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { ElemID, CORE_ANNOTATIONS, ListType, BuiltinTypes, InstanceElement } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
 import { ZUORA_BILLING, CUSTOM_OBJECT_DEFINITION_TYPE, LIST_ALL_SETTINGS_TYPE, SETTINGS_TYPE_PREFIX } from './constants'
@@ -261,6 +262,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: ZuoraApiConfig['types'] = {
       ],
     },
   },
+  [`${SETTINGS_TYPE_PREFIX}Gateway`]: {
+    transformation: {
+      idFields: ['gatewayName'],
+    },
+  },
   [`${SETTINGS_TYPE_PREFIX}Currency`]: {
     transformation: {
       idFields: ['currencyCode'],
@@ -482,4 +488,37 @@ export const configType = createMatchingObjectType<ZuoraConfig>({
 export type FilterContext = {
   [FETCH_CONFIG]: ZuoraFetchConfig
   [API_DEFINITIONS_CONFIG]: ZuoraApiConfig
+}
+
+const FIXING_SYSTEM_CONFIGURATION_INTRO = 'Fixing system configuration for the following types:'
+
+export const getUpdatedConfig = (
+  currentConfig: ZuoraConfig
+): { config: InstanceElement[]; message: string } | undefined => {
+  if (currentConfig[API_DEFINITIONS_CONFIG].types[`${SETTINGS_TYPE_PREFIX}Gateway`]?.transformation?.idFields === undefined) {
+    // fix id for Settings_Gateway
+    const updatedConfig = new InstanceElement(
+      ElemID.CONFIG_NAME,
+      configType,
+      _.defaultsDeep(
+        currentConfig,
+        {
+          [API_DEFINITIONS_CONFIG]: {
+            types: {
+              [`${SETTINGS_TYPE_PREFIX}Gateway`]: {
+                transformation: {
+                  idFields: ['gatewayName'],
+                },
+              },
+            },
+          },
+        },
+      ),
+    )
+    return {
+      config: [updatedConfig],
+      message: [FIXING_SYSTEM_CONFIGURATION_INTRO, `${SETTINGS_TYPE_PREFIX}Gateway`].join(' '),
+    }
+  }
+  return undefined
 }

--- a/packages/zuora-billing-adapter/src/config.ts
+++ b/packages/zuora-billing-adapter/src/config.ts
@@ -497,26 +497,25 @@ export const getUpdatedConfig = (
 ): { config: InstanceElement[]; message: string } | undefined => {
   if (currentConfig[API_DEFINITIONS_CONFIG].types[`${SETTINGS_TYPE_PREFIX}Gateway`]?.transformation?.idFields === undefined) {
     // fix id for Settings_Gateway
-    const updatedConfig = new InstanceElement(
-      ElemID.CONFIG_NAME,
-      configType,
-      _.defaultsDeep(
-        currentConfig,
-        {
-          [API_DEFINITIONS_CONFIG]: {
-            types: {
-              [`${SETTINGS_TYPE_PREFIX}Gateway`]: {
-                transformation: {
-                  idFields: ['gatewayName'],
+    return {
+      config: [new InstanceElement(
+        ElemID.CONFIG_NAME,
+        configType,
+        _.defaultsDeep(
+          currentConfig,
+          {
+            [API_DEFINITIONS_CONFIG]: {
+              types: {
+                [`${SETTINGS_TYPE_PREFIX}Gateway`]: {
+                  transformation: {
+                    idFields: ['gatewayName'],
+                  },
                 },
               },
             },
           },
-        },
-      ),
-    )
-    return {
-      config: [updatedConfig],
+        ),
+      )],
       message: [FIXING_SYSTEM_CONFIGURATION_INTRO, `${SETTINGS_TYPE_PREFIX}Gateway`].join(' '),
     }
   }

--- a/packages/zuora-billing-adapter/test/config.test.ts
+++ b/packages/zuora-billing-adapter/test/config.test.ts
@@ -1,0 +1,79 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { getUpdatedConfig, FETCH_CONFIG, DEFAULT_INCLUDE_TYPES, DEFAULT_SETTINGS_INCLUDE_TYPES, API_DEFINITIONS_CONFIG, DEFAULT_API_DEFINITIONS } from '../src/config'
+
+describe('config', () => {
+  describe('getUpdatedConfig', () => {
+    it('should not update the config when Settings_Gateway config is correct', () => {
+      expect(getUpdatedConfig({
+        [FETCH_CONFIG]: {
+          includeTypes: DEFAULT_INCLUDE_TYPES,
+          settingsIncludeTypes: DEFAULT_SETTINGS_INCLUDE_TYPES,
+        },
+        [API_DEFINITIONS_CONFIG]: DEFAULT_API_DEFINITIONS,
+      })).toBeUndefined()
+    })
+    it('should update the config when the ', () => {
+      const initialConfig = {
+        [FETCH_CONFIG]: {
+          includeTypes: DEFAULT_INCLUDE_TYPES,
+          settingsIncludeTypes: DEFAULT_SETTINGS_INCLUDE_TYPES,
+        },
+        [API_DEFINITIONS_CONFIG]: {
+          swagger: {
+            url: 'http://localhost:1234',
+          },
+          typeDefaults: {
+            transformation: {
+              idFields: ['a', 'b'],
+            },
+          },
+          types: {
+            aaa: {
+              transformation: {
+                idFields: ['a', 'b'],
+              },
+            },
+          },
+        },
+      }
+      const res = getUpdatedConfig(initialConfig)
+      expect(res).toBeDefined()
+      expect(res?.message).toEqual('Fixing system configuration for the following types: Settings_Gateway')
+      expect(res?.config).toHaveLength(1)
+      expect(res?.config[0].value).toEqual({
+        fetch: initialConfig[FETCH_CONFIG],
+        apiDefinitions: {
+          swagger: initialConfig[API_DEFINITIONS_CONFIG].swagger,
+          typeDefaults: initialConfig[API_DEFINITIONS_CONFIG].typeDefaults,
+          types: {
+            aaa: {
+              transformation: {
+                idFields: ['a', 'b'],
+              },
+            },
+            Settings_Gateway: {
+              transformation: {
+                idFields: ['gatewayName'],
+              },
+            },
+          },
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
Fix id for `Settings_Gateway` to use the gateway name + add a change suggestion to fix the system config.

---
_Release Notes_: 
Zuora-Billing adapter:
* Use indicative id for Payment Gateways

---
_User Notifications_: 
Zuora-Billing:
* A few changes related to `Settings_Gateway` type and instances