### PR TITLE
SALTO-1658 Handle type inconsistencies in transformValues

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -184,8 +184,10 @@ export const transformValues = async (
         : transformed
     }
 
-    if ((_.isPlainObject(newVal) || !allowEmpty)
-      && (isObjectType(fieldType) || isMapType(fieldType))) {
+    if (isObjectType(fieldType) || isMapType(fieldType)) {
+      if (!_.isPlainObject(newVal)) {
+        return newVal
+      }
       const transformed = _.omitBy(
         await transformValues({
           values: newVal,

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -186,7 +186,10 @@ export const transformValues = async (
 
     if (isObjectType(fieldType) || isMapType(fieldType)) {
       if (!_.isPlainObject(newVal)) {
-        return newVal
+        if (strict) {
+          log.debug(`Value mis-match for field ${field?.name} - value is not an object`)
+        }
+        return (_.isEmpty(newVal) && !allowEmpty) ? undefined : newVal
       }
       const transformed = _.omitBy(
         await transformValues({

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -892,7 +892,7 @@ describe('Test utils.ts', () => {
         })
       })
     })
-    describe('with InstanceElement', () => {
+    describe('with valid InstanceElement', () => {
       let result: InstanceElement
       beforeEach(async () => {
         result = await transformElement({ element: inst, transformFunc, strict: false })
@@ -923,7 +923,38 @@ describe('Test utils.ts', () => {
         expect(_.isEmpty(callArgs?.field?.annotations)).toBeFalsy()
       })
     })
+    describe('with invalid InstanceElement', () => {
+      let otherObjType: ObjectType
+      let invalidInst: InstanceElement
+      let result: InstanceElement
+      beforeEach(async () => {
+        const nestedType = new ObjectType({ elemID: new ElemID('salesforce', 'nested') })
+        otherObjType = new ObjectType({
+          elemID: new ElemID('salesforce', 'obj'),
+          fields: {
+            nested: { refType: nestedType },
+            nestedArray: { refType: new ListType(nestedType) },
+          },
+        })
+        invalidInst = new InstanceElement(
+          'invalid',
+          otherObjType,
+          {
+            nested: 'aaa',
+            nestedArray: ['aaa', 'bbb'],
+          },
+        )
 
+        result = await transformElement({ element: invalidInst, transformFunc, strict: false })
+      })
+      it('should return a new instance', () => {
+        expect(isInstanceElement(result)).toBeTruthy()
+      })
+      it('should correctly handle type inconsistencies', () => {
+        expect(result.value.nested).toEqual('aaa')
+        expect(result.value.nestedArray).toEqual(['aaa', 'bbb'])
+      })
+    })
     describe('allowEmpty', () => {
       const element = new InstanceElement(
         'instance',

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -927,7 +927,7 @@ describe('Test utils.ts', () => {
       let otherObjType: ObjectType
       let invalidInst: InstanceElement
       let result: InstanceElement
-      beforeEach(async () => {
+      beforeEach(() => {
         const nestedType = new ObjectType({ elemID: new ElemID('salesforce', 'nested') })
         otherObjType = new ObjectType({
           elemID: new ElemID('salesforce', 'obj'),
@@ -944,13 +944,16 @@ describe('Test utils.ts', () => {
             nestedArray: ['aaa', 'bbb'],
           },
         )
-
+      })
+      it('should correctly handle type inconsistencies when strict=false', async () => {
         result = await transformElement({ element: invalidInst, transformFunc, strict: false })
-      })
-      it('should return a new instance', () => {
         expect(isInstanceElement(result)).toBeTruthy()
+        expect(result.value.nested).toEqual('aaa')
+        expect(result.value.nestedArray).toEqual(['aaa', 'bbb'])
       })
-      it('should correctly handle type inconsistencies', () => {
+      it('should correctly handle type inconsistencies when strict=true', async () => {
+        result = await transformElement({ element: invalidInst, transformFunc, strict: true })
+        expect(isInstanceElement(result)).toBeTruthy()
         expect(result.value.nested).toEqual('aaa')
         expect(result.value.nestedArray).toEqual(['aaa', 'bbb'])
       })


### PR DESCRIPTION
Handle the case where a field's type is an object or array, while the instance value is a string (or string array).

---

Adding this as it was recently the cause of some invalid instance values (due to an incorrect type), there may be some other edge cases that can occur when types are inconsistent.

---
_Release Notes_: 
Core:
* Fix issue where if an instance had a nested string value while the field type expected an object, the string would be deconstructed in the nacl.

---
_User Notifications_: 
None (already covered in https://github.com/salto-io/salto/pull/2451)