### PR TITLE
SALTO-1563 Netsuite: Identify references that are only part of the field

### DIFF
--- a/packages/netsuite-adapter/src/filters/instance_references.ts
+++ b/packages/netsuite-adapter/src/filters/instance_references.ts
@@ -49,14 +49,15 @@ const isRegExpFullMatch = (regExpMatches: Array<RegExpExecArray | null>): boolea
 )
 
 const addDependencies = (instance: InstanceElement, deps: Array<ElemID>): void => {
+  if (deps.length === 0) {
+    return
+  }
   const dependenciesList = _.uniqBy(
     makeArray(instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES])
       .concat(deps.map(dep => ({ reference: new ReferenceExpression(dep) }))),
     ref => ref.reference.elemID.getFullName()
   )
-  if (dependenciesList.length > 0) {
-    instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] = dependenciesList
-  }
+  instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] = dependenciesList
 }
 
 /**


### PR DESCRIPTION
We encountered a situation where a value is composed of both string value and a reference.
1. A filter was added that split it to 2 fields and compose it back upon deploy.
2. Added generated dependency containing the references element while keeping the value as is.

---
_Release Notes_: 
* netsuite-adapter

---
_User Notifications_: 
A one time notification will appear due to the addition of _generaeted_dependencies annotation.
