### PR TITLE
SAAS-3250: fixed load workspace failure in some cases of syntax errors

### DIFF
--- a/packages/adapter-api/package.json
+++ b/packages/adapter-api/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@salto-io/dag": "0.3.3",
     "@salto-io/lowerdash": "0.3.3",
+    "@salto-io/logging": "0.3.3",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -18,7 +18,7 @@ import { BuiltinTypes, CORE_ANNOTATIONS } from '../src/builtins'
 import {
   Field, InstanceElement, ObjectType, PrimitiveType, isObjectType, isInstanceElement,
   PrimitiveTypes, ListType, isPrimitiveType, isType, isListType, isEqualElements, Variable,
-  isVariable, isMapType, MapType, isContainerType, createRefToElmWithValue,
+  isVariable, isMapType, MapType, isContainerType, createRefToElmWithValue, PlaceholderObjectType,
 } from '../src/elements'
 import { ElemID, INSTANCE_ANNOTATIONS } from '../src/element_id'
 import { TypeReference } from '../src/values'
@@ -765,6 +765,13 @@ describe('Test elements.ts', () => {
       const objRef = createRefToElmWithValue(obj)
       expect(objRef.elemID).toEqual(obj.elemID)
       expect(objRef.value).toEqual(obj)
+    })
+  })
+
+  describe('getType', () => {
+    it('Should return placeholder type if type is not ObjectType', async () => {
+      const instance = new InstanceElement('instance', BuiltinTypes.STRING as unknown as ObjectType)
+      expect(await instance.getType()).toBeInstanceOf(PlaceholderObjectType)
     })
   })
 })

--- a/packages/adapter-api/tsconfig.json
+++ b/packages/adapter-api/tsconfig.json
@@ -14,5 +14,6 @@
     "references": [
         { "path": "../dag" },
         { "path": "../lowerdash" },
+        { "path": "../logging" },
     ]
 }


### PR DESCRIPTION
This PR fixes the load workspace crashing for some cases of syntax errors in the workspace

---

The issue is happening when for example I have the type

```
type adapter.someType {
  annotations {
  }
  string internalId {
  }
}
```
and I create a syntax error with the type, for example removing the first {

```
type adapter.someType
  annotations {
  }
  string internalId {
  }
}
```
This will cause us to parse the 

```
string internalId {
}
```
as a top level type, which will therefore have the id `string._config.instance.internalId`

When we try to get the type of that instance we will get an error since the id `string._config` returns the primitve value of string and we expect an `ObjectType`

---
_Release Notes_: 
Core:
- Fixed an issue with the workspace failing to load for some cases of syntax errors in the workspace

---
_User Notifications_: 
None