### PR TITLE
upgrade rocksdb version to support backup

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "@salto-io/logging": "0.3.3",
     "@salto-io/lowerdash": "0.3.3",
     "@salto-io/netsuite-adapter": "0.3.3",
-    "@salto-io/rocksdb": "5.1.1-salto-16",
+    "@salto-io/rocksdb": "5.1.1-salto-17",
     "@salto-io/salesforce-adapter": "0.3.3",
     "@salto-io/stripe-adapter": "0.3.3",
     "@salto-io/workato-adapter": "0.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1630,10 +1630,10 @@
     node-watch "0.7.1"
     xml2js "0.4.23"
 
-"@salto-io/rocksdb@5.1.1-salto-16":
-  version "5.1.1-salto-16"
-  resolved "https://registry.yarnpkg.com/@salto-io/rocksdb/-/rocksdb-5.1.1-salto-16.tgz#49e15d82dde9cb1fed49da4bd43941005921d11e"
-  integrity sha512-059tSVGH6sSOY9hrYrAdp8jfcK3ZrkpMjcNVKpHgXiEXYyCytqdSeCWxngUoOUDyO4RTQ5mFPczEYsp13P+Dzw==
+"@salto-io/rocksdb@5.1.1-salto-17":
+  version "5.1.1-salto-17"
+  resolved "https://registry.yarnpkg.com/@salto-io/rocksdb/-/rocksdb-5.1.1-salto-17.tgz#547d4781f40c7ceab6da79541d6de404be92b812"
+  integrity sha512-Reckjh1Ykp8EWQ2Zma0p2cp2egKlJwVoIw/+OeNfM/LGU3aQZTw1114DkmZ8+58Xf91oVfB5Iteu2TroCPUEpA==
   dependencies:
     abstract-leveldown "^7.0.0"
     napi-macros "^2.0.0"


### PR DESCRIPTION
_Upgrade RocksDB version to support backup_

---

_Upgrade RocksDB version to support backup for the SaaS_
Relates to https://salto-io.atlassian.net/browse/SALTO-1606
---
_Release Notes_: 
None
