### PR TITLE
SALTO-1665 Change fallback behavior for resolving non-element references

### DIFF
--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -1695,6 +1695,21 @@ describe('transformer', () => {
           ),
         })).toEqual('Test__c')
       })
+      it('should resolve to current value if referenced value is not an element', async () => {
+        const testField = refObject.fields.test
+        const refValue = { obj: { with: { some: 'details' } } }
+        expect(await getLookUpName({
+          ref: new ReferenceExpression(testField.elemID, refValue),
+          field: mockLayoutItem.fields.field,
+          path: mockLayoutInstance.elemID.createNestedID(
+            'layoutSections', '0', 'layoutColumns', '0', 'layoutItems', '0', 'field'
+          ),
+        })).toEqual(refValue)
+        expect(await getLookUpName({
+          ref: new ReferenceExpression(testField.elemID, refValue),
+          field: mockLayoutItem.fields.field,
+        })).toEqual(refValue)
+      })
     })
     describe('with fields in workflow field update instance', () => {
       const workflowFieldUpdate = new ObjectType({


### PR DESCRIPTION
When attempting to serialize a reference that we expected to be an element, fallback to serializing the current value (even if there is a rule that expects it to be an element).

---

Note that this means that unresolved references will be silently replaced with the "unresolved reference" placeholder (which is expected to fail downstream).

~Still missing a test - will add before merging.~

---
_Release Notes_: 
Salesforce adapter:
* Fix an error when attempting to deploy custom object instances with unresolved references

---
_User Notifications_: 
None