### PR TITLE
SALTO-979 Fix detailed plan for nested objects in CLI

### DIFF
--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -108,7 +108,6 @@ const formatValue = async (value: Element | Value): Promise<string> => {
     (_.isEmpty(types) ? '' : indent(`\nannotations:${await formatValue(types)}`, 2))
   const formatFields = async (fields: Record<string, Field>): Promise<string> =>
     (_.isEmpty(fields) ? '' : indent(`\nfields:${await formatValue(fields)}`, 2))
-
   if (isInstanceElement(value)) {
     return formatValue(value.value)
   }
@@ -145,7 +144,7 @@ const formatValue = async (value: Element | Value): Promise<string> => {
     const formattedKeys = (await awu(_.entries(value))
       .map(async ([k, v]) => `${k}: ${await formatValue(v)}`).toArray())
       .join('\n')
-    return `\n${indent(formattedKeys, 2)}`
+    return `\n${indent(`{\n${indent(formattedKeys, 1)}\n}`, 2)}`
   }
   if (value instanceof ReferenceExpression) {
     return isElement(value.value) ? value.elemID.getFullName() : formatValue(value.value)

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -309,6 +309,36 @@ describe('formatter', () => {
           expect(output).not.toContain('bla')
         })
       })
+      describe('with array of objects', () => {
+        const formatedObjectsExpectedResults = `[
+          {
+            name: "salsal"
+            nicknames: ["o","s","s"]
+            office: 
+                {
+                  label: "1"
+                  name: "2"
+                }
+          },
+          {
+            name: "to"
+            nicknames: ["s","a","a","s"]
+            office: 
+                {
+                  label: "a"
+                  name: "b"
+                }
+          }]`
+        beforeAll(async () => {
+          const instanceBefore = allElements[6] as InstanceElement
+          const instanceAfter = allElements[7] as InstanceElement
+          const instanceChange = detailedChange('modify', instanceBefore.elemID, instanceBefore, instanceAfter)
+          output = await formatChange(instanceChange, true)
+        })
+        it('should match expected value', () => {
+          expect(output).toContain(formatedObjectsExpectedResults)
+        })
+      })
     })
   })
   describe('formatFetchChangeForApproval', () => {

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -247,8 +247,52 @@ export const elements = (): Element[] => {
     'test', saltoEmployee,
     { name: 'FirstEmployee', nicknames: ['you', 'hi'], office: { label: 'bla', name: 'foo' } }
   )
-
-  return [BuiltinTypes.STRING, saltoAddr, saltoOffice, saltoEmployee, saltoEmployeeInstance]
+  const objectFormatTesting = new ObjectType({
+    elemID: new ElemID('salto', 'test1'),
+    fields: {
+      country: { refType: new ListType(saltoEmployee) },
+    },
+  })
+  const objectFormatTestingInstanceBefore = new InstanceElement('myinstance', objectFormatTesting, {
+    country: [
+      {
+        name: 'sal',
+        nicknames: ['o', 's', 's'],
+      },
+      {
+        name: 'to',
+        nicknames: ['s', 'a', 'a', 's'],
+        office: {
+          label: 'a',
+          name: 'b',
+        },
+      },
+    ],
+  })
+  const objectFormatTestingInstanceAfter = new InstanceElement('myinstance', objectFormatTesting, {
+    country: [
+      {
+        name: 'salsal',
+        nicknames: ['o', 's', 's'],
+        office: {
+          label: '1',
+          name: '2',
+        },
+      },
+      {
+        name: 'to',
+        nicknames: ['s', 'a', 'a', 's'],
+        office: {
+          label: 'a',
+          name: 'b',
+        },
+      },
+    ],
+  })
+  return [
+    BuiltinTypes.STRING, saltoAddr, saltoOffice, saltoEmployee, saltoEmployeeInstance,
+    objectFormatTesting, objectFormatTestingInstanceBefore, objectFormatTestingInstanceAfter,
+  ]
 }
 
 export const mockErrors = (errors: SaltoError[]): wsErrors.Errors => ({


### PR DESCRIPTION
following the ticket [SALTO-979](https://salto-io.atlassian.net/browse/SALTO-979), I added a separation between different objects in the detailed plan for deploy.

---

_Release Notes_: 
CLI: improve the display for a list of objects in the deploy's detailed plan

---