### PR TITLE
SAAS-3128: added more retries for single object in sdf client

### DIFF
--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -90,6 +90,7 @@ const ALL = 'ALL'
 const ADDITIONAL_FILE_PATTERN = '.template.'
 
 export const MINUTE_IN_MILLISECONDS = 1000 * 60
+const SINGLE_OBJECT_RETRIES = 5
 const READ_CONCURRENCY = 100
 
 const INVALID_DEPENDENCIES = ['ADVANCEDEXPENSEMANAGEMENT', 'SUBSCRIPTIONBILLING', 'WMSSYSTEM', 'BILLINGACCOUNTS']
@@ -480,7 +481,7 @@ export default class SdfClient {
     suiteAppId: string | undefined,
   ): Promise<FailedTypes> {
     const importObjectsChunk = async (
-      { type, ids, index, total }: ObjectsChunk, retry = true
+      { type, ids, index, total }: ObjectsChunk, retriesLeft = SINGLE_OBJECT_RETRIES
     ): Promise<FailedTypes> => {
       const retryFetchFailedInstances = async (
         failedInstancesIds: string[]
@@ -514,12 +515,12 @@ export default class SdfClient {
       } catch (e) {
         log.warn('Failed to fetch chunk %d/%d with %d objects of type: %s with suiteApp: %s', index, total, ids.length, type, suiteAppId)
         log.warn(e)
-        if (!retry) {
+        if (retriesLeft === 0) {
           throw e
         }
         if (ids.length === 1) {
           log.debug('Retrying to fetch chunk %d/%d with a single object of type: %s', index, total, type)
-          return importObjectsChunk({ type, ids, index, total }, false)
+          return importObjectsChunk({ type, ids, index, total }, retriesLeft - 1)
         }
         log.debug('Retrying to fetch chunk %d/%d with %d objects of type: %s with smaller chunks', index, total, ids.length, type)
         const middle = (ids.length + 1) / 2

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -90,7 +90,7 @@ const ALL = 'ALL'
 const ADDITIONAL_FILE_PATTERN = '.template.'
 
 export const MINUTE_IN_MILLISECONDS = 1000 * 60
-const SINGLE_OBJECT_RETRIES = 5
+const SINGLE_OBJECT_RETRIES = 3
 const READ_CONCURRENCY = 100
 
 const INVALID_DEPENDENCIES = ['ADVANCEDEXPENSEMANAGEMENT', 'SUBSCRIPTIONBILLING', 'WMSSYSTEM', 'BILLINGACCOUNTS']
@@ -519,7 +519,7 @@ export default class SdfClient {
           throw e
         }
         if (ids.length === 1) {
-          log.debug('Retrying to fetch chunk %d/%d with a single object of type: %s', index, total, type)
+          log.debug('Retrying to fetch chunk %d/%d with a single object of type: %s. %d retries left', index, total, type, retriesLeft - 1)
           return importObjectsChunk({ type, ids, index, total }, retriesLeft - 1)
         }
         log.debug('Retrying to fetch chunk %d/%d with %d objects of type: %s with smaller chunks', index, total, ids.length, type)

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -412,7 +412,7 @@ describe('netsuite client', () => {
       const ids = [
         { type: 'addressForm', scriptId: 'a' },
       ]
-      let isFirstImportTry = true
+      let numberOfTries = 0
       mockExecuteAction.mockImplementation(context => {
         if (context.commandName === COMMANDS.LIST_OBJECTS) {
           return Promise.resolve({
@@ -421,8 +421,8 @@ describe('netsuite client', () => {
           })
         }
         if (context.commandName === COMMANDS.IMPORT_OBJECTS) {
-          if (isFirstImportTry) {
-            isFirstImportTry = false
+          if (numberOfTries < 2) {
+            numberOfTries += 1
             return Promise.resolve({
               isSuccess: () => false,
               data: { failedImports: [] },
@@ -437,8 +437,8 @@ describe('netsuite client', () => {
       })
       const client = mockClient({ fetchAllTypesAtOnce: false })
       await client.getCustomObjects(typeNames, typeNamesQuery)
-      // createProject & setupAccount & listObjects & 2*importObjects & deleteAuthId
-      const numberOfExecuteActions = 6
+      // createProject & setupAccount & listObjects & 3*importObjects & deleteAuthId
+      const numberOfExecuteActions = 7
       expect(mockExecuteAction).toHaveBeenCalledTimes(numberOfExecuteActions)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
@@ -451,6 +451,12 @@ describe('netsuite client', () => {
 
       expect(mockExecuteAction).toHaveBeenNthCalledWith(5, importObjectsCommandMatcher)
       expect(mockExecuteAction.mock.calls[4][0].arguments).toEqual(expect.objectContaining({
+        type: 'addressForm',
+        scriptid: 'a',
+      }))
+
+      expect(mockExecuteAction).toHaveBeenNthCalledWith(6, importObjectsCommandMatcher)
+      expect(mockExecuteAction.mock.calls[5][0].arguments).toEqual(expect.objectContaining({
         type: 'addressForm',
         scriptid: 'a',
       }))


### PR DESCRIPTION
Increased the number of retries for signle object in SDF client

---
_Release Notes_: 
None

---
_User Notifications_: 
None