### PR TITLE
SALTO-1676: hotfix for missing static file error

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -147,8 +147,9 @@ const buildMultiEnvSource = (
   const getStaticFile = async (
     filePath: string,
     encoding: BufferEncoding,
+    envName? : string
   ): Promise<StaticFile> => {
-    const sourcesFiles = (await Promise.all(Object.values(getActiveSources())
+    const sourcesFiles = (await Promise.all(Object.values(getActiveSources(envName))
       .map(src => src.getStaticFile(filePath, encoding))))
       .filter(values.isDefined)
     if (sourcesFiles.length > 1
@@ -169,6 +170,7 @@ const buildMultiEnvSource = (
         async staticFile => await getStaticFile(
           staticFile.filepath,
           staticFile.encoding,
+          envName
         ) ?? staticFile
       ),
       persistent,


### PR DESCRIPTION
When a cache invalidation takes place, the multi env source will attempt to recover the files while using the wrong static file source. If the files are not there - missing file error will be created.

The following PR is a hotfix for this issue which does not address the real root cause (wrong multi env source is used during cache invalidation in the workspace). The root cause will be fixed in another PR later on today.  (And this PR will be reverted) 

---

Release Notes:
- Fixed issue where static files would be loaded incorrectly in workspaces with multiple environments, causing missing static files and / or incorrect deploy plans
