### PR TITLE
fixed nacl source rename cause nacl invalidation(SALTO-1669)

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -871,7 +871,7 @@ const buildNaclFilesSource = (
       await naclFilesStore.rename(name)
       await staticFilesSource.rename(name)
       const currentState = await getState()
-      await currentState.parsedNaclFiles.rename(name)
+      await currentState.parsedNaclFiles.rename(getRemoteMapNamespace('parsed_nacl_files', name))
       const newCurrentState = await createNaclFilesState(
         remoteMapCreator,
         staticFilesSource,
@@ -893,6 +893,11 @@ const buildNaclFilesSource = (
         currentState.referencedIndex.entries()
       )
       await currentState.referencedIndex.clear()
+      const currentHash = await currentState.metadata.get(HASH_KEY)
+      if (currentHash !== undefined) {
+        await newCurrentState.metadata.set(HASH_KEY, currentHash)
+      }
+      await currentState.metadata.clear()
       state = Promise.resolve(newCurrentState)
     },
 


### PR DESCRIPTION
_When the rename function of a nacl file source was invoked, the cache was updated as needed causing future cache invalidations._

---

_Specifically - the hash value of the nacl file source was not updated, and the parsed nacl file source was renamed with a bad name. (both of these were corrected in the next action using the cache invalidation mechanism, so the only effect was slowness in the next workspace load)_

---
_Release Notes_: 
_Fixed slowness due to cache invalidation after an environment rename (SALTO-1669)_

---
_User Notifications_: 
_NA_
