### PR TITLE
SALTO-1676: Single multienv source

### DIFF
--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -529,7 +529,7 @@ const elementOpenDef = createWorkspaceCommand({
 
 type ElementListArgs = {
   elementSelector: string[]
-  mode: FromSource['source']
+  mode: FromSource
 } & EnvArg
 
 const listElements = async (
@@ -539,7 +539,7 @@ const listElements = async (
   elmSelectors: ElementSelector[]
 ): Promise<CliExitCode> => {
   const elemIds = await awu(
-    await workspace.getElementIdsBySelectors(elmSelectors, mode, true)
+    await workspace.getElementIdsBySelectors(elmSelectors, { source: mode }, true)
   ).toArray()
 
   output.stdout.write(Prompts.LIST_MESSAGE(elemIds.map(id => id.getFullName())))
@@ -568,7 +568,7 @@ export const listAction: WorkspaceCommandAction<ElementListArgs> = async ({
     if (!validWorkspace) {
       return CliExitCode.AppError
     }
-    return await listElements(workspace, output, { source: mode }, validSelectors)
+    return await listElements(workspace, output, mode, validSelectors)
   } catch (e) {
     errorOutputLine(formatListFailed(e.message), output)
     return CliExitCode.AppError

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -83,5 +83,5 @@ export {
   UnresolvedElemIDs,
   isValidEnvName,
   FromSource,
-  FromSourceWithEnv
+  FromSourceWithEnv,
 }

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -17,6 +17,7 @@ import * as errors from './src/errors'
 import * as nacl from './src/workspace/nacl_files'
 import { Workspace, SourceFragment, StateRecency, loadWorkspace, isValidEnvName,
   EnvironmentsSources, EnvironmentSource, initWorkspace, WorkspaceComponents, UnresolvedElemIDs,
+  FromSourceWithEnv,
   COMMON_ENV_PREFIX } from './src/workspace/workspace'
 import * as hiddenValues from './src/workspace/hidden_values'
 import * as configSource from './src/workspace/config_source'
@@ -82,4 +83,5 @@ export {
   UnresolvedElemIDs,
   isValidEnvName,
   FromSource,
+  FromSourceWithEnv
 }

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -85,14 +85,7 @@ type MultiEnvState = {
 
 export type EnvsChanges = Record<string, ChangeSet<Change>>
 
-export type FromSource = {
-  source: 'env'
-  envName?: string
-} | {
-  source: 'common'
-} | {
-  source: 'all'
-}
+export type FromSource = 'env' | 'common' | 'all'
 
 export type MultiEnvSource = {
   updateNaclFiles: (
@@ -134,7 +127,7 @@ export type MultiEnvSource = {
   getElementIdsBySelectors: (
     env: string,
     selectors: ElementSelector[],
-    fromSoruce?: FromSource,
+    fromSource?: FromSource,
     compact?: boolean,
   ) => Promise<AsyncIterable<ElemID>>
   demote: (ids: ElemID[]) => Promise<EnvsChanges>
@@ -368,9 +361,9 @@ const buildMultiEnvSource = (
 
   const determineSource = async (
     env: string,
-    fromSource: Pick<FromSource, 'source'>
+    source: FromSource,
   ): Promise<ElementsSource> => {
-    switch (fromSource.source) {
+    switch (source) {
       case 'env': {
         return envSources()[env]
       }
@@ -386,7 +379,7 @@ const buildMultiEnvSource = (
   const getElementIdsBySelectors = async (
     env: string,
     selectors: ElementSelector[],
-    fromSource: Pick<FromSource, 'source'> = { source: 'env' },
+    fromSource: FromSource = 'env',
     compact = false,
   ): Promise<AsyncIterable<ElemID>> => {
     const relevantSource: ElementsSource = await determineSource(env, fromSource)

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -652,6 +652,11 @@ const buildMultiEnvSource = (
           await s.clear(args)
         })
       const currentState = await getState()
+      await awu(Object.values(currentState.states))
+        .forEach(async s => {
+          await s.elements.clear()
+          await s.mergeErrors.clear()
+        })
       await currentState.mergeManager.clear()
       state = undefined
     },

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -103,7 +103,7 @@ export type EnvironmentsSources = {
   sources: Record<string, EnvironmentSource>
 }
 
-type FromSourceWithEnv = {
+export type FromSourceWithEnv = {
   source: 'env'
   fromEnv? : string
 }

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -796,8 +796,7 @@ export const loadWorkspace = async (
     serviceConfig: (name, defaultValue) => adaptersConfig.getAdapter(name, defaultValue),
     serviceConfigPaths: adaptersConfig.getElementNaclFiles,
     isEmpty: async (naclFilesOnly = false): Promise<boolean> => {
-      const isNaclFilesSourceEmpty = !naclFilesSource
-        || await (await getLoadedNaclFilesSource()).isEmpty(currentEnv())
+      const isNaclFilesSourceEmpty = await (await getLoadedNaclFilesSource()).isEmpty(currentEnv())
       return isNaclFilesSourceEmpty && (naclFilesOnly || state().isEmpty())
     },
     hasElementsInServices: async (serviceNames: string[]): Promise<boolean> => {

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -800,13 +800,10 @@ export const loadWorkspace = async (
         || await (await getLoadedNaclFilesSource()).isEmpty(currentEnv())
       return isNaclFilesSourceEmpty && (naclFilesOnly || state().isEmpty())
     },
-    hasElementsInServices: async (serviceNames: string[]): Promise<boolean> => (
-      await (awu(await (
-        await (await getLoadedNaclFilesSource()).getElementsSource(currentEnv())
-      ).list()).find(
-        elemId => serviceNames.includes(elemId.adapter)
-      )) !== undefined
-    ),
+    hasElementsInServices: async (serviceNames: string[]): Promise<boolean> => {
+      const source = await (await getLoadedNaclFilesSource()).getElementsSource(currentEnv())
+      return awu(await source.list()).some(elemId => serviceNames.includes(elemId.adapter))
+    },
     hasElementsInEnv: async envName => {
       const envSource = environmentsSources.sources[envName]
       if (envSource === undefined) {
@@ -1037,13 +1034,6 @@ export const loadWorkspace = async (
       if (persist) {
         await config.setWorkspaceConfig(workspaceConfig)
       }
-      naclFilesSource = multiEnvSource(
-        _.mapValues(environmentsSources.sources, e => e.naclFiles),
-        environmentsSources.commonSourceName,
-        remoteMapCreator,
-        persistent,
-        mergedRecoveryMode
-      )
     },
 
     getStateRecency: async (serviceName: string): Promise<StateRecency> => {

--- a/packages/workspace/test/common/nacl_file_source.ts
+++ b/packages/workspace/test/common/nacl_file_source.ts
@@ -37,7 +37,7 @@ export const createMockNaclFileSource = (
   changes: ChangeSet<Change> = { changes: [], cacheValid: true },
   staticFileSource = mockStaticFilesSource()
 ): MockInterface<NaclFilesSource> => {
-  const currentElements = elements
+  let currentElements = elements
   const getElementNaclFiles = (elemID: ElemID): string[] =>
     Object.entries(naclFiles).filter(([_filename, fileElements]) => fileElements.find(
       element => resolvePath(element, elemID) !== undefined
@@ -62,7 +62,9 @@ export const createMockNaclFileSource = (
     deleteAll: mockFunction<NaclFilesSource['deleteAll']>().mockImplementation(async (_ids: ThenableIterable<ElemID>) => Promise.resolve(undefined)),
     getAll: mockFunction<NaclFilesSource['getAll']>().mockImplementation(async () => awu(currentElements)),
     getElementsSource: mockFunction<NaclFilesSource['getElementsSource']>().mockImplementation(async () => createInMemoryElementSource(currentElements)),
-    clear: mockFunction<NaclFilesSource['clear']>().mockResolvedValue(),
+    clear: mockFunction<NaclFilesSource['clear']>().mockImplementation(async _args => {
+      currentElements = []
+    }),
     rename: mockFunction<NaclFilesSource['rename']>().mockResolvedValue(),
     flush: mockFunction<NaclFilesSource['flush']>().mockResolvedValue(),
     updateNaclFiles: mockFunction<NaclFilesSource['updateNaclFiles']>().mockResolvedValue(changes),

--- a/packages/workspace/test/utils.ts
+++ b/packages/workspace/test/utils.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { Value, StaticFile, calculateStaticFileHash, ObjectType, isObjectType, TypeElement } from '@salto-io/adapter-api'
 import { values, collections } from '@salto-io/lowerdash'
 import { Functions, FunctionImplementation, FunctionExpression } from '../src/parser/functions'
-import { StaticFilesSource } from '../src/workspace/static_files/common'
+import { StaticFilesSource, MissingStaticFile } from '../src/workspace/static_files/common'
 import { File } from '../src/workspace/dir_store'
 import { RemoteMap, RemoteMapEntry, CreateRemoteMapParams, RemoteMapCreator } from '../src/workspace/remote_map'
 
@@ -61,9 +61,13 @@ export const registerTestFunction = (
   )
 )
 
-export const mockStaticFilesSource = (): StaticFilesSource => ({
-  getStaticFile: jest.fn(),
-  getContent: jest.fn(),
+export const mockStaticFilesSource = (staticFiles: StaticFile[] = []): StaticFilesSource => ({
+  getStaticFile: jest.fn().mockImplementation((filepath: string, _encoding: BufferEncoding) => (
+    staticFiles.find(sf => sf.filepath === filepath) ?? new MissingStaticFile(filepath)
+  )),
+  getContent: jest.fn().mockImplementation((filepath: string) => (
+    staticFiles.find(sf => sf.filepath === filepath)?.content ?? undefined
+  )),
   persistStaticFile: jest.fn().mockReturnValue([]),
   flush: jest.fn(),
   clone: jest.fn(),

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -854,7 +854,7 @@ describe('multi env source', () => {
   describe('sync', () => {
     it('should route the removal to the proper env sources when specified', async () => {
       const selectors = createElementSelectors(['salto.*']).validSelectors
-      jest.spyOn(routers, 'routeRemoveFrom').mockResolvedValue({ primarySource: [], commonSource: [], secondarySources: {} })
+      jest.spyOn(routers, 'routeRemoveFrom').mockResolvedValue({ commonSource: [], envSources: {} })
       await source.sync(
         [],
         { inactive: await awu(await source.getElementIdsBySelectors(selectors)).toArray() },
@@ -958,7 +958,10 @@ describe('multi env source', () => {
         await awu(await source.getElementIdsBySelectors(selectors, { source: 'env' }, true)).toArray()
       )
       expect(routers.routePromote).toHaveBeenCalledWith(
-        [envElemID, objectElemID], envSource, commonSource, { inactive: inactiveSource }
+        [envElemID, objectElemID], 'active', commonSource, {
+          active: envSource,
+          inactive: inactiveSource,
+        }
       )
     })
   })
@@ -972,7 +975,10 @@ describe('multi env source', () => {
         await source.getElementIdsBySelectors(selectors, { source: 'common' }, true)
       ).toArray())
       expect(routers.routeDemote).toHaveBeenCalledWith(
-        [commonObject.elemID, objectElemID], envSource, commonSource, { inactive: inactiveSource }
+        [commonObject.elemID, objectElemID], commonSource, {
+          active: envSource,
+          inactive: inactiveSource,
+        }
       )
     })
   })
@@ -984,7 +990,10 @@ describe('multi env source', () => {
       )
       await source.demoteAll()
       expect(routers.routeDemote).toHaveBeenCalledWith(
-        [envElemID, objectElemID], envSource, commonSource, { inactive: inactiveSource }
+        [envElemID, objectElemID], commonSource, {
+          active: envSource,
+          inactive: inactiveSource,
+        }
       )
     })
   })

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -913,7 +913,7 @@ describe('multi env source', () => {
       it('should extract the proper ids without overlaps when compact=true', async () => {
         const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
         const res = await awu(
-          await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'env' }, true)
+          await source.getElementIdsBySelectors(activePrefix, selectors, 'env', true)
         ).toArray()
         expect(res.map(id => id.getFullName()).sort()).toEqual([
           envElemID,
@@ -923,7 +923,7 @@ describe('multi env source', () => {
 
       it('should extract the proper ids from a specific env when passed', async () => {
         const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
-        const res = await awu(await source.getElementIdsBySelectors(inactivePrefix, selectors, { source: 'env' })).toArray()
+        const res = await awu(await source.getElementIdsBySelectors(inactivePrefix, selectors, 'env')).toArray()
         expect(res.map(id => id.getFullName()).sort()).toEqual([
           inactiveElemID,
           inactiveElemID.createNestedID('field', 'field'),
@@ -935,7 +935,7 @@ describe('multi env source', () => {
     describe('from=common should select only common elements', () => {
       it('should extract the proper ids with overlaps when compact=false', async () => {
         const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
-        const res = await awu(await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'common' })).toArray()
+        const res = await awu(await source.getElementIdsBySelectors(activePrefix, selectors, 'common')).toArray()
         expect(res.map(id => id.getFullName()).sort()).toEqual([
           commonObject.elemID,
           commonObject.elemID.createNestedID('field', 'field'),
@@ -946,7 +946,7 @@ describe('multi env source', () => {
       it('should extract the proper ids without overlaps when compact=true', async () => {
         const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
         const res = await awu(
-          await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'common' }, true)
+          await source.getElementIdsBySelectors(activePrefix, selectors, 'common', true)
         ).toArray()
         expect(res.map(id => id.getFullName()).sort()).toEqual([
           commonObject.elemID,
@@ -957,7 +957,7 @@ describe('multi env source', () => {
     describe('from=both should select both env and common elements', () => {
       it('should extract the proper ids with overlaps when compact=false', async () => {
         const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
-        const res = await awu(await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'all' })).toArray()
+        const res = await awu(await source.getElementIdsBySelectors(activePrefix, selectors, 'all')).toArray()
         expect(res.map(id => id.getFullName()).sort()).toEqual([
           commonObject.elemID,
           commonObject.elemID.createNestedID('field', 'field'),
@@ -971,7 +971,7 @@ describe('multi env source', () => {
       it('should extract the proper ids without overlaps when compact=true', async () => {
         const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
         const res = await awu(
-          await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'all' }, true)
+          await source.getElementIdsBySelectors(activePrefix, selectors, 'all', true)
         ).toArray()
         expect(res.map(id => id.getFullName()).sort()).toEqual([
           commonObject.elemID,
@@ -989,7 +989,7 @@ describe('multi env source', () => {
       )
       await source.promote(
         activePrefix,
-        await awu(await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'env' }, true)).toArray()
+        await awu(await source.getElementIdsBySelectors(activePrefix, selectors, 'env', true)).toArray()
       )
       expect(routers.routePromote).toHaveBeenCalledWith(
         [envElemID, objectElemID], 'active', commonSource, {
@@ -1006,7 +1006,7 @@ describe('multi env source', () => {
         () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
       )
       await source.demote(await awu(
-        await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'common' }, true)
+        await source.getElementIdsBySelectors(activePrefix, selectors, 'common', true)
       ).toArray())
       expect(routers.routeDemote).toHaveBeenCalledWith(
         [commonObject.elemID, objectElemID], commonSource, {
@@ -1089,6 +1089,20 @@ describe('multi env source', () => {
       expect(await src.getStaticFile(
         staticFile.filepath, staticFile.encoding, activePrefix
       )).toEqual(new MissingStaticFile(staticFile.filepath))
+    })
+  })
+
+  describe('clear', () => {
+    it('should clear the envSource', async () => {
+      const src = multiEnvSource(
+        sources,
+        commonPrefix,
+        () => Promise.resolve(new InMemoryRemoteMap()),
+        false
+      )
+      await src.clear()
+      const postClearElements = await awu(await source.getAll('active')).toArray()
+      expect(postClearElements).toEqual([])
     })
   })
 })

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -1101,7 +1101,7 @@ describe('multi env source', () => {
         false
       )
       await src.clear()
-      const postClearElements = await awu(await source.getAll('active')).toArray()
+      const postClearElements = await awu(await src.getAll('active')).toArray()
       expect(postClearElements).toEqual([])
     })
   })

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -923,7 +923,7 @@ describe('multi env source', () => {
 
       it('should extract the proper ids from a specific env when passed', async () => {
         const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
-        const res = await awu(await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'env', envName: 'inactive' })).toArray()
+        const res = await awu(await source.getElementIdsBySelectors(inactivePrefix, selectors, { source: 'env' })).toArray()
         expect(res.map(id => id.getFullName()).sort()).toEqual([
           inactiveElemID,
           inactiveElemID.createNestedID('field', 'field'),

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -192,7 +192,6 @@ const sources = {
 }
 const source = multiEnvSource(
   sources,
-  activePrefix,
   commonPrefix,
   () => Promise.resolve(new InMemoryRemoteMap()),
   true
@@ -238,7 +237,7 @@ describe('multi env source', () => {
           id: envElemID,
         },
       ]
-      await source.updateNaclFiles(changes)
+      await source.updateNaclFiles(activePrefix, changes)
       expect(envSource.updateNaclFiles).toHaveBeenCalled()
       expect(commonSource.updateNaclFiles).toHaveBeenCalled()
       expect(inactiveSource.updateNaclFiles).not.toHaveBeenCalled()
@@ -260,24 +259,26 @@ describe('multi env source', () => {
           [primarySourceName]: mockPrimaryNaclFileSource,
           [secondarySourceName]: mockSecondaryNaclFileSource,
         },
-        primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
         true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
-      const currentElements = await awu(await multiEnvSourceWithMockSources.getAll()).toArray()
+      const currentElements = await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray()
       expect(currentElements).toHaveLength(2)
       const detailedChange = { ...change, id: commonElemID, path: ['test'] } as DetailedChange
       const elementChanges = (await multiEnvSourceWithMockSources
-        .updateNaclFiles([detailedChange]))
+        .updateNaclFiles(primarySourceName, [detailedChange]))
       expect(elementChanges[primarySourceName].changes).toEqual([change])
       const mergedSaltoObject = new ObjectType({
         elemID: objectElemID, fields: { ...commonFragment.fields, ...envFragment.fields },
       })
-      expect(sortElemArray(await awu(await multiEnvSourceWithMockSources.getAll()).toArray()))
-        .toEqual(sortElemArray([mergedSaltoObject, envObject, commonObject]))
+      expect(sortElemArray(
+        await awu(await multiEnvSourceWithMockSources.getAll(primarySourceName)).toArray()
+      )).toEqual(sortElemArray([mergedSaltoObject, envObject, commonObject]))
     })
     it('should change inner state upon update with removal', async () => {
       const change = { action: 'remove', data: { before: commonFragment } } as Change<ObjectType>
@@ -292,14 +293,15 @@ describe('multi env source', () => {
           [commonSourceName]: mockCommonNaclFileSource,
           [primarySourceName]: mockPrimaryNaclFileSource,
         },
-        primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
         true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
-      const currentElements = await awu(await multiEnvSourceWithMockSources.getAll()).toArray()
+      const currentElements = await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray()
       expect(currentElements).toHaveLength(2)
       const mergedSaltoObject = new ObjectType({
         elemID: objectElemID, fields: { ...commonFragment.fields, ...envFragment.fields },
@@ -311,11 +313,12 @@ describe('multi env source', () => {
         id: objectElemID,
       } as DetailedChange
       const elementChanges = (await multiEnvSourceWithMockSources
-        .updateNaclFiles([detailedChange]))
+        .updateNaclFiles(primarySourceName, [detailedChange]))
       expect(Object.keys(elementChanges).length).toEqual(1)
       expect(elementChanges[primarySourceName].changes).toEqual([_.omit(detailedChange, ['path', 'id'])])
-      expect(sortElemArray(await awu(await multiEnvSourceWithMockSources.getAll()).toArray()))
-        .toEqual(sortElemArray([envObject, envFragment]))
+      expect(sortElemArray(
+        await awu(await multiEnvSourceWithMockSources.getAll(primarySourceName)).toArray()
+      )).toEqual(sortElemArray([envObject, envFragment]))
     })
     it('should change inner state upon update with modification with multiple changes', async () => {
       const newEnvFragment = new ObjectType({
@@ -348,14 +351,15 @@ describe('multi env source', () => {
           [commonSourceName]: mockCommonNaclFileSource,
           [primarySourceName]: mockPrimaryNaclFileSource,
         },
-        primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
         true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
-      const currentElements = await awu(await multiEnvSourceWithMockSources.getAll()).toArray()
+      const currentElements = await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray()
       expect(currentElements).toHaveLength(2)
       const mergedSaltoObject = currentElements.find(e => e.elemID.isEqual(objectElemID))
       const detailedChanges = [
@@ -379,9 +383,11 @@ describe('multi env source', () => {
         },
       ] as DetailedChange[]
       const elementChanges = (
-        await multiEnvSourceWithMockSources.updateNaclFiles(detailedChanges)
+        await multiEnvSourceWithMockSources.updateNaclFiles(primarySourceName, detailedChanges)
       )
-      const elements = await awu(await multiEnvSourceWithMockSources.getAll()).toArray()
+      const elements = await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray()
       expect(
         _.sortBy(elementChanges[primarySourceName]
           .changes, c => getChangeElement(c).elemID.getFullName())
@@ -400,7 +406,9 @@ describe('multi env source', () => {
   })
   describe('list', () => {
     it('should list elements from all active sources and not inactive sources', async () => {
-      const elements = await awu(await source.list()).toArray()
+      const elements = await awu(
+        await (await source.getElementsSource(activePrefix)).list()
+      ).toArray()
       expect(await awu(elements).toArray()).toHaveLength(3)
       await expectToContainAllItems(elements, [commonElemID, envElemID, objectElemID])
       expect(elements).not.toContain(inactiveElemID)
@@ -411,13 +419,12 @@ describe('multi env source', () => {
       const srcs = {}
       const src = multiEnvSource(
         srcs,
-        activePrefix,
         commonPrefix,
         () => Promise.resolve(new InMemoryRemoteMap()),
         true
       )
       await src.load({})
-      expect(await src.isEmpty()).toBeTruthy()
+      expect(await src.isEmpty(activePrefix)).toBeTruthy()
     })
     it('should return true when some sources have files', async () => {
       const srcs = {
@@ -427,13 +434,12 @@ describe('multi env source', () => {
       }
       const src = multiEnvSource(
         srcs,
-        activePrefix,
         commonPrefix,
         () => Promise.resolve(new InMemoryRemoteMap()),
         true
       )
       await src.load({})
-      expect(await src.isEmpty()).toBeFalsy()
+      expect(await src.isEmpty(activePrefix)).toBeFalsy()
     })
     it('should look at elements from all active sources and not inactive sources', async () => {
       const srcs = {
@@ -442,30 +448,33 @@ describe('multi env source', () => {
       }
       const src = multiEnvSource(
         srcs,
-        activePrefix,
         commonPrefix,
         () => Promise.resolve(new InMemoryRemoteMap()),
         true
       )
       await src.load({})
-      expect(await src.isEmpty()).toBeTruthy()
+      expect(await src.isEmpty(activePrefix)).toBeTruthy()
     })
   })
   describe('get', () => {
     it('should return the merged element', async () => {
-      const elem = (await source.get(objectElemID)) as ObjectType
+      const elem = (await (
+        await source.getElementsSource(activePrefix)
+      ).get(objectElemID)) as ObjectType
       expect(Object.keys(elem.fields).sort()).toEqual([
         'commonField',
         'envField',
       ])
     })
     it('should not return the elements from inactive envs', async () => {
-      expect(await source.get(inactiveElemID)).not.toBeDefined()
+      expect(
+        await (await source.getElementsSource(activePrefix)).get(inactiveElemID)
+      ).not.toBeDefined()
     })
   })
   describe('getElementSource', () => {
     it('should return an element source according to env even if state is set', async () => {
-      const primarySource = await source.getElementsSource()
+      const primarySource = await source.getElementsSource(activePrefix)
       const primarySourceByEnvName = await source.getElementsSource(activePrefix)
       const secondarySourceByEnvName = await source.getElementsSource(inactivePrefix)
       expect(primarySource).toEqual(primarySourceByEnvName)
@@ -474,7 +483,7 @@ describe('multi env source', () => {
   })
   describe('getAll', () => {
     it('should return all merged elements', async () => {
-      const elements = await awu(await source.getAll()).toArray()
+      const elements = await awu(await source.getAll(activePrefix)).toArray()
       expect(elements).toHaveLength(3)
       await expectToContainAllItems(
         awu(elements).map(e => e.elemID),
@@ -503,7 +512,7 @@ describe('multi env source', () => {
   })
   describe('listNaclFiles', () => {
     it('shoud list all Nacl files', async () => {
-      const naclFiles = await source.listNaclFiles()
+      const naclFiles = await source.listNaclFiles(activePrefix)
       expect(naclFiles).toHaveLength(4)
       await expectToContainAllItems(naclFiles, [
         ..._.keys(commonNaclFiles),
@@ -550,20 +559,23 @@ describe('multi env source', () => {
           [primarySourceName]: mockPrimaryNaclFileSource,
           [inactiveSourceName]: mockInacvtiveNaclFileSource,
         },
-        primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
         true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
-      const currentElements = await awu(await multiEnvSourceWithMockSources.getAll()).toArray()
+      const currentElements = await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray()
       expect(currentElements).toHaveLength(2)
       const elementChanges = (await multiEnvSourceWithMockSources.setNaclFiles(
         { filename: path.join(ENVS_PREFIX, inactiveSourceName, 'env.nacl'), buffer: 'test' }
       ))
       expect(elementChanges).not.toHaveProperty(primarySourceName)
-      const elements = await awu(await multiEnvSourceWithMockSources.getAll()).toArray()
+      const elements = await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray()
       expect(elements).toHaveLength(2)
     })
     it('should change inner state upon set with addition', async () => {
@@ -579,14 +591,15 @@ describe('multi env source', () => {
           [commonSourceName]: mockCommonNaclFileSource,
           [primarySourceName]: mockPrimaryNaclFileSource,
         },
-        primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
         true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
-      const currentElements = await awu(await multiEnvSourceWithMockSources.getAll()).toArray()
+      const currentElements = await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray()
       expect(currentElements).toHaveLength(2)
       const elementChanges = (await multiEnvSourceWithMockSources.setNaclFiles(
         { filename: 'test', buffer: 'test' }
@@ -595,8 +608,9 @@ describe('multi env source', () => {
       const mergedSaltoObject = new ObjectType({
         elemID: objectElemID, fields: { ...commonFragment.fields, ...envFragment.fields },
       })
-      expect(sortElemArray(await awu(await multiEnvSourceWithMockSources.getAll()).toArray()))
-        .toEqual(sortElemArray([mergedSaltoObject, envObject, commonObject]))
+      expect(sortElemArray(await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray())).toEqual(sortElemArray([mergedSaltoObject, envObject, commonObject]))
     })
     it('should change inner state upon set with removal', async () => {
       const change = { action: 'remove', data: { before: envObject } } as Change<ObjectType>
@@ -611,14 +625,15 @@ describe('multi env source', () => {
           [commonSourceName]: mockCommonNaclFileSource,
           [primarySourceName]: mockPrimaryNaclFileSource,
         },
-        primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
         true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
-      const currentElements = await awu(await multiEnvSourceWithMockSources.getAll()).toArray()
+      const currentElements = await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray()
       expect(currentElements).toHaveLength(2)
       const elementChanges = (await multiEnvSourceWithMockSources.setNaclFiles(
         { filename: path.join(ENVS_PREFIX, primarySourceName, 'env.nacl'), buffer: 'test' }
@@ -627,7 +642,7 @@ describe('multi env source', () => {
       const mergedSaltoObject = new ObjectType({
         elemID: objectElemID, fields: { ...commonFragment.fields, ...envFragment.fields },
       })
-      expect(await awu(await multiEnvSourceWithMockSources.getAll())
+      expect(await awu(await multiEnvSourceWithMockSources.getAll(primarySourceName))
         .toArray()).toEqual([mergedSaltoObject])
     })
     it('should change inner state upon set with modification', async () => {
@@ -655,14 +670,15 @@ describe('multi env source', () => {
           [commonSourceName]: mockCommonNaclFileSource,
           [primarySourceName]: mockPrimaryNaclFileSource,
         },
-        primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
         true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
-      const currentElements = await awu(await multiEnvSourceWithMockSources.getAll()).toArray()
+      const currentElements = await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray()
       expect(currentElements).toHaveLength(2)
       const elementChanges = (await multiEnvSourceWithMockSources.setNaclFiles(
         { filename: path.join(ENVS_PREFIX, primarySourceName, 'env.nacl'), buffer: 'test' }
@@ -671,8 +687,9 @@ describe('multi env source', () => {
       const mergedSaltoObject = new ObjectType({
         elemID: objectElemID, fields: { ...commonFragment.fields, ...envFragment.fields },
       })
-      expect(sortElemArray(await awu(await multiEnvSourceWithMockSources.getAll()).toArray()))
-        .toEqual(sortElemArray([mergedSaltoObject, newEnvObject]))
+      expect(sortElemArray(await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray())).toEqual(sortElemArray([mergedSaltoObject, newEnvObject]))
     })
     it('should not change inner state upon set that ends up with the same state', async () => {
       const removal = { action: 'remove', data: { before: envObject } } as Change<ObjectType>
@@ -690,22 +707,24 @@ describe('multi env source', () => {
           [commonSourceName]: mockCommonNaclFileSource,
           [primarySourceName]: mockPrimaryNaclFileSource,
         },
-        primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
         true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
-      const currentElements = await awu(await multiEnvSourceWithMockSources.getAll()).toArray()
+      const currentElements = await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray()
       expect(currentElements).toHaveLength(2)
       const elementChanges = (await multiEnvSourceWithMockSources.setNaclFiles(
         { filename: path.join(ENVS_PREFIX, primarySourceName, 'env.nacl'), buffer: 'test' },
         { filename: 'test', buffer: 'test' },
       ))
       expect(elementChanges[primarySourceName].changes).toEqual([])
-      expect(sortElemArray(await awu(await multiEnvSourceWithMockSources.getAll()).toArray()))
-        .toEqual(sortElemArray(currentElements))
+      expect(sortElemArray(await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray())).toEqual(sortElemArray(currentElements))
     })
   })
   describe('removeNaclFiles', () => {
@@ -732,19 +751,22 @@ describe('multi env source', () => {
           [commonSourceName]: mockCommonNaclFileSource,
           [primarySourceName]: mockPrimaryNaclFileSource,
         },
-        primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
         true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
-      const currentElements = await awu(await multiEnvSourceWithMockSources.getAll()).toArray()
+      const currentElements = await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray()
       expect(currentElements).toHaveLength(2)
       const elementChanges = (await multiEnvSourceWithMockSources
         .removeNaclFiles('test.nacl'))
       expect(elementChanges[primarySourceName].changes).toEqual([change])
-      expect(await awu(await multiEnvSourceWithMockSources.getAll()).toArray()).toEqual([envObject])
+      expect(await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray()).toEqual([envObject])
     })
     it('should change inner state upon remove of multiple files', async () => {
       const removalCommon = { action: 'remove', data: { before: commonObject } } as Change<ObjectType>
@@ -762,20 +784,23 @@ describe('multi env source', () => {
           [commonSourceName]: mockCommonNaclFileSource,
           [primarySourceName]: mockPrimaryNaclFileSource,
         },
-        primarySourceName,
         commonSourceName,
         () => Promise.resolve(new InMemoryRemoteMap()),
         true
       )
       await multiEnvSourceWithMockSources.load({})
       // NOTE: the getAll call initialize the init state
-      const currentElements = await awu(await multiEnvSourceWithMockSources.getAll()).toArray()
+      const currentElements = await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray()
       expect(currentElements).toHaveLength(2)
       const elementChanges = (await multiEnvSourceWithMockSources.removeNaclFiles(
         'test.nacl', path.join(ENVS_PREFIX, primarySourceName, 'env.nacl')
       ))
       expect(elementChanges[primarySourceName].changes).toEqual([removalPrimary, removalCommon])
-      expect(await awu(await multiEnvSourceWithMockSources.getAll()).toArray()).toEqual([])
+      expect(await awu(
+        await multiEnvSourceWithMockSources.getAll(primarySourceName)
+      ).toArray()).toEqual([])
     })
   })
   describe('getSourceMap', () => {
@@ -791,7 +816,7 @@ describe('multi env source', () => {
   })
   describe('getSourceRanges', () => {
     it('should return source ranges from the active sources only', async () => {
-      const ranges = await source.getSourceRanges(objectElemID)
+      const ranges = await source.getSourceRanges(activePrefix, objectElemID)
       const filenames = ranges.map(r => r.filename)
       expect(filenames).toHaveLength(2)
 
@@ -803,7 +828,7 @@ describe('multi env source', () => {
   })
   describe('getErrors', () => {
     it('should return errors from the active sources only', async () => {
-      const errors = await source.getErrors()
+      const errors = await source.getErrors(activePrefix)
       const filenames = errors.parse.map(e => e.subject.filename)
       expect(filenames).toHaveLength(2)
       await expectToContainAllItems(filenames, [
@@ -834,8 +859,8 @@ describe('multi env source', () => {
       jest.spyOn(routers, 'routeCopyTo').mockImplementationOnce(
         () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
       )
-      await source.copyTo(await awu(await source
-        .getElementIdsBySelectors(selectors)).toArray(), ['inactive'])
+      await source.copyTo(activePrefix, await awu(await source
+        .getElementIdsBySelectors(activePrefix, selectors)).toArray(), ['inactive'])
       expect(routers.routeCopyTo).toHaveBeenCalledWith(
         [envElemID, objectElemID], envSource, { inactive: inactiveSource }
       )
@@ -845,7 +870,10 @@ describe('multi env source', () => {
       jest.spyOn(routers, 'routeCopyTo').mockImplementationOnce(
         () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
       )
-      await source.copyTo(await awu(await source.getElementIdsBySelectors(selectors)).toArray())
+      await source.copyTo(
+        activePrefix,
+        await awu(await source.getElementIdsBySelectors(activePrefix, selectors)).toArray()
+      )
       expect(routers.routeCopyTo).toHaveBeenCalledWith(
         [envElemID, objectElemID], envSource, { inactive: inactiveSource }
       )
@@ -856,8 +884,11 @@ describe('multi env source', () => {
       const selectors = createElementSelectors(['salto.*']).validSelectors
       jest.spyOn(routers, 'routeRemoveFrom').mockResolvedValue({ commonSource: [], envSources: {} })
       await source.sync(
+        activePrefix,
         [],
-        { inactive: await awu(await source.getElementIdsBySelectors(selectors)).toArray() },
+        { inactive: await awu(
+          await source.getElementIdsBySelectors(activePrefix, selectors)
+        ).toArray() },
         ['inactive'],
       )
       expect(routers.routeRemoveFrom).toHaveBeenCalledWith(
@@ -869,7 +900,9 @@ describe('multi env source', () => {
     describe('from=env should select only env elements', () => {
       it('should extract the proper ids with overlaps when compact=false', async () => {
         const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
-        const res = await awu(await source.getElementIdsBySelectors(selectors)).toArray()
+        const res = await awu(
+          await source.getElementIdsBySelectors(activePrefix, selectors)
+        ).toArray()
         expect(res.map(id => id.getFullName()).sort()).toEqual([
           envElemID,
           envElemID.createNestedID('field', 'field'),
@@ -880,7 +913,7 @@ describe('multi env source', () => {
       it('should extract the proper ids without overlaps when compact=true', async () => {
         const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
         const res = await awu(
-          await source.getElementIdsBySelectors(selectors, { source: 'env' }, true)
+          await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'env' }, true)
         ).toArray()
         expect(res.map(id => id.getFullName()).sort()).toEqual([
           envElemID,
@@ -890,7 +923,7 @@ describe('multi env source', () => {
 
       it('should extract the proper ids from a specific env when passed', async () => {
         const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
-        const res = await awu(await source.getElementIdsBySelectors(selectors, { source: 'env', envName: 'inactive' })).toArray()
+        const res = await awu(await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'env', envName: 'inactive' })).toArray()
         expect(res.map(id => id.getFullName()).sort()).toEqual([
           inactiveElemID,
           inactiveElemID.createNestedID('field', 'field'),
@@ -902,7 +935,7 @@ describe('multi env source', () => {
     describe('from=common should select only common elements', () => {
       it('should extract the proper ids with overlaps when compact=false', async () => {
         const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
-        const res = await awu(await source.getElementIdsBySelectors(selectors, { source: 'common' })).toArray()
+        const res = await awu(await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'common' })).toArray()
         expect(res.map(id => id.getFullName()).sort()).toEqual([
           commonObject.elemID,
           commonObject.elemID.createNestedID('field', 'field'),
@@ -913,7 +946,7 @@ describe('multi env source', () => {
       it('should extract the proper ids without overlaps when compact=true', async () => {
         const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
         const res = await awu(
-          await source.getElementIdsBySelectors(selectors, { source: 'common' }, true)
+          await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'common' }, true)
         ).toArray()
         expect(res.map(id => id.getFullName()).sort()).toEqual([
           commonObject.elemID,
@@ -924,7 +957,7 @@ describe('multi env source', () => {
     describe('from=both should select both env and common elements', () => {
       it('should extract the proper ids with overlaps when compact=false', async () => {
         const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
-        const res = await awu(await source.getElementIdsBySelectors(selectors, { source: 'all' })).toArray()
+        const res = await awu(await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'all' })).toArray()
         expect(res.map(id => id.getFullName()).sort()).toEqual([
           commonObject.elemID,
           commonObject.elemID.createNestedID('field', 'field'),
@@ -938,7 +971,7 @@ describe('multi env source', () => {
       it('should extract the proper ids without overlaps when compact=true', async () => {
         const selectors = createElementSelectors(['salto.*', 'salto.*.field.*']).validSelectors
         const res = await awu(
-          await source.getElementIdsBySelectors(selectors, { source: 'all' }, true)
+          await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'all' }, true)
         ).toArray()
         expect(res.map(id => id.getFullName()).sort()).toEqual([
           commonObject.elemID,
@@ -955,7 +988,8 @@ describe('multi env source', () => {
         () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
       )
       await source.promote(
-        await awu(await source.getElementIdsBySelectors(selectors, { source: 'env' }, true)).toArray()
+        activePrefix,
+        await awu(await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'env' }, true)).toArray()
       )
       expect(routers.routePromote).toHaveBeenCalledWith(
         [envElemID, objectElemID], 'active', commonSource, {
@@ -972,7 +1006,7 @@ describe('multi env source', () => {
         () => Promise.resolve({ primarySource: [], commonSource: [], secondarySources: {} })
       )
       await source.demote(await awu(
-        await source.getElementIdsBySelectors(selectors, { source: 'common' }, true)
+        await source.getElementIdsBySelectors(activePrefix, selectors, { source: 'common' }, true)
       ).toArray())
       expect(routers.routeDemote).toHaveBeenCalledWith(
         [commonObject.elemID, objectElemID], commonSource, {
@@ -1002,7 +1036,6 @@ describe('multi env source', () => {
     it('should not allow flush when the ws is non-persistent', async () => {
       const nonPSource = multiEnvSource(
         sources,
-        activePrefix,
         commonPrefix,
         () => Promise.resolve(new InMemoryRemoteMap()),
         false
@@ -1023,13 +1056,12 @@ describe('multi env source', () => {
       envSrcStaticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(new MissingStaticFile(''))
       const src = multiEnvSource(
         sources,
-        activePrefix,
         commonPrefix,
         () => Promise.resolve(new InMemoryRemoteMap()),
         false
       )
       expect(await src.getStaticFile(
-        staticFile.filepath, staticFile.encoding
+        staticFile.filepath, staticFile.encoding, activePrefix
       )).toEqual(staticFile)
     })
     it('should return the file it is present in the env source and the hashes match', async () => {
@@ -1037,13 +1069,12 @@ describe('multi env source', () => {
       envSrcStaticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(staticFile)
       const src = multiEnvSource(
         sources,
-        activePrefix,
         commonPrefix,
         () => Promise.resolve(new InMemoryRemoteMap()),
         false
       )
       expect(await src.getStaticFile(
-        staticFile.filepath, staticFile.encoding
+        staticFile.filepath, staticFile.encoding, activePrefix
       )).toEqual(staticFile)
     })
     it('should return missingStaticFile if the file is not present in any of the sources', async () => {
@@ -1051,13 +1082,12 @@ describe('multi env source', () => {
       envSrcStaticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(new MissingStaticFile(''))
       const src = multiEnvSource(
         sources,
-        activePrefix,
         commonPrefix,
         () => Promise.resolve(new InMemoryRemoteMap()),
         false
       )
       expect(await src.getStaticFile(
-        staticFile.filepath, staticFile.encoding
+        staticFile.filepath, staticFile.encoding, activePrefix
       )).toEqual(new MissingStaticFile(staticFile.filepath))
     })
   })

--- a/packages/workspace/test/workspace/multi_env/routers.test.ts
+++ b/packages/workspace/test/workspace/multi_env/routers.test.ts
@@ -218,6 +218,16 @@ const envSource = createMockNaclFileSource([
   'test:/partiallyCommonObjEnv.nacl': [partiallyCommonObjEnv],
 })
 const secEnv = createMockNaclFileSource([envObj, envCommonOnlyFieldObject])
+const primarySrcName = 'primarySource'
+const secSrcName = 'secSource'
+const envSources = {
+  [primarySrcName]: envSource,
+  [secSrcName]: secEnv,
+}
+
+const onlyPrimSrc = {
+  [primarySrcName]: envSource,
+}
 
 describe('default fetch routing', () => {
   it('should route add changes to common when there is only one configured env', async () => {
@@ -226,11 +236,17 @@ describe('default fetch routing', () => {
       data: { after: newObj },
       id: newObj.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'default')
-    expect(routedChanges.primarySource).toHaveLength(0)
+    const routedChanges = await routeChanges(
+      [change],
+      primarySrcName,
+      commonSource,
+      { [primarySrcName]: envSource },
+      'default'
+    )
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(1)
     expect(routedChanges.commonSource && routedChanges.commonSource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 
   it('should route add changes to primary env when there are more then one configured env', async () => {
@@ -239,11 +255,13 @@ describe('default fetch routing', () => {
       data: { after: newObj },
       id: newObj.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, { sec: secEnv }, 'default')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'default')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(
+      routedChanges.envSources?.[primarySrcName][0]
+    ).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 
   it('should handle ridiculously large changeset without stack overflow', async () => {
@@ -256,12 +274,12 @@ describe('default fetch routing', () => {
     for (let i = 0; i < 140000; i += 1) {
       changes.push(change)
     }
-    await routeChanges(changes, envSource, commonSource, { sec: secEnv }, 'default')
+    await routeChanges(changes, primarySrcName, commonSource, envSources, 'default')
   })
 
   it('should handle empty changeset without error', async () => {
     const changes: DetailedChange[] = []
-    await routeChanges(changes, envSource, commonSource, { sec: secEnv }, 'default')
+    await routeChanges(changes, primarySrcName, commonSource, envSources, 'default')
   })
 
   it('should route nested add changes to primary env when the containing element is not in common', async () => {
@@ -270,11 +288,13 @@ describe('default fetch routing', () => {
       data: { after: 'value' },
       id: envOnlyObj.elemID.createNestedID('attr', 'newAttr'),
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, { sec: secEnv }, 'default')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'default')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(
+      routedChanges.envSources?.[primarySrcName][0]
+    ).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 
   it('should route nested add changes to primary env when the containing element is in common but also in primary env', async () => {
@@ -283,11 +303,13 @@ describe('default fetch routing', () => {
       data: { after: 'value' },
       id: commonObj.elemID.createNestedID('attr', 'newAttr'),
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, { sec: secEnv }, 'default')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'default')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(
+      routedChanges.envSources?.[primarySrcName][0]
+    ).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 
   it('should route nested add changes to common when the containing element is only in common', async () => {
@@ -296,11 +318,11 @@ describe('default fetch routing', () => {
       data: { after: 'value' },
       id: commonOnlyObject.elemID.createNestedID('attr', 'newAttr'),
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, { sec: secEnv }, 'default')
-    expect(routedChanges.primarySource).toHaveLength(0)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'default')
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(1)
     expect(routedChanges.commonSource && routedChanges.commonSource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 
   it('should route nested add changes to common when the direct parent is only in common', async () => {
@@ -309,11 +331,11 @@ describe('default fetch routing', () => {
       data: { after: 'value' },
       id: commonObj.fields.commonField.elemID.createNestedID('label'),
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, { sec: secEnv }, 'default')
-    expect(routedChanges.primarySource).toHaveLength(0)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'default')
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(1)
     expect(routedChanges.commonSource && routedChanges.commonSource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 
   it('should route common modify changes to common', async () => {
@@ -322,11 +344,11 @@ describe('default fetch routing', () => {
       data: { before: false, after: true },
       id: commonObj.elemID.createNestedID('attr', 'boolean'),
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'override')
-    expect(routedChanges.primarySource).toHaveLength(0)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(1)
     expect(routedChanges.commonSource && routedChanges.commonSource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 
   it('should route env modify changes to env', async () => {
@@ -336,11 +358,13 @@ describe('default fetch routing', () => {
       data: { before: envObj.fields[envField.name], after: newEnvField },
       id: newEnvField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'default')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'default')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(
+      routedChanges.envSources?.[primarySrcName][0]
+    ).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route common remove changes to common', async () => {
     const change: DetailedChange = {
@@ -348,11 +372,11 @@ describe('default fetch routing', () => {
       data: { before: commonObj.fields.commonField },
       id: commonObj.fields.commonField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'default')
-    expect(routedChanges.primarySource).toHaveLength(0)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'default')
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(1)
     expect(routedChanges.commonSource && routedChanges.commonSource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route env remove changes to env', async () => {
     const change: DetailedChange = {
@@ -360,11 +384,13 @@ describe('default fetch routing', () => {
       data: { before: envObj.fields.envField },
       id: envObj.fields.envField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'default')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'default')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(
+      routedChanges.envSources?.[primarySrcName][0]
+    ).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should split shared remove changes to all environments', async () => {
     const change: DetailedChange = {
@@ -372,17 +398,16 @@ describe('default fetch routing', () => {
       data: { before: sharedObject },
       id: commonObj.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, { sec: secEnv }, 'default')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'default')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(1)
     const commonChangeElement = routedChanges.commonSource
         && (routedChanges.commonSource[0] as RemovalDiff<ObjectType>).data.before
-    const envChangeElement = routedChanges.primarySource
-        && (routedChanges.primarySource[0] as RemovalDiff<ObjectType>).data.before
+    const envChangeElement = routedChanges.envSources?.[primarySrcName]
+        && (routedChanges.envSources?.[primarySrcName][0] as RemovalDiff<ObjectType>).data.before
     expect(commonChangeElement).toEqual(commonObj)
     expect(envChangeElement).toEqual(envObj)
-    expect(routedChanges.secondarySources).toBeDefined()
-    expect(routedChanges.secondarySources?.sec).toHaveLength(1)
+    expect(routedChanges.envSources?.[secSrcName]).toHaveLength(1)
   })
   it('should route add changes of values of env specific elements to the '
     + 'env when there are multiple envs configured', async () => {
@@ -392,11 +417,13 @@ describe('default fetch routing', () => {
       data: { after: newField },
       id: newField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, { sec: secEnv }, 'default')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'default')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(
+      routedChanges.envSources?.[primarySrcName][0]
+    ).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route add changes of values of env specific elements to the '
     + 'env when there is only one env configured', async () => {
@@ -406,11 +433,13 @@ describe('default fetch routing', () => {
       data: { after: newField },
       id: newField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'default')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'default')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(
+      routedChanges.envSources?.[primarySrcName][0]
+    ).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route add changes of values of common elements to the primary env', async () => {
     const newField = new Field(commonObj, 'dreams', BuiltinTypes.STRING)
@@ -419,11 +448,13 @@ describe('default fetch routing', () => {
       data: { after: newField },
       id: newField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'default')
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'default')
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource).toHaveLength(1)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
+    expect(
+      routedChanges.envSources?.[primarySrcName][0]
+    ).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route add changes of values of split elements to the common when there is only one env', async () => {
     const newField = new Field(splitObjJoined, 'dreams', BuiltinTypes.STRING)
@@ -432,11 +463,11 @@ describe('default fetch routing', () => {
       data: { after: newField },
       id: newField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'default')
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'default')
     expect(routedChanges.commonSource).toHaveLength(1)
-    expect(routedChanges.primarySource).toHaveLength(0)
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource && routedChanges.commonSource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 })
 
@@ -447,11 +478,13 @@ describe('align fetch routing', () => {
       data: { after: newObj },
       id: newObj.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'align')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(
+      routedChanges.envSources?.[primarySrcName][0]
+    ).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 
   it('should drop add changes if the mergeable id is in common', async () => {
@@ -460,10 +493,10 @@ describe('align fetch routing', () => {
       data: { after: 'B' },
       id: commonObj.elemID.createNestedID('attr', 'arr', '0', 'b'),
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'align')
-    expect(routedChanges.primarySource).toHaveLength(0)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 
   it('should route add changes to primary source and wrap if direct parent is missing', async () => {
@@ -472,13 +505,13 @@ describe('align fetch routing', () => {
       data: { after: 'TEST' },
       id: partiallyCommonObjCommon.fields.commonField.elemID.createNestedID('test'),
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'align')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    const primaryChange = routedChanges.primarySource && routedChanges.primarySource[0]
+    const primaryChange = routedChanges.envSources?.[primarySrcName][0]
     expect(primaryChange?.id).toEqual(partiallyCommonObjCommon.fields.commonField.elemID)
     expect(isField(getChangeElement(primaryChange as Change<Field>))).toBeTruthy()
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 
   it('should drop common modify changes', async () => {
@@ -487,10 +520,10 @@ describe('align fetch routing', () => {
       data: { before: commonObj.fields.commonField, after: commonObj.fields.commonField },
       id: commonObj.fields.commonField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'align')
-    expect(routedChanges.primarySource).toHaveLength(0)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 
   it('should route env modify changes to env', async () => {
@@ -499,11 +532,13 @@ describe('align fetch routing', () => {
       data: { before: envObj, after: envObj },
       id: envObj.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'align')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(
+      routedChanges.envSources?.[primarySrcName][0]
+    ).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 
   it('should split shared modify changes and drop the common part', async () => {
@@ -512,16 +547,19 @@ describe('align fetch routing', () => {
       data: { before: sharedObject, after: sharedObject },
       id: commonObj.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'align')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    const envChangeBeforeElement = routedChanges.primarySource
-        && (routedChanges.primarySource[0] as ModificationDiff<ObjectType>).data.before
+    const envChangeBeforeElement = routedChanges.envSources?.[primarySrcName]
+        && (
+          routedChanges.envSources?.[primarySrcName][0] as ModificationDiff<ObjectType>
+        ).data.before
     expect(envChangeBeforeElement).toEqual(envObj)
-    const envChangeAfterElement = routedChanges.primarySource
-        && (routedChanges.primarySource[0] as ModificationDiff<ObjectType>).data.after
+    const envChangeAfterElement = routedChanges.envSources?.[primarySrcName]
+        && (routedChanges.envSources?.[primarySrcName][0] as ModificationDiff<ObjectType>
+        ).data.after
     expect(envChangeAfterElement).toEqual(envObj)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should drop common remove changes', async () => {
     const change: DetailedChange = {
@@ -529,10 +567,10 @@ describe('align fetch routing', () => {
       data: { before: commonObj.fields.commonField },
       id: commonObj.fields.commonField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'align')
-    expect(routedChanges.primarySource).toHaveLength(0)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route env remove changes to env', async () => {
     const change: DetailedChange = {
@@ -540,11 +578,12 @@ describe('align fetch routing', () => {
       data: { before: envObj },
       id: envObj.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'align')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(routedChanges.envSources?.[primarySrcName]
+      && routedChanges.envSources?.[primarySrcName][0]).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should split shared remove changes and drop common part', async () => {
     const change: DetailedChange = {
@@ -552,13 +591,15 @@ describe('align fetch routing', () => {
       data: { before: sharedObject },
       id: commonObj.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'align')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges(
+      [change], primarySrcName, commonSource, onlyPrimSrc, 'align'
+    )
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    const envChangeElement = routedChanges.primarySource
-        && (routedChanges.primarySource[0] as RemovalDiff<ObjectType>).data.before
+    const envChangeElement = routedChanges.envSources?.[primarySrcName]
+        && (routedChanges.envSources?.[primarySrcName][0] as RemovalDiff<ObjectType>).data.before
     expect(envChangeElement).toEqual(envObj)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route add changes of values of env specific elements to the env', async () => {
     const newField = new Field(envOnlyObj, 'dreams', BuiltinTypes.STRING)
@@ -567,11 +608,14 @@ describe('align fetch routing', () => {
       data: { after: newField },
       id: newField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'align')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(
+      routedChanges.envSources?.[primarySrcName]
+      && routedChanges.envSources?.[primarySrcName][0]
+    ).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route add changes of values of common elements to env', async () => {
     const newField = new Field(commonObj, 'dreams', BuiltinTypes.STRING)
@@ -580,11 +624,13 @@ describe('align fetch routing', () => {
       data: { after: newField },
       id: newField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'align')
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource).toHaveLength(1)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
+    expect(
+      routedChanges.envSources?.[primarySrcName] && routedChanges.envSources?.[primarySrcName][0]
+    ).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route add changes of instance annotations to env as annotations in a wrapped instance', async () => {
     const change: DetailedChange = {
@@ -592,10 +638,12 @@ describe('align fetch routing', () => {
       data: { after: [new ReferenceExpression(commonObj.elemID)] },
       id: commonInstance.elemID.createNestedID(INSTANCE_ANNOTATIONS.GENERATED_DEPENDENCIES),
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'align')
+    const routedChanges = await routeChanges(
+      [change], primarySrcName, commonSource, onlyPrimSrc, 'align'
+    )
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource).toHaveLength(1)
-    const envChange = routedChanges.primarySource?.[0] as DetailedChange
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
+    const envChange = routedChanges.envSources?.[primarySrcName]?.[0] as DetailedChange
     expect(envChange.action).toEqual('add')
     const envChangeInstance = getChangeElement(envChange) as InstanceElement
     expect(envChangeInstance).toBeInstanceOf(InstanceElement)
@@ -613,11 +661,13 @@ describe('override fetch routing', () => {
       data: { after: newObj },
       id: newObj.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'override')
-    expect(routedChanges.primarySource).toHaveLength(0)
+    const routedChanges = await routeChanges(
+      [change], primarySrcName, commonSource, onlyPrimSrc, 'override'
+    )
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(1)
     expect(routedChanges.commonSource && routedChanges.commonSource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 
   it('should route common modify changes to common', async () => {
@@ -626,11 +676,13 @@ describe('override fetch routing', () => {
       data: { before: commonObj.fields.commonField, after: commonObj.fields.commonField },
       id: commonObj.fields.commonField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'override')
-    expect(routedChanges.primarySource).toHaveLength(0)
+    const routedChanges = await routeChanges(
+      [change], primarySrcName, commonSource, onlyPrimSrc, 'override'
+    )
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(1)
     expect(routedChanges.commonSource && routedChanges.commonSource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route env modify changes to env', async () => {
     const change: DetailedChange = {
@@ -638,11 +690,15 @@ describe('override fetch routing', () => {
       data: { before: envObj.fields.envField, after: envObj.fields.envField },
       id: envObj.fields.envField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'override')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges(
+      [change], primarySrcName, commonSource, onlyPrimSrc, 'override'
+    )
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(
+      routedChanges.envSources?.[primarySrcName] && routedChanges.envSources?.[primarySrcName][0]
+    ).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should split shared modify changes to common and env', async () => {
     const change: DetailedChange = {
@@ -650,22 +706,24 @@ describe('override fetch routing', () => {
       data: { before: sharedObject, after: sharedObject },
       id: commonObj.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'override')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(1)
     const commonChangeBeforeElement = routedChanges.commonSource
         && (routedChanges.commonSource[0] as ModificationDiff<ObjectType>).data.before
-    const envChangeBeforeElement = routedChanges.primarySource
-        && (routedChanges.primarySource[0] as ModificationDiff<ObjectType>).data.before
+    const envChangeBeforeElement = routedChanges.envSources?.[primarySrcName]
+        && (routedChanges.envSources?.[primarySrcName][0] as ModificationDiff<ObjectType>
+        ).data.before
     expect(commonChangeBeforeElement).toEqual(commonObj)
     expect(envChangeBeforeElement).toEqual(envObj)
     const commonChangeAfterElement = routedChanges.commonSource
         && (routedChanges.commonSource[0] as ModificationDiff<ObjectType>).data.after
-    const envChangeAfterElement = routedChanges.primarySource
-        && (routedChanges.primarySource[0] as ModificationDiff<ObjectType>).data.after
+    const envChangeAfterElement = routedChanges.envSources?.[primarySrcName]
+        && (routedChanges.envSources?.[primarySrcName][0] as ModificationDiff<ObjectType>
+        ).data.after
     expect(commonChangeAfterElement).toEqual(commonObj)
     expect(envChangeAfterElement).toEqual(envObj)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route common remove changes to common', async () => {
     const change: DetailedChange = {
@@ -673,11 +731,11 @@ describe('override fetch routing', () => {
       data: { before: commonObj.fields.commonField },
       id: commonObj.fields.commonField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'override')
-    expect(routedChanges.primarySource).toHaveLength(0)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(1)
     expect(routedChanges.commonSource && routedChanges.commonSource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route env remove changes to env', async () => {
     const change: DetailedChange = {
@@ -685,11 +743,12 @@ describe('override fetch routing', () => {
       data: { before: envObj.fields.envField },
       id: envObj.fields.envField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'override')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(routedChanges.envSources?.[primarySrcName]
+      && routedChanges.envSources?.[primarySrcName][0]).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should split shared remove changes to common and env', async () => {
     const change: DetailedChange = {
@@ -697,17 +756,16 @@ describe('override fetch routing', () => {
       data: { before: sharedObject },
       id: commonObj.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, { sec: secEnv }, 'override')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'override')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(1)
     const commonChangeElement = routedChanges.commonSource
         && (routedChanges.commonSource[0] as RemovalDiff<ObjectType>).data.before
-    const envChangeElement = routedChanges.primarySource
-        && (routedChanges.primarySource[0] as RemovalDiff<ObjectType>).data.before
+    const envChangeElement = routedChanges.envSources?.[primarySrcName]
+        && (routedChanges.envSources?.[primarySrcName][0] as RemovalDiff<ObjectType>).data.before
     expect(commonChangeElement).toEqual(commonObj)
     expect(envChangeElement).toEqual(envObj)
-    expect(routedChanges.secondarySources).toBeDefined()
-    expect(routedChanges.secondarySources?.sec).toHaveLength(1)
+    expect(routedChanges.envSources?.[secSrcName]).toHaveLength(1)
   })
   it('should route add changes of values of env specific elements to the env', async () => {
     const newField = new Field(envOnlyObj, 'dreams', BuiltinTypes.STRING)
@@ -716,11 +774,12 @@ describe('override fetch routing', () => {
       data: { after: newField },
       id: newField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'override')
-    expect(routedChanges.primarySource).toHaveLength(1)
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(routedChanges.envSources?.[primarySrcName]
+      && routedChanges.envSources?.[primarySrcName][0]).toEqual(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route add changes of values of common elements to the common', async () => {
     const newField = new Field(commonObj, 'dreams', BuiltinTypes.STRING)
@@ -729,11 +788,11 @@ describe('override fetch routing', () => {
       data: { after: newField },
       id: newField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'override')
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
     expect(routedChanges.commonSource).toHaveLength(1)
-    expect(routedChanges.primarySource).toHaveLength(0)
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource && routedChanges.commonSource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route add changes of values of split elements to the common', async () => {
     const newField = new Field(splitObjJoined, 'dreams', BuiltinTypes.STRING)
@@ -742,11 +801,11 @@ describe('override fetch routing', () => {
       data: { after: newField },
       id: newField.elemID,
     }
-    const routedChanges = await routeChanges([change], envSource, commonSource, {}, 'override')
+    const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
     expect(routedChanges.commonSource).toHaveLength(1)
-    expect(routedChanges.primarySource).toHaveLength(0)
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource && routedChanges.commonSource[0]).toEqual(change)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
 })
 
@@ -759,15 +818,16 @@ describe('isolated routing', () => {
     }
     const routedChanges = await routeChanges(
       [change],
-      envSource,
+      primarySrcName,
       commonSource,
-      { sec: secEnv },
+      envSources,
       'isolated'
     )
-    expect(routedChanges.primarySource).toHaveLength(1)
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
-    expect(routedChanges.primarySource && routedChanges.primarySource[0])
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
+    expect(routedChanges.envSources?.[primarySrcName]
+      && routedChanges.envSources?.[primarySrcName][0])
       .toMatchObject(change)
   })
   it('should route an env modification change to env', async () => {
@@ -779,16 +839,17 @@ describe('isolated routing', () => {
     }
     const routedChanges = await routeChanges(
       [change],
-      envSource,
+      primarySrcName,
       commonSource,
-      { sec: secEnv },
+      envSources,
       'isolated'
     )
-    expect(routedChanges.primarySource).toHaveLength(1)
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
-    expect(routedChanges.primarySource && routedChanges.primarySource[0])
-      .toMatchObject(change)
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
+    expect(
+      routedChanges.envSources?.[primarySrcName] && routedChanges.envSources?.[primarySrcName][0]
+    ).toMatchObject(change)
   })
   it('should route an env remove diff to env', async () => {
     const change: DetailedChange = {
@@ -798,15 +859,16 @@ describe('isolated routing', () => {
     }
     const routedChanges = await routeChanges(
       [change],
-      envSource,
+      primarySrcName,
       commonSource,
-      { sec: secEnv },
+      envSources,
       'isolated'
     )
-    expect(routedChanges.primarySource).toHaveLength(1)
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
-    expect(_.isEmpty(routedChanges.secondarySources)).toBeTruthy()
-    expect(routedChanges.primarySource && routedChanges.primarySource[0])
+    expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
+    expect(routedChanges.envSources?.[primarySrcName]
+      && routedChanges.envSources?.[primarySrcName][0])
       .toMatchObject(change)
   })
   it('should route a common modification diff to common and revert the change in secondary envs', async () => {
@@ -817,15 +879,15 @@ describe('isolated routing', () => {
     }
     const routedChanges = await routeChanges(
       [specificChange],
-      envSource,
+      primarySrcName,
       commonSource,
-      { sec: secEnv },
+      envSources,
       'isolated'
     )
-    expect(routedChanges.primarySource).toHaveLength(1)
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(1)
-    expect(routedChanges.secondarySources?.sec).toHaveLength(1)
-    expect(routedChanges.primarySource?.[0]).toEqual({
+    expect(routedChanges.envSources?.[secSrcName]).toHaveLength(1)
+    expect(routedChanges.envSources?.[primarySrcName]?.[0]).toEqual({
       action: 'add',
       data: { after: specificChange.data.after },
       id: specificChange.id,
@@ -837,7 +899,7 @@ describe('isolated routing', () => {
       id: specificChange.id,
       path: ['test', 'path'],
     })
-    expect(routedChanges.secondarySources?.sec[0]).toEqual({
+    expect(routedChanges.envSources?.[secSrcName][0]).toEqual({
       action: 'add',
       data: { after: specificChange.data.before },
       id: specificChange.id,
@@ -857,12 +919,12 @@ describe('isolated routing', () => {
     }
     const routedChanges = await routeChanges(
       [splitObjChange, splitInstChange],
-      envSource,
+      primarySrcName,
       commonSource,
-      { sec: secEnv },
+      envSources,
       'isolated'
     )
-    expect(routedChanges.primarySource).toHaveLength(0)
+    expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(2)
     expect(routedChanges.commonSource && routedChanges.commonSource[0].action).toEqual('remove')
     expect(routedChanges.commonSource && routedChanges.commonSource[0].id)
@@ -871,7 +933,7 @@ describe('isolated routing', () => {
     expect(routedChanges.commonSource && routedChanges.commonSource[1].id)
       .toEqual(splitInstanceJoined.elemID)
 
-    const secChanges = routedChanges.secondarySources?.sec
+    const secChanges = routedChanges.envSources?.[secSrcName]
     expect(secChanges).toHaveLength(5)
     expect(secChanges && secChanges[0]).toEqual({
       action: 'add',
@@ -912,14 +974,15 @@ describe('isolated routing', () => {
     }
     const routedChanges = await routeChanges(
       [change],
-      envSource,
+      primarySrcName,
       commonSource,
-      { sec: secEnv },
+      envSources,
       'isolated'
     )
-    expect(routedChanges.primarySource).toHaveLength(1)
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(1)
-    expect(routedChanges.primarySource && routedChanges.primarySource[0]).toMatchObject({
+    expect(routedChanges.envSources?.[primarySrcName]
+      && routedChanges.envSources?.[primarySrcName][0]).toMatchObject({
       action: 'remove',
       data: { before: envObj },
       id: envObj.elemID,
@@ -933,7 +996,8 @@ describe('isolated routing', () => {
     const expectedChanges = detailedCompare(envObj, sharedObject)
       .map(expectedChange => ({ ...expectedChange, path: ['test', 'path'] }))
     expectedChanges.forEach(
-      expectedChange => expect(routedChanges.secondarySources?.sec).toContainEqual(expectedChange)
+      expectedChange => expect(routedChanges.envSources?.[secSrcName])
+        .toContainEqual(expectedChange)
     )
   })
 
@@ -950,13 +1014,14 @@ describe('isolated routing', () => {
     }
     const routedChanges = await routeChanges(
       [removeChange, addChange],
-      envSource,
+      primarySrcName,
       commonSource,
-      { sec: secEnv },
+      envSources,
       'isolated'
     )
-    expect(routedChanges.primarySource).toHaveLength(1)
-    const primaryChange = routedChanges.primarySource && routedChanges.primarySource[0]
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
+    const primaryChange = routedChanges
+      .envSources?.[primarySrcName] && routedChanges.envSources?.[primarySrcName][0]
     expect(primaryChange).toEqual({
       action: 'add',
       id: commonInstance.elemID,
@@ -979,7 +1044,7 @@ describe('isolated routing', () => {
       },
       path: ['test', 'path'],
     })
-    const secondaryChange = routedChanges.secondarySources?.sec?.[0]
+    const secondaryChange = routedChanges.envSources?.[secSrcName]?.[0]
     expect(secondaryChange).toEqual({
       action: 'add',
       id: commonInstance.elemID,
@@ -1017,26 +1082,26 @@ describe('isolated routing', () => {
     const afterField = afterObject.fields.ofdreams
     const routedChanges = await routeChanges(
       [specificChange],
-      envSource,
+      primarySrcName,
       commonSource,
-      { sec: secEnv },
+      envSources,
       'isolated'
     )
-    expect(routedChanges.primarySource).toHaveLength(1)
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(1)
-    expect(routedChanges.secondarySources?.sec).toHaveLength(1)
-    expect(routedChanges.primarySource?.[0].action).toEqual('add')
-    const primaryChangeData = routedChanges.primarySource?.[0] as AdditionDiff<Field>
-    expect(routedChanges.primarySource?.[0].id).toEqual(fieldID)
+    expect(routedChanges.envSources?.[secSrcName]).toHaveLength(1)
+    expect(routedChanges.envSources?.[primarySrcName]?.[0].action).toEqual('add')
+    const primaryChangeData = routedChanges.envSources?.[primarySrcName]?.[0] as AdditionDiff<Field>
+    expect(routedChanges.envSources?.[primarySrcName]?.[0].id).toEqual(fieldID)
     expect(primaryChangeData.data.after.refType.elemID).toEqual(afterField.refType.elemID)
     expect(primaryChangeData.data.after.annotations).toEqual(afterField.annotations)
 
     expect(routedChanges.commonSource?.[0].action).toEqual('remove')
     expect(routedChanges.commonSource?.[0].id).toEqual(specificChange.id)
 
-    expect(routedChanges.primarySource?.[0].action).toEqual('add')
-    const secChangeData = routedChanges.secondarySources?.sec[0] as AdditionDiff<Field>
-    expect(routedChanges.secondarySources?.sec[0].id).toEqual(fieldID)
+    expect(routedChanges.envSources?.[primarySrcName]?.[0].action).toEqual('add')
+    const secChangeData = routedChanges.envSources?.[secSrcName][0] as AdditionDiff<Field>
+    expect(routedChanges.envSources?.[secSrcName][0].id).toEqual(fieldID)
     expect(secChangeData.data.after.refType.elemID).toEqual(beforeField.refType.elemID)
     expect(secChangeData.data.after.annotations).toEqual(beforeField.annotations)
   })
@@ -1049,25 +1114,26 @@ describe('isolated routing', () => {
     }
     const routedChanges = await routeChanges(
       [specificChange],
-      envSource,
+      primarySrcName,
       commonSource,
-      { sec: secEnv },
+      envSources,
       'isolated'
     )
-    expect(routedChanges.primarySource).toHaveLength(1)
+    expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(1)
-    expect(routedChanges.secondarySources?.sec).toHaveLength(1)
-    expect(routedChanges.primarySource?.[0].action).toEqual('add')
-    const primaryChangeData = routedChanges.primarySource?.[0] as AdditionDiff<ObjectType>
-    expect(routedChanges.primarySource?.[0].id).toEqual(commonObjWithList.elemID)
+    expect(routedChanges.envSources?.[secSrcName]).toHaveLength(1)
+    expect(routedChanges.envSources?.[primarySrcName]?.[0].action).toEqual('add')
+    const primaryChangeData = routedChanges
+      .envSources?.[primarySrcName]?.[0] as AdditionDiff<ObjectType>
+    expect(routedChanges.envSources?.[primarySrcName]?.[0].id).toEqual(commonObjWithList.elemID)
     expect(primaryChangeData.data.after.annotations.list).toEqual([1, 2, 3, 4])
 
     expect(routedChanges.commonSource?.[0].action).toEqual('remove')
     expect(routedChanges.commonSource?.[0].id).toEqual(specificChange.id)
 
-    expect(routedChanges.primarySource?.[0].action).toEqual('add')
-    const secChangeData = routedChanges.secondarySources?.sec[0] as AdditionDiff<Field>
-    expect(routedChanges.secondarySources?.sec[0].id).toEqual(commonObjWithList.elemID)
+    expect(routedChanges.envSources?.[primarySrcName]?.[0].action).toEqual('add')
+    const secChangeData = routedChanges.envSources?.[secSrcName][0] as AdditionDiff<Field>
+    expect(routedChanges.envSources?.[secSrcName][0].id).toEqual(commonObjWithList.elemID)
     expect(secChangeData.data.after.annotations.list).toEqual([1, 2, 3])
   })
 })
@@ -1228,30 +1294,32 @@ describe('track', () => {
     }
   )
   const commonSrc = createMockNaclFileSource(commonElements, { 'default.nacl': commonElements })
-  const secondarySources = {
-    sec: createMockNaclFileSource(secondaryElements, { 'default.nacl': secondaryElements }),
+
+  const trackEnvSources = {
+    [primarySrcName]: primarySrc,
+    [secSrcName]: createMockNaclFileSource(secondaryElements, { 'default.nacl': secondaryElements }),
   }
 
   it('should throw the proper error when trying to move an element which is not in the origin env', async () => {
     await expect(routePromote(
       [ElemID.fromFullName('salto.noop')],
-      primarySrc,
+      primarySrcName,
       commonSrc,
-      secondarySources
+      trackEnvSources
     )).rejects.toThrow('does not exist in origin')
   })
 
   it('should move an entire element in two diff files if not in common and split in source', async () => {
     const changes = await routePromote(
       [onlyInEnvElemID],
-      primarySrc,
+      primarySrcName,
       commonSrc,
-      secondarySources
+      trackEnvSources
     )
-    expect(changes.primarySource).toHaveLength(1)
+    expect(changes.envSources?.[primarySrcName]).toHaveLength(1)
     expect(changes.commonSource).toHaveLength(2)
-    expect(changes.secondarySources?.sec).toHaveLength(0)
-    const primaryChange = changes.primarySource && changes.primarySource[0]
+    expect(changes.envSources?.[secSrcName]).toHaveLength(0)
+    const primaryChange = changes.envSources?.[primarySrcName]?.[0]
     expect(primaryChange?.id).toEqual(onlyInEnvElemID)
     expect(primaryChange?.action).toEqual('remove')
     const firstPartCommonChange = changes.commonSource && changes.commonSource[0]
@@ -1267,11 +1335,11 @@ describe('track', () => {
   it('should create detailed changes when an element fragment is present in the common source', async () => {
     const changes = await routePromote(
       [splitObjEnv.elemID],
-      primarySrc,
+      primarySrcName,
       commonSrc,
-      secondarySources
+      trackEnvSources
     )
-    expect(changes.primarySource).toHaveLength(1)
+    expect(changes.envSources?.[primarySrcName]).toHaveLength(1)
     expect(changes.commonSource).toHaveLength(6)
     expect(hasChanges(changes.commonSource || [], [
       { action: 'add', id: splitObjEnv.elemID.createNestedID('annotation', 'env') },
@@ -1289,11 +1357,11 @@ describe('track', () => {
         onlyInEnvObj.fields.str.elemID,
         onlyInEnvObj.elemID.createNestedID('attr', 'str'),
       ],
-      primarySrc,
+      primarySrcName,
       commonSrc,
-      secondarySources
+      trackEnvSources
     )
-    expect(changes.primarySource).toHaveLength(2)
+    expect(changes.envSources?.[primarySrcName]).toHaveLength(2)
     expect(changes.commonSource).toHaveLength(1)
     expect(hasChanges(changes.commonSource || [], [
       { action: 'add', id: onlyInEnvObj.elemID },
@@ -1306,11 +1374,11 @@ describe('track', () => {
         splitObjEnv.fields.envField.elemID,
         splitObjEnv.elemID.createNestedID('attr', 'env'),
       ],
-      primarySrc,
+      primarySrcName,
       commonSrc,
-      secondarySources
+      trackEnvSources
     )
-    expect(changes.primarySource).toHaveLength(2)
+    expect(changes.envSources?.[primarySrcName]).toHaveLength(2)
     expect(changes.commonSource).toHaveLength(2)
     expect(hasChanges(changes.commonSource || [], [
       { action: 'add', id: splitObjEnv.fields.envField.elemID },
@@ -1321,11 +1389,11 @@ describe('track', () => {
   it('should maintain file structure when moving an element to common', async () => {
     const changes = await routePromote(
       [multiFileInstace.elemID],
-      primarySrc,
+      primarySrcName,
       commonSrc,
-      secondarySources
+      trackEnvSources
     )
-    expect(changes.primarySource).toHaveLength(1)
+    expect(changes.envSources?.[primarySrcName]).toHaveLength(1)
     expect(changes.commonSource).toHaveLength(2)
     expect(changes.commonSource).toEqual([
       { action: 'add',
@@ -1342,50 +1410,50 @@ describe('track', () => {
   it('should delete the elements in all secondary envs as when promoted apps exist there', async () => {
     const changes = await routePromote(
       [inSecObject.elemID],
-      primarySrc,
+      primarySrcName,
       commonSrc,
-      secondarySources
+      trackEnvSources
     )
-    expect(changes.primarySource).toHaveLength(1)
+    expect(changes.envSources?.[primarySrcName]).toHaveLength(1)
     expect(changes.commonSource).toHaveLength(1)
-    expect(changes.secondarySources?.sec).toHaveLength(1)
+    expect(changes.envSources?.[secSrcName]).toHaveLength(1)
   })
   it('should delete the elements that exist in the secondary envs when not all promoted elems exist there', async () => {
     const changes = await routePromote(
       [multiFileInstace.elemID, inSecObject.elemID],
-      primarySrc,
+      primarySrcName,
       commonSrc,
-      secondarySources
+      trackEnvSources
     )
-    expect(changes.primarySource).toHaveLength(2)
+    expect(changes.envSources?.[primarySrcName]).toHaveLength(2)
     expect(changes.commonSource).toHaveLength(3)
-    expect(changes.secondarySources?.sec).toHaveLength(1)
+    expect(changes.envSources?.[secSrcName]).toHaveLength(1)
   })
 
   it('should do nothing if only exists in common', async () => {
     const changes = await routePromote(
       [onlyInCommon.elemID],
-      primarySrc,
+      primarySrcName,
       commonSrc,
-      secondarySources,
+      trackEnvSources,
     )
-    expect(changes.primarySource).toHaveLength(0)
+    expect(changes.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(changes.commonSource).toHaveLength(0)
-    expect(changes.secondarySources?.sec).toHaveLength(0)
+    expect(changes.envSources?.[secSrcName]).toHaveLength(0)
   })
 
   it('should route a nested field attr where the object does not exists in common', async () => {
     const annoID = onlyInEnvObj.fields.str.elemID.createNestedID('anno')
     const changes = await routePromote(
       [annoID],
-      primarySrc,
+      primarySrcName,
       commonSrc,
-      secondarySources,
+      trackEnvSources,
     )
-    expect(changes.primarySource).toHaveLength(1)
+    expect(changes.envSources?.[primarySrcName]).toHaveLength(1)
     expect(changes.commonSource).toHaveLength(1)
-    expect(changes.secondarySources?.sec).toHaveLength(0)
-    expect(changes.primarySource?.[0].id).toEqual(annoID)
+    expect(changes.envSources?.[secSrcName]).toHaveLength(0)
+    expect(changes.envSources?.[primarySrcName][0].id).toEqual(annoID)
     expect(changes.commonSource?.[0].id).toEqual(onlyInEnvObj.elemID)
   })
 })
@@ -1504,31 +1572,30 @@ describe('untrack', () => {
     'default.nacl': [onlyInCommon, splitObjCommon, missingFromPrimCommon, multiFileCommonDefault],
     'other.nacl': [multiFileCommonOther],
   })
-  const secondarySources = {
-    sec: createMockNaclFileSource(secondaryElements, { 'default.nacl': secondaryElements }),
+  const untrackEnvSource = {
+    [primarySrcName]: primarySrc,
+    [secSrcName]: createMockNaclFileSource(secondaryElements, { 'default.nacl': secondaryElements }),
   }
 
   it('should throw the proper error when trying to move an element which is not in the origin env', async () => {
     await expect(routeDemote(
       [ElemID.fromFullName('salto.noop')],
-      primarySrc,
       commonSrc,
-      secondarySources
+      untrackEnvSource
     )).rejects.toThrow('does not exist in origin')
   })
 
   it('should move add element which is only in common to all envs', async () => {
     const changes = await routeDemote(
       [onlyInCommon.elemID],
-      primarySrc,
       commonSrc,
-      secondarySources
+      untrackEnvSource
     )
     expect(changes.commonSource).toHaveLength(1)
-    expect(changes.primarySource).toHaveLength(1)
-    expect(changes.secondarySources?.sec).toHaveLength(1)
-    expect(changes.primarySource).toEqual(changes.secondarySources?.sec)
-    expect(hasChanges(changes.primarySource || [], [
+    expect(changes.envSources?.[primarySrcName]).toHaveLength(1)
+    expect(changes.envSources?.[secSrcName]).toHaveLength(1)
+    expect(changes.envSources?.[primarySrcName]).toEqual(changes.envSources?.[secSrcName])
+    expect(hasChanges(changes.envSources?.[primarySrcName] ?? [], [
       { action: 'add', id: onlyInCommon.elemID },
     ])).toBeTruthy()
   })
@@ -1536,15 +1603,14 @@ describe('untrack', () => {
   it('should create detailed changes for elements which are in common and have env fragments', async () => {
     const changes = await routeDemote(
       [splitObjEnv.elemID],
-      primarySrc,
       commonSrc,
-      secondarySources
+      untrackEnvSource
     )
     expect(changes.commonSource).toHaveLength(1)
-    expect(changes.primarySource).toHaveLength(5)
-    expect(changes.secondarySources?.sec).toHaveLength(5)
-    expect(changes.primarySource).toEqual(changes.secondarySources?.sec)
-    expect(hasChanges(changes.primarySource || [], [
+    expect(changes.envSources?.[primarySrcName]).toHaveLength(5)
+    expect(changes.envSources?.[secSrcName]).toHaveLength(5)
+    expect(changes.envSources?.[primarySrcName]).toEqual(changes.envSources?.[secSrcName])
+    expect(hasChanges(changes.envSources?.[primarySrcName] ?? [], [
       { action: 'add', id: splitObjCommon.elemID.createNestedID('annotation', 'common') },
       { action: 'add', id: splitObjCommon.elemID.createNestedID('attr', 'split', 'common') },
       { action: 'add', id: splitObjCommon.elemID.createNestedID('attr', 'common') },
@@ -1556,17 +1622,16 @@ describe('untrack', () => {
   it('should create a different set of detailed changes accodrding the data in the actual env', async () => {
     const changes = await routeDemote(
       [missingFromPrimCommon.elemID],
-      primarySrc,
       commonSrc,
-      secondarySources
+      untrackEnvSource
     )
     expect(changes.commonSource).toHaveLength(1)
-    expect(changes.primarySource).toHaveLength(1)
-    expect(changes.secondarySources?.sec).toHaveLength(1)
-    expect(hasChanges(changes.primarySource || [], [
+    expect(changes.envSources?.[primarySrcName]).toHaveLength(1)
+    expect(changes.envSources?.[secSrcName]).toHaveLength(1)
+    expect(hasChanges(changes.envSources?.[primarySrcName] ?? [], [
       { action: 'add', id: missingFromPrimCommon.elemID },
     ])).toBeTruthy()
-    expect(hasChanges(changes.secondarySources?.sec ?? [], [
+    expect(hasChanges(changes.envSources?.[secSrcName] ?? [], [
       { action: 'add', id: missingFromPrimCommon.elemID.createNestedID('common') },
     ])).toBeTruthy()
   })
@@ -1574,15 +1639,14 @@ describe('untrack', () => {
   it('should wrap nested ids if the target env does not have the top level element', async () => {
     const changes = await routeDemote(
       [onlyInCommon.elemID.createNestedID('attr', 'str')],
-      primarySrc,
       commonSrc,
-      secondarySources
+      untrackEnvSource
     )
     expect(changes.commonSource).toHaveLength(1)
-    expect(changes.primarySource).toHaveLength(1)
-    expect(changes.secondarySources?.sec).toHaveLength(1)
-    expect(changes.primarySource).toEqual(changes.secondarySources?.sec)
-    expect(hasChanges(changes.primarySource || [], [
+    expect(changes.envSources?.[primarySrcName]).toHaveLength(1)
+    expect(changes.envSources?.[secSrcName]).toHaveLength(1)
+    expect(changes.envSources?.[primarySrcName]).toEqual(changes.envSources?.[secSrcName])
+    expect(hasChanges(changes.envSources?.[primarySrcName] ?? [], [
       { action: 'add', id: onlyInCommon.elemID },
     ])).toBeTruthy()
   })
@@ -1590,15 +1654,14 @@ describe('untrack', () => {
   it('should maitain file structure', async () => {
     const changes = await routeDemote(
       [multiFileCommon.elemID],
-      primarySrc,
       commonSrc,
-      secondarySources
+      untrackEnvSource
     )
     expect(changes.commonSource).toHaveLength(1)
-    expect(changes.primarySource).toHaveLength(2)
-    expect(changes.secondarySources?.sec).toHaveLength(2)
-    expect(changes.primarySource).toEqual(changes.secondarySources?.sec)
-    expect(changes.primarySource).toEqual([
+    expect(changes.envSources?.[primarySrcName]).toHaveLength(2)
+    expect(changes.envSources?.[secSrcName]).toHaveLength(2)
+    expect(changes.envSources?.[primarySrcName]).toEqual(changes.envSources?.[secSrcName])
+    expect(changes.envSources?.[primarySrcName]).toEqual([
       { action: 'add', id: multiFileCommon.elemID, path: ['default'], data: { after: multiFileCommonDefault } },
       { action: 'add', id: multiFileCommon.elemID, path: ['other'], data: { after: multiFileCommonOther } },
     ])
@@ -1690,7 +1753,7 @@ describe('copyTo', () => {
     }
   )
   const secondarySources = {
-    sec: createMockNaclFileSource(secondaryElements, { 'default.nacl': secondaryElements }),
+    [secSrcName]: createMockNaclFileSource(secondaryElements, { 'default.nacl': secondaryElements }),
   }
 
   it('should throw the proper error when trying to move an element which is not in the origin env', async () => {
@@ -1707,10 +1770,10 @@ describe('copyTo', () => {
       primarySrc,
       secondarySources
     )
-    expect(changes.primarySource).toHaveLength(0)
+    expect(changes.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(changes.commonSource).toHaveLength(0)
-    expect(changes.secondarySources?.sec).toHaveLength(1)
-    const secondaryChange = changes.secondarySources?.sec && changes.secondarySources?.sec[0]
+    expect(changes.envSources?.[secSrcName]).toHaveLength(1)
+    const secondaryChange = changes.envSources?.[secSrcName] && changes.envSources?.[secSrcName][0]
     expect(secondaryChange?.id).toEqual(onlyInEnv1Obj.elemID)
     expect(secondaryChange?.action).toEqual('add')
     expect(secondaryChange?.data).toEqual({ after: onlyInEnv1Obj })
@@ -1722,10 +1785,10 @@ describe('copyTo', () => {
       primarySrc,
       secondarySources
     )
-    expect(changes.primarySource).toHaveLength(0)
+    expect(changes.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(changes.commonSource).toHaveLength(0)
-    expect(changes.secondarySources?.sec).toHaveLength(4)
-    expect(hasChanges(changes.secondarySources?.sec || [], [
+    expect(changes.envSources?.[secSrcName]).toHaveLength(4)
+    expect(hasChanges(changes.envSources?.[secSrcName] || [], [
       { action: 'remove', id: splitObjEnv2.fields.e2Field.elemID },
       { action: 'add', id: splitObjEnv1.fields.e1Field.elemID },
       { action: 'remove', id: splitObjEnv2.fields.splitField.elemID.createNestedID('common') },
@@ -1743,10 +1806,10 @@ describe('copyTo', () => {
       primarySrc,
       secondarySources
     )
-    expect(changes.primarySource).toHaveLength(0)
+    expect(changes.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(changes.commonSource).toHaveLength(0)
-    expect(changes.secondarySources?.sec).toHaveLength(1)
-    expect(hasChanges(changes.secondarySources?.sec || [], [
+    expect(changes.envSources?.[secSrcName]).toHaveLength(1)
+    expect(hasChanges(changes.envSources?.[secSrcName] || [], [
       { action: 'add', id: onlyInEnv1Obj.elemID },
     ])).toBeTruthy()
   })
@@ -1757,10 +1820,10 @@ describe('copyTo', () => {
       primarySrc,
       secondarySources
     )
-    expect(changes.primarySource).toHaveLength(0)
+    expect(changes.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(changes.commonSource).toHaveLength(0)
-    expect(changes.secondarySources?.sec).toHaveLength(1)
-    expect(hasChanges(changes.secondarySources?.sec || [], [
+    expect(changes.envSources?.[secSrcName]).toHaveLength(1)
+    expect(hasChanges(changes.envSources?.[secSrcName] || [], [
       { action: 'add', id: splitObjEnv1.fields.e1Field.elemID },
     ])).toBeTruthy()
   })
@@ -1771,10 +1834,10 @@ describe('copyTo', () => {
       primarySrc,
       secondarySources
     )
-    expect(changes.primarySource).toHaveLength(0)
+    expect(changes.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(changes.commonSource).toHaveLength(0)
-    expect(changes.secondarySources?.sec).toHaveLength(2)
-    expect(changes.secondarySources?.sec).toEqual([
+    expect(changes.envSources?.[secSrcName]).toHaveLength(2)
+    expect(changes.envSources?.[secSrcName]).toEqual([
       { action: 'add',
         id: multiFileInstace.elemID,
         path: ['default'],
@@ -1799,9 +1862,8 @@ describe('routeRemoveFrom', () => {
       'env',
     )
     expect(changes).toEqual({
-      primarySource: [],
       commonSource: [],
-      secondarySources: {
+      envSources: {
         env: [{
           action: 'remove',
           id: existingElemID,
@@ -1813,19 +1875,22 @@ describe('routeRemoveFrom', () => {
   })
 
   it('should return the removal changes as primary when no env name was passed', async () => {
+    const srcName = 'src'
     const changes = await routeRemoveFrom(
       [existingElemID, notExistingElemID],
       createMockNaclFileSource([existingObject]),
+      srcName
     )
     expect(changes).toEqual({
-      primarySource: [{
-        action: 'remove',
-        id: existingElemID,
-        path: undefined,
-        data: { before: existingObject },
-      }],
       commonSource: [],
-      secondarySources: {},
+      envSources: {
+        [srcName]: [{
+          action: 'remove',
+          id: existingElemID,
+          path: undefined,
+          data: { before: existingObject },
+        }],
+      },
     })
   })
 })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -3744,8 +3744,7 @@ describe('nacl sources reuse', () => {
     await ws.flush()
     const invocations = createMultiEnvSrcEnvInvocationCount(mockMuiltiEnv)
     expect(invocations).toEqual({
-      default: 1,
-      inactive: 1,
+      '': 2,
     })
   })
 
@@ -3753,8 +3752,7 @@ describe('nacl sources reuse', () => {
     await ws.elements(true, 'inactive')
     const invocations = createMultiEnvSrcEnvInvocationCount(mockMuiltiEnv)
     expect(invocations).toEqual({
-      default: 1,
-      inactive: 1,
+      '': 2,
     })
   })
 })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -3730,29 +3730,13 @@ describe('nacl sources reuse', () => {
     mockMuiltiEnv.mockReset()
   })
 
-  const createMultiEnvSrcEnvInvocationCount = (
-    mockFunc: jest.SpyInstance
-  ): Record<string, number> => (
-    mockFunc.mock.calls.reduce((acc, args) => {
-      const envName = args[1]
-      acc[envName] = (acc[envName] ?? 0) + 1
-      return acc
-    }, {})
-  )
-
-  it('should create only one copy of each env on initiation', async () => {
+  it('should create only one copy the multi env source', async () => {
     await ws.flush()
-    const invocations = createMultiEnvSrcEnvInvocationCount(mockMuiltiEnv)
-    expect(invocations).toEqual({
-      '': 2,
-    })
+    expect(mockMuiltiEnv).toHaveBeenCalledTimes(1)
   })
 
   it('should not create a new copy of a secondary env when invoking a command directly on the secondary env', async () => {
     await ws.elements(true, 'inactive')
-    const invocations = createMultiEnvSrcEnvInvocationCount(mockMuiltiEnv)
-    expect(invocations).toEqual({
-      '': 2,
-    })
+    expect(mockMuiltiEnv).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -3135,7 +3135,7 @@ describe('workspace', () => {
     const defaultElem = new ObjectType({
       elemID,
       annotationRefsOrTypes: {
-        static: new TypeReference(BuiltinTypes.STRING.elemID),
+        static: BuiltinTypes.STRING,
       },
       annotations: {
         static: defaultStaticFile,

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -3211,6 +3211,29 @@ describe('workspace', () => {
       expect(elemStaticFile.content).toEqual(inactiveStaticFile.content)
     })
   })
+
+  describe('isEmpty', () => {
+    it('should return true if the workspace is empty', async () => {
+      const ws = await createWorkspace(
+        mockDirStore(undefined, undefined, {}),
+        mockState([])
+      )
+      expect(await ws.isEmpty()).toBeTruthy()
+    })
+
+    it('should return false is the workspace is not empty', async () => {
+      const ws = await createWorkspace()
+      expect(await ws.isEmpty()).toBeFalsy()
+    })
+
+    it('should return true if state is not empty but the withNaclFilesOnly flag is provided', async () => {
+      const ws = await createWorkspace(
+        mockDirStore(undefined, undefined, {}),
+        mockState([new ObjectType({ elemID: new ElemID('salto', 'something') })])
+      )
+      expect(await ws.isEmpty(true)).toBeTruthy()
+    })
+  })
 })
 
 describe('getElementNaclFiles', () => {


### PR DESCRIPTION
_Modify the workspace structure to hold a single multienv source instead of a multi env source for each environment_

---

Until this PR, the workspace contained a multienv source for each existing environment, and a hidden assumption was made that operations that only involves one env will be done on a multienv source in which that env is the primary source. To make things even more confusing, some of the multienv source function did expose the ability to access data (or modify) the non primary nacl files sources while other did not. This has caused SALTO-1676 since the `getStaticFiles` method was invoked on the wrong element source.

To fix this, and to prevent similar mistakes from happening, the workspace now holds only a single multi env source. To do that, the following steps were taken (each of them in a separate commit):
  - Modify the `RoutedChanges` interface to contain env names, and not their functional part in the operation (so no more 'primary env' and 'secondary envs'. We use env names.
  - The multienv source does not hold the current active env and is completely unaware of it. 
  - Methods in the multienv source now enforce the env variable to be passed explicitly. (Unless one of the argument is a file path, in which the env is not needed since it is implied) 
  - The workspace was changed to hold only a single multienv source
---
_Release Notes_: 
_Fixed issue where static files would be loaded incorrectly in workspaces with multiple environments, causing missing static files and / or incorrect deploy plans)_

---
_User Notifications_: 
_NA_
