### PR TITLE
SALTO-1681 Sort Zendesk dynamic content item variants

### DIFF
--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -27,6 +27,7 @@ import { ZENDESK_SUPPORT } from './constants'
 import changeValidator from './change_validator'
 import { paginate } from './client/pagination'
 import fieldReferencesFilter from './filters/field_references'
+import unorderedListsFilter from './filters/unordered_lists'
 
 const log = logger(module)
 const { createPaginator } = clientUtils
@@ -35,6 +36,8 @@ const { getAllElements } = elementUtils.ducktype
 
 export const DEFAULT_FILTERS = [
   fieldReferencesFilter,
+  // unorderedListsFilter should run after fieldReferencesFilter
+  unorderedListsFilter,
 ]
 
 export interface ZendeskAdapterParams {

--- a/packages/zendesk-support-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-support-adapter/src/filters/unordered_lists.ts
@@ -1,0 +1,45 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  Element, isInstanceElement, isReferenceExpression,
+} from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+
+/**
+ * Sort lists whose order changes between fetches, to avoid unneeded noise.
+ */
+const filterCreator: FilterCreator = () => ({
+  onFetch: async (elements: Element[]): Promise<void> => {
+    const dynamicContentItemInstances = (elements
+      .filter(isInstanceElement)
+      .filter(e => e.refType.elemID.name === 'dynamic_content_item'))
+
+    dynamicContentItemInstances.forEach(inst => {
+      if (Array.isArray(inst.value.variants) && inst.value.variants.every(variant =>
+        isReferenceExpression(variant.locale_id) && isInstanceElement(variant.locale_id.value))
+      ) {
+        inst.value.variants = _.sortBy(
+          inst.value.variants,
+          // at most one variant is allowed per locale
+          variant => ([variant.locale_id.value.value?.locale])
+        )
+      }
+    })
+  },
+})
+
+export default filterCreator

--- a/packages/zendesk-support-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/unordered_lists.test.ts
@@ -1,0 +1,155 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ObjectType, ElemID, InstanceElement, Element, isInstanceElement, ReferenceExpression,
+} from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import ZuoraClient from '../../src/client/client'
+import { paginate } from '../../src/client/pagination'
+import { ZENDESK_SUPPORT } from '../../src/constants'
+import filterCreator from '../../src/filters/unordered_lists'
+
+describe('Unordered lists filter', () => {
+  let client: ZuoraClient
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  let filter: FilterType
+
+  const generateElements = (): Element[] => {
+    const localeType = new ObjectType({
+      elemID: new ElemID(ZENDESK_SUPPORT, 'locale'),
+    })
+    const localeEN = new InstanceElement(
+      'en_US',
+      localeType,
+      { locale: 'en-US' },
+    )
+    const localeHE = new InstanceElement(
+      'he',
+      localeType,
+      { locale: 'he' },
+    )
+    const localeES = new InstanceElement(
+      'es',
+      localeType,
+      { locale: 'es' },
+    )
+
+    const dynamicContentItemType = new ObjectType({
+      elemID: new ElemID(ZENDESK_SUPPORT, 'dynamic_content_item'),
+    })
+    const withPopulatedRefs = new InstanceElement(
+      'refs',
+      dynamicContentItemType,
+      {
+        variants: [
+          { locale_id: new ReferenceExpression(localeEN.elemID, localeEN), content: 'a' },
+          { locale_id: new ReferenceExpression(localeHE.elemID, localeHE), content: 'c' },
+          { locale_id: new ReferenceExpression(localeES.elemID, localeES), content: 'b' },
+        ],
+      },
+    )
+    const withSomeUnpopulatedRefs = new InstanceElement(
+      'missing',
+      dynamicContentItemType,
+      {
+        variants: [
+          { locale_id: new ReferenceExpression(localeEN.elemID), content: 'a' },
+          { locale_id: new ReferenceExpression(localeHE.elemID), content: 'c' },
+          { locale_id: new ReferenceExpression(localeES.elemID, localeES), content: 'b' },
+        ],
+      },
+    )
+    const withSomeValues = new InstanceElement(
+      'vals',
+      dynamicContentItemType,
+      {
+        variants: [
+          { locale_id: 456, content: 'b' },
+          { locale_id: 123, content: 'a' },
+          { locale_id: new ReferenceExpression(localeEN.elemID, localeEN), content: 'c' },
+        ],
+      },
+    )
+    const empty = new InstanceElement(
+      'empty',
+      dynamicContentItemType,
+      {},
+    )
+    return [
+      localeType, localeEN, localeHE, localeES,
+      dynamicContentItemType, withPopulatedRefs, withSomeUnpopulatedRefs, withSomeValues, empty,
+    ]
+  }
+
+  let elements: Element[]
+
+  beforeAll(async () => {
+    client = new ZuoraClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      }),
+      config: {
+        fetch: {
+          includeTypes: [],
+        },
+        apiDefinitions: {
+          typeDefaults: {
+            transformation: {
+              idFields: ['name'],
+            },
+          },
+          types: {},
+        },
+      },
+    }) as FilterType
+
+    elements = generateElements()
+    await filter.onFetch(elements)
+  })
+
+  it('sort correctly when all references are populated', async () => {
+    const instances = elements.filter(isInstanceElement).filter(e => e.elemID.name === 'refs')
+    expect(instances[0].value.variants).toHaveLength(3)
+    expect(instances[0].value.variants[0].locale_id.elemID.name).toEqual('en_US')
+    expect(instances[0].value.variants[1].locale_id.elemID.name).toEqual('es')
+    expect(instances[0].value.variants[2].locale_id.elemID.name).toEqual('he')
+  })
+
+  it('not change order when not all references are populated', async () => {
+    const instances = elements.filter(isInstanceElement).filter(e => e.elemID.name === 'missing')
+    expect(instances[0].value.variants).toHaveLength(3)
+    expect(instances[0].value.variants[0].locale_id.elemID.name).toEqual('en_US')
+    expect(instances[0].value.variants[1].locale_id.elemID.name).toEqual('he')
+    expect(instances[0].value.variants[2].locale_id.elemID.name).toEqual('es')
+  })
+
+  it('not change order when not all values are references', async () => {
+    const instances = elements.filter(isInstanceElement).filter(e => e.elemID.name === 'vals')
+    expect(instances[0].value.variants).toHaveLength(3)
+    expect(instances[0].value.variants[0].locale_id).toEqual(456)
+    expect(instances[0].value.variants[1].locale_id).toEqual(123)
+    expect(instances[0].value.variants[2].locale_id.elemID.name).toEqual('en_US')
+  })
+  it('do nothing when instance structure is not as expected', async () => {
+    const instances = elements.filter(isInstanceElement).filter(e => e.elemID.name === 'empty')
+    expect(instances[0].value).toEqual({})
+  })
+})


### PR DESCRIPTION
The variants' order may change when creating a sandbox.

---

This should eventually be supported as part of the simple-adapter config, but we need to see more cases first (this is the 2nd one after a couple of fields in Zuora that needed different sorting).

---
_Release Notes_: 
Zendesk adapter:
* Sort the dynamic content item variants to avoid unneeded differences between sandboxes.

---
_User Notifications_: 
Zendesk adapter:
* Changes in `dynamic_content_item` instances (under the `variants` field)