### PR TITLE
SALTO-1689 fix simple adapter extraction of standalone fields inside lists

### DIFF
--- a/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
+++ b/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
@@ -88,7 +88,7 @@ const addFieldTypeAndInstances = async ({
   )
 
   const elements: Element[] = []
-  const currentType = await type.fields[fieldName].refType.getResolvedValue()
+  const currentType = await type.fields[fieldName].getType()
   if (!isObjectType(await getInnerType(currentType))) {
     const fieldType = generateType({
       adapterName,
@@ -99,13 +99,13 @@ const addFieldTypeAndInstances = async ({
       transformationConfigByType,
       transformationDefaultConfig,
     })
-    type.fields[fieldName].refType = isListType(type.fields[fieldName].refType.type)
+    type.fields[fieldName].refType = isListType(await type.fields[fieldName].getType())
       ? createRefToElmWithValue(new ListType(createRefToElmWithValue(fieldType.type)))
       : createRefToElmWithValue(fieldType.type)
     elements.push(fieldType.type, ...fieldType.nestedTypes)
   }
 
-  const updatedFieldType = await type.fields[fieldName].refType.getResolvedValue()
+  const updatedFieldType = await type.fields[fieldName].getType()
   const fieldType = await getInnerType(updatedFieldType)
   if (!isObjectType(fieldType)) {
     // should not happen

--- a/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
+++ b/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
@@ -99,8 +99,8 @@ const addFieldTypeAndInstances = async ({
       transformationConfigByType,
       transformationDefaultConfig,
     })
-    type.fields[fieldName].refType = isListType(await type.fields[fieldName].getType())
-      ? createRefToElmWithValue(new ListType(createRefToElmWithValue(fieldType.type)))
+    type.fields[fieldName].refType = isListType(currentType)
+      ? createRefToElmWithValue(new ListType(fieldType.type))
       : createRefToElmWithValue(fieldType.type)
     elements.push(fieldType.type, ...fieldType.nestedTypes)
   }

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -66,8 +66,8 @@ describe('adapter', () => {
           ),
           elementsSource: buildElementsSourceFromElements([]),
         }).fetch({ progressReporter: { reportProgress: () => null } })
-        expect(elements).toHaveLength(270)
-        expect(elements.filter(isObjectType)).toHaveLength(154)
+        expect(elements).toHaveLength(268)
+        expect(elements.filter(isObjectType)).toHaveLength(152)
         expect(elements.filter(isInstanceElement)).toHaveLength(116)
         expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
           'zendesk_support.account_setting',
@@ -251,7 +251,6 @@ describe('adapter', () => {
           'zendesk_support.ticket_field.instance.text_agent_field_431_1900000813305@ussu',
           'zendesk_support.ticket_field.instance.tickettype_Type_1500004937782',
           'zendesk_support.ticket_field__custom_field_options',
-          'zendesk_support.ticket_field__custom_field_options',
           'zendesk_support.ticket_field__custom_field_options.instance.multiselect_agent_dropdown_643_for_agent_1500009152882_ussssu__v1_1500015072702@uuuuuumuuu',
           'zendesk_support.ticket_field__custom_field_options.instance.multiselect_agent_dropdown_643_for_agent_1500009152882_ussssu__v2_1500015072722@uuuuuumuuu',
           'zendesk_support.ticket_field__system_field_options',
@@ -302,7 +301,6 @@ describe('adapter', () => {
           'zendesk_support.user_field.instance.numeric65',
           'zendesk_support.user_field.instance.regex_6546',
           'zendesk_support.user_field.instance.this_is_a_checkbox',
-          'zendesk_support.user_field__custom_field_options',
           'zendesk_support.user_field__custom_field_options',
           'zendesk_support.user_field__custom_field_options.instance.dropdown_25__Choice1_1500001753322',
           'zendesk_support.user_field__custom_field_options.instance.dropdown_25__another_choice_1500001753342@uuusu',


### PR DESCRIPTION
We have an option in simple adapters to mark fields as "standalone", which means they should be converted to separate instances and referenced from the instance that originally contained them. We do this for swagger adapters and for ducktype adapters - for the ducktype variant there were a couple of issues in cases when the field being extracted was a list:
1. The generated type was the inner type instead of the list (this on its own does not cause issues besides the inconsistency, since we had to handle this gracefully due to needs in the Salesforce adapter).
2. We would sometimes re-generate the nested types when we didn't need to. This could cause us in some cases to have the same type definition twice, which can cause it to be omitted from the nacls.

Both should be fixed here.

---
_Release Notes_: 
Zendesk adapter: 
* Fix a few field types that were not marked as lists.

---
_User Notifications_: 
None