### PR TITLE
SALTO-1694: added hash invalidation on putAll and deleteAll of parsed nacl files cache

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
@@ -195,6 +195,7 @@ export const createParseResultCache = (
     },
     putAll: async (files: Record<string, ParsedNaclFile>): Promise<void> => {
       const { metadata, errors, referenced, sourceMap, elements } = await cacheSources
+      cachedHash = undefined
       const errorEntriesToAdd = awu(Object.keys(files))
         .map(async file => {
           const value = (await files[file].data.errors()) ?? []
@@ -256,9 +257,11 @@ export const createParseResultCache = (
       return (awu(Object.values(await cacheSources))
         .forEach(async source => source.delete(filename)))
     },
-    deleteAll: async (filenames: string[]): Promise<void> =>
-      (awu(Object.values(await cacheSources)).forEach(source =>
-        source.deleteAll(filenames))),
+    deleteAll: async (filenames: string[]): Promise<void> => {
+      cachedHash = undefined
+      await awu(Object.values(await cacheSources)).forEach(source =>
+        source.deleteAll(filenames))
+    },
     getHash: async () => {
       if (!cachedHash) {
         cachedHash = ''


### PR DESCRIPTION
_Added hash in mem cache invalidation in parsed nacl files cache_

---

_The `ParsedNaclFileCache` module expose a `getHash` function that returns a hash value based on the hashes of all of the cached files, and is used by the `naclFileSource` module to create its own hash. In order to prevent unneeded calculations, that hash value is cached in memory. However, the `deleteAll` and `putAll` methods do not invalidate that cash when invoked, leading for the `getHash` method to return outdated value.r_

---
_Release Notes_: 
_Core_:
- fixed issue that would cause unneeded cache invalidation and lead to slow loading times

---
_User Notifications_: 
_NA_
