### PR TITLE
SALTO-1629: Fixed field configuration request type

### DIFF
--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -146,7 +146,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       paginationField: 'startAt',
     },
   },
-  PageBeanFieldConfiguration: {
+  PageBeanFieldConfigurationDetails: {
     request: {
       url: '/rest/api/3/fieldconfiguration',
       paginationField: 'startAt',
@@ -159,7 +159,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       ],
     },
   },
-  FieldConfiguration: {
+  FieldConfigurationDetails: {
     transformation: {
       fieldTypeOverrides: [
         { fieldName: 'fields', fieldType: 'list<FieldConfigurationItem>' },
@@ -206,7 +206,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   FilterDetails: {
     transformation: {
       fieldTypeOverrides: [
-        { fieldName: 'columns', fieldType: 'ColumnItem' },
+        { fieldName: 'columns', fieldType: 'list<ColumnItem>' },
       ],
     },
   },
@@ -267,6 +267,23 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       queryParams: {
         expand: 'description,lead,issueTypes,url,projectKeys,permissions',
       },
+      recurseInto: [
+        {
+          type: 'PageBeanComponentWithIssueCount',
+          toField: 'components',
+          context: [{ name: 'projectIdOrKey', fromField: 'id' }],
+        },
+      ],
+    },
+  },
+  Project: {
+    transformation: {
+      fieldTypeOverrides: [{ fieldName: 'components', fieldType: 'list<ComponentWithIssueCount>' }],
+    },
+  },
+  ComponentWithIssueCount: {
+    transformation: {
+      fieldsToOmit: [{ fieldName: 'issueCount' }],
     },
   },
   PageBeanScreen: {
@@ -413,7 +430,7 @@ export const DEFAULT_INCLUDE_ENDPOINTS: string[] = [
   'rest__api__3__configuration__timetracking__list', // TimeTrackingProvider
   'PageBeanDashboard',
   'PageBeanField',
-  'PageBeanFieldConfiguration',
+  'PageBeanFieldConfigurationDetails',
   'PageBeanFieldConfigurationScheme',
   'PageBeanFieldConfigurationIssueTypeItem',
   'PageBeanFilterDetails',


### PR DESCRIPTION
- The FieldConfiguration type was renamed to FieldConfigurationDetails in swagger
- Added components as a field on project
- Fixed columns field type in FilterDetails

---

The internal name of the type changed in swagger and the config has to be updated accordingly

---
_Release Notes_: 
Jira Adapter:
Bug fixes:
- Fixed issue with FieldConfiguration failing to fetch

New features:
- Now fetching components under projects  

---
_User Notifications_: 
Jira adapter:
- Default adapter configuration has changed, please run `salto workspace clean -ncrsg` to reset the configuration in your workspace
