### PR TITLE
SALTO-1702: added references and referencedBy indexes

### DIFF
--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -196,6 +196,10 @@ export class ElemID {
         && this.nameParts.length === 1)
   }
 
+  isBaseLevel(): boolean {
+    return (this.idType === 'field' && this.nameParts.length === 1) || this.isTopLevel()
+  }
+
   isEqual(other: ElemID): boolean {
     return this.getFullName() === other.getFullName()
   }

--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -196,7 +196,7 @@ export class ElemID {
         && this.nameParts.length === 1)
   }
 
-  isBaseLevel(): boolean {
+  isBaseId(): boolean {
     return (this.idType === 'field' && this.nameParts.length === 1) || this.isTopLevel()
   }
 

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -333,6 +333,30 @@ describe('Test elements.ts', () => {
       })
     })
 
+    describe('isBaseLevel', () => {
+      it('should return true for type ID', () => {
+        expect(typeId.isBaseLevel()).toBeTruthy()
+      })
+      it('should return true for field ID', () => {
+        expect(fieldId.isBaseLevel()).toBeTruthy()
+      })
+      it('should return false for annotation ID', () => {
+        expect(annotationTypeId.isBaseLevel()).toBeFalsy()
+      })
+      it('should return true for instance ID', () => {
+        expect(typeInstId.isBaseLevel()).toBeTruthy()
+      })
+      it('should return false for value ID', () => {
+        expect(valueId.isBaseLevel()).toBeFalsy()
+      })
+      it('should return true for config type ID', () => {
+        expect(configTypeId.isBaseLevel()).toBeTruthy()
+      })
+      it('should return true for config instance ID', () => {
+        expect(configInstId.isBaseLevel()).toBeTruthy()
+      })
+    })
+
     describe('fromFullName', () => {
       it('should create elem ID from its full name', () => {
         [typeId, fieldId, annotationTypesId, annotationTypeId, typeInstId, valueId, configTypeId,

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -335,25 +335,25 @@ describe('Test elements.ts', () => {
 
     describe('isBaseLevel', () => {
       it('should return true for type ID', () => {
-        expect(typeId.isBaseLevel()).toBeTruthy()
+        expect(typeId.isBaseId()).toBeTruthy()
       })
       it('should return true for field ID', () => {
-        expect(fieldId.isBaseLevel()).toBeTruthy()
+        expect(fieldId.isBaseId()).toBeTruthy()
       })
       it('should return false for annotation ID', () => {
-        expect(annotationTypeId.isBaseLevel()).toBeFalsy()
+        expect(annotationTypeId.isBaseId()).toBeFalsy()
       })
       it('should return true for instance ID', () => {
-        expect(typeInstId.isBaseLevel()).toBeTruthy()
+        expect(typeInstId.isBaseId()).toBeTruthy()
       })
       it('should return false for value ID', () => {
-        expect(valueId.isBaseLevel()).toBeFalsy()
+        expect(valueId.isBaseId()).toBeFalsy()
       })
       it('should return true for config type ID', () => {
-        expect(configTypeId.isBaseLevel()).toBeTruthy()
+        expect(configTypeId.isBaseId()).toBeTruthy()
       })
       it('should return true for config instance ID', () => {
-        expect(configInstId.isBaseLevel()).toBeTruthy()
+        expect(configInstId.isBaseId()).toBeTruthy()
       })
     })
 

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -373,6 +373,8 @@ export const mockWorkspace = ({
     getSourceMap: mockFunction<Workspace['getSourceMap']>().mockResolvedValue(new parser.SourceMap()),
     getSourceRanges: mockFunction<Workspace['getSourceRanges']>().mockResolvedValue([]),
     getElementReferencedFiles: mockFunction<Workspace['getElementReferencedFiles']>().mockResolvedValue([]),
+    getElementOutgoingReferences: mockFunction<Workspace['getElementOutgoingReferences']>().mockResolvedValue([]),
+    getElementIncomingReferences: mockFunction<Workspace['getElementIncomingReferences']>().mockResolvedValue([]),
     getElementNaclFiles: mockFunction<Workspace['getElementNaclFiles']>().mockResolvedValue([]),
     getElementIdsBySelectors: mockFunction<Workspace['getElementIdsBySelectors']>().mockResolvedValue(awu([])),
     getParsedNaclFile: mockFunction<Workspace['getParsedNaclFile']>(),

--- a/packages/workspace/src/workspace/reference_indexes.ts
+++ b/packages/workspace/src/workspace/reference_indexes.ts
@@ -1,0 +1,214 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, ElemID, getChangeElement, isReferenceExpression, isRemovalChange, Element, isObjectType, isModificationChange, ModificationChange, toChange } from '@salto-io/adapter-api'
+import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { ElementsSource } from './elements_source'
+import { RemoteMap } from './remote_map'
+
+const { awu } = collections.asynciterable
+
+const log = logger(module)
+export const REFERENCE_INDEXES_VERSION = 1
+export const REFERENCE_INDEXES_KEY = 'reference_indexes'
+
+type ReferenceDetails = {
+  referenceBy: ElemID
+  reference: ElemID
+}
+
+const getReferences = (element: Element): ReferenceDetails[] => {
+  const references: ReferenceDetails[] = []
+  walkOnElement({
+    element,
+    func: ({ value, path: referenceBy }) => {
+      if (isReferenceExpression(value)) {
+        references.push({ referenceBy, reference: value.elemID })
+      }
+      return WALK_NEXT_STEP.RECURSE
+    },
+  })
+  return references
+}
+
+const updateIndex = (index: RemoteMap<ElemID[]>, id: string, values: ElemID[]): Promise<void> => (
+  values.length !== 0 ? index.set(id, values) : index.delete(id)
+)
+
+const updateReferencesIndex = async (
+  changes: Change<Element>[],
+  index: RemoteMap<ElemID[]>,
+  elementToReferences: Record<string, ReferenceDetails[]>
+): Promise<void> => {
+  await Promise.all(changes.map(async change => {
+    const element = getChangeElement(change)
+
+    const references = elementToReferences[element.elemID.getFullName()]
+    const baseIdToReferences = !isRemovalChange(change) ? _(references)
+      .groupBy(reference => reference.referenceBy.createBaseID().parent.getFullName())
+      .mapValues(referencesGroup => referencesGroup.map(ref => ref.reference))
+      .value() : {}
+
+    await updateIndex(
+      index,
+      element.elemID.getFullName(),
+      baseIdToReferences[element.elemID.getFullName()] ?? []
+    )
+    if (isObjectType(element)) {
+      await Promise.all(
+        Object.values(element.fields)
+          .map(async field => updateIndex(
+            index,
+            field.elemID.getFullName(),
+            baseIdToReferences[field.elemID.getFullName()] ?? []
+          ))
+      )
+    }
+  }))
+}
+
+const updateIdOfReferenceByIndex = async (
+  id: string,
+  referencesGroup: ReferenceDetails[],
+  index: RemoteMap<ElemID[]>,
+  elementToReferences: Record<string, ReferenceDetails[]>,
+  idToAction: Record<string, string>,
+): Promise<void> => {
+  const oldReferencedBy = await index.get(id) ?? []
+
+  const referenceByGroup = new Set(
+    referencesGroup.map(ref => ref.referenceBy.createTopLevelParentID().parent.getFullName())
+  )
+
+  const newReferencedBy = oldReferencedBy.filter(
+    elemId => !referenceByGroup.has(elemId.createTopLevelParentID().parent.getFullName())
+  )
+
+  newReferencedBy.push(
+    ...Array.from(referenceByGroup)
+      .flatMap(elemId => (idToAction[elemId] !== 'remove' ? elementToReferences[elemId] : []))
+      .filter(ref => ref.reference.createBaseID().parent.getFullName() === id)
+      .map(ref => ref.referenceBy)
+  )
+
+  await updateIndex(index, id, _.uniq(newReferencedBy))
+}
+
+const getRemovedReferencesFromChange = (
+  change: ModificationChange<Element>,
+  elementToReferences: Record<string, ReferenceDetails[]>,
+): ReferenceDetails[] => {
+  const beforeReferences = getReferences(change.data.before)
+  const afterReferences = elementToReferences[getChangeElement(change).elemID.getFullName()]
+  return _.differenceBy(beforeReferences, afterReferences, ref => `${ref.reference.getFullName()} - ${ref.referenceBy.getFullName()}`)
+}
+
+const getRemovedReferences = (
+  changes: Change<Element>[],
+  elementToReferences: Record<string, ReferenceDetails[]>
+): ReferenceDetails[] => changes
+  .filter(isModificationChange)
+  .flatMap(change => getRemovedReferencesFromChange(change, elementToReferences))
+
+const updateReferencedByIndex = async (
+  changes: Change<Element>[],
+  index: RemoteMap<ElemID[]>,
+  elementToReferences: Record<string, ReferenceDetails[]>
+): Promise<void> => {
+  const idToAction = _(changes)
+    .keyBy(change => getChangeElement(change).elemID.getFullName())
+    .mapValues(change => change.action)
+    .value()
+
+  const removedReferences = getRemovedReferences(changes, elementToReferences)
+
+  const referenceByChanges = _(elementToReferences)
+    .values()
+    .concat(removedReferences)
+    .flatten()
+    .groupBy(({ reference }) => reference.createBaseID().parent.getFullName())
+    .value()
+
+  await Promise.all(
+    _(referenceByChanges)
+      .entries()
+      .map(async ([id, referencesGroup]) => {
+        await updateIdOfReferenceByIndex(
+          id,
+          referencesGroup,
+          index,
+          elementToReferences,
+          idToAction,
+        )
+      })
+      .value()
+  )
+}
+
+const getAllElementsChanges = async (
+  currentChanges: Change<Element>[],
+  elementsSource: ElementsSource,
+): Promise<Change<Element>[]> => awu(await elementsSource.getAll())
+  .map(element => toChange({ after: element }))
+  .concat(currentChanges)
+  .toArray()
+
+export const updateReferenceIndexes = async (
+  changes: Change<Element>[],
+  referencesIndex: RemoteMap<ElemID[]>,
+  referencedByIndex: RemoteMap<ElemID[]>,
+  mapsVersions: RemoteMap<number>,
+  elementsSource: ElementsSource,
+  isCacheValid: boolean,
+): Promise<void> => {
+  log.debug('Starting to update reference indexes')
+
+  let relevantChanges = changes
+  const isVersionMatch = await mapsVersions.get(REFERENCE_INDEXES_KEY) === REFERENCE_INDEXES_VERSION
+  if (!isCacheValid || !isVersionMatch) {
+    if (!isVersionMatch) {
+      log.info('references indexes maps are out of date, re-indexing')
+    }
+    if (!isCacheValid) {
+      log.info('cache is invalid, re-indexing references indexes')
+    }
+    await Promise.all([
+      referencesIndex.clear(),
+      referencedByIndex.clear(),
+      mapsVersions.set(REFERENCE_INDEXES_KEY, REFERENCE_INDEXES_VERSION),
+    ])
+    relevantChanges = await getAllElementsChanges(changes, elementsSource)
+  }
+
+  const elementToReferences = Object.fromEntries(relevantChanges
+    .map(getChangeElement)
+    .map(element => [element.elemID.getFullName(), getReferences(element)]))
+
+  await updateReferencesIndex(
+    relevantChanges,
+    referencesIndex,
+    elementToReferences,
+  )
+
+  await updateReferencedByIndex(
+    relevantChanges,
+    referencedByIndex,
+    elementToReferences,
+  )
+  log.debug('Finished to update reference indexes')
+}

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -19,7 +19,7 @@ import { Element, SaltoError, SaltoElementError, ElemID, InstanceElement, Detail
   Value, toChange, isRemovalChange, getChangeElement,
   ReadOnlyElementsSource, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { applyDetailedChanges, resolvePath } from '@salto-io/adapter-utils'
+import { applyDetailedChanges, resolvePath, safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections, promises, values } from '@salto-io/lowerdash'
 import { ValidationError, validateElements, isUnresolvedRefError } from '../validator'
 import { SourceRange, ParseError, SourceMap } from '../parser'
@@ -42,6 +42,7 @@ import { createMergeManager, ElementMergeManager, ChangeSet, createEmptyChangeSe
 import { RemoteMap, RemoteMapCreator } from './remote_map'
 import { serialize, deserializeMergeErrors, deserializeSingleElement, deserializeValidationErrors } from '../serializer/elements'
 import { AdaptersConfigSource } from './adapters_config_source'
+import { updateReferenceIndexes } from './reference_indexes'
 
 const log = logger(module)
 
@@ -153,6 +154,8 @@ export type Workspace = {
   getSourceMap: (filename: string) => Promise<SourceMap>
   getSourceRanges: (elemID: ElemID) => Promise<SourceRange[]>
   getElementReferencedFiles: (id: ElemID) => Promise<string[]>
+  getElementOutgoingReferences: (id: ElemID) => Promise<ElemID[]>
+  getElementIncomingReferences: (id: ElemID) => Promise<ElemID[]>
   getElementNaclFiles: (id: ElemID) => Promise<string[]>
   getElementIdsBySelectors: (
     selectors: ElementSelector[],
@@ -206,6 +209,9 @@ type SingleState = {
   merged: ElementsSource
   errors: RemoteMap<MergeError[]>
   validationErrors: RemoteMap<ValidationError[]>
+  referencedBy: RemoteMap<ElemID[]>
+  references: RemoteMap<ElemID[]>
+  mapsVersions: RemoteMap<number>
 }
 type WorkspaceState = {
   states: Record<string, SingleState>
@@ -308,6 +314,24 @@ export const loadWorkspace = async (
             namespace: getRemoteMapNamespace('validationErrors', envName),
             serialize: validationErrors => serialize(validationErrors, 'keepRef'),
             deserialize: async data => deserializeValidationErrors(data),
+            persistent,
+          }),
+          referencedBy: await remoteMapCreator<ElemID[]>({
+            namespace: getRemoteMapNamespace('referencedBy', envName),
+            serialize: val => safeJsonStringify(val.map(id => id.getFullName())),
+            deserialize: data => JSON.parse(data).map((id: string) => ElemID.fromFullName(id)),
+            persistent,
+          }),
+          references: await remoteMapCreator<ElemID[]>({
+            namespace: getRemoteMapNamespace('references', envName),
+            serialize: val => safeJsonStringify(val.map(id => id.getFullName())),
+            deserialize: data => JSON.parse(data).map((id: string) => ElemID.fromFullName(id)),
+            persistent,
+          }),
+          mapsVersions: await remoteMapCreator<number>({
+            namespace: getRemoteMapNamespace('mapsVersions', envName),
+            serialize: val => val.toString(),
+            deserialize: async data => parseInt(data, 10),
             persistent,
           }),
         }]).toArray())
@@ -503,6 +527,16 @@ export const loadWorkspace = async (
         await stateToBuild.states[envName].validationErrors.clear()
       }
       const { changes } = changeResult
+
+      await updateReferenceIndexes(
+        changes,
+        stateToBuild.states[envName].references,
+        stateToBuild.states[envName].referencedBy,
+        stateToBuild.states[envName].mapsVersions,
+        stateToBuild.states[envName].merged,
+        changeResult.cacheValid,
+      )
+
       const changedElements = changes
         .filter(isAdditionOrModificationChange)
         .map(getChangeElement)
@@ -864,6 +898,22 @@ export const loadWorkspace = async (
     getElementReferencedFiles: async id => (
       (await getLoadedNaclFilesSource()).getElementReferencedFiles(currentEnv(), id)
     ),
+    getElementOutgoingReferences: async id => {
+      if (!id.createBaseID().parent.isEqual(id)) {
+        log.warn(`getElementOutgoingReferences only support base ids, received ${id.getFullName()}`)
+        throw new Error(`getElementOutgoingReferences only support base ids, received ${id.getFullName()}`)
+      }
+      return await (await getWorkspaceState()).states[currentEnv()]
+        .references.get(id.getFullName()) ?? []
+    },
+    getElementIncomingReferences: async id => {
+      if (!id.createBaseID().parent.isEqual(id)) {
+        log.warn(`getElementIncomingReferences only support base ids, received ${id.getFullName()}`)
+        throw new Error(`getElementIncomingReferences only support base ids, received ${id.getFullName()}`)
+      }
+      return await (await getWorkspaceState()).states[currentEnv()]
+        .referencedBy.get(id.getFullName()) ?? []
+    },
     getElementNaclFiles: async id => (
       (await getLoadedNaclFilesSource()).getElementNaclFiles(currentEnv(), id)
     ),

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -899,14 +899,14 @@ export const loadWorkspace = async (
       (await getLoadedNaclFilesSource()).getElementReferencedFiles(currentEnv(), id)
     ),
     getElementOutgoingReferences: async id => {
-      if (!id.isBaseLevel()) {
+      if (!id.isBaseId()) {
         throw new Error(`getElementOutgoingReferences only support base ids, received ${id.getFullName()}`)
       }
       return await (await getWorkspaceState()).states[currentEnv()]
         .referenceTargets.get(id.getFullName()) ?? []
     },
     getElementIncomingReferences: async id => {
-      if (!id.isBaseLevel()) {
+      if (!id.isBaseId()) {
         throw new Error(`getElementIncomingReferences only support base ids, received ${id.getFullName()}`)
       }
       return await (await getWorkspaceState()).states[currentEnv()]

--- a/packages/workspace/test/workspace/reference_indexes.test.ts
+++ b/packages/workspace/test/workspace/reference_indexes.test.ts
@@ -1,0 +1,352 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { mockFunction, MockInterface } from '@salto-io/test-utils'
+import { REFERENCE_INDEXES_VERSION, updateReferenceIndexes } from '../../src/workspace/reference_indexes'
+import { createInMemoryElementSource, ElementsSource } from '../../src/workspace/elements_source'
+import { RemoteMap } from '../../src/workspace/remote_map'
+
+const createMockRemoteMap = <T>(): MockInterface<RemoteMap<T>> => ({
+  delete: mockFunction<RemoteMap<T>['delete']>(),
+  get: mockFunction<RemoteMap<T>['get']>(),
+  getMany: mockFunction<RemoteMap<T>['getMany']>(),
+  has: mockFunction<RemoteMap<T>['has']>(),
+  set: mockFunction<RemoteMap<T>['set']>(),
+  setAll: mockFunction<RemoteMap<T>['setAll']>(),
+  deleteAll: mockFunction<RemoteMap<T>['deleteAll']>(),
+  entries: mockFunction<RemoteMap<T>['entries']>(),
+  keys: mockFunction<RemoteMap<T>['keys']>(),
+  values: mockFunction<RemoteMap<T>['values']>(),
+  flush: mockFunction<RemoteMap<T>['flush']>(),
+  revert: mockFunction<RemoteMap<T>['revert']>(),
+  clear: mockFunction<RemoteMap<T>['clear']>(),
+  close: mockFunction<RemoteMap<T>['close']>(),
+  isEmpty: mockFunction<RemoteMap<T>['isEmpty']>(),
+})
+
+describe('updateReferenceIndexes', () => {
+  let referencesIndex: MockInterface<RemoteMap<ElemID[]>>
+  let referencedByIndex: MockInterface<RemoteMap<ElemID[]>>
+  let mapsVersions: MockInterface<RemoteMap<number>>
+  let elementsSource: ElementsSource
+  let object: ObjectType
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    referencesIndex = createMockRemoteMap<ElemID[]>()
+
+    referencedByIndex = createMockRemoteMap<ElemID[]>()
+    referencedByIndex.get.mockResolvedValue([])
+
+    mapsVersions = createMockRemoteMap<number>()
+    mapsVersions.get.mockResolvedValue(REFERENCE_INDEXES_VERSION)
+
+    elementsSource = createInMemoryElementSource()
+
+    object = new ObjectType({
+      elemID: new ElemID('test', 'object'),
+      annotations: {
+        typeRef: new ReferenceExpression(new ElemID('test', 'target1')),
+        inner: {
+          innerTypeRef: new ReferenceExpression(new ElemID('test', 'target1', 'attr', 'someAttr')),
+        },
+      },
+      fields: {
+        someField: {
+          refType: BuiltinTypes.STRING,
+          annotations: { fieldRef: new ReferenceExpression(new ElemID('test', 'target2')) },
+        },
+      },
+    })
+
+    instance = new InstanceElement(
+      'instance',
+      object,
+      { someValue: new ReferenceExpression(new ElemID('test', 'target2', 'instance', 'someInstance')) },
+      undefined,
+      { someAnnotation: new ReferenceExpression(new ElemID('test', 'target2', 'field', 'someField', 'value')) },
+    )
+  })
+
+  describe('when got new elements', () => {
+    beforeEach(async () => {
+      const changes = [toChange({ after: instance }), toChange({ after: object })]
+      await updateReferenceIndexes(
+        changes,
+        referencesIndex,
+        referencedByIndex,
+        mapsVersions,
+        elementsSource,
+        true
+      )
+    })
+    it('should update references index correctly', () => {
+      expect(referencesIndex.set).toHaveBeenCalledWith(
+        'test.object.instance.instance',
+        [
+          new ElemID('test', 'target2', 'field', 'someField', 'value'),
+          new ElemID('test', 'target2', 'instance', 'someInstance'),
+        ]
+      )
+
+      expect(referencesIndex.set).toHaveBeenCalledWith(
+        'test.object',
+        [
+          new ElemID('test', 'target1'),
+          new ElemID('test', 'target1', 'attr', 'someAttr'),
+        ]
+      )
+
+      expect(referencesIndex.set).toHaveBeenCalledWith(
+        'test.object.field.someField',
+        [
+          new ElemID('test', 'target2'),
+        ]
+      )
+    })
+
+    it('should update referencedBy index correctly', () => {
+      expect(referencedByIndex.set).toHaveBeenCalledWith(
+        'test.target1',
+        [
+          new ElemID('test', 'object', 'attr', 'typeRef'),
+          new ElemID('test', 'object', 'attr', 'inner', 'innerTypeRef'),
+        ]
+      )
+
+      expect(referencedByIndex.set).toHaveBeenCalledWith(
+        'test.target2',
+        [
+          new ElemID('test', 'object', 'field', 'someField', 'fieldRef'),
+        ]
+      )
+
+      expect(referencedByIndex.set).toHaveBeenCalledWith(
+        'test.target2.instance.someInstance',
+        [
+          new ElemID('test', 'object', 'instance', 'instance', 'someValue'),
+        ]
+      )
+
+      expect(referencedByIndex.set).toHaveBeenCalledWith(
+        'test.target2.field.someField',
+        [
+          new ElemID('test', 'object', 'instance', 'instance', 'someAnnotation'),
+        ]
+      )
+    })
+  })
+
+  describe('when elements were modified', () => {
+    beforeEach(async () => {
+      const instanceAfter = instance.clone()
+      delete instanceAfter.annotations.someAnnotation
+      instanceAfter.annotations.someAnnotation2 = new ReferenceExpression(new ElemID('test', 'target2', 'instance', 'someInstance', 'value'))
+      const changes = [toChange({ before: instance, after: instanceAfter })]
+      referencesIndex.get.mockImplementation(async id => (
+        instanceAfter.elemID.getFullName() === id
+          ? [
+            new ElemID('test', 'target2', 'instance', 'someInstance'),
+            new ElemID('test', 'target2', 'field', 'someField', 'value'),
+          ]
+          : undefined
+      ))
+
+      referencedByIndex.get.mockImplementation(async id => {
+        if (id === 'test.target2.field.someField') {
+          return [
+            new ElemID('test', 'object', 'instance', 'instance', 'someAnnotation'),
+          ]
+        }
+
+        if (id === 'test.target2.instance.someInstance') {
+          return [
+            new ElemID('test', 'object', 'instance', 'instance', 'someValue'),
+          ]
+        }
+        return undefined
+      })
+
+      await updateReferenceIndexes(
+        changes,
+        referencesIndex,
+        referencedByIndex,
+        mapsVersions,
+        elementsSource,
+        true
+      )
+    })
+
+    it('should update references index correctly', () => {
+      expect(referencesIndex.set).toHaveBeenCalledWith(
+        'test.object.instance.instance',
+        [
+          new ElemID('test', 'target2', 'instance', 'someInstance', 'value'),
+          new ElemID('test', 'target2', 'instance', 'someInstance'),
+        ]
+      )
+    })
+
+    it('should update referencedBy index correctly', () => {
+      expect(referencedByIndex.set).toHaveBeenCalledWith(
+        'test.target2.instance.someInstance',
+        [
+          new ElemID('test', 'object', 'instance', 'instance', 'someAnnotation2'),
+          new ElemID('test', 'object', 'instance', 'instance', 'someValue'),
+        ]
+      )
+
+      expect(referencedByIndex.delete).toHaveBeenCalledWith(
+        'test.target2.field.someField',
+      )
+    })
+  })
+
+  describe('when elements were removed', () => {
+    beforeEach(async () => {
+      const changes = [toChange({ before: instance })]
+      referencesIndex.get.mockImplementation(async id => (
+        instance.elemID.getFullName() === id
+          ? [
+            new ElemID('test', 'target2', 'instance', 'someInstance'),
+            new ElemID('test', 'target2', 'field', 'someField', 'value'),
+          ]
+          : undefined
+      ))
+
+      referencedByIndex.get.mockImplementation(async id => {
+        if (id === 'test.target2.field.someField') {
+          return [
+            new ElemID('test', 'object', 'instance', 'instance', 'someAnnotation'),
+          ]
+        }
+
+        if (id === 'test.target2.instance.someInstance') {
+          return [
+            new ElemID('test', 'object', 'instance', 'instance', 'someValue'),
+          ]
+        }
+        return undefined
+      })
+
+      await updateReferenceIndexes(
+        changes,
+        referencesIndex,
+        referencedByIndex,
+        mapsVersions,
+        elementsSource,
+        true
+      )
+    })
+
+    it('should update references index correctly', () => {
+      expect(referencesIndex.delete).toHaveBeenCalledWith(
+        'test.object.instance.instance',
+      )
+    })
+
+    it('should update referencedBy index correctly', () => {
+      expect(referencedByIndex.delete).toHaveBeenCalledWith(
+        'test.target2.instance.someInstance',
+      )
+
+      expect(referencedByIndex.delete).toHaveBeenCalledWith(
+        'test.target2.field.someField',
+      )
+    })
+  })
+
+  describe('invalid indexes', () => {
+    describe('When cache is invalid', () => {
+      beforeEach(async () => {
+        await elementsSource.set(instance)
+        await updateReferenceIndexes(
+          [],
+          referencesIndex,
+          referencedByIndex,
+          mapsVersions,
+          elementsSource,
+          false
+        )
+      })
+      it('should update references index correctly', () => {
+        expect(referencesIndex.set).toHaveBeenCalledWith(
+          'test.object.instance.instance',
+          [
+            new ElemID('test', 'target2', 'field', 'someField', 'value'),
+            new ElemID('test', 'target2', 'instance', 'someInstance'),
+          ]
+        )
+      })
+
+      it('should update referencedBy index correctly', () => {
+        expect(referencedByIndex.set).toHaveBeenCalledWith(
+          'test.target2.instance.someInstance',
+          [
+            new ElemID('test', 'object', 'instance', 'instance', 'someValue'),
+          ]
+        )
+
+        expect(referencedByIndex.set).toHaveBeenCalledWith(
+          'test.target2.field.someField',
+          [
+            new ElemID('test', 'object', 'instance', 'instance', 'someAnnotation'),
+          ]
+        )
+      })
+    })
+
+    describe('When indexes are out of date', () => {
+      beforeEach(async () => {
+        await elementsSource.set(instance)
+        mapsVersions.get.mockResolvedValue(0)
+        await updateReferenceIndexes(
+          [],
+          referencesIndex,
+          referencedByIndex,
+          mapsVersions,
+          elementsSource,
+          true
+        )
+      })
+      it('should update references index correctly', () => {
+        expect(referencesIndex.set).toHaveBeenCalledWith(
+          'test.object.instance.instance',
+          [
+            new ElemID('test', 'target2', 'field', 'someField', 'value'),
+            new ElemID('test', 'target2', 'instance', 'someInstance'),
+          ]
+        )
+      })
+
+      it('should update referencedBy index correctly', () => {
+        expect(referencedByIndex.set).toHaveBeenCalledWith(
+          'test.target2.instance.someInstance',
+          [
+            new ElemID('test', 'object', 'instance', 'instance', 'someValue'),
+          ]
+        )
+
+        expect(referencedByIndex.set).toHaveBeenCalledWith(
+          'test.target2.field.someField',
+          [
+            new ElemID('test', 'object', 'instance', 'instance', 'someAnnotation'),
+          ]
+        )
+      })
+    })
+  })
+})

--- a/packages/workspace/test/workspace/reference_indexes.test.ts
+++ b/packages/workspace/test/workspace/reference_indexes.test.ts
@@ -107,6 +107,7 @@ describe('updateReferenceIndexes', () => {
         [
           new ElemID('test', 'target1'),
           new ElemID('test', 'target1', 'attr', 'someAttr'),
+          new ElemID('test', 'target2'),
         ]
       )
 
@@ -131,6 +132,7 @@ describe('updateReferenceIndexes', () => {
         'test.target2',
         [
           new ElemID('test', 'object', 'field', 'someField', 'fieldRef'),
+          new ElemID('test', 'object', 'instance', 'instance', 'someAnnotation'),
         ]
       )
 
@@ -212,6 +214,10 @@ describe('updateReferenceIndexes', () => {
       expect(referencedByIndex.delete).toHaveBeenCalledWith(
         'test.target2.field.someField',
       )
+
+      expect(referencedByIndex.delete).toHaveBeenCalledWith(
+        'test.target2',
+      )
     })
   })
 
@@ -265,6 +271,10 @@ describe('updateReferenceIndexes', () => {
 
       expect(referencedByIndex.delete).toHaveBeenCalledWith(
         'test.target2.field.someField',
+      )
+
+      expect(referencedByIndex.delete).toHaveBeenCalledWith(
+        'test.target2',
       )
     })
   })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2739,6 +2739,38 @@ describe('workspace', () => {
     })
   })
 
+  describe('getElementOutgoingReferences', () => {
+    let workspace: Workspace
+
+    beforeAll(async () => {
+      workspace = await createWorkspace()
+    })
+
+    it('None-base type should throw', async () => {
+      await expect(workspace.getElementOutgoingReferences(new ElemID('adapter', 'type', 'attr', 'aaa'))).rejects.toThrow()
+    })
+
+    it('None-exist type should return empty array', async () => {
+      expect(await workspace.getElementOutgoingReferences(new ElemID('adapter', 'notExists'))).toEqual([])
+    })
+  })
+
+  describe('getElementIncomingReferences', () => {
+    let workspace: Workspace
+
+    beforeAll(async () => {
+      workspace = await createWorkspace()
+    })
+
+    it('None-base type should throw', async () => {
+      await expect(workspace.getElementIncomingReferences(new ElemID('adapter', 'type', 'attr', 'aaa'))).rejects.toThrow()
+    })
+
+    it('None-exist type should return empty array', async () => {
+      expect(await workspace.getElementIncomingReferences(new ElemID('adapter', 'notExists'))).toEqual([])
+    })
+  })
+
   describe('hasElementsInEnv', () => {
     let workspace: Workspace
     beforeEach(async () => {


### PR DESCRIPTION
Added `references` index to get the elements a certain element references and a `referencedBy` index to get all the elements that reference a certain element

---
Performance:
On NetSuite big account:
With the indexes first fetch took:
771.637 seconds

without the indexes:
764.718 seconds

without the indexes

---
_Release Notes_: 
None

---
_User Notifications_: 
None