### PR TITLE
SALTO-1703: changed remote map clear to change the persistent db only when flush is called

### DIFF
--- a/packages/core/test/workspace/local/remote_map.test.ts
+++ b/packages/core/test/workspace/local/remote_map.test.ts
@@ -163,6 +163,24 @@ describe('test operations on remote db', () => {
       expect(await remoteMap.get(elemID)).toBeUndefined()
     })
 
+    it('deleted elements should not be returned from keys', async () => {
+      const elemID = elements[0].elemID.getFullName()
+      await remoteMap.set(elemID, elements[0])
+      expect(await awu(remoteMap.keys()).toArray()).toContain(elements[0].elemID.getFullName())
+      await remoteMap.delete(elemID)
+      expect(await awu(remoteMap.keys()).toArray()).not.toContain(elements[0].elemID.getFullName())
+    })
+
+    it('deleted elements should not be returned from keys with pages', async () => {
+      const elemID = elements[0].elemID.getFullName()
+      await remoteMap.set(elemID, elements[0])
+      expect(await awu(remoteMap.keys({ pageSize: 2 })).flat().toArray())
+        .toContain(elements[0].elemID.getFullName())
+      await remoteMap.delete(elemID)
+      expect(await awu(remoteMap.keys({ pageSize: 2 })).flat().toArray())
+        .not.toContain(elements[0].elemID.getFullName())
+    })
+
     it('should delete all elements chosen when deleting all', async () => {
       await remoteMap.setAll(createAsyncIterable(elements))
       await remoteMap.deleteAll(awu(createAsyncIterable(elements.slice(1))).map(entry => entry.key))
@@ -183,24 +201,41 @@ describe('test operations on remote db', () => {
         await remoteMap.set(elements[0].elemID.getFullName(), elements[0])
         expect(await awu(remoteMap.keys()).toArray()).not.toHaveLength(0)
         await remoteMap.clear()
+        await remoteMap.set(elements[1].elemID.getFullName(), elements[1])
       })
-      it('should clear the results from keys', async () => {
-        expect(await awu(remoteMap.keys()).toArray()).toHaveLength(0)
+      it('should return keys that were only set after clear', async () => {
+        expect(await awu(remoteMap.keys()).toArray()).toEqual([elements[1].elemID.getFullName()])
       })
-      it('should clear the results from values', async () => {
-        expect(await awu(remoteMap.values()).toArray()).toHaveLength(0)
+      it('should return values that were only set after clear', async () => {
+        const vals = await awu(remoteMap.values()).toArray()
+        expect(vals).toHaveLength(1)
+        expect(vals[0].isEqual(elements[1])).toBeTruthy()
       })
-      it('should clear the results from entries', async () => {
-        expect(await awu(remoteMap.entries()).toArray()).toHaveLength(0)
+      it('should return entries that were only set after clear', async () => {
+        const entries = await awu(remoteMap.entries()).toArray()
+        expect(entries).toHaveLength(1)
+        expect(entries[0].key).toBe(elements[1].elemID.getFullName())
+        expect(entries[0].value.isEqual(elements[1])).toBeTruthy()
       })
-      it('should return false from has', async () => {
+      it('should return false for cleared keys', async () => {
         expect(await remoteMap.has(elements[0].elemID.getFullName())).toBeFalsy()
       })
-      it('should return undefined from get', async () => {
-        expect(await remoteMap.get(elements[0].elemID.getFullName())).toBeUndefined()
+
+      it('should return true for keys set after clear', async () => {
+        expect(await remoteMap.has(elements[1].elemID.getFullName())).toBeTruthy()
       })
-      it('should return undefined from getMany', async () => {
-        expect(await remoteMap.getMany([elements[0].elemID.getFullName()])).toEqual([undefined])
+      it('should return from get only values set after clear', async () => {
+        expect(await remoteMap.get(elements[0].elemID.getFullName())).toBeUndefined()
+        expect((await remoteMap.get(elements[1].elemID.getFullName()))
+          ?.isEqual(elements[1])).toBeTruthy()
+      })
+      it('should return from getMany only values set after clear', async () => {
+        const vals = await remoteMap.getMany([
+          elements[0].elemID.getFullName(),
+          elements[1].elemID.getFullName(),
+        ])
+        expect(vals[0]).toBeUndefined()
+        expect(vals[1]?.isEqual(elements[1])).toBeTruthy()
       })
       it('should return true from flush', async () => {
         expect(await remoteMap.flush()).toBeTruthy()

--- a/packages/core/test/workspace/local/remote_map.test.ts
+++ b/packages/core/test/workspace/local/remote_map.test.ts
@@ -178,11 +178,33 @@ describe('test operations on remote db', () => {
     })
   })
   describe('clear', () => {
-    it('should clear the remote map', async () => {
-      await remoteMap.set(elements[0].elemID.getFullName(), elements[0])
-      expect(await awu(remoteMap.keys()).toArray()).not.toHaveLength(0)
-      await remoteMap.clear()
-      expect(await awu(remoteMap.keys()).toArray()).toHaveLength(0)
+    describe('when called in writeable remote map', async () => {
+      beforeEach(async () => {
+        await remoteMap.set(elements[0].elemID.getFullName(), elements[0])
+        expect(await awu(remoteMap.keys()).toArray()).not.toHaveLength(0)
+        await remoteMap.clear()
+      })
+      it('should clear the results from keys', async () => {
+        expect(await awu(remoteMap.keys()).toArray()).toHaveLength(0)
+      })
+      it('should clear the results from values', async () => {
+        expect(await awu(remoteMap.values()).toArray()).toHaveLength(0)
+      })
+      it('should clear the results from entries', async () => {
+        expect(await awu(remoteMap.entries()).toArray()).toHaveLength(0)
+      })
+      it('should return false from has', async () => {
+        expect(await remoteMap.has(elements[0].elemID.getFullName())).toBeFalsy()
+      })
+      it('should return undefined from get', async () => {
+        expect(await remoteMap.get(elements[0].elemID.getFullName())).toBeUndefined()
+      })
+      it('should return undefined from getMany', async () => {
+        expect(await remoteMap.getMany([elements[0].elemID.getFullName()])).toEqual([undefined])
+      })
+      it('should return true from flush', async () => {
+        expect(await remoteMap.flush()).toBeTruthy()
+      })
     })
     describe('read only', () => {
       it('should throw an error', async () => {


### PR DESCRIPTION
Changed `clear` in remote map to change the persistent db only when flush is called

Before this PR, since clear did not happen on flush, flush after clear would return false (no changes were flushed) which cause an `elementsUpdate` in the SaaS to not be sent.
This caused errors in the UI in some cases to not disappear after fixed


---
_Release Notes_: 
None (I'm not await of an effect this has in the OSS)

---
_User Notifications_: 
None