### PR TITLE
SAAS-2861: Support element selectors with multiple values separated with pipes ('|')

### DIFF
--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -61,7 +61,7 @@ const match = (elemId: ElemID, selector: ElementSelector, includeNested = false)
 
 
 const createRegex = (selector: string, caseInSensitive: boolean): RegExp => new RegExp(
-  `^${selector.replace(/\*/g, '[^\\.]*')}$`, caseInSensitive ? 'i' : undefined
+  `^(${selector.replace(/\*/g, '[^\\.]*')})$`, caseInSensitive ? 'i' : undefined
 )
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -128,6 +128,23 @@ describe('element selector', () => {
     expect(selectedElements).toEqual([elements[0]])
   })
 
+  it('should only select specific types when given multiple typeNames', async () => {
+    const elements = [
+      new ElemID('salesforce', 'sometype'),
+      new ElemID('salesforce', 'sometypewithsameprefix'),
+      new ElemID('salesforce', 'withsamesuffixsometype'),
+      new ElemID('salesforce', 'othertype'),
+      new ElemID('salesforce', 'othertypewithsameprefix'),
+      new ElemID('salesforce', 'withsamesuffixothertype'),
+      new ElemID('otheradapter', 'sometype'),
+      new ElemID('otheradapter', 'othertype'),
+      new ElemID('salesforce', 'othertype', 'instance', 'y'),
+      new ElemID('salesforce', 'sometype', 'instance', 'x'),
+    ]
+    const selectedElements = await selectElements({ elements, selectors: ['salesforce.sometype|othertype'] })
+    expect(selectedElements).toEqual([elements[0], elements[3]])
+  })
+
   it('should handle asterisks in field type and instance name', async () => {
     const elements = [
       new ElemID('salesforce', 'sometype', 'instance', 'one_instance'),


### PR DESCRIPTION
Until now if a user would set a selector with pipes, e.g. `salesforce.Lead|Task` it would match also `LeadConvertSettings`.

---
_Release Notes_: 
Core: Support element selectors with multiple values separated with pipes ('|')

---
_User Notifications_: 
None