### PR TITLE
SALTO-1628: add support in go-to-service for SuiteApp instance elements

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -123,7 +123,6 @@ export default class NetsuiteAdapter implements AdapterOperations {
       convertLists,
       consistentValues,
       replaceInstanceReferencesFilter,
-      serviceUrls,
       SDFInternalIds,
       dataInstancesAttributes,
       redundantFields,
@@ -142,6 +141,8 @@ export default class NetsuiteAdapter implements AdapterOperations {
       savedSearchesAuthorInformation,
       translationConverter,
       accountSpecificValues,
+      // serviceUrls must run after suiteAppInternalIds filter
+      serviceUrls,
     ],
     typesToSkip = [
       INTEGRATION, // The imported xml has no values, especially no SCRIPT_ID, for standard

--- a/packages/netsuite-adapter/src/filters/service_urls.ts
+++ b/packages/netsuite-adapter/src/filters/service_urls.ts
@@ -25,6 +25,7 @@ import setRoleUrls from '../service_url/role'
 import setSublistsUrls from '../service_url/sublist'
 import setSavedSearchUrls from '../service_url/savedsearch'
 import setConstantUrls from '../service_url/constant_urls'
+import setSuiteAppUrls from '../service_url/suiteapp_elements_url'
 
 const log = logger(module)
 
@@ -39,6 +40,7 @@ const SERVICE_URL_SETTERS = [
   setSublistsUrls,
   setSavedSearchUrls,
   setConstantUrls,
+  setSuiteAppUrls,
 ]
 
 const filterCreator: FilterCreator = ({ client }): FilterWith<'onFetch'> => ({

--- a/packages/netsuite-adapter/src/service_url/suiteapp_elements_url.ts
+++ b/packages/netsuite-adapter/src/service_url/suiteapp_elements_url.ts
@@ -18,6 +18,7 @@ import { CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { isDataObjectType } from '../types'
 import { ServiceUrlSetter } from './types'
+import { ITEM_TYPE_TO_SEARCH_STRING } from '../data_elements/types'
 
 const { awu } = collections.asynciterable
 
@@ -37,7 +38,6 @@ const TYPE_TO_URL: Record<string, (id: string) => string> = {
   partner: id => `app/common/entity/partner.nl?id=${id}`,
   solution: id => `app/crm/support/kb/solution.nl?id=${id}`,
   item: id => `app/common/item/item.nl?id=${id}`,
-  itemGroup: id => `app/common/item/item.nl?id=${id}`,
 }
 
 const setServiceUrl: ServiceUrlSetter = async (elements, client) => {
@@ -45,7 +45,7 @@ const setServiceUrl: ServiceUrlSetter = async (elements, client) => {
     .filter(isInstanceElement)
     .filter(async element => isDataObjectType(await element.getType()))
     .forEach(element => {
-      const typeName = (element.elemID.typeName).slice(-4) === 'Item' ? 'item' : element.elemID.typeName
+      const typeName = element.elemID.typeName in ITEM_TYPE_TO_SEARCH_STRING ? 'item' : element.elemID.typeName
       const url = element.value.internalId !== undefined
         ? TYPE_TO_URL[typeName]?.(element.value.internalId)
         : undefined

--- a/packages/netsuite-adapter/src/service_url/suiteapp_elements_url.ts
+++ b/packages/netsuite-adapter/src/service_url/suiteapp_elements_url.ts
@@ -1,0 +1,58 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { isDataObjectType } from '../types'
+import { ServiceUrlSetter } from './types'
+
+const { awu } = collections.asynciterable
+
+
+const TYPE_TO_URL: Record<string, (id: string) => string> = {
+  account: id => `app/accounting/account/account.nl?id=${id}`,
+  subsidiary: id => `app/common/otherlists/subsidiarytype.nl?id=${id}`,
+  department: id => `app/common/otherlists/departmenttype.nl?id=${id}`,
+  classification: id => `app/common/otherlists/classtype.nl?id=${id}`,
+  location: id => `app/common/otherlists/locationtype.nl?id=${id}`,
+  currency: id => `app/common/multicurrency/currency.nl?e=T&id=${id}`,
+  customer: id => `app/common/entity/custjob.nl?id=${id}`,
+  accountingPeriod: id => `app/setup/period/fiscalperiod.nl?e=T&id=${id}`,
+  employee: id => `app/common/entity/employee.nl?id=${id}`,
+  job: id => `app/accounting/project/project.nl?id=${id}`,
+  manufacturingCostTemplate: id => `app/accounting/manufacturing/mfgcosttemplate.nl?id=${id}`,
+  partner: id => `app/common/entity/partner.nl?id=${id}`,
+  solution: id => `app/crm/support/kb/solution.nl?id=${id}`,
+  item: id => `app/common/item/item.nl?id=${id}`,
+  itemGroup: id => `app/common/item/item.nl?id=${id}`,
+}
+
+const setServiceUrl: ServiceUrlSetter = async (elements, client) => {
+  await awu(elements)
+    .filter(isInstanceElement)
+    .filter(async element => isDataObjectType(await element.getType()))
+    .forEach(element => {
+      const typeName = (element.elemID.typeName).slice(-4) === 'Item' ? 'item' : element.elemID.typeName
+      const url = element.value.internalId !== undefined
+        ? TYPE_TO_URL[typeName]?.(element.value.internalId)
+        : undefined
+      if (url !== undefined) {
+        element.annotations[CORE_ANNOTATIONS.SERVICE_URL] = new URL(url, client.url).href
+      }
+    })
+}
+
+export default setServiceUrl

--- a/packages/netsuite-adapter/test/service_url/suiteapp_elements.test.ts
+++ b/packages/netsuite-adapter/test/service_url/suiteapp_elements.test.ts
@@ -28,9 +28,19 @@ describe('setSuiteAppElementsUrl', () => {
     elements = [
       new InstanceElement('A', new ObjectType({ elemID: new ElemID(NETSUITE, 'account'), annotations: { source: 'soap' } }), { internalId: '123' }),
       new InstanceElement('B', new ObjectType({ elemID: new ElemID(NETSUITE, 'subsidiary'), annotations: { source: 'soap' } }), { internalId: '124' }),
-      new InstanceElement('C', new ObjectType({ elemID: new ElemID(NETSUITE, 'manufacturingCostTemplate'), annotations: { source: 'soap' } }), { internalId: '125' }),
-      new InstanceElement('D', new ObjectType({ elemID: new ElemID(NETSUITE, 'inventoryItem'), annotations: { source: 'soap' } }), { internalId: '126' }),
-      new InstanceElement('E', new ObjectType({ elemID: new ElemID(NETSUITE, 'assemblyItem'), annotations: { source: 'soap' } }), { internalId: '127' }),
+      new InstanceElement('C', new ObjectType({ elemID: new ElemID(NETSUITE, 'department'), annotations: { source: 'soap' } }), { internalId: '125' }),
+      new InstanceElement('D', new ObjectType({ elemID: new ElemID(NETSUITE, 'classification'), annotations: { source: 'soap' } }), { internalId: '126' }),
+      new InstanceElement('E', new ObjectType({ elemID: new ElemID(NETSUITE, 'location'), annotations: { source: 'soap' } }), { internalId: '127' }),
+      new InstanceElement('F', new ObjectType({ elemID: new ElemID(NETSUITE, 'currency'), annotations: { source: 'soap' } }), { internalId: '128' }),
+      new InstanceElement('G', new ObjectType({ elemID: new ElemID(NETSUITE, 'customer'), annotations: { source: 'soap' } }), { internalId: '129' }),
+      new InstanceElement('H', new ObjectType({ elemID: new ElemID(NETSUITE, 'accountingPeriod'), annotations: { source: 'soap' } }), { internalId: '130' }),
+      new InstanceElement('I', new ObjectType({ elemID: new ElemID(NETSUITE, 'employee'), annotations: { source: 'soap' } }), { internalId: '131' }),
+      new InstanceElement('J', new ObjectType({ elemID: new ElemID(NETSUITE, 'job'), annotations: { source: 'soap' } }), { internalId: '132' }),
+      new InstanceElement('K', new ObjectType({ elemID: new ElemID(NETSUITE, 'manufacturingCostTemplate'), annotations: { source: 'soap' } }), { internalId: '133' }),
+      new InstanceElement('L', new ObjectType({ elemID: new ElemID(NETSUITE, 'partner'), annotations: { source: 'soap' } }), { internalId: '134' }),
+      new InstanceElement('M', new ObjectType({ elemID: new ElemID(NETSUITE, 'solution'), annotations: { source: 'soap' } }), { internalId: '135' }),
+      new InstanceElement('N', new ObjectType({ elemID: new ElemID(NETSUITE, 'inventoryItem'), annotations: { source: 'soap' } }), { internalId: '136' }),
+      new InstanceElement('O', new ObjectType({ elemID: new ElemID(NETSUITE, 'assemblyItem'), annotations: { source: 'soap' } }), { internalId: '137' }),
     ]
   })
 
@@ -38,9 +48,19 @@ describe('setSuiteAppElementsUrl', () => {
     await setSuiteAppUrls(elements, client)
     expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/accounting/account/account.nl?id=123')
     expect(elements[1].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/otherlists/subsidiarytype.nl?id=124')
-    expect(elements[2].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/accounting/manufacturing/mfgcosttemplate.nl?id=125')
-    expect(elements[3].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/item/item.nl?id=126')
-    expect(elements[4].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/item/item.nl?id=127')
+    expect(elements[2].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/otherlists/departmenttype.nl?id=125')
+    expect(elements[3].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/otherlists/classtype.nl?id=126')
+    expect(elements[4].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/otherlists/locationtype.nl?id=127')
+    expect(elements[5].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/multicurrency/currency.nl?e=T&id=128')
+    expect(elements[6].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/entity/custjob.nl?id=129')
+    expect(elements[7].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/setup/period/fiscalperiod.nl?e=T&id=130')
+    expect(elements[8].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/entity/employee.nl?id=131')
+    expect(elements[9].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/accounting/project/project.nl?id=132')
+    expect(elements[10].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/accounting/manufacturing/mfgcosttemplate.nl?id=133')
+    expect(elements[11].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/entity/partner.nl?id=134')
+    expect(elements[12].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/crm/support/kb/solution.nl?id=135')
+    expect(elements[13].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/item/item.nl?id=136')
+    expect(elements[14].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/item/item.nl?id=137')
   })
 
   it('should not set url if the type name is not in list', async () => {

--- a/packages/netsuite-adapter/test/service_url/suiteapp_elements.test.ts
+++ b/packages/netsuite-adapter/test/service_url/suiteapp_elements.test.ts
@@ -1,0 +1,57 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import setSuiteAppUrls from '../../src/service_url/suiteapp_elements_url'
+import NetsuiteClient from '../../src/client/client'
+import { NETSUITE } from '../../src/constants'
+
+describe('setSuiteAppElementsUrl', () => {
+  const client = {
+    url: 'https://tstdrv2259448.app.netsuite.com',
+  } as unknown as NetsuiteClient
+  let elements: InstanceElement[]
+  beforeAll(() => {
+    elements = [
+      new InstanceElement('A', new ObjectType({ elemID: new ElemID(NETSUITE, 'account'), annotations: { source: 'soap' } }), { internalId: '123' }),
+      new InstanceElement('B', new ObjectType({ elemID: new ElemID(NETSUITE, 'subsidiary'), annotations: { source: 'soap' } }), { internalId: '124' }),
+      new InstanceElement('C', new ObjectType({ elemID: new ElemID(NETSUITE, 'manufacturingCostTemplate'), annotations: { source: 'soap' } }), { internalId: '125' }),
+      new InstanceElement('D', new ObjectType({ elemID: new ElemID(NETSUITE, 'inventoryItem'), annotations: { source: 'soap' } }), { internalId: '126' }),
+      new InstanceElement('E', new ObjectType({ elemID: new ElemID(NETSUITE, 'assemblyItem'), annotations: { source: 'soap' } }), { internalId: '127' }),
+    ]
+  })
+
+  it('should set the right url', async () => {
+    await setSuiteAppUrls(elements, client)
+    expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/accounting/account/account.nl?id=123')
+    expect(elements[1].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/otherlists/subsidiarytype.nl?id=124')
+    expect(elements[2].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/accounting/manufacturing/mfgcosttemplate.nl?id=125')
+    expect(elements[3].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/item/item.nl?id=126')
+    expect(elements[4].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://tstdrv2259448.app.netsuite.com/app/common/item/item.nl?id=127')
+  })
+
+  it('should not set url if the type name is not in list', async () => {
+    const unknownType = new InstanceElement('unknown', new ObjectType({ elemID: new ElemID(NETSUITE, 'bla'), annotations: { source: 'soap' } }), { internalId: '101' })
+    await setSuiteAppUrls([unknownType], client)
+    expect(unknownType.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+  })
+
+  it('should not set url if the internalId is undefined', async () => {
+    const noInternalId = new InstanceElement('noInternalId', new ObjectType({ elemID: new ElemID(NETSUITE, 'account'), annotations: { source: 'soap' } }))
+    await setSuiteAppUrls([noInternalId], client)
+    expect(noInternalId.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Add support in go-to-service for SuiteApp elements.

---

I replaced the serviceUrl filter order in adapter.ts as we need the internalId of elements in order to apply the go-to-service option.

---
_Release Notes_: 
Add go-to-service option for new types of instance elements in Netsuite
