### PR TITLE
SALTO-1712: add issue type details to default fetch config

### DIFF
--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -365,6 +365,14 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       paginationField: 'startAt',
     },
   },
+  IssueTypeDetails: {
+    request: {
+      url: '/rest/api/3/issuetype',
+    },
+    transformation: {
+      dataField: '.',
+    },
+  },
 
   // Jira API
   'agile__1_0__board@uuvuu': {
@@ -434,6 +442,7 @@ export const DEFAULT_INCLUDE_ENDPOINTS: string[] = [
   'PageBeanFieldConfigurationScheme',
   'PageBeanFieldConfigurationIssueTypeItem',
   'PageBeanFilterDetails',
+  'IssueTypeDetails',
   'IssueLinkTypes',
   'SecuritySchemes',
   'PageBeanIssueTypeScheme',


### PR DESCRIPTION


---

see [this commit](https://github.com/salto-io/adapter-sample-jira-workspace/commit/6c1b546f908ecf6cf91eba02fea2cf3a596a5aa2) for the affect on an example workspace

---
_Release Notes_: 
Jira adapter
- Added issue type to default fetch configuration

---
_User Notifications_: 
_None_