### PR TITLE
SALTO-1710 rename inner references on element rename

### DIFF
--- a/packages/core/src/core/rename.ts
+++ b/packages/core/src/core/rename.ts
@@ -18,7 +18,7 @@ import { ElemID, Element, isElement, InstanceElement, DetailedChange,
   isReferenceExpression, ReferenceExpression, getChangeElement, isRemovalOrModificationChange,
   isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
-import { applyDetailedChanges, setPath, walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { applyDetailedChanges, transformElement, walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { ElementsSource, getElementsPathHints, PathIndex, splitElementByPath, State, Workspace } from '@salto-io/workspace'
 
 const { awu } = collections.asynciterable
@@ -72,28 +72,28 @@ export const renameChecks = async (
   }
 }
 
-const getReferences = (
-  element: Element,
-  referredElemId: ElemID
-): { path: ElemID; value: ReferenceExpression }[] => {
-  const references: { path: ElemID; value: ReferenceExpression }[] = []
-  const func: WalkOnFunc = ({ path, value }) => {
-    if (isReferenceExpression(value)
-    && (referredElemId.isEqual(value.elemID) || referredElemId.isParentOf(value.elemID))) {
-      references.push({ path, value })
-      return WALK_NEXT_STEP.SKIP
-    }
-    return WALK_NEXT_STEP.RECURSE
-  }
-  walkOnElement({ element, func })
-  return references
-}
+const isReferenceOfElement = <T>(
+  value: T,
+  elemId: ElemID
+): boolean =>
+    isReferenceExpression(value)
+    && (elemId.isEqual(value.elemID) || elemId.isParentOf(value.elemID))
 
-const getRenameElementChanges = (
+const getUpdatedReference = (
+  referenceExpression: ReferenceExpression,
+  targetElemId: ElemID
+): ReferenceExpression => new ReferenceExpression(
+  targetElemId.createNestedID(...referenceExpression.elemID.createTopLevelParentID().path),
+  referenceExpression.value,
+  referenceExpression.topLevelParent
+)
+
+const getRenameElementChanges = async (
+  elementsSource: ElementsSource,
   sourceElemId: ElemID,
   targetElemId: ElemID,
   sourceElements: InstanceElement[]
-): DetailedChange[] => {
+): Promise<DetailedChange[]> => {
   const removeChange = {
     id: sourceElemId,
     action: 'remove' as const,
@@ -103,19 +103,18 @@ const getRenameElementChanges = (
   }
 
   // updating references inside the renamed element
-  sourceElements.forEach(element => {
-    const references = getReferences(element, sourceElemId)
-    references.forEach(reference => {
-      const updatedReference = new ReferenceExpression(
-        targetElemId.createNestedID(...reference.value.elemID.createTopLevelParentID().path),
-        reference.value.value,
-        reference.value.topLevelParent
-      )
-      setPath(element, reference.path, updatedReference)
-    })
-  })
+  const updatedElements = await Promise.all(sourceElements.map(element => transformElement({
+    element,
+    transformFunc: ({ value }) => (
+      isReferenceOfElement(value, sourceElemId)
+        ? getUpdatedReference(value, targetElemId)
+        : value
+    ),
+    elementsSource,
+    strict: false,
+  })))
 
-  const addChanges = sourceElements.map(element => ({
+  const addChanges = updatedElements.map(element => ({
     id: targetElemId,
     action: 'add' as const,
     data: {
@@ -137,26 +136,32 @@ const getRenameReferencesChanges = async (
   sourceElemId: ElemID,
   targetElemId: ElemID
 ): Promise<DetailedChange[]> => {
+  const getReferences = (element: Element): { path: ElemID; value: ReferenceExpression }[] => {
+    const references: { path: ElemID; value: ReferenceExpression }[] = []
+    const func: WalkOnFunc = ({ path, value }) => {
+      if (isReferenceOfElement(value, sourceElemId)) {
+        references.push({ path, value })
+        return WALK_NEXT_STEP.SKIP
+      }
+      return WALK_NEXT_STEP.RECURSE
+    }
+    walkOnElement({ element, func })
+    return references
+  }
+
   const references = await awu(await elementsSource.getAll())
     // filtering the renamed element - its references are taken care in getRenameElementChanges
     .filter(element => !sourceElemId.isEqual(element.elemID))
-    .flatMap(element => getReferences(element, sourceElemId)).toArray()
+    .flatMap(element => getReferences(element)).toArray()
 
-  return references.map(reference => {
-    const targetReference = new ReferenceExpression(
-      targetElemId.createNestedID(...reference.value.elemID.createTopLevelParentID().path),
-      reference.value.value,
-      reference.value.topLevelParent
-    )
-    return {
-      id: reference.path,
-      action: 'modify',
-      data: {
-        before: reference.value,
-        after: targetReference,
-      },
-    }
-  })
+  return references.map(reference => ({
+    id: reference.path,
+    action: 'modify',
+    data: {
+      before: reference.value,
+      after: getUpdatedReference(reference.value, targetElemId),
+    },
+  }))
 }
 
 const renameElementPathIndex = async (
@@ -191,11 +196,11 @@ export const renameElement = async (
     ? await splitElementByPath(source, index)
     : [source]
 
-  const elementChanges = getRenameElementChanges(sourceElemId, targetElemId, elements)
+  const elementChanges = await getRenameElementChanges(
+    elementsSource, sourceElemId, targetElemId, elements
+  )
   const referencesChanges = await getRenameReferencesChanges(
-    elementsSource,
-    sourceElemId,
-    targetElemId
+    elementsSource, sourceElemId, targetElemId
   )
 
   if (isDefined(index)) {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -563,12 +563,14 @@ describe('api.ts', () => {
     beforeAll(async () => {
       const workspaceElements = mockElements.getAllElements()
       const ws = mockWorkspace({ elements: workspaceElements })
-      const sourceElemId = new ElemID('salto', 'employee', 'instance', 'instance')
+      const sourceElemId = new ElemID('salto', 'employee', 'instance', 'original')
       const sourceElement = await ws.getValue(sourceElemId)
       const targetElement = new InstanceElement(
         'renamed',
         sourceElement.refType,
-        sourceElement.value,
+        _.merge({}, sourceElement.value, {
+          friend: new ReferenceExpression(ElemID.fromFullName('salto.employee.instance.renamed')),
+        }),
         sourceElement.path,
         sourceElement.annotations
       )

--- a/packages/core/test/common/elements.ts
+++ b/packages/core/test/common/elements.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS, BuiltinTypes, ElemID, ObjectType, InstanceElement, PrimitiveType, ListType, MapType, ReferenceExpression, Field } from '@salto-io/adapter-api'
+import { setPath } from '@salto-io/adapter-utils'
 
 type AllElementsTypes = [PrimitiveType, ObjectType, ObjectType,
     ObjectType, InstanceElement, ListType, MapType, InstanceElement, Field]
@@ -94,6 +95,11 @@ export const getAllElements = (): AllElementsTypes => {
     'instance',
     saltoEmployee,
     { name: 'FirstEmployee', nicknames: ['you', 'hi'], office: { label: 'bla', name: 'foo', seats: { c1: 'n1', c2: 'n2' } } }
+  )
+  setPath(
+    saltoEmployeeInstance,
+    saltoEmployeeInstance.elemID.createNestedID('friend'),
+    new ReferenceExpression(saltoEmployeeInstance.elemID)
   )
 
   const anotherSaltoEmployeeInstance = new InstanceElement(

--- a/packages/core/test/common/elements.ts
+++ b/packages/core/test/common/elements.ts
@@ -16,7 +16,7 @@
 import { CORE_ANNOTATIONS, BuiltinTypes, ElemID, ObjectType, InstanceElement, PrimitiveType, ListType, MapType, ReferenceExpression, Field } from '@salto-io/adapter-api'
 
 type AllElementsTypes = [PrimitiveType, ObjectType, ObjectType,
-    ObjectType, InstanceElement, ListType, MapType, InstanceElement, Field]
+    ObjectType, InstanceElement, ListType, MapType, InstanceElement, InstanceElement, Field]
 export const getAllElements = (): AllElementsTypes => {
   const addrElemID = new ElemID('salto', 'address')
   const saltoAddr = new ObjectType({
@@ -96,13 +96,22 @@ export const getAllElements = (): AllElementsTypes => {
     { name: 'FirstEmployee', nicknames: ['you', 'hi'], office: { label: 'bla', name: 'foo', seats: { c1: 'n1', c2: 'n2' } } }
   )
 
+  const saltoEmployeeToRename = new InstanceElement(
+    'original',
+    saltoEmployee,
+    { name: 'FirstEmployee',
+      nicknames: ['you', 'hi'],
+      office: { label: 'bla', name: 'foo', seats: { c1: 'n1', c2: 'n2' } },
+      friend: new ReferenceExpression(employeeElemID.createNestedID('instance', 'original')) }
+  )
+
   const anotherSaltoEmployeeInstance = new InstanceElement(
     'anotherInstance',
     saltoEmployee,
     { name: 'FirstEmployee',
       nicknames: ['you', 'hi'],
       office: { label: 'bla', name: 'foo', seats: { c1: 'n1', c2: 'n2' } },
-      friend: new ReferenceExpression(saltoEmployeeInstance.elemID),
+      friend: new ReferenceExpression(saltoEmployeeToRename.elemID),
       parent: new ReferenceExpression(saltoEmployee.elemID) }
   )
 
@@ -110,5 +119,5 @@ export const getAllElements = (): AllElementsTypes => {
 
   return [BuiltinTypes.STRING, saltoAddr, saltoOffice,
     saltoEmployee, saltoEmployeeInstance, stringListType, stringMapType,
-    anotherSaltoEmployeeInstance, fieldElement]
+    saltoEmployeeToRename, anotherSaltoEmployeeInstance, fieldElement]
 }

--- a/packages/core/test/common/elements.ts
+++ b/packages/core/test/common/elements.ts
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 import { CORE_ANNOTATIONS, BuiltinTypes, ElemID, ObjectType, InstanceElement, PrimitiveType, ListType, MapType, ReferenceExpression, Field } from '@salto-io/adapter-api'
-import { setPath } from '@salto-io/adapter-utils'
 
 type AllElementsTypes = [PrimitiveType, ObjectType, ObjectType,
     ObjectType, InstanceElement, ListType, MapType, InstanceElement, Field]
@@ -95,11 +94,6 @@ export const getAllElements = (): AllElementsTypes => {
     'instance',
     saltoEmployee,
     { name: 'FirstEmployee', nicknames: ['you', 'hi'], office: { label: 'bla', name: 'foo', seats: { c1: 'n1', c2: 'n2' } } }
-  )
-  setPath(
-    saltoEmployeeInstance,
-    saltoEmployeeInstance.elemID.createNestedID('friend'),
-    new ReferenceExpression(saltoEmployeeInstance.elemID)
   )
 
   const anotherSaltoEmployeeInstance = new InstanceElement(

--- a/packages/core/test/core/plan/plan.test.ts
+++ b/packages/core/test/core/plan/plan.test.ts
@@ -110,7 +110,7 @@ describe('getPlan', () => {
   it('should split elements on addition if their fields create a dependency cycle', async () => {
     const [plan, splitElem] = await planWithSplitElem(true)
     const planItems = [...plan.itemsByEvalOrder()]
-    expect(planItems).toHaveLength(6)
+    expect(planItems).toHaveLength(7)
     const splitElemChanges = planItems
       .filter(item => item.groupKey === splitElem.elemID.getFullName())
     expect(splitElemChanges).toHaveLength(2)
@@ -122,7 +122,7 @@ describe('getPlan', () => {
     const [plan, splitElem] = await planWithSplitElem(false)
 
     const planItems = [...plan.itemsByEvalOrder()]
-    expect(planItems).toHaveLength(6)
+    expect(planItems).toHaveLength(7)
     const splitElemChanges = planItems
       .filter(item => item.groupKey === splitElem.elemID.getFullName())
     expect(splitElemChanges).toHaveLength(2)
@@ -140,13 +140,13 @@ describe('getPlan', () => {
   it('should ignore cycles within a group', async () => {
     const plan = await planWithDependencyCycleWithinAGroup(false)
     const planItems = [...plan.itemsByEvalOrder()]
-    expect(planItems).toHaveLength(5)
+    expect(planItems).toHaveLength(6)
   })
 
   it('should ignore cycles within a group with change validators', async () => {
     const plan = await planWithDependencyCycleWithinAGroup(true)
     const planItems = [...plan.itemsByEvalOrder()]
-    expect(planItems).toHaveLength(5)
+    expect(planItems).toHaveLength(6)
   })
 
   describe('with custom group key function', () => {

--- a/packages/core/test/core/rename.test.ts
+++ b/packages/core/test/core/rename.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { DetailedChange, ElemID, getChangeElement, InstanceElement, isAdditionChange, isInstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
-import { resolvePath } from '@salto-io/adapter-utils'
+import { resolvePath, setPath } from '@salto-io/adapter-utils'
 import * as workspace from '@salto-io/workspace'
 import * as rename from '../../src/core/rename'
 
@@ -96,6 +96,11 @@ describe('rename.ts', () => {
     let targetElement: InstanceElement
     beforeAll(async () => {
       const sourceElement = await ws.getValue(sourceElemId)
+      setPath(
+        sourceElement,
+        sourceElemId.createNestedID('friend'),
+        new ReferenceExpression(sourceElemId)
+      )
 
       targetElement = new InstanceElement(
         'renamed',

--- a/packages/core/test/core/rename.test.ts
+++ b/packages/core/test/core/rename.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { DetailedChange, ElemID, InstanceElement, isInstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { DetailedChange, ElemID, getChangeElement, InstanceElement, isAdditionChange, isInstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { resolvePath } from '@salto-io/adapter-utils'
 import * as workspace from '@salto-io/workspace'
 import * as rename from '../../src/core/rename'
@@ -93,10 +93,11 @@ describe('rename.ts', () => {
   describe('renameElement', () => {
     let expectedChanges: DetailedChange[]
     let changes: DetailedChange[]
+    let targetElement: InstanceElement
     beforeAll(async () => {
       const sourceElement = await ws.getValue(sourceElemId)
 
-      const targetElement = new InstanceElement(
+      targetElement = new InstanceElement(
         'renamed',
         sourceElement.refType,
         sourceElement.value,
@@ -122,6 +123,12 @@ describe('rename.ts', () => {
     })
     it('should return changes', () => {
       expect(changes).toEqual(expectedChanges)
+    })
+    it('should rename references in the renamed element', () => {
+      const addChange = changes.find(isAdditionChange)
+      expect(addChange).toBeDefined()
+      expect(getChangeElement(addChange as DetailedChange).value.friend)
+        .toEqual(new ReferenceExpression(targetElement.elemID))
     })
     it('should update pathIndex', async () => {
       const topLevelPaths = [['salto', 'records', 'instance', 'main'],


### PR DESCRIPTION
solving bug on SALTO-1476 - references to the source element weren't changed if they were inside the source element itself.

---
_Release Notes_: 
* core
bug fix - rename inner references on element rename