### PR TITLE
SALTO-1717: Change picklist value set annotation type to a list

### DIFF
--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -487,7 +487,7 @@ export class Types {
       annotationRefsOrTypes: {
         ...Types.commonAnnotationTypes,
         [FIELD_ANNOTATIONS.FIELD_DEPENDENCY]: Types.fieldDependencyType,
-        [FIELD_ANNOTATIONS.VALUE_SET]: Types.valueSetType,
+        [FIELD_ANNOTATIONS.VALUE_SET]: new ListType(Types.valueSetType),
         [FIELD_ANNOTATIONS.RESTRICTED]: BuiltinTypes.BOOLEAN,
         [VALUE_SET_FIELDS.VALUE_SET_NAME]: BuiltinTypes.STRING,
         [VALUE_SET_DEFINITION_FIELDS.SORTED]: BuiltinTypes.BOOLEAN,


### PR DESCRIPTION
The annotation on the picklist contains a list of values, the type should be a list as well

---


---
_Release Notes_: 
Salesforce Adapter:
- Fixed annotation type under picklist field type

---
_User Notifications_: 
- The Salesforce picklist type definition will change the next time a fetch is done on a salesforce workspace