### PR TITLE
Fixed Netsuite e2e for NetSuite empty account

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -139,7 +139,7 @@ describe('Netsuite adapter E2E with real account', () => {
       FILE,
       {
         description: randomString,
-        ...(withSuiteApp ? { [PATH]: '/Images/InnerFolder/e2eTest.js' } : {}),
+        ...(withSuiteApp ? { [PATH]: '/Images/e2eTest.js' } : {}),
       }
     )
 
@@ -147,7 +147,7 @@ describe('Netsuite adapter E2E with real account', () => {
       FOLDER,
       {
         description: randomString,
-        ...(withSuiteApp ? { [PATH]: '/Images/InnerFolder' } : {}),
+        ...(withSuiteApp ? { [PATH]: '/Images' } : {}),
       }
     )
 

--- a/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
@@ -571,6 +571,37 @@ describe('suiteapp_file_cabinet', () => {
           .deploy([change], 'update')
         expect(errors).toEqual([new Error('Failed to find the internal id of the file /instance10000')])
         expect(appliedChanges).toHaveLength(0)
+        expect(mockSuiteAppClient.updateFileCabinetInstances).not.toHaveBeenCalledWith()
+      })
+
+      it('should return both update errors and invalid instance errors', async () => {
+        const notExistsChange = toChange({
+          before: new InstanceElement(
+            'instance10000',
+            folder,
+            {
+              path: '/instance10000',
+            }
+          ),
+          after: new InstanceElement(
+            'instance10000',
+            folder,
+            {
+              path: '/instance10000',
+              description: 'aaa',
+            }
+          ),
+        })
+
+        mockSuiteAppClient.updateFileCabinetInstances.mockRejectedValue(new Error('someError'))
+        const { appliedChanges, errors } = await createSuiteAppFileCabinetOperations(suiteAppClient)
+          .deploy([changes[0], notExistsChange], 'update')
+        expect(errors).toEqual([
+          new Error('someError'),
+          new Error('Failed to find the internal id of the file /instance10000'),
+        ])
+        expect(appliedChanges).toHaveLength(0)
+        expect(mockSuiteAppClient.updateFileCabinetInstances).not.toHaveBeenCalledWith()
       })
 
       it('should return an error if file parent is not found', async () => {


### PR DESCRIPTION
before this PR the e2e assumed that a folder with a path /images/innerFolder exists on the account. Fixed it to not have this assumption

In addition, fixed some minor bugs that made the error message less clear:
- There was a situation when we called deploy without any files
- When there was an error in the deployment, we would not return the errors of the invalid instances to deploy


---
_Release Notes_: 
Netsuite Adapter:
Improved the error message when trying to create a file in a folder that does not exist

---
_User Notifications_: 
None