### PR TITLE
SALTO-1702: improved references indexes performance

### DIFF
--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -196,6 +196,10 @@ export class ElemID {
         && this.nameParts.length === 1)
   }
 
+  isBaseId(): boolean {
+    return (this.idType === 'field' && this.nameParts.length === 1) || this.isTopLevel()
+  }
+
   isEqual(other: ElemID): boolean {
     return this.getFullName() === other.getFullName()
   }

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -333,6 +333,30 @@ describe('Test elements.ts', () => {
       })
     })
 
+    describe('isBaseLevel', () => {
+      it('should return true for type ID', () => {
+        expect(typeId.isBaseId()).toBeTruthy()
+      })
+      it('should return true for field ID', () => {
+        expect(fieldId.isBaseId()).toBeTruthy()
+      })
+      it('should return false for annotation ID', () => {
+        expect(annotationTypeId.isBaseId()).toBeFalsy()
+      })
+      it('should return true for instance ID', () => {
+        expect(typeInstId.isBaseId()).toBeTruthy()
+      })
+      it('should return false for value ID', () => {
+        expect(valueId.isBaseId()).toBeFalsy()
+      })
+      it('should return true for config type ID', () => {
+        expect(configTypeId.isBaseId()).toBeTruthy()
+      })
+      it('should return true for config instance ID', () => {
+        expect(configInstId.isBaseId()).toBeTruthy()
+      })
+    })
+
     describe('fromFullName', () => {
       it('should create elem ID from its full name', () => {
         [typeId, fieldId, annotationTypesId, annotationTypeId, typeInstId, valueId, configTypeId,

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -373,6 +373,8 @@ export const mockWorkspace = ({
     getSourceMap: mockFunction<Workspace['getSourceMap']>().mockResolvedValue(new parser.SourceMap()),
     getSourceRanges: mockFunction<Workspace['getSourceRanges']>().mockResolvedValue([]),
     getElementReferencedFiles: mockFunction<Workspace['getElementReferencedFiles']>().mockResolvedValue([]),
+    getElementOutgoingReferences: mockFunction<Workspace['getElementOutgoingReferences']>().mockResolvedValue([]),
+    getElementIncomingReferences: mockFunction<Workspace['getElementIncomingReferences']>().mockResolvedValue([]),
     getElementNaclFiles: mockFunction<Workspace['getElementNaclFiles']>().mockResolvedValue([]),
     getElementIdsBySelectors: mockFunction<Workspace['getElementIdsBySelectors']>().mockResolvedValue(awu([])),
     getParsedNaclFile: mockFunction<Workspace['getParsedNaclFile']>(),

--- a/packages/workspace/src/workspace/reference_indexes.ts
+++ b/packages/workspace/src/workspace/reference_indexes.ts
@@ -1,0 +1,238 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, ElemID, getChangeElement, isReferenceExpression, Element, isModificationChange, toChange, isObjectTypeChange, isRemovalOrModificationChange, isAdditionOrModificationChange } from '@salto-io/adapter-api'
+import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { ElementsSource } from './elements_source'
+import { RemoteMap } from './remote_map'
+
+const { awu } = collections.asynciterable
+
+const log = logger(module)
+export const REFERENCE_INDEXES_VERSION = 1
+export const REFERENCE_INDEXES_KEY = 'reference_indexes'
+
+type ReferenceDetails = {
+  referenceSource: ElemID
+  referenceTarget: ElemID
+}
+
+type ChangeReferences = {
+  removed: ReferenceDetails[]
+  currentAndNew: ReferenceDetails[]
+}
+
+const getReferences = (element: Element): ReferenceDetails[] => {
+  const references: ReferenceDetails[] = []
+  walkOnElement({
+    element,
+    func: ({ value, path: referenceSource }) => {
+      if (isReferenceExpression(value)) {
+        references.push({ referenceSource, referenceTarget: value.elemID })
+      }
+      return WALK_NEXT_STEP.RECURSE
+    },
+  })
+  return references
+}
+
+const getReferenceDetailsIdentifier = (referenceDetails: ReferenceDetails): string =>
+  `${referenceDetails.referenceTarget.getFullName()} - ${referenceDetails.referenceSource.getFullName()}`
+
+const getReferencesFromChange = (change: Change<Element>): ChangeReferences => {
+  const before = isRemovalOrModificationChange(change) ? getReferences(change.data.before) : []
+  const after = isAdditionOrModificationChange(change) ? getReferences(change.data.after) : []
+
+  const afterIds = new Set(after.map(getReferenceDetailsIdentifier))
+  const removedReferences = before.filter(ref => !afterIds.has(getReferenceDetailsIdentifier(ref)))
+  return {
+    removed: removedReferences,
+    currentAndNew: after,
+  }
+}
+
+const updateIndex = (index: RemoteMap<ElemID[]>, id: string, values: ElemID[]): Promise<void> => (
+  values.length !== 0
+    ? index.set(id, _.uniqBy(values, elemId => elemId.getFullName()))
+    : index.delete(id)
+)
+
+const updateReferenceTargetsIndex = async (
+  changes: Change<Element>[],
+  index: RemoteMap<ElemID[]>,
+  changeToReferences: Record<string, ChangeReferences>
+): Promise<void> => {
+  await Promise.all(changes.map(async change => {
+    const references = changeToReferences[getChangeElement(change).elemID.getFullName()]
+      .currentAndNew
+    const baseIdToReferences = _(references)
+      .groupBy(reference => reference.referenceSource.createBaseID().parent.getFullName())
+      .mapValues(referencesGroup => referencesGroup.map(ref => ref.referenceTarget))
+      .value()
+
+    if (isObjectTypeChange(change)) {
+      const type = getChangeElement(change)
+
+      const allFields = isModificationChange(change)
+        ? {
+          ...change.data.before.fields,
+          ...type.fields,
+        }
+        : type.fields
+      await Promise.all(
+        Object.values(allFields)
+          .map(async field => updateIndex(
+            index,
+            field.elemID.getFullName(),
+            baseIdToReferences[field.elemID.getFullName()] ?? []
+          ))
+      )
+    }
+    const elemId = getChangeElement(change).elemID.getFullName()
+    await updateIndex(
+      index,
+      elemId,
+      changeToReferences[elemId].currentAndNew
+        .map(ref => ref.referenceTarget),
+    )
+  }))
+}
+
+const updateIdOfReferenceSourcesIndex = async (
+  id: string,
+  referenceSourcesGroup: ElemID[],
+  allChangedReferenceSources: Set<string>,
+  index: RemoteMap<ElemID[]>,
+  changeToReferences: Record<string, ChangeReferences>,
+): Promise<void> => {
+  const oldReferenceSources = await index.get(id) ?? []
+
+  const unchangedReferenceSources = oldReferenceSources.filter(
+    elemId => !allChangedReferenceSources.has(elemId.createTopLevelParentID().parent.getFullName())
+  )
+
+  const currentId = ElemID.fromFullName(id)
+  const changedReferenceSources = referenceSourcesGroup
+    .flatMap(elemId => changeToReferences[elemId.getFullName()].currentAndNew)
+    .filter(ref => currentId.isParentOf(ref.referenceTarget)
+        || currentId.isEqual(ref.referenceTarget))
+    .map(ref => ref.referenceSource)
+
+  await updateIndex(index, id, _.concat(unchangedReferenceSources, changedReferenceSources))
+}
+
+const updateReferenceSourcesIndex = async (
+  changes: Change<Element>[],
+  index: RemoteMap<ElemID[]>,
+  changeToReferences: Record<string, ChangeReferences>
+): Promise<void> => {
+  const removedReferences = Object.values(changeToReferences).flatMap(change => change.removed)
+  const addedReferences = Object.values(changeToReferences).flatMap(change => change.currentAndNew)
+
+  const referenceSourcesChanges = _(addedReferences)
+    .concat(removedReferences)
+    .groupBy(({ referenceTarget }) => referenceTarget.createBaseID().parent.getFullName())
+    .mapValues(refs => refs.map(ref => ref.referenceSource))
+    .value()
+
+  // Add to a type its fields references
+  Object.entries(referenceSourcesChanges).forEach(([targetId, sourceIds]) => {
+    const elemId = ElemID.fromFullName(targetId)
+    if (elemId.idType === 'field') {
+      const topLevelId = elemId.createTopLevelParentID().parent.getFullName()
+      if (referenceSourcesChanges[topLevelId] === undefined) {
+        referenceSourcesChanges[topLevelId] = []
+      }
+      referenceSourcesChanges[topLevelId].push(...sourceIds)
+    }
+  })
+
+  const changedReferenceSources = new Set(
+    changes
+      .map(getChangeElement)
+      .map(elem => elem.elemID.getFullName())
+  )
+
+  await Promise.all(
+    Object.entries(referenceSourcesChanges)
+      .map(async ([id, referenceSourcesGroup]) => {
+        await updateIdOfReferenceSourcesIndex(
+          id,
+          _.uniqBy(
+            referenceSourcesGroup.map(elemId => elemId.createTopLevelParentID().parent),
+            elemId => elemId.getFullName()
+          ),
+          changedReferenceSources,
+          index,
+          changeToReferences,
+        )
+      })
+  )
+}
+
+const getAllElementsChanges = async (
+  currentChanges: Change<Element>[],
+  elementsSource: ElementsSource,
+): Promise<Change<Element>[]> => awu(await elementsSource.getAll())
+  .map(element => toChange({ after: element }))
+  .concat(currentChanges)
+  .toArray()
+
+export const updateReferenceIndexes = async (
+  changes: Change<Element>[],
+  referenceTargetsIndex: RemoteMap<ElemID[]>,
+  referenceSourcesIndex: RemoteMap<ElemID[]>,
+  mapVersions: RemoteMap<number>,
+  elementsSource: ElementsSource,
+  isCacheValid: boolean,
+): Promise<void> => log.time(async () => {
+  let relevantChanges = changes
+  const isVersionMatch = await mapVersions.get(REFERENCE_INDEXES_KEY) === REFERENCE_INDEXES_VERSION
+  if (!isCacheValid || !isVersionMatch) {
+    if (!isVersionMatch) {
+      relevantChanges = await getAllElementsChanges(changes, elementsSource)
+      log.info('references indexes maps are out of date, re-indexing')
+    }
+    if (!isCacheValid) {
+      log.info('cache is invalid, re-indexing references indexes')
+    }
+    await Promise.all([
+      referenceTargetsIndex.clear(),
+      referenceSourcesIndex.clear(),
+      mapVersions.set(REFERENCE_INDEXES_KEY, REFERENCE_INDEXES_VERSION),
+    ])
+  }
+
+  const changeToReferences = Object.fromEntries(relevantChanges
+    .map(change => [
+      getChangeElement(change).elemID.getFullName(),
+      getReferencesFromChange(change),
+    ]))
+
+  await updateReferenceTargetsIndex(
+    relevantChanges,
+    referenceTargetsIndex,
+    changeToReferences,
+  )
+
+  await updateReferenceSourcesIndex(
+    relevantChanges,
+    referenceSourcesIndex,
+    changeToReferences,
+  )
+}, 'updating references indexes')

--- a/packages/workspace/test/workspace/reference_indexes.test.ts
+++ b/packages/workspace/test/workspace/reference_indexes.test.ts
@@ -1,0 +1,426 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { mockFunction, MockInterface } from '@salto-io/test-utils'
+import { REFERENCE_INDEXES_VERSION, updateReferenceIndexes } from '../../src/workspace/reference_indexes'
+import { createInMemoryElementSource, ElementsSource } from '../../src/workspace/elements_source'
+import { RemoteMap } from '../../src/workspace/remote_map'
+
+const createMockRemoteMap = <T>(): MockInterface<RemoteMap<T>> => ({
+  delete: mockFunction<RemoteMap<T>['delete']>(),
+  get: mockFunction<RemoteMap<T>['get']>(),
+  getMany: mockFunction<RemoteMap<T>['getMany']>(),
+  has: mockFunction<RemoteMap<T>['has']>(),
+  set: mockFunction<RemoteMap<T>['set']>(),
+  setAll: mockFunction<RemoteMap<T>['setAll']>(),
+  deleteAll: mockFunction<RemoteMap<T>['deleteAll']>(),
+  entries: mockFunction<RemoteMap<T>['entries']>(),
+  keys: mockFunction<RemoteMap<T>['keys']>(),
+  values: mockFunction<RemoteMap<T>['values']>(),
+  flush: mockFunction<RemoteMap<T>['flush']>(),
+  revert: mockFunction<RemoteMap<T>['revert']>(),
+  clear: mockFunction<RemoteMap<T>['clear']>(),
+  close: mockFunction<RemoteMap<T>['close']>(),
+  isEmpty: mockFunction<RemoteMap<T>['isEmpty']>(),
+})
+
+describe('updateReferenceIndexes', () => {
+  let referenceTargetsIndex: MockInterface<RemoteMap<ElemID[]>>
+  let referenceSourcesIndex: MockInterface<RemoteMap<ElemID[]>>
+  let mapVersions: MockInterface<RemoteMap<number>>
+  let elementsSource: ElementsSource
+  let object: ObjectType
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    referenceTargetsIndex = createMockRemoteMap<ElemID[]>()
+
+    referenceSourcesIndex = createMockRemoteMap<ElemID[]>()
+    referenceSourcesIndex.get.mockResolvedValue([])
+
+    mapVersions = createMockRemoteMap<number>()
+    mapVersions.get.mockResolvedValue(REFERENCE_INDEXES_VERSION)
+
+    elementsSource = createInMemoryElementSource()
+
+    object = new ObjectType({
+      elemID: new ElemID('test', 'object'),
+      annotations: {
+        typeRef: new ReferenceExpression(new ElemID('test', 'target1')),
+        inner: {
+          innerTypeRef: new ReferenceExpression(new ElemID('test', 'target1', 'attr', 'someAttr')),
+        },
+      },
+      fields: {
+        someField: {
+          refType: BuiltinTypes.STRING,
+          annotations: { fieldRef: new ReferenceExpression(new ElemID('test', 'target2')) },
+        },
+        fieldWithRefToType: {
+          refType: BuiltinTypes.STRING,
+          annotations: { fieldRef: new ReferenceExpression(new ElemID('test', 'object')) },
+        },
+      },
+    })
+
+    instance = new InstanceElement(
+      'instance',
+      object,
+      { someValue: new ReferenceExpression(new ElemID('test', 'target2', 'instance', 'someInstance')) },
+      undefined,
+      { someAnnotation: new ReferenceExpression(new ElemID('test', 'target2', 'field', 'someField', 'value')) },
+    )
+  })
+
+  describe('when got new elements', () => {
+    beforeEach(async () => {
+      const changes = [toChange({ after: instance }), toChange({ after: object })]
+      await updateReferenceIndexes(
+        changes,
+        referenceTargetsIndex,
+        referenceSourcesIndex,
+        mapVersions,
+        elementsSource,
+        true
+      )
+    })
+    it('should add the new references to the referenceTargets index', () => {
+      expect(referenceTargetsIndex.set).toHaveBeenCalledWith(
+        'test.object.instance.instance',
+        [
+          new ElemID('test', 'target2', 'field', 'someField', 'value'),
+          new ElemID('test', 'target2', 'instance', 'someInstance'),
+        ]
+      )
+
+      expect(referenceTargetsIndex.set).toHaveBeenCalledWith(
+        'test.object',
+        [
+          new ElemID('test', 'target1'),
+          new ElemID('test', 'target1', 'attr', 'someAttr'),
+          new ElemID('test', 'target2'),
+          new ElemID('test', 'object'),
+        ]
+      )
+
+      expect(referenceTargetsIndex.set).toHaveBeenCalledWith(
+        'test.object.field.someField',
+        [
+          new ElemID('test', 'target2'),
+        ]
+      )
+
+      expect(referenceTargetsIndex.set).toHaveBeenCalledWith(
+        'test.object.field.fieldWithRefToType',
+        [
+          new ElemID('test', 'object'),
+        ]
+      )
+    })
+
+    it('should add the new references to the referenceSources index', () => {
+      expect(referenceSourcesIndex.set).toHaveBeenCalledWith(
+        'test.target1',
+        [
+          new ElemID('test', 'object', 'attr', 'typeRef'),
+          new ElemID('test', 'object', 'attr', 'inner', 'innerTypeRef'),
+        ]
+      )
+
+      expect(referenceSourcesIndex.set).toHaveBeenCalledWith(
+        'test.target2',
+        [
+          new ElemID('test', 'object', 'field', 'someField', 'fieldRef'),
+          new ElemID('test', 'object', 'instance', 'instance', 'someAnnotation'),
+        ]
+      )
+
+      expect(referenceSourcesIndex.set).toHaveBeenCalledWith(
+        'test.target2.instance.someInstance',
+        [
+          new ElemID('test', 'object', 'instance', 'instance', 'someValue'),
+        ]
+      )
+
+      expect(referenceSourcesIndex.set).toHaveBeenCalledWith(
+        'test.target2.field.someField',
+        [
+          new ElemID('test', 'object', 'instance', 'instance', 'someAnnotation'),
+        ]
+      )
+
+      expect(referenceSourcesIndex.set).toHaveBeenCalledWith(
+        'test.object',
+        [
+          new ElemID('test', 'object', 'field', 'fieldWithRefToType', 'fieldRef'),
+        ]
+      )
+    })
+  })
+
+  describe('when elements were modified', () => {
+    beforeEach(async () => {
+      const instanceAfter = instance.clone()
+      delete instanceAfter.annotations.someAnnotation
+      instanceAfter.annotations.someAnnotation2 = new ReferenceExpression(new ElemID('test', 'target2', 'instance', 'someInstance', 'value'))
+      const changes = [toChange({ before: instance, after: instanceAfter })]
+      referenceTargetsIndex.get.mockImplementation(async id => (
+        instanceAfter.elemID.getFullName() === id
+          ? [
+            new ElemID('test', 'target2', 'instance', 'someInstance'),
+            new ElemID('test', 'target2', 'field', 'someField', 'value'),
+          ]
+          : undefined
+      ))
+
+      referenceSourcesIndex.get.mockImplementation(async id => {
+        if (id === 'test.target2.field.someField') {
+          return [
+            new ElemID('test', 'object', 'instance', 'instance', 'someAnnotation'),
+          ]
+        }
+
+        if (id === 'test.target2.instance.someInstance') {
+          return [
+            new ElemID('test', 'object', 'instance', 'instance', 'someValue'),
+          ]
+        }
+        return undefined
+      })
+
+      await updateReferenceIndexes(
+        changes,
+        referenceTargetsIndex,
+        referenceSourcesIndex,
+        mapVersions,
+        elementsSource,
+        true
+      )
+    })
+
+    it('old values should be removed and new values should be added from referenceTargets index', () => {
+      expect(referenceTargetsIndex.set).toHaveBeenCalledWith(
+        'test.object.instance.instance',
+        [
+          new ElemID('test', 'target2', 'instance', 'someInstance', 'value'),
+          new ElemID('test', 'target2', 'instance', 'someInstance'),
+        ]
+      )
+    })
+
+    it('should add the new references to referenceSources index', () => {
+      expect(referenceSourcesIndex.set).toHaveBeenCalledWith(
+        'test.target2.instance.someInstance',
+        [
+          new ElemID('test', 'object', 'instance', 'instance', 'someAnnotation2'),
+          new ElemID('test', 'object', 'instance', 'instance', 'someValue'),
+        ]
+      )
+    })
+
+    it('should remove old references from referenceSources index', () => {
+      expect(referenceSourcesIndex.delete).toHaveBeenCalledWith(
+        'test.target2.field.someField',
+      )
+
+      expect(referenceSourcesIndex.delete).toHaveBeenCalledWith(
+        'test.target2',
+      )
+    })
+  })
+
+  describe('when a field was deleted', () => {
+    beforeEach(async () => {
+      const objectAfter = object.clone()
+      delete objectAfter.fields.someField
+
+      const changes = [toChange({ before: object, after: objectAfter })]
+
+      referenceSourcesIndex.get.mockImplementation(async id => {
+        if (id === 'test.target2') {
+          return [
+            new ElemID('test', 'object', 'field', 'someField', 'fieldRef'),
+          ]
+        }
+
+        return undefined
+      })
+
+      await updateReferenceIndexes(
+        changes,
+        referenceTargetsIndex,
+        referenceSourcesIndex,
+        mapVersions,
+        elementsSource,
+        true
+      )
+    })
+
+    it('should remove the references from the referenceTargets index', () => {
+      expect(referenceTargetsIndex.delete).toHaveBeenCalledWith(
+        'test.object.field.someField',
+      )
+    })
+
+    it('should remove the references from the referenceSources index', () => {
+      expect(referenceSourcesIndex.delete).toHaveBeenCalledWith(
+        'test.target2',
+      )
+    })
+  })
+
+  describe('when elements were removed', () => {
+    beforeEach(async () => {
+      const changes = [toChange({ before: instance })]
+      referenceTargetsIndex.get.mockImplementation(async id => (
+        instance.elemID.getFullName() === id
+          ? [
+            new ElemID('test', 'target2', 'instance', 'someInstance'),
+            new ElemID('test', 'target2', 'field', 'someField', 'value'),
+          ]
+          : undefined
+      ))
+
+      referenceSourcesIndex.get.mockImplementation(async id => {
+        if (id === 'test.target2.field.someField') {
+          return [
+            new ElemID('test', 'object', 'instance', 'instance', 'someAnnotation'),
+          ]
+        }
+
+        if (id === 'test.target2.instance.someInstance') {
+          return [
+            new ElemID('test', 'object', 'instance', 'instance', 'someValue'),
+          ]
+        }
+        return undefined
+      })
+
+      await updateReferenceIndexes(
+        changes,
+        referenceTargetsIndex,
+        referenceSourcesIndex,
+        mapVersions,
+        elementsSource,
+        true
+      )
+    })
+
+    it('should remove the references from the referenceTargets index', () => {
+      expect(referenceTargetsIndex.delete).toHaveBeenCalledWith(
+        'test.object.instance.instance',
+      )
+    })
+
+    it('should remove the references from the referenceSources index', () => {
+      expect(referenceSourcesIndex.delete).toHaveBeenCalledWith(
+        'test.target2.instance.someInstance',
+      )
+
+      expect(referenceSourcesIndex.delete).toHaveBeenCalledWith(
+        'test.target2.field.someField',
+      )
+
+      expect(referenceSourcesIndex.delete).toHaveBeenCalledWith(
+        'test.target2',
+      )
+    })
+  })
+
+  describe('invalid indexes', () => {
+    describe('When cache is invalid', () => {
+      beforeEach(async () => {
+        await updateReferenceIndexes(
+          [toChange({ after: instance })],
+          referenceTargetsIndex,
+          referenceSourcesIndex,
+          mapVersions,
+          elementsSource,
+          false
+        )
+      })
+      it('should update referenceTargets index using the element source', () => {
+        expect(referenceTargetsIndex.clear).toHaveBeenCalled()
+        expect(referenceTargetsIndex.set).toHaveBeenCalledWith(
+          'test.object.instance.instance',
+          [
+            new ElemID('test', 'target2', 'field', 'someField', 'value'),
+            new ElemID('test', 'target2', 'instance', 'someInstance'),
+          ]
+        )
+      })
+
+      it('should update referenceSources index using the element source', () => {
+        expect(referenceSourcesIndex.clear).toHaveBeenCalled()
+        expect(referenceSourcesIndex.set).toHaveBeenCalledWith(
+          'test.target2.instance.someInstance',
+          [
+            new ElemID('test', 'object', 'instance', 'instance', 'someValue'),
+          ]
+        )
+
+        expect(referenceSourcesIndex.set).toHaveBeenCalledWith(
+          'test.target2.field.someField',
+          [
+            new ElemID('test', 'object', 'instance', 'instance', 'someAnnotation'),
+          ]
+        )
+      })
+    })
+
+    describe('When indexes are out of date', () => {
+      beforeEach(async () => {
+        await elementsSource.set(instance)
+        mapVersions.get.mockResolvedValue(0)
+        await updateReferenceIndexes(
+          [],
+          referenceTargetsIndex,
+          referenceSourcesIndex,
+          mapVersions,
+          elementsSource,
+          true
+        )
+      })
+      it('should update referenceTargets index using the element source', () => {
+        expect(referenceTargetsIndex.clear).toHaveBeenCalled()
+        expect(referenceTargetsIndex.set).toHaveBeenCalledWith(
+          'test.object.instance.instance',
+          [
+            new ElemID('test', 'target2', 'field', 'someField', 'value'),
+            new ElemID('test', 'target2', 'instance', 'someInstance'),
+          ]
+        )
+      })
+
+      it('should update referenceSources index using the element source', () => {
+        expect(referenceSourcesIndex.clear).toHaveBeenCalled()
+        expect(referenceSourcesIndex.set).toHaveBeenCalledWith(
+          'test.target2.instance.someInstance',
+          [
+            new ElemID('test', 'object', 'instance', 'instance', 'someValue'),
+          ]
+        )
+
+        expect(referenceSourcesIndex.set).toHaveBeenCalledWith(
+          'test.target2.field.someField',
+          [
+            new ElemID('test', 'object', 'instance', 'instance', 'someAnnotation'),
+          ]
+        )
+      })
+    })
+  })
+})

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2739,6 +2739,38 @@ describe('workspace', () => {
     })
   })
 
+  describe('getElementOutgoingReferences', () => {
+    let workspace: Workspace
+
+    beforeAll(async () => {
+      workspace = await createWorkspace()
+    })
+
+    it('None-base type should throw', async () => {
+      await expect(workspace.getElementOutgoingReferences(new ElemID('adapter', 'type', 'attr', 'aaa'))).rejects.toThrow()
+    })
+
+    it('None-exist type should return empty array', async () => {
+      expect(await workspace.getElementOutgoingReferences(new ElemID('adapter', 'notExists'))).toEqual([])
+    })
+  })
+
+  describe('getElementIncomingReferences', () => {
+    let workspace: Workspace
+
+    beforeAll(async () => {
+      workspace = await createWorkspace()
+    })
+
+    it('None-base type should throw', async () => {
+      await expect(workspace.getElementIncomingReferences(new ElemID('adapter', 'type', 'attr', 'aaa'))).rejects.toThrow()
+    })
+
+    it('None-exist type should return empty array', async () => {
+      expect(await workspace.getElementIncomingReferences(new ElemID('adapter', 'notExists'))).toEqual([])
+    })
+  })
+
   describe('hasElementsInEnv', () => {
     let workspace: Workspace
     beforeEach(async () => {


### PR DESCRIPTION
Improved references indexes performance

on Nitzan Env with profiles, it takes now 2 minutes (out of 30 minutes of the applying changes part and 40 minutes for the whole fetch)

No need to review the revert commit

---
_Release Notes_: 
None

---
_User Notifications_: 
None