### PR TITLE
SALTO-1660 Extend reference coverage in Zuora

### DIFF
--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -20,7 +20,7 @@ import { logger } from '@salto-io/logging'
 import { values as lowerDashValues, collections, multiIndex } from '@salto-io/lowerdash'
 import {
   ReferenceSerializationStrategy, ExtendedReferenceTargetDefinition, ReferenceResolverFinder,
-  generateReferenceResolverFinder, FieldReferenceDefinition,
+  FieldReferenceResolver, generateReferenceResolverFinder, FieldReferenceDefinition,
 } from './reference_mapping'
 import { ContextFunc } from './context'
 
@@ -172,21 +172,27 @@ export const replaceReferenceValues = async <
  *
  */
 export const addReferences = async <
-  T extends string
+  T extends string,
+  GerericFieldReferenceDefinition extends FieldReferenceDefinition<T>
 >({
   elements,
   defs,
   fieldsToGroupBy = ['id'],
   contextStrategyLookup,
   isEqualValue,
+  fieldReferenceResolverCreator,
 }: {
   elements: Element[]
-  defs: FieldReferenceDefinition<T>[]
+  defs: GerericFieldReferenceDefinition[]
   fieldsToGroupBy?: string[]
   contextStrategyLookup?: Record<T, ContextFunc>
   isEqualValue?: ValueIsEqualFunc
+  fieldReferenceResolverCreator?:
+    (def: GerericFieldReferenceDefinition) => FieldReferenceResolver<T>
 }): Promise<void> => {
-  const resolverFinder = generateReferenceResolverFinder<T>(defs)
+  const resolverFinder = generateReferenceResolverFinder<T, GerericFieldReferenceDefinition>(
+    defs, fieldReferenceResolverCreator
+  )
   const instances = elements.filter(isInstanceElement)
 
   // copied from Salesforce - both should be handled similarly:

--- a/packages/adapter-components/src/references/index.ts
+++ b/packages/adapter-components/src/references/index.ts
@@ -15,4 +15,4 @@
 */
 export { neighborContextGetter, ContextFunc, ContextValueMapperFunc } from './context'
 export { addReferences, replaceReferenceValues } from './field_references'
-export { FieldReferenceDefinition, ReferenceResolverFinder, ReferenceTargetDefinition, ExtendedReferenceTargetDefinition } from './reference_mapping'
+export { ReferenceSerializationStrategy, ReferenceSerializationStrategyName, ReferenceSerializationStrategyLookup, FieldReferenceDefinition, FieldReferenceResolver, ReferenceResolverFinder, ReferenceTargetDefinition, ExtendedReferenceTargetDefinition } from './reference_mapping'

--- a/packages/adapter-components/src/references/reference_mapping.ts
+++ b/packages/adapter-components/src/references/reference_mapping.ts
@@ -27,8 +27,8 @@ export type ReferenceSerializationStrategy = {
   lookupIndexName?: string
 }
 
-type ReferenceSerializationStrategyName = 'fullValue' | 'id' | 'name'
-const ReferenceSerializationStrategyLookup: Record<
+export type ReferenceSerializationStrategyName = 'fullValue' | 'id' | 'name'
+export const ReferenceSerializationStrategyLookup: Record<
   ReferenceSerializationStrategyName, ReferenceSerializationStrategy
 > = {
   fullValue: {
@@ -137,10 +137,17 @@ export type ReferenceResolverFinder<T extends string> = (
  * Generates a function that filters the relevant resolvers for a given field.
  */
 export const generateReferenceResolverFinder = <
-  T extends string
->(defs: FieldReferenceDefinition<T>[]): ReferenceResolverFinder<T> => {
+  T extends string,
+  GerericFieldReferenceDefinition extends FieldReferenceDefinition<T>
+>(
+    defs: GerericFieldReferenceDefinition[],
+    fieldReferenceResolverCreator?:
+      (def: GerericFieldReferenceDefinition) => FieldReferenceResolver<T>
+  ): ReferenceResolverFinder<T> => {
   const referenceDefinitions = defs.map(
-    def => FieldReferenceResolver.create<T>(def)
+    def => (fieldReferenceResolverCreator
+      ? fieldReferenceResolverCreator(def)
+      : FieldReferenceResolver.create<T>(def))
   )
 
   const matchersByFieldName = _(referenceDefinitions)

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -197,7 +197,7 @@ const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition<
  */
 const filter: FilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
-    await referenceUtils.addReferences<ReferenceContextStrategyName>({
+    await referenceUtils.addReferences({
       elements,
       defs: fieldNameToTypeMappingDefs,
       fieldsToGroupBy: ['id', 'name'],

--- a/packages/zuora-billing-adapter/src/adapter.ts
+++ b/packages/zuora-billing-adapter/src/adapter.ts
@@ -28,6 +28,8 @@ import fieldReferencesFilter from './filters/field_references'
 import objectDefsFilter from './filters/object_defs'
 import objectDefSplitFilter from './filters/object_def_split'
 import workflowAndTaskReferencesFilter from './filters/workflow_and_task_references'
+import objectReferencesFilter from './filters/object_references'
+import financeInformationReferencesFilter from './filters/finance_information_references'
 import unorderedListsFilter from './filters/unordered_lists'
 import changeValidator from './change_validator'
 import { ZUORA_BILLING, LIST_ALL_SETTINGS_TYPE, SETTINGS_TYPE_PREFIX, CUSTOM_OBJECT_DEFINITION_TYPE } from './constants'
@@ -50,6 +52,10 @@ export const DEFAULT_FILTERS = [
 
   // fieldReferencesFilter should run after all elements were created
   fieldReferencesFilter,
+
+  objectReferencesFilter,
+
+  financeInformationReferencesFilter,
 
   // objectDefSplitFilter should run at the end - splits elements to divide to multiple files
   objectDefSplitFilter,

--- a/packages/zuora-billing-adapter/src/constants.ts
+++ b/packages/zuora-billing-adapter/src/constants.ts
@@ -48,10 +48,3 @@ export const PRODUCT_RATE_PLAN_TYPE = 'ProductRatePlanType'
 export const ACCOUNTING_CODE_ITEM_TYPE = 'AccountingCodeItem'
 export const LIST_ALL_SETTINGS_TYPE = 'ListAllSettings'
 export const SETTINGS_TYPE_PREFIX = 'Settings_'
-
-// workflow consts
-export const WORKFLOW_PARAMS_REF = 'Workflow'
-export const WORKFLOW_PARAMS_PATH = ['additionalProperties', 'parameters', 'fields']
-export const TASK_PARAM_FIELDS_PATH = ['parameters', 'fields']
-export const TASK_REFS_NAME_PARTS_SLICE = [-2, Infinity]
-export const TASK_REFS_REGEX = /(\w+\.)+(\w+)/g

--- a/packages/zuora-billing-adapter/src/constants.ts
+++ b/packages/zuora-billing-adapter/src/constants.ts
@@ -28,6 +28,7 @@ export const OBJECTS_PATH = 'Objects'
 // annotations
 export const METADATA_TYPE = 'metadataType'
 export const LABEL = 'label'
+export const TYPE = 'type'
 export const REQUIRED = 'required'
 export const FILTERABLE = 'filterable'
 export const DESCRIPTION = 'description'

--- a/packages/zuora-billing-adapter/src/constants.ts
+++ b/packages/zuora-billing-adapter/src/constants.ts
@@ -48,3 +48,10 @@ export const PRODUCT_RATE_PLAN_TYPE = 'ProductRatePlanType'
 export const ACCOUNTING_CODE_ITEM_TYPE = 'AccountingCodeItem'
 export const LIST_ALL_SETTINGS_TYPE = 'ListAllSettings'
 export const SETTINGS_TYPE_PREFIX = 'Settings_'
+
+// workflow consts
+export const WORKFLOW_PARAMS_REF = 'Workflow'
+export const WORKFLOW_PARAMS_PATH = ['additionalProperties', 'parameters', 'fields']
+export const TASK_PARAM_FIELDS_PATH = ['parameters', 'fields']
+export const TASK_REFS_NAME_PARTS_SLICE = [-2, Infinity]
+export const TASK_REFS_REGEX = /(\w+\.)+(\w+)/g

--- a/packages/zuora-billing-adapter/src/constants.ts
+++ b/packages/zuora-billing-adapter/src/constants.ts
@@ -28,7 +28,7 @@ export const OBJECTS_PATH = 'Objects'
 // annotations
 export const METADATA_TYPE = 'metadataType'
 export const LABEL = 'label'
-export const TYPE = 'type'
+export const OBJECT_TYPE = 'objectType'
 export const REQUIRED = 'required'
 export const FILTERABLE = 'filterable'
 export const DESCRIPTION = 'description'

--- a/packages/zuora-billing-adapter/src/element_utils.ts
+++ b/packages/zuora-billing-adapter/src/element_utils.ts
@@ -18,7 +18,7 @@ import {
   isInstanceElement, Element, isObjectType, isField, Field, InstanceElement, ObjectType,
 } from '@salto-io/adapter-api'
 import {
-  CUSTOM_FIELD, CUSTOM_OBJECT, ZUORA_CUSTOM_SUFFIX, METADATA_TYPE, STANDARD_OBJECT,
+  CUSTOM_FIELD, CUSTOM_OBJECT, ZUORA_CUSTOM_SUFFIX, METADATA_TYPE, STANDARD_OBJECT, OBJECT_TYPE,
 } from './constants'
 
 const { awu } = collections.asynciterable
@@ -43,12 +43,12 @@ export const getObjectDefs = async (elements: Element[]): Promise<ObjectType[]> 
   await awu(elements).filter(isObjectDef).toArray() as ObjectType[]
 
 // This function is used to find references of standard and custom objects in workflows and tasks.
-// Custom Objects referred there as 'default__<annotations.type>'.
+// Custom Objects referred there as 'default__<annotations.objectType>'.
 // It is used in workflow_and_tasks_references filter and object_references filter.
 export const getTypeNameAsReferenced = async (type: Element): Promise<string> => (
   isObjectType(type) && await metadataType(type) === CUSTOM_OBJECT
-    ? `default__${type.annotations.type}`.toLowerCase()
-    : type.elemID.name.toLowerCase()
+    ? `default__${type.annotations[OBJECT_TYPE]}`.toLowerCase()
+    : type.annotations[OBJECT_TYPE].toLowerCase()
 )
 
 export const isCustomField = (field: Field): boolean => (

--- a/packages/zuora-billing-adapter/src/element_utils.ts
+++ b/packages/zuora-billing-adapter/src/element_utils.ts
@@ -18,7 +18,6 @@ import {
 } from '@salto-io/adapter-api'
 import {
   CUSTOM_FIELD, CUSTOM_OBJECT, ZUORA_CUSTOM_SUFFIX, METADATA_TYPE, STANDARD_OBJECT,
-  CUSTOM_OBJECT_SUFFIX,
 } from './constants'
 
 export const metadataType = async (element: Element): Promise<string | undefined> => {
@@ -39,8 +38,8 @@ export const isObjectDef = async (element: Element): Promise<boolean> => (
 
 export const getTypeNameAsReferenced = (type: Element): string => (
   isObjectType(type) && type.annotations[METADATA_TYPE] === CUSTOM_OBJECT
-    // Custom Objects referred as 'default__<typeName>' instead of '<typeName>__c'
-    ? `default__${type.elemID.name.toLowerCase().slice(0, -CUSTOM_OBJECT_SUFFIX.length)}`
+    // Custom Objects referred as 'default__<annotations.type>'
+    ? `default__${type.annotations.type}`.toLowerCase()
     : type.elemID.name.toLowerCase()
 )
 

--- a/packages/zuora-billing-adapter/src/element_utils.ts
+++ b/packages/zuora-billing-adapter/src/element_utils.ts
@@ -39,7 +39,7 @@ export const isObjectDef = async (element: Element): Promise<boolean> => (
 
 export const getTypeNameAsReferenced = (type: Element): string => (
   isObjectType(type) && type.annotations[METADATA_TYPE] === CUSTOM_OBJECT
-    // Custom Objects referred as 'default_<typeName>' instead of '<typeName>__c'
+    // Custom Objects referred as 'default__<typeName>' instead of '<typeName>__c'
     ? `default__${type.elemID.name.toLowerCase().slice(0, -CUSTOM_OBJECT_SUFFIX.length)}`
     : type.elemID.name.toLowerCase()
 )

--- a/packages/zuora-billing-adapter/src/element_utils.ts
+++ b/packages/zuora-billing-adapter/src/element_utils.ts
@@ -18,6 +18,7 @@ import {
 } from '@salto-io/adapter-api'
 import {
   CUSTOM_FIELD, CUSTOM_OBJECT, ZUORA_CUSTOM_SUFFIX, METADATA_TYPE, STANDARD_OBJECT,
+  CUSTOM_OBJECT_SUFFIX,
 } from './constants'
 
 export const metadataType = async (element: Element): Promise<string | undefined> => {
@@ -34,6 +35,13 @@ export const metadataType = async (element: Element): Promise<string | undefined
 export const isObjectDef = async (element: Element): Promise<boolean> => (
   isObjectType(element)
   && [CUSTOM_OBJECT, STANDARD_OBJECT].includes(await metadataType(element) || 'unknown')
+)
+
+export const getTypeNameAsReferenced = (type: Element): string => (
+  isObjectType(type) && type.annotations[METADATA_TYPE] === CUSTOM_OBJECT
+    // Custom Objects referred as 'default_<typeName>' instead of '<typeName>__c'
+    ? `default__${type.elemID.name.toLowerCase().slice(0, -CUSTOM_OBJECT_SUFFIX.length)}`
+    : type.elemID.name.toLowerCase()
 )
 
 export const isCustomField = (field: Field): boolean => (

--- a/packages/zuora-billing-adapter/src/element_utils.ts
+++ b/packages/zuora-billing-adapter/src/element_utils.ts
@@ -13,12 +13,15 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { collections } from '@salto-io/lowerdash'
 import {
-  isInstanceElement, Element, isObjectType, isField, Field, InstanceElement,
+  isInstanceElement, Element, isObjectType, isField, Field, InstanceElement, ObjectType,
 } from '@salto-io/adapter-api'
 import {
   CUSTOM_FIELD, CUSTOM_OBJECT, ZUORA_CUSTOM_SUFFIX, METADATA_TYPE, STANDARD_OBJECT,
 } from './constants'
+
+const { awu } = collections.asynciterable
 
 export const metadataType = async (element: Element): Promise<string | undefined> => {
   if (isInstanceElement(element)) {
@@ -35,6 +38,9 @@ export const isObjectDef = async (element: Element): Promise<boolean> => (
   isObjectType(element)
   && [CUSTOM_OBJECT, STANDARD_OBJECT].includes(await metadataType(element) || 'unknown')
 )
+
+export const getObjectDefs = async (elements: Element[]): Promise<ObjectType[]> =>
+  await awu(elements).filter(isObjectDef).toArray() as ObjectType[]
 
 export const getTypeNameAsReferenced = async (type: Element): Promise<string> => (
   isObjectType(type) && await metadataType(type) === CUSTOM_OBJECT

--- a/packages/zuora-billing-adapter/src/element_utils.ts
+++ b/packages/zuora-billing-adapter/src/element_utils.ts
@@ -42,9 +42,11 @@ export const isObjectDef = async (element: Element): Promise<boolean> => (
 export const getObjectDefs = async (elements: Element[]): Promise<ObjectType[]> =>
   await awu(elements).filter(isObjectDef).toArray() as ObjectType[]
 
+// This function is used to find references of standard and custom objects in workflows and tasks.
+// Custom Objects referred there as 'default__<annotations.type>'.
+// It is used in workflow_and_tasks_references filter and object_references filter.
 export const getTypeNameAsReferenced = async (type: Element): Promise<string> => (
   isObjectType(type) && await metadataType(type) === CUSTOM_OBJECT
-    // Custom Objects referred as 'default__<annotations.type>'
     ? `default__${type.annotations.type}`.toLowerCase()
     : type.elemID.name.toLowerCase()
 )

--- a/packages/zuora-billing-adapter/src/element_utils.ts
+++ b/packages/zuora-billing-adapter/src/element_utils.ts
@@ -36,8 +36,8 @@ export const isObjectDef = async (element: Element): Promise<boolean> => (
   && [CUSTOM_OBJECT, STANDARD_OBJECT].includes(await metadataType(element) || 'unknown')
 )
 
-export const getTypeNameAsReferenced = (type: Element): string => (
-  isObjectType(type) && type.annotations[METADATA_TYPE] === CUSTOM_OBJECT
+export const getTypeNameAsReferenced = async (type: Element): Promise<string> => (
+  isObjectType(type) && await metadataType(type) === CUSTOM_OBJECT
     // Custom Objects referred as 'default__<annotations.type>'
     ? `default__${type.annotations.type}`.toLowerCase()
     : type.elemID.name.toLowerCase()

--- a/packages/zuora-billing-adapter/src/filters/field_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/field_references.ts
@@ -18,7 +18,43 @@ import { references as referenceUtils } from '@salto-io/adapter-components'
 import { WORKFLOW_DETAILED_TYPE, TASK_TYPE, SETTINGS_TYPE_PREFIX } from '../constants'
 import { FilterCreator } from '../filter'
 
-const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition<never>[] = [
+type ZuoraReferenceSerializationStrategyName = 'currencyCode' | 'segmentName'
+const ZuoraReferenceSerializationStrategyLookup: Record<
+  ZuoraReferenceSerializationStrategyName | referenceUtils.ReferenceSerializationStrategyName,
+  referenceUtils.ReferenceSerializationStrategy
+> = {
+  ...referenceUtils.ReferenceSerializationStrategyLookup,
+  currencyCode: {
+    serialize: ({ ref }) => ref.value.value.currencyCode,
+    lookup: val => val,
+    lookupIndexName: 'currencyCode',
+  },
+  segmentName: {
+    serialize: ({ ref }) => ref.value.value.segmentName,
+    lookup: val => val,
+    lookupIndexName: 'segmentName',
+  },
+}
+
+type ZuoraFieldReferenceDefinition<T extends string | never> =
+  referenceUtils.FieldReferenceDefinition<T> & {
+  zuoraSerializationStrategy?: ZuoraReferenceSerializationStrategyName
+}
+
+class ZuoraFieldReferenceResolver<T extends string>
+  extends referenceUtils.FieldReferenceResolver<T> {
+  constructor(def: ZuoraFieldReferenceDefinition<T>) {
+    super({ src: def.src })
+    this.serializationStrategy = ZuoraReferenceSerializationStrategyLookup[
+      def.zuoraSerializationStrategy ?? def.serializationStrategy ?? 'fullValue'
+    ]
+    this.target = def.target
+      ? { ...def.target, lookup: this.serializationStrategy.lookup }
+      : undefined
+  }
+}
+
+const fieldNameToTypeMappingDefs: ZuoraFieldReferenceDefinition<never>[] = [
   {
     src: { field: 'source_workflow_id', parentTypes: ['Linkage'] },
     serializationStrategy: 'id',
@@ -40,9 +76,81 @@ const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition<never>
     target: { type: `${SETTINGS_TYPE_PREFIX}CommunicationProfile` },
   },
   {
+    src: { field: 'emailTemplateName', parentTypes: [`${SETTINGS_TYPE_PREFIX}Notification`] },
+    serializationStrategy: 'name',
+    target: { type: 'PublicEmailTemplate' },
+  },
+  {
     src: { field: 'revenueRecognitionRuleName', parentTypes: ['GETProductRatePlanChargeType'] },
     serializationStrategy: 'name',
     target: { type: `${SETTINGS_TYPE_PREFIX}RevenueRecognitionRule` },
+  },
+  {
+    src: { field: 'uom', parentTypes: ['GETProductRatePlanChargeType'] },
+    serializationStrategy: 'name',
+    target: { type: `${SETTINGS_TYPE_PREFIX}UnitOfMeasure` },
+  },
+  {
+    src: { field: 'taxCode', parentTypes: ['GETProductRatePlanChargeType'] },
+    serializationStrategy: 'name',
+    target: { type: `${SETTINGS_TYPE_PREFIX}TaxCode` },
+  },
+  {
+    src: { field: 'discountClass', parentTypes: ['GETProductRatePlanChargeType'] },
+    serializationStrategy: 'name',
+    target: { type: `${SETTINGS_TYPE_PREFIX}DiscountSetting` },
+  },
+  {
+    src: { field: 'appliedProductRatePlanId', parentTypes: ['GETProductDiscountApplyDetailsType'] },
+    serializationStrategy: 'id',
+    target: { type: 'ProductRatePlanType' },
+  },
+  {
+    src: { field: 'appliedProductRatePlanChargeId', parentTypes: ['GETProductDiscountApplyDetailsType'] },
+    serializationStrategy: 'id',
+    target: { type: 'GETProductRatePlanChargeType' },
+  },
+  {
+    src: { field: 'id', parentTypes: ['PaymentGatewayResponse', `${SETTINGS_TYPE_PREFIX}GatewayResponse`] },
+    serializationStrategy: 'id',
+    target: { type: `${SETTINGS_TYPE_PREFIX}Gateway` },
+  },
+  {
+    src: { field: 'taxEngineId', parentTypes: [`${SETTINGS_TYPE_PREFIX}TaxCode`, `${SETTINGS_TYPE_PREFIX}TaxCompany`] },
+    serializationStrategy: 'id',
+    target: { type: `${SETTINGS_TYPE_PREFIX}TaxEngine` },
+  },
+  {
+    src: { field: 'taxCompanyId', parentTypes: [`${SETTINGS_TYPE_PREFIX}TaxCode`] },
+    serializationStrategy: 'id',
+    target: { type: `${SETTINGS_TYPE_PREFIX}TaxCompany` },
+  },
+  {
+    src: { field: 'pageId', parentTypes: ['HostedPage'] },
+    serializationStrategy: 'id',
+    target: { type: `${SETTINGS_TYPE_PREFIX}HostedPaymentPage` },
+  },
+  {
+    src: { field: 'currency', parentTypes: ['GETProductRatePlanChargePricingType'] },
+    zuoraSerializationStrategy: 'currencyCode',
+    target: { type: `${SETTINGS_TYPE_PREFIX}Currency` },
+  },
+  {
+    src: { field: 'homeCurrencyCode', parentTypes: [`${SETTINGS_TYPE_PREFIX}FxCurrency`] },
+    zuoraSerializationStrategy: 'currencyCode',
+    target: { type: `${SETTINGS_TYPE_PREFIX}Currency` },
+  },
+  {
+    src: { field: 'segmentName', parentTypes: [`${SETTINGS_TYPE_PREFIX}RuleDetail`] },
+    zuoraSerializationStrategy: 'segmentName',
+    target: { type: `${SETTINGS_TYPE_PREFIX}Segment` },
+  },
+
+  // the following are future references - target objects aren't supported on the api yet
+  {
+    src: { field: 'entityId', parentTypes: [`${SETTINGS_TYPE_PREFIX}Role`] },
+    serializationStrategy: 'id',
+    target: { type: `${SETTINGS_TYPE_PREFIX}EntityNode` },
   },
 ]
 
@@ -55,7 +163,8 @@ const filter: FilterCreator = () => ({
     await referenceUtils.addReferences({
       elements,
       defs: fieldNameToTypeMappingDefs,
-      fieldsToGroupBy: ['id', 'name'],
+      fieldsToGroupBy: ['id', 'name', 'currencyCode', 'segmentName'],
+      fieldReferenceResolverCreator: defs => new ZuoraFieldReferenceResolver(defs),
     })
   },
 })

--- a/packages/zuora-billing-adapter/src/filters/field_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/field_references.ts
@@ -36,14 +36,12 @@ const ZuoraReferenceSerializationStrategyLookup: Record<
   },
 }
 
-type ZuoraFieldReferenceDefinition<T extends string | never> =
-  referenceUtils.FieldReferenceDefinition<T> & {
+type ZuoraFieldReferenceDefinition = referenceUtils.FieldReferenceDefinition<never> & {
   zuoraSerializationStrategy?: ZuoraReferenceSerializationStrategyName
 }
 
-class ZuoraFieldReferenceResolver<T extends string>
-  extends referenceUtils.FieldReferenceResolver<T> {
-  constructor(def: ZuoraFieldReferenceDefinition<T>) {
+class ZuoraFieldReferenceResolver extends referenceUtils.FieldReferenceResolver<never> {
+  constructor(def: ZuoraFieldReferenceDefinition) {
     super({ src: def.src })
     this.serializationStrategy = ZuoraReferenceSerializationStrategyLookup[
       def.zuoraSerializationStrategy ?? def.serializationStrategy ?? 'fullValue'
@@ -54,7 +52,7 @@ class ZuoraFieldReferenceResolver<T extends string>
   }
 }
 
-const fieldNameToTypeMappingDefs: ZuoraFieldReferenceDefinition<never>[] = [
+const fieldNameToTypeMappingDefs: ZuoraFieldReferenceDefinition[] = [
   {
     src: { field: 'source_workflow_id', parentTypes: ['Linkage'] },
     serializationStrategy: 'id',

--- a/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
@@ -20,7 +20,7 @@ import { ACCOUNTING_CODE_ITEM_TYPE, PRODUCT_RATE_PLAN_TYPE } from '../constants'
 import { FilterCreator } from '../filter'
 
 const { isDefined } = values
-const { toAsyncIterable, awu } = collections.asynciterable
+const { toAsyncIterable } = collections.asynciterable
 
 const addFinanceInformationDependencies = (
   inst: InstanceElement,
@@ -70,17 +70,19 @@ const addFinanceInformationDependencies = (
  * (an object field in ProductRatePlan->ProductRatePlanCharges)
  */
 const filterCreator: FilterCreator = () => ({
-  // TODO: in onDeploy - create the deleted fields in the pattern of '.*AccountingCodeType'
+  // TODO: in preDeploy - create the deleted fields in the pattern of '.*AccountingCodeType'
   // from the 'type' value of the referred AccountingCodeItem in the fields in the pattern of
   // '.*AccountingCode'.
   onFetch: async (elements: Element[]): Promise<void> => {
     const instances = elements.filter(isInstanceElement)
 
-    const productRatePlanInstances = instances
-      .filter(inst => inst.elemID.typeName === PRODUCT_RATE_PLAN_TYPE)
+    const productRatePlanInstances = instances.filter(
+      inst => inst.elemID.typeName === PRODUCT_RATE_PLAN_TYPE
+    )
 
-    const accountingCodeItems = await awu(instances).filter(inst =>
-      inst.elemID.typeName === ACCOUNTING_CODE_ITEM_TYPE).toArray() as InstanceElement[]
+    const accountingCodeItems = instances.filter(
+      inst => inst.elemID.typeName === ACCOUNTING_CODE_ITEM_TYPE
+    )
 
     if (_.isEmpty(productRatePlanInstances) || _.isEmpty(accountingCodeItems)) {
       return

--- a/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
@@ -52,6 +52,9 @@ const addFinanceInformationDependencies = (
         if (isDefined(accountingCodeItem)) {
           // one field should be with with a reference, and the second is unnecessary
           financeInformation[key] = new ReferenceExpression(accountingCodeItem)
+          // TODO: when this adapter would be able to deploy,
+          // this field should be created on preDeploy
+          // so it won't considered as deleted at the service
           _.unset(financeInformation, `${key}Type`)
         }
       })
@@ -63,6 +66,9 @@ const addFinanceInformationDependencies = (
  * (an object field in ProductRatePlan->ProductRatePlanCharges)
  */
 const filterCreator: FilterCreator = () => ({
+  // TODO: in onDeploy - create the deleted fields in the pattern of '.*AccountingCodeType'
+  // from the 'type' value of the referred AccountingCodeItem in the fields in the pattern of
+  // '.*AccountingCode'.
   onFetch: async (elements: Element[]): Promise<void> => {
     const instances = elements.filter(isInstanceElement)
 
@@ -80,7 +86,8 @@ const filterCreator: FilterCreator = () => ({
       .addIndex({
         name: 'accountingCodeItemsLookup',
         filter: isInstanceElement,
-        // id name changes are currently not allowed so it's ok to use the elem id
+        // we want to look for the AccountingCodeItem by its name & type
+        // (they're unique for each instance)
         key: item => [item.value.name.toLowerCase(), item.value.type.toLowerCase()],
         map: item => item.elemID,
       }).process(toAsyncIterable(accountingCodeItems))

--- a/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
@@ -1,0 +1,74 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { Element, InstanceElement, isInstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { values } from '@salto-io/lowerdash'
+import { ACCOUNTING_CODE_ITEM_TYPE, PRODUCT_RATE_PLAN_TYPE } from '../constants'
+import { FilterCreator } from '../filter'
+
+const { isDefined } = values
+
+const addFinanceInformationDependencies = (
+  inst: InstanceElement,
+  accountingCodeItems: InstanceElement[]
+): void => {
+  const { productRatePlanCharges } = inst.value
+  if (!_.isArray(productRatePlanCharges)) {
+    return
+  }
+
+  productRatePlanCharges.forEach(charge => {
+    const { financeInformation } = charge
+    if (!_.isPlainObject(financeInformation)) {
+      return
+    }
+
+    Object.keys(financeInformation)
+      .filter(key => /^.*AccountingCode$/.test(key))
+      .forEach(key => {
+        const accountingCodeItem = accountingCodeItems.find(item =>
+          item.value.name === financeInformation[key] && item.value.type === financeInformation[`${key}Type`])
+        if (isDefined(accountingCodeItem)) {
+          financeInformation[key] = new ReferenceExpression(accountingCodeItem.elemID.createNestedID('name'))
+          financeInformation[`${key}Type`] = new ReferenceExpression(accountingCodeItem.elemID.createNestedID('type'))
+        }
+      })
+  })
+}
+
+/**
+ * Add references to fields used as parameters in workflow tasks.
+ */
+const filterCreator: FilterCreator = () => ({
+  onFetch: async (elements: Element[]): Promise<void> => {
+    const instances = elements.filter(isInstanceElement)
+
+    const productRatePlanInstances = instances
+      .filter(inst => inst.elemID.typeName === PRODUCT_RATE_PLAN_TYPE)
+
+    const accountingCodeItems = instances.filter(inst =>
+      inst.elemID.typeName === ACCOUNTING_CODE_ITEM_TYPE)
+    if (_.isEmpty(productRatePlanInstances) || _.isEmpty(accountingCodeItems)) {
+      return
+    }
+
+    productRatePlanInstances.forEach(inst => {
+      addFinanceInformationDependencies(inst, accountingCodeItems)
+    })
+  },
+})
+
+export default filterCreator

--- a/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
@@ -37,8 +37,14 @@ const addFinanceInformationDependencies = (
     }
 
     Object.keys(financeInformation)
+      // financeInformation entries comes in couples - '.*AccountingCode' and '.*AccountingCodeType'
+      // for example:
+      // deferredRevenueAccountingCode & deferredRevenueAccountingCodeType
+      // recognizedRevenueAccountingCode & recognizedRevenueAccountingCodeType
       .filter(key => /^.*AccountingCode$/.test(key))
       .forEach(key => {
+        // each couple of fields (as mentioned above) refer to an accountingCodeItem
+        // with a unique combination of name & type
         const accountingCodeItem = accountingCodeItems.find(item =>
           item.value.name === financeInformation[key] && item.value.type === financeInformation[`${key}Type`])
         if (isDefined(accountingCodeItem)) {
@@ -50,7 +56,8 @@ const addFinanceInformationDependencies = (
 }
 
 /**
- * Add references to fields used as parameters in workflow tasks.
+ * Add references to fields in financeInformation
+ * (an object field in ProductRatePlan->ProductRatePlanCharges)
  */
 const filterCreator: FilterCreator = () => ({
   onFetch: async (elements: Element[]): Promise<void> => {

--- a/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
@@ -37,7 +37,7 @@ const addFinanceInformationDependencies = (
     }
 
     Object.keys(financeInformation)
-      // financeInformation entries comes in couples - '.*AccountingCode' and '.*AccountingCodeType'
+      // financeInformation fields comes in couples - '.*AccountingCode' and '.*AccountingCodeType'
       // for example:
       // deferredRevenueAccountingCode & deferredRevenueAccountingCodeType
       // recognizedRevenueAccountingCode & recognizedRevenueAccountingCodeType
@@ -48,8 +48,9 @@ const addFinanceInformationDependencies = (
         const accountingCodeItem = accountingCodeItems.find(item =>
           item.value.name === financeInformation[key] && item.value.type === financeInformation[`${key}Type`])
         if (isDefined(accountingCodeItem)) {
-          financeInformation[key] = new ReferenceExpression(accountingCodeItem.elemID.createNestedID('name'))
-          financeInformation[`${key}Type`] = new ReferenceExpression(accountingCodeItem.elemID.createNestedID('type'))
+          // one field should be with with a reference, and the second is unnecessary
+          financeInformation[key] = new ReferenceExpression(accountingCodeItem.elemID)
+          _.omit(financeInformation, `${key}Type`)
         }
       })
   })

--- a/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
@@ -37,6 +37,7 @@ const addFinanceInformationDependencies = (
       return
     }
 
+    const references: Record<string, ReferenceExpression> = {}
     Object.keys(financeInformation)
       // financeInformation fields comes in couples - '.*AccountingCode' and '.*AccountingCodeType'
       // for example:
@@ -50,14 +51,17 @@ const addFinanceInformationDependencies = (
           financeInformation[key]?.toLowerCase(), financeInformation[`${key}Type`]?.toLowerCase()
         )
         if (isDefined(accountingCodeItem)) {
-          // one field should be with with a reference, and the second is unnecessary
-          financeInformation[key] = new ReferenceExpression(accountingCodeItem)
-          // TODO: when this adapter would be able to deploy,
-          // this field should be created on preDeploy
-          // so it won't considered as deleted at the service
-          _.unset(financeInformation, `${key}Type`)
+          references[key] = new ReferenceExpression(accountingCodeItem)
         }
       })
+
+    charge.financeInformation = _.merge(
+      // TODO: when this adapter would be able to deploy,
+      // those fields should be created on preDeploy
+      // so they won't considered as deleted at the service
+      _.omit(financeInformation, Object.keys(references).map(key => `${key}Type`)),
+      references,
+    )
   })
 }
 

--- a/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
@@ -50,7 +50,7 @@ const addFinanceInformationDependencies = (
         if (isDefined(accountingCodeItem)) {
           // one field should be with with a reference, and the second is unnecessary
           financeInformation[key] = new ReferenceExpression(accountingCodeItem.elemID)
-          _.omit(financeInformation, `${key}Type`)
+          _.unset(financeInformation, `${key}Type`)
         }
       })
   })

--- a/packages/zuora-billing-adapter/src/filters/object_defs.ts
+++ b/packages/zuora-billing-adapter/src/filters/object_defs.ts
@@ -24,7 +24,7 @@ import { logger } from '@salto-io/logging'
 import { values as lowerdashValues, promises } from '@salto-io/lowerdash'
 import {
   ZUORA_BILLING, CUSTOM_OBJECT, CUSTOM_OBJECT_DEFINITION_TYPE, OBJECTS_PATH, METADATA_TYPE,
-  STANDARD_OBJECT_DEFINITION_TYPE, CUSTOM_OBJECT_SUFFIX, LABEL, TYPE,
+  STANDARD_OBJECT_DEFINITION_TYPE, CUSTOM_OBJECT_SUFFIX, LABEL, OBJECT_TYPE,
   FIELD_RELATIONSHIP_ANNOTATIONS, REQUIRED, FILTERABLE, DESCRIPTION, INTERNAL_ID, STANDARD_OBJECT,
 } from '../constants'
 import { FilterCreator } from '../filter'
@@ -57,29 +57,11 @@ const flattenAdditionalProperties = (val: Values): Values => ({
   ...val[ADDITIONAL_PROPERTIES_FIELD],
 })
 
-// this function makes sure that CustomObject elements would have their original 'type' value kept
-// because overwise it is replaced in their elemID by '<type>__c'
-const getAnnotations = (inst: InstanceElement): Values => (
-  isStandardObjectInstance(inst)
-    ? {
-      [METADATA_TYPE]: isStandardObjectInstance(inst) ? STANDARD_OBJECT : CUSTOM_OBJECT,
-      [LABEL]: inst.value.schema.label,
-      [DESCRIPTION]: inst.value.schema.description,
-      [INTERNAL_ID]: inst.value.additionalProperties?.Id,
-    }
-    : {
-      [METADATA_TYPE]: isStandardObjectInstance(inst) ? STANDARD_OBJECT : CUSTOM_OBJECT,
-      [LABEL]: inst.value.schema.label,
-      [DESCRIPTION]: inst.value.schema.description,
-      [INTERNAL_ID]: inst.value.additionalProperties?.Id,
-      [TYPE]: inst.value.type,
-    }
-)
-
 const createObjectFromInstance = async (inst: InstanceElement): Promise<ObjectType> => {
+  const { schema, type } = inst.value
   const {
-    properties, required, filterable,
-  } = inst.value.schema
+    properties, required, filterable, description, label,
+  } = schema
   const requiredFields = new Set(required)
   const filterableFields = new Set(filterable)
   const obj = new ObjectType({
@@ -101,8 +83,15 @@ const createObjectFromInstance = async (inst: InstanceElement): Promise<ObjectTy
       [LABEL]: BuiltinTypes.STRING,
       [DESCRIPTION]: BuiltinTypes.STRING,
       [INTERNAL_ID]: BuiltinTypes.HIDDEN_STRING,
+      [OBJECT_TYPE]: BuiltinTypes.STRING,
     },
-    annotations: getAnnotations(inst),
+    annotations: {
+      [METADATA_TYPE]: isStandardObjectInstance(inst) ? STANDARD_OBJECT : CUSTOM_OBJECT,
+      [LABEL]: label,
+      [DESCRIPTION]: description,
+      [INTERNAL_ID]: inst.value.additionalProperties?.Id,
+      [OBJECT_TYPE]: type,
+    },
     // id name changes are currently not allowed so it's ok to use the elem id
     path: [ZUORA_BILLING, OBJECTS_PATH, pathNaclCase(naclCase(inst.elemID.name))],
   })

--- a/packages/zuora-billing-adapter/src/filters/object_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/object_references.ts
@@ -93,14 +93,12 @@ const filterCreator: FilterCreator = () => ({
       .addIndex({
         name: 'typeLowercaseLookup',
         filter: isObjectDef,
-        // id name changes are currently not allowed so it's ok to use the elem id
         key: async type => [await getTypeNameAsReferenced(type)],
         map: type => type.elemID,
       })
       .addIndex({
         name: 'fieldLowercaseLookup',
         filter: isField,
-        // id name changes are currently not allowed so it's ok to use the elem id
         key: async field => [
           await getTypeNameAsReferenced(field.parent), field.elemID.name.toLowerCase(),
         ],

--- a/packages/zuora-billing-adapter/src/filters/object_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/object_references.ts
@@ -57,14 +57,14 @@ const filterCreator: FilterCreator = () => ({
         name: 'typeLowercaseLookup',
         filter: isObjectDef,
         // id name changes are currently not allowed so it's ok to use the elem id
-        key: type => [getTypeNameAsReferenced(type)],
+        key: async type => [await getTypeNameAsReferenced(type)],
         map: type => type.elemID,
       })
       .addIndex({
         name: 'fieldLowercaseLookup',
         filter: isField,
         // id name changes are currently not allowed so it's ok to use the elem id
-        key: field => [getTypeNameAsReferenced(field.parent), field.elemID.name],
+        key: async field => [await getTypeNameAsReferenced(field.parent), field.elemID.name],
         map: field => field.elemID,
       })
       .process(

--- a/packages/zuora-billing-adapter/src/filters/object_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/object_references.ts
@@ -1,0 +1,128 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  Element, InstanceElement, isInstanceElement, ReferenceExpression,
+  isField, ObjectType,
+} from '@salto-io/adapter-api'
+import { resolvePath, setPath } from '@salto-io/adapter-utils'
+import { collections, multiIndex } from '@salto-io/lowerdash'
+import { SETTINGS_TYPE_PREFIX, TASK_TYPE } from '../constants'
+import { FilterCreator } from '../filter'
+import { isObjectDef } from '../element_utils'
+
+const { flatMapAsync, toAsyncIterable, awu } = collections.asynciterable
+
+type ObjectFieldDependency = {
+  typeReferencePath: string[]
+  fieldReferencePath?: string[]
+  parentTypes: string[]
+}
+
+const dependencies: ObjectFieldDependency[] = [
+  {
+    typeReferencePath: ['object'],
+    parentTypes: [TASK_TYPE],
+  },
+  {
+    typeReferencePath: ['object'],
+    fieldReferencePath: ['field'],
+    parentTypes: [`${SETTINGS_TYPE_PREFIX}Segment`],
+  },
+]
+
+/**
+ * Add references to fields that represent objects and fields.
+ */
+const filterCreator: FilterCreator = () => ({
+  onFetch: async (elements: Element[]): Promise<void> => {
+    // for now only supporting standard objects - not clear if and how custom objects can be
+    // referenced from workflows
+
+    const objectDefs = await awu(elements).filter(isObjectDef).toArray() as ObjectType[]
+    const {
+      typeLowercaseLookup, fieldLowercaseLookup,
+    } = await multiIndex.buildMultiIndex<Element>()
+      .addIndex({
+        name: 'typeLowercaseLookup',
+        filter: isObjectDef,
+        // id name changes are currently not allowed so it's ok to use the elem id
+        key: type => [type.elemID.name.toLowerCase()],
+        map: type => type.elemID,
+      })
+      .addIndex({
+        name: 'fieldLowercaseLookup',
+        filter: isField,
+        // id name changes are currently not allowed so it's ok to use the elem id
+        key: field => [field.elemID.typeName.toLowerCase(), field.elemID.name],
+        map: field => field.elemID,
+      })
+      .process(
+        flatMapAsync(toAsyncIterable(objectDefs), obj => [obj, ...Object.values(obj.fields)])
+      )
+
+    const addObjectFieldDependency = (
+      inst: InstanceElement,
+      typeReferencePath: string[],
+      fieldReferencePath?: string[]
+    ): void => {
+      const typeElemId = inst.elemID.createNestedID(...typeReferencePath)
+      const typeName = resolvePath(inst, typeElemId)
+      if (!_.isString(typeName)) {
+        return
+      }
+
+      const objId = typeLowercaseLookup.get(typeName.toLowerCase())
+      if (_.isUndefined(objId)) {
+        return
+      }
+
+      setPath(inst, typeElemId, new ReferenceExpression(objId))
+
+      if (_.isUndefined(fieldReferencePath)) {
+        return
+      }
+
+      const fieldElemId = inst.elemID.createNestedID(...fieldReferencePath)
+      const fieldName = resolvePath(inst, fieldElemId)
+      if (!_.isString(fieldName)) {
+        return
+      }
+
+      const fieldId = fieldLowercaseLookup.get(typeName.toLowerCase(), fieldName)
+      if (_.isUndefined(fieldId)) {
+        return
+      }
+
+      setPath(inst, fieldElemId, new ReferenceExpression(fieldId))
+    }
+
+    const instances = elements.filter(isInstanceElement)
+    dependencies.forEach(dependency => {
+      const dependentInstances = instances.filter(inst =>
+        dependency.parentTypes.includes(inst.elemID.typeName))
+      if (!_.isEmpty(dependentInstances)) {
+        dependentInstances.forEach(instance => addObjectFieldDependency(
+          instance,
+          dependency.typeReferencePath,
+          dependency.fieldReferencePath
+        ))
+      }
+    })
+  },
+})
+
+export default filterCreator

--- a/packages/zuora-billing-adapter/src/filters/object_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/object_references.ts
@@ -15,16 +15,15 @@
 */
 import _ from 'lodash'
 import {
-  Element, InstanceElement, isInstanceElement, ReferenceExpression,
-  isField, ObjectType,
+  Element, InstanceElement, isInstanceElement, ReferenceExpression, isField,
 } from '@salto-io/adapter-api'
 import { resolvePath, setPath } from '@salto-io/adapter-utils'
 import { collections, multiIndex } from '@salto-io/lowerdash'
 import { SETTINGS_TYPE_PREFIX, TASK_TYPE } from '../constants'
 import { FilterCreator } from '../filter'
-import { getTypeNameAsReferenced, isObjectDef } from '../element_utils'
+import { getObjectDefs, getTypeNameAsReferenced, isObjectDef } from '../element_utils'
 
-const { flatMapAsync, toAsyncIterable, awu } = collections.asynciterable
+const { flatMapAsync, toAsyncIterable } = collections.asynciterable
 
 type ObjectFieldDependency = {
   typeReferencePath: string[]
@@ -49,7 +48,7 @@ const dependencies: ObjectFieldDependency[] = [
  */
 const filterCreator: FilterCreator = () => ({
   onFetch: async (elements: Element[]): Promise<void> => {
-    const objectDefs = await awu(elements).filter(isObjectDef).toArray() as ObjectType[]
+    const objectDefs = await getObjectDefs(elements)
     const {
       typeLowercaseLookup, fieldLowercaseLookup,
     } = await multiIndex.buildMultiIndex<Element>()

--- a/packages/zuora-billing-adapter/src/filters/object_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/object_references.ts
@@ -22,7 +22,7 @@ import { resolvePath, setPath } from '@salto-io/adapter-utils'
 import { collections, multiIndex } from '@salto-io/lowerdash'
 import { SETTINGS_TYPE_PREFIX, TASK_TYPE } from '../constants'
 import { FilterCreator } from '../filter'
-import { isObjectDef } from '../element_utils'
+import { getTypeNameAsReferenced, isObjectDef } from '../element_utils'
 
 const { flatMapAsync, toAsyncIterable, awu } = collections.asynciterable
 
@@ -60,14 +60,14 @@ const filterCreator: FilterCreator = () => ({
         name: 'typeLowercaseLookup',
         filter: isObjectDef,
         // id name changes are currently not allowed so it's ok to use the elem id
-        key: type => [type.elemID.name.toLowerCase()],
+        key: type => [getTypeNameAsReferenced(type)],
         map: type => type.elemID,
       })
       .addIndex({
         name: 'fieldLowercaseLookup',
         filter: isField,
         // id name changes are currently not allowed so it's ok to use the elem id
-        key: field => [field.elemID.typeName.toLowerCase(), field.elemID.name],
+        key: field => [getTypeNameAsReferenced(field.parent), field.elemID.name],
         map: field => field.elemID,
       })
       .process(

--- a/packages/zuora-billing-adapter/src/filters/object_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/object_references.ts
@@ -49,9 +49,6 @@ const dependencies: ObjectFieldDependency[] = [
  */
 const filterCreator: FilterCreator = () => ({
   onFetch: async (elements: Element[]): Promise<void> => {
-    // for now only supporting standard objects - not clear if and how custom objects can be
-    // referenced from workflows
-
     const objectDefs = await awu(elements).filter(isObjectDef).toArray() as ObjectType[]
     const {
       typeLowercaseLookup, fieldLowercaseLookup,

--- a/packages/zuora-billing-adapter/src/filters/object_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/object_references.ts
@@ -73,7 +73,7 @@ const addObjectFieldDependency = (
     return
   }
 
-  const fieldId = fieldLowercaseLookup.get(typeName.toLowerCase(), fieldName)
+  const fieldId = fieldLowercaseLookup.get(typeName.toLowerCase(), fieldName.toLowerCase())
   if (_.isUndefined(fieldId)) {
     return
   }
@@ -101,7 +101,9 @@ const filterCreator: FilterCreator = () => ({
         name: 'fieldLowercaseLookup',
         filter: isField,
         // id name changes are currently not allowed so it's ok to use the elem id
-        key: async field => [await getTypeNameAsReferenced(field.parent), field.elemID.name],
+        key: async field => [
+          await getTypeNameAsReferenced(field.parent), field.elemID.name.toLowerCase(),
+        ],
         map: field => field.elemID,
       })
       .process(

--- a/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
@@ -141,7 +141,7 @@ const addStringsReferencesDependency = (
       return undefined
     }).filter(isDefined)
 
-    _.uniqBy(references, reference => reference.elemID.getFullName()).forEach(
+    references.forEach(
       reference => dependencies.push({ reference, location: new ReferenceExpression(path) })
     )
 

--- a/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
@@ -204,7 +204,7 @@ const filterCreator: FilterCreator = () => ({
     const workflowInstances = instances
       .filter(inst => inst.elemID.typeName === WORKFLOW_DETAILED_TYPE)
     const taskInstances = instances.filter(inst => inst.elemID.typeName === TASK_TYPE)
-    if (_.isEmpty(workflowInstances) && _.isEmpty(taskInstances)) {
+    if (workflowInstances.length === 0 && taskInstances.length === 0) {
       return
     }
 

--- a/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
@@ -212,14 +212,14 @@ const filterCreator: FilterCreator = () => ({
         name: 'typeLowercaseLookup',
         filter: isObjectDef,
         // id name changes are currently not allowed so it's ok to use the elem id
-        key: type => [getTypeNameAsReferenced(type)],
+        key: async type => [await getTypeNameAsReferenced(type)],
         map: type => type.elemID,
       })
       .addIndex({
         name: 'fieldLowercaseLookup',
         filter: isField,
         // id name changes are currently not allowed so it's ok to use the elem id
-        key: field => [getTypeNameAsReferenced(field.parent), field.elemID.name],
+        key: async field => [await getTypeNameAsReferenced(field.parent), field.elemID.name],
         map: field => field.elemID,
       })
       .process(

--- a/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
@@ -215,14 +215,12 @@ const filterCreator: FilterCreator = () => ({
       .addIndex({
         name: 'typeLowercaseLookup',
         filter: isObjectDef,
-        // id name changes are currently not allowed so it's ok to use the elem id
         key: async type => [await getTypeNameAsReferenced(type)],
         map: type => type.elemID,
       })
       .addIndex({
         name: 'fieldLowercaseLookup',
         filter: isField,
-        // id name changes are currently not allowed so it's ok to use the elem id
         key: async field => [
           await getTypeNameAsReferenced(field.parent), field.elemID.name.toLowerCase(),
         ],

--- a/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
@@ -132,12 +132,13 @@ const addStringsReferencesDependency = (
         return undefined
       }
 
-      return workflowParams.some(field =>
-        field.object_name === WORKFLOW_PARAMS_REF && field.field_name === fieldName)
-        ? new ReferenceExpression(
+      if (workflowParams.some(field =>
+        field.object_name === WORKFLOW_PARAMS_REF && field.field_name === fieldName)) {
+        return new ReferenceExpression(
           parentWorkflow.elemID.createNestedID(...WORKFLOW_PARAMS_PATH)
         )
-        : undefined
+      }
+      return undefined
     }).filter(isDefined)
 
     _.uniqBy(references, reference => reference.elemID.getFullName()).forEach(

--- a/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
@@ -183,7 +183,7 @@ const filterCreator: FilterCreator = () => ({
       return
     }
     const workflowType = elements.filter(isObjectType)
-      .find(e => e.elemID.name === WORKFLOW_EXPORT_TYPE)
+      .find(e => e.elemID.name === WORKFLOW_DETAILED_TYPE)
     if (workflowType === undefined) {
       log.warn('Could not find %s object type', WORKFLOW_DETAILED_TYPE)
       return

--- a/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
@@ -58,7 +58,7 @@ const addWorkflowDependencies = (
       return
     }
     fieldDef.object_name = new ReferenceExpression(objId)
-    const fieldId = fieldLowercaseLookup.get(objName, fieldDef.field_name)
+    const fieldId = fieldLowercaseLookup.get(objName, fieldDef.field_name?.toLowerCase())
     if (fieldId !== undefined) {
       fieldDef.field_name = new ReferenceExpression(fieldId)
     }
@@ -83,7 +83,7 @@ const addParameterFieldsFieldDependency = (
     return Object.keys(fieldMapping as object).flatMap(fieldName => {
       // not looking up custom objects for now - if we did, they'd need to have
       // CUSTOM_OBJECT_SUFFIX appended for lookup
-      const fieldId = fieldLowercaseLookup.get(typeName.toLowerCase(), fieldName)
+      const fieldId = fieldLowercaseLookup.get(typeName.toLowerCase(), fieldName.toLowerCase())
       if (fieldId !== undefined) {
         return [{
           reference: new ReferenceExpression(fieldId),
@@ -116,7 +116,7 @@ const addStringsReferencesDependency = (
     }
 
     const references = potentialReferences.map(({ typeName, fieldName }) => {
-      const fieldId = fieldLowercaseLookup.get(typeName.toLowerCase(), fieldName)
+      const fieldId = fieldLowercaseLookup.get(typeName.toLowerCase(), fieldName.toLowerCase())
       if (isDefined(fieldId)) {
         return new ReferenceExpression(fieldId)
       }
@@ -223,7 +223,9 @@ const filterCreator: FilterCreator = () => ({
         name: 'fieldLowercaseLookup',
         filter: isField,
         // id name changes are currently not allowed so it's ok to use the elem id
-        key: async field => [await getTypeNameAsReferenced(field.parent), field.elemID.name],
+        key: async field => [
+          await getTypeNameAsReferenced(field.parent), field.elemID.name.toLowerCase(),
+        ],
         map: field => field.elemID,
       })
       .process(

--- a/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
@@ -16,19 +16,19 @@
 import _ from 'lodash'
 import {
   Element, isObjectType, InstanceElement, ElemID, isInstanceElement, ReferenceExpression,
-  isField, ObjectType, CORE_ANNOTATIONS, isReferenceExpression,
+  isField, CORE_ANNOTATIONS, isReferenceExpression,
 } from '@salto-io/adapter-api'
 import { extendGeneratedDependencies, FlatDetailedDependency, resolvePath, walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, multiIndex, values } from '@salto-io/lowerdash'
 import { TASK_TYPE, WORKFLOW_EXPORT_TYPE, WORKFLOW_DETAILED_TYPE } from '../constants'
 import { FilterCreator } from '../filter'
-import { getTypeNameAsReferenced, isObjectDef } from '../element_utils'
+import { getObjectDefs, getTypeNameAsReferenced, isObjectDef } from '../element_utils'
 
 const { isDefined } = values
 
 const log = logger(module)
-const { flatMapAsync, toAsyncIterable, awu } = collections.asynciterable
+const { flatMapAsync, toAsyncIterable } = collections.asynciterable
 
 const WORKFLOW_PARAMS_REF = 'Workflow'
 const WORKFLOW_PARAMS_PATH = ['additionalProperties', 'parameters', 'fields']
@@ -204,7 +204,7 @@ const filterCreator: FilterCreator = () => ({
       return
     }
 
-    const objectDefs = await awu(elements).filter(isObjectDef).toArray() as ObjectType[]
+    const objectDefs = await getObjectDefs(elements)
     const {
       typeLowercaseLookup, fieldLowercaseLookup,
     } = await multiIndex.buildMultiIndex<Element>()

--- a/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
@@ -204,9 +204,6 @@ const filterCreator: FilterCreator = () => ({
       return
     }
 
-    // for now only supporting standard objects - not clear if and how custom objects can be
-    // referenced from workflows
-
     const objectDefs = await awu(elements).filter(isObjectDef).toArray() as ObjectType[]
     const {
       typeLowercaseLookup, fieldLowercaseLookup,

--- a/packages/zuora-billing-adapter/test/filters/field_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/field_references.test.ts
@@ -18,7 +18,7 @@ import { client as clientUtils, filterUtils } from '@salto-io/adapter-components
 import filterCreator from '../../src/filters/field_references'
 import ZuoraClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
-import { ZUORA_BILLING } from '../../src/constants'
+import { SETTINGS_TYPE_PREFIX, TASK_TYPE, WORKFLOW_DETAILED_TYPE, ZUORA_BILLING } from '../../src/constants'
 
 
 describe('Field references filter', () => {
@@ -54,13 +54,13 @@ describe('Field references filter', () => {
   })
 
   const workflowType = new ObjectType({
-    elemID: new ElemID(ZUORA_BILLING, 'DetailedWorkflow'),
+    elemID: new ElemID(ZUORA_BILLING, WORKFLOW_DETAILED_TYPE),
     fields: {
       id: { refType: BuiltinTypes.NUMBER },
     },
   })
   const taskType = new ObjectType({
-    elemID: new ElemID(ZUORA_BILLING, 'Task'),
+    elemID: new ElemID(ZUORA_BILLING, TASK_TYPE),
     fields: {
       id: { refType: BuiltinTypes.NUMBER },
     },
@@ -92,6 +92,30 @@ describe('Field references filter', () => {
       revenueRecognitionRuleName: { refType: BuiltinTypes.STRING },
     },
   })
+  const currencyType = new ObjectType({
+    elemID: new ElemID(ZUORA_BILLING, `${SETTINGS_TYPE_PREFIX}Currency`),
+    fields: {
+      currencyCode: { refType: BuiltinTypes.STRING },
+    },
+  })
+  const productRatePlanChargePricingType = new ObjectType({
+    elemID: new ElemID(ZUORA_BILLING, 'GETProductRatePlanChargePricingType'),
+    fields: {
+      currency: { refType: BuiltinTypes.STRING },
+    },
+  })
+  const segmentType = new ObjectType({
+    elemID: new ElemID(ZUORA_BILLING, `${SETTINGS_TYPE_PREFIX}Segment`),
+    fields: {
+      segmentName: { refType: BuiltinTypes.STRING },
+    },
+  })
+  const ruleDetailType = new ObjectType({
+    elemID: new ElemID(ZUORA_BILLING, `${SETTINGS_TYPE_PREFIX}RuleDetail`),
+    fields: {
+      segmentName: { refType: BuiltinTypes.STRING },
+    },
+  })
 
   const generateElements = (
   ): Element[] => ([
@@ -112,6 +136,14 @@ describe('Field references filter', () => {
     new InstanceElement('chargeType66', productRatePlanChargeType, { revenueRecognitionRuleName: 'unknown rule' }),
     someOtherType,
     new InstanceElement('otherType55', someOtherType, { revenueRecognitionRuleName: 'rule5 name' }),
+    currencyType,
+    new InstanceElement('USD', currencyType, { currencyCode: 'USD' }),
+    productRatePlanChargePricingType,
+    new InstanceElement('pricing', productRatePlanChargePricingType, { currency: 'USD' }),
+    segmentType,
+    new InstanceElement('segment', segmentType, { segmentName: 'segment' }),
+    ruleDetailType,
+    new InstanceElement('rule', ruleDetailType, { segmentName: 'segment' }),
   ])
 
   describe('on fetch', () => {
@@ -127,9 +159,9 @@ describe('Field references filter', () => {
         e => isInstanceElement(e) && e.refType.elemID.name === 'Linkage'
       )[0] as InstanceElement
       expect(link.value.source_workflow_id).toBeInstanceOf(ReferenceExpression)
-      expect(link.value.source_workflow_id?.elemID.getFullName()).toEqual('zuora_billing.DetailedWorkflow.instance.workflow123')
+      expect(link.value.source_workflow_id?.elemID.getFullName()).toEqual(`zuora_billing.${WORKFLOW_DETAILED_TYPE}.instance.workflow123`)
       expect(link.value.target_task_id).toBeInstanceOf(ReferenceExpression)
-      expect(link.value.target_task_id?.elemID.getFullName()).toEqual('zuora_billing.Task.instance.task22')
+      expect(link.value.target_task_id?.elemID.getFullName()).toEqual(`zuora_billing.${TASK_TYPE}.instance.task22`)
 
       const chargeTypes = elements.filter(
         e => isInstanceElement(e)
@@ -138,6 +170,22 @@ describe('Field references filter', () => {
       ) as InstanceElement[]
       expect(chargeTypes[0].value.revenueRecognitionRuleName).toBeInstanceOf(ReferenceExpression)
       expect(chargeTypes[0].value.revenueRecognitionRuleName.elemID.getFullName()).toEqual('zuora_billing.Settings_RevenueRecognitionRule.instance.rule5')
+
+      const pricingInstance = elements.find(
+        e => isInstanceElement(e)
+        && e.refType.elemID.name === 'GETProductRatePlanChargePricingType'
+        && e.elemID.name === 'pricing'
+      ) as InstanceElement
+      expect(pricingInstance.value.currency).toBeInstanceOf(ReferenceExpression)
+      expect(pricingInstance.value.currency.elemID.getFullName()).toEqual(`zuora_billing.${SETTINGS_TYPE_PREFIX}Currency.instance.USD`)
+
+      const ruleDetailInstance = elements.find(
+        e => isInstanceElement(e)
+        && e.refType.elemID.name === `${SETTINGS_TYPE_PREFIX}RuleDetail`
+        && e.elemID.name === 'rule'
+      ) as InstanceElement
+      expect(ruleDetailInstance.value.segmentName).toBeInstanceOf(ReferenceExpression)
+      expect(ruleDetailInstance.value.segmentName.elemID.getFullName()).toEqual(`zuora_billing.${SETTINGS_TYPE_PREFIX}Segment.instance.segment`)
     })
 
     it('should not resolve fields in unexpected types even if field name matches', () => {

--- a/packages/zuora-billing-adapter/test/filters/finance_information_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/finance_information_references.test.ts
@@ -120,9 +120,8 @@ describe('finance information references filter', () => {
       const ratePlan = elements.find(e => e.elemID.name === 'rate_plan') as InstanceElement
       const { financeInformation } = ratePlan.value.productRatePlanCharges[0]
       expect(financeInformation.someAccountingCode).toBeInstanceOf(ReferenceExpression)
-      expect(financeInformation.someAccountingCode.elemID.getFullName()).toEqual(`zuora_billing.${ACCOUNTING_CODE_ITEM_TYPE}.instance.Cash_Check.name`)
-      expect(financeInformation.someAccountingCodeType).toBeInstanceOf(ReferenceExpression)
-      expect(financeInformation.someAccountingCodeType.elemID.getFullName()).toEqual(`zuora_billing.${ACCOUNTING_CODE_ITEM_TYPE}.instance.Cash_Check.type`)
+      expect(financeInformation.someAccountingCode.elemID.getFullName()).toEqual(`zuora_billing.${ACCOUNTING_CODE_ITEM_TYPE}.instance.Cash_Check`)
+      expect(financeInformation.someAccountingCodeType).toBeUndefined()
 
       // if the accounting code item doesn't exists the value isn't replaced
       expect(financeInformation.notAnAccountingCode).toEqual('invalid')

--- a/packages/zuora-billing-adapter/test/filters/finance_information_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/finance_information_references.test.ts
@@ -1,0 +1,139 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, InstanceElement, Element, ReferenceExpression } from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import ZuoraClient from '../../src/client/client'
+import { paginate } from '../../src/client/pagination'
+import { ZUORA_BILLING, PRODUCT_RATE_PLAN_TYPE, ACCOUNTING_CODE_ITEM_TYPE } from '../../src/constants'
+import filterCreator from '../../src/filters/finance_information_references'
+
+describe('finance information references filter', () => {
+  let client: ZuoraClient
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  let filter: FilterType
+
+  const generateElements = (): Element[] => {
+    const productRatePlanType = new ObjectType({
+      elemID: new ElemID(ZUORA_BILLING, PRODUCT_RATE_PLAN_TYPE),
+    })
+
+    const productRatePlanInstance = new InstanceElement(
+      'rate_plan',
+      productRatePlanType,
+      {
+        productRatePlanCharges: [
+          {
+            description: 'charges with finance information',
+            financeInformation: {
+              someAccountingCode: 'Check',
+              someAccountingCodeType: 'Cash',
+              notAnAccountingCode: 'invalid',
+              notAnAccountingCodeType: 'also invalid',
+            },
+          },
+          {
+            description: 'charges without finance information',
+          },
+        ],
+      }
+    )
+
+    const productRatePlanInstance2 = new InstanceElement(
+      'rate_plan2',
+      productRatePlanType,
+    )
+
+    const accountingCodeItemType = new ObjectType({
+      elemID: new ElemID(ZUORA_BILLING, ACCOUNTING_CODE_ITEM_TYPE),
+    })
+
+    const accountingCodeItem = new InstanceElement(
+      'Cash_Check',
+      accountingCodeItemType,
+      {
+        name: 'Check',
+        type: 'Cash',
+      }
+    )
+
+    return [
+      productRatePlanType,
+      productRatePlanInstance,
+      productRatePlanInstance2,
+      accountingCodeItemType,
+      accountingCodeItem,
+    ]
+  }
+
+  beforeAll(() => {
+    client = new ZuoraClient({
+      credentials: { baseURL: 'http://localhost', clientId: 'id', clientSecret: 'secret' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      }),
+      config: {
+        fetch: {
+          includeTypes: [],
+        },
+        apiDefinitions: {
+          swagger: { url: 'ignore' },
+          typeDefaults: {
+            transformation: {
+              idFields: ['name'],
+            },
+          },
+          types: {},
+        },
+      },
+    }) as FilterType
+  })
+
+  describe('finance information references', () => {
+    let origElements: Element[]
+    let elements: Element[]
+    beforeAll(async () => {
+      origElements = generateElements()
+      elements = generateElements()
+      await filter.onFetch(elements)
+    })
+    it('should add references', () => {
+      expect(elements).not.toEqual(origElements)
+      expect(elements.length).toEqual(origElements.length)
+
+      const ratePlan = elements.find(e => e.elemID.name === 'rate_plan') as InstanceElement
+      const { financeInformation } = ratePlan.value.productRatePlanCharges[0]
+      expect(financeInformation.someAccountingCode).toBeInstanceOf(ReferenceExpression)
+      expect(financeInformation.someAccountingCode.elemID.getFullName()).toEqual(`zuora_billing.${ACCOUNTING_CODE_ITEM_TYPE}.instance.Cash_Check.name`)
+      expect(financeInformation.someAccountingCodeType).toBeInstanceOf(ReferenceExpression)
+      expect(financeInformation.someAccountingCodeType.elemID.getFullName()).toEqual(`zuora_billing.${ACCOUNTING_CODE_ITEM_TYPE}.instance.Cash_Check.type`)
+
+      // if the accounting code item doesn't exists the value isn't replaced
+      expect(financeInformation.notAnAccountingCode).toEqual('invalid')
+      expect(financeInformation.notAnAccountingCodeType).toEqual('also invalid')
+    })
+  })
+  it('should return when theres no accounting code items', async () => {
+    const origElements = generateElements()
+      .filter(e => e.elemID.typeName !== ACCOUNTING_CODE_ITEM_TYPE)
+    const elements = generateElements().filter(e => e.elemID.typeName !== ACCOUNTING_CODE_ITEM_TYPE)
+    await filter.onFetch(elements)
+    expect(elements).toEqual(origElements)
+  })
+})

--- a/packages/zuora-billing-adapter/test/filters/object_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/object_references.test.ts
@@ -17,7 +17,7 @@ import { ObjectType, ElemID, InstanceElement, Element, ReferenceExpression, Buil
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
 import ZuoraClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
-import { ZUORA_BILLING, TASK_TYPE, STANDARD_OBJECT, METADATA_TYPE, SETTINGS_TYPE_PREFIX } from '../../src/constants'
+import { ZUORA_BILLING, TASK_TYPE, STANDARD_OBJECT, METADATA_TYPE, SETTINGS_TYPE_PREFIX, OBJECT_TYPE } from '../../src/constants'
 import filterCreator from '../../src/filters/object_references'
 
 /* eslint-disable camelcase */
@@ -102,6 +102,7 @@ describe('object references filter', () => {
         },
         annotations: {
           [METADATA_TYPE]: STANDARD_OBJECT,
+          [OBJECT_TYPE]: 'account',
         },
       }),
     ]

--- a/packages/zuora-billing-adapter/test/filters/object_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/object_references.test.ts
@@ -1,0 +1,187 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, InstanceElement, Element, ReferenceExpression, BuiltinTypes } from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import ZuoraClient from '../../src/client/client'
+import { paginate } from '../../src/client/pagination'
+import { ZUORA_BILLING, TASK_TYPE, STANDARD_OBJECT, METADATA_TYPE, SETTINGS_TYPE_PREFIX } from '../../src/constants'
+import filterCreator from '../../src/filters/object_references'
+
+/* eslint-disable camelcase */
+
+describe('object references filter', () => {
+  let client: ZuoraClient
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  let filter: FilterType
+
+  const generateElements = (): Element[] => {
+    const taskType = new ObjectType({
+      elemID: new ElemID(ZUORA_BILLING, TASK_TYPE),
+    })
+
+    const task1 = new InstanceElement(
+      'task1',
+      taskType,
+      {
+        id: 13,
+        name: 'do one thing',
+        action_type: 'Export',
+        object: 'account',
+        call_type: 'SOAP',
+      },
+    )
+    const task2 = new InstanceElement(
+      'task2',
+      taskType,
+      {
+        id: 23,
+        name: 'do one more thing',
+        object: 'invalid',
+        call_type: 'SOAP',
+      },
+    )
+
+    const task3 = new InstanceElement(
+      'task3',
+      taskType,
+      {
+        id: 23,
+        name: 'do one more thing',
+        call_type: 'SOAP',
+      },
+    )
+
+    const segmentType = new ObjectType({
+      elemID: new ElemID(ZUORA_BILLING, `${SETTINGS_TYPE_PREFIX}Segment`),
+    })
+
+    const segment1 = new InstanceElement(
+      'segment1',
+      segmentType,
+      {
+        object: 'account',
+        field: 'Id',
+      }
+    )
+
+    const segment2 = new InstanceElement(
+      'segment2',
+      segmentType,
+      {
+        object: 'account',
+        field: 'notId',
+      }
+    )
+
+    const segment3 = new InstanceElement(
+      'segment3',
+      segmentType,
+      {
+        object: 'account',
+      }
+    )
+
+    const standardObjects = [
+      new ObjectType({
+        elemID: new ElemID(ZUORA_BILLING, 'account'),
+        fields: {
+          Id: { refType: BuiltinTypes.STRING },
+        },
+        annotations: {
+          [METADATA_TYPE]: STANDARD_OBJECT,
+        },
+      }),
+    ]
+
+    return [
+      taskType,
+      task1,
+      task2,
+      task3,
+      segmentType,
+      segment1,
+      segment2,
+      segment3,
+      ...standardObjects,
+    ]
+  }
+
+  beforeAll(() => {
+    client = new ZuoraClient({
+      credentials: { baseURL: 'http://localhost', clientId: 'id', clientSecret: 'secret' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      }),
+      config: {
+        fetch: {
+          includeTypes: [],
+        },
+        apiDefinitions: {
+          swagger: { url: 'ignore' },
+          typeDefaults: {
+            transformation: {
+              idFields: ['name'],
+            },
+          },
+          types: {},
+        },
+      },
+    }) as FilterType
+  })
+
+  describe('object references', () => {
+    let origElements: Element[]
+    let elements: Element[]
+    beforeAll(async () => {
+      origElements = generateElements()
+      elements = generateElements()
+      await filter.onFetch(elements)
+    })
+    it('should add references', () => {
+      expect(elements).not.toEqual(origElements)
+      expect(elements.length).toEqual(origElements.length)
+
+      const task1 = elements.find(e => e.elemID.name === 'task1') as InstanceElement
+      expect(task1.value.object).toBeInstanceOf(ReferenceExpression)
+      expect(task1.value.object.elemID.getFullName()).toEqual('zuora_billing.account')
+
+      const segment1 = elements.find(e => e.elemID.name === 'segment1') as InstanceElement
+      expect(segment1.value.object).toBeInstanceOf(ReferenceExpression)
+      expect(segment1.value.field).toBeInstanceOf(ReferenceExpression)
+      expect(segment1.value.object.elemID.getFullName()).toEqual('zuora_billing.account')
+      expect(segment1.value.field.elemID.getFullName()).toEqual('zuora_billing.account.field.Id')
+    })
+    it('shouldn\'t add references if invalid', () => {
+      const task2 = elements.find(e => e.elemID.name === 'task2') as InstanceElement
+      expect(task2.value.object).toEqual('invalid')
+
+      const segment2 = elements.find(e => e.elemID.name === 'segment2') as InstanceElement
+      expect(segment2.value.object).toBeInstanceOf(ReferenceExpression)
+      expect(segment2.value.object.elemID.getFullName()).toEqual('zuora_billing.account')
+      expect(segment2.value.field).toEqual('notId')
+    })
+  })
+  it('should return without doing nothing when there are no instances', async () => {
+    const origElements = generateElements().filter(e => e.elemID.idType !== 'instance')
+    const elements = generateElements().filter(e => e.elemID.idType !== 'instance')
+    await filter.onFetch(elements)
+    expect(elements).toEqual(origElements)
+  })
+})

--- a/packages/zuora-billing-adapter/test/filters/workflow_and_task_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/workflow_and_task_references.test.ts
@@ -13,15 +13,16 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import {
   ObjectType, ElemID, InstanceElement, Element, ReferenceExpression, BuiltinTypes,
-  isInstanceElement, isReferenceExpression,
+  isInstanceElement, isReferenceExpression, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
 import { DetailedDependency } from '@salto-io/adapter-utils'
 import ZuoraClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
-import { ZUORA_BILLING, WORKFLOW_DETAILED_TYPE, TASK_TYPE, STANDARD_OBJECT, METADATA_TYPE } from '../../src/constants'
+import { ZUORA_BILLING, WORKFLOW_DETAILED_TYPE, TASK_TYPE, STANDARD_OBJECT, METADATA_TYPE, WORKFLOW_EXPORT_TYPE } from '../../src/constants'
 import filterCreator from '../../src/filters/workflow_and_task_references'
 
 /* eslint-disable camelcase */
@@ -32,6 +33,9 @@ describe('Workflow and task references filter', () => {
   let filter: FilterType
 
   const generateElements = (): Element[] => {
+    const workflowTopType = new ObjectType({
+      elemID: new ElemID(ZUORA_BILLING, WORKFLOW_EXPORT_TYPE),
+    })
     const workflowType = new ObjectType({
       elemID: new ElemID(ZUORA_BILLING, WORKFLOW_DETAILED_TYPE),
     })
@@ -49,15 +53,26 @@ describe('Workflow and task references filter', () => {
         type: 'Workflow::Setup',
         additionalProperties: {
           parameters: {
-            fields: [{
-              index: '0',
-              default: '',
-              datatype: 'Text',
-              required: true,
-              callout_id: 'BillRunID',
-              field_name: 'Id',
-              object_name: 'Billingrun',
-            }],
+            fields: [
+              {
+                index: '0',
+                default: '',
+                datatype: 'Text',
+                required: true,
+                callout_id: 'BillRunID',
+                field_name: 'Id',
+                object_name: 'Billingrun',
+              },
+              {
+                index: '1',
+                default: '',
+                datatype: 'Text',
+                required: true,
+                callout_id: 'workflow_param',
+                field_name: 'param',
+                object_name: 'Workflow',
+              },
+            ],
           },
           ondemand_trigger: true,
           callout_trigger: true,
@@ -118,15 +133,35 @@ describe('Workflow and task references filter', () => {
         type: 'Workflow::Setup',
         additionalProperties: {
           parameters: {
-            fields: [{
-              index: '0',
-              default: '',
-              datatype: 'Text',
-              required: true,
-              callout_id: 'BillRunID',
-              field_name: 'Id',
-              object_name: 'invalid',
-            }],
+            fields: [
+              {
+                index: '0',
+                default: '',
+                datatype: 'Text',
+                required: true,
+                callout_id: 'BillRunID',
+                field_name: 'Id',
+                object_name: 'invalid',
+              },
+              {
+                index: '1',
+                default: '',
+                datatype: 'Text',
+                required: true,
+                callout_id: '',
+                field_name: '',
+                not_object_name: '',
+              },
+              {
+                index: '2',
+                default: '',
+                datatype: 'Text',
+                required: true,
+                callout_id: 'BillRunID',
+                field_name: 'not_a_field',
+                object_name: 'Billingrun',
+              },
+            ],
           },
           ondemand_trigger: true,
           callout_trigger: true,
@@ -148,6 +183,23 @@ describe('Workflow and task references filter', () => {
         delete_ttl: 30,
       },
     )
+
+    const w1 = new InstanceElement(
+      'w1',
+      workflowTopType,
+      {
+        workflow: new ReferenceExpression(wf1.elemID),
+      }
+    )
+
+    const w2 = new InstanceElement(
+      'w2',
+      workflowTopType,
+      {
+        workflow: new ReferenceExpression(wf2.elemID),
+      }
+    )
+
     const task1 = new InstanceElement(
       'task1',
       taskType,
@@ -167,13 +219,20 @@ describe('Workflow and task references filter', () => {
               InvoiceDate: 'true',
               InvoiceNumber: 'true',
             },
+            NotAPlainObject: 'false',
           },
-          where_clause: "Refund.ReasonCode = 'Chargeback' and Invoice.Balance > 0",
+          where_clause: "Refund.ReasonCode = 'Chargeback' and Invoice.Balance > 0 and Data.Workflow.param != 3 or Data.Workflow.not_a_param == 2",
         },
         action_type: 'Export',
         object: 'RefundInvoicePayment',
         call_type: 'SOAP',
       },
+      undefined,
+      {
+        [CORE_ANNOTATIONS.PARENT]: [
+          new ReferenceExpression(w1.elemID),
+        ],
+      }
     )
     const task2 = new InstanceElement(
       'task2',
@@ -181,6 +240,29 @@ describe('Workflow and task references filter', () => {
       {
         id: 23,
         name: 'do one more thing',
+        parameters: {
+          where_clause: 'Data.Workflow.param == 2',
+        },
+        object: 'Account',
+        call_type: 'SOAP',
+      },
+      undefined,
+      {
+        [CORE_ANNOTATIONS.PARENT]: [
+          new ReferenceExpression(w2.elemID),
+        ],
+      }
+    )
+
+    const task3 = new InstanceElement(
+      'task3',
+      taskType,
+      {
+        id: 24,
+        name: 'do one more thing',
+        parameters: {
+          where_clause: 'Data.Workflow.param == 2',
+        },
         object: 'Account',
         call_type: 'SOAP',
       },
@@ -234,7 +316,20 @@ describe('Workflow and task references filter', () => {
       }),
     ]
 
-    return [workflowType, taskType, wf1, wf2, wf3, task1, task2, ...standardObjects]
+    return [
+      workflowTopType,
+      workflowType,
+      taskType,
+      w1,
+      w2,
+      wf1,
+      wf2,
+      wf3,
+      task1,
+      task2,
+      task3,
+      ...standardObjects,
+    ]
   }
 
   beforeAll(() => {
@@ -263,7 +358,34 @@ describe('Workflow and task references filter', () => {
       },
     }) as FilterType
   })
-
+  describe('fail when there are no types or instances', () => {
+    let origElements: Element[]
+    let elements: Element[]
+    it(`should return when ${WORKFLOW_EXPORT_TYPE} type doesn't exists`, async () => {
+      origElements = generateElements().filter(e => e.elemID.typeName !== WORKFLOW_EXPORT_TYPE || e.elemID.idType !== 'type')
+      elements = generateElements().filter(e => e.elemID.typeName !== WORKFLOW_EXPORT_TYPE || e.elemID.idType !== 'type')
+      await filter.onFetch(elements)
+      expect(elements).toEqual(origElements)
+    })
+    it(`should return when ${WORKFLOW_DETAILED_TYPE} type doesn't exists`, async () => {
+      origElements = generateElements().filter(e => e.elemID.typeName !== WORKFLOW_DETAILED_TYPE || e.elemID.idType !== 'type')
+      elements = generateElements().filter(e => e.elemID.typeName !== WORKFLOW_DETAILED_TYPE || e.elemID.idType !== 'type')
+      await filter.onFetch(elements)
+      expect(elements).toEqual(origElements)
+    })
+    it(`should return when ${TASK_TYPE} type doesn't exists`, async () => {
+      origElements = generateElements().filter(e => e.elemID.typeName !== TASK_TYPE || e.elemID.idType !== 'type')
+      elements = generateElements().filter(e => e.elemID.typeName !== TASK_TYPE || e.elemID.idType !== 'type')
+      await filter.onFetch(elements)
+      expect(elements).toEqual(origElements)
+    })
+    it(`should return when there aren't any instances of ${WORKFLOW_DETAILED_TYPE} and ${TASK_TYPE}`, async () => {
+      origElements = generateElements().filter(e => ![WORKFLOW_DETAILED_TYPE, TASK_TYPE].includes(e.elemID.typeName) || e.elemID.idType !== 'instance')
+      elements = generateElements().filter(e => ![WORKFLOW_DETAILED_TYPE, TASK_TYPE].includes(e.elemID.typeName) || e.elemID.idType !== 'instance')
+      await filter.onFetch(elements)
+      expect(elements).toEqual(origElements)
+    })
+  })
   describe('workflow and task references', () => {
     let origElements: Element[]
     let elements: Element[]
@@ -273,8 +395,10 @@ describe('Workflow and task references filter', () => {
       await filter.onFetch(elements)
     })
     it('add references in workflows', () => {
+      expect(elements).not.toEqual(origElements)
       expect(elements.length).toEqual(origElements.length)
-      const workflows = elements.filter(isInstanceElement).filter(e => e.elemID.typeName === 'DetailedWorkflow')
+      const workflows = elements.filter(isInstanceElement)
+        .filter(e => e.elemID.typeName === WORKFLOW_DETAILED_TYPE)
       expect(workflows).toHaveLength(3)
 
       const wf1Param0 = workflows[0].value.additionalProperties.parameters.fields[0]
@@ -287,16 +411,18 @@ describe('Workflow and task references filter', () => {
     })
     it('add references in tasks', () => {
       expect(elements.length).toEqual(origElements.length)
-      const tasks = elements.filter(isInstanceElement).filter(e => e.elemID.typeName === 'Task')
-      expect(tasks).toHaveLength(2)
+      const tasks = elements.filter(isInstanceElement).filter(e => e.elemID.typeName === TASK_TYPE)
+      expect(tasks).toHaveLength(3)
 
-      expect(tasks[0].value.object).toBeInstanceOf(ReferenceExpression)
-      expect((tasks[0].value.object as ReferenceExpression).elemID.getFullName()).toEqual('zuora_billing.RefundInvoicePayment')
       // eslint-disable-next-line no-underscore-dangle
       const task1Deps = tasks[0].annotations._generated_dependencies as DetailedDependency[]
       expect(task1Deps.map(e => e.reference).every(isReferenceExpression)).toBeTruthy()
-      expect(task1Deps.map(e => e.occurrences).every(oc => oc === undefined)).toBeTruthy()
+      expect(task1Deps.every(
+        e => !_.isEmpty(e.occurrences)
+        && e.occurrences?.every(oc => isReferenceExpression(oc.location))
+      )).toBeTruthy()
       expect(task1Deps.map(e => e.reference.elemID.getFullName())).toEqual([
+        'zuora_billing.DetailedWorkflow.instance.wf1.additionalProperties.parameters.fields',
         'zuora_billing.Invoice.field.Id',
         // Invoice.Balance and InvoiceDate do not exist on the object so they are not referenced
         'zuora_billing.Invoice.field.InvoiceNumber',
@@ -305,10 +431,10 @@ describe('Workflow and task references filter', () => {
         'zuora_billing.Refund.field.RefundDate',
       ])
 
-      expect(tasks[1].value.object).toBeInstanceOf(ReferenceExpression)
-      expect((tasks[1].value.object as ReferenceExpression).elemID.getFullName()).toEqual('zuora_billing.account')
       // eslint-disable-next-line no-underscore-dangle
       expect(tasks[1].annotations._generated_dependencies).toBeUndefined()
+      // eslint-disable-next-line no-underscore-dangle
+      expect(tasks[2].annotations._generated_dependencies).toBeUndefined()
     })
     it('not add references in workflows when the referenced objects is missing', () => {
       expect(elements.length).toEqual(origElements.length)

--- a/packages/zuora-billing-adapter/test/filters/workflow_and_task_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/workflow_and_task_references.test.ts
@@ -22,7 +22,7 @@ import { client as clientUtils, filterUtils } from '@salto-io/adapter-components
 import { DetailedDependency } from '@salto-io/adapter-utils'
 import ZuoraClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
-import { ZUORA_BILLING, WORKFLOW_DETAILED_TYPE, TASK_TYPE, STANDARD_OBJECT, METADATA_TYPE, WORKFLOW_EXPORT_TYPE } from '../../src/constants'
+import { ZUORA_BILLING, WORKFLOW_DETAILED_TYPE, TASK_TYPE, STANDARD_OBJECT, METADATA_TYPE, WORKFLOW_EXPORT_TYPE, OBJECT_TYPE } from '../../src/constants'
 import filterCreator from '../../src/filters/workflow_and_task_references'
 
 /* eslint-disable camelcase */
@@ -276,12 +276,14 @@ describe('Workflow and task references filter', () => {
         },
         annotations: {
           [METADATA_TYPE]: STANDARD_OBJECT,
+          [OBJECT_TYPE]: 'account',
         },
       }),
       new ObjectType({
         elemID: new ElemID(ZUORA_BILLING, 'RefundInvoicePayment'),
         annotations: {
           [METADATA_TYPE]: STANDARD_OBJECT,
+          [OBJECT_TYPE]: 'RefundInvoicePayment',
         },
       }),
       new ObjectType({
@@ -291,6 +293,7 @@ describe('Workflow and task references filter', () => {
         },
         annotations: {
           [METADATA_TYPE]: STANDARD_OBJECT,
+          [OBJECT_TYPE]: 'Billingrun',
         },
       }),
       new ObjectType({
@@ -302,6 +305,7 @@ describe('Workflow and task references filter', () => {
         },
         annotations: {
           [METADATA_TYPE]: STANDARD_OBJECT,
+          [OBJECT_TYPE]: 'Refund',
         },
       }),
       new ObjectType({
@@ -312,6 +316,7 @@ describe('Workflow and task references filter', () => {
         },
         annotations: {
           [METADATA_TYPE]: STANDARD_OBJECT,
+          [OBJECT_TYPE]: 'Invoice',
         },
       }),
     ]


### PR DESCRIPTION
### Note: this is the second PR for this ticket, following [https://github.com/salto-io/salto/pull/2522](url)
### it also contains the commit of that PR - please review it there.

Found and added more references in Zuara. 
Some references were replaced with the value itself, some were added to `_generated_dependencies` (if they were inside strings)

---
_Additional context for reviewer_
this is the second PR for this ticket, followed by [https://github.com/salto-io/salto/pull/2500](url)

---
_Release Notes_: 
* zuara-billing-adapter
Added references to objects and instances

---
_User Notifications_: 
* changed to references:
`zuora_billing.Settings_Notification.emailTemplateName`
`zuora_billing.ProductRatePlanType.productRatePlanCharges[...].uom`
`zuora_billing.ProductRatePlanType.productRatePlanCharges[...].taxCode`
`zuora_billing.ProductRatePlanType.productRatePlanCharges[...].discountClass`
`zuora_billing.ProductRatePlanType.productRatePlanCharges[...].productDiscountApplyDetails[...].appliedProductRatePlanId`
`zuora_billing.PaymentGatewayResponse.id`
`zuora_billing.Settings_GatewayResponse.id`
`zuora_billing.Settings_TaxCode.taxEngineId`
`zuora_billing.Settings_TaxCode.taxCompanyId`
`zuora_billing.Settings_TaxCompany.taxEngineId`
`zuora_billing.HostedPage.pageId`
`zuora_billing.ProductRatePlanType.productRatePlanCharges[...].pricing[...].currency`
`zuora_billing.Settings_FxCurrency.homeCurrencyCode`
`zuara_billing.Settings_RuleDetail.segmentName`

* add field `occurrences` to `zuora_billing.Task` instances to refer to the fields that the references were extracted from.
