### PR TITLE
SALTO-1650 Support OAuth in Zendesk

### DIFF
--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -100,12 +100,14 @@ export const validateCredentials = async <TCredentials>(
   return accountId
 }
 
+export type AuthParams = {
+  auth?: AxiosBasicCredentials
+  headers?: Record<string, unknown>
+}
+
 type AxiosConnectionParams<TCredentials> = {
   retryOptions: RetryOptions
-  authParamsFunc: (creds: TCredentials) => Promise<{
-    auth?: AxiosBasicCredentials
-    headers?: Record<string, unknown>
-  }>
+  authParamsFunc: (creds: TCredentials) => Promise<AuthParams>
   baseURLFunc: (creds: TCredentials) => string
   credValidateFunc: ({ credentials, connection }: {
     credentials: TCredentials

--- a/packages/zendesk-support-adapter/src/auth.ts
+++ b/packages/zendesk-support-adapter/src/auth.ts
@@ -23,6 +23,18 @@ export type UsernamePasswordCredentials = {
   subdomain: string
 }
 
+export type OauthAccessTokenCredentials = {
+  accessToken: string
+  subdomain: string
+}
+
+export type OauthRequestParameters = {
+  clientId: string
+  clientSecret: string
+  port: number
+  subdomain: string
+}
+
 export const usernamePasswordCredentialsType = createMatchingObjectType<
   UsernamePasswordCredentials
 >({
@@ -43,4 +55,61 @@ export const usernamePasswordCredentialsType = createMatchingObjectType<
   },
 })
 
-export type Credentials = UsernamePasswordCredentials
+export const oauthAccessTokenCredentialsType = createMatchingObjectType<
+  OauthAccessTokenCredentials
+>({
+  elemID: new ElemID(constants.ZENDESK_SUPPORT),
+  fields: {
+    accessToken: {
+      refType: BuiltinTypes.STRING,
+      annotations: { _required: true },
+    },
+    subdomain: {
+      refType: BuiltinTypes.STRING,
+      annotations: { _required: true },
+    },
+  },
+})
+
+export const oauthRequestParametersType = createMatchingObjectType<
+  OauthRequestParameters
+>({
+  elemID: new ElemID(constants.ZENDESK_SUPPORT),
+  fields: {
+    clientId: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        message: 'Client ID',
+        _required: true,
+      },
+    },
+    clientSecret: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        message: 'Client Secret',
+        _required: true,
+      },
+    },
+    port: {
+      refType: BuiltinTypes.NUMBER,
+      annotations: {
+        message: 'Port',
+        _required: true,
+      },
+    },
+    subdomain: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        message: 'subdomain',
+        _required: true,
+      },
+    },
+  },
+})
+
+export type Credentials = UsernamePasswordCredentials | OauthAccessTokenCredentials
+
+export const isOauthAccessTokenCredentials = (
+  creds: Credentials
+): creds is OauthAccessTokenCredentials =>
+  (creds as OauthAccessTokenCredentials).accessToken !== undefined

--- a/packages/zendesk-support-adapter/src/client/connection.ts
+++ b/packages/zendesk-support-adapter/src/client/connection.ts
@@ -15,8 +15,9 @@
 */
 import { AccountId } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
+import { AuthParams } from '@salto-io/adapter-components/src/client/http_connection'
 import { logger } from '@salto-io/logging'
-import { Credentials, UsernamePasswordCredentials } from '../auth'
+import { Credentials, isOauthAccessTokenCredentials, OauthAccessTokenCredentials, UsernamePasswordCredentials } from '../auth'
 
 const log = logger(module)
 
@@ -26,9 +27,8 @@ const MARKETPLACE_NAME = 'Salto'
 const MARKETPLACE_ORG_ID = 5110
 const MARKETPLACE_APP_ID = 608042
 
-// TODO change validation when switching to oauth
 export const validateCredentials = async ({ credentials, connection }: {
-  credentials: UsernamePasswordCredentials
+  credentials: Credentials
   connection: clientUtils.APIConnection
 }): Promise<AccountId> => {
   try {
@@ -41,20 +41,39 @@ export const validateCredentials = async ({ credentials, connection }: {
   return credentials.subdomain
 }
 
+const usernamePasswordAuthParamsFunc = (
+  { username, password }: UsernamePasswordCredentials
+): AuthParams => ({
+  auth: {
+    username,
+    password,
+  },
+  headers: {
+    'X-Zendesk-Marketplace-Name': MARKETPLACE_NAME,
+    'X-Zendesk-Marketplace-Organization-Id': MARKETPLACE_ORG_ID,
+    'X-Zendesk-Marketplace-App-Id': MARKETPLACE_APP_ID,
+  },
+})
+
+const accessTokenAuthParamsFunc = (
+  { accessToken }: OauthAccessTokenCredentials
+): AuthParams => ({
+  headers: {
+    Authorization: `Bearer ${accessToken}`,
+    'X-Zendesk-Marketplace-Name': MARKETPLACE_NAME,
+    'X-Zendesk-Marketplace-Organization-Id': MARKETPLACE_ORG_ID,
+    'X-Zendesk-Marketplace-App-Id': MARKETPLACE_APP_ID,
+  },
+})
+
 export const createConnection: clientUtils.ConnectionCreator<Credentials> = retryOptions => (
   clientUtils.axiosConnection({
     retryOptions,
-    authParamsFunc: async ({ username, password }: Credentials) => ({
-      auth: {
-        username,
-        password,
-      },
-      headers: {
-        'X-Zendesk-Marketplace-Name': MARKETPLACE_NAME,
-        'X-Zendesk-Marketplace-Organization-Id': MARKETPLACE_ORG_ID,
-        'X-Zendesk-Marketplace-App-Id': MARKETPLACE_APP_ID,
-      },
-    }),
+    authParamsFunc: async (creds: Credentials) => (
+      isOauthAccessTokenCredentials(creds)
+        ? accessTokenAuthParamsFunc(creds)
+        : usernamePasswordAuthParamsFunc(creds)
+    ),
     baseURLFunc: ({ subdomain }) => baseUrl(subdomain),
     credValidateFunc: validateCredentials,
   })

--- a/salto.code-workspace
+++ b/salto.code-workspace
@@ -97,6 +97,10 @@
 			"path": "packages/graph-exporter"
 		},
 		{
+			"name": "zendesk-support-adapter",
+			"path": "packages/zendesk-support-adapter"
+		},
+		{
 			"name": "zuora-billing-adapter",
 			"path": "packages/zuora-billing-adapter"
 		},


### PR DESCRIPTION
Added support of OAuth authentication in Zendesk - using implicit grant flow.

---
_Release Notes_: 
* zendesk-support-adapter
added OAuth client - use `salto service add zendesk_support` with parameter `-a oauth`
