### PR TITLE
SALTO-1684 Support singleton types in swagger based simple adapters

### DIFF
--- a/packages/adapter-components/src/config/transformation.ts
+++ b/packages/adapter-components/src/config/transformation.ts
@@ -55,6 +55,8 @@ export type TransformationConfig = {
 
   // set '.' to indicate that the full object should be returned
   dataField?: string
+  // set to true if the defined instance element has only one instance
+  isSingleton?: boolean
 }
 
 export type TransformationDefaultConfig = types.PickyRequired<Partial<TransformationConfig>, 'idFields'>

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  InstanceElement, Values, ObjectType, ReferenceExpression, CORE_ANNOTATIONS,
+  InstanceElement, Values, ObjectType, ReferenceExpression, CORE_ANNOTATIONS, ElemID,
 } from '@salto-io/adapter-api'
 import { pathNaclCase, naclCase, transformValues, TransformFunc } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -99,9 +99,20 @@ export const toBasicInstance = async ({
     parent && nestName ? `${parent.elemID.name}${ID_SEPARATOR}${name}` : String(name)
   )
   const adapterName = type.elemID.adapter
-
+  const filePath = type.isSettings ? 
+    [
+      adapterName,
+      RECORDS_PATH,
+      pathNaclCase(type.elemID.name),
+    ] :
+    [
+      adapterName,
+      RECORDS_PATH,
+      pathNaclCase(type.elemID.name),
+      fileName ? pathNaclCase(naclCase(fileName)) : pathNaclCase(naclName),
+    ]
   return new InstanceElement(
-    naclName,
+    type.isSettings ? ElemID.CONFIG_NAME : naclName,
     type,
     await transformValues({
       values: entryData,
@@ -110,12 +121,7 @@ export const toBasicInstance = async ({
       transformFunc: ({ value }) => (value === null ? undefined : value),
       strict: false,
     }),
-    [
-      adapterName,
-      RECORDS_PATH,
-      pathNaclCase(type.elemID.name),
-      fileName ? pathNaclCase(naclCase(fileName)) : pathNaclCase(naclName),
-    ],
+    filePath,
     parent
       ? { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parent.elemID, parent)] }
       : undefined,

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -396,7 +396,10 @@ const getInstancesForType = async (params: GetEntriesParams): Promise<InstanceEl
   const transformationDefaultConfig = typeDefaultConfig.transformation
   try {
     const { entries, objType } = await getEntriesForType(params)
-
+    if (objType.isSettings && entries.length > 1) {
+      log.warn(`Found more than one instance for singleton type: ${typeName}`)
+      throw new InvalidTypeConfig(`Could not fetch type ${typeName}, singleton types should not have more than one instance`)
+    }
     return generateInstancesForType({
       entries,
       objType,

--- a/packages/adapter-components/src/elements/swagger/type_elements/type_config_override.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/type_config_override.ts
@@ -155,4 +155,14 @@ export const fixTypes = (
         typeName,
       )
     })
+
+  // update isSettings field in case of singleton
+  Object.keys(typeConfig)
+    .filter(typeName => getTypeTransformationConfig(typeName).isSingleton)
+    .forEach(typeName => {
+      const type = definedTypes[typeName]
+      if (type !== undefined) {
+        type.isSettings = true
+      }
+    })
 }

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -213,6 +213,11 @@ describe('swagger_type_elements', () => {
                   ],
                 },
               },
+              foodDetails: {
+                transformation: {
+                  isSingleton: true,
+                },
+              },
             },
           },
         )
@@ -281,6 +286,10 @@ describe('swagger_type_elements', () => {
       it('should not add types that did not already exist', () => {
         const order = allTypes.NewType as ObjectType
         expect(order).toBeUndefined()
+      })
+      it('should be a isSetting type', () => {
+        const foodDet = allTypes.foodDetails as ObjectType
+        expect(foodDet.isSettings).toEqual(true)
       })
     })
 

--- a/packages/zuora-billing-adapter/src/adapter.ts
+++ b/packages/zuora-billing-adapter/src/adapter.ts
@@ -166,7 +166,7 @@ export default class ZuoraAdapter implements AdapterOperations {
       t => t !== standardObjectTypeName
     )
     // settings include types can be fetched with the regular include types, since their types
-    // were already generatedטוב
+    // were already generated
     const settingsIncludeTypes = (this.userConfig[FETCH_CONFIG].settingsIncludeTypes ?? []).map(
       t => `${SETTINGS_TYPE_PREFIX}${t}`
     )


### PR DESCRIPTION
Support marking types as "singleton" types for swagger based simple-adapters.

---

Changes:
1.  add singleton field in type's config
2. make singleton types "setting" types when the objectType is created
3. validate there's only one instance of singleton types
4. change the name and path for instances of singleton types
5. tests

---
_Release Notes_: 
Support marking types as "singleton" types, for types that have only one instance

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
