### PR TITLE
Salto-1642: dont separate salesforce installed package custom fields

### DIFF
--- a/packages/salesforce-adapter/jest.config.js
+++ b/packages/salesforce-adapter/jest.config.js
@@ -35,6 +35,7 @@ module.exports = deepMerge(
         statements: 95,
       },
     },
+    setupFilesAfterEnv: ["jest-extended/all"],
   },
 )
 

--- a/packages/salesforce-adapter/package.json
+++ b/packages/salesforce-adapter/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^1.7.0",
     "jest": "^26.6.3",
+    "jest-extended": "^1.2.0",
     "jest-junit": "^12.0.0",
     "jsforce-types": "https://github.com/salto-io/jsforce-types.git",
     "nock": "^12.0.1",

--- a/packages/salesforce-adapter/src/filters/custom_object_split.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_split.ts
@@ -19,7 +19,7 @@ import { pathNaclCase } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { isCustom, isCustomObject } from '../transformers/transformer'
 import { FilterWith } from '../filter'
-import { getObjectDirectoryPath } from './custom_objects'
+import { getNamespaceObjectDirectoryPath, getObjectDirectoryPath } from './custom_objects'
 
 const { awu } = collections.asynciterable
 
@@ -43,14 +43,13 @@ const createCustomFieldsObject = (customObject: ObjectType): ObjectType => {
     }
   )
 }
-
 const customObjectToSplitElements = async (customObject: ObjectType): Promise<ObjectType[]> => {
   const annotationsObject = new ObjectType({
     elemID: customObject.elemID,
     annotationRefsOrTypes: customObject.annotationRefTypes,
     annotations: customObject.annotations,
     path: [
-      ...getObjectDirectoryPath(customObject),
+      ...await getNamespaceObjectDirectoryPath(customObject),
       annotationsFileName(customObject.elemID.name),
     ],
   })
@@ -58,7 +57,7 @@ const customObjectToSplitElements = async (customObject: ObjectType): Promise<Ob
     elemID: customObject.elemID,
     fields: _.pickBy(customObject.fields, f => !isCustom(f.elemID.getFullName())),
     path: [
-      ...getObjectDirectoryPath(customObject),
+      ...await getNamespaceObjectDirectoryPath(customObject),
       standardFieldsFileName(customObject.elemID.name),
     ],
   })

--- a/packages/salesforce-adapter/src/filters/custom_object_split.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_split.ts
@@ -37,7 +37,7 @@ const createCustomFieldsObject = async (customObject: ObjectType): Promise<Objec
       elemID: customObject.elemID,
       fields: customFields,
       path: [
-        ...await getObjectDirectoryPath(customObject),
+        ...getObjectDirectoryPath(customObject),
         customFieldsFileName(customObject.elemID.name),
       ],
     }
@@ -50,7 +50,7 @@ const customObjectToSplitElements = async (customObject: ObjectType): Promise<Ob
     annotationRefsOrTypes: customObject.annotationRefTypes,
     annotations: customObject.annotations,
     path: [
-      ...await getObjectDirectoryPath(customObject),
+      ...getObjectDirectoryPath(customObject),
       annotationsFileName(customObject.elemID.name),
     ],
   })
@@ -58,7 +58,7 @@ const customObjectToSplitElements = async (customObject: ObjectType): Promise<Ob
     elemID: customObject.elemID,
     fields: _.pickBy(customObject.fields, f => !isCustom(f.elemID.getFullName())),
     path: [
-      ...await getObjectDirectoryPath(customObject),
+      ...getObjectDirectoryPath(customObject),
       standardFieldsFileName(customObject.elemID.name),
     ],
   })

--- a/packages/salesforce-adapter/src/filters/custom_object_split.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_split.ts
@@ -14,13 +14,11 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Element, ObjectType, Field, isObjectType } from '@salto-io/adapter-api'
+import { Element, isObjectType, ObjectType } from '@salto-io/adapter-api'
 import { pathNaclCase } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { isCustomObject, isCustom, relativeApiName } from '../transformers/transformer'
+import { isCustom, isCustomObject } from '../transformers/transformer'
 import { FilterWith } from '../filter'
-import { API_NAME } from '../constants'
-import { getNamespace, getNamespaceFromString } from './utils'
 import { getObjectDirectoryPath } from './custom_objects'
 
 const { awu } = collections.asynciterable
@@ -29,55 +27,24 @@ export const annotationsFileName = (objectName: string): string => `${pathNaclCa
 export const standardFieldsFileName = (objectName: string): string => `${pathNaclCase(objectName)}StandardFields`
 export const customFieldsFileName = (objectName: string): string => `${pathNaclCase(objectName)}CustomFields`
 
-const createCustomFieldsObjects = async (customObject: ObjectType): Promise<ObjectType[]> => {
-  const createCustomFieldObject = async (
-    fields: Record<string, Field>, namespace?: string,
-  ): Promise<ObjectType> =>
-    (new ObjectType(
-      {
-        elemID: customObject.elemID,
-        fields,
-        path: [
-          ...await getObjectDirectoryPath(customObject, namespace),
-          customFieldsFileName(customObject.elemID.name),
-        ],
-      }
-    ))
+const createCustomFieldsObject = async (customObject: ObjectType): Promise<ObjectType> => {
   const customFields = _.pickBy(
     customObject.fields,
     f => isCustom(f.elemID.getFullName())
   )
-
-  // When there's an object namespace, all the custom fields are in the same object
-  const objNamespace = await getNamespace(customObject)
-  if (!_.isUndefined(objNamespace) && !_.isEmpty(customFields)) {
-    return [await createCustomFieldObject(customFields, objNamespace)]
-  }
-
-  const getFieldDefNamespace = (f: Field): string | undefined => (
-    getNamespaceFromString(relativeApiName(f.annotations?.[API_NAME] ?? ''))
+  return new ObjectType(
+    {
+      elemID: customObject.elemID,
+      fields: customFields,
+      path: [
+        ...await getObjectDirectoryPath(customObject),
+        customFieldsFileName(customObject.elemID.name),
+      ],
+    }
   )
-  const packagedFields = _.pickBy(customFields, f => getFieldDefNamespace(f) !== undefined)
-  const regularCustomFields = _.pickBy(customFields, f => getFieldDefNamespace(f) === undefined)
-  const namespaceToFields = _.mapValues(
-    _.groupBy(packagedFields, (field: Field) => getFieldDefNamespace(field)),
-    (fields: Field[]) => _.keyBy(fields, 'name')
-  )
-
-  // Custom fields that belong to a package go in a separate element
-  const customFieldsObjects = await awu(Object.entries(namespaceToFields))
-    .map(async ([fieldNamespace, packageFields]) =>
-      createCustomFieldObject(packageFields, fieldNamespace)).toArray()
-
-  if (!_.isEmpty(regularCustomFields)) {
-    // Custom fields that has no namespace go in a separate element
-    const customPart = await createCustomFieldObject(regularCustomFields)
-    customFieldsObjects.push(customPart)
-  }
-  return customFieldsObjects
 }
 
-const customObjectToSplittedElements = async (customObject: ObjectType): Promise<ObjectType[]> => {
+const customObjectToSplitElements = async (customObject: ObjectType): Promise<ObjectType[]> => {
   const annotationsObject = new ObjectType({
     elemID: customObject.elemID,
     annotationRefsOrTypes: customObject.annotationRefTypes,
@@ -95,26 +62,23 @@ const customObjectToSplittedElements = async (customObject: ObjectType): Promise
       standardFieldsFileName(customObject.elemID.name),
     ],
   })
-  const customFieldsObjects = await createCustomFieldsObjects(customObject)
-  return [...customFieldsObjects, standardFieldsObject, annotationsObject]
+  const customFieldsObject = await createCustomFieldsObject(customObject)
+  return [customFieldsObject, standardFieldsObject, annotationsObject]
 }
 
 const filterCreator = (): FilterWith<'onFetch'> => ({
   onFetch: async (elements: Element[]) => {
     const customObjects = await awu(elements).filter(isCustomObject).toArray() as ObjectType[]
-    const newSplittedCustomObjects = await awu(customObjects)
-      .flatMap(customObjectToSplittedElements)
+    const allSplitCustomObjects = await awu(customObjects)
+      .flatMap(customObjectToSplitElements)
       .toArray()
     _.pullAllWith(
       elements,
       customObjects,
-      // No need to check for custom objectness since all of the elements in
-      // the second params are custom objects.
-      (elementA: Element, elementB: Element): boolean => isObjectType(elementA)
-        && isObjectType(elementB)
-        && elementA.isEqual(elementB)
+      (element: Element, customObject: ObjectType): boolean =>
+        isObjectType(element) && element.isEqual(customObject)
     )
-    elements.push(...newSplittedCustomObjects)
+    elements.push(...allSplitCustomObjects)
   },
 })
 

--- a/packages/salesforce-adapter/src/filters/layouts.ts
+++ b/packages/salesforce-adapter/src/filters/layouts.ts
@@ -23,7 +23,7 @@ import { apiName, isCustomObject } from '../transformers/transformer'
 import { FilterCreator } from '../filter'
 import { addElementParentReference, isInstanceOfType, buildElementsSourceForFetch } from './utils'
 import { SALESFORCE, LAYOUT_TYPE_ID_METADATA_TYPE, WEBLINK_METADATA_TYPE } from '../constants'
-import { getObjectDirectoryPath } from './custom_objects'
+import { getNamespaceObjectDirectoryPath } from './custom_objects'
 
 const { awu } = collections.asynciterable
 
@@ -49,7 +49,7 @@ const fixLayoutPath = async (
   layoutName: string,
 ): Promise<void> => {
   layout.path = [
-    ...await getObjectDirectoryPath(customObject),
+    ...await getNamespaceObjectDirectoryPath(customObject),
     layout.elemID.typeName,
     pathNaclCase(naclCase(layoutName)),
   ]

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -13,8 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import 'jest-extended'
 import _ from 'lodash'
-import { ObjectType, BuiltinTypes, Element } from '@salto-io/adapter-api'
+import { ObjectType, BuiltinTypes, Element, ElemID } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/custom_object_split'
 import { CUSTOM_OBJECT_TYPE_ID } from '../../src/filters/custom_objects'
 import { FilterWith } from '../../src/filter'
@@ -120,4 +121,80 @@ describe('Custom Object Split filter', () => {
       .isEqual(customObject.fields.custom_namespace__c)).toBeTruthy()
   })
 })
+  describe('when split elements contains empty objects', () => {
+    const getSplitElementsPaths = async (...customObjects: ObjectType[]): Promise<string[][]> => {
+      const splitElements = await runFilter(...customObjects)
+      return splitElements.map(customObject => customObject.path as string[] ?? [])
+    }
+
+    it('should filter out empty standard fields object', async () => {
+      const objectWithNoStandardFields = new ObjectType({
+        elemID: CUSTOM_OBJECT_TYPE_ID,
+        fields: {
+          custom__c: {
+            refType: BuiltinTypes.STRING,
+          },
+          custom_namespace__c: {
+            refType: BuiltinTypes.STRING,
+            annotations: {
+              [API_NAME]: 'objectRandom__c.namespace__random__c',
+            },
+          },
+        },
+        annotations: {
+          [METADATA_TYPE]: CUSTOM_OBJECT,
+          [API_NAME]: 'objectRandom__c',
+        },
+      })
+      const splitElementsPaths = await getSplitElementsPaths(objectWithNoStandardFields)
+      expect(splitElementsPaths).toIncludeSameMembers([
+        [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectCustomFields'],
+        [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectAnnotations'],
+      ])
+    })
+    it('should filter out empty custom fields object', async () => {
+      const objectWithNoCustomFields = new ObjectType({
+        elemID: CUSTOM_OBJECT_TYPE_ID,
+        fields: {
+          standard: {
+            refType: BuiltinTypes.STRING,
+          },
+        },
+        annotations: {
+          [METADATA_TYPE]: CUSTOM_OBJECT,
+          [API_NAME]: 'objectRandom__c',
+        },
+      })
+      const splitElementsPaths = await getSplitElementsPaths(objectWithNoCustomFields)
+      expect(splitElementsPaths).toIncludeSameMembers([
+        [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectStandardFields'],
+        [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectAnnotations'],
+      ])
+    })
+  })
+  it('should not split non-custom object', async () => {
+    const nonCustomObject = new ObjectType({
+      elemID: new ElemID(SALESFORCE, 'NonCustomObject'),
+      fields: {
+        standard: {
+          refType: BuiltinTypes.STRING,
+        },
+        custom__c: {
+          refType: BuiltinTypes.STRING,
+        },
+        custom_namespace__c: {
+          refType: BuiltinTypes.STRING,
+          annotations: {
+            [API_NAME]: 'objectRandom__c.namespace__random__c',
+          },
+        },
+      },
+      annotations: {
+        [METADATA_TYPE]: 'NonCustomObject',
+        [API_NAME]: 'objectRandom__c',
+      },
+    })
+    const splitElements = await runFilter(nonCustomObject)
+    expect(splitElements).toEqual([nonCustomObject])
+  })
 })

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -124,7 +124,7 @@ describe('Custom Object Split filter', () => {
   describe('when split elements contains empty objects', () => {
     const getSplitElementsPaths = async (...customObjects: ObjectType[]): Promise<string[][]> => {
       const splitElements = await runFilter(...customObjects)
-      return splitElements.map(customObject => customObject.path as string[] ?? [])
+      return splitElements.map(customObject => customObject.path as string[])
     }
 
     it('should filter out empty standard fields object', async () => {

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -78,7 +78,7 @@ describe('Custom Object Split filter', () => {
     description                 |   customObject
     ${'non namespace object'}   |   ${noNameSpaceObject}
     ${'namespace object'}       |   ${namespaceObject}
-  `('$description', ({ customObject }: { customObject: ObjectType }) => {
+  `('$description', ({ customObject }) => {
   let elements: Element[]
 
   beforeEach(async () => {

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -14,27 +14,27 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import 'jest-extended'
-import { BuiltinTypes, Element, Field, isObjectType, ObjectType } from '@salto-io/adapter-api'
+import { ObjectType, BuiltinTypes, Element } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/custom_object_split'
 import { CUSTOM_OBJECT_TYPE_ID } from '../../src/filters/custom_objects'
 import { FilterWith } from '../../src/filter'
-import { API_NAME, CUSTOM_OBJECT, METADATA_TYPE, OBJECTS_PATH, SALESFORCE } from '../../src/constants'
-import { isCustom } from '../../src/transformers/transformer'
+import { METADATA_TYPE, CUSTOM_OBJECT, API_NAME, SALESFORCE, INSTALLED_PACKAGES_PATH, OBJECTS_PATH } from '../../src/constants'
 
 
-describe('custom object split filter', () => {
-  const SPLIT_CUSTOM_OBJECTS_DIR_PATH = [SALESFORCE, OBJECTS_PATH, 'CustomObject']
-
-  const NON_NAMESPACE_OBJECT = new ObjectType({
+describe('Custom Object Split filter', () => {
+  type FilterType = FilterWith<'onFetch'>
+  const filter = (): FilterType => filterCreator() as FilterType
+  const noNameSpaceObject = new ObjectType({
     elemID: CUSTOM_OBJECT_TYPE_ID,
     fields: {
-      standardField: {
+      standard: {
         refType: BuiltinTypes.STRING,
       },
-      customField__c: {
+      // eslint-disable-next-line camelcase
+      custom__c: {
         refType: BuiltinTypes.STRING,
       },
+      // eslint-disable-next-line camelcase
       custom_namespace__c: {
         refType: BuiltinTypes.STRING,
         annotations: {
@@ -47,16 +47,17 @@ describe('custom object split filter', () => {
       [API_NAME]: 'objectRandom__c',
     },
   })
-
-  const NAMESPACE_OBJECT = new ObjectType({
+  const withNamespaceOject = new ObjectType({
     elemID: CUSTOM_OBJECT_TYPE_ID,
     fields: {
-      standardField: {
+      standard: {
         refType: BuiltinTypes.STRING,
       },
-      customField__c: {
+      // eslint-disable-next-line camelcase
+      custom__c: {
         refType: BuiltinTypes.STRING,
       },
+      // eslint-disable-next-line camelcase
       custom_namespace__c: {
         refType: BuiltinTypes.STRING,
         annotations: {
@@ -70,100 +71,100 @@ describe('custom object split filter', () => {
     },
   })
 
-  const isCustomField = (f: Field): boolean => isCustom(f.elemID.getFullName())
-  const isStandardField = (f: Field): boolean => !isCustomField(f)
-  const elementHasPath = (e: Element, path: string[]): boolean => _.isEqual(e.path, path)
-  const getCustomFields = (e: ObjectType): Field[] => Object.values<Field>(e.fields)
-    .filter(isCustomField)
-  const getStandardFields = (e: ObjectType): Field[] => Object.values<Field>(e.fields)
-    .filter(isStandardField)
-
-  describe.each`
-    description                 |   customObject
-    ${'non namespace object'}   |   ${NON_NAMESPACE_OBJECT}
-    ${'namespace object'}       |   ${NAMESPACE_OBJECT}
-  `('$description', ({ customObject }: {customObject: ObjectType}) => {
-  let splitElements: Element[]
-  let expectedCustomFields: Field[]
-  let expectedStandardFields: Field[]
-
-  const runFilter = async (): Promise<Element[]> => {
-        type FilterType = FilterWith<'onFetch'>
-        const filter = (): FilterType => filterCreator() as FilterType
-        const elements = [customObject]
-        await filter().onFetch(elements)
-        return elements
-  }
-  beforeAll(async () => {
-    splitElements = await runFilter()
-    expectedCustomFields = getCustomFields(customObject)
-    expectedStandardFields = getStandardFields(customObject)
-  })
-  it('splits into three objects', () => {
-    expect(splitElements).toHaveLength(3)
-    expect(splitElements).toSatisfyAll(isObjectType)
-  })
-
-  describe('annotations object', () => {
-    let annotationsObject: ObjectType
-    beforeAll(() => {
-      const annotationsObjectPath = SPLIT_CUSTOM_OBJECTS_DIR_PATH.concat('CustomObjectAnnotations')
-      annotationsObject = <ObjectType>splitElements
-        .find(e => elementHasPath(e, annotationsObjectPath))
-    })
-    it('contains all annotations', () => {
-      expect(annotationsObject.annotations).toMatchObject(customObject.annotations)
+  describe('should split non-Namespace Custom Object to elements', () => {
+    let elements: Element[]
+    beforeEach(async () => {
+      elements = [noNameSpaceObject]
+      await filter().onFetch(elements)
+      expect(elements).toBeDefined()
+      expect(elements.length).toEqual(4)
     })
 
-    it('contains no fields', () => {
-      expect(annotationsObject.fields).toBeEmpty()
-    })
-  })
-
-  describe('standard fields object', () => {
-    let standardFieldsObject: ObjectType
-
-    beforeAll(() => {
-      const standardFieldsObjectPath = SPLIT_CUSTOM_OBJECTS_DIR_PATH.concat('CustomObjectStandardFields')
-      standardFieldsObject = <ObjectType>splitElements
-        .find(e => elementHasPath(e, standardFieldsObjectPath))
+    it('should create annotations object', () => {
+      const annotationsObj = elements.find(obj =>
+        _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
+          'CustomObject', 'CustomObjectAnnotations'])) as ObjectType
+      expect(annotationsObj).toBeDefined()
+      expect(Object.values(annotationsObj.fields).length).toEqual(0)
+      expect(annotationsObj.annotations[METADATA_TYPE]).toEqual(CUSTOM_OBJECT)
     })
 
-    it('only contains all standard fields', () => {
-      const receivedFields = Object.values(standardFieldsObject.fields)
-      expect(receivedFields).toHaveLength(expectedStandardFields.length)
-      _.zip(receivedFields, expectedStandardFields).forEach(([received, expected]) => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        expect(received!.isEqual(expected!)).toBeTrue()
-      })
+    it('should create standard fields object', () => {
+      const standardFieldsObj = elements.find(obj =>
+        _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
+          'CustomObject', 'CustomObjectStandardFields'])) as ObjectType
+      expect(standardFieldsObj).toBeDefined()
+      expect(Object.values(standardFieldsObj.annotations).length).toEqual(0)
+      expect(standardFieldsObj.fields.standard).toBeDefined()
+      expect(standardFieldsObj.fields.standard
+        .isEqual(noNameSpaceObject.fields.standard)).toBeTruthy()
     })
 
-    it('contains no annotations', () => {
-      expect(standardFieldsObject.annotations).toBeEmpty()
+    it('should create custom fields object', () => {
+      const customFieldsObj = elements.find(obj =>
+        _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
+          'CustomObject', 'CustomObjectCustomFields'])) as ObjectType
+      expect(customFieldsObj).toBeDefined()
+      expect(Object.values(customFieldsObj.annotations).length).toEqual(0)
+      expect(customFieldsObj.fields.custom__c).toBeDefined()
+      expect(customFieldsObj.fields.custom__c
+        .isEqual(noNameSpaceObject.fields.custom__c)).toBeTruthy()
+    })
+
+    it('should create namespace custom fields object', () => {
+      const packageCustomFieldsObj = elements.find(obj =>
+        _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
+          'CustomObject', 'CustomObjectCustomFields'])) as ObjectType
+      expect(packageCustomFieldsObj).toBeDefined()
+      expect(Object.values(packageCustomFieldsObj.annotations).length).toEqual(0)
+      expect(packageCustomFieldsObj.fields.custom_namespace__c).toBeDefined()
+      expect(packageCustomFieldsObj.fields.custom_namespace__c
+        .isEqual(noNameSpaceObject.fields.custom_namespace__c)).toBeTruthy()
     })
   })
 
-  describe('custom fields object', () => {
-    let customFieldsObject: ObjectType
 
-    beforeAll(() => {
-      const customFieldsObjectPath = SPLIT_CUSTOM_OBJECTS_DIR_PATH.concat('CustomObjectCustomFields')
-      customFieldsObject = <ObjectType>splitElements
-        .find(e => elementHasPath(e, customFieldsObjectPath))
+  describe('should split namespace Custom Object to elements', () => {
+    let elements: Element[]
+    beforeEach(async () => {
+      elements = [withNamespaceOject]
+      await filter().onFetch(elements)
+      expect(elements).toBeDefined()
+      expect(elements.length).toEqual(3)
     })
 
-    it('only contains all custom fields', () => {
-      const receivedFields = Object.values(customFieldsObject.fields)
-      expect(receivedFields).toHaveLength(expectedCustomFields.length)
-      _.zip(receivedFields, expectedCustomFields).forEach(([received, expected]) => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        expect(received!.isEqual(expected!)).toBeTrue()
-      })
+    it('should create annotations object inside the installed packages folder', () => {
+      const annotationsObj = elements.find(obj =>
+        _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
+          'CustomObject', 'CustomObjectAnnotations'])) as ObjectType
+      expect(annotationsObj).toBeDefined()
+      expect(Object.values(annotationsObj.fields).length).toEqual(0)
+      expect(annotationsObj.annotations[METADATA_TYPE]).toEqual(CUSTOM_OBJECT)
     })
 
-    it('contains no annotations', () => {
-      expect(customFieldsObject.annotations).toBeEmpty()
+    it('should create standard fields object inside the installed packages folder', () => {
+      const standardFieldsObj = elements.find(obj =>
+        _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
+          'CustomObject', 'CustomObjectStandardFields'])) as ObjectType
+      expect(standardFieldsObj).toBeDefined()
+      expect(Object.values(standardFieldsObj.annotations).length).toEqual(0)
+      expect(standardFieldsObj.fields.standard).toBeDefined()
+      expect(standardFieldsObj.fields.standard
+        .isEqual(withNamespaceOject.fields.standard)).toBeTruthy()
+    })
+
+    it('should create namespace custom fields object with all custom fields inside the installed packages folder', () => {
+      const customFieldsObj = elements.find(obj =>
+        _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
+          'CustomObject', 'CustomObjectCustomFields'])) as ObjectType
+      expect(customFieldsObj).toBeDefined()
+      expect(Object.values(customFieldsObj.annotations).length).toEqual(0)
+      expect(customFieldsObj.fields.custom_namespace__c).toBeDefined()
+      expect(customFieldsObj.fields.custom_namespace__c
+        .isEqual(withNamespaceOject.fields.custom_namespace__c)).toBeTruthy()
+      expect(customFieldsObj.fields.custom__c).toBeDefined()
+      expect(customFieldsObj.fields.custom__c
+        .isEqual(withNamespaceOject.fields.custom__c)).toBeTruthy()
     })
   })
-})
 })

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -14,157 +14,154 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ObjectType, BuiltinTypes, Element } from '@salto-io/adapter-api'
+import { BuiltinTypes, Element, Field, isObjectType, ObjectType } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/custom_object_split'
 import { CUSTOM_OBJECT_TYPE_ID } from '../../src/filters/custom_objects'
 import { FilterWith } from '../../src/filter'
-import { METADATA_TYPE, CUSTOM_OBJECT, API_NAME, SALESFORCE, INSTALLED_PACKAGES_PATH, OBJECTS_PATH } from '../../src/constants'
+import { API_NAME, CUSTOM_OBJECT, METADATA_TYPE, OBJECTS_PATH, SALESFORCE } from '../../src/constants'
+import { isCustom } from '../../src/transformers/transformer'
 
 
-describe('Custom Object Split filter', () => {
-  type FilterType = FilterWith<'onFetch'>
-  const filter = (): FilterType => filterCreator() as FilterType
-  const noNameSpaceObject = new ObjectType({
-    elemID: CUSTOM_OBJECT_TYPE_ID,
-    fields: {
-      standard: {
-        refType: BuiltinTypes.STRING,
-      },
-      // eslint-disable-next-line camelcase
-      custom__c: {
-        refType: BuiltinTypes.STRING,
-      },
-      // eslint-disable-next-line camelcase
-      custom_namespace__c: {
-        refType: BuiltinTypes.STRING,
-        annotations: {
-          [API_NAME]: 'objectRandom__c.namespace__random__c',
-        },
+const SPLIT_CUSTOM_OBJECTS_DIR_PATH = [SALESFORCE, OBJECTS_PATH, 'CustomObject']
+
+const NON_NAMESPACE_OBJECT = new ObjectType({
+  elemID: CUSTOM_OBJECT_TYPE_ID,
+  fields: {
+    standardField: {
+      refType: BuiltinTypes.STRING,
+    },
+    customField__c: {
+      refType: BuiltinTypes.STRING,
+    },
+    custom_namespace__c: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        [API_NAME]: 'objectRandom__c.namespace__random__c',
       },
     },
-    annotations: {
-      [METADATA_TYPE]: CUSTOM_OBJECT,
-      [API_NAME]: 'objectRandom__c',
+  },
+  annotations: {
+    [METADATA_TYPE]: CUSTOM_OBJECT,
+    [API_NAME]: 'objectRandom__c',
+  },
+})
+
+const NAMESPACE_OBJECT = new ObjectType({
+  elemID: CUSTOM_OBJECT_TYPE_ID,
+  fields: {
+    standardField: {
+      refType: BuiltinTypes.STRING,
     },
+    customField__c: {
+      refType: BuiltinTypes.STRING,
+    },
+    custom_namespace__c: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        [API_NAME]: 'namespace__objectRandom__c.namespace__api_name',
+      },
+    },
+  },
+  annotations: {
+    [METADATA_TYPE]: CUSTOM_OBJECT,
+    [API_NAME]: 'namespace__objectRandom__c',
+  },
+})
+
+const isCustomField = (f: Field): boolean => isCustom(f.elemID.getFullName())
+const isStandardField = (f: Field): boolean => !isCustomField(f)
+const elementHasPath = (e: Element, path: string[]): boolean => _.isEqual(e.path, path)
+const getCustomFields = (e: ObjectType): Field[] => Object.values<Field>(e.fields)
+  .filter(isCustomField)
+const getStandardFields = (e: ObjectType): Field[] => Object.values<Field>(e.fields)
+  .filter(isStandardField)
+
+
+describe('custom object split filter', () => {
+  describe.each`
+    description                 |   customObject
+    ${'non namespace object'}   |   ${NON_NAMESPACE_OBJECT}
+    ${'namespace object'}       |   ${NAMESPACE_OBJECT}
+  `('$description', ({ customObject }: {customObject: ObjectType}) => {
+  let splitElements: Element[]
+  let objectCustomFields: Field[]
+  let objectStandardFields: Field[]
+
+  const runFilter = async (): Promise<Element[]> => {
+        type FilterType = FilterWith<'onFetch'>
+        const filter = (): FilterType => filterCreator() as FilterType
+        const elements = [customObject]
+        await filter().onFetch(elements)
+        return elements
+  }
+  beforeAll(async () => {
+    splitElements = await runFilter()
+    objectCustomFields = getCustomFields(customObject)
+    objectStandardFields = getStandardFields(customObject)
   })
-  const withNamespaceOject = new ObjectType({
-    elemID: CUSTOM_OBJECT_TYPE_ID,
-    fields: {
-      standard: {
-        refType: BuiltinTypes.STRING,
-      },
-      // eslint-disable-next-line camelcase
-      custom__c: {
-        refType: BuiltinTypes.STRING,
-      },
-      // eslint-disable-next-line camelcase
-      custom_namespace__c: {
-        refType: BuiltinTypes.STRING,
-        annotations: {
-          [API_NAME]: 'namespace__objectRandom__c.namespace__api_name',
-        },
-      },
-    },
-    annotations: {
-      [METADATA_TYPE]: CUSTOM_OBJECT,
-      [API_NAME]: 'namespace__objectRandom__c',
-    },
+  test('splits into three objects', () => {
+    expect(splitElements).toHaveLength(3)
+    expect(splitElements).toSatisfyAll(isObjectType)
   })
 
-  describe('should split non-Namespace Custom Object to elements', () => {
-    let elements: Element[]
-    beforeEach(async () => {
-      elements = [noNameSpaceObject]
-      await filter().onFetch(elements)
-      expect(elements).toBeDefined()
-      expect(elements.length).toEqual(4)
+  describe('annotations object', () => {
+    let annotationsObject: ObjectType
+    beforeAll(() => {
+      const annotationsObjectPath = SPLIT_CUSTOM_OBJECTS_DIR_PATH.concat('CustomObjectAnnotations')
+      annotationsObject = <ObjectType>splitElements
+        .find(e => elementHasPath(e, annotationsObjectPath))
+    })
+    test('contains all annotations', () => {
+      expect(annotationsObject.annotations).toMatchObject(customObject.annotations)
     })
 
-    it('should create annotations object', () => {
-      const annotationsObj = elements.find(obj =>
-        _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
-          'CustomObject', 'CustomObjectAnnotations'])) as ObjectType
-      expect(annotationsObj).toBeDefined()
-      expect(Object.values(annotationsObj.fields).length).toEqual(0)
-      expect(annotationsObj.annotations[METADATA_TYPE]).toEqual(CUSTOM_OBJECT)
-    })
-
-    it('should create standard fields object', () => {
-      const standardFieldsObj = elements.find(obj =>
-        _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
-          'CustomObject', 'CustomObjectStandardFields'])) as ObjectType
-      expect(standardFieldsObj).toBeDefined()
-      expect(Object.values(standardFieldsObj.annotations).length).toEqual(0)
-      expect(standardFieldsObj.fields.standard).toBeDefined()
-      expect(standardFieldsObj.fields.standard
-        .isEqual(noNameSpaceObject.fields.standard)).toBeTruthy()
-    })
-
-    it('should create custom fields object', () => {
-      const customFieldsObj = elements.find(obj =>
-        _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
-          'CustomObject', 'CustomObjectCustomFields'])) as ObjectType
-      expect(customFieldsObj).toBeDefined()
-      expect(Object.values(customFieldsObj.annotations).length).toEqual(0)
-      expect(customFieldsObj.fields.custom__c).toBeDefined()
-      expect(customFieldsObj.fields.custom__c
-        .isEqual(noNameSpaceObject.fields.custom__c)).toBeTruthy()
-    })
-
-    it('should create namespace custom fields object', () => {
-      const packageCustomFieldsObj = elements.find(obj =>
-        _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
-          'CustomObject', 'CustomObjectCustomFields'])) as ObjectType
-      expect(packageCustomFieldsObj).toBeDefined()
-      expect(Object.values(packageCustomFieldsObj.annotations).length).toEqual(0)
-      expect(packageCustomFieldsObj.fields.custom_namespace__c).toBeDefined()
-      expect(packageCustomFieldsObj.fields.custom_namespace__c
-        .isEqual(noNameSpaceObject.fields.custom_namespace__c)).toBeTruthy()
+    test('contains no fields', () => {
+      expect(annotationsObject.fields).toBeEmpty()
     })
   })
 
+  describe('standard fields object', () => {
+    let standardFieldsObject: ObjectType
 
-  describe('should split namespace Custom Object to elements', () => {
-    let elements: Element[]
-    beforeEach(async () => {
-      elements = [withNamespaceOject]
-      await filter().onFetch(elements)
-      expect(elements).toBeDefined()
-      expect(elements.length).toEqual(3)
+    beforeAll(() => {
+      const standardFieldsObjectPath = SPLIT_CUSTOM_OBJECTS_DIR_PATH.concat('CustomObjectStandardFields')
+      standardFieldsObject = <ObjectType>splitElements
+        .find(e => elementHasPath(e, standardFieldsObjectPath))
     })
 
-    it('should create annotations object inside the installed packages folder', () => {
-      const annotationsObj = elements.find(obj =>
-        _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
-          'CustomObject', 'CustomObjectAnnotations'])) as ObjectType
-      expect(annotationsObj).toBeDefined()
-      expect(Object.values(annotationsObj.fields).length).toEqual(0)
-      expect(annotationsObj.annotations[METADATA_TYPE]).toEqual(CUSTOM_OBJECT)
+    test('contains all standard fields', () => {
+      expect(standardFieldsObject).toContainFields(objectStandardFields)
     })
 
-    it('should create standard fields object inside the installed packages folder', () => {
-      const standardFieldsObj = elements.find(obj =>
-        _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
-          'CustomObject', 'CustomObjectStandardFields'])) as ObjectType
-      expect(standardFieldsObj).toBeDefined()
-      expect(Object.values(standardFieldsObj.annotations).length).toEqual(0)
-      expect(standardFieldsObj.fields.standard).toBeDefined()
-      expect(standardFieldsObj.fields.standard
-        .isEqual(withNamespaceOject.fields.standard)).toBeTruthy()
+    test('contains no custom fields', () => {
+      expect(standardFieldsObject).not.toContainAnyField(objectCustomFields)
     })
 
-    it('should create namespace custom fields object with all custom fields inside the installed packages folder', () => {
-      const customFieldsObj = elements.find(obj =>
-        _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
-          'CustomObject', 'CustomObjectCustomFields'])) as ObjectType
-      expect(customFieldsObj).toBeDefined()
-      expect(Object.values(customFieldsObj.annotations).length).toEqual(0)
-      expect(customFieldsObj.fields.custom_namespace__c).toBeDefined()
-      expect(customFieldsObj.fields.custom_namespace__c
-        .isEqual(withNamespaceOject.fields.custom_namespace__c)).toBeTruthy()
-      expect(customFieldsObj.fields.custom__c).toBeDefined()
-      expect(customFieldsObj.fields.custom__c
-        .isEqual(withNamespaceOject.fields.custom__c)).toBeTruthy()
+    test('contains no annotations', () => {
+      expect(standardFieldsObject.annotations).toBeEmpty()
     })
   })
+
+  describe('custom fields object', () => {
+    let customFieldsObject: ObjectType
+
+    beforeAll(() => {
+      const customFieldsObjectPath = SPLIT_CUSTOM_OBJECTS_DIR_PATH.concat('CustomObjectCustomFields')
+      customFieldsObject = <ObjectType>splitElements
+        .find(e => elementHasPath(e, customFieldsObjectPath))
+    })
+
+    test('contains all custom fields', () => {
+      expect(customFieldsObject).toContainFields(objectCustomFields)
+    })
+
+    test('contains no standard fields', () => {
+      expect(customFieldsObject).not.toContainAnyField(objectStandardFields)
+    })
+
+    test('contains no annotations', () => {
+      expect(customFieldsObject.annotations).toBeEmpty()
+    })
+  })
+})
 })

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -24,6 +24,12 @@ import { METADATA_TYPE, CUSTOM_OBJECT, API_NAME, SALESFORCE, OBJECTS_PATH } from
 describe('Custom Object Split filter', () => {
   type FilterType = FilterWith<'onFetch'>
   const filter = (): FilterType => filterCreator() as FilterType
+  const runFilter = async (...customObjects: ObjectType[]): Promise<Element[]> => {
+    const elements = [...customObjects]
+    await filter().onFetch(elements)
+    return elements
+  }
+
   const noNameSpaceObject = new ObjectType({
     elemID: CUSTOM_OBJECT_TYPE_ID,
     fields: {
@@ -73,9 +79,9 @@ describe('Custom Object Split filter', () => {
     ${'namespace object'}       |   ${namespaceObject}
   `('$description', ({ customObject }: { customObject: ObjectType }) => {
   let elements: Element[]
+
   beforeEach(async () => {
-    elements = [customObject]
-    await filter().onFetch(elements)
+    elements = await runFilter(customObject)
     expect(elements).toBeDefined()
     expect(elements.length).toEqual(3)
   })

--- a/packages/salesforce-adapter/test/filters/layouts.test.ts
+++ b/packages/salesforce-adapter/test/filters/layouts.test.ts
@@ -21,7 +21,7 @@ import makeFilter, { LAYOUT_TYPE_ID } from '../../src/filters/layouts'
 import * as constants from '../../src/constants'
 import { FilterWith } from '../../src/filter'
 import mockClient from '../client'
-import { getObjectDirectoryPath } from '../../src/filters/custom_objects'
+import { getNamespaceObjectDirectoryPath } from '../../src/filters/custom_objects'
 
 describe('Test layout filter', () => {
   describe('Test layout fetch', () => {
@@ -41,7 +41,10 @@ describe('Test layout filter', () => {
           },
         }
       )
-      const testSobjPath = [...await getObjectDirectoryPath(testSObj), pathNaclCase(apiName)]
+      const testSobjPath = [
+        ...await getNamespaceObjectDirectoryPath(testSObj),
+        pathNaclCase(apiName),
+      ]
       testSObj.path = testSobjPath
 
       const shortName = 'Test Layout'

--- a/yarn.lock
+++ b/yarn.lock
@@ -778,6 +778,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^27.4.2":
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.4.2.tgz#96536ebd34da6392c2b7c7737d693885b5dd44a5"
+  integrity sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
 "@jsdevtools/ono@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
@@ -2239,6 +2250,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yargs@^16.0.0":
+  version "16.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
+  integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
+  dependencies:
+    "@types/yargs-parser" "*"
+
 "@typescript-eslint/eslint-plugin@4.22.1":
   version "4.22.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.1.tgz#6bcdbaa4548553ab861b4e5f34936ead1349a543"
@@ -2678,6 +2696,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -2704,6 +2727,11 @@ ansi-styles@^4.1.0:
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 any-promise@^1.0.0:
   version "1.3.0"
@@ -4309,6 +4337,11 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
+diff-sequences@^27.4.0:
+  version "27.4.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.4.0.tgz#d783920ad8d06ec718a060d00196dfef25b132a5"
+  integrity sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==
 
 diff@^4.0.2:
   version "4.0.2"
@@ -6912,6 +6945,16 @@ jest-diff@^26.0.0, jest-diff@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
+jest-diff@^27.2.5, jest-diff@^27.4.2:
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.4.2.tgz#786b2a5211d854f848e2dcc1e324448e9481f36f"
+  integrity sha512-ujc9ToyUZDh9KcqvQDkk/gkbf6zSaeEg9AiBxtttXW59H/AcqEYp1ciXAtJp+jXWva5nAf/ePtSsgWwE5mqp4Q==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.4.0"
+    jest-get-type "^27.4.0"
+    pretty-format "^27.4.2"
+
 jest-docblock@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
@@ -6963,10 +7006,25 @@ jest-environment-node@^26.6.2:
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
 
+jest-extended@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/jest-extended/-/jest-extended-1.2.0.tgz#6ef87d806bd9501a0aeae56fe8c7af73777987ed"
+  integrity sha512-KYc5DgD+/8viJSEKBzb1vRXe/rEEQUxEovBTdNEer9A6lzvHvhuyslM5tQFBz8TbLEkicCmsEcQF+4N7GiPTLg==
+  dependencies:
+    expect "^26.6.2"
+    jest-diff "^27.2.5"
+    jest-get-type "^27.0.6"
+    jest-matcher-utils "^27.2.4"
+
 jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
   integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
+
+jest-get-type@^27.0.6, jest-get-type@^27.4.0:
+  version "27.4.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.4.0.tgz#7503d2663fffa431638337b3998d39c5e928e9b5"
+  integrity sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==
 
 jest-haste-map@^26.6.2:
   version "26.6.2"
@@ -7040,6 +7098,16 @@ jest-matcher-utils@^26.6.2:
     jest-diff "^26.6.2"
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
+
+jest-matcher-utils@^27.2.4:
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.4.2.tgz#d17c5038607978a255e0a9a5c32c24e984b6c60b"
+  integrity sha512-jyP28er3RRtMv+fmYC/PKG8wvAmfGcSNproVTW2Y0P/OY7/hWUOmsPfxN1jOhM+0u2xU984u2yEagGivz9OBGQ==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.4.2"
+    jest-get-type "^27.4.0"
+    pretty-format "^27.4.2"
 
 jest-message-util@^26.6.2:
   version "26.6.2"
@@ -9401,6 +9469,16 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     "@jest/types" "^26.6.2"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.4.2:
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.4.2.tgz#e4ce92ad66c3888423d332b40477c87d1dac1fb8"
+  integrity sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==
+  dependencies:
+    "@jest/types" "^27.4.2"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
 process-nextick-args@~2.0.0:


### PR DESCRIPTION
The custom_object_split filter no longer splits custom fields of installed packages to separate files

---
_Release Notes_: 
Salesforce Adapter:
- Installed Packages Custom fields will sit with the rest of the object's CustomFields.
---
_User Notifications_: 
- All of the {OBJECT_NAME}CustomFields.nacl files under the  InstalledPackages directory will be removed from your workspace.
- Your {OBJECT_NAME}CustomFields.nacl files under the Objects directory may change to include the installed packages custom fields. (in case you had CustomFields from installed packages)
