### PR TITLE
SALTO-1736: Add tests for toInstanceElements

### DIFF
--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -82,11 +82,16 @@ export const toBasicInstance = async ({
     transformationDefaultConfig,
   )
 
-  const nameParts = idFields.map(field => _.get(entry, field))
-  if (nameParts.includes(undefined)) {
+  const nameParts = _.isEmpty(idFields)
+    ? undefined
+    : idFields.map(field => _.get(entry, field))
+
+  if (_.isUndefined(nameParts)) {
+    log.warn('no id fields were provided')
+  } else if (nameParts.includes(undefined)) {
     log.warn(`could not find id for entry - expected id fields ${idFields}, available fields ${Object.keys(entry)}`)
   }
-  const name = nameParts.every(part => part !== undefined && part !== '') ? nameParts.map(String).join('_') : defaultName
+  const name = nameParts?.every(part => part !== undefined && part !== '') ? nameParts.map(String).join('_') : defaultName
 
   const fileNameParts = (fileNameFields !== undefined
     ? fileNameFields.map(field => _.get(entry, field))

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -1097,6 +1097,14 @@ describe('swagger_instance_elements', () => {
           const { elemID } = await getInstance(params)
           return elemID.name
         }
+        /**
+         * This test demonstrates a bug that causes collusion between element ids.
+         * Please refer to [this]{@link https://salto-io.atlassian.net/browse/SALTO-1738} ticket
+         */
+        it('generates id with value "null" when one null field is given', async () => {
+          const elementIdName = await getInstanceIdName({ idFields: ['nullField'] })
+          expect(elementIdName).toEqual(naclCase('null'))
+        })
         it('generates id with non undefined fields', async () => {
           const elementIdName = await getInstanceIdName({ idFields: ['id', 'name', 'number', 'list', 'nullField'] })
           expect(elementIdName).toEqual(naclCase(`${ID}_${NAME}_${NUMBER}_${LIST}_null`))

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -1051,6 +1051,7 @@ describe('swagger_instance_elements', () => {
                 number: NUMBER,
                 list: LIST,
                 emptyField: '',
+                nullField: null,
               },
             ].flatMap(extractPageEntries)
           }))
@@ -1097,22 +1098,23 @@ describe('swagger_instance_elements', () => {
           return elemID.name
         }
         it('generates id with non undefined fields', async () => {
-          const elementIdName = await getInstanceIdName({ idFields: ['id', 'name', 'number', 'list'] })
-          expect(elementIdName).toEqual(naclCase(`${ID}_${NAME}_${NUMBER}_${LIST}`))
+          const elementIdName = await getInstanceIdName({ idFields: ['id', 'name', 'number', 'list', 'nullField'] })
+          expect(elementIdName).toEqual(naclCase(`${ID}_${NAME}_${NUMBER}_${LIST}_null`))
         })
 
         describe('uses default name as id', () => {
+          const EXPECTED_DEFAULT_NAME = 'unnamed_0'
           it('no fields are provided', async () => {
             const elementIdName = await getInstanceIdName({ idFields: [] })
-            expect(elementIdName).toEqual(naclCase('unnamed_0'))
+            expect(elementIdName).toEqual(naclCase(EXPECTED_DEFAULT_NAME))
           })
           it('contains undefined field', async () => {
             const elementIdName = await getInstanceIdName({ idFields: ['id', 'name', 'undefinedField', 'number'] })
-            expect(elementIdName).toEqual(naclCase('unnamed_0'))
+            expect(elementIdName).toEqual(naclCase(EXPECTED_DEFAULT_NAME))
           })
           it('contain empty field', async () => {
             const elementIdName = await getInstanceIdName({ idFields: ['id', 'name', 'emptyField', 'number'] })
-            expect(elementIdName).toEqual(naclCase('unnamed_0'))
+            expect(elementIdName).toEqual(naclCase(EXPECTED_DEFAULT_NAME))
           })
         })
       })
@@ -1123,21 +1125,25 @@ describe('swagger_instance_elements', () => {
           return path?.[path.length - 1] ?? ''
         }
         it('generates name with non undefined fields', async () => {
-          const fileName: string = await getInstanceFileName({ fileNameFields: ['id', 'name', 'number', 'emptyField'] })
+          const fileName = await getInstanceFileName({ fileNameFields: ['id', 'name', 'number', 'emptyField'] })
           expect(fileName).toEqual(pathNaclCase(naclCase(`${ID}_${NAME}_${NUMBER}_`)))
         })
 
         describe('uses naclName as filename', () => {
           it('no fields are provided', async () => {
-            const fileName: string = await getInstanceFileName({ fileNameFields: [], idFields: ['id', 'name', 'number', 'list'] })
+            const fileName = await getInstanceFileName({ fileNameFields: [], idFields: ['id', 'name', 'number', 'list'] })
             expect(fileName).toEqual(pathNaclCase(naclCase(`${ID}_${NAME}_${NUMBER}_${LIST}`)))
           })
           it('contains field of unsupported type: list', async () => {
-            const fileName: string = await getInstanceFileName({ fileNameFields: ['id', 'name', 'list', 'number'], idFields: ['id', 'name', 'number'] })
+            const fileName = await getInstanceFileName({ fileNameFields: ['id', 'name', 'list', 'number'], idFields: ['id', 'name', 'number'] })
             expect(fileName).toEqual(pathNaclCase(naclCase(`${ID}_${NAME}_${NUMBER}`)))
           })
           it('contains undefined field', async () => {
-            const fileName: string = await getInstanceFileName({ fileNameFields: ['id', 'name', 'undefinedField', 'number'], idFields: ['id', 'name', 'number'] })
+            const fileName = await getInstanceFileName({ fileNameFields: ['id', 'name', 'undefinedField', 'number'], idFields: ['id', 'name', 'number'] })
+            expect(fileName).toEqual(pathNaclCase(naclCase(`${ID}_${NAME}_${NUMBER}`)))
+          })
+          it('contains null field', async () => {
+            const fileName = await getInstanceFileName({ fileNameFields: ['id', 'name', 'nullField', 'number'], idFields: ['id', 'name', 'number'] })
             expect(fileName).toEqual(pathNaclCase(naclCase(`${ID}_${NAME}_${NUMBER}`)))
           })
         })

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -1146,6 +1146,10 @@ describe('swagger_instance_elements', () => {
             const fileName = await getInstanceFileName({ fileNameFields: ['id', 'name', 'nullField', 'number'], idFields: ['id', 'name', 'number'] })
             expect(fileName).toEqual(pathNaclCase(naclCase(`${ID}_${NAME}_${NUMBER}`)))
           })
+          it('all fields are empty strings', async () => {
+            const fileName = await getInstanceFileName({ fileNameFields: ['emptyField'], idFields: ['id', 'name', 'number'] })
+            expect(fileName).toEqual(pathNaclCase(naclCase(`${ID}_${NAME}_${NUMBER}`)))
+          })
         })
       })
     })


### PR DESCRIPTION
Tests were missing for the method instance_elements.toBasicInstance.
---
- Added tests that cover the transformation of element id and filename.
- Fixed a bug that generated element id with value 'instance' (and not unnamed_{index} as expected) when no id fields are provided.
---
_Release Notes_: 
adapter-components:
- Generating default name when no id fields are provided.

---
_User Notifications_: 
If you happened to have elements or filenames with the value "instance", they will change in your workspace to unnamed_{index}.
