### PR TITLE
SALTO-1725: fixed default values config

### DIFF
--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -87,7 +87,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           context: [{ name: 'fieldId', fromField: 'id' }],
           conditions: [{
             fromField: 'schema.custom',
-            match: FIELD_TYPES_WITH_OPTIONS,
+            // This condition is to avoid trying to fetch the default value
+            // for unsupported types (e.g., com.atlassian.jira.ext.charting:timeinstatus)
+            // for which Jira will return "Retrieving default value for provided
+            // custom field is not supported."
+            match: ['com.atlassian.jira.plugin.system.customfieldtypes:*'],
           }],
         },
         {


### PR DESCRIPTION
It looks like fetching default values is supported for all custom types fields. Changed the config accordingly

---
_Release Notes_: 
None (Jira adapter is not officially deployed)

---
_User Notifications_: 
None