### PR TITLE
SALTO-1270: Modify ChangeValidation severity to WARN when deploying instance with ACCOUNT_SPECIFIC_VALUE

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
@@ -19,7 +19,7 @@ import {
   ChangeError,
   ChangeValidator,
   getChangeElement,
-  InstanceElement, isAdditionChange,
+  InstanceElement,
   isAdditionOrModificationChange,
   isInstanceChange,
 } from '@salto-io/adapter-api'
@@ -60,25 +60,11 @@ const changeValidator: ChangeValidator = async changes => (
       if (!hasAccountSpecificValue(instance)) {
         return undefined
       }
-      // We identified ACCOUNT_SPECIFIC_VALUE only in workflows and script related types,
-      // e.g. clientscript, restlet etc.
-      // These types have an isinactive field. If it indicates that the instance is enabled and
-      // we deploy it, without the real value behind the ACCOUNT_SPECIFIC_VALUE, it might be
-      // created invalid since some data is missing.
-      // Since the SAAS doesn't present the validation output yet (SAAS-1542), we set it to ERROR.
-      if (isAdditionChange(change) && !instance.value.isinactive) {
-        return {
-          elemID: instance.elemID,
-          severity: 'Error',
-          message: 'New instances that have fields with ACCOUNT_SPECIFIC_VALUE can be deployed only when they are inactive',
-          detailedMessage: 'New instances that have fields with ACCOUNT_SPECIFIC_VALUE can be deployed only when they are inactive',
-        } as ChangeError
-      }
       return {
         elemID: instance.elemID,
         severity: 'Warning',
-        message: 'Fields with ACCOUNT_SPECIFIC_VALUE will be skipped and not deployed',
-        detailedMessage: 'Fields with ACCOUNT_SPECIFIC_VALUE will be skipped and not deployed',
+        message: 'Element contains fields with account specific values. These fields will be skipped from the deployment.',
+        detailedMessage: 'Fields with account specific values (ACCOUNT_SPECIFIC_VALUE) will be skipped from the deployment. After deploying this element, please make sure these fields are mapped correctly in NetSuite.',
       } as ChangeError
     })
     .filter(isDefined)

--- a/packages/netsuite-adapter/test/change_validators/account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/account_specific_values.test.ts
@@ -80,26 +80,4 @@ describe('account specific value validator', () => {
     expect(changeErrors[0].severity).toEqual('Warning')
     expect(changeErrors[0].elemID).toEqual(instance.elemID)
   })
-
-  it('should have Warning ChangeError when creating an inactive instance with ACCOUNT_SPECIFIC_VALUE', async () => {
-    instance.value.name = ACCOUNT_SPECIFIC_VALUE
-    instance.value.isinactive = true
-    const changeErrors = await accountSpecificValueValidator(
-      [toChange({ after: instance })]
-    )
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0].severity).toEqual('Warning')
-    expect(changeErrors[0].elemID).toEqual(instance.elemID)
-  })
-
-  it('should have Error ChangeError when creating an active instance with ACCOUNT_SPECIFIC_VALUE', async () => {
-    instance.value.name = ACCOUNT_SPECIFIC_VALUE
-    instance.value.isinactive = false
-    const changeErrors = await accountSpecificValueValidator(
-      [toChange({ after: instance })]
-    )
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0].severity).toEqual('Error')
-    expect(changeErrors[0].elemID).toEqual(instance.elemID)
-  })
 })


### PR DESCRIPTION
_Release Notes_: 
Set a Warning change validation when creating an instance that is enabled but contain ACCOUNT_SPECIFIC_VALUE instead of ignoring this change.