### PR TITLE
SALTO-1702: changed include nested to include fields and attributes for types

### DIFF
--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -55,7 +55,7 @@ const testNames = (
 const match = (elemId: ElemID, selector: ElementSelector, includeNested = false): boolean =>
   selector.adapterSelector.test(elemId.adapter)
   && selector.typeNameSelector.test(elemId.typeName)
-  && ((selector.idTypeSelector === elemId.idType) || (includeNested && selector.idTypeSelector === 'type' && elemId.idType !== 'instance'))
+  && ((selector.idTypeSelector === elemId.idType) || (includeNested && selector.idTypeSelector === 'type' && elemId.createTopLevelParentID().parent.idType === 'type'))
   && testNames(
     elemId.getFullNameParts().slice(ElemID.NUM_ELEM_ID_NON_NAME_PARTS),
     selector.nameSelectors ?? [],

--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -46,21 +46,19 @@ type ElementIDContainer = {
 }
 
 const testNames = (
-  nameArray: readonly string[], nameSelectors?: RegExp[], includeNested = false
+  nameArray: readonly string[], nameSelectors: RegExp[], includeNested = false
 ): boolean =>
-  (nameSelectors
-    ? ((nameArray.length === nameSelectors.length
-      || (includeNested && nameArray.length > nameSelectors.length))
-      && nameSelectors.every((regex, i) => regex.test(nameArray[i])))
-    : nameArray.length === 0)
+  ((nameArray.length === nameSelectors.length
+    || (includeNested && nameArray.length > nameSelectors.length))
+    && nameSelectors.every((regex, i) => regex.test(nameArray[i])))
 
 const match = (elemId: ElemID, selector: ElementSelector, includeNested = false): boolean =>
   selector.adapterSelector.test(elemId.adapter)
   && selector.typeNameSelector.test(elemId.typeName)
-  && (selector.idTypeSelector === elemId.idType)
+  && ((selector.idTypeSelector === elemId.idType) || (includeNested && selector.idTypeSelector === 'type' && elemId.idType !== 'instance'))
   && testNames(
     elemId.getFullNameParts().slice(ElemID.NUM_ELEM_ID_NON_NAME_PARTS),
-    selector.nameSelectors,
+    selector.nameSelectors ?? [],
     includeNested
   )
 

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -189,6 +189,19 @@ describe('element selector', () => {
     expect(selectedElements).toEqual([elements[0], elements[1], elements[2]])
   })
 
+  it('should select fields and attributes when includeNested is true', async () => {
+    const elements = [
+      new ElemID('salesforce', 'sometype'),
+      new ElemID('salesforce', 'sometype', 'field', 'A',),
+      new ElemID('salesforce', 'sometype', 'attr', 'B', 'B', 'C'),
+      new ElemID('salesforce', 'sometype', 'instance', 'NotA'),
+    ]
+    const selectedElements = await selectElements(
+      { elements, selectors: ['salesforce.*'], includeNested: true }
+    )
+    expect(selectedElements).toEqual([elements[0], elements[1], elements[2]])
+  })
+
   it('should select elements with the same selector length when includeNested is false and name selectors length is 2', async () => {
     const elements = [
       new ElemID('salesforce', 'sometype', 'instance', 'A'),


### PR DESCRIPTION
Changed element selector `includeNested` to also include fields and attributes for type selectors

---
_Release Notes_: 
None (CLI does not use includeNested)

---
_User Notifications_: 
None