### PR TITLE
SALTO-1697 convert Jira setting instances to singleton

### DIFF
--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -50,6 +50,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   Configuration: {
     transformation: {
       dataField: '.',
+      isSingleton: true,
     },
   },
   PageBeanDashboard: {
@@ -376,6 +377,16 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     transformation: {
       dataField: '.',
     },
+  },
+  AttachmentSettings: {
+    transformation: {
+      isSingleton: true,
+    },
+  },
+  Permissions_permissions: {
+    transformation: {
+      isSingleton: true,
+    }
   },
 
   // Jira API

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -386,7 +386,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   Permissions_permissions: {
     transformation: {
       isSingleton: true,
-    }
+    },
   },
 
   // Jira API


### PR DESCRIPTION
Convert Jira setting instances to singleton:
AttachmentSettings
Configuration
Permissions_permissions 

---

This change follows the new option to define instances as singleton types in swagger adapters.=

---
