### PR TITLE
SAAS-1519 - When an element is marked, right click menu operations are not executed

### DIFF
--- a/packages/lang-server/src/token.ts
+++ b/packages/lang-server/src/token.ts
@@ -33,8 +33,6 @@ export const getToken = (fileContent: string, position: EditorPosition):
   const lexerToken = wu(parser.tokenizeContent(line)).find(
     token => token.col - 1 <= position.col && position.col < token.col + token.value.length,
   )
-  // eslint-disable-next-line no-console
-  console.log(lexerToken)
   if (lexerToken === undefined) {
     return undefined
   }

--- a/packages/lang-server/src/token.ts
+++ b/packages/lang-server/src/token.ts
@@ -30,10 +30,11 @@ export const getToken = (fileContent: string, position: EditorPosition):
   // This is done to avoid parsing the entire file
   // and cause us to not support multiline tokens
   const line = lines[position.line]
-
   const lexerToken = wu(parser.tokenizeContent(line)).find(
-    token => token.col - 1 <= position.col && position.col < token.col + token.value.length - 1,
+    token => token.col - 1 <= position.col && position.col < token.col + token.value.length,
   )
+  // eslint-disable-next-line no-console
+  console.log(lexerToken)
   if (lexerToken === undefined) {
     return undefined
   }

--- a/packages/lang-server/test/token.test.ts
+++ b/packages/lang-server/test/token.test.ts
@@ -53,6 +53,6 @@ describe('Test go to definitions', () => {
     expect(getToken(naclFileContent, { line: 135, col: 0 })).toEqual({ value: 'vs.person', type: 'word' })
   })
   it('For a position of the last character of a valid token the right token should be return', () => {
-    expect(getToken(naclFileContent, { line: 135, col: 8 })).toEqual({ value: 'vs.person', type: 'word' })
+    expect(getToken(naclFileContent, { line: 135, col: 9 })).toEqual({ value: 'vs.person', type: 'word' })
   })
 })


### PR DESCRIPTION
bug fix , right click menu operations were not executed when the cursor was on the last char or when element was marked

---

https://salto-io.atlassian.net/browse/SAAS-1519
