### PR TITLE
SALTO-1758 extract standard-format references for fields and columns

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -161,8 +161,10 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     serializationStrategy: 'relativeApiName',
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
+  // note: not all field values under ReportColumn match this rule - but it's ok because
+  // only the ones that match are currently extracted (SALTO-1758)
   {
-    src: { field: 'field', parentTypes: ['ProfileFieldLevelSecurity', 'FilterItem', 'PermissionSetFieldPermissions'] },
+    src: { field: 'field', parentTypes: ['ProfileFieldLevelSecurity', 'FilterItem', 'PermissionSetFieldPermissions', 'ReportColumn'] },
     target: { type: CUSTOM_FIELD },
   },
   {
@@ -471,6 +473,21 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     src: { field: CPQ_CONSTRAINT_FIELD, parentTypes: [CPQ_PRICE_SCHEDULE, CPQ_DISCOUNT_SCHEDULE] },
     serializationStrategy: 'scheduleConstraintFieldMapping',
     target: { parent: CPQ_QUOTE, type: CUSTOM_FIELD },
+  },
+
+  // note: not all column and xColumn values match this rule - but it's ok because
+  // only the ones that match are currently extracted (SALTO-1758)
+  {
+    src: { field: 'groupingColumn', parentTypes: ['Report'] },
+    target: { type: CUSTOM_FIELD },
+  },
+  {
+    src: { field: 'secondaryGroupingColumn', parentTypes: ['Report'] },
+    target: { type: CUSTOM_FIELD },
+  },
+  {
+    src: { field: 'column', parentTypes: ['ReportFilterItem', 'DashboardFilterColumn', 'DashboardTableColumn'] },
+    target: { type: CUSTOM_FIELD },
   },
 ]
 


### PR DESCRIPTION
Extract part of the referenced fields and columns in reports and dashboards.
Note that not all are covered, because there are different formatting options, and in order to know we can safely serialize the reference back to its original form, our current mechanism requires there to be at most one valid serialization.

---

In the future, we can extend this by either adding the other variants under `_generated_dependencies`, or having a smarter serialization mechanism that follows the Salesforce rules for these specific types. But for now, I believe these should be safe and cover some common scenarios.

---
_Release Notes_: 
Salesforce adapter: Extend reference coverage for reports and dashboards

---
_User Notifications_: 
Additional references in Salesforce reports and dashboards.