### PR TITLE
SALTO-1698: Refactor item instances into their parents instances

### DIFF
--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -183,7 +183,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       recurseInto: [
         {
           type: 'PageBeanFieldConfigurationIssueTypeItem',
-          toField: 'fieldConfigurationIssueTypeItems',
+          toField: 'items',
           context: [{ name: 'schemeId', fromField: 'id' }],
         },
       ],
@@ -191,7 +191,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   },
   FieldConfigurationScheme: {
     transformation: {
-      fieldTypeOverrides: [{ fieldName: 'fieldConfigurationIssueTypeItems', fieldType: 'list<FieldConfigurationIssueTypeItem>' }],
+      fieldTypeOverrides: [{ fieldName: 'items', fieldType: 'list<FieldConfigurationIssueTypeItem>' }],
     },
   },
   PageBeanFieldConfigurationIssueTypeItem: { // FieldConfigurationIssueTypeItem
@@ -238,7 +238,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       recurseInto: [
         {
           type: 'PageBeanIssueTypeSchemeMapping',
-          toField: 'issueTypeIds',
+          toField: 'issueTypes',
           context: [{ name: 'schemeId', fromField: 'id' }],
         },
       ],
@@ -246,7 +246,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   },
   IssueTypeScheme: {
     transformation: {
-      fieldTypeOverrides: [{ fieldName: 'issueTypeIds', fieldType: 'list<IssueTypeSchemeMapping>' }],
+      fieldTypeOverrides: [{ fieldName: 'issueTypes', fieldType: 'list<IssueTypeSchemeMapping>' }],
     },
   },
   PageBeanIssueTypeSchemeMapping: {
@@ -267,7 +267,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       recurseInto: [
         {
           type: 'PageBeanIssueTypeScreenSchemeItem',
-          toField: 'issueTypeScreenSchemeItems',
+          toField: 'items',
           context: [{ name: 'schemeId', fromField: 'id' }],
         },
       ],
@@ -275,7 +275,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   },
   IssueTypeScreenScheme: {
     transformation: {
-      fieldTypeOverrides: [{ fieldName: 'issueTypeScreenSchemeItems', fieldType: 'list<IssueTypeScreenSchemeItem>' }],
+      fieldTypeOverrides: [{ fieldName: 'items', fieldType: 'list<IssueTypeScreenSchemeItem>' }],
     },
   },
   PageBeanIssueTypeScreenSchemeItem: {

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -176,16 +176,33 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       paginationField: 'startAt',
     },
   },
-  PageBeanFieldConfigurationScheme: {
+  PageBeanFieldConfigurationScheme: { // FieldConfigurationScheme
     request: {
       url: '/rest/api/3/fieldconfigurationscheme',
       paginationField: 'startAt',
+      recurseInto: [
+        {
+          type: 'PageBeanFieldConfigurationIssueTypeItem',
+          toField: 'fieldConfigurationIssueTypeItems',
+          context: [{ name: 'schemeId', fromField: 'id' }],
+        },
+      ],
     },
   },
-  PageBeanFieldConfigurationIssueTypeItem: {
+  FieldConfigurationScheme: {
+    transformation: {
+      fieldTypeOverrides: [{ fieldName: 'fieldConfigurationIssueTypeItems', fieldType: 'list<FieldConfigurationIssueTypeItem>' }],
+    },
+  },
+  PageBeanFieldConfigurationIssueTypeItem: { // FieldConfigurationIssueTypeItem
     request: {
-      url: '/rest/api/3/fieldconfigurationscheme/mapping',
+      url: '/rest/api/3/fieldconfigurationscheme/mapping?fieldConfigurationSchemeId={schemeId}',
       paginationField: 'startAt',
+    },
+  },
+  FieldConfigurationIssueTypeItem: {
+    transformation: {
+      fieldsToOmit: [{ fieldName: 'fieldConfigurationSchemeId' }],
     },
   },
   PageBeanFilterDetails: {
@@ -218,24 +235,58 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     request: {
       url: '/rest/api/3/issuetypescheme',
       paginationField: 'startAt',
+      recurseInto: [
+        {
+          type: 'PageBeanIssueTypeSchemeMapping',
+          toField: 'issueTypeIds',
+          context: [{ name: 'schemeId', fromField: 'id' }],
+        },
+      ],
+    },
+  },
+  IssueTypeScheme: {
+    transformation: {
+      fieldTypeOverrides: [{ fieldName: 'issueTypeIds', fieldType: 'list<IssueTypeSchemeMapping>' }],
     },
   },
   PageBeanIssueTypeSchemeMapping: {
     request: {
-      url: '/rest/api/3/issuetypescheme/mapping',
+      url: '/rest/api/3/issuetypescheme/mapping?issueTypeSchemeId={schemeId}',
       paginationField: 'startAt',
+    },
+  },
+  IssueTypeSchemeMapping: {
+    transformation: {
+      fieldsToOmit: [{ fieldName: 'issueTypeSchemeId' }],
     },
   },
   PageBeanIssueTypeScreenScheme: {
     request: {
       url: '/rest/api/3/issuetypescreenscheme',
       paginationField: 'startAt',
+      recurseInto: [
+        {
+          type: 'PageBeanIssueTypeScreenSchemeItem',
+          toField: 'issueTypeScreenSchemeItems',
+          context: [{ name: 'schemeId', fromField: 'id' }],
+        },
+      ],
+    },
+  },
+  IssueTypeScreenScheme: {
+    transformation: {
+      fieldTypeOverrides: [{ fieldName: 'issueTypeScreenSchemeItems', fieldType: 'list<IssueTypeScreenSchemeItem>' }],
     },
   },
   PageBeanIssueTypeScreenSchemeItem: {
     request: {
-      url: '/rest/api/3/issuetypescreenscheme/mapping',
+      url: '/rest/api/3/issuetypescreenscheme/mapping?issueTypeScreenSchemeId={schemeId}',
       paginationField: 'startAt',
+    },
+  },
+  IssueTypeScreenSchemeItem: {
+    transformation: {
+      fieldsToOmit: [{ fieldName: 'issueTypeScreenSchemeId' }],
     },
   },
   PageBeanNotificationScheme: {


### PR DESCRIPTION
Added Children information to Jira Schemes

---
Some Jira schemes lacked information about their children records. This information was in a different Mapping records, that linked them both. The mapping records were removed, and instead we include the relevant children infos under their parents.

---
_Release Notes_: 
Jira Adapter:
The following Schemes include the ids of their children:
* FieldConfigurationScheme
* IssueTypeScheme
* IssueTypeScreenScheme
---
_User Notifications_:
_None_