### PR TITLE
SALTO-1759: Create config suggestion when salesforce returns sf:INVALID_TYPE

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -93,7 +93,13 @@ const isAlreadyDeletedError = (error: SfError): boolean => (
 
 export type ErrorFilter = (error: Error) => boolean
 
-const isSFDCUnhandledException = (error: Error): boolean => error.name !== 'sf:UNKNOWN_EXCEPTION'
+const NON_TRANSIENT_ERROR_TYPES = [
+  'sf:UNKNOWN_EXCEPTION',
+  'sf:INVALID_TYPE',
+]
+const isSFDCUnhandledException = (error: Error): boolean => (
+  !NON_TRANSIENT_ERROR_TYPES.includes(error.name)
+)
 
 const validateCRUDResult = (isDelete: boolean): decorators.InstanceMethodDecorator =>
   decorators.wrapMethodWith(

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -215,6 +215,20 @@ describe('salesforce client', () => {
         .toEqual({ result: [], errors: ['FakeName'] })
       expect(dodoScope.isDone()).toBeTruthy()
     })
+
+    it('should return error when response is a non transient salesforce error', async () => {
+      const dodoScope = nock(`http://dodo22/services/Soap/m/${API_VERSION}`)
+        .post(/.*/)
+        .times(1)
+        .reply(
+          500,
+          { 'a:Envelope': { 'a:Body': { 'a:Fault': { faultcode: 'sf:INVALID_TYPE', faultstring: 'INVALID_TYPE: This type of metadata is not available for this organization' } } } },
+          headers,
+        )
+      expect(await client.readMetadata('FakeType', 'FakeName'))
+        .toEqual({ result: [], errors: ['FakeName'] })
+      expect(dodoScope.isDone()).toBeTruthy()
+    })
   })
 
   describe('with suppressed errors', () => {


### PR DESCRIPTION
We see this type of error is non transient and therefore if it happens
we assume it will always happen and we should skip whatever element caused it

---

---
_Release Notes_: 
- Avoid failure on fetch due to sf:INVALID_TYPE errors

---
_User Notifications_: 
_None_
