### PR TITLE
SALTO-1765 Fix type for additional field that is inconsistent with its swagger definition

### DIFF
--- a/packages/zuora-billing-adapter/src/config.ts
+++ b/packages/zuora-billing-adapter/src/config.ts
@@ -217,6 +217,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: ZuoraApiConfig['types'] = {
     transformation: {
       fieldTypeOverrides: [
         { fieldName: 'price', fieldType: 'number' },
+        { fieldName: 'discountAmount', fieldType: 'number' },
         { fieldName: 'discountPercentage', fieldType: 'number' },
         { fieldName: 'includedUnits', fieldType: 'number' },
         { fieldName: 'overagePrice', fieldType: 'number' },


### PR DESCRIPTION
Fix another field that is listed as string but its value is actually a number.

---

_Release Notes_: 
Zuora Billing:
* Fix field types that are inconsistent between the Zuora definition and actual value

---
_User Notifications_: 
None (currently not applied to existing workspaces - see SAAS-2783)