### PR TITLE
SALTO 1642: Don't split custom fields from installed packages for SalesForce custom objects

### DIFF
--- a/packages/salesforce-adapter/jest.config.js
+++ b/packages/salesforce-adapter/jest.config.js
@@ -35,6 +35,7 @@ module.exports = deepMerge(
         statements: 95,
       },
     },
+    setupFilesAfterEnv: ["jest-extended/all"],
   },
 )
 

--- a/packages/salesforce-adapter/package.json
+++ b/packages/salesforce-adapter/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^1.7.0",
     "jest": "^26.6.3",
+    "jest-extended": "^1.2.0",
     "jest-junit": "^12.0.0",
     "jsforce-types": "https://github.com/salto-io/jsforce-types.git",
     "nock": "^12.0.1",

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -13,17 +13,30 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import 'jest-extended'
 import _ from 'lodash'
-import { ObjectType, BuiltinTypes, Element } from '@salto-io/adapter-api'
+import { BuiltinTypes, Element, ElemID, ObjectType } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/custom_object_split'
 import { CUSTOM_OBJECT_TYPE_ID } from '../../src/filters/custom_objects'
 import { FilterWith } from '../../src/filter'
-import { METADATA_TYPE, CUSTOM_OBJECT, API_NAME, SALESFORCE, INSTALLED_PACKAGES_PATH, OBJECTS_PATH } from '../../src/constants'
+import {
+  API_NAME,
+  CUSTOM_OBJECT,
+  INSTALLED_PACKAGES_PATH,
+  METADATA_TYPE,
+  OBJECTS_PATH,
+  SALESFORCE,
+} from '../../src/constants'
 
 
 describe('Custom Object Split filter', () => {
   type FilterType = FilterWith<'onFetch'>
   const filter = (): FilterType => filterCreator() as FilterType
+  const runFilter = async (...customObjects: ObjectType[]): Promise<Element[]> => {
+    const elements = [...customObjects]
+    await filter().onFetch(elements)
+    return elements
+  }
   const noNameSpaceObject = new ObjectType({
     elemID: CUSTOM_OBJECT_TYPE_ID,
     fields: {
@@ -47,7 +60,7 @@ describe('Custom Object Split filter', () => {
       [API_NAME]: 'objectRandom__c',
     },
   })
-  const withNamespaceOject = new ObjectType({
+  const namespaceObject = new ObjectType({
     elemID: CUSTOM_OBJECT_TYPE_ID,
     fields: {
       standard: {
@@ -74,10 +87,7 @@ describe('Custom Object Split filter', () => {
   describe('should split non-Namespace Custom Object to elements', () => {
     let elements: Element[]
     beforeEach(async () => {
-      elements = [noNameSpaceObject]
-      await filter().onFetch(elements)
-      expect(elements).toBeDefined()
-      expect(elements.length).toEqual(4)
+      elements = await runFilter(noNameSpaceObject)
     })
 
     it('should create annotations object', () => {
@@ -100,7 +110,7 @@ describe('Custom Object Split filter', () => {
         .isEqual(noNameSpaceObject.fields.standard)).toBeTruthy()
     })
 
-    it('should create custom fields object', () => {
+    it('should create custom fields object with all custom fields', () => {
       const customFieldsObj = elements.find(obj =>
         _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
           'CustomObject', 'CustomObjectCustomFields'])) as ObjectType
@@ -109,28 +119,16 @@ describe('Custom Object Split filter', () => {
       expect(customFieldsObj.fields.custom__c).toBeDefined()
       expect(customFieldsObj.fields.custom__c
         .isEqual(noNameSpaceObject.fields.custom__c)).toBeTruthy()
-    })
-
-    it('should create namespace custom fields object', () => {
-      const packageCustomFieldsObj = elements.find(obj =>
-        _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
-          'CustomObject', 'CustomObjectCustomFields'])) as ObjectType
-      expect(packageCustomFieldsObj).toBeDefined()
-      expect(Object.values(packageCustomFieldsObj.annotations).length).toEqual(0)
-      expect(packageCustomFieldsObj.fields.custom_namespace__c).toBeDefined()
-      expect(packageCustomFieldsObj.fields.custom_namespace__c
+      expect(customFieldsObj.fields.custom_namespace__c).toBeDefined()
+      expect(customFieldsObj.fields.custom_namespace__c
         .isEqual(noNameSpaceObject.fields.custom_namespace__c)).toBeTruthy()
     })
   })
 
-
   describe('should split namespace Custom Object to elements', () => {
     let elements: Element[]
     beforeEach(async () => {
-      elements = [withNamespaceOject]
-      await filter().onFetch(elements)
-      expect(elements).toBeDefined()
-      expect(elements.length).toEqual(3)
+      elements = await runFilter(namespaceObject)
     })
 
     it('should create annotations object inside the installed packages folder', () => {
@@ -150,7 +148,7 @@ describe('Custom Object Split filter', () => {
       expect(Object.values(standardFieldsObj.annotations).length).toEqual(0)
       expect(standardFieldsObj.fields.standard).toBeDefined()
       expect(standardFieldsObj.fields.standard
-        .isEqual(withNamespaceOject.fields.standard)).toBeTruthy()
+        .isEqual(namespaceObject.fields.standard)).toBeTruthy()
     })
 
     it('should create namespace custom fields object with all custom fields inside the installed packages folder', () => {
@@ -161,10 +159,88 @@ describe('Custom Object Split filter', () => {
       expect(Object.values(customFieldsObj.annotations).length).toEqual(0)
       expect(customFieldsObj.fields.custom_namespace__c).toBeDefined()
       expect(customFieldsObj.fields.custom_namespace__c
-        .isEqual(withNamespaceOject.fields.custom_namespace__c)).toBeTruthy()
+        .isEqual(namespaceObject.fields.custom_namespace__c)).toBeTruthy()
       expect(customFieldsObj.fields.custom__c).toBeDefined()
       expect(customFieldsObj.fields.custom__c
-        .isEqual(withNamespaceOject.fields.custom__c)).toBeTruthy()
+        .isEqual(namespaceObject.fields.custom__c)).toBeTruthy()
     })
+  })
+
+  describe('when split elements contain empty objects', () => {
+    const getSplitElementsPaths = async (...customObjects: ObjectType[]): Promise<string[][]> => {
+      const splitElements = await runFilter(...customObjects)
+      return splitElements.map(customObject => customObject.path as string[])
+    }
+
+    it('should filter out empty standard fields object', async () => {
+      const objectWithNoStandardFields = new ObjectType({
+        elemID: CUSTOM_OBJECT_TYPE_ID,
+        fields: {
+          custom__c: {
+            refType: BuiltinTypes.STRING,
+          },
+          custom_namespace__c: {
+            refType: BuiltinTypes.STRING,
+            annotations: {
+              [API_NAME]: 'objectRandom__c.namespace__random__c',
+            },
+          },
+        },
+        annotations: {
+          [METADATA_TYPE]: CUSTOM_OBJECT,
+          [API_NAME]: 'objectRandom__c',
+        },
+      })
+      const splitElementsPaths = await getSplitElementsPaths(objectWithNoStandardFields)
+      expect(splitElementsPaths).toIncludeSameMembers([
+        [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectCustomFields'],
+        [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectAnnotations'],
+      ])
+    })
+    it('should filter out empty custom fields object', async () => {
+      const objectWithNoCustomFields = new ObjectType({
+        elemID: CUSTOM_OBJECT_TYPE_ID,
+        fields: {
+          standard: {
+            refType: BuiltinTypes.STRING,
+          },
+        },
+        annotations: {
+          [METADATA_TYPE]: CUSTOM_OBJECT,
+          [API_NAME]: 'objectRandom__c',
+        },
+      })
+      const splitElementsPaths = await getSplitElementsPaths(objectWithNoCustomFields)
+      expect(splitElementsPaths).toIncludeSameMembers([
+        [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectStandardFields'],
+        [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectAnnotations'],
+      ])
+    })
+  })
+
+  it('should not split non-custom object', async () => {
+    const nonCustomObject = new ObjectType({
+      elemID: new ElemID(SALESFORCE, 'NonCustomObject'),
+      fields: {
+        standard: {
+          refType: BuiltinTypes.STRING,
+        },
+        custom__c: {
+          refType: BuiltinTypes.STRING,
+        },
+        custom_namespace__c: {
+          refType: BuiltinTypes.STRING,
+          annotations: {
+            [API_NAME]: 'objectRandom__c.namespace__random__c',
+          },
+        },
+      },
+      annotations: {
+        [METADATA_TYPE]: 'NonCustomObject',
+        [API_NAME]: 'objectRandom__c',
+      },
+    })
+    const splitElements = await runFilter(nonCustomObject)
+    expect(splitElements).toEqual([nonCustomObject])
   })
 })

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -15,6 +15,7 @@
 */
 import 'jest-extended'
 import _ from 'lodash'
+import { values } from '@salto-io/lowerdash'
 import { BuiltinTypes, Element, ElemID, ObjectType } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/custom_object_split'
 import { CUSTOM_OBJECT_TYPE_ID } from '../../src/filters/custom_objects'
@@ -167,9 +168,10 @@ describe('Custom Object Split filter', () => {
   })
 
   describe('when split elements contain empty objects', () => {
-    const getSplitElementsPaths = async (...customObjects: ObjectType[]): Promise<string[][]> => {
+    const getSplitElementsPaths = async (...customObjects: ObjectType[])
+      : Promise<(readonly string[])[]> => {
       const splitElements = await runFilter(...customObjects)
-      return splitElements.map(customObject => customObject.path as string[])
+      return splitElements.map(customObject => (customObject.path)).filter(values.isDefined)
     }
 
     it('should filter out empty standard fields object', async () => {


### PR DESCRIPTION
Custom fields for Salesforce custom objects will all be under the same file in the Objects directory.

---

Custom fields that came from installed packages for Salesforce custom objects were separated to a different file under the InstalledPackages directory. This created an unnecessary noise in the workspace, hence they're not separated anymore and instead will be under the same file.

---
_Release Notes_: 
Salesforce Adapter:
- Custom fields will all persist under the same file (depending on the namespace).
- Will no longer create `nacls` for empty Annotations, StandardFields or CustomFields objects. 

---
_User Notifications_: 
_None_