### PR TITLE
SALTO-1715: added deploy function to filter

### DIFF
--- a/packages/adapter-utils/src/filter.ts
+++ b/packages/adapter-utils/src/filter.ts
@@ -90,10 +90,10 @@ export const filtersRunner = <
     deploy: async changes => (
       awu(filtersWith('deploy')).reduce(
         async (total, current) => {
-          const res = await current.deploy(total.leftoverChanges)
+          const { deployResult, leftoverChanges } = await current.deploy(total.leftoverChanges)
           return {
-            deployResult: concatObjects([total.deployResult, res.deployResult]),
-            leftoverChanges: res.leftoverChanges,
+            deployResult: concatObjects([total.deployResult, deployResult]),
+            leftoverChanges,
           }
         },
         {

--- a/packages/lowerdash/src/objects.ts
+++ b/packages/lowerdash/src/objects.ts
@@ -16,9 +16,11 @@
 import _ from 'lodash'
 import { isDefined } from './values'
 
-export const concatObjects = <T extends Record<string, unknown[] | undefined>>(objects: T[]): T => (
+export const concatObjects = <
+  T extends Record<string, ReadonlyArray<unknown> | unknown[] | undefined>
+>(objects: T[]): T => (
   _.mapValues(
     _.groupBy(objects.flatMap(Object.entries), ([key]) => key),
     lists => lists.map(([_key, list]) => list).filter(isDefined).flat()
   ) as T
-)
+  )

--- a/packages/lowerdash/test/collections/asynciterable.test.ts
+++ b/packages/lowerdash/test/collections/asynciterable.test.ts
@@ -539,6 +539,16 @@ describe('asynciterable', () => {
         })
       })
     })
+
+    describe('reduce', () => {
+      it('should return the reduced value', async () => {
+        const res = await awu([1, 2, 3]).reduce(
+          async (total, current, index) => total + current + index,
+          0,
+        )
+        expect(res).toEqual(9)
+      })
+    })
   })
 
   describe('handleErrorsAsync', () => {

--- a/packages/salesforce-adapter/test/filters/filters.test.ts
+++ b/packages/salesforce-adapter/test/filters/filters.test.ts
@@ -25,7 +25,7 @@ import { mockTypes } from '../mock_elements'
 describe('SalesforceAdapter filters', () => {
   describe('when filter methods are implemented', () => {
     let adapter: SalesforceAdapter
-    let filter: MockInterface<FilterWith<'onFetch' | 'onDeploy' | 'preDeploy' | 'onPostFetch'>>
+    let filter: MockInterface<FilterWith<'onFetch' | 'onDeploy' | 'deploy' | 'preDeploy' | 'onPostFetch'>>
     let filterCreator: jest.MockedFunction<FilterCreator>
     let connection: ReturnType<typeof mockAdapter>['connection']
     const mockFetchOpts: MockInterface<FetchOptions> = {
@@ -36,6 +36,7 @@ describe('SalesforceAdapter filters', () => {
       filter = {
         onFetch: mockFunction<(typeof filter)['onFetch']>().mockResolvedValue(),
         preDeploy: mockFunction<(typeof filter)['preDeploy']>().mockResolvedValue(),
+        deploy: mockFunction<(typeof filter)['deploy']>(),
         onDeploy: mockFunction<(typeof filter)['onDeploy']>().mockResolvedValue(),
         onPostFetch: mockFunction<(typeof filter)['onPostFetch']>().mockResolvedValue(),
       }


### PR DESCRIPTION
Added a deploy function to filter to allow deploying changes through filters for the simple adapters deployment 

---
_Release Notes_: 
None

---
_User Notifications_: 
None