### PR TITLE
expose get nacl file envs (SALTO-1768)

### DIFF
--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -418,6 +418,7 @@ export const mockWorkspace = ({
     getSearchableNamesOfEnv: mockFunction<Workspace['getSearchableNamesOfEnv']>(),
     listUnresolvedReferences: mockFunction<Workspace['listUnresolvedReferences']>(),
     getElementSourceOfPath: mockFunction<Workspace['getElementSourceOfPath']>(),
+    getFileEnvs: mockFunction<Workspace['getFileEnvs']>(),
   }
 }
 

--- a/packages/core/src/local-workspace/adapters_config.ts
+++ b/packages/core/src/local-workspace/adapters_config.ts
@@ -17,7 +17,7 @@
 import path from 'path'
 import { nacl, staticFiles, adaptersConfigSource as acs, remoteMap } from '@salto-io/workspace'
 import { DetailedChange, ObjectType } from '@salto-io/adapter-api'
-import { localDirectoryStore } from './dir_store'
+import { localDirectoryStore, createExtensionFileFilter } from './dir_store'
 import { buildLocalStaticFilesCache } from './static_files_cache'
 
 const createNaclSource = async (
@@ -29,7 +29,7 @@ const createNaclSource = async (
   const naclFilesStore = localDirectoryStore({
     baseDir,
     accessiblePath: path.join(...acs.CONFIG_PATH),
-    fileFilter: `*${nacl.FILE_EXTENSION}`,
+    fileFilter: createExtensionFileFilter(nacl.FILE_EXTENSION),
     encoding: 'utf8',
   })
 

--- a/packages/core/src/local-workspace/dir_store.ts
+++ b/packages/core/src/local-workspace/dir_store.ts
@@ -44,7 +44,7 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
   accessiblePath = '',
   encoding?: BufferEncoding,
   fileFilter?: FilePathFilter,
-  directoryFilter?: (path: string) => boolean,
+  directoryFilter?: FilePathFilter,
   initUpdated?: FileMap<T>,
   initDeleted? : string[],
 ): dirStore.SyncDirectoryStore<T> => {
@@ -306,8 +306,8 @@ type LocalDirectoryStoreParams = {
   nameSuffix?: string
   accessiblePath?: string
   encoding?: 'utf8'
-  fileFilter?: (path: string) => boolean
-  directoryFilter?: (path: string) => boolean
+  fileFilter?: FilePathFilter
+  directoryFilter?: FilePathFilter
 }
 
 export function localDirectoryStore(params: Omit<LocalDirectoryStoreParams, 'encoding'>):

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -20,9 +20,10 @@ import { DetailedChange, ObjectType } from '@salto-io/adapter-api'
 import { exists, isEmptyDir, rm } from '@salto-io/file'
 import { Workspace, loadWorkspace, EnvironmentsSources, initWorkspace, nacl, remoteMap,
   configSource as cs, staticFiles, dirStore, WorkspaceComponents, errors, elementSource,
-  COMMON_ENV_PREFIX, isValidEnvName, EnvironmentSource, EnvConfig, adaptersConfigSource } from '@salto-io/workspace'
+  COMMON_ENV_PREFIX, isValidEnvName, EnvironmentSource, EnvConfig, adaptersConfigSource
+} from '@salto-io/workspace'
+import { localDirectoryStore, createExtensionFileFilter } from './dir_store'
 import { collections } from '@salto-io/lowerdash'
-import { localDirectoryStore } from './dir_store'
 import { CONFIG_DIR_NAME, getConfigDir, getLocalStoragePath } from '../app_config'
 import { localState } from './state'
 import { workspaceConfigSource } from './workspace_config'
@@ -75,7 +76,7 @@ export const getNaclFilesSourceParams = (
     baseDir: sourceBaseDir,
     name,
     encoding: 'utf8',
-    fileFilter: `*${FILE_EXTENSION}`,
+    fileFilter: createExtensionFileFilter(FILE_EXTENSION),
     directoryFilter: dirPathToIgnore,
   })
 

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -20,10 +20,9 @@ import { DetailedChange, ObjectType } from '@salto-io/adapter-api'
 import { exists, isEmptyDir, rm } from '@salto-io/file'
 import { Workspace, loadWorkspace, EnvironmentsSources, initWorkspace, nacl, remoteMap,
   configSource as cs, staticFiles, dirStore, WorkspaceComponents, errors, elementSource,
-  COMMON_ENV_PREFIX, isValidEnvName, EnvironmentSource, EnvConfig, adaptersConfigSource
-} from '@salto-io/workspace'
-import { localDirectoryStore, createExtensionFileFilter } from './dir_store'
+  COMMON_ENV_PREFIX, isValidEnvName, EnvironmentSource, EnvConfig, adaptersConfigSource } from '@salto-io/workspace'
 import { collections } from '@salto-io/lowerdash'
+import { localDirectoryStore, createExtensionFileFilter } from './dir_store'
 import { CONFIG_DIR_NAME, getConfigDir, getLocalStoragePath } from '../app_config'
 import { localState } from './state'
 import { workspaceConfigSource } from './workspace_config'

--- a/packages/core/test/common/nacl_file_source.ts
+++ b/packages/core/test/common/nacl_file_source.ts
@@ -47,6 +47,6 @@ export const createMockNaclFileSource = (): MockInterface<nacl.NaclFilesSource> 
   load: mockFunction<nacl.NaclFilesSource['load']>(),
   getSearchableNames: mockFunction<nacl.NaclFilesSource['getSearchableNames']>(),
   getStaticFile: mockFunction<nacl.NaclFilesSource['getStaticFile']>(),
-  doesIncludePath: mockFunction<nacl.NaclFilesSource['doesIncludePath']>(),
+  isPathIncluded: mockFunction<nacl.NaclFilesSource['isPathIncluded']>(),
 
 })

--- a/packages/core/test/common/nacl_file_source.ts
+++ b/packages/core/test/common/nacl_file_source.ts
@@ -47,4 +47,6 @@ export const createMockNaclFileSource = (): MockInterface<nacl.NaclFilesSource> 
   load: mockFunction<nacl.NaclFilesSource['load']>(),
   getSearchableNames: mockFunction<nacl.NaclFilesSource['getSearchableNames']>(),
   getStaticFile: mockFunction<nacl.NaclFilesSource['getStaticFile']>(),
+  doesIncludePath: mockFunction<nacl.NaclFilesSource['doesIncludePath']>(),
+
 })

--- a/packages/core/test/workspace/local/adapters_config.test.ts
+++ b/packages/core/test/workspace/local/adapters_config.test.ts
@@ -15,7 +15,7 @@
 */
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import { nacl, remoteMap, validator } from '@salto-io/workspace'
-import { localDirectoryStore } from '../../../src/local-workspace/dir_store'
+import { localDirectoryStore, createExtensionFileFilter } from '../../../src/local-workspace/dir_store'
 import { buildLocalAdaptersConfigSource } from '../../../src/local-workspace/adapters_config'
 import { createMockNaclFileSource } from '../../common/nacl_file_source'
 
@@ -71,9 +71,9 @@ describe('adapters local config', () => {
       expect(localDirectoryStore).toHaveBeenCalledWith({
         baseDir: 'baseDir',
         accessiblePath: 'salto.config/adapters',
-        fileFilter: '*.nacl',
         encoding: 'utf8',
       })
+      expect(createExtensionFileFilter).toHaveBeenCalledWith('.nacl')
     })
   })
 })

--- a/packages/core/test/workspace/local/directory_store.test.ts
+++ b/packages/core/test/workspace/local/directory_store.test.ts
@@ -417,7 +417,7 @@ describe('localDirectoryStore', () => {
     })
   })
 
-  describe('doesIncludePath', () => {
+  describe('isPathIncluded', () => {
     const baseDir = '/base'
     const fileFilter = (filePath: string): boolean => path.extname(filePath) === '.nacl'
     const directoryFilter = (filePath: string): boolean => (
@@ -426,16 +426,16 @@ describe('localDirectoryStore', () => {
     const naclFileStore = localDirectoryStore({ baseDir, encoding, fileFilter, directoryFilter })
 
     it('should return true for file which are in the path and passes both the directory and file filters', () => {
-      expect(naclFileStore.doesIncludePath(path.resolve(baseDir, 'sup.nacl'))).toBeTruthy()
+      expect(naclFileStore.isPathIncluded(path.resolve(baseDir, 'sup.nacl'))).toBeTruthy()
     })
     it('should return false for file which are in the path and do not path the files filter', () => {
-      expect(naclFileStore.doesIncludePath(path.resolve(baseDir, 'sup.exe'))).toBeFalsy()
+      expect(naclFileStore.isPathIncluded(path.resolve(baseDir, 'sup.exe'))).toBeFalsy()
     })
     it('should return false for file which are in the path and do not path the directory filter', () => {
-      expect(naclFileStore.doesIncludePath(path.resolve(baseDir, 'exclude', 'sup.nacl'))).toBeFalsy()
+      expect(naclFileStore.isPathIncluded(path.resolve(baseDir, 'exclude', 'sup.nacl'))).toBeFalsy()
     })
     it('should return false for files which are not in the path', () => {
-      expect(naclFileStore.doesIncludePath(path.resolve('/nope', 'sup.nacl'))).toBeFalsy()
+      expect(naclFileStore.isPathIncluded(path.resolve('/nope', 'sup.nacl'))).toBeFalsy()
     })
   })
 })

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -77,6 +77,7 @@ dirStore.SyncDirectoryStore<T> => {
     isEmpty: mockFunction<dirStore.SyncDirectoryStore<T>['isEmpty']>(),
     getFullPath: mockFunction<dirStore.SyncDirectoryStore<T>['getFullPath']>().mockImplementation(filepath => `full-${filepath}`),
     getSync: mockFunction<dirStore.SyncDirectoryStore<T>['getSync']>(),
+    doesIncludePath: mockFunction<dirStore.SyncDirectoryStore<T>['doesIncludePath']>(),
   }
 }
 

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -77,7 +77,7 @@ dirStore.SyncDirectoryStore<T> => {
     isEmpty: mockFunction<dirStore.SyncDirectoryStore<T>['isEmpty']>(),
     getFullPath: mockFunction<dirStore.SyncDirectoryStore<T>['getFullPath']>().mockImplementation(filepath => `full-${filepath}`),
     getSync: mockFunction<dirStore.SyncDirectoryStore<T>['getSync']>(),
-    doesIncludePath: mockFunction<dirStore.SyncDirectoryStore<T>['doesIncludePath']>(),
+    isPathIncluded: mockFunction<dirStore.SyncDirectoryStore<T>['isPathIncluded']>(),
   }
 }
 

--- a/packages/workspace/src/workspace/dir_store.ts
+++ b/packages/workspace/src/workspace/dir_store.ts
@@ -36,6 +36,7 @@ export type DirectoryStore<T extends ContentType> = {
   clone(): DirectoryStore<T>
   isEmpty(): Promise<boolean>
   getFullPath(filename: string): string
+  doesIncludePath(filePath: string): boolean
 }
 
 export type SyncDirectoryStore<T extends ContentType> = DirectoryStore<T> & {

--- a/packages/workspace/src/workspace/dir_store.ts
+++ b/packages/workspace/src/workspace/dir_store.ts
@@ -36,7 +36,7 @@ export type DirectoryStore<T extends ContentType> = {
   clone(): DirectoryStore<T>
   isEmpty(): Promise<boolean>
   getFullPath(filename: string): string
-  doesIncludePath(filePath: string): boolean
+  isPathIncluded(filePath: string): boolean
 }
 
 export type SyncDirectoryStore<T extends ContentType> = DirectoryStore<T> & {

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -144,6 +144,7 @@ export type MultiEnvSource = {
   getSearchableNamesOfEnv: (env: string) => Promise<string[]>
   flush: () => Promise<void>
   rename: (name: string) => Promise<void>
+  getFileEnvs: (filePath: string) => {envName: string; isStatic?: boolean}[]
 }
 
 const buildMultiEnvSource = (
@@ -568,6 +569,18 @@ const buildMultiEnvSource = (
     }))
   }
 
+  const getFileEnvs = (filePath: string): {envName: string; isStatic?: boolean}[] => {
+    const source = getSourceForNaclFile(filePath)
+    const envPrefix = getSourceNameForNaclFile(filePath)
+    const { included, isStatic } = source.source.doesIncludePath(source.relPath)
+    if (!included) {
+      return []
+    }
+    return envPrefix === commonSourceName
+      ? Object.keys(envSources()).map(envName => ({ envName, isStatic }))
+      : [{ envName: envPrefix, isStatic }]
+  }
+
   return {
     getNaclFile,
     updateNaclFiles,
@@ -684,6 +697,7 @@ const buildMultiEnvSource = (
       return naclSource === undefined ? [] : naclSource.getSearchableNames()
     },
     getStaticFile,
+    getFileEnvs,
   }
 }
 

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -93,6 +93,7 @@ export type NaclFilesSource<Changes=ChangeSet<Change>> = Omit<ElementsSource, 'c
     filePath: string,
     encoding: BufferEncoding,
   ) => Promise<StaticFile | undefined>
+  doesIncludePath: (filePath: string) => {included: boolean; isStatic?: boolean}
 }
 
 type NaclFilesState = {
@@ -945,6 +946,16 @@ const buildNaclFilesSource = (
       }
       return undefined
     },
+    doesIncludePath: filePath => {
+      if (naclFilesStore.doesIncludePath(filePath)) {
+        return { included: true, isStatic: false }
+      }
+      if (staticFilesSource.doesIncludePath(filePath)) {
+        return { included: true, isStatic: true }
+      }
+      return { included: false }
+    },
+
   }
 }
 

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -93,7 +93,7 @@ export type NaclFilesSource<Changes=ChangeSet<Change>> = Omit<ElementsSource, 'c
     filePath: string,
     encoding: BufferEncoding,
   ) => Promise<StaticFile | undefined>
-  doesIncludePath: (filePath: string) => {included: boolean; isStatic?: boolean}
+  isPathIncluded: (filePath: string) => {included: boolean; isNacl?: boolean}
 }
 
 type NaclFilesState = {
@@ -946,12 +946,12 @@ const buildNaclFilesSource = (
       }
       return undefined
     },
-    doesIncludePath: filePath => {
-      if (naclFilesStore.doesIncludePath(filePath)) {
-        return { included: true, isStatic: false }
+    isPathIncluded: filePath => {
+      if (naclFilesStore.isPathIncluded(filePath)) {
+        return { included: true, isNacl: true }
       }
-      if (staticFilesSource.doesIncludePath(filePath)) {
-        return { included: true, isStatic: true }
+      if (staticFilesSource.isPathIncluded(filePath)) {
+        return { included: true, isNacl: false }
       }
       return { included: false }
     },

--- a/packages/workspace/src/workspace/static_files/common.ts
+++ b/packages/workspace/src/workspace/static_files/common.ts
@@ -33,6 +33,7 @@ export type StaticFilesSource = {
   getTotalSize: () => Promise<number>
   clone: () => StaticFilesSource
   delete: (staticFile: StaticFile) => Promise<void>
+  doesIncludePath: (path: string) => boolean
 }
 
 export class MissingStaticFile extends InvalidStaticFile {

--- a/packages/workspace/src/workspace/static_files/common.ts
+++ b/packages/workspace/src/workspace/static_files/common.ts
@@ -33,7 +33,7 @@ export type StaticFilesSource = {
   getTotalSize: () => Promise<number>
   clone: () => StaticFilesSource
   delete: (staticFile: StaticFile) => Promise<void>
-  doesIncludePath: (path: string) => boolean
+  isPathIncluded: (path: string) => boolean
 }
 
 export class MissingStaticFile extends InvalidStaticFile {

--- a/packages/workspace/src/workspace/static_files/source.ts
+++ b/packages/workspace/src/workspace/static_files/source.ts
@@ -149,6 +149,7 @@ export const buildStaticFilesSource = (
     delete: async (staticFile: StaticFile): Promise<void> => (
       staticFilesDirStore.delete(staticFile.filepath)
     ),
+    doesIncludePath: filePath => staticFilesSource.doesIncludePath(filePath),
   }
   return staticFilesSource
 }

--- a/packages/workspace/src/workspace/static_files/source.ts
+++ b/packages/workspace/src/workspace/static_files/source.ts
@@ -149,7 +149,7 @@ export const buildStaticFilesSource = (
     delete: async (staticFile: StaticFile): Promise<void> => (
       staticFilesDirStore.delete(staticFile.filepath)
     ),
-    doesIncludePath: filePath => staticFilesSource.doesIncludePath(filePath),
+    isPathIncluded: filePath => staticFilesSource.isPathIncluded(filePath),
   }
   return staticFilesSource
 }

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -236,6 +236,7 @@ export type Workspace = {
   getSearchableNamesOfEnv(env?: string): Promise<string[]>
   listUnresolvedReferences(completeFromEnv?: string): Promise<UnresolvedElemIDs>
   getElementSourceOfPath(filePath: string, includeHidden?: boolean): Promise<ReadOnlyElementsSource>
+  getFileEnvs(filePath: string): {envName: string; isStatic?: boolean}[]
 }
 
 type SingleState = {
@@ -1275,6 +1276,7 @@ export const loadWorkspace = async (
         ? adaptersConfig.getElements()
         : elementsImpl(includeHidden)
     ),
+    getFileEnvs: filePath => naclFilesSource.getFileEnvs(filePath),
   }
 }
 

--- a/packages/workspace/test/common/nacl_file_source.ts
+++ b/packages/workspace/test/common/nacl_file_source.ts
@@ -116,7 +116,7 @@ export const createMockNaclFileSource = (
         ? sfile
         : undefined
     }),
-    doesIncludePath: mockFunction<NaclFilesSource['doesIncludePath']>().mockImplementation(filePath => ({
+    isPathIncluded: mockFunction<NaclFilesSource['isPathIncluded']>().mockImplementation(filePath => ({
       included: naclFiles[filePath] !== undefined,
     })),
 

--- a/packages/workspace/test/common/nacl_file_source.ts
+++ b/packages/workspace/test/common/nacl_file_source.ts
@@ -116,5 +116,9 @@ export const createMockNaclFileSource = (
         ? sfile
         : undefined
     }),
+    doesIncludePath: mockFunction<NaclFilesSource['doesIncludePath']>().mockImplementation(filePath => ({
+      included: naclFiles[filePath] !== undefined,
+    })),
+
   })
 }

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -299,6 +299,7 @@ export const mockDirStore = (
     getTotalSize: jest.fn(),
     clone: () => mockDirStore(exclude),
     getFullPath: filename => filename,
+    doesIncludePath: jest.fn().mockResolvedValue(true),
   }
 }
 

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -299,7 +299,7 @@ export const mockDirStore = (
     getTotalSize: jest.fn(),
     clone: () => mockDirStore(exclude),
     getFullPath: filename => filename,
-    doesIncludePath: jest.fn().mockResolvedValue(true),
+    isPathIncluded: jest.fn().mockResolvedValue(true),
   }
 }
 

--- a/packages/workspace/test/utils.ts
+++ b/packages/workspace/test/utils.ts
@@ -76,7 +76,7 @@ export const mockStaticFilesSource = (staticFiles: StaticFile[] = []): StaticFil
   getTotalSize: jest.fn(),
   clear: jest.fn(),
   delete: jest.fn(),
-  doesIncludePath: jest.fn().mockImplementation(
+  isPathIncluded: jest.fn().mockImplementation(
     filePath => staticFiles.find(f => f.filepath === filePath) !== undefined
   ),
 })

--- a/packages/workspace/test/utils.ts
+++ b/packages/workspace/test/utils.ts
@@ -76,6 +76,9 @@ export const mockStaticFilesSource = (staticFiles: StaticFile[] = []): StaticFil
   getTotalSize: jest.fn(),
   clear: jest.fn(),
   delete: jest.fn(),
+  doesIncludePath: jest.fn().mockImplementation(
+    filePath => staticFiles.find(f => f.filepath === filePath) !== undefined
+  ),
 })
 
 export const persistentMockCreateRemoteMap = (): RemoteMapCreator => {

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -1110,4 +1110,23 @@ describe('multi env source', () => {
       expect(postClearElements).toEqual([])
     })
   })
+
+  describe('getFileEnvs', () => {
+    const src = multiEnvSource(
+      sources,
+      commonPrefix,
+      () => Promise.resolve(new InMemoryRemoteMap()),
+      false
+    )
+
+    it('should return a single env when the file is included in the env source', () => {
+      expect(src.getFileEnvs('envs/active/env.nacl')).toEqual([{ envName: 'active' }])
+    })
+    it('should return all envs if the file is included in the common source', () => {
+      expect(src.getFileEnvs('common.nacl')).toEqual([{ envName: 'active' }, { envName: 'inactive' }])
+    })
+    it('should return an empty array if the file is not included in any env', () => {
+      expect(src.getFileEnvs('envs/active/not_a_file.nacl')).toEqual([])
+    })
+  })
 })

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
@@ -49,6 +49,7 @@ describe('Nacl Files Source', () => {
       getTotalSize: () => Promise.resolve(0),
       clone: () => mockDirStore,
       getFullPath: filename => filename,
+      doesIncludePath: jest.fn().mockResolvedValue(true),
     }
     mockedStaticFilesSource = mockStaticFilesSource()
   })

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
@@ -49,7 +49,7 @@ describe('Nacl Files Source', () => {
       getTotalSize: () => Promise.resolve(0),
       clone: () => mockDirStore,
       getFullPath: filename => filename,
-      doesIncludePath: jest.fn().mockResolvedValue(true),
+      isPathIncluded: jest.fn().mockResolvedValue(true),
     }
     mockedStaticFilesSource = mockStaticFilesSource()
   })

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -128,7 +128,7 @@ describe('Nacl Files Source', () => {
       getTotalSize: () => Promise.resolve(0),
       clone: () => mockDirStore,
       getFullPath: filename => filename,
-      doesIncludePath: jest.fn(),
+      isPathIncluded: jest.fn(),
     }
     mockedStaticFilesSource = mockStaticFilesSource()
     mockCache = createParseResultCache(
@@ -529,7 +529,7 @@ describe('Nacl Files Source', () => {
     })
   })
 
-  describe('doesIncludePath', () => {
+  describe('isPathIncluded', () => {
     let src: NaclFilesSource
     const staticFileSource = mockStaticFilesSource([
       new StaticFile({
@@ -548,24 +548,24 @@ describe('Nacl Files Source', () => {
       )
     })
     it('should mark a path of a nacl file as included', () => {
-      (mockDirStore.doesIncludePath as jest.Mock).mockReturnValue(true)
-      expect(src.doesIncludePath('whateves.nacl')).toEqual({
+      (mockDirStore.isPathIncluded as jest.Mock).mockReturnValue(true)
+      expect(src.isPathIncluded('whateves.nacl')).toEqual({
         included: true,
-        isStatic: false,
+        isNacl: true,
       })
     })
 
     it('should mark a static file as included', () => {
-      (mockDirStore.doesIncludePath as jest.Mock).mockReturnValue(false)
-      expect(src.doesIncludePath('static-files/fff.txt')).toEqual({
+      (mockDirStore.isPathIncluded as jest.Mock).mockReturnValue(false)
+      expect(src.isPathIncluded('static-files/fff.txt')).toEqual({
         included: true,
-        isStatic: true,
+        isNacl: false,
       })
     })
 
     it('should mark a missing file as not included', () => {
-      (mockDirStore.doesIncludePath as jest.Mock).mockReturnValue(false)
-      expect(src.doesIncludePath('whateves.nacl')).toEqual({
+      (mockDirStore.isPathIncluded as jest.Mock).mockReturnValue(false)
+      expect(src.isPathIncluded('whateves.nacl')).toEqual({
         included: false,
       })
     })

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -128,6 +128,7 @@ describe('Nacl Files Source', () => {
       getTotalSize: () => Promise.resolve(0),
       clone: () => mockDirStore,
       getFullPath: filename => filename,
+      doesIncludePath: jest.fn(),
     }
     mockedStaticFilesSource = mockStaticFilesSource()
     mockCache = createParseResultCache(
@@ -525,6 +526,48 @@ describe('Nacl Files Source', () => {
       expect(await src.getStaticFile(
         staticFile.filepath, staticFile.encoding
       )).toEqual(staticFile)
+    })
+  })
+
+  describe('doesIncludePath', () => {
+    let src: NaclFilesSource
+    const staticFileSource = mockStaticFilesSource([
+      new StaticFile({
+        content: Buffer.from('FFF'),
+        filepath: 'static-files/fff.txt',
+        hash: '###',
+      }),
+    ])
+    beforeEach(async () => {
+      src = await naclFilesSource(
+        '',
+        mockDirStore,
+        staticFileSource,
+        () => Promise.resolve(new InMemoryRemoteMap()),
+        false
+      )
+    })
+    it('should mark a path of a nacl file as included', () => {
+      (mockDirStore.doesIncludePath as jest.Mock).mockReturnValue(true)
+      expect(src.doesIncludePath('whateves.nacl')).toEqual({
+        included: true,
+        isStatic: false,
+      })
+    })
+
+    it('should mark a static file as included', () => {
+      (mockDirStore.doesIncludePath as jest.Mock).mockReturnValue(false)
+      expect(src.doesIncludePath('static-files/fff.txt')).toEqual({
+        included: true,
+        isStatic: true,
+      })
+    })
+
+    it('should mark a missing file as not included', () => {
+      (mockDirStore.doesIncludePath as jest.Mock).mockReturnValue(false)
+      expect(src.doesIncludePath('whateves.nacl')).toEqual({
+        included: false,
+      })
     })
   })
 })

--- a/packages/workspace/test/workspace/static_files/source.test.ts
+++ b/packages/workspace/test/workspace/static_files/source.test.ts
@@ -58,7 +58,7 @@ describe('Static Files', () => {
         clone: () => mockDirStore,
         getSync: jest.fn(),
         getFullPath: filename => filename,
-        doesIncludePath: jest.fn().mockResolvedValue(true),
+        isPathIncluded: jest.fn().mockResolvedValue(true),
       }
       staticFilesSource = buildStaticFilesSource(
         mockDirStore,

--- a/packages/workspace/test/workspace/static_files/source.test.ts
+++ b/packages/workspace/test/workspace/static_files/source.test.ts
@@ -58,6 +58,7 @@ describe('Static Files', () => {
         clone: () => mockDirStore,
         getSync: jest.fn(),
         getFullPath: filename => filename,
+        doesIncludePath: jest.fn().mockResolvedValue(true),
       }
       staticFilesSource = buildStaticFilesSource(
         mockDirStore,


### PR DESCRIPTION
_Exposes a function that will tell which env a specific path belongs to_

---
---
_Release Notes_: 
_Exposed a method that, provided with a path, returns which environments contains the file, and if it is a static file_

---
_User Notifications_: 
_NA._
