### PR TITLE
SALTO-1684 Add support in singleton types in ducktype

### DIFF
--- a/packages/adapter-components/src/config/ducktype.ts
+++ b/packages/adapter-components/src/config/ducktype.ts
@@ -75,18 +75,13 @@ export const validateApiDefinitionConfig = (
       isDefined,
     ),
   )
-  const configMap = _.pickBy(
-    _.mapValues(adapterApiConfig.types, typeDef => typeDef.transformation),
-    isDefined,
-  )
-  // TODO: remove this check once singleton types are implemented in ducktype
-  if (Object.values(configMap).some(def => def.isSingleton !== undefined)) {
-    throw new Error('transformation.isSingleton flag is not supported in this adapter')
-  }
   validateTransoformationConfig(
     apiDefinitionConfigPath,
     adapterApiConfig.typeDefaults.transformation,
-    configMap,
+    _.pickBy(
+      _.mapValues(adapterApiConfig.types, typeDef => typeDef.transformation),
+      isDefined,
+    ),
   )
 }
 

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -135,6 +135,11 @@ export const getTypeAndInstances = async ({
     })].filter(isDefined)
   }).toArray()
 
+  if (type.isSettings && instances.length > 1) {
+    log.warn(`Expected one instance for singleton type: ${type.elemID.name} but received: ${instances.length}`)
+    throw new Error(`Could not fetch type ${type.elemID.name}, singleton types should not have more than one instance`)
+  }
+
   const elements = [type, ...nestedTypes, ...instances]
 
   await extractStandaloneFields({

--- a/packages/adapter-components/src/elements/ducktype/type_elements.ts
+++ b/packages/adapter-components/src/elements/ducktype/type_elements.ts
@@ -237,6 +237,7 @@ export const generateType = ({
     elemID: new ElemID(adapterName, naclName),
     fields,
     path,
+    isSettings: transformationConfigByType[naclName]?.isSingleton ?? false,
   })
 
   return { type, nestedTypes }

--- a/packages/adapter-components/test/config/ducktype.test.ts
+++ b/packages/adapter-components/test/config/ducktype.test.ts
@@ -142,32 +142,6 @@ describe('config_ducktype', () => {
         },
       )).toThrow(new Error('Duplicate fieldsToOmit params found in PATH for the following types: abc'))
     })
-    // TODO: remove this test once singleton types are implemented in ducktype
-    it('should throw if isSingleton flag is on', () => {
-      expect(() => validateDuckTypeApiDefinitionConfig(
-        'PATH',
-        {
-          typeDefaults: {
-            transformation: {
-              idFields: ['a', 'b'],
-            },
-          },
-          types: {
-            abc: {
-              transformation: {
-                idFields: ['something', 'else'],
-              },
-            },
-            aaa: {
-              transformation: {
-                idFields: ['something'],
-                isSingleton: true,
-              },
-            },
-          },
-        },
-      )).toThrow(new Error('transformation.isSingleton flag is not supported in this adapter'))
-    })
   })
 
   describe('validateFetchConfig', () => {

--- a/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
@@ -557,6 +557,60 @@ describe('ducktype_type_elements', () => {
       expect(nestedTypes).toHaveLength(0)
       expect(type.path).toEqual([ADAPTER_NAME, TYPES_PATH, SUBTYPES_PATH, 'parent_type', 'subtypeName'])
     })
+    it('should mark singleton types as isSettings=true', () => {
+      const entries = [
+        {
+          id: 41619,
+          api_collection_id: 11815,
+          flow_id: 1381119,
+          flow_ids: [1381119, 1382229],
+          name: 'ab321',
+          method: 'GET',
+          url: 'https://some.url.com/a/bbb/user/{id}',
+          legacy_url: null,
+          base_path: '/a/bbb/user/{id}',
+          path: 'user/{id}',
+          active: false,
+          legacy: false,
+          created_at: '2020-12-21T16:08:03.762-08:00',
+          updated_at: '2020-12-21T16:08:03.762-08:00',
+        },
+      ]
+      const { type, nestedTypes } = generateType({
+        adapterName: ADAPTER_NAME,
+        name: 'typeName',
+        entries,
+        hasDynamicFields: false,
+        isSubType: false,
+        transformationConfigByType: {
+          typeName: {
+            isSingleton: true,
+          },
+        },
+        transformationDefaultConfig: { idFields: [] },
+      })
+      expect(type.isEqual(new ObjectType({
+        elemID: new ElemID(ADAPTER_NAME, 'typeName'),
+        fields: {
+          id: { refType: BuiltinTypes.NUMBER },
+          api_collection_id: { refType: BuiltinTypes.NUMBER },
+          flow_id: { refType: BuiltinTypes.NUMBER },
+          flow_ids: { refType: new ListType(BuiltinTypes.NUMBER) },
+          name: { refType: BuiltinTypes.STRING },
+          method: { refType: BuiltinTypes.STRING },
+          url: { refType: BuiltinTypes.STRING },
+          legacy_url: { refType: BuiltinTypes.UNKNOWN },
+          base_path: { refType: BuiltinTypes.STRING },
+          path: { refType: BuiltinTypes.STRING },
+          active: { refType: BuiltinTypes.BOOLEAN },
+          legacy: { refType: BuiltinTypes.BOOLEAN },
+          created_at: { refType: BuiltinTypes.STRING },
+          updated_at: { refType: BuiltinTypes.STRING },
+        },
+        isSettings: true,
+      }))).toBeTruthy()
+      expect(nestedTypes).toHaveLength(0)
+    })
   })
 
   describe('toNestedTypeName', () => {


### PR DESCRIPTION
Support marking types as "singleton" types for ducktype based simple-adapters.

---

_Additional context for reviewer_
Following the [previous pr](https://github.com/salto-io/salto/pull/2502), this pr adds support in "singleton" type for ducktype adapters.

---
_Release Notes_: 
Support marking types as "singleton" types, for types that have only one instance

