### PR TITLE
SALTO-1764: Enable purgeOnDelete for salesforce e2e tests

### DIFF
--- a/packages/cli/e2e_test/helpers/salesforce.ts
+++ b/packages/cli/e2e_test/helpers/salesforce.ts
@@ -93,6 +93,14 @@ export const getSalesforceOAuthCreds = (creds: OauthAccessTokenCredentials): Ins
   )
 }
 
+export const getSalesforceClient = (credentials: UsernamePasswordCredentials): SalesforceClient => (
+  new SalesforceClient({
+    credentials: new UsernamePasswordCredentials(credentials),
+    // Default to purge on delete to avoid leaving definitions in the recycle bin
+    config: { deploy: { purgeOnDelete: true } },
+  })
+)
+
 export const addElements = async <T extends InstanceElement | ObjectType>(
   client: SalesforceClient,
   elements: T[]

--- a/packages/cli/e2e_test/multi_env.test.ts
+++ b/packages/cli/e2e_test/multi_env.test.ts
@@ -22,7 +22,7 @@ import tmp from 'tmp-promise'
 import { writeFile, rm } from '@salto-io/file'
 import { isObjectType, ObjectType, Element, isInstanceElement } from '@salto-io/adapter-api'
 import { CredsLease } from '@salto-io/e2e-credentials-store'
-import { addElements, objectExists, naclNameToSFName, instanceExists, removeElements, getSalesforceCredsInstance } from './helpers/salesforce'
+import { addElements, objectExists, naclNameToSFName, instanceExists, removeElements, getSalesforceCredsInstance, getSalesforceClient } from './helpers/salesforce'
 import * as callbacks from '../src/callbacks'
 import {
   runInit,
@@ -193,8 +193,8 @@ describe('multi env tests', () => {
     env2CredsLease = await salesforceTestHelpers().credentials('ENV_2')
     env1Creds = env1CredsLease.value
     env2Creds = env2CredsLease.value
-    env1Client = new SalesforceClient({ credentials: new UsernamePasswordCredentials(env1Creds) })
-    env2Client = new SalesforceClient({ credentials: new UsernamePasswordCredentials(env2Creds) })
+    env1Client = getSalesforceClient(env1Creds)
+    env2Client = getSalesforceClient(env2Creds)
 
     baseDir = (await tmp.dir()).path
     saltoHomeDir = (await tmp.dir()).path

--- a/packages/cli/e2e_test/salto.test.ts
+++ b/packages/cli/e2e_test/salto.test.ts
@@ -42,7 +42,7 @@ import {
   runPreviewGetPlan,
   runClean,
 } from './helpers/workspace'
-import { instanceExists, objectExists, getSalesforceCredsInstance } from './helpers/salesforce'
+import { instanceExists, objectExists, getSalesforceCredsInstance, getSalesforceClient } from './helpers/salesforce'
 
 const { awu } = collections.asynciterable
 // let lastPlan: Plan
@@ -110,9 +110,7 @@ describe('cli e2e', () => {
 
     process.env[SALTO_HOME_VAR] = homePath
     credsLease = await salesforceTestHelpers().credentials()
-    client = new SalesforceClient({
-      credentials: new UsernamePasswordCredentials(credsLease.value),
-    })
+    client = getSalesforceClient(credsLease.value)
     jest.spyOn(DeployCommandImpl, 'shouldDeploy').mockImplementation(
       (p: Plan): Promise<boolean> => {
         const { length } = [...wu(p.itemsByEvalOrder())]

--- a/packages/salesforce-adapter/e2e_test/adapter.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { ElemID, ServiceIds } from '@salto-io/adapter-api'
 import SalesforceClient from '../src/client/client'
@@ -32,7 +33,12 @@ const mockGetElemIdFunc = (adapterName: string, _serviceIds: ServiceIds, name: s
   ElemID => new ElemID(adapterName, name)
 
 const realAdapter = ({ adapterParams, credentials }: Opts, config?: SalesforceConfig): Reals => {
-  const client = (adapterParams && adapterParams.client) || new SalesforceClient({ credentials })
+  // Default to purge on delete to avoid leaving definitions in the recycle bin
+  const clientConfig = _.merge({ deploy: { purgeOnDelete: true } }, config?.client)
+  const client = (
+    (adapterParams && adapterParams.client)
+    || new SalesforceClient({ credentials, config: clientConfig })
+  )
   const adapter = new SalesforceAdapter({
     client,
     config: config ?? {},

--- a/packages/salesforce-adapter/e2e_test/setup.ts
+++ b/packages/salesforce-adapter/e2e_test/setup.ts
@@ -21,7 +21,6 @@ import { CustomField, ProfileInfo } from '../src/client/types'
 import { createDeployPackage } from '../src/transformers/xml_transformer'
 import { MetadataValues, createInstanceElement } from '../src/transformers/transformer'
 import SalesforceClient from '../src/client/client'
-import { objectExists } from './utils'
 import { mockTypes, mockDefaultValues } from '../test/mock_elements'
 
 
@@ -63,16 +62,10 @@ export const CUSTOM_FIELD_NAMES = {
 
 export const removeCustomObjectsWithVariousFields = async (client: SalesforceClient):
   Promise<void> => {
-  const deleteCustomObject = async (objectName: string): Promise<void> => {
-    if (await objectExists(client, constants.CUSTOM_FIELD, summaryFieldName)) {
-      await client.delete(constants.CUSTOM_FIELD, summaryFieldName)
-    }
-    if (await objectExists(client, constants.CUSTOM_OBJECT, objectName)) {
-      await client.delete(constants.CUSTOM_OBJECT, objectName)
-    }
-  }
-  await Promise.all([customObjectWithFieldsName, customObjectAddFieldsName]
-    .map(o => deleteCustomObject(o)))
+  const deployPkg = createDeployPackage()
+  deployPkg.delete(mockTypes.CustomObject, customObjectWithFieldsName)
+  deployPkg.delete(mockTypes.CustomObject, customObjectAddFieldsName)
+  await client.deploy(await deployPkg.getZip())
 }
 
 export const verifyElementsExist = async (client: SalesforceClient): Promise<void> => {

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -78,6 +78,11 @@ export const mockTypes = {
       dirName: 'aura',
     },
   }),
+  CustomObject: createMetadataObjectType({
+    annotations: {
+      metadataType: 'CustomObject',
+    },
+  }),
   StaticResource: createMetadataObjectType({
     annotations: {
       metadataType: 'StaticResource',


### PR DESCRIPTION
Change default in salesforce related e2e tests to purgeOnDelete=true
to avoid leaving junk in the recycle bin

---

Without purge on delete, when we delete a custom object or custom field they go to the recycle bin (and they still count towards the org's total custom objects / fields limit), we have reached a point where some accounts in our e2e credentials pool were hitting that limit

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
