### PR TITLE
remove unused OAuth param in Zendesk - clientSecret

### DIFF
--- a/packages/zendesk-support-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-support-adapter/src/adapter_creator.ts
@@ -37,7 +37,6 @@ const { validateDuckTypeApiDefinitionConfig } = configUtils
 Steps for OAuth authentication in zendesk:
 1. add oauth client in https://{subdomain}.zendesk.com/admin/apps-integrations/apis/apis/oauth_clients/
   - specify "client name" and "redirect url" and click save
-  - keep the generated oauth token - it's your salto client's secret
 
 2. go to this page:
 https://{subdomain}.zendesk.com/oauth/authorizations/new?response_type=token&redirect_uri={your_redirect_url}&client_id={your_unique_identifier}&scope=read%20write

--- a/packages/zendesk-support-adapter/src/auth.ts
+++ b/packages/zendesk-support-adapter/src/auth.ts
@@ -30,7 +30,6 @@ export type OauthAccessTokenCredentials = {
 
 export type OauthRequestParameters = {
   clientId: string
-  clientSecret: string
   port: number
   subdomain: string
 }
@@ -80,13 +79,6 @@ export const oauthRequestParametersType = createMatchingObjectType<
       refType: BuiltinTypes.STRING,
       annotations: {
         message: 'Client ID',
-        _required: true,
-      },
-    },
-    clientSecret: {
-      refType: BuiltinTypes.STRING,
-      annotations: {
-        message: 'Client Secret',
         _required: true,
       },
     },

--- a/packages/zendesk-support-adapter/test/adapter_creator.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter_creator.test.ts
@@ -53,7 +53,6 @@ describe('adapter creator', () => {
     expect((adapter.authenticationMethods.oauth as OAuthMethod).createFromOauthResponse(
       {
         clientId: 'client',
-        clientSecret: 'secret',
         port: 8080,
         subdomain: 'abc',
       },


### PR DESCRIPTION
clientSecret param isn't used in the implicit  OAuth grant flow that we use on Zendesk, so there's no reason to ask for it from the user.

---
_Release Notes_: 
Zendesk Support Adapter:
- remove clientSecret param on OAuth authentication mode
