### PR TITLE
Fix link in salesforce config documentation

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -124,7 +124,7 @@ salesforce {
 | [metadata](#metadata-configuration-options)                 | Fetch all metdata                                | Specified the metadata fetch
 | [data](#data-management-configuration-options) | {} (do not manage data)       | Data management configuration object names will not be fetched in case they are matched in includeObjects
 | fetchAllCustomSettings                                      | true                                             | Whether to fetch all the custom settings instances. When false, it is still possible to choose specific custom settings instances via the `data` option
-| optionalFeatures (#optional-features)                       | {} (all enabled)                                 | Granular control over which features are enabled in the adapter, by default all features are enabled in order to get the most information. can be used to turn off features that cause problems until they are solved
+| [optionalFeatures](#optional-features)                      | {} (all enabled)                                 | Granular control over which features are enabled in the adapter, by default all features are enabled in order to get the most information. can be used to turn off features that cause problems until they are solved
 
 ## Metadata configuration options
 


### PR DESCRIPTION

---
Text was not formatted as a proper markdown link like the other sections

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_