### PR TITLE
SATLO-1715: replaced loggedin with authenticated

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -25,6 +25,7 @@ import { FilterCreator, Filter, filtersRunner } from './filter'
 import fieldReferences from './filters/field_references'
 import referenceBySelfLinkFilter from './filters/references_by_self_link'
 import issueTypeSchemeReferences from './filters/issue_type_scheme_references'
+import authenticatedPermissionFilter from './filters/authenticated_permission'
 import { JIRA } from './constants'
 import { removeScopedObjects } from './client/pagination'
 
@@ -36,6 +37,7 @@ export const DEFAULT_FILTERS = [
   fieldReferences,
   referenceBySelfLinkFilter,
   issueTypeSchemeReferences,
+  authenticatedPermissionFilter,
 ]
 
 export interface JiraAdapterParams {

--- a/packages/jira-adapter/src/filters/authenticated_permission.ts
+++ b/packages/jira-adapter/src/filters/authenticated_permission.ts
@@ -1,0 +1,63 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, isInstanceElement } from '@salto-io/adapter-api'
+import { transformValues } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import { FilterCreator } from '../filter'
+
+const { awu } = collections.asynciterable
+
+/**
+ * Replaces 'loggedin' type with 'authenticated'
+ * because this is the expected value on deploy for this kind of permission.
+ */
+const filter: FilterCreator = () => ({
+  onFetch: async (elements: Element[]) => {
+    await awu(elements)
+      .filter(isInstanceElement)
+      .forEach(async instance => {
+        instance.value = await transformValues({
+          values: instance.value,
+          type: await instance.getType(),
+          strict: false,
+          allowEmpty: true,
+          transformFunc: ({ value, field }) => {
+            if (value === 'loggedin' && field?.name === 'type' && field.parent.elemID.name === 'SharePermission') {
+              return 'authenticated'
+            }
+            return value
+          },
+        }) ?? {}
+      })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/test/filters/authenticated_permission.test.ts
+++ b/packages/jira-adapter/test/filters/authenticated_permission.test.ts
@@ -1,0 +1,72 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { JIRA } from '../../src/constants'
+import authenticatedPermissionFilter from '../../src/filters/authenticated_permission'
+import { mockClient, getDefaultAdapterConfig } from '../utils'
+
+describe('authenticatedPermissionFilter', () => {
+  let filter: filterUtils.Filter
+  let instance: InstanceElement
+  let type: ObjectType
+  beforeEach(async () => {
+    const { client, paginator } = mockClient()
+    filter = authenticatedPermissionFilter({
+      client,
+      paginator,
+      config: await getDefaultAdapterConfig(),
+    })
+
+    const sharePermissionType = new ObjectType({
+      elemID: new ElemID(JIRA, 'SharePermission'),
+      fields: {
+        type: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, 'someType'),
+      fields: { permissions: { refType: sharePermissionType } },
+    })
+
+    instance = new InstanceElement(
+      'instance',
+      type,
+      {
+        permissions: {
+          type: 'loggedin',
+        },
+      }
+    )
+  })
+
+  it('should replace "loggedin" to "authenticated" in SharePermission instances', async () => {
+    await filter.onFetch?.([instance])
+    expect(instance.value).toEqual({ permissions: { type: 'authenticated' } })
+  })
+  it('should not replace non "loggedin"', async () => {
+    instance.value.permissions.type = 'notLoggedIn'
+    await filter.onFetch?.([instance])
+    expect(instance.value).toEqual({ permissions: { type: 'notLoggedIn' } })
+  })
+
+  it('should not replace "loggedin" if type is not SharePermission', async () => {
+    delete type.fields.permissions
+    await filter.onFetch?.([instance])
+    expect(instance.value).toEqual({ permissions: { type: 'loggedin' } })
+  })
+})

--- a/packages/jira-adapter/test/filters/authenticated_permission.test.ts
+++ b/packages/jira-adapter/test/filters/authenticated_permission.test.ts
@@ -55,23 +55,23 @@ describe('authenticatedPermissionFilter', () => {
     )
   })
 
-  it('should replace the value of type from "loggedin" to "authenticated" in SharePermission', async () => {
+  it('should replace SharePermission.type from "loggedin" to "authenticated"', async () => {
     await filter.onFetch([instance])
     expect(instance.value).toEqual({ permissions: { type: 'authenticated' } })
   })
-  it('should not replace the value of type that is not "loggedin" in SharePermission', async () => {
+  it('should not replace when SharePermission.type is not "loggedin"', async () => {
     instance.value.permissions.type = 'notLoggedIn'
     await filter.onFetch([instance])
     expect(instance.value).toEqual({ permissions: { type: 'notLoggedIn' } })
   })
 
-  it('should not replace the value "loggedin" of type if the field type is not SharePermission', async () => {
+  it('should not replace when field type isnt SharePermission', async () => {
     type.fields.permissions = new Field(type, 'permissions', BuiltinTypes.UNKNOWN)
     await filter.onFetch([instance])
     expect(instance.value).toEqual({ permissions: { type: 'loggedin' } })
   })
 
-  it('should not replace the value "loggedin" of field that is not "type" in SharePermission', async () => {
+  it('should not replace when field name isnt "type"', async () => {
     instance.value.permissions.type = 'notLoggedIn'
     instance.value.permissions.other = 'loggedIn'
     await filter.onFetch([instance])


### PR DESCRIPTION
Replace `loggedin` value with `authenticated` in `SharePermission` value

When fetching we get the value `loggedin` as a type of permission but when deploying we need to deploy with the type `authenticated` for the same kind of permission so I changed on fetch the value of `loggedin` with `authenticated`


---
_Release Notes_: 
None

---
_User Notifications_: 
None