### PR TITLE
added a log line when creating an empty fetch from result due to error (SALTO-1802)

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -671,17 +671,21 @@ export const fetchChanges = async (
   })
 }
 
-const createEmptyFetchChangeDueToError = (errMsg: string): FetchChangesResult => ({
-  changes: [],
-  elements: [],
-  mergeErrors: [],
-  unmergedElements: [],
-  updatedConfig: {},
-  errors: [{
-    message: errMsg,
-    severity: 'Error',
-  }],
-})
+const createEmptyFetchChangeDueToError = (errMsg: string): FetchChangesResult => {
+  log.warn(`creating empty fetch result due to ${errMsg}`)
+  return {
+    changes: [],
+    elements: [],
+    mergeErrors: [],
+    unmergedElements: [],
+    updatedConfig: {},
+    errors: [{
+      message: errMsg,
+      severity: 'Error',
+    }],
+  }
+}
+
 export const fetchChangesFromWorkspace = async (
   otherWorkspace: Workspace,
   fetchServices: string[],


### PR DESCRIPTION
…

_Added a log line when creating an empty fetch from due to mismatch error_

_Release Notes_: 
_NA_

---
_User Notifications_: 
_NA_
