### PR TITLE
SALTO-1715: added generateLookupFunc to simple adapter infra

### DIFF
--- a/packages/adapter-components/src/references/index.ts
+++ b/packages/adapter-components/src/references/index.ts
@@ -14,5 +14,5 @@
 * limitations under the License.
 */
 export { neighborContextGetter, ContextFunc, ContextValueMapperFunc } from './context'
-export { addReferences, replaceReferenceValues } from './field_references'
+export { addReferences, replaceReferenceValues, generateLookupFunc } from './field_references'
 export { ReferenceSerializationStrategy, ReferenceSerializationStrategyName, ReferenceSerializationStrategyLookup, FieldReferenceDefinition, FieldReferenceResolver, ReferenceResolverFinder, ReferenceTargetDefinition, ExtendedReferenceTargetDefinition } from './reference_mapping'

--- a/packages/adapter-components/src/references/reference_mapping.ts
+++ b/packages/adapter-components/src/references/reference_mapping.ts
@@ -138,11 +138,11 @@ export type ReferenceResolverFinder<T extends string> = (
  */
 export const generateReferenceResolverFinder = <
   T extends string,
-  GerericFieldReferenceDefinition extends FieldReferenceDefinition<T>
+  GenericFieldReferenceDefinition extends FieldReferenceDefinition<T>
 >(
-    defs: GerericFieldReferenceDefinition[],
+    defs: GenericFieldReferenceDefinition[],
     fieldReferenceResolverCreator?:
-      (def: GerericFieldReferenceDefinition) => FieldReferenceResolver<T>
+      (def: GenericFieldReferenceDefinition) => FieldReferenceResolver<T>
   ): ReferenceResolverFinder<T> => {
   const referenceDefinitions = defs.map(
     def => (fieldReferenceResolverCreator


### PR DESCRIPTION
Added `generateLookupFunc` for simple adapters to use to resolve references on deploy

---
_Release Notes_: 
None

---
_User Notifications_: 
None