### PR TITLE
use cached hash value in nacl file source when the ignore file changes flag is set (SALTO-1807)

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -529,9 +529,9 @@ const buildNaclFilesSource = (
       sourceName,
       persistent
     )
-    const preChangeHash = await currentState.parsedNaclFiles.getHash()
     const modifiedNaclFiles: NaclFile[] = []
     if (!ignoreFileChanges) {
+      const preChangeHash = await currentState.parsedNaclFiles.getHash()
       const cacheFilenames = await currentState.parsedNaclFiles.list()
       const naclFilenames = new Set(await naclFilesStore.list())
       const fileNames = new Set()
@@ -562,6 +562,7 @@ const buildNaclFilesSource = (
       result.changes.preChangeHash = preChangeHash
       return result
     }
+    const preChangeHash = await currentState.metadata.get(HASH_KEY)
     return {
       changes: { changes: [], cacheValid: true, preChangeHash, postChangeHash: preChangeHash },
       state: currentState,


### PR DESCRIPTION
…

_Use cached hash value in nacl file source when the ignore file changes flag is set_

---

_The ignore file changes flow is designed to minimize rocks db interactions in order to expedite the workspace loading time. It should be used in cases in which using the already cached values is good enough.

In the previous flow, the pre change hash that is used by the nacl file source was calculated by concating and hashing the hash values of all of the workspace files. However - since we *ignore* these changes - using the cached hash value is enough._

---
_Release Notes_: 
_Improved workspace loading time when the ignore nacl file changes flag is set_

---
_User Notifications_: 
_NA_
