### PR TITLE
SALTO-1559: NetSuite: Identify references from bundles and SuiteApps

### DIFF
--- a/packages/netsuite-adapter/src/filters/instance_references.ts
+++ b/packages/netsuite-adapter/src/filters/instance_references.ts
@@ -138,7 +138,7 @@ const customTypeServiceIdsToElemIds = async (
   return serviceIdsToElemIds
 }
 
-const needsDependecy = (serviceIdInfoRecord: ServiceIdInfo): boolean => {
+const shouldExtractToGenereatedDependency = (serviceIdInfoRecord: ServiceIdInfo): boolean => {
   if (serviceIdInfoRecord[CAPTURED_APPID] != null
     || serviceIdInfoRecord[CAPTURED_BUNDLEID] != null) {
     return true
@@ -190,14 +190,14 @@ const replaceReferenceValues = async (
       }
 
       if (path?.isAttrID() && path.createParentID().name === CORE_ANNOTATIONS.PARENT) {
-        if (!needsDependecy(serviceIdInfoRecord)) {
+        if (!shouldExtractToGenereatedDependency(serviceIdInfoRecord)) {
           returnValue = new ReferenceExpression(elemID.createBaseID().parent)
           return
         }
         dependenciesToAdd.push(elemID.createBaseID().parent)
         return
       }
-      if (!needsDependecy(serviceIdInfoRecord)) {
+      if (!shouldExtractToGenereatedDependency(serviceIdInfoRecord)) {
         returnValue = new ReferenceExpression(elemID)
         return
       }

--- a/packages/netsuite-adapter/src/filters/instance_references.ts
+++ b/packages/netsuite-adapter/src/filters/instance_references.ts
@@ -30,15 +30,25 @@ const { makeArray } = collections.array
 
 const CAPTURED_SERVICE_ID = 'serviceId'
 const CAPTURED_TYPE = 'type'
+const CAPTURED_APPID = 'appid'
+const CAPTURED_BUNDLEID = 'bundleid'
+
+const TYPE_REGEX = `type=(?<${CAPTURED_TYPE}>[a-z_]+), `
+const APPID_REGEX = `appid=(?<${CAPTURED_APPID}>[a-z_\\.]+), `
+const BUNDLEID_REGEX = `bundleid=(?<${CAPTURED_BUNDLEID}>\\d+), `
+const SERVICE_ID_REGEX = `${SCRIPT_ID}=(?<${CAPTURED_SERVICE_ID}>[a-z0-9_]+(\\.[a-z0-9_]+)*)`
+
 // e.g. '[scriptid=customworkflow1]' & '[scriptid=customworkflow1.workflowstate17.workflowaction33]'
 //  & '[type=customsegment, scriptid=cseg1]'
-const scriptIdReferenceRegex = new RegExp(`\\[(type=(?<${CAPTURED_TYPE}>[a-z_]+), )?${SCRIPT_ID}=(?<${CAPTURED_SERVICE_ID}>[a-z0-9_]+(\\.[a-z0-9_]+)*)]`, 'g')
+const scriptIdReferenceRegex = new RegExp(`\\[(${BUNDLEID_REGEX})?(${APPID_REGEX})?(${TYPE_REGEX})?${SERVICE_ID_REGEX}]`, 'g')
 // e.g. '[/Templates/filename.html]' & '[/SuiteScripts/script.js]'
 const pathReferenceRegex = new RegExp(`^\\[(?<${CAPTURED_SERVICE_ID}>\\/.+)]$`)
 
 type ServiceIdInfo = {
   [CAPTURED_SERVICE_ID]: string
   [CAPTURED_TYPE]?: string
+  [CAPTURED_APPID]?: string
+  [CAPTURED_BUNDLEID]?: string
   isFullMatch: boolean
 }
 
@@ -86,6 +96,8 @@ const captureServiceIdInfo = (value: string): ServiceIdInfo[] => {
     .map(serviceIdRef => ({
       [CAPTURED_SERVICE_ID]: serviceIdRef[CAPTURED_SERVICE_ID],
       [CAPTURED_TYPE]: serviceIdRef[CAPTURED_TYPE],
+      [CAPTURED_APPID]: serviceIdRef[CAPTURED_APPID],
+      [CAPTURED_BUNDLEID]: serviceIdRef[CAPTURED_BUNDLEID],
       isFullMatch,
     }))
 }
@@ -124,6 +136,19 @@ const customTypeServiceIdsToElemIds = async (
     elementsSource: typesElementSourceWrapper(),
   })
   return serviceIdsToElemIds
+}
+
+const needsDependecy = (serviceIdInfoRecord: ServiceIdInfo): boolean => {
+  if (serviceIdInfoRecord[CAPTURED_APPID] != null
+    || serviceIdInfoRecord[CAPTURED_BUNDLEID] != null) {
+    return true
+  }
+
+  if (serviceIdInfoRecord.isFullMatch) {
+    return false
+  }
+
+  return true
 }
 
 export const getInstanceServiceIdRecords = async (
@@ -165,14 +190,14 @@ const replaceReferenceValues = async (
       }
 
       if (path?.isAttrID() && path.createParentID().name === CORE_ANNOTATIONS.PARENT) {
-        if (serviceIdInfoRecord.isFullMatch) {
+        if (!needsDependecy(serviceIdInfoRecord)) {
           returnValue = new ReferenceExpression(elemID.createBaseID().parent)
           return
         }
         dependenciesToAdd.push(elemID.createBaseID().parent)
         return
       }
-      if (serviceIdInfoRecord.isFullMatch) {
+      if (!needsDependecy(serviceIdInfoRecord)) {
         returnValue = new ReferenceExpression(elemID)
         return
       }

--- a/packages/netsuite-adapter/test/filters/instance_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/instance_references.test.ts
@@ -96,6 +96,9 @@ describe('instance_references filter', () => {
           refToScriptIdOfAnotherType: '[type=transactionbodycustomfield, scriptid=cseg_1]',
           stringWithMultipleRef: '[type=customsegment, scriptid=cseg_1]|STDBODYCUSTOMER|[type=customsegment, scriptid=cseg_1]|[scriptid=top_level.one_nesting.two_nesting]',
           stringWithMultipleNonExistingRef: '[type=nonExistingType, scriptid=nonExist]:STDBODYCUSTOMER:[scriptid=nonExisting.one_nesting]',
+          refWithAppId: '[appid=foo.bar, scriptid=top_level]',
+          refToCustomSegmentWithAppId: '[appid=foo.bar, type=customsegment, scriptid=cseg_1]',
+          refWithBundleId: '[bundleid=123, scriptid=top_level]',
         },
         undefined,
         {
@@ -251,6 +254,45 @@ describe('instance_references filter', () => {
         .toEqual('[type=transactionbodycustomfield, scriptid=cseg_1]')
     })
 
+    it('should not replace appid and scriptid references', async () => {
+      await filterCreator({
+        client: {} as NetsuiteClient,
+        elementsSourceIndex,
+        elementsSource: buildElementsSourceFromElements([]),
+        isPartial: false,
+      }).onFetch?.([fileInstance, workflowInstance, instanceWithRefs])
+
+
+      expect(instanceWithRefs.value.refWithAppId)
+        .toEqual('[appid=foo.bar, scriptid=top_level]')
+    })
+
+    it('should not replace appid, type and scriptid references', async () => {
+      await filterCreator({
+        client: {} as NetsuiteClient,
+        elementsSourceIndex,
+        elementsSource: buildElementsSourceFromElements([]),
+        isPartial: false,
+      }).onFetch?.([fileInstance, workflowInstance, instanceWithRefs])
+
+
+      expect(instanceWithRefs.value.refToCustomSegmentWithAppId)
+        .toEqual('[appid=foo.bar, type=customsegment, scriptid=cseg_1]')
+    })
+
+    it('should not replace bundleid and scriptid references', async () => {
+      await filterCreator({
+        client: {} as NetsuiteClient,
+        elementsSourceIndex,
+        elementsSource: buildElementsSourceFromElements([]),
+        isPartial: false,
+      }).onFetch?.([fileInstance, workflowInstance, instanceWithRefs])
+
+
+      expect(instanceWithRefs.value.refWithBundleId)
+        .toEqual('[bundleid=123, scriptid=top_level]')
+    })
+
     it('should not replace path references for unresolved ref', async () => {
       await filterCreator({
         client: {} as NetsuiteClient,
@@ -315,7 +357,7 @@ describe('instance_references filter', () => {
         .toEqual('[type=customsegment, scriptid=cseg_1]|STDBODYCUSTOMER|[type=customsegment, scriptid=cseg_1]|[scriptid=top_level.one_nesting.two_nesting]')
 
       expect(instanceWithRefs.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES])
-        .toHaveLength(2)
+        .toHaveLength(3)
       expect(instanceWithRefs.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES])
         .toEqual([
           { reference: new ReferenceExpression(
@@ -323,6 +365,9 @@ describe('instance_references filter', () => {
           ) },
           { reference: new ReferenceExpression(
             workflowInstance.elemID.createNestedID('workflowstates', 'workflowstate', '0', 'workflowactions', '0', 'setfieldvalueaction', '0', SCRIPT_ID)
+          ) },
+          { reference: new ReferenceExpression(
+            workflowInstance.elemID.createNestedID(SCRIPT_ID)
           ) },
         ])
     })


### PR DESCRIPTION
Identify references with `appid` and `bundleid` fields, and add their salto reference to `_generated_dependencies`.

---

_Additional context for reviewer_

See attached JIRA bug for context.

---
_Release Notes_: 
NetSuite references in the form of `[appid=foo.bar, scriptid=someid]` or `[bundleid=123, scriptid=someid]` will now add a `_generated_dependencies` section when fetching. This helps find references and dependencies better.

---
_User Notifications_: 
NetSuite references in the form of `[appid=foo.bar, scriptid=someid]` or `[bundleid=123, scriptid=someid]` will now add a `_generated_dependencies` section when fetching.
