### PR TITLE
SALTO-1770: add dependency change for standalone fields

### DIFF
--- a/packages/adapter-components/package.json
+++ b/packages/adapter-components/package.json
@@ -40,7 +40,8 @@
     "bottleneck": "^2.19.5",
     "lodash": "^4.17.21",
     "qs": "^6.10.1",
-    "soap": "^0.37.0"
+    "soap": "^0.37.0",
+    "wu": "^2.1.0"
   },
   "devDependencies": {
     "@salto-io/test-utils": "0.3.6",

--- a/packages/adapter-components/src/deployment/dependency/index.ts
+++ b/packages/adapter-components/src/deployment/dependency/index.ts
@@ -13,7 +13,4 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export * as changeValidators from './change_validators'
-export * as dependency from './dependency'
-export * from './deployment'
-export * from './annotations'
+export { removeStandaloneFieldDependency } from './remove_standalone_field_dependency'

--- a/packages/adapter-components/src/deployment/dependency/remove_standalone_field_dependency.ts
+++ b/packages/adapter-components/src/deployment/dependency/remove_standalone_field_dependency.ts
@@ -15,27 +15,22 @@
 */
 import wu from 'wu'
 import {
-  getChangeElement, DependencyChanger, dependencyChange,
-  isReferenceExpression, ChangeId, isInstanceElement,
+  getChangeElement, DependencyChanger, dependencyChange, isReferenceExpression, ChangeId,
 } from '@salto-io/adapter-api'
 import { getParents } from '@salto-io/adapter-utils'
 
 export const removeStandaloneFieldDependency: DependencyChanger = async (
   changes, deps
 ) => {
-  const isChangeFromParentToChild = ([src, target]: [ChangeId, ChangeId]): boolean => {
+  const isDependnecyFromParentToChild = ([src, target]: [ChangeId, ChangeId]): boolean => {
     const sourceChange = changes.get(src)
     const targetChange = changes.get(target)
-    if (sourceChange == null || targetChange == null) {
+    if (sourceChange === undefined || targetChange === undefined) {
       return false
     }
-    const sourceElement = getChangeElement(sourceChange)
-    const targetElement = getChangeElement(targetChange)
-    if (!isInstanceElement(sourceElement) || !isInstanceElement(targetElement)) {
-      return false
-    }
-    return getParents(targetElement)
-      .find(e => isReferenceExpression(e) && e.elemID.isEqual(sourceElement.elemID)) != null
+    return getParents(getChangeElement(targetChange))
+      .find(e => isReferenceExpression(e)
+        && e.elemID.isEqual(getChangeElement(sourceChange).elemID)) != null
   }
 
   const allDependencies = wu(deps)
@@ -45,6 +40,6 @@ export const removeStandaloneFieldDependency: DependencyChanger = async (
     .flatten(true)
 
   return allDependencies
-    .filter(isChangeFromParentToChild)
+    .filter(isDependnecyFromParentToChild)
     .map(([source, target]) => dependencyChange('remove', source, target))
 }

--- a/packages/adapter-components/src/deployment/dependency/remove_standalone_field_dependency.ts
+++ b/packages/adapter-components/src/deployment/dependency/remove_standalone_field_dependency.ts
@@ -1,0 +1,64 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import wu from 'wu'
+import { collections, values } from '@salto-io/lowerdash'
+import {
+  getChangeElement, DependencyChanger, dependencyChange, isInstanceElement,
+  CORE_ANNOTATIONS, isReferenceExpression, ChangeId, InstanceElement, Change,
+} from '@salto-io/adapter-api'
+
+const { makeArray } = collections.array
+
+type ChangeNode = { nodeId: ChangeId; change: Change<InstanceElement> }
+type CircularDepsPair = {
+  src: ChangeNode
+  dst: ChangeNode
+}
+
+export const removeStandaloneFieldDependency: DependencyChanger = async (
+  changes, deps
+) => {
+  const instancesChanges = collections.iterable.groupBy(
+    wu(changes).filter(([_id, change]) => isInstanceElement(getChangeElement(change))),
+    ([_id, change]) => getChangeElement(change).elemID.getFullName(),
+  )
+  const circularReferences: CircularDepsPair[] = []
+  wu(instancesChanges).forEach(([_id, instanceChanges]) => {
+    instanceChanges.forEach(change => {
+      const nodeId = change[0]
+      const references = deps.get(nodeId)
+      wu(references ?? []).forEach(refId => {
+        const refChange = changes.get(refId)
+        if (refChange
+          && isInstanceElement(getChangeElement(refChange))
+          && (deps.get(refId) ?? new Set()).has(nodeId)) {
+          circularReferences.push({
+            src: { nodeId, change: change[1] as Change<InstanceElement> },
+            dst: { nodeId: refId, change: refChange as Change<InstanceElement> },
+          })
+        }
+      })
+    })
+  })
+  return circularReferences.map(pair => {
+    const searchedId = getChangeElement(pair.dst.change).elemID.getFullName()
+    if (makeArray(getChangeElement(pair.src.change).annotations[CORE_ANNOTATIONS.PARENT])
+      .find(e => isReferenceExpression(e) && e.elemID.getFullName() === searchedId)) {
+      return dependencyChange('remove', pair.dst.nodeId, pair.src.nodeId)
+    }
+    return undefined
+  }).filter(values.isDefined)
+}

--- a/packages/adapter-components/test/deployment/dependency/remove_standalone_field_dependency.test.ts
+++ b/packages/adapter-components/test/deployment/dependency/remove_standalone_field_dependency.test.ts
@@ -114,22 +114,6 @@ describe('dependency changers', () => {
       dependencyChanges = [...await removeStandaloneFieldDependency(inputChanges, inputDeps)]
       expect(dependencyChanges).toHaveLength(0)
     })
-    it('should not remove if the annotation is on ObjectTypes', async () => {
-      const newChildType = childType.clone()
-      newChildType.annotations[CORE_ANNOTATIONS.PARENT] = [
-        new ReferenceExpression(parentType.elemID),
-      ]
-      const inputChanges = new Map([
-        [0, toChange({ after: parentType })],
-        [1, toChange({ after: newChildType })],
-      ])
-      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
-        [0, new Set([1])],
-        [1, new Set([0])],
-      ])
-      dependencyChanges = [...await removeStandaloneFieldDependency(inputChanges, inputDeps)]
-      expect(dependencyChanges).toHaveLength(0)
-    })
     it('should not remove if the dep is only one way', async () => {
       const inputChanges = new Map([
         [0, toChange({ after: parentInstance })],

--- a/packages/adapter-components/test/deployment/dependency/remove_standalone_field_dependency.test.ts
+++ b/packages/adapter-components/test/deployment/dependency/remove_standalone_field_dependency.test.ts
@@ -1,0 +1,145 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, InstanceElement, ElemID, ReferenceExpression,
+  BuiltinTypes, DependencyChange, toChange, ListType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import {
+  removeStandaloneFieldDependency,
+} from '../../../src/deployment/dependency'
+
+describe('dependency changers', () => {
+  let parentType: ObjectType
+  let childType: ObjectType
+  let parentInstance: InstanceElement
+  let childInstance: InstanceElement
+  let dependencyChanges: DependencyChange[]
+  const stringListType = new ListType(BuiltinTypes.STRING)
+  beforeEach(() => {
+    parentType = new ObjectType({
+      elemID: new ElemID('salto', 'parent'),
+      fields: {
+        id: {
+          refType: BuiltinTypes.STRING,
+          annotations: { _required: true },
+        },
+        childs: { refType: stringListType },
+      },
+    })
+    childType = new ObjectType({
+      elemID: new ElemID('salto', 'child'),
+      fields: {
+        id: {
+          refType: BuiltinTypes.STRING,
+          annotations: { _required: true },
+        },
+      },
+      annotationRefsOrTypes: {
+        [CORE_ANNOTATIONS.PARENT]: BuiltinTypes.STRING,
+      },
+    })
+    parentInstance = new InstanceElement(
+      'inst',
+      parentType,
+      {
+        id: '1',
+        childs: [new ReferenceExpression(new ElemID('salto', 'child', 'instance', 'inst'))],
+      },
+    )
+    childInstance = new InstanceElement(
+      'inst',
+      childType,
+      {
+        id: '2',
+      },
+      undefined,
+      {
+        _parent: [new ReferenceExpression(new ElemID('salto', 'parent', 'instance', 'inst'))],
+      },
+    )
+  })
+
+  describe('removeStandaloneFieldDependency', () => {
+    it('should remove dependency between the parent to the child', async () => {
+      const inputChanges = new Map([
+        [0, toChange({ after: parentInstance })],
+        [1, toChange({ after: childInstance })],
+      ])
+      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+        [0, new Set([1])],
+        [1, new Set([0])],
+      ])
+      dependencyChanges = [...await removeStandaloneFieldDependency(inputChanges, inputDeps)]
+      expect(dependencyChanges).toHaveLength(1)
+      expect(dependencyChanges[0].action).toEqual('remove')
+      expect(dependencyChanges[0].dependency.source).toEqual(0)
+      expect(dependencyChanges[0].dependency.target).toEqual(1)
+    })
+    it('should not remove if there are no deps', async () => {
+      const inputChanges = new Map([
+        [0, toChange({ after: parentInstance })],
+        [1, toChange({ after: childInstance })],
+      ])
+      dependencyChanges = [...await removeStandaloneFieldDependency(inputChanges, new Map())]
+      expect(dependencyChanges).toHaveLength(0)
+    })
+    it('should not remove if the annotation is not _parent', async () => {
+      const newChildInstance = new InstanceElement(
+        'inst',
+        childType,
+        { id: '2' },
+        undefined,
+        { parent: [new ReferenceExpression(new ElemID('salto', 'parent', 'instance', 'inst'))] },
+      )
+      const inputChanges = new Map([
+        [0, toChange({ after: parentInstance })],
+        [1, toChange({ after: newChildInstance })],
+      ])
+      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+        [0, new Set([1])],
+        [1, new Set([0])],
+      ])
+      dependencyChanges = [...await removeStandaloneFieldDependency(inputChanges, inputDeps)]
+      expect(dependencyChanges).toHaveLength(0)
+    })
+    it('should not remove if the annotation is on ObjectTypes', async () => {
+      const newChildType = childType.clone()
+      newChildType.annotations[CORE_ANNOTATIONS.PARENT] = [
+        new ReferenceExpression(parentType.elemID),
+      ]
+      const inputChanges = new Map([
+        [0, toChange({ after: parentType })],
+        [1, toChange({ after: newChildType })],
+      ])
+      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+        [0, new Set([1])],
+        [1, new Set([0])],
+      ])
+      dependencyChanges = [...await removeStandaloneFieldDependency(inputChanges, inputDeps)]
+      expect(dependencyChanges).toHaveLength(0)
+    })
+    it('should not remove if the dep is only one way', async () => {
+      const inputChanges = new Map([
+        [0, toChange({ after: parentInstance })],
+        [1, toChange({ after: childInstance })],
+      ])
+      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+        [0, new Set([1])],
+      ])
+      dependencyChanges = [...await removeStandaloneFieldDependency(inputChanges, inputDeps)]
+      expect(dependencyChanges).toHaveLength(0)
+    })
+  })
+})

--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -107,7 +107,6 @@ export default class ZendeskAdapter implements AdapterOperations {
     progressReporter.reportProgress({ message: 'Fetching types and instances' })
     const elements = await this.getElements()
 
-
     log.debug('going to run filters on %d fetched elements', elements.length)
     progressReporter.reportProgress({ message: 'Running filters for additional information' })
     await (await this.createFiltersRunner()).onFetch(elements)
@@ -187,6 +186,7 @@ export default class ZendeskAdapter implements AdapterOperations {
   public get deployModifiers(): DeployModifiers {
     return {
       changeValidator,
+      dependencyChanger: deploymentUtils.dependency.removeStandaloneFieldDependency,
     }
   }
 }


### PR DESCRIPTION
_Add dependency changer that removes the edge in the plan graph from the parent to the child in order to support deploy on standalone fields_

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---