### PR TITLE
SALTO-1752 netsuite - add change validator for invalid values

### DIFF
--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -25,6 +25,7 @@ import saveSearchMoveEnvironment from './change_validators/saved_search_move_env
 import fileValidator from './change_validators/file_changes'
 import immutableChangesValidator from './change_validators/immutable_changes'
 import subInstancesValidator from './change_validators/subinstances'
+import invalidValuesValidator from './change_validators/invalid_values'
 import safeDeployValidator, { FetchByQueryFunc } from './change_validators/safe_deploy'
 import { validateDependsOnInvalidElement } from './change_validators/dependencies'
 
@@ -39,6 +40,7 @@ const changeValidators: ChangeValidator[] = [
   removeListItemValidator,
   fileValidator,
   subInstancesValidator,
+  invalidValuesValidator,
 ]
 
 const nonSuiteAppValidators: ChangeValidator[] = [

--- a/packages/netsuite-adapter/src/change_validators/invalid_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/invalid_values.ts
@@ -1,0 +1,84 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { values } from '@salto-io/lowerdash'
+import {
+  ChangeValidator,
+  getChangeElement,
+  isAdditionOrModificationChange,
+  isInstanceChange,
+  isModificationChange,
+  SaltoErrorSeverity,
+  Value,
+} from '@salto-io/adapter-api'
+import { isCustomType } from '../types'
+
+const { isDefined } = values
+
+type InvalidValue = {
+  typeName: string
+  path: string[]
+  value: Value
+  error: {
+    severity: SaltoErrorSeverity
+    detailedMessage: string
+  }
+}
+
+const invalidValues: InvalidValue[] = [
+  {
+    typeName: 'role',
+    path: ['subsidiaryoption'],
+    value: 'SELECTED',
+    error: {
+      severity: 'Error',
+      detailedMessage: 'role.subsidiaryoption cannot be deployed with value "SELECTED"',
+    },
+  },
+]
+
+const changeValidator: ChangeValidator = async changes => {
+  const instanceChanges = _.groupBy(
+    changes
+      .filter(isAdditionOrModificationChange)
+      .filter(isInstanceChange)
+      // TODO: should we check non-CustomTypes too?
+      .filter(change => isCustomType(getChangeElement(change).refType.elemID)),
+    change => getChangeElement(change).elemID.typeName
+  )
+
+  return invalidValues.flatMap(({ typeName, path, value, error }) => {
+    if (!(typeName in instanceChanges)) {
+      return []
+    }
+
+    return instanceChanges[typeName].map(change => {
+      const instance = getChangeElement(change)
+      if (_.get(instance.value, path) !== value
+        || (isModificationChange(change) && _.get(change.data.before.value, path) === value)) {
+        return undefined
+      }
+
+      return {
+        ...error,
+        elemID: instance.elemID,
+        message: `Invalid value in ${typeName}.${path.join('.')}`,
+      }
+    }).filter(isDefined)
+  })
+}
+
+export default changeValidator

--- a/packages/netsuite-adapter/test/change_validators/invalid_values.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/invalid_values.test.ts
@@ -1,0 +1,87 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, toChange } from '@salto-io/adapter-api'
+import invalidValuesValidator from '../../src/change_validators/invalid_values'
+import { customTypes } from '../../src/types'
+import { SCRIPT_ID, ROLE, ADDRESS_FORM } from '../../src/constants'
+
+
+describe('invalid values validator', () => {
+  const origInstance = new InstanceElement(
+    'instance',
+    customTypes[ROLE],
+    {
+      isinactive: false,
+      [SCRIPT_ID]: 'customrole1009',
+      name: 'workato_intg',
+      subsidiaryoption: 'ALL',
+    }
+  )
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    instance = origInstance.clone()
+  })
+
+  it('should not have ChangeError when deployoong a type that doesn\'t have invalid value', async () => {
+    const anotherInstance = new InstanceElement(
+      'instance',
+      customTypes[ADDRESS_FORM],
+      {
+        [SCRIPT_ID]: 'custform_2_t1440050_248',
+        name: 'My Address Form',
+      }
+    )
+
+    const after = anotherInstance.clone()
+    after.value.name = 'Changed'
+    const changeErrors = await invalidValuesValidator(
+      [toChange({ before: instance, after })]
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should not have ChangeError when deploying an instance without invalid value', async () => {
+    const after = instance.clone()
+    after.value.subsidiaryoption = 'OWN'
+    const changeErrors = await invalidValuesValidator(
+      [toChange({ before: instance, after })]
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('should have error ChangeError when modifying an invalid value', async () => {
+    const after = instance.clone()
+    after.value.subsidiaryoption = 'SELECTED'
+    const changeErrors = await invalidValuesValidator(
+      [toChange({ before: instance, after })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].elemID).toEqual(instance.elemID)
+  })
+
+  it('should not have error ChangeError when modifying an instance with unchanged invalid value', async () => {
+    const before = instance.clone()
+    const after = instance.clone()
+    before.value.subsidiaryoption = 'SELECTED'
+    after.value.subsidiaryoption = 'SELECTED'
+    after.value.name = 'changed'
+    const changeErrors = await invalidValuesValidator(
+      [toChange({ before, after })]
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Some values are not supported to deploy by Netsuite yet - they fail the deploy or ignored. 
For example:  When role has "Subsidiaries Restrictions" and the "Accessible Subsidiaries" is set to "Selected" mode, the XML that represents the role does not contain the information of the specific selected subsidiaries. If this field is changed to "SELECTED" in the nacl (and was not fetched) then the deploy fails.
We want to validate this values before trying to deploy.

---
_Release Notes_: 
Netsuite Adapter:
- add change validator for invalid values
