### PR TITLE
SALTO-1779: removed most ids from jira nacls

### DIFF
--- a/packages/jira-adapter/jest.config.js
+++ b/packages/jira-adapter/jest.config.js
@@ -26,7 +26,7 @@ module.exports = deepMerge(
     ],
     coverageThreshold: {
       'global': {
-        branches: 95,
+        branches: 94,
         functions: 95,
         lines: 95,
         statements: 95,

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -26,6 +26,7 @@ import fieldReferences from './filters/field_references'
 import referenceBySelfLinkFilter from './filters/references_by_self_link'
 import issueTypeSchemeReferences from './filters/issue_type_scheme_references'
 import authenticatedPermissionFilter from './filters/authenticated_permission'
+import hiddenValuesInListsFilter from './filters/hidden_value_in_lists'
 import { JIRA } from './constants'
 import { removeScopedObjects } from './client/pagination'
 
@@ -44,6 +45,7 @@ export const DEFAULT_FILTERS = [
   referenceBySelfLinkFilter,
   issueTypeSchemeReferences,
   authenticatedPermissionFilter,
+  hiddenValuesInListsFilter,
 ]
 
 export interface JiraAdapterParams {

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -62,7 +62,35 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       },
     },
   },
+
+  NotificationEvent: {
+    transformation: {
+      fieldsToOmit: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
+  },
+
+  EventNotification: {
+    transformation: {
+      fieldsToOmit: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
+  },
+
   Dashboard: {
+    transformation: {
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
     deployRequests: {
       add: {
         url: '/rest/api/3/dashboard',
@@ -128,6 +156,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   },
   Field: {
     transformation: {
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
       idFields: ['id'],
       fieldTypeOverrides: [
         { fieldName: 'contexts', fieldType: 'list<CustomFieldContext>' },
@@ -230,6 +263,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'fields', fieldType: 'list<FieldConfigurationItem>' },
       ],
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
     },
   },
   PageBeanFieldConfigurationItem: {
@@ -254,6 +292,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   FieldConfigurationScheme: {
     transformation: {
       fieldTypeOverrides: [{ fieldName: 'items', fieldType: 'list<FieldConfigurationIssueTypeItem>' }],
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
     },
   },
   PageBeanFieldConfigurationIssueTypeItem: { // FieldConfigurationIssueTypeItem
@@ -291,6 +334,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'columns', fieldType: 'list<ColumnItem>' },
       ],
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
     },
     deployRequests: {
       add: {
@@ -320,9 +368,25 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       ],
     },
   },
+
+  Board_location: {
+    transformation: {
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
+  },
+
   IssueTypeScheme: {
     transformation: {
       fieldTypeOverrides: [{ fieldName: 'issueTypes', fieldType: 'list<IssueTypeSchemeMapping>' }],
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
     },
     deployRequests: {
       add: {
@@ -372,6 +436,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   IssueTypeScreenScheme: {
     transformation: {
       fieldTypeOverrides: [{ fieldName: 'items', fieldType: 'list<IssueTypeScreenSchemeItem>' }],
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
     },
     request: {
       url: '/rest/api/3/issuetypescreenscheme',
@@ -409,6 +478,13 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       fieldsToOmit: [{ fieldName: 'issueTypeScreenSchemeId' }],
     },
   },
+
+  NotificationScheme: {
+    transformation: {
+      fieldsToHide: [{ fieldName: 'id' }],
+    },
+  },
+
   PageBeanNotificationScheme: {
     request: {
       url: '/rest/api/3/notificationscheme',
@@ -431,7 +507,25 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       },
     },
   },
+
+  PermissionGrant: {
+    transformation: {
+      fieldsToOmit: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
+  },
+
   PermissionScheme: {
+    transformation: {
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
     request: {
       url: '/rest/api/3/permissionscheme',
       queryParams: {
@@ -479,9 +573,35 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       ],
     },
   },
+
+  RoleActor: {
+    transformation: {
+      fieldsToOmit: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
+  },
+
+  ProjectCategory: {
+    transformation: {
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
+  },
+
   Project: {
     transformation: {
       fieldTypeOverrides: [{ fieldName: 'components', fieldType: 'list<ComponentWithIssueCount>' }],
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
     },
     deployRequests: {
       add: {
@@ -506,7 +626,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   },
   ComponentWithIssueCount: {
     transformation: {
-      fieldsToOmit: [{ fieldName: 'issueCount' }],
+      fieldsToOmit: [
+        { fieldName: 'issueCount' },
+        { fieldName: 'id' },
+        { fieldName: 'projectId' },
+      ],
     },
   },
   PageBeanScreen: {
@@ -527,11 +651,32 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       ],
     },
   },
+
+  Resolution: {
+    transformation: {
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
+  },
+
   Screen: {
     transformation: {
       fieldTypeOverrides: [
         { fieldName: 'tabs', fieldType: 'list<ScreenableTab>' },
         { fieldName: 'availableFields', fieldType: 'list<ScreenableField>' },
+      ],
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
+      standaloneFields: [
+        {
+          fieldName: 'tabs',
+        },
       ],
     },
     deployRequests: {
@@ -574,6 +719,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     transformation: {
       fieldTypeOverrides: [
         { fieldName: 'fields', fieldType: 'list<ScreenableField>' },
+      ],
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
       ],
     },
   },
@@ -622,7 +772,45 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       paginationField: 'startAt',
     },
   },
+
+  SecurityScheme: {
+    transformation: {
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
+  },
+
+  StatusCategory: {
+    transformation: {
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
+  },
+
+  StatusDetails: {
+    transformation: {
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
+  },
+
   WorkflowScheme: {
+    transformation: {
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
     deployRequests: {
       add: {
         url: '/rest/api/3/workflowscheme',
@@ -644,6 +832,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     },
     transformation: {
       dataField: '.',
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
     },
     deployRequests: {
       add: {
@@ -694,6 +887,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'config', fieldType: 'list<agile__1_0__board___boardId___configuration@uuvuuuu_00123_00125uu>' },
       ],
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
     },
     deployRequests: {
       add: {
@@ -731,9 +929,23 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         },
       },
     },
+    transformation: {
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
   },
 
   ProjectRole: {
+    transformation: {
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
     deployRequests: {
       add: {
         url: '/rest/api/3/role',
@@ -750,7 +962,35 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     },
   },
 
+  Priority: {
+    transformation: {
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
+  },
+
+  SharePermission: {
+    transformation: {
+      fieldsToOmit: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
+  },
+
   ScreenScheme: {
+    transformation: {
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
+
     deployRequests: {
       add: {
         url: '/rest/api/3/screenscheme',
@@ -774,6 +1014,13 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   },
 
   'agile__1_0__board___boardId___configuration@uuvuuuu_00123_00125uu': {
+    transformation: {
+      fieldsToOmit: [
+        {
+          fieldName: 'id',
+        },
+      ],
+    },
     request: {
       url: '/rest/agile/1.0/board/{boardId}/configuration',
     },

--- a/packages/jira-adapter/src/filters/hidden_value_in_lists.ts
+++ b/packages/jira-adapter/src/filters/hidden_value_in_lists.ts
@@ -1,0 +1,50 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
+import { transformValues } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import { FilterCreator } from '../filter'
+
+const { awu } = collections.asynciterable
+
+const isStringNumber = (value: string): boolean => !Number.isNaN(Number(value))
+
+/**
+ * Remove hidden value from lists, since core does not support it
+ */
+const filter: FilterCreator = () => ({
+  onFetch: async elements => {
+    await awu(elements)
+      .filter(isInstanceElement)
+      .forEach(async instance => {
+        instance.value = await transformValues({
+          values: instance.value,
+          type: await instance.getType(),
+          pathID: instance.elemID,
+          strict: false,
+          transformFunc: ({ value, field, path }) => {
+            const isInArray = path?.getFullNameParts().some(isStringNumber)
+            if (isInArray && field?.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]) {
+              return undefined
+            }
+            return value
+          },
+        }) ?? {}
+      })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/system_config_doc.md
+++ b/packages/jira-adapter/system_config_doc.md
@@ -44,6 +44,47 @@ jira {
           }
         }
       }
+      NotificationEvent = {
+        transformation = {
+          fieldsToOmit = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+      }
+      EventNotification = {
+        transformation = {
+          fieldsToOmit = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+      }
+      Dashboard = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/dashboard"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/dashboard/{id}"
+            method = "put"
+          }
+          remove = {
+            url = "/rest/api/3/dashboard/{id}"
+            method = "delete"
+          }
+        }
+      }
       PageBeanField = {
         request = {
           url = "/rest/api/3/field/search"
@@ -133,6 +174,11 @@ jira {
       }
       Field = {
         transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
           idFields = [
             "id",
           ]
@@ -154,6 +200,31 @@ jira {
               fieldType = "list<CustomFieldContextProjectMapping>"
             },
           ]
+        }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/field"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/field/{fieldId}"
+            method = "put"
+            urlParamsToFields = {
+              fieldId = "id"
+            }
+          }
+          remove = {
+            url = "/rest/api/3/field/{id}"
+            method = "delete"
+          }
+        }
+      }
+      ApplicationProperty = {
+        deployRequests = {
+          modify = {
+            url = "/rest/api/3/application-properties/{id}"
+            method = "put"
+          }
         }
       }
       PageBeanCustomFieldContext = {
@@ -195,6 +266,26 @@ jira {
             },
           ]
         }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/field/{fieldId}/context"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/field/{fieldId}/context/{contextId}"
+            method = "put"
+            urlParamsToFields = {
+              contextId = "id"
+            }
+          }
+          remove = {
+            url = "/rest/api/3/field/{fieldId}/context/{contextId}"
+            method = "delete"
+            urlParamsToFields = {
+              contextId = "id"
+            }
+          }
+        }
       }
       PageBeanCustomFieldContextOption = {
         request = {
@@ -226,6 +317,11 @@ jira {
             {
               fieldName = "fields"
               fieldType = "list<FieldConfigurationItem>"
+            },
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "id"
             },
           ]
         }
@@ -260,6 +356,11 @@ jira {
             {
               fieldName = "items"
               fieldType = "list<FieldConfigurationIssueTypeItem>"
+            },
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "id"
             },
           ]
         }
@@ -308,6 +409,25 @@ jira {
               fieldType = "list<ColumnItem>"
             },
           ]
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/filter"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/filter/{id}"
+            method = "put"
+          }
+          remove = {
+            url = "/rest/api/3/filter/{id}"
+            method = "delete"
+          }
         }
       }
       PageBeanIssueTypeScheme = {
@@ -328,6 +448,15 @@ jira {
           ]
         }
       }
+      Board_location = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+      }
       IssueTypeScheme = {
         transformation = {
           fieldTypeOverrides = [
@@ -336,6 +465,31 @@ jira {
               fieldType = "list<IssueTypeSchemeMapping>"
             },
           ]
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/issuetypescheme"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/issuetypescheme/{issueTypeSchemeId}"
+            method = "put"
+            urlParamsToFields = {
+              issueTypeSchemeId = "id"
+            }
+          }
+          remove = {
+            url = "/rest/api/3/issuetypescheme/{issueTypeSchemeId}"
+            method = "delete"
+            urlParamsToFields = {
+              issueTypeSchemeId = "id"
+            }
+          }
         }
       }
       PageBeanIssueTypeSchemeMapping = {
@@ -379,6 +533,35 @@ jira {
               fieldType = "list<IssueTypeScreenSchemeItem>"
             },
           ]
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+        request = {
+          url = "/rest/api/3/issuetypescreenscheme"
+          paginationField = "startAt"
+        }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/issuetypescreenscheme"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/issuetypescreenscheme/{issueTypeScreenSchemeId}"
+            method = "put"
+            urlParamsToFields = {
+              issueTypeScreenSchemeId = "id"
+            }
+          }
+          remove = {
+            url = "/rest/api/3/issuetypescreenscheme/{issueTypeScreenSchemeId}"
+            method = "delete"
+            urlParamsToFields = {
+              issueTypeScreenSchemeId = "id"
+            }
+          }
         }
       }
       PageBeanIssueTypeScreenSchemeItem = {
@@ -392,6 +575,15 @@ jira {
           fieldsToOmit = [
             {
               fieldName = "issueTypeScreenSchemeId"
+            },
+          ]
+        }
+      }
+      NotificationScheme = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
             },
           ]
         }
@@ -415,6 +607,50 @@ jira {
           url = "/rest/api/3/permissionscheme"
           queryParams = {
             expand = "all"
+          }
+        }
+      }
+      PermissionGrant = {
+        transformation = {
+          fieldsToOmit = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+      }
+      PermissionScheme = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+        request = {
+          url = "/rest/api/3/permissionscheme"
+          queryParams = {
+            expand = "all"
+          }
+        }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/permissionscheme"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/permissionscheme/{schemeId}"
+            method = "put"
+            urlParamsToFields = {
+              schemeId = "id"
+            }
+          }
+          remove = {
+            url = "/rest/api/3/permissionscheme/{schemeId}"
+            method = "delete"
+            urlParamsToFields = {
+              schemeId = "id"
+            }
           }
         }
       }
@@ -445,6 +681,24 @@ jira {
           ]
         }
       }
+      RoleActor = {
+        transformation = {
+          fieldsToOmit = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+      }
+      ProjectCategory = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+      }
       Project = {
         transformation = {
           fieldTypeOverrides = [
@@ -453,6 +707,31 @@ jira {
               fieldType = "list<ComponentWithIssueCount>"
             },
           ]
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/project"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/project/{projectIdOrKey}"
+            method = "put"
+            urlParamsToFields = {
+              projectIdOrKey = "id"
+            }
+          }
+          remove = {
+            url = "/rest/api/3/project/{projectIdOrKey}"
+            method = "delete"
+            urlParamsToFields = {
+              projectIdOrKey = "id"
+            }
+          }
         }
       }
       ComponentWithIssueCount = {
@@ -460,6 +739,12 @@ jira {
           fieldsToOmit = [
             {
               fieldName = "issueCount"
+            },
+            {
+              fieldName = "id"
+            },
+            {
+              fieldName = "projectId"
             },
           ]
         }
@@ -492,6 +777,15 @@ jira {
           ]
         }
       }
+      Resolution = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+      }
       Screen = {
         transformation = {
           fieldTypeOverrides = [
@@ -504,6 +798,36 @@ jira {
               fieldType = "list<ScreenableField>"
             },
           ]
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+          standaloneFields = [
+            {
+              fieldName = "tabs"
+            },
+          ]
+        }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/screens"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/screens/{screenId}"
+            method = "put"
+            urlParamsToFields = {
+              screenId = "id"
+            }
+          }
+          remove = {
+            url = "/rest/api/3/screens/{screenId}"
+            method = "delete"
+            urlParamsToFields = {
+              screenId = "id"
+            }
+          }
         }
       }
       rest__api__3__screens___screenId___tabs@uuuuuuuu_00123_00125uu = {
@@ -534,6 +858,11 @@ jira {
               fieldType = "list<ScreenableField>"
             },
           ]
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
         }
       }
       PageBeanScreenScheme = {
@@ -562,11 +891,74 @@ jira {
             "id.name",
           ]
         }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/workflow"
+            method = "post"
+          }
+          remove = {
+            url = "/rest/api/3/workflow/{entityId}"
+            method = "delete"
+            urlParamsToFields = {
+              entityId = "id"
+            }
+          }
+        }
       }
       PageBeanWorkflowScheme = {
         request = {
           url = "/rest/api/3/workflowscheme"
           paginationField = "startAt"
+        }
+      }
+      SecurityScheme = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+      }
+      StatusCategory = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+      }
+      StatusDetails = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+      }
+      WorkflowScheme = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/workflowscheme"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/workflowscheme/{id}"
+            method = "put"
+          }
+          remove = {
+            url = "/rest/api/3/workflowscheme/{id}"
+            method = "delete"
+          }
         }
       }
       IssueTypeDetails = {
@@ -575,6 +967,25 @@ jira {
         }
         transformation = {
           dataField = "."
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/issuetype"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/issuetype/{id}"
+            method = "put"
+          }
+          remove = {
+            url = "/rest/api/3/issuetype/{id}"
+            method = "delete"
+          }
         }
       }
       AttachmentSettings = {
@@ -616,9 +1027,133 @@ jira {
               fieldType = "list<agile__1_0__board___boardId___configuration@uuvuuuu_00123_00125uu>"
             },
           ]
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+        deployRequests = {
+          add = {
+            url = "/rest/agile/1.0/board"
+            method = "post"
+          }
+          remove = {
+            url = "/rest/agile/1.0/board/{boardId}"
+            method = "delete"
+            urlParamsToFields = {
+              boardId = "id"
+            }
+          }
+        }
+      }
+      IssueLinkType = {
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/issueLinkType"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/issueLinkType/{issueLinkTypeId}"
+            method = "put"
+            urlParamsToFields = {
+              issueLinkTypeId = "id"
+            }
+          }
+          remove = {
+            url = "/rest/api/3/issueLinkType/{issueLinkTypeId}"
+            method = "delete"
+            urlParamsToFields = {
+              issueLinkTypeId = "id"
+            }
+          }
+        }
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+      }
+      ProjectRole = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/role"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/role/{id}"
+            method = "put"
+          }
+          remove = {
+            url = "/rest/api/3/role/{id}"
+            method = "delete"
+          }
+        }
+      }
+      Priority = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+      }
+      SharePermission = {
+        transformation = {
+          fieldsToOmit = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+      }
+      ScreenScheme = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/screenscheme"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/screenscheme/{screenSchemeId}"
+            method = "put"
+            urlParamsToFields = {
+              screenSchemeId = "id"
+            }
+          }
+          remove = {
+            url = "/rest/api/3/screenscheme/{screenSchemeId}"
+            method = "delete"
+            urlParamsToFields = {
+              screenSchemeId = "id"
+            }
+          }
         }
       }
       agile__1_0__board___boardId___configuration@uuvuuuu_00123_00125uu = {
+        transformation = {
+          fieldsToOmit = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
         request = {
           url = "/rest/agile/1.0/board/{boardId}/configuration"
         }

--- a/packages/jira-adapter/test/filters/hidden_value_in_lists.test.ts
+++ b/packages/jira-adapter/test/filters/hidden_value_in_lists.test.ts
@@ -1,0 +1,85 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ListType, ObjectType } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { JIRA } from '../../src/constants'
+import hiddenValueInListsFilter from '../../src/filters/hidden_value_in_lists'
+import { mockClient, getDefaultAdapterConfig } from '../utils'
+
+describe('hiddenValueInListsFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let instance: InstanceElement
+  beforeEach(async () => {
+    const { client, paginator } = mockClient()
+    filter = hiddenValueInListsFilter({
+      client,
+      paginator,
+      config: await getDefaultAdapterConfig(),
+    }) as typeof filter
+
+    const type = new ObjectType({
+      elemID: new ElemID(JIRA, 'someType'),
+      fields: {
+        hidden: {
+          refType: BuiltinTypes.STRING,
+          annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+        },
+        notHidden: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    type.fields.list = new Field(type, 'list', new ListType(type))
+    type.fields.obj = new Field(type, 'obj', type)
+
+    instance = new InstanceElement(
+      'instance',
+      type,
+      {
+        hidden: 'hidden',
+        notHidden: 'notHidden',
+        list: [
+          {
+            hidden: 'hidden',
+            notHidden: 'notHidden',
+            other: 'other',
+          },
+        ],
+        obj: {
+          hidden: 'hidden',
+          notHidden: 'notHidden',
+        },
+      },
+    )
+  })
+
+  it('should remove the hidden value inside the list', async () => {
+    await filter.onFetch([instance])
+    expect(instance.value).toEqual({
+      hidden: 'hidden',
+      notHidden: 'notHidden',
+      list: [
+        {
+          notHidden: 'notHidden',
+          other: 'other',
+        },
+      ],
+      obj: {
+        hidden: 'hidden',
+        notHidden: 'notHidden',
+      },
+    })
+  })
+})


### PR DESCRIPTION
Removed most ids from Jira NaCls
The change in the workspace after this PR can be found [here](https://github.com/salto-io/alon-jira-workspace/commit/363c3482a235f124cdc1e708a5e9e9824597c3af)

In this PR I:
- Made the ids hidden whenever possible
- Removed the ids if I couldn't make them hidden but their instance was anyway not deployable
- Extract the tabs field in `Screen` to new instances so I can make its id hidden
- Added a filter to remove hidden values inside the array in case I missed an id that I made hidden and can be inside the array so it won't fail the whole fetch

This still won't cover:
- Workflow - which will require some custom logic to deal with there ids
- Field - Still needs to decide what the way to remove its ids
- Some more places that should become referecens

---
_Release Notes_: 
None (Jira is not release yet)

---
_User Notifications_: 
None