### PR TITLE
SALTO-1815: Add applied changes result to deploy

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -116,7 +116,7 @@ export interface DeployResult {
   success: boolean
   errors: DeployError[]
   changes?: Iterable<FetchChange>
-  appliedChanges?: Iterable<Change>
+  appliedChanges?: Change[]
 }
 
 export const deploy = async (

--- a/packages/core/src/core/deploy.ts
+++ b/packages/core/src/core/deploy.ts
@@ -71,7 +71,7 @@ export const deployActions = async (
   adapters: Record<string, AdapterOperations>,
   reportProgress: (item: PlanItem, status: ItemStatus, details?: string) => void,
   postDeployAction: (appliedChanges: ReadonlyArray<Change>) => Promise<void>
-): Promise<{ errors: DeployError[]; appliedChanges: readonly Change[]}> => {
+): Promise<{ errors: DeployError[]; appliedChanges: Change[]}> => {
   const appliedChanges: Change[] = []
   try {
     await deployPlan.walkAsync(async (itemId: PlanItemId): Promise<void> => {

--- a/packages/core/src/core/deploy.ts
+++ b/packages/core/src/core/deploy.ts
@@ -71,13 +71,15 @@ export const deployActions = async (
   adapters: Record<string, AdapterOperations>,
   reportProgress: (item: PlanItem, status: ItemStatus, details?: string) => void,
   postDeployAction: (appliedChanges: ReadonlyArray<Change>) => Promise<void>
-): Promise<DeployError[]> => {
+): Promise<{ errors: DeployError[]; appliedChanges: readonly Change[]}> => {
+  const appliedChanges: Change[] = []
   try {
     await deployPlan.walkAsync(async (itemId: PlanItemId): Promise<void> => {
       const item = deployPlan.getItem(itemId) as PlanItem
       reportProgress(item, 'started')
       try {
         const result = await deployAction(item, adapters)
+        result.appliedChanges.forEach(appliedChange => appliedChanges.push(appliedChange))
         // Update element with changes so references to it
         // will have an updated version throughout the deploy plan
         updatePlanElement(item, result.appliedChanges)
@@ -99,7 +101,7 @@ export const deployActions = async (
         throw error
       }
     })
-    return []
+    return { errors: [], appliedChanges }
   } catch (error) {
     const deployErrors: DeployError[] = []
     if (error instanceof WalkError) {
@@ -118,6 +120,6 @@ export const deployActions = async (
         })
       }
     }
-    return deployErrors
+    return { errors: deployErrors, appliedChanges }
   }
 }

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -333,6 +333,14 @@ describe('api.ts', () => {
       it('should return success false for the overall deploy', () => {
         expect(result.success).toBeFalsy()
       })
+      it('should return applied changes for the overall deploy', () => {
+        expect(result.appliedChanges).toHaveLength(1)
+        const appliedChanges = [...(result.appliedChanges ?? [])].filter(isModificationChange)
+        expect(appliedChanges).toHaveLength(1)
+        const [appliedChange] = appliedChanges
+        expect(appliedChange?.action).toEqual('modify')
+        expect(appliedChange?.data?.after).toEqual(existingEmployee)
+      })
       it('should update state with applied change', () => {
         expect(stateSet).toHaveBeenCalledWith(existingEmployee)
       })


### PR DESCRIPTION
This PR adds the "AppliedChange" data in the `deployResult` API.
This gives consumers of deploy API the ability to generate an accurate list of Changes that were successfully deployed \ failed.

Todo
- [x] Add tests

---

_Release Notes_: 
Add 'appliedChanges' to 'DeployResult' API to allow consumers to assess requested changes \ deployed changes

---
_User Notifications_: 
None