### PR TITLE
SALTO-1715: added getLookupName func for the Jira adapter

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -29,6 +29,7 @@ import authenticatedPermissionFilter from './filters/authenticated_permission'
 import hiddenValuesInListsFilter from './filters/hidden_value_in_lists'
 import { JIRA } from './constants'
 import { removeScopedObjects } from './client/pagination'
+import { getLookUpName } from './references'
 
 const {
   generateTypes,
@@ -188,7 +189,7 @@ export default class JiraAdapter implements AdapterOperations {
       changesToDeploy.map(async change => {
         try {
           const response = await deployChange(
-            await resolveChangeElement(change, ({ ref }) => ref.value),
+            await resolveChangeElement(change, getLookUpName),
             this.client,
             this.userConfig.apiDefinitions
               .types[getChangeElement(change).elemID.typeName]?.deployRequests,

--- a/packages/jira-adapter/src/filters/field_references.ts
+++ b/packages/jira-adapter/src/filters/field_references.ts
@@ -16,25 +16,8 @@
 import { Element } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
+import { referencesRules } from '../references'
 import { FilterCreator } from '../filter'
-
-const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition<never>[] = [
-  {
-    src: { field: 'issueTypeId', parentTypes: ['IssueTypeSchemeMapping', 'IssueTypeScreenSchemeItem', 'FieldConfigurationIssueTypeItem'] },
-    serializationStrategy: 'id',
-    target: { type: 'IssueTypeDetails' },
-  },
-  {
-    src: { field: 'fieldConfigurationId', parentTypes: ['FieldConfigurationIssueTypeItem'] },
-    serializationStrategy: 'id',
-    target: { type: 'FieldConfigurationDetails' },
-  },
-  {
-    src: { field: 'screenSchemeId', parentTypes: ['IssueTypeScreenSchemeItem'] },
-    serializationStrategy: 'id',
-    target: { type: 'ScreenScheme' },
-  },
-]
 
 /**
  * Convert field values into references, based on predefined rules.
@@ -43,7 +26,7 @@ const filter: FilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
     await referenceUtils.addReferences({
       elements,
-      defs: fieldNameToTypeMappingDefs,
+      defs: referencesRules,
       isEqualValue: (lhs, rhs) => _.toString(lhs) === _.toString(rhs),
     })
   },

--- a/packages/jira-adapter/src/references.ts
+++ b/packages/jira-adapter/src/references.ts
@@ -1,0 +1,37 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { references as referenceUtils } from '@salto-io/adapter-components'
+
+
+export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] = [
+  {
+    src: { field: 'issueTypeId', parentTypes: ['IssueTypeSchemeMapping', 'IssueTypeScreenSchemeItem', 'FieldConfigurationIssueTypeItem'] },
+    serializationStrategy: 'id',
+    target: { type: 'IssueTypeDetails' },
+  },
+  {
+    src: { field: 'fieldConfigurationId', parentTypes: ['FieldConfigurationIssueTypeItem'] },
+    serializationStrategy: 'id',
+    target: { type: 'FieldConfigurationDetails' },
+  },
+  {
+    src: { field: 'screenSchemeId', parentTypes: ['IssueTypeScreenSchemeItem'] },
+    serializationStrategy: 'id',
+    target: { type: 'ScreenScheme' },
+  },
+]
+
+export const getLookUpName = referenceUtils.generateLookupFunc(referencesRules)


### PR DESCRIPTION
Added `getLookupName` to resolve references using the rules we defined in Jira.

---
_Release Notes_: 
None

---
_User Notifications_: 
None