### PR TITLE
SALTO-1822 SALTO-1789 Correctly support arrays without converting them to additional properties unneccessarily, allow isSingle for recurseInto

### DIFF
--- a/packages/adapter-components/src/config/request.ts
+++ b/packages/adapter-components/src/config/request.ts
@@ -138,7 +138,10 @@ export const createRequestConfigs = (
     },
   })
 
-  const recurseIntoConditionType = new ObjectType({
+  // either fromField or fromContext is required - not enforcing in nacl for now
+  const recurseIntoConditionType = createMatchingObjectType<
+    RecurseIntoConditionBase & Partial<RecurseIntoCondition
+  >>({
     elemID: new ElemID(adapter, 'recurseIntoCondition'),
     fields: {
       match: {
@@ -147,7 +150,6 @@ export const createRequestConfigs = (
           _required: true,
         },
       },
-      // either fromField or fromContext is required - not enforcing in nacl for now
       fromField: {
         refType: BuiltinTypes.STRING,
       },

--- a/packages/adapter-components/src/config/request.ts
+++ b/packages/adapter-components/src/config/request.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { ElemID, ObjectType, BuiltinTypes, CORE_ANNOTATIONS, FieldDefinition, MapType, ListType, ActionName, createRestriction } from '@salto-io/adapter-api'
+import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { findDuplicates } from './validation_utils'
 
@@ -101,37 +102,37 @@ export const createRequestConfigs = (
       },
     },
   })
-  const dependsOnConfigType = new ObjectType({
+  const dependsOnConfigType = createMatchingObjectType<DependsOnConfig>({
     elemID: new ElemID(adapter, 'dependsOnConfig'),
     fields: {
       pathParam: {
         refType: BuiltinTypes.STRING,
         annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
+          _required: true,
         },
       },
       from: {
         refType: dependsOnFromConfig,
         annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
+          _required: true,
         },
       },
     },
   })
 
-  const recurseIntoContextType = new ObjectType({
+  const recurseIntoContextType = createMatchingObjectType<RecurseIntoContext>({
     elemID: new ElemID(adapter, 'recurseIntoContext'),
     fields: {
       name: {
         refType: BuiltinTypes.STRING,
         annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
+          _required: true,
         },
       },
       fromField: {
         refType: BuiltinTypes.STRING,
         annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
+          _required: true,
         },
       },
     },
@@ -143,7 +144,7 @@ export const createRequestConfigs = (
       match: {
         refType: new ListType(BuiltinTypes.STRING),
         annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
+          _required: true,
         },
       },
       // either fromField or fromContext is required - not enforcing in nacl for now
@@ -155,19 +156,19 @@ export const createRequestConfigs = (
       },
     },
   })
-  const recurseIntoConfigType = new ObjectType({
+  const recurseIntoConfigType = createMatchingObjectType<RecurseIntoConfig>({
     elemID: new ElemID(adapter, 'recurseIntoConfig'),
     fields: {
       toField: {
         refType: BuiltinTypes.STRING,
         annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
+          _required: true,
         },
       },
       type: {
         refType: BuiltinTypes.STRING,
         annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
+          _required: true,
         },
       },
       isSingle: {
@@ -176,7 +177,7 @@ export const createRequestConfigs = (
       context: {
         refType: new ListType(recurseIntoContextType),
         annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
+          _required: true,
         },
       },
       conditions: {

--- a/packages/adapter-components/src/config/request.ts
+++ b/packages/adapter-components/src/config/request.ts
@@ -51,6 +51,7 @@ type RecurseIntoContext = {
 type RecurseIntoConfig = {
   toField: string
   type: string
+  isSingle?: boolean
   context: RecurseIntoContext[]
   conditions?: RecurseIntoCondition[]
 }
@@ -118,6 +119,72 @@ export const createRequestConfigs = (
     },
   })
 
+  const recurseIntoContextType = new ObjectType({
+    elemID: new ElemID(adapter, 'recurseIntoContext'),
+    fields: {
+      name: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+        },
+      },
+      fromField: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+        },
+      },
+    },
+  })
+
+  const recurseIntoConditionType = new ObjectType({
+    elemID: new ElemID(adapter, 'recurseIntoCondition'),
+    fields: {
+      match: {
+        refType: new ListType(BuiltinTypes.STRING),
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+        },
+      },
+      // either fromField or fromContext is required - not enforcing in nacl for now
+      fromField: {
+        refType: BuiltinTypes.STRING,
+      },
+      fromContext: {
+        refType: BuiltinTypes.STRING,
+      },
+    },
+  })
+  const recurseIntoConfigType = new ObjectType({
+    elemID: new ElemID(adapter, 'recurseIntoConfig'),
+    fields: {
+      toField: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+        },
+      },
+      type: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+        },
+      },
+      isSingle: {
+        refType: BuiltinTypes.BOOLEAN,
+      },
+      context: {
+        refType: new ListType(recurseIntoContextType),
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+        },
+      },
+      conditions: {
+        refType: new ListType(recurseIntoConditionType),
+      },
+    },
+  })
+
   const sharedEndpointFields: Record<string, FieldDefinition> = {
     url: {
       refType: BuiltinTypes.STRING,
@@ -140,6 +207,9 @@ export const createRequestConfigs = (
     },
     dependsOn: {
       refType: new ListType(dependsOnConfigType),
+    },
+    recurseInto: {
+      refType: new ListType(recurseIntoConfigType),
     },
     ...sharedEndpointFields,
     ...additionalFields,

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import {
   InstanceElement, Values, ObjectType, isObjectType, ReferenceExpression, isReferenceExpression,
-  isListType, isMapType,
+  isListType, isMapType, TypeElement, PrimitiveType, MapType,
 } from '@salto-io/adapter-api'
 import { transformElement, TransformFunc, safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -124,6 +124,15 @@ const extractStandaloneFields = async (
   return [updatedInst, ...additionalInstances]
 }
 
+const getListDeepInnerType = async (
+  type: TypeElement,
+): Promise<ObjectType | PrimitiveType | MapType> => {
+  if (!isListType(type)) {
+    return type
+  }
+  return getListDeepInnerType(await type.getInnerType())
+}
+
 /**
  * Normalize the element's values, by nesting swagger additionalProperties under the
  * additionalProperties field in order to align with the type.
@@ -132,20 +141,34 @@ const extractStandaloneFields = async (
  */
 const normalizeElementValues = (instance: InstanceElement): Promise<InstanceElement> => {
   const transformAdditionalProps: TransformFunc = async ({ value, field, path }) => {
+    if (Array.isArray(value)) {
+      // will handle in inner call
+      return value
+    }
+
     const fieldType = path?.isEqual(instance.elemID)
       ? await instance.getType()
       : await field?.getType()
+
+    if (fieldType === undefined) {
+      return value
+    }
+    const fieldInnerType = await getListDeepInnerType(fieldType)
     if (
-      !isObjectType(fieldType)
-      || fieldType.fields[ADDITIONAL_PROPERTIES_FIELD] === undefined
-      || !isMapType(await fieldType.fields[ADDITIONAL_PROPERTIES_FIELD].getType())
+      !isObjectType(fieldInnerType)
+      || fieldInnerType.fields[ADDITIONAL_PROPERTIES_FIELD] === undefined
+      || !isMapType(await fieldInnerType.fields[ADDITIONAL_PROPERTIES_FIELD].getType())
     ) {
       return value
     }
 
-    const additionalProps = _.pickBy(
-      value,
-      (_val, key) => !Object.keys(fieldType.fields).includes(key),
+    const additionalProps = _.merge(
+      _.pickBy(
+        value,
+        (_val, key) => !Object.keys(fieldInnerType.fields).includes(key),
+      ),
+      // if the value already has additional properties, give them precedence
+      value[ADDITIONAL_PROPERTIES_FIELD],
     )
     return {
       ..._.omit(value, Object.keys(additionalProps)),
@@ -351,7 +374,9 @@ const getEntriesForType = async (
     return { entries, objType }
   }
 
-  const getExtraFieldValues = (entry: Values): Promise<[string, Values[]][]> => Promise.all(
+  const getExtraFieldValues = (
+    entry: Values
+  ): Promise<[string, Values | Values[]][]> => Promise.all(
     recurseInto
       .filter(({ conditions }) => shouldRecurseIntoEntry(entry, requestContext, conditions))
       .map(async nested => {
@@ -360,7 +385,7 @@ const getEntriesForType = async (
             contextDef => [contextDef.name, _.get(entry, contextDef.fromField)]
           )
         )
-        const nestedEntries = await getEntriesForType({
+        const { entries: nestedEntries } = await getEntriesForType({
           ...params,
           typeName: nested.type,
           requestContext: {
@@ -368,7 +393,10 @@ const getEntriesForType = async (
             ...nestedRequestContext,
           },
         })
-        return [nested.toField, nestedEntries.entries] as [string, Values[]]
+        if (nested.isSingle && nestedEntries.length === 1) {
+          return [nested.toField, nestedEntries[0]] as [string, Values]
+        }
+        return [nested.toField, nestedEntries] as [string, Values[]]
       })
   )
 

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -396,6 +396,7 @@ const getEntriesForType = async (
         if (nested.isSingle && nestedEntries.length === 1) {
           return [nested.toField, nestedEntries[0]] as [string, Values]
         }
+        log.warn(`Expected a single value in recurseInto result for ${typeName}.${nested.toField} but received: ${nestedEntries.length}, keeping as list`)
         return [nested.toField, nestedEntries] as [string, Values[]]
       })
   )

--- a/packages/adapter-components/test/config/request.test.ts
+++ b/packages/adapter-components/test/config/request.test.ts
@@ -20,8 +20,8 @@ describe('config_request', () => {
   describe('createRequestConfigs', () => {
     it('should return default config type when no custom fields were added', async () => {
       const { fetch: { request, requestDefault } } = createRequestConfigs('myAdapter')
-      expect(Object.keys(request.fields)).toHaveLength(5)
-      expect(Object.keys(request.fields).sort()).toEqual(['dependsOn', 'paginationField', 'queryParams', 'recursiveQueryByResponseField', 'url'])
+      expect(Object.keys(request.fields)).toHaveLength(6)
+      expect(Object.keys(request.fields).sort()).toEqual(['dependsOn', 'paginationField', 'queryParams', 'recurseInto', 'recursiveQueryByResponseField', 'url'])
       expect(request.fields.url.refType.elemID.isEqual(BuiltinTypes.STRING.elemID)).toBeTruthy()
       expect(request.fields.paginationField.refType.elemID.isEqual(BuiltinTypes.STRING.elemID))
         .toBeTruthy()
@@ -40,8 +40,8 @@ describe('config_request', () => {
         recursiveQueryByResponseFieldType.refInnerType.elemID.isEqual(BuiltinTypes.STRING.elemID)
       ).toBeTruthy()
 
-      expect(Object.keys(requestDefault.fields)).toHaveLength(4)
-      expect(Object.keys(requestDefault.fields).sort()).toEqual(['dependsOn', 'paginationField', 'queryParams', 'recursiveQueryByResponseField'])
+      expect(Object.keys(requestDefault.fields)).toHaveLength(5)
+      expect(Object.keys(requestDefault.fields).sort()).toEqual(['dependsOn', 'paginationField', 'queryParams', 'recurseInto', 'recursiveQueryByResponseField'])
       expect(
         requestDefault.fields.paginationField.refType.elemID.isEqual(BuiltinTypes.STRING.elemID)
       ).toBeTruthy()
@@ -68,11 +68,11 @@ describe('config_request', () => {
         'myAdapter',
         { a: { refType: BuiltinTypes.STRING } },
       )
-      expect(Object.keys(request.fields)).toHaveLength(6)
-      expect(Object.keys(request.fields).sort()).toEqual(['a', 'dependsOn', 'paginationField', 'queryParams', 'recursiveQueryByResponseField', 'url'])
+      expect(Object.keys(request.fields)).toHaveLength(7)
+      expect(Object.keys(request.fields).sort()).toEqual(['a', 'dependsOn', 'paginationField', 'queryParams', 'recurseInto', 'recursiveQueryByResponseField', 'url'])
       expect(request.fields.a.refType.elemID.isEqual(BuiltinTypes.STRING.elemID)).toBeTruthy()
-      expect(Object.keys(requestDefault.fields)).toHaveLength(5)
-      expect(Object.keys(requestDefault.fields).sort()).toEqual(['a', 'dependsOn', 'paginationField', 'queryParams', 'recursiveQueryByResponseField'])
+      expect(Object.keys(requestDefault.fields)).toHaveLength(6)
+      expect(Object.keys(requestDefault.fields).sort()).toEqual(['a', 'dependsOn', 'paginationField', 'queryParams', 'recurseInto', 'recursiveQueryByResponseField'])
       expect(requestDefault.fields.a.refType.elemID.isEqual(BuiltinTypes.STRING.elemID))
         .toBeTruthy()
     })

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -852,14 +852,12 @@ describe('swagger_instance_elements', () => {
         nestedFieldFinder: returnFullEntry,
       })
       expect(res).toHaveLength(1)
-      expect(res.map(e => e.elemID.getFullName())).toEqual([
-        `${ADAPTER_NAME}.Pet.instance.mouse`,
-      ])
+      const petInst = res[0]
+      expect(petInst.elemID.getFullName()).toEqual(`${ADAPTER_NAME}.Pet.instance.mouse`)
       expect(mockPaginator).toHaveBeenCalledTimes(1)
       expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet', recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
 
-      const petInst = res.find(e => e.elemID.name === 'mouse')
-      expect(petInst?.isEqual(new InstanceElement(
+      expect(petInst.isEqual(new InstanceElement(
         'mouse',
         objectTypes.Pet,
         {
@@ -919,14 +917,12 @@ describe('swagger_instance_elements', () => {
         nestedFieldFinder: returnFullEntry,
       })
       expect(res).toHaveLength(1)
-      expect(res.map(e => e.elemID.getFullName())).toEqual([
-        `${ADAPTER_NAME}.Pet.instance.mouse`,
-      ])
+      const petInst = res[0]
+      expect(petInst.elemID.getFullName()).toEqual(`${ADAPTER_NAME}.Pet.instance.mouse`)
       expect(mockPaginator).toHaveBeenCalledTimes(1)
       expect(mockPaginator).toHaveBeenCalledWith({ url: '/pet', recursiveQueryParams: undefined, paginationField: undefined }, expect.anything())
 
-      const petInst = res.find(e => e.elemID.name === 'mouse')
-      expect(petInst?.isEqual(new InstanceElement(
+      expect(petInst.isEqual(new InstanceElement(
         'mouse',
         objectTypes.Pet,
         {

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -879,7 +879,7 @@ describe('swagger_instance_elements', () => {
       ))).toBeTruthy()
     })
 
-    it('should not put existing field values under additionalProperties even if they unexpectedly contain single vlaues', async () => {
+    it('should not put existing field values under additionalProperties even if they unexpectedly contain single values', async () => {
       const objectTypes = generateObjectTypes()
 
       mockPaginator = mockFunction<Paginator>().mockImplementation(
@@ -1068,7 +1068,7 @@ describe('swagger_instance_elements', () => {
           expect.objectContaining({ url: expect.stringMatching(/\/pet\/fish\/owner\/.*\/nicknames/) })
         )
       })
-      it('should return nested value list in the instance when isSingle is false and single item when isSingle=true', () => {
+      it('should return nested value list in the instance when isSingle is falsy and single item when isSingle=true', () => {
         expect(instances).toHaveLength(3)
         const [dog, cat, fish] = instances
         expect(dog.value).toHaveProperty(


### PR DESCRIPTION
1. When a field is not a list type but the value is an array (and vice versa), keep the value under the field with a type warning instead of the current behavior of moving it to `additionalProperties`
2. Add a `isSingle` flag for `recurseInto` to allow having a non-list `recurseInto` value
3. Add missing type definitions for `recurseInto`


---

These two together should help avoid some custom logic needed for jira references.

---
_Release Notes_: 
None (infra changes)

---
_User Notifications_: 
None