### PR TITLE
(SALTO-1823) change dummy adapter to avoid creating the restriction annotation

### DIFF
--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -353,7 +353,10 @@ export const generateElements = async (
   }
 
   const generateAnnotations = async (annoTypes: TypeMap, hidden = false): Promise<Values> => {
-    const anno = await mapValuesAsync(annoTypes, type => generateValue(type, hidden))
+    const anno = await mapValuesAsync(
+      _.omit(annoTypes, CORE_ANNOTATIONS.RESTRICTION) as TypeMap,
+      type => generateValue(type, hidden)
+    )
     if (hidden) {
       anno[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
     }


### PR DESCRIPTION
…

_change dummy adapter to avoid creating the restriction annotation_

---

_The dummy adapters creates the restriction annotation, and proceeds to create the values without semantic understanding of the restriction leading to validation errors._

---
_Release Notes_: 
_NA_

---
_User Notifications_: 
_NA_
