### PR TITLE
SALTO-1715: issue type schema deploy

### DIFF
--- a/packages/adapter-utils/src/filter.ts
+++ b/packages/adapter-utils/src/filter.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, Change, PostFetchOptions } from '@salto-io/adapter-api'
+import { Element, Change, PostFetchOptions, DeployResult } from '@salto-io/adapter-api'
 import { types, promises, values, collections, objects } from '@salto-io/lowerdash'
 
 const { awu } = collections.asynciterable
@@ -32,10 +32,7 @@ export type Filter<T extends FilterResult | void, DeployInfo=void> = Partial<{
   onFetch(elements: Element[]): Promise<T | void>
   preDeploy(changes: Change[]): Promise<void>
   deploy(changes: Change[]): Promise<{
-    deployResult: {
-      appliedChanges: Change[]
-      errors: Error[]
-    }
+    deployResult: DeployResult
     leftoverChanges: Change[]
   }>
   onDeploy(changes: Change[], deployInfo: DeployInfo): Promise<void>
@@ -101,8 +98,8 @@ export const filtersRunner = <
         },
         {
           deployResult: {
-            appliedChanges: [] as Change[],
-            errors: [] as Error[],
+            appliedChanges: [] as ReadonlyArray<Change>,
+            errors: [] as ReadonlyArray<Error>,
           },
           leftoverChanges: changes,
         }

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -30,7 +30,7 @@ import issueTypeSchemeReferences from './filters/issue_type_schemas/issue_type_s
 import issueTypeSchemeFilter from './filters/issue_type_schemas/issue_type_scheme'
 import authenticatedPermissionFilter from './filters/authenticated_permission'
 import hiddenValuesInListsFilter from './filters/hidden_value_in_lists'
-import deployFilter from './filters/deploy'
+import defaultDeployFilter from './filters/default_deploy'
 import { JIRA } from './constants'
 import { removeScopedObjects } from './client/pagination'
 
@@ -52,7 +52,8 @@ export const DEFAULT_FILTERS = [
   overrideProjectSchemeFieldsTypes,
   hiddenValuesInListsFilter,
   fieldReferences,
-  deployFilter,
+  // Must be last
+  defaultDeployFilter,
 ]
 
 export interface JiraAdapterParams {

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -194,10 +194,11 @@ export default class JiraAdapter implements AdapterOperations {
 
     const { deployResult: { appliedChanges, errors } } = await runner.deploy(changesToDeploy)
 
-    await runner.onDeploy(appliedChanges)
+    const changesToReturn = [...appliedChanges]
+    await runner.onDeploy(changesToReturn)
 
     return {
-      appliedChanges,
+      appliedChanges: changesToReturn,
       errors,
     }
   }

--- a/packages/jira-adapter/src/filters/default_deploy.ts
+++ b/packages/jira-adapter/src/filters/default_deploy.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { isInstanceChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { deployChange } from '../deployment'
+import { FilterCreator } from '../filter'
+
+const filter: FilterCreator = ({ client, config }) => ({
+  deploy: async changes => {
+    const result = await Promise.all(
+      changes.filter(isInstanceChange).map(async change => {
+        try {
+          await deployChange(change, client, config.apiDefinitions)
+          return change
+        } catch (err) {
+          if (!_.isError(err)) {
+            throw err
+          }
+          return err
+        }
+      })
+    )
+
+    const [errors, appliedChanges] = _.partition(result, _.isError)
+    return {
+      leftoverChanges: [],
+      deployResult: {
+        errors,
+        appliedChanges,
+      },
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -158,6 +158,20 @@ describe('adapter', () => {
 
       expect((getChangeElement(appliedChanges[0]) as InstanceElement)?.value.id).toEqual(2)
     })
+    it('should not add the new id on addition if received an invalid response', async () => {
+      deployChangeMock.mockResolvedValue([])
+      const instance = new InstanceElement('instance', new ObjectType({ elemID: new ElemID(JIRA, 'obj') }))
+      const { appliedChanges } = await adapter.deploy({
+        changeGroup: {
+          groupID: 'group',
+          changes: [
+            toChange({ after: instance }),
+          ],
+        },
+      })
+
+      expect((getChangeElement(appliedChanges[0]) as InstanceElement)?.value.id).toBeUndefined()
+    })
   })
   describe('deployModifiers', () => {
     it('should have change validator', () => {


### PR DESCRIPTION
Added support for deploying `IssueTypeSchema`

---

- Changed `issueTypes` to `issueTypesIds` in `IssueTypeSchema` because this is the name that is expected on create
- Called the modification endpoints of  issueTypesIds on modification

---
_Release Notes_: 
None

---
_User Notifications_: 
None