### PR TITLE
SALTO-1824 avoid noise from timestamp changes

### DIFF
--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -27,6 +27,7 @@ const DEFAULT_ID_FIELDS = ['id']
 export const FIELDS_TO_OMIT: configUtils.FieldToOmitType[] = [
   { fieldName: 'object', fieldType: 'string' },
   { fieldName: 'created', fieldType: 'number' },
+  { fieldName: 'updated', fieldType: 'number' },
 ]
 
 export const CLIENT_CONFIG = 'client'
@@ -78,6 +79,14 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: StripeApiConfig['types'] = {
     },
     transformation: {
       dataField: 'data',
+    },
+  },
+  reporting_report_type: {
+    transformation: {
+      fieldsToHide: [
+        { fieldName: 'data_available_end', fieldType: 'number' },
+        { fieldName: 'data_available_start', fieldType: 'number' },
+      ],
     },
   },
   tax_rate: {

--- a/packages/stripe-adapter/system_config_doc.md
+++ b/packages/stripe-adapter/system_config_doc.md
@@ -50,6 +50,10 @@ stripe {
             fieldName = "created"
             fieldType = "number"
           },
+          {
+            fieldName = "updated"
+            fieldType = "number"
+          },
         ]
       }
     }
@@ -103,6 +107,20 @@ stripe {
         }
         transformation = {
           dataField = "data"
+        }
+      }
+      reporting_report_type = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "data_available_end"
+              fieldType = "number"
+            },
+            {
+              fieldName = "data_available_start"
+              fieldType = "number"
+            },
+          ]
         }
       }
       tax_rate = {


### PR DESCRIPTION
Omit/hide timestamp fields that get changed a lot

---

_Release Notes_: 
Stripe adapter:
* Omit some timestamps from types such as report types

---
_User Notifications_: 
* Values in `stripe.*.instance.*.updated`, and in `stripe.reporting_report_type.instance.*.data_available_start` and `stripe.reporting_report_type.instance.*.data_available_end` will be removed from the nacls
* Adding the annotations `stripe.reporting_report_type.field.data_available_start._hidden_value` and `stripe.reporting_report_type.field.data_available_end._hidden_value`