### PR TITLE
Removed required annotations from adapter-component

### DIFF
--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -64,15 +64,12 @@ export const createAdapterApiConfigType = ({
   }
   transformationTypes: { transformation: ObjectType; transformationDefault: ObjectType }
 }): ObjectType => {
-  const typeDefaultsConfigType = createMatchingObjectType<TypeDefaultsConfig>({
+  const typeDefaultsConfigType = createMatchingObjectType<Partial<TypeDefaultsConfig>>({
     elemID: new ElemID(adapter, 'typeDefaultsConfig'),
     fields: {
       request: { refType: requestTypes.fetch.requestDefault },
       transformation: {
         refType: transformationTypes.transformationDefault,
-        annotations: {
-          _required: true,
-        },
       },
     },
   })
@@ -88,20 +85,14 @@ export const createAdapterApiConfigType = ({
     },
   })
 
-  const adapterApiConfigType = createMatchingObjectType<AdapterApiConfig>({
+  const adapterApiConfigType = createMatchingObjectType<Partial<AdapterApiConfig>>({
     elemID: new ElemID(adapter, 'adapterApiConfig'),
     fields: {
       types: {
         refType: new MapType(typesConfigType),
-        annotations: {
-          _required: true,
-        },
       },
       typeDefaults: {
         refType: typeDefaultsConfigType,
-        annotations: {
-          _required: true,
-        },
       },
       apiVersion: {
         refType: BuiltinTypes.STRING,

--- a/packages/adapter-components/src/config/swagger.ts
+++ b/packages/adapter-components/src/config/swagger.ts
@@ -105,9 +105,6 @@ const createSwaggerDefinitionsBaseConfigType = (
     fields: {
       url: {
         refType: BuiltinTypes.STRING,
-        annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
-        },
       },
       typeNameOverrides: {
         refType: new ListType(typeNameOverrideConfig),

--- a/packages/adapter-components/src/config/transformation.ts
+++ b/packages/adapter-components/src/config/transformation.ts
@@ -142,9 +142,6 @@ export const createTransformationConfigTypes = (
     fields: {
       idFields: {
         refType: new ListType(BuiltinTypes.STRING),
-        annotations: {
-          [CORE_ANNOTATIONS.REQUIRED]: true,
-        },
       },
       ...sharedTransformationFields,
     },

--- a/packages/adapter-components/test/config/transformation.test.ts
+++ b/packages/adapter-components/test/config/transformation.test.ts
@@ -27,9 +27,6 @@ describe('config_transformation', () => {
       expect(idFieldsType.refInnerType.elemID.isEqual(BuiltinTypes.STRING.elemID)).toBeTruthy()
 
       expect(Object.keys(transformationDefault.fields).sort()).toEqual(['dataField', 'fieldTypeOverrides', 'fieldsToHide', 'fieldsToOmit', 'fileNameFields', 'idFields', 'standaloneFields'])
-      expect(transformationDefault.fields.idFields.annotations[CORE_ANNOTATIONS.REQUIRED]).toEqual(
-        true
-      )
       const idFieldsDefaultType = await transformationDefault.fields.idFields.getType() as ListType
       expect(idFieldsDefaultType).toBeInstanceOf(ListType)
       expect(idFieldsType.refInnerType.elemID.isEqual(BuiltinTypes.STRING.elemID)).toBeTruthy()

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1165,25 +1165,21 @@ export type JiraConfig = {
 
 const defaultApiDefinitionsType = createSwaggerAdapterApiConfigType({ adapter: JIRA })
 
-const apiDefinitionsType = createMatchingObjectType<JiraApiConfig>({
+const apiDefinitionsType = createMatchingObjectType<Partial<JiraApiConfig>>({
   elemID: new ElemID(JIRA, 'apiDefinitions'),
   fields: {
     apiVersion: { refType: BuiltinTypes.STRING },
     typeDefaults: {
       refType: defaultApiDefinitionsType.fields.typeDefaults.refType,
-      annotations: { _required: true },
     },
     types: {
       refType: defaultApiDefinitionsType.fields.types.refType,
-      annotations: { _required: true },
     },
     jiraSwagger: {
       refType: defaultApiDefinitionsType.fields.swagger.refType,
-      annotations: { _required: true },
     },
     platformSwagger: {
       refType: defaultApiDefinitionsType.fields.swagger.refType,
-      annotations: { _required: true },
     },
     supportedTypes: {
       refType: new ListType(BuiltinTypes.STRING),

--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -121,7 +121,7 @@ const ALL_SUPPORTED_TYPES = [
 // noinspection UnnecessaryLocalVariableJS
 export const DEFAULT_INCLUDE_TYPES = ALL_SUPPORTED_TYPES
 
-export const DEFAULT_CONFIG = {
+export const DEFAULT_CONFIG: StripeConfig = {
   [FETCH_CONFIG]: {
     includeTypes: DEFAULT_INCLUDE_TYPES,
   },

--- a/packages/workato-adapter/src/config.ts
+++ b/packages/workato-adapter/src/config.ts
@@ -135,7 +135,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
   },
 }
 
-export const DEFAULT_CONFIG = {
+export const DEFAULT_CONFIG: WorkatoConfig = {
   [FETCH_CONFIG]: {
     includeTypes: [
       ...Object.keys(_.pickBy(DEFAULT_TYPES, def => def.request !== undefined)),

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -1066,7 +1066,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
   // not included yet: satisfaction_reason (returns 403), sunshine apis
 }
 
-export const DEFAULT_CONFIG = {
+export const DEFAULT_CONFIG: ZendeskConfig = {
   [FETCH_CONFIG]: {
     includeTypes: [
       ...Object.keys(_.pickBy(DEFAULT_TYPES, def => def.request !== undefined)),

--- a/packages/zuora-billing-adapter/src/config.ts
+++ b/packages/zuora-billing-adapter/src/config.ts
@@ -692,7 +692,7 @@ export const DEFAULT_INCLUDE_TYPES = [
   WORKFLOW_EXPORT_TYPE,
 ]
 
-export const DEFAULT_CONFIG = {
+export const DEFAULT_CONFIG: ZuoraConfig = {
   [FETCH_CONFIG]: {
     includeTypes: DEFAULT_INCLUDE_TYPES,
     settingsIncludeTypes: DEFAULT_SETTINGS_INCLUDE_TYPES,


### PR DESCRIPTION
Removed required annotation from  types in simple adapters so when overriding it partially we won't get warnings that that values are missing

---
_Release Notes_: 
None

---
_User Notifications_: 
None