### PR TITLE
SALTO-1828: fixed circular dependency issue on serialize

### DIFF
--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -145,7 +145,8 @@ export const serialize = <T = Element>(
     if (isElement(e.value)) {
       return saltoClassReplacer(new ReferenceExpression(e.value.elemID))
     }
-    return e.value
+    // eslint-disable-next-line no-use-before-define
+    return _.cloneDeepWith(e.value, replacer)
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const resolveCircles = (v: any): any => (


### PR DESCRIPTION
Fixed a bug of circular dependency error on serializing (an example can be found [here](https://salto-io.atlassian.net/browse/SALTO-1828))

---
The issue was that in https://github.com/salto-io/salto/blob/main/packages/workspace/src/serializer/elements.ts#L188 we expect the replacer to run on every node of the element before passing to the `JSON.stringify`. However, when we return the value of the reference in https://github.com/salto-io/salto/blob/main/packages/workspace/src/serializer/elements.ts#L148 the replacer function won't run on `e.value` values which can create circular dependencies

---
_Release Notes_: 
Core:
- Fixed a bug of circular dependency error for some cases of NaCls with inner references

---
_User Notifications_: 
None