### PR TITLE
SALTO-1831: fixed hidden values inside objects

### DIFF
--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -62,7 +62,11 @@ export const getElementHiddenParts = async <T extends Element>(
   const hiddenFunc = isInstanceElement(stateElement) ? isHiddenValue : isHidden
   const storeHiddenPaths: TransformFunc = async ({ value, field, path }) => {
     if (await hiddenFunc(field, elementsSource)) {
-      if (path !== undefined) {
+      if (
+        path !== undefined
+        && (workspaceElement === undefined
+          || resolvePath(workspaceElement, path.createParentID()) !== undefined)
+      ) {
         hiddenPaths.add(path.getFullName())
         let ancestor = path.createParentID()
         while (!ancestorsOfHiddenPaths.has(ancestor.getFullName())) {
@@ -110,10 +114,7 @@ export const getElementHiddenParts = async <T extends Element>(
       // no overlap between ancestorsOfHiddenPaths and hiddenPaths
       path !== undefined
         && (
-          (isAncestorOfHiddenPath(path)
-            && (workspaceElement === undefined
-              || resolvePath(workspaceElement, path) !== undefined))
-          || isNestedHiddenPath(path)
+          isAncestorOfHiddenPath(path) || isNestedHiddenPath(path)
         )
         ? value
         : undefined

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -62,11 +62,13 @@ export const getElementHiddenParts = async <T extends Element>(
   const hiddenFunc = isInstanceElement(stateElement) ? isHiddenValue : isHidden
   const storeHiddenPaths: TransformFunc = async ({ value, field, path }) => {
     if (await hiddenFunc(field, elementsSource)) {
-      if (
-        path !== undefined
-        && (workspaceElement === undefined
-          || resolvePath(workspaceElement, path.createParentID()) !== undefined)
-      ) {
+      if (path !== undefined) {
+        if (workspaceElement !== undefined) {
+          const workspaceValue = resolvePath(workspaceElement, path.createParentID())
+          if (workspaceValue === undefined || isReferenceExpression(workspaceValue)) {
+            return undefined
+          }
+        }
         hiddenPaths.add(path.getFullName())
         let ancestor = path.createParentID()
         while (!ancestorsOfHiddenPaths.has(ancestor.getFullName())) {

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -63,9 +63,10 @@ export const getElementHiddenParts = async <T extends Element>(
   const storeHiddenPaths: TransformFunc = async ({ value, field, path }) => {
     if (await hiddenFunc(field, elementsSource)) {
       if (path !== undefined) {
-        if (workspaceElement !== undefined) {
-          const workspaceValue = resolvePath(workspaceElement, path.createParentID())
-          if (workspaceValue === undefined || isReferenceExpression(workspaceValue)) {
+        const parentPath = path.createParentID()
+        if (!parentPath.isBaseID() && workspaceElement !== undefined) {
+          const workspaceValue = resolvePath(workspaceElement, parentPath)
+          if (!_.isPlainObject(workspaceValue)) {
             return undefined
           }
         }

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { values, collections, promises } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
-import { transformElement, TransformFunc, transformValues, applyFunctionToChangeData, elementAnnotationTypes, safeJsonStringify } from '@salto-io/adapter-utils'
+import { transformElement, TransformFunc, transformValues, applyFunctionToChangeData, elementAnnotationTypes, safeJsonStringify, resolvePath } from '@salto-io/adapter-utils'
 import { CORE_ANNOTATIONS, Element, isInstanceElement, isType, TypeElement, getField,
   DetailedChange, isRemovalChange, ElemID, isObjectType, ObjectType, Values,
   isRemovalOrModificationChange, isAdditionOrModificationChange, isElement, isField,
@@ -108,7 +108,13 @@ export const getElementHiddenParts = async <T extends Element>(
       // Keep traversing as long as we might reach nested hidden parts.
       // Note: it is ok to check isAncestorOfHiddenPath before isNestedHiddenPath, because there is
       // no overlap between ancestorsOfHiddenPaths and hiddenPaths
-      path !== undefined && (isAncestorOfHiddenPath(path) || isNestedHiddenPath(path))
+      path !== undefined
+        && (
+          (isAncestorOfHiddenPath(path)
+            && (workspaceElement === undefined
+              || resolvePath(workspaceElement, path) !== undefined))
+          || isNestedHiddenPath(path)
+        )
         ? value
         : undefined
     ),

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -66,6 +66,8 @@ export const getElementHiddenParts = async <T extends Element>(
         const parentPath = path.createParentID()
         if (!parentPath.isBaseID() && workspaceElement !== undefined) {
           const workspaceValue = resolvePath(workspaceElement, parentPath)
+          // If the parent value is not an object, (e.g., deleted or replaced with a primitive),
+          // we don't want to merge hidden values from state
           if (!_.isPlainObject(workspaceValue)) {
             return undefined
           }
@@ -115,10 +117,7 @@ export const getElementHiddenParts = async <T extends Element>(
       // Keep traversing as long as we might reach nested hidden parts.
       // Note: it is ok to check isAncestorOfHiddenPath before isNestedHiddenPath, because there is
       // no overlap between ancestorsOfHiddenPaths and hiddenPaths
-      path !== undefined
-        && (
-          isAncestorOfHiddenPath(path) || isNestedHiddenPath(path)
-        )
+      path !== undefined && (isAncestorOfHiddenPath(path) || isNestedHiddenPath(path))
         ? value
         : undefined
     ),

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -91,7 +91,7 @@ describe('mergeWithHidden', () => {
     })
   })
 
-  describe('when parent value were deleted', () => {
+  describe('when the parent value in the workspace is not an object', () => {
     let result: MergeResult
     beforeEach(async () => {
       const innerType = new ObjectType({
@@ -110,19 +110,32 @@ describe('mergeWithHidden', () => {
       const type = new ObjectType({
         elemID: new ElemID('adapter', 'type'),
         fields: {
-          obj: { refType: innerType },
+          obj1: { refType: innerType },
+          obj2: { refType: innerType },
+          obj3: { refType: innerType },
+          obj4: { refType: innerType },
         },
       })
 
       const stateInstance = new InstanceElement(
         'instance',
         type,
-        { obj: { hidden: 'hidden', notHidden: 'notHidden' } },
+        {
+          obj1: { hidden: 'hidden', notHidden: 'notHidden' },
+          obj2: { hidden: 'hidden', notHidden: 'notHidden' },
+          obj3: { hidden: 'hidden', notHidden: 'notHidden' },
+          obj4: { hidden: 'hidden', notHidden: 'notHidden' },
+        },
       )
 
       const workspaceInstance = new InstanceElement(
         'instance',
         type,
+        {
+          obj2: 2,
+          obj3: [],
+          obj4: { notHidden: 'notHidden2' },
+        }
       )
 
       result = await mergeWithHidden(
@@ -133,10 +146,14 @@ describe('mergeWithHidden', () => {
     it('should not have merge errors', async () => {
       expect(await awu(result.errors.values()).flat().toArray()).toHaveLength(0)
     })
-    it('should not add the hidden value to the instance', async () => {
+    it('should not add the hidden value to the instance when parent value is not an object', async () => {
       const instance = (await awu(result.merged.values())
         .find(isInstanceElement)) as InstanceElement
-      expect(instance.value).toEqual({})
+      expect(instance.value).toEqual({
+        obj2: 2,
+        obj3: [],
+        obj4: { hidden: 'hidden', notHidden: 'notHidden2' },
+      })
     })
   })
 


### PR DESCRIPTION
Changed `mergeWithHidden` to not create parent object if it was deleted from the workspace element

---
_Release Notes_: 
None (I don't think it currently has an effect on users)

---
_User Notifications_: 
None