### PR TITLE
(SALTO-1853) improved ws load concurrency

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -232,11 +232,13 @@ const buildMultiEnvSource = (
       getRemoteMapNamespace('multi_env_mergeManager'),
       persistent,
       mergedRecoveryMode)
-      await mergeManager.init()
     }
     const current = {
       states,
       mergeManager,
+    }
+    if (Object.values(envChanges).every(changeSet => changeSet.changes.length === 0)) {
+      return { state: current, changes: {} }
     }
     const changesInCommon = (envChanges[commonSourceName]
       ?.changes ?? []).length > 0

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -563,9 +563,13 @@ const buildNaclFilesSource = (
       result.changes.preChangeHash = preChangeHash
       return result
     }
-    const preChangeHash = await currentState.metadata.get(HASH_KEY)
     return {
-      changes: { changes: [], cacheValid: true, preChangeHash, postChangeHash: preChangeHash },
+      changes: {
+        changes: [],
+        cacheValid: true,
+        preChangeHash: undefined,
+        postChangeHash: undefined,
+      },
       state: currentState,
     }
   }

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -920,13 +920,11 @@ const buildNaclFilesSource = (
     ),
     updateNaclFiles,
     setNaclFiles: async (...naclFiles) => {
-      const preChangeHash = (await getState()).parsedNaclFiles.getHash()
       await setNaclFiles(...naclFiles)
       const res = await buildNaclFilesStateInner(
         await parseNaclFiles(naclFiles, (await getState()).parsedNaclFiles, functions)
       )
       state = Promise.resolve(res.state)
-      res.changes.preChangeHash = await preChangeHash
       return res.changes
     },
     getSourceMap,

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -394,7 +394,6 @@ export const loadWorkspace = async (
           mergedRecoveryMode,
         ),
       }
-      await initializedState.mergeManager.init()
       return initializedState
     }
 
@@ -608,10 +607,7 @@ export const loadWorkspace = async (
     const relevantEnvs = awu(envs())
       .filter(async name =>
         (workspaceChanges[name]?.changes ?? []).length > 0
-        || (stateOnlyChanges[name]?.changes ?? []).length > 0
-        // Even without changes, it's possible that things moved between common and env
-        || workspaceChanges[name]?.postChangeHash
-          !== await stateToBuild.mergeManager.getHash(MULTI_ENV_SOURCE_PREFIX + name))
+        || (stateOnlyChanges[name]?.changes ?? []).length > 0)
 
     await relevantEnvs.forEach(async envName => { await updateWorkspace(envName) })
     return stateToBuild

--- a/packages/workspace/test/workspace/nacl_files/elements_cache.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/elements_cache.test.ts
@@ -56,16 +56,29 @@ describe('test cache manager', () => {
     })
 
     it('If flush was unsuccessful, clears on init', async () => {
+      const mapCreator = persistentMockCreateRemoteMap()
+      const origManager = await createMergeManager(
+        flushables, {},
+        mapCreator,
+        NAMESPACE,
+        true
+      )
       flushables[1].flush = () => {
         throw new Error('Error within flush')
       }
       try {
-        await manager.flush()
+        await origManager.flush()
         throw new Error('Flush should throw exception!')
       } catch {
         // Do nothing
       }
-      await manager.init()
+      const nextManager = await createMergeManager(
+        flushables, {},
+        mapCreator,
+        NAMESPACE,
+        true
+      )
+      await nextManager.getHash('')
       await Promise.all(flushables.map(async flushable => {
         expect(flushable.clear).toHaveBeenCalled()
       }))

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -259,7 +259,7 @@ describe('Nacl Files Source', () => {
       )).load({ ignoreFileChanges: true })
       expect(mockDirStore.list as jest.Mock).not.toHaveBeenCalled()
     })
-    it('should only access the HASH_KEY in rocksdb when ignore file changes is set', async () => {
+    it('should not access rocks db when ignore file changes flag is set', async () => {
       mockDirStore.list = jest.fn().mockImplementation(async () => awu([]))
       const retrievedKeys: string[] = []
       await (await naclFilesSource(
@@ -279,7 +279,7 @@ describe('Nacl Files Source', () => {
         },
         true
       )).load({ ignoreFileChanges: true })
-      expect(retrievedKeys).toEqual([naclFileSourceModule.HASH_KEY])
+      expect(retrievedKeys).toEqual([])
     })
   })
 


### PR DESCRIPTION
_ improved ws load concurrency_

---

_In order to reduce rocks db access in the ws load:
1. Avoid getting the hash value when ignore file changes is used (return undefined instead)
2. Avoid performing merge calculation if no changes were detected.
3. init the merger in a lazy fashion,

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
