### PR TITLE
SALTO-1778: Fixed deployment config for several types

### DIFF
--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -299,6 +299,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       ],
     },
   },
+
   FieldsConfigurationIssueTypeItem: {
     request: {
       url: '/rest/api/3/fieldconfigurationscheme/mapping?fieldConfigurationSchemeId={schemeId}',
@@ -417,7 +418,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       recurseInto: [
         {
           type: 'IssueTypeScreenSchemeItems',
-          toField: 'items',
+          toField: 'issueTypeMappings',
           context: [{ name: 'schemeId', fromField: 'id' }],
         },
       ],
@@ -425,7 +426,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   },
   IssueTypeScreenScheme: {
     transformation: {
-      fieldTypeOverrides: [{ fieldName: 'items', fieldType: 'list<IssueTypeScreenSchemeItem>' }],
+      fieldTypeOverrides: [{ fieldName: 'issueTypeMappings', fieldType: 'list<IssueTypeScreenSchemeItem>' }],
       fieldsToHide: [
         {
           fieldName: 'id',
@@ -487,8 +488,16 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     request: {
       url: '/rest/api/3/permissionscheme',
       queryParams: {
-        expand: 'all',
+        expand: 'permissions,user',
       },
+    },
+  },
+
+  PermissionHolder: {
+    transformation: {
+      fieldTypeOverrides: [
+        { fieldName: 'user', fieldType: 'User' },
+      ],
     },
   },
 
@@ -600,6 +609,20 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
+    },
+    deployRequests: {
+      add: {
+        url: '/rest/api/3/projectCategory',
+        method: 'post',
+      },
+      modify: {
+        url: '/rest/api/3/projectCategory/{id}',
+        method: 'put',
+      },
+      remove: {
+        url: '/rest/api/3/projectCategory/{id}',
+        method: 'delete',
+      },
     },
   },
 
@@ -928,6 +951,12 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     },
     transformation: {
       dataField: '.',
+      fieldTypeOverrides: [
+        { fieldName: 'untranslatedName', fieldType: 'string' },
+      ],
+      fieldsToOmit: [
+        { fieldName: 'subtask' },
+      ],
       fieldsToHide: [
         {
           fieldName: 'id',

--- a/packages/jira-adapter/src/references.ts
+++ b/packages/jira-adapter/src/references.ts
@@ -108,6 +108,16 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
     serializationStrategy: 'id',
     target: { type: 'Status' },
   },
+  {
+    src: { field: 'parameter', parentTypes: ['PermissionHolder'] },
+    serializationStrategy: 'id',
+    target: { type: 'Field' },
+  },
+  {
+    src: { field: 'parameter', parentTypes: ['PermissionHolder'] },
+    serializationStrategy: 'id',
+    target: { type: 'ProjectRole' },
+  },
 ]
 
 export const getLookUpName = referenceUtils.generateLookupFunc(referencesRules)


### PR DESCRIPTION
Made small config changes to the types IssueTypeScreenScheme, IssueTypeDetailsk PermissionScheme and ProjectCategory will be deployable

---

IssueTypeScreenScheme:
- Changed the field `items` to `issueTypeMappings`

IssueTypeDetails:
- Added field for `untranslatedName`
- Removed subtask field (not deployable and we already have `hierarchyLevel` that says the same thing)

PermissionScheme:
- Removed additional parameters from expand that includes data that already included in the `parameter` field
- Added field for user

ProjectCategory:
- added deploymentRequests config

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
None
