### PR TITLE
SALTO-1866 do not hide ids by default

### DIFF
--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -536,7 +536,6 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       sourceTypeName: 'ticket_forms__ticket_forms',
       fieldsToHide: FIELDS_TO_HIDE.concat([
         { fieldName: 'id', fieldType: 'number' },
-        { fieldName: 'domain_verification_code' },
       ]),
     },
     deployRequests: {

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -33,7 +33,6 @@ export const FIELDS_TO_OMIT: configUtils.FieldToOmitType[] = [
   { fieldName: 'count', fieldType: 'number' },
 ]
 export const FIELDS_TO_HIDE: configUtils.FieldToHideType[] = [
-  { fieldName: 'id', fieldType: 'number' },
   { fieldName: 'created_at', fieldType: 'string' },
   { fieldName: 'updated_at', fieldType: 'string' },
 ]
@@ -59,6 +58,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
   group: {
     transformation: {
       sourceTypeName: 'groups__groups',
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -87,6 +87,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
   custom_role: {
     transformation: {
       sourceTypeName: 'custom_roles__custom_roles',
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
       fieldsToOmit: FIELDS_TO_OMIT.concat([
         // always 0 - https://developer.zendesk.com/api-reference/ticketing/account-configuration/custom_roles/#json-format
         { fieldName: 'role_type', fieldType: 'number' },
@@ -120,6 +121,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
   organization: {
     transformation: {
       sourceTypeName: 'organizations__organizations',
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -150,6 +152,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       sourceTypeName: 'views__views',
       idFields: ['title'],
       fileNameFields: ['title'],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -175,16 +178,12 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       },
     },
   },
-  view__execution__custom_fields: {
-    transformation: {
-      fieldsToHide: FIELDS_TO_HIDE.filter(field => field.fieldName !== 'id'),
-    },
-  },
   trigger: {
     transformation: {
       sourceTypeName: 'triggers__triggers',
       idFields: ['title'],
       fileNameFields: ['title'],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -214,6 +213,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
     transformation: {
       sourceTypeName: 'trigger_categories__trigger_categories',
       fileNameFields: ['name'],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id' }),
     },
     deployRequests: {
       add: {
@@ -244,6 +244,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       sourceTypeName: 'automations__automations',
       idFields: ['title'],
       fileNameFields: ['title'],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -274,6 +275,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       sourceTypeName: 'sla_policies__sla_policies',
       idFields: ['title'],
       fileNameFields: ['title'],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -303,12 +305,14 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
     transformation: {
       sourceTypeName: 'sla_policies_definitions__definitions',
       isSingleton: true,
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
   target: {
     transformation: {
       sourceTypeName: 'targets__targets',
       idFields: ['title', 'type'], // looks like title is unique so not adding id
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -339,6 +343,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       sourceTypeName: 'macros__macros',
       idFields: ['title'],
       fileNameFields: ['title'],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -367,17 +372,20 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
   macro_action: {
     transformation: {
       sourceTypeName: 'macros_actions__actions',
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
   macro_category: {
     transformation: {
       sourceTypeName: 'macros_categories__categories',
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
   macro_definition: {
     transformation: {
       sourceTypeName: 'macros_definitions__definitions',
       isSingleton: true,
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
   brand: {
@@ -388,6 +396,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       fieldTypeOverrides: [
         { fieldName: 'help_center_state', fieldType: 'string', restrictions: { enforce_value: true, values: ['enabled', 'disabled', 'restricted'] } },
       ],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -418,11 +427,13 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       sourceTypeName: 'locales__locales',
       idFields: ['locale'],
       fileNameFields: ['locale'],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
   business_hours_schedule: {
     transformation: {
       sourceTypeName: 'business_hours_schedules__schedules',
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -455,6 +466,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
         { fieldName: 'status', fieldType: 'string', restrictions: { enforce_value: true, values: ['accepted', 'declined', 'pending', 'inactive'] } },
         { fieldName: 'type', fieldType: 'string', restrictions: { enforce_value: true, values: ['inbound', 'outbound'] } },
       ],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -490,7 +502,10 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
         { fieldName: 'forwarding_status', fieldType: 'string', restrictions: { enforce_value: true, values: ['unknown', 'waiting', 'verified', 'failed'] } },
         { fieldName: 'spf_status', fieldType: 'string', restrictions: { enforce_value: true, values: ['unknown', 'verified', 'failed'] } },
       ],
-      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'domain_verification_code' }),
+      fieldsToHide: FIELDS_TO_HIDE.concat([
+        { fieldName: 'id', fieldType: 'number' },
+        { fieldName: 'domain_verification_code' },
+      ]),
     },
     deployRequests: {
       add: {
@@ -519,6 +534,10 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
   ticket_form: {
     transformation: {
       sourceTypeName: 'ticket_forms__ticket_forms',
+      fieldsToHide: FIELDS_TO_HIDE.concat([
+        { fieldName: 'id', fieldType: 'number' },
+        { fieldName: 'domain_verification_code' },
+      ]),
     },
     deployRequests: {
       add: {
@@ -550,6 +569,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       idFields: ['type', 'title'],
       fileNameFields: ['type', 'title'],
       standaloneFields: [{ fieldName: 'custom_field_options' }],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -575,6 +595,11 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       },
     },
   },
+  ticket_field__custom_field_options: {
+    transformation: {
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
+    },
+  },
   user_field: {
     transformation: {
       sourceTypeName: 'user_fields__user_fields',
@@ -583,6 +608,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       fieldTypeOverrides: [
         { fieldName: 'type', fieldType: 'string', restrictions: { enforce_value: true, values: ['checkbox', 'date', 'decimal', 'dropdown', 'integer', 'regexp', 'text', 'textarea'] } },
       ],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -608,6 +634,11 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       },
     },
   },
+  user_field__custom_field_options: {
+    transformation: {
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
+    },
+  },
   user_field_order: {
     deployRequests: {
       modify: {
@@ -624,6 +655,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       fieldTypeOverrides: [
         { fieldName: 'type', fieldType: 'string', restrictions: { enforce_value: true, values: ['checkbox', 'date', 'decimal', 'dropdown', 'integer', 'regexp', 'text', 'textarea'] } },
       ],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -649,7 +681,15 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       },
     },
   },
+  organization_field__custom_field_options: {
+    transformation: {
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
+    },
+  },
   organization_field_order: {
+    transformation: {
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
+    },
     deployRequests: {
       modify: {
         url: '/organization_fields/reorder',
@@ -660,6 +700,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
   routing_attribute: {
     transformation: {
       sourceTypeName: 'routing_attributes__attributes',
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -690,6 +731,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       sourceTypeName: 'routing_attribute_definitions__definitions',
       hasDynamicFields: true,
       isSingleton: true,
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
   workspace: {
@@ -697,6 +739,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       sourceTypeName: 'workspaces__workspaces',
       idFields: ['title'],
       fileNameFields: ['title'],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -735,6 +778,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
   app_installation: {
     transformation: {
       sourceTypeName: 'app_installations__installations',
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
       fieldsToOmit: FIELDS_TO_OMIT.concat({ fieldName: 'updated', fieldType: 'string' }),
       idFields: ['settings.name'],
       fileNameFields: ['settings.name'],
@@ -765,6 +809,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
   },
   app_owned: {
     transformation: {
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
       sourceTypeName: 'apps_owned__apps',
     },
   },
@@ -772,7 +817,10 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
     transformation: {
       sourceTypeName: 'oauth_clients__clients',
       idFields: ['identifier'],
-      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'secret', fieldType: 'string' }),
+      fieldsToHide: FIELDS_TO_HIDE.concat([
+        { fieldName: 'id', fieldType: 'number' },
+        { fieldName: 'secret', fieldType: 'string' },
+      ]),
     },
     deployRequests: {
       add: {
@@ -801,12 +849,14 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
   oauth_global_client: {
     transformation: {
       sourceTypeName: 'oauth_global_clients__global_clients',
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
   account_setting: {
     transformation: {
       sourceTypeName: 'account_settings__settings',
       isSingleton: true,
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       modify: {
@@ -819,11 +869,13 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
   resource_collection: {
     transformation: {
       sourceTypeName: 'resource_collections__resource_collections',
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
   monitored_twitter_handle: {
     transformation: {
       sourceTypeName: 'monitored_twitter_handles__monitored_twitter_handles',
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
 
@@ -880,6 +932,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
     transformation: {
       sourceTypeName: 'trigger_definitions__definitions',
       isSingleton: true,
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
   trigger_categories: {
@@ -936,6 +989,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       // no unique identifier for individual items
       dataField: '.',
       isSingleton: true,
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
   // eslint-disable-next-line camelcase
@@ -945,12 +999,16 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
     },
     transformation: {
       isSingleton: true,
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
   // eslint-disable-next-line camelcase
   macros_definitions: { // has some overlaps with macro_actions
     request: {
       url: '/macros/definitions',
+    },
+    transformation: {
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
   brands: {
@@ -969,6 +1027,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
     transformation: {
       dataField: '.',
       standaloneFields: [{ fieldName: 'variants' }],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
     deployRequests: {
       add: {
@@ -998,6 +1057,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
     transformation: {
       // Will be changed after SALTO-1687 + SALTO-1688
       idFields: ['locale_id'],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
   locales: {
@@ -1056,6 +1116,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
     transformation: {
       dataField: 'ticket_fields',
       fileNameFields: ['title'],
+      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
     },
   },
   // eslint-disable-next-line camelcase

--- a/packages/zendesk-support-adapter/system_config_doc.md
+++ b/packages/zendesk-support-adapter/system_config_doc.md
@@ -934,9 +934,6 @@ zendesk_support {
               fieldName = "id"
               fieldType = "number"
             },
-            {
-              fieldName = "domain_verification_code"
-            },
           ]
         }
         deployRequests = {

--- a/packages/zendesk-support-adapter/system_config_doc.md
+++ b/packages/zendesk-support-adapter/system_config_doc.md
@@ -10,20 +10,11 @@ zendesk_support {
       transformation = {
         idFields = [
           "name",
-          "id",
         ]
         fileNameFields = [
           "name",
         ]
         fieldsToOmit = [
-          {
-            fieldName = "created_at"
-            fieldType = "string"
-          },
-          {
-            fieldName = "updated_at"
-            fieldType = "string"
-          },
           {
             fieldName = "extended_input_schema"
           },
@@ -39,12 +30,36 @@ zendesk_support {
             fieldType = "number"
           },
         ]
+        fieldsToHide = [
+          {
+            fieldName = "created_at"
+            fieldType = "string"
+          },
+          {
+            fieldName = "updated_at"
+            fieldType = "string"
+          },
+        ]
       }
     }
     types = {
       group = {
         transformation = {
           sourceTypeName = "groups__groups"
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
         deployRequests = {
           add = {
@@ -73,6 +88,44 @@ zendesk_support {
       custom_role = {
         transformation = {
           sourceTypeName = "custom_roles__custom_roles"
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
+          fieldsToOmit = [
+            {
+              fieldName = "extended_input_schema"
+            },
+            {
+              fieldName = "extended_output_schema"
+            },
+            {
+              fieldName = "url"
+              fieldType = "string"
+            },
+            {
+              fieldName = "count"
+              fieldType = "number"
+            },
+            {
+              fieldName = "role_type"
+              fieldType = "number"
+            },
+            {
+              fieldName = "team_member_count"
+              fieldType = "number"
+            },
+          ]
         }
         deployRequests = {
           add = {
@@ -101,6 +154,20 @@ zendesk_support {
       organization = {
         transformation = {
           sourceTypeName = "organizations__organizations"
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
         deployRequests = {
           add = {
@@ -131,10 +198,23 @@ zendesk_support {
           sourceTypeName = "views__views"
           idFields = [
             "title",
-            "id",
           ]
           fileNameFields = [
             "title",
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
           ]
         }
         deployRequests = {
@@ -166,10 +246,23 @@ zendesk_support {
           sourceTypeName = "triggers__triggers"
           idFields = [
             "title",
-            "id",
           ]
           fileNameFields = [
             "title",
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
           ]
         }
         deployRequests = {
@@ -202,6 +295,19 @@ zendesk_support {
           fileNameFields = [
             "name",
           ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+            },
+          ]
         }
         deployRequests = {
           add = {
@@ -232,10 +338,23 @@ zendesk_support {
           sourceTypeName = "automations__automations"
           idFields = [
             "title",
-            "id",
           ]
           fileNameFields = [
             "title",
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
           ]
         }
         deployRequests = {
@@ -267,10 +386,23 @@ zendesk_support {
           sourceTypeName = "sla_policies__sla_policies"
           idFields = [
             "title",
-            "id",
           ]
           fileNameFields = [
             "title",
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
           ]
         }
         deployRequests = {
@@ -301,6 +433,20 @@ zendesk_support {
         transformation = {
           sourceTypeName = "sla_policies_definitions__definitions"
           isSingleton = true
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       target = {
@@ -309,6 +455,20 @@ zendesk_support {
           idFields = [
             "title",
             "type",
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
           ]
         }
         deployRequests = {
@@ -340,10 +500,23 @@ zendesk_support {
           sourceTypeName = "macros__macros"
           idFields = [
             "title",
-            "id",
           ]
           fileNameFields = [
             "title",
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
           ]
         }
         deployRequests = {
@@ -373,22 +546,83 @@ zendesk_support {
       macro_action = {
         transformation = {
           sourceTypeName = "macros_actions__actions"
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       macro_category = {
         transformation = {
           sourceTypeName = "macros_categories__categories"
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       macro_definition = {
         transformation = {
           sourceTypeName = "macros_definitions__definitions"
           isSingleton = true
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       brand = {
         transformation = {
           sourceTypeName = "brands__brands"
+          fieldsToOmit = [
+            {
+              fieldName = "extended_input_schema"
+            },
+            {
+              fieldName = "extended_output_schema"
+            },
+            {
+              fieldName = "url"
+              fieldType = "string"
+            },
+            {
+              fieldName = "count"
+              fieldType = "number"
+            },
+            {
+              fieldName = "logo"
+            },
+          ]
           fieldTypeOverrides = [
             {
               fieldName = "help_center_state"
@@ -401,6 +635,20 @@ zendesk_support {
                   "restricted",
                 ]
               }
+            },
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
             },
           ]
         }
@@ -437,11 +685,39 @@ zendesk_support {
           fileNameFields = [
             "locale",
           ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       business_hours_schedule = {
         transformation = {
           sourceTypeName = "business_hours_schedules__schedules"
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
         deployRequests = {
           add = {
@@ -496,6 +772,20 @@ zendesk_support {
               }
             },
           ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
         deployRequests = {
           add = {
@@ -521,9 +811,9 @@ zendesk_support {
           }
         }
       }
-      recipient_address = {
+      support_address = {
         transformation = {
-          sourceTypeName = "recipient_addresses__recipient_addresses"
+          sourceTypeName = "support_addresses__recipient_addresses"
           fieldTypeOverrides = [
             {
               fieldName = "cname_status"
@@ -586,6 +876,23 @@ zendesk_support {
               }
             },
           ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+            {
+              fieldName = "domain_verification_code"
+            },
+          ]
         }
         deployRequests = {
           add = {
@@ -614,6 +921,23 @@ zendesk_support {
       ticket_form = {
         transformation = {
           sourceTypeName = "ticket_forms__ticket_forms"
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+            {
+              fieldName = "domain_verification_code"
+            },
+          ]
         }
         deployRequests = {
           add = {
@@ -645,7 +969,6 @@ zendesk_support {
           idFields = [
             "type",
             "title",
-            "id",
           ]
           fileNameFields = [
             "type",
@@ -654,6 +977,20 @@ zendesk_support {
           standaloneFields = [
             {
               fieldName = "custom_field_options"
+            },
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
             },
           ]
         }
@@ -679,6 +1016,24 @@ zendesk_support {
               ticketFieldId = "id"
             }
           }
+        }
+      }
+      ticket_field__custom_field_options = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       user_field = {
@@ -711,6 +1066,20 @@ zendesk_support {
               }
             },
           ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
         deployRequests = {
           add = {
@@ -733,6 +1102,32 @@ zendesk_support {
             urlParamsToFields = {
               userFieldId = "id"
             }
+          }
+        }
+      }
+      user_field__custom_field_options = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
+        }
+      }
+      user_field_order = {
+        deployRequests = {
+          modify = {
+            url = "/user_fields/reorder"
+            method = "put"
           }
         }
       }
@@ -766,6 +1161,20 @@ zendesk_support {
               }
             },
           ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
         deployRequests = {
           add = {
@@ -791,9 +1200,65 @@ zendesk_support {
           }
         }
       }
+      organization_field__custom_field_options = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
+        }
+      }
+      organization_field_order = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
+        }
+        deployRequests = {
+          modify = {
+            url = "/organization_fields/reorder"
+            method = "put"
+          }
+        }
+      }
       routing_attribute = {
         transformation = {
           sourceTypeName = "routing_attributes__attributes"
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
         deployRequests = {
           add = {
@@ -824,6 +1289,20 @@ zendesk_support {
           sourceTypeName = "routing_attribute_definitions__definitions"
           hasDynamicFields = true
           isSingleton = true
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       workspace = {
@@ -831,10 +1310,23 @@ zendesk_support {
           sourceTypeName = "workspaces__workspaces"
           idFields = [
             "title",
-            "id",
           ]
           fileNameFields = [
             "title",
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
           ]
         }
         deployRequests = {
@@ -861,10 +1353,22 @@ zendesk_support {
           }
         }
       }
+      workspace__selected_macros = {
+        transformation = {
+          fieldsToHide = [
+          ]
+        }
+      }
+      workspace__apps = {
+        transformation = {
+          fieldsToHide = [
+          ]
+        }
+      }
       app_installation = {
         transformation = {
           sourceTypeName = "app_installations__installations"
-          fieldsToOmit = [
+          fieldsToHide = [
             {
               fieldName = "created_at"
               fieldType = "string"
@@ -873,6 +1377,12 @@ zendesk_support {
               fieldName = "updated_at"
               fieldType = "string"
             },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
+          fieldsToOmit = [
             {
               fieldName = "extended_input_schema"
             },
@@ -925,12 +1435,47 @@ zendesk_support {
       }
       app_owned = {
         transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
           sourceTypeName = "apps_owned__apps"
         }
       }
       oauth_client = {
         transformation = {
           sourceTypeName = "oauth_clients__clients"
+          idFields = [
+            "identifier",
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+            {
+              fieldName = "secret"
+              fieldType = "string"
+            },
+          ]
         }
         deployRequests = {
           add = {
@@ -959,12 +1504,40 @@ zendesk_support {
       oauth_global_client = {
         transformation = {
           sourceTypeName = "oauth_global_clients__global_clients"
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       account_setting = {
         transformation = {
           sourceTypeName = "account_settings__settings"
           isSingleton = true
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
         deployRequests = {
           modify = {
@@ -977,11 +1550,39 @@ zendesk_support {
       resource_collection = {
         transformation = {
           sourceTypeName = "resource_collections__resource_collections"
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       monitored_twitter_handle = {
         transformation = {
           sourceTypeName = "monitored_twitter_handles__monitored_twitter_handles"
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       groups = {
@@ -1022,6 +1623,34 @@ zendesk_support {
       triggers = {
         request = {
           url = "/triggers"
+        }
+      }
+      trigger_definitions = {
+        request = {
+          url = "/triggers/definitions"
+        }
+        transformation = {
+          dataField = "definitions"
+        }
+      }
+      trigger_definition = {
+        transformation = {
+          sourceTypeName = "trigger_definitions__definitions"
+          isSingleton = true
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       trigger_categories = {
@@ -1074,6 +1703,20 @@ zendesk_support {
         transformation = {
           dataField = "."
           isSingleton = true
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       macro_categories = {
@@ -1082,11 +1725,41 @@ zendesk_support {
         }
         transformation = {
           isSingleton = true
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       macros_definitions = {
         request = {
           url = "/macros/definitions"
+        }
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       brands = {
@@ -1103,6 +1776,25 @@ zendesk_support {
         }
         transformation = {
           dataField = "."
+          standaloneFields = [
+            {
+              fieldName = "variants"
+            },
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
         deployRequests = {
           add = {
@@ -1128,6 +1820,27 @@ zendesk_support {
           }
         }
       }
+      dynamic_content_item__variants = {
+        transformation = {
+          idFields = [
+            "locale_id",
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
+        }
+      }
       locales = {
         request = {
           url = "/locales"
@@ -1146,7 +1859,7 @@ zendesk_support {
           url = "/sharing_agreements"
         }
       }
-      recipient_addresses = {
+      support_addresses = {
         request = {
           url = "/recipient_addresses"
         }
@@ -1163,6 +1876,14 @@ zendesk_support {
           dataField = "ticket_forms"
         }
       }
+      ticket_form_order = {
+        deployRequests = {
+          modify = {
+            url = "/ticket_forms/reorder"
+            method = "put"
+          }
+        }
+      }
       ticket_fields = {
         request = {
           url = "/ticket_fields"
@@ -1171,6 +1892,20 @@ zendesk_support {
           dataField = "ticket_fields"
           fileNameFields = [
             "title",
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
           ]
         }
       }


### PR DESCRIPTION
Avoid hiding the id field by default, because that can cause merge conflicts for nested types that appear inside lists.


---
_Release Notes_: 
Zendesk adapter:
* Fix zendesk config that could cause invalid elements

---
_User Notifications_: 
Fix some zendesk types that had merge conflicts after the first fetch