### PR TITLE
SALTO-1780: removed redundant values from the Jira instances

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -24,6 +24,7 @@ import { JiraConfig, getApiDefinitions } from './config'
 import { FilterCreator, Filter, filtersRunner } from './filter'
 import fieldReferences from './filters/field_references'
 import referenceBySelfLinkFilter from './filters/references_by_self_link'
+import removeSelfFilter from './filters/remove_self'
 import addReferencesToProjectSchemes from './filters/add_references_to_project_schemes'
 import overrideProjectSchemeFieldsTypes from './filters/override_project_scheme_fields_types'
 import issueTypeSchemeReferences from './filters/issue_type_schemas/issue_type_scheme_references'
@@ -55,6 +56,8 @@ export const DEFAULT_FILTERS = [
   overrideProjectSchemeFieldsTypes,
   hiddenValuesInListsFilter,
   referenceBySelfLinkFilter,
+  // Must run after referenceBySelfLinkFilter
+  removeSelfFilter,
   fieldReferences,
   // Must be last
   defaultDeployFilter,

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -54,11 +54,11 @@ export const DEFAULT_FILTERS = [
   boardFilter,
   addReferencesToProjectSchemes,
   overrideProjectSchemeFieldsTypes,
-  hiddenValuesInListsFilter,
   referenceBySelfLinkFilter,
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,
   fieldReferences,
+  hiddenValuesInListsFilter,
   // Must be last
   defaultDeployFilter,
 ]

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -58,7 +58,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       url: '/rest/api/3/dashboard/search',
       paginationField: 'startAt',
       queryParams: {
-        expand: 'description,owner,viewUrl,favouritedCount,sharePermissions',
+        expand: 'description,owner,sharePermissions',
       },
     },
   },
@@ -89,6 +89,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         {
           fieldName: 'id',
         },
+      ],
+      fieldsToOmit: [
+        { fieldName: 'isFavourite' },
       ],
     },
     deployRequests: {
@@ -188,6 +191,13 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     },
   },
   ApplicationProperty: {
+    transformation: {
+      fieldsToOmit: [
+        {
+          fieldName: 'key',
+        },
+      ],
+    },
     deployRequests: {
       modify: {
         url: '/rest/api/3/application-properties/{id}',
@@ -315,7 +325,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     request: {
       url: '/rest/api/3/filter/search',
       queryParams: {
-        expand: 'description,owner,jql,searchUrl,viewUrl,sharePermissions,subscriptions',
+        expand: 'description,owner,jql,sharePermissions,subscriptions',
       },
       paginationField: 'startAt',
       recurseInto: [

--- a/packages/jira-adapter/src/filters/remove_self.ts
+++ b/packages/jira-adapter/src/filters/remove_self.ts
@@ -1,20 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-/*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with
@@ -58,7 +43,7 @@ const filter: FilterCreator = () => ({
         }) ?? {}
       })
 
-    await awu(elements)
+    elements
       .filter(isObjectType)
       .forEach(async type => {
         delete type.fields.self

--- a/packages/jira-adapter/src/filters/remove_self.ts
+++ b/packages/jira-adapter/src/filters/remove_self.ts
@@ -1,0 +1,69 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, isInstanceElement, isObjectType } from '@salto-io/adapter-api'
+import { transformValues } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import { FilterCreator } from '../filter'
+
+const { awu } = collections.asynciterable
+
+/**
+ * Removes 'self' values from types and instances
+ */
+const filter: FilterCreator = () => ({
+  onFetch: async (elements: Element[]) => {
+    await awu(elements)
+      .filter(isInstanceElement)
+      .forEach(async instance => {
+        instance.value = await transformValues({
+          values: instance.value,
+          type: await instance.getType(),
+          pathID: instance.elemID,
+          strict: false,
+          allowEmpty: true,
+          transformFunc: ({ value, path }) => {
+            if (path?.name === 'self') {
+              return undefined
+            }
+            return value
+          },
+        }) ?? {}
+      })
+
+    await awu(elements)
+      .filter(isObjectType)
+      .forEach(async type => {
+        delete type.fields.self
+      })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/test/filters/remove_self.test.ts
+++ b/packages/jira-adapter/test/filters/remove_self.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/filters/remove_self.test.ts
+++ b/packages/jira-adapter/test/filters/remove_self.test.ts
@@ -1,0 +1,69 @@
+/*
+*                      Copyright 2021 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { DEFAULT_CONFIG } from '../../src/config'
+import { JIRA } from '../../src/constants'
+import removeSelfFilter from '../../src/filters/remove_self'
+import { mockClient } from '../utils'
+
+describe('removeSelfFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let instance: InstanceElement
+  let type: ObjectType
+  beforeEach(async () => {
+    const { client, paginator } = mockClient()
+    filter = removeSelfFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    }) as typeof filter
+
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, 'someType'),
+      fields: {
+        self: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    instance = new InstanceElement(
+      'instance',
+      type,
+      {
+        self: 'someSelf',
+        obj: {
+          self: 'someSelf2',
+          other: 'other',
+        },
+        other: 'other',
+      }
+    )
+  })
+
+  it('should remove self from types', async () => {
+    await filter.onFetch([type])
+    expect(type.fields.self).toBeUndefined()
+  })
+  it('should remove self from instanecs', async () => {
+    await filter.onFetch([instance])
+    expect(instance.value).toEqual({
+      other: 'other',
+      obj: {
+        other: 'other',
+      },
+    })
+  })
+})


### PR DESCRIPTION
Removed:
- self (after we use it to create references)
- viewUrl (URL to the relevant page in the UI)
- favouritedCount (number of people who starred the object in the UI)
- isFavourite (whether the current user starred the object in the UI)
- key (same value as id)
- searchUrl (link to the search page of a filter)


---
_Release Notes_: 
None

---
_User Notifications_: 
None