### PR TITLE
SALTO-1715: removed 'not found in swagger' that appears for every type in Jira

### DIFF
--- a/packages/adapter-components/src/elements/swagger/deployment/annotations.ts
+++ b/packages/adapter-components/src/elements/swagger/deployment/annotations.ts
@@ -132,7 +132,6 @@ export const addDeploymentAnnotationsFromSwagger = async (
     }
     const endpointUrl = getSwaggerEndpoint(endpoint.url, baseUrls)
     if (swagger.document.paths[endpointUrl]?.[endpoint.method] === undefined) {
-      log.warn(`${type.elemID.getFullName()} endpoint ${endpointUrl} not found in swagger`)
       return
     }
 


### PR DESCRIPTION
Because in Jira we look for the types in two different swaggers, we always get "not found in swagger" warning for the swagger the type is not in, which makes the log to be written for all the types.

---
_Release Notes_: 
None

---
_User Notifications_: 
None