### PR TITLE
SALTO-1832 pass 'resolveRoot' parameter to resolveElement 

### DIFF
--- a/packages/workspace/src/expressions.ts
+++ b/packages/workspace/src/expressions.ts
@@ -128,7 +128,8 @@ export const resolveReferenceExpression = async (
   const resolvedRootElement = resolveRoot ? await resolveElement(
     rootElement,
     elementsSource,
-    workingSetElements
+    workingSetElements,
+    resolveRoot
   ) : undefined
 
   const value = resolvePath(rootElement, fullElemID)


### PR DESCRIPTION
in `resolveReferenceExpression`, when `resolveRoot = true`, `resolveElement` is called but `resolveRoot` wasn't passed into it. It should be passed.

---
_Release Notes_: 
None

---
_User Notifications_: 
None