### PR TITLE
Update source code headers to 2022

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 
 Licenses under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/build_utils/deep_merge.js
+++ b/build_utils/deep_merge.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/build_utils/find_conflicting_versions.js
+++ b/build_utils/find_conflicting_versions.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/build_utils/verify_tsconfig_references.js
+++ b/build_utils/verify_tsconfig_references.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/docs/showdown_wrapper.js
+++ b/docs/showdown_wrapper.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/eslint/adapter-api.rules.js
+++ b/eslint/adapter-api.rules.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/eslintrc.js
+++ b/eslintrc.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with
@@ -52,7 +52,7 @@ module.exports = {
         'header/header': [2, "block",
             [
                 "",
-                "*                      Copyright 2021 Salto Labs Ltd.",
+                "*                      Copyright 2022 Salto Labs Ltd.",
                 "*",
                 "* Licensed under the Apache License, Version 2.0 (the \"License\");",
                 "* you may not use this file except in compliance with",

--- a/jest.base.config.js
+++ b/jest.base.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/index.ts
+++ b/packages/adapter-api/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/jest.config.js
+++ b/packages/adapter-api/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/src/authentication_types.ts
+++ b/packages/adapter-api/src/authentication_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/src/change.ts
+++ b/packages/adapter-api/src/change.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/src/change_group.ts
+++ b/packages/adapter-api/src/change_group.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/src/core_annotations.ts
+++ b/packages/adapter-api/src/core_annotations.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/src/dependency_changer.ts
+++ b/packages/adapter-api/src/dependency_changer.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/src/error.ts
+++ b/packages/adapter-api/src/error.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/src/utils.ts
+++ b/packages/adapter-api/src/utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/test/builtins.test.ts
+++ b/packages/adapter-api/test/builtins.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/test/change.test.ts
+++ b/packages/adapter-api/test/change.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/test/dependency_changer.test.ts
+++ b/packages/adapter-api/test/dependency_changer.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/test/utils.test.ts
+++ b/packages/adapter-api/test/utils.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/index.ts
+++ b/packages/adapter-components/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/jest.config.js
+++ b/packages/adapter-components/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/scripts/client/mock_replies.py
+++ b/packages/adapter-components/scripts/client/mock_replies.py
@@ -1,4 +1,4 @@
-#                      Copyright 2021 Salto Labs Ltd.
+#                      Copyright 2022 Salto Labs Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with

--- a/packages/adapter-components/src/auth/index.ts
+++ b/packages/adapter-components/src/auth/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/auth/oauth.ts
+++ b/packages/adapter-components/src/auth/oauth.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/client/base.ts
+++ b/packages/adapter-components/src/client/base.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/client/config.ts
+++ b/packages/adapter-components/src/client/config.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/client/constants.ts
+++ b/packages/adapter-components/src/client/constants.ts
@@ -1,6 +1,6 @@
 
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/client/decorators.ts
+++ b/packages/adapter-components/src/client/decorators.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/client/index.ts
+++ b/packages/adapter-components/src/client/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/client/pagination.ts
+++ b/packages/adapter-components/src/client/pagination.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/client/rate_limit.ts
+++ b/packages/adapter-components/src/client/rate_limit.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/config/ducktype.ts
+++ b/packages/adapter-components/src/config/ducktype.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/config/merge.ts
+++ b/packages/adapter-components/src/config/merge.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/config/request.ts
+++ b/packages/adapter-components/src/config/request.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/config/swagger.ts
+++ b/packages/adapter-components/src/config/swagger.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/config/transformation.ts
+++ b/packages/adapter-components/src/config/transformation.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/config/validation_utils.ts
+++ b/packages/adapter-components/src/config/validation_utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/deployment/annotations.ts
+++ b/packages/adapter-components/src/deployment/annotations.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/deployment/change_validators/check_deployment_based_on_config.ts
+++ b/packages/adapter-components/src/deployment/change_validators/check_deployment_based_on_config.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/deployment/change_validators/deploy_not_supported.ts
+++ b/packages/adapter-components/src/deployment/change_validators/deploy_not_supported.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/deployment/change_validators/deploy_types_not_supported.ts
+++ b/packages/adapter-components/src/deployment/change_validators/deploy_types_not_supported.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/deployment/change_validators/index.ts
+++ b/packages/adapter-components/src/deployment/change_validators/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/deployment/dependency/index.ts
+++ b/packages/adapter-components/src/deployment/dependency/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/deployment/dependency/remove_standalone_field_dependency.ts
+++ b/packages/adapter-components/src/deployment/dependency/remove_standalone_field_dependency.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/deployment/deployment.ts
+++ b/packages/adapter-components/src/deployment/deployment.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/deployment/index.ts
+++ b/packages/adapter-components/src/deployment/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/constants.ts
+++ b/packages/adapter-components/src/elements/constants.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/ducktype/index.ts
+++ b/packages/adapter-components/src/elements/ducktype/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/ducktype/instance_elements.ts
+++ b/packages/adapter-components/src/elements/ducktype/instance_elements.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
+++ b/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/ducktype/type_elements.ts
+++ b/packages/adapter-components/src/elements/ducktype/type_elements.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/element_getter.ts
+++ b/packages/adapter-components/src/elements/element_getter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/field_finder.ts
+++ b/packages/adapter-components/src/elements/field_finder.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/index.ts
+++ b/packages/adapter-components/src/elements/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/request_parameters.ts
+++ b/packages/adapter-components/src/elements/request_parameters.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/soap/index.ts
+++ b/packages/adapter-components/src/elements/soap/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/soap/type_elements/complex_types_converter.ts
+++ b/packages/adapter-components/src/elements/soap/type_elements/complex_types_converter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/soap/type_elements/object_types_linker.ts
+++ b/packages/adapter-components/src/elements/soap/type_elements/object_types_linker.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/soap/type_elements/types_generator.ts
+++ b/packages/adapter-components/src/elements/soap/type_elements/types_generator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/soap/type_elements/utils.ts
+++ b/packages/adapter-components/src/elements/soap/type_elements/utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/subtypes.ts
+++ b/packages/adapter-components/src/elements/subtypes.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/swagger/deployment/additional_properties.ts
+++ b/packages/adapter-components/src/elements/swagger/deployment/additional_properties.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/swagger/deployment/annotations.ts
+++ b/packages/adapter-components/src/elements/swagger/deployment/annotations.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/swagger/index.ts
+++ b/packages/adapter-components/src/elements/swagger/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/swagger/swagger.ts
+++ b/packages/adapter-components/src/elements/swagger/swagger.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/swagger/type_elements/swagger_parser.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/swagger_parser.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/swagger/type_elements/type_config_override.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/type_config_override.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -1,6 +1,6 @@
 
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/filter_utils.ts
+++ b/packages/adapter-components/src/filter_utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/references/context.ts
+++ b/packages/adapter-components/src/references/context.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/references/index.ts
+++ b/packages/adapter-components/src/references/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/src/references/reference_mapping.ts
+++ b/packages/adapter-components/src/references/reference_mapping.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/auth/oauth.test.ts
+++ b/packages/adapter-components/test/auth/oauth.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/client/common.ts
+++ b/packages/adapter-components/test/client/common.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/client/config.test.ts
+++ b/packages/adapter-components/test/client/config.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/client/decorators.test.ts
+++ b/packages/adapter-components/test/client/decorators.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/client/http_client.test.ts
+++ b/packages/adapter-components/test/client/http_client.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/client/http_connection.test.ts
+++ b/packages/adapter-components/test/client/http_connection.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/client/pagination.test.ts
+++ b/packages/adapter-components/test/client/pagination.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/client/rate_limit.test.ts
+++ b/packages/adapter-components/test/client/rate_limit.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/config/ducktype.test.ts
+++ b/packages/adapter-components/test/config/ducktype.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/config/merge.test.ts
+++ b/packages/adapter-components/test/config/merge.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/config/request.test.ts
+++ b/packages/adapter-components/test/config/request.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/config/shared.test.ts
+++ b/packages/adapter-components/test/config/shared.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/config/swagger.test.ts
+++ b/packages/adapter-components/test/config/swagger.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/config/transformation.test.ts
+++ b/packages/adapter-components/test/config/transformation.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/config/validation_utils.test.ts
+++ b/packages/adapter-components/test/config/validation_utils.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/deployment/change_validators/check_deployment.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/check_deployment.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/deployment/change_validators/deploy_not_supported.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/deploy_not_supported.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/deployment/change_validators/deploy_types_not_supported.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/deploy_types_not_supported.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/deployment/dependency/remove_standalone_field_dependency.test.ts
+++ b/packages/adapter-components/test/deployment/dependency/remove_standalone_field_dependency.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/deployment/deployment.test.ts
+++ b/packages/adapter-components/test/deployment/deployment.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/elements/ducktype/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/instance_elements.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/elements/ducktype/standalone_field_extractor.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/standalone_field_extractor.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/elements/ducktype/transformer.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/transformer.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/type_elements.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/elements/field_finder.test.ts
+++ b/packages/adapter-components/test/elements/field_finder.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/elements/request_parameters.test.ts
+++ b/packages/adapter-components/test/elements/request_parameters.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/elements/soap/types_generator.test.ts
+++ b/packages/adapter-components/test/elements/soap/types_generator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/elements/subtypes.test.ts
+++ b/packages/adapter-components/test/elements/subtypes.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/elements/swagger/deployment/additional_properties.test.ts
+++ b/packages/adapter-components/test/elements/swagger/deployment/additional_properties.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/elements/swagger/deployment/annotations.test.ts
+++ b/packages/adapter-components/test/elements/swagger/deployment/annotations.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -1,6 +1,6 @@
 
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/elements/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/type_elements.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-components/test/references/field_references.test.ts
+++ b/packages/adapter-components/test/references/field_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/index.ts
+++ b/packages/adapter-utils/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/jest.config.js
+++ b/packages/adapter-utils/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/src/change_validator.ts
+++ b/packages/adapter-utils/src/change_validator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/src/compare.ts
+++ b/packages/adapter-utils/src/compare.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/src/decorators.ts
+++ b/packages/adapter-utils/src/decorators.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/src/dependencies.ts
+++ b/packages/adapter-utils/src/dependencies.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/src/deploy.ts
+++ b/packages/adapter-utils/src/deploy.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/src/element.ts
+++ b/packages/adapter-utils/src/element.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/src/element_source.ts
+++ b/packages/adapter-utils/src/element_source.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/src/filter.ts
+++ b/packages/adapter-utils/src/filter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/src/nacl_case_utils.ts
+++ b/packages/adapter-utils/src/nacl_case_utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/src/walk_element.ts
+++ b/packages/adapter-utils/src/walk_element.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/test/change_validator.test.ts
+++ b/packages/adapter-utils/test/change_validator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/test/common.ts
+++ b/packages/adapter-utils/test/common.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/test/compare.test.ts
+++ b/packages/adapter-utils/test/compare.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/test/decorators.test.ts
+++ b/packages/adapter-utils/test/decorators.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/test/dependencies.test.ts
+++ b/packages/adapter-utils/test/dependencies.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/test/deploy.test.ts
+++ b/packages/adapter-utils/test/deploy.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/test/element.test.ts
+++ b/packages/adapter-utils/test/element.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/test/element_source.test.ts
+++ b/packages/adapter-utils/test/element_source.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/test/filter.test.ts
+++ b/packages/adapter-utils/test/filter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/test/nacl_case_utils.test.ts
+++ b/packages/adapter-utils/test/nacl_case_utils.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/adapter-utils/test/walk_element.test.ts
+++ b/packages/adapter-utils/test/walk_element.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/e2e_test/helpers/salesforce.ts
+++ b/packages/cli/e2e_test/helpers/salesforce.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/e2e_test/helpers/templates.ts
+++ b/packages/cli/e2e_test/helpers/templates.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/e2e_test/helpers/workspace.ts
+++ b/packages/cli/e2e_test/helpers/workspace.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/e2e_test/jest_environment.ts
+++ b/packages/cli/e2e_test/jest_environment.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/e2e_test/multi_env.test.ts
+++ b/packages/cli/e2e_test/multi_env.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/e2e_test/salto.test.ts
+++ b/packages/cli/e2e_test/salto.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/package_native.js
+++ b/packages/cli/package_native.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/cli_oauth_authenticator.ts
+++ b/packages/cli/src/cli_oauth_authenticator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/command_builder.ts
+++ b/packages/cli/src/command_builder.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/command_register.ts
+++ b/packages/cli/src/command_register.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/commands/common/accounts.ts
+++ b/packages/cli/src/commands/common/accounts.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/commands/common/config_override.ts
+++ b/packages/cli/src/commands/common/config_override.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/commands/common/env.ts
+++ b/packages/cli/src/commands/common/env.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/commands/common/options.ts
+++ b/packages/cli/src/commands/common/options.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/commands/workspace.ts
+++ b/packages/cli/src/commands/workspace.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/fonts.ts
+++ b/packages/cli/src/fonts.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/ora_spinner.ts
+++ b/packages/cli/src/ora_spinner.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/outputer.ts
+++ b/packages/cli/src/outputer.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/workspace/errors.ts
+++ b/packages/cli/src/workspace/errors.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/callbacks.test.ts
+++ b/packages/cli/test/callbacks.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/cli_oauth_authenticator.test.ts
+++ b/packages/cli/test/cli_oauth_authenticator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/command_builder.test.ts
+++ b/packages/cli/test/command_builder.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/commands/commons.test.ts
+++ b/packages/cli/test/commands/commons.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/commands/diff.test.ts
+++ b/packages/cli/test/commands/diff.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/commands/env.test.ts
+++ b/packages/cli/test/commands/env.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/commands/restore.test.ts
+++ b/packages/cli/test/commands/restore.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/commands/service.test.ts
+++ b/packages/cli/test/commands/service.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/commands/workspace.test.ts
+++ b/packages/cli/test/commands/workspace.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/ora_spinner.test.ts
+++ b/packages/cli/test/ora_spinner.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/telemetry.test.ts
+++ b/packages/cli/test/telemetry.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/workspace/errors.test.ts
+++ b/packages/cli/test/workspace/errors.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/test/workspace/workspace.test.ts
+++ b/packages/cli/test/workspace/workspace.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/cli/webpack.config.js
+++ b/packages/cli/webpack.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/app_config.ts
+++ b/packages/core/src/app_config.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/adapters/change_validators.ts
+++ b/packages/core/src/core/adapters/change_validators.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/adapters/creators.ts
+++ b/packages/core/src/core/adapters/creators.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/adapters/custom_group_key.ts
+++ b/packages/core/src/core/adapters/custom_group_key.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/adapters/dependency_changers.ts
+++ b/packages/core/src/core/adapters/dependency_changers.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/adapters/index.ts
+++ b/packages/core/src/core/adapters/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/adapters/progress.ts
+++ b/packages/core/src/core/adapters/progress.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/clean.ts
+++ b/packages/core/src/core/clean.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/deploy/deploy_summary.ts
+++ b/packages/core/src/core/deploy/deploy_summary.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/deploy/index.ts
+++ b/packages/core/src/core/deploy/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/diff.ts
+++ b/packages/core/src/core/diff.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/list.ts
+++ b/packages/core/src/core/list.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/change_validators/check_deployment_annotations.ts
+++ b/packages/core/src/core/plan/change_validators/check_deployment_annotations.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/change_validators/index.ts
+++ b/packages/core/src/core/plan/change_validators/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/change_validators/unresolved_references.ts
+++ b/packages/core/src/core/plan/change_validators/unresolved_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/common.ts
+++ b/packages/core/src/core/plan/common.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/dependency/add_after_remove_dependecy.ts
+++ b/packages/core/src/core/plan/dependency/add_after_remove_dependecy.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/dependency/dependency.ts
+++ b/packages/core/src/core/plan/dependency/dependency.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/dependency/index.ts
+++ b/packages/core/src/core/plan/dependency/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/dependency/instance_fields_dependency.ts
+++ b/packages/core/src/core/plan/dependency/instance_fields_dependency.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/dependency/object_field_dependency.ts
+++ b/packages/core/src/core/plan/dependency/object_field_dependency.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/dependency/reference_dependency.ts
+++ b/packages/core/src/core/plan/dependency/reference_dependency.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/dependency/type_dependency.ts
+++ b/packages/core/src/core/plan/dependency/type_dependency.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/diff.ts
+++ b/packages/core/src/core/plan/diff.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/filter.ts
+++ b/packages/core/src/core/plan/filter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/group.ts
+++ b/packages/core/src/core/plan/group.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/index.ts
+++ b/packages/core/src/core/plan/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/plan/plan_item.ts
+++ b/packages/core/src/core/plan/plan_item.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/rename.ts
+++ b/packages/core/src/core/rename.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/core/restore.ts
+++ b/packages/core/src/core/restore.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/local-workspace/adapters_config.ts
+++ b/packages/core/src/local-workspace/adapters_config.ts
@@ -1,6 +1,6 @@
 
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/local-workspace/dir_store.ts
+++ b/packages/core/src/local-workspace/dir_store.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/local-workspace/errors.ts
+++ b/packages/core/src/local-workspace/errors.ts
@@ -1,6 +1,6 @@
 
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/local-workspace/rocksdb.ts
+++ b/packages/core/src/local-workspace/rocksdb.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/local-workspace/state.ts
+++ b/packages/core/src/local-workspace/state.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/local-workspace/static_files_cache.ts
+++ b/packages/core/src/local-workspace/static_files_cache.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/local-workspace/workspace_config.ts
+++ b/packages/core/src/local-workspace/workspace_config.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/local-workspace/workspace_config_types.ts
+++ b/packages/core/src/local-workspace/workspace_config_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -1,6 +1,6 @@
 
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/app_config.test.ts
+++ b/packages/core/test/app_config.test.ts
@@ -1,6 +1,6 @@
 
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/common/elements.ts
+++ b/packages/core/test/common/elements.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/common/helpers.ts
+++ b/packages/core/test/common/helpers.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/common/nacl_file_source.ts
+++ b/packages/core/test/common/nacl_file_source.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/common/plan.ts
+++ b/packages/core/test/common/plan.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/common/plan_generator.ts
+++ b/packages/core/test/common/plan_generator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/common/state.ts
+++ b/packages/core/test/common/state.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/common/workspace.ts
+++ b/packages/core/test/common/workspace.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/adapters/adapters.test.ts
+++ b/packages/core/test/core/adapters/adapters.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/adapters/dependency_changers.test.ts
+++ b/packages/core/test/core/adapters/dependency_changers.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/clean.test.ts
+++ b/packages/core/test/core/clean.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/deploy/deploy_summary.test.ts
+++ b/packages/core/test/core/deploy/deploy_summary.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/diff.test.ts
+++ b/packages/core/test/core/diff.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/plan/change_validators/check_deployment_annotations.test.ts
+++ b/packages/core/test/core/plan/change_validators/check_deployment_annotations.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/plan/change_validators/index.test.ts
+++ b/packages/core/test/core/plan/change_validators/index.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/plan/change_validators/unresolved_references.test.ts
+++ b/packages/core/test/core/plan/change_validators/unresolved_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/plan/dependency.test.ts
+++ b/packages/core/test/core/plan/dependency.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/plan/diff.test.ts
+++ b/packages/core/test/core/plan/diff.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/plan/filter.test.ts
+++ b/packages/core/test/core/plan/filter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/plan/plan.test.ts
+++ b/packages/core/test/core/plan/plan.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/plan/plan_item.test.ts
+++ b/packages/core/test/core/plan/plan_item.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/rename.test.ts
+++ b/packages/core/test/core/rename.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/core/restore.test.ts
+++ b/packages/core/test/core/restore.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/telemetry.test.ts
+++ b/packages/core/test/telemetry.test.ts
@@ -1,6 +1,6 @@
 
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/workspace/local/adapters_config.test.ts
+++ b/packages/core/test/workspace/local/adapters_config.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/workspace/local/directory_store.test.ts
+++ b/packages/core/test/workspace/local/directory_store.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/workspace/local/remote_map.test.ts
+++ b/packages/core/test/workspace/local/remote_map.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/workspace/local/remote_map_connection.test.ts
+++ b/packages/core/test/workspace/local/remote_map_connection.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/workspace/local/state.test.ts
+++ b/packages/core/test/workspace/local/state.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/workspace/local/static_files_cache.test.ts
+++ b/packages/core/test/workspace/local/static_files_cache.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/workspace/local/workspace.test.ts
+++ b/packages/core/test/workspace/local/workspace.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/core/test/workspace/local/workspace_config.test.ts
+++ b/packages/core/test/workspace/local/workspace_config.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dag/index.ts
+++ b/packages/dag/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dag/jest.config.js
+++ b/packages/dag/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dag/src/diff.ts
+++ b/packages/dag/src/diff.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dag/src/group.ts
+++ b/packages/dag/src/group.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dag/src/nodemap.ts
+++ b/packages/dag/src/nodemap.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dag/test/group.test.ts
+++ b/packages/dag/test/group.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dag/test/nodemap.test.ts
+++ b/packages/dag/test/nodemap.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dummy-adapter/index.ts
+++ b/packages/dummy-adapter/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dummy-adapter/jest.config.js
+++ b/packages/dummy-adapter/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dummy-adapter/src/adapter.ts
+++ b/packages/dummy-adapter/src/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dummy-adapter/test/adapter.test.ts
+++ b/packages/dummy-adapter/test/adapter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dummy-adapter/test/adapter_creator.test.ts
+++ b/packages/dummy-adapter/test/adapter_creator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dummy-adapter/test/generator.test.ts
+++ b/packages/dummy-adapter/test/generator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/dummy-adapter/test/test_params.ts
+++ b/packages/dummy-adapter/test/test_params.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/jest-dynalite-config.js
+++ b/packages/e2e-credentials-store/jest-dynalite-config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/jest.config.js
+++ b/packages/e2e-credentials-store/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/cli/argparser.ts
+++ b/packages/e2e-credentials-store/src/cli/argparser.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/cli/commands/adapters.ts
+++ b/packages/e2e-credentials-store/src/cli/commands/adapters.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/cli/commands/clear.ts
+++ b/packages/e2e-credentials-store/src/cli/commands/clear.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/cli/commands/free.ts
+++ b/packages/e2e-credentials-store/src/cli/commands/free.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/cli/commands/index.ts
+++ b/packages/e2e-credentials-store/src/cli/commands/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/cli/commands/lease.ts
+++ b/packages/e2e-credentials-store/src/cli/commands/lease.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/cli/commands/list.ts
+++ b/packages/e2e-credentials-store/src/cli/commands/list.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/cli/commands/register.ts
+++ b/packages/e2e-credentials-store/src/cli/commands/register.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/cli/commands/unregister.ts
+++ b/packages/e2e-credentials-store/src/cli/commands/unregister.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/cli/index.ts
+++ b/packages/e2e-credentials-store/src/cli/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/cli/stream.ts
+++ b/packages/e2e-credentials-store/src/cli/stream.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/cli/types.ts
+++ b/packages/e2e-credentials-store/src/cli/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/index.ts
+++ b/packages/e2e-credentials-store/src/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/jest-environment/circus_events.ts
+++ b/packages/e2e-credentials-store/src/jest-environment/circus_events.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/jest-environment/creds.ts
+++ b/packages/e2e-credentials-store/src/jest-environment/creds.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/jest-environment/index.ts
+++ b/packages/e2e-credentials-store/src/jest-environment/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/jest-environment/interval_scheduler.ts
+++ b/packages/e2e-credentials-store/src/jest-environment/interval_scheduler.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/process_env.ts
+++ b/packages/e2e-credentials-store/src/process_env.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/repo_params.ts
+++ b/packages/e2e-credentials-store/src/repo_params.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/src/types.ts
+++ b/packages/e2e-credentials-store/src/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/e2e-credentials-store/test/cli/index.test.ts
+++ b/packages/e2e-credentials-store/test/cli/index.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/file/index.ts
+++ b/packages/file/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/file/jest.config.js
+++ b/packages/file/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/file/src/file.ts
+++ b/packages/file/src/file.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/file/test/file.test.ts
+++ b/packages/file/test/file.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/index.ts
+++ b/packages/hubspot-adapter/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/jest.config.js
+++ b/packages/hubspot-adapter/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/adapter.ts
+++ b/packages/hubspot-adapter/src/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/adapter_creator.ts
+++ b/packages/hubspot-adapter/src/adapter_creator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/change_validator.ts
+++ b/packages/hubspot-adapter/src/change_validator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/change_validators/form_field.ts
+++ b/packages/hubspot-adapter/src/change_validators/form_field.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/change_validators/json_type.ts
+++ b/packages/hubspot-adapter/src/change_validators/json_type.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/change_validators/readonly.ts
+++ b/packages/hubspot-adapter/src/change_validators/readonly.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/client/client.ts
+++ b/packages/hubspot-adapter/src/client/client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/client/madku.ts
+++ b/packages/hubspot-adapter/src/client/madku.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/client/types.ts
+++ b/packages/hubspot-adapter/src/client/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/constants.ts
+++ b/packages/hubspot-adapter/src/constants.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/filter.ts
+++ b/packages/hubspot-adapter/src/filter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/filters/form_field.ts
+++ b/packages/hubspot-adapter/src/filters/form_field.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/filters/instance_transform.ts
+++ b/packages/hubspot-adapter/src/filters/instance_transform.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/filters/useridentifier.ts
+++ b/packages/hubspot-adapter/src/filters/useridentifier.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/src/transformers/transformer.ts
+++ b/packages/hubspot-adapter/src/transformers/transformer.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/adapter.creator.test.ts
+++ b/packages/hubspot-adapter/test/adapter.creator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/adapter.test.ts
+++ b/packages/hubspot-adapter/test/adapter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/change_validators/form_field.test.ts
+++ b/packages/hubspot-adapter/test/change_validators/form_field.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/change_validators/json_type.test.ts
+++ b/packages/hubspot-adapter/test/change_validators/json_type.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/change_validators/readonly.test.ts
+++ b/packages/hubspot-adapter/test/change_validators/readonly.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/client.test.ts
+++ b/packages/hubspot-adapter/test/client.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/client.ts
+++ b/packages/hubspot-adapter/test/client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/common/mock_elements.ts
+++ b/packages/hubspot-adapter/test/common/mock_elements.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/common/mock_types.ts
+++ b/packages/hubspot-adapter/test/common/mock_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/connection.ts
+++ b/packages/hubspot-adapter/test/connection.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/filters/filters.test.ts
+++ b/packages/hubspot-adapter/test/filters/filters.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/filters/form_field.test.ts
+++ b/packages/hubspot-adapter/test/filters/form_field.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/filters/useridentifier.test.ts
+++ b/packages/hubspot-adapter/test/filters/useridentifier.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/mock.ts
+++ b/packages/hubspot-adapter/test/mock.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/hubspot-adapter/test/transformers/transformer.test.ts
+++ b/packages/hubspot-adapter/test/transformers/transformer.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/index.ts
+++ b/packages/jira-adapter/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/auth.ts
+++ b/packages/jira-adapter/src/auth.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/change_validator.ts
+++ b/packages/jira-adapter/src/change_validator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/client/client.ts
+++ b/packages/jira-adapter/src/client/client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/client/connection.ts
+++ b/packages/jira-adapter/src/client/connection.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/client/pagination.ts
+++ b/packages/jira-adapter/src/client/pagination.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/deployment.ts
+++ b/packages/jira-adapter/src/deployment.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filter.ts
+++ b/packages/jira-adapter/src/filter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/add_references_to_project_schemes.ts
+++ b/packages/jira-adapter/src/filters/add_references_to_project_schemes.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/authenticated_permission.ts
+++ b/packages/jira-adapter/src/filters/authenticated_permission.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/default_deploy.ts
+++ b/packages/jira-adapter/src/filters/default_deploy.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/deploy.ts
+++ b/packages/jira-adapter/src/filters/deploy.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/field_references.ts
+++ b/packages/jira-adapter/src/filters/field_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/hidden_value_in_lists.ts
+++ b/packages/jira-adapter/src/filters/hidden_value_in_lists.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme.ts
+++ b/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme_references.ts
+++ b/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/override_project_scheme_fields_types.ts
+++ b/packages/jira-adapter/src/filters/override_project_scheme_fields_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/references_by_self_link.ts
+++ b/packages/jira-adapter/src/filters/references_by_self_link.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/workflow/post_functions_types.ts
+++ b/packages/jira-adapter/src/filters/workflow/post_functions_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/workflow/validators_types.ts
+++ b/packages/jira-adapter/src/filters/workflow/validators_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/filters/workflow/workflow.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow.ts
@@ -1,20 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-/*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/src/references.ts
+++ b/packages/jira-adapter/src/references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/adapter_creator.test.ts
+++ b/packages/jira-adapter/test/adapter_creator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/change_validator.test.ts
+++ b/packages/jira-adapter/test/change_validator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/client/client.test.ts
+++ b/packages/jira-adapter/test/client/client.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/client/connection.test.ts
+++ b/packages/jira-adapter/test/client/connection.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/client/pagination.test.ts
+++ b/packages/jira-adapter/test/client/pagination.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/filters/add_references_to_project_schemes.test.ts
+++ b/packages/jira-adapter/test/filters/add_references_to_project_schemes.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/filters/authenticated_permission.test.ts
+++ b/packages/jira-adapter/test/filters/authenticated_permission.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/filters/hidden_value_in_lists.test.ts
+++ b/packages/jira-adapter/test/filters/hidden_value_in_lists.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme_references.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/filters/override_project_scheme_fields_types.test.ts
+++ b/packages/jira-adapter/test/filters/override_project_scheme_fields_types.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/filters/references_by_self_link.test.ts
+++ b/packages/jira-adapter/test/filters/references_by_self_link.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/filters/workflow.test.ts
+++ b/packages/jira-adapter/test/filters/workflow.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/filters/workflow_values.ts
+++ b/packages/jira-adapter/test/filters/workflow_values.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/mock_elements.ts
+++ b/packages/jira-adapter/test/mock_elements.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/jira-adapter/test/utils.ts
+++ b/packages/jira-adapter/test/utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/index.ts
+++ b/packages/lang-server/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/jest.config.js
+++ b/packages/lang-server/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/src/completions/provider.ts
+++ b/packages/lang-server/src/completions/provider.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/src/completions/suggestions.ts
+++ b/packages/lang-server/src/completions/suggestions.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/src/context.ts
+++ b/packages/lang-server/src/context.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/src/definitions.ts
+++ b/packages/lang-server/src/definitions.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/src/diagnostics.ts
+++ b/packages/lang-server/src/diagnostics.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/src/location.ts
+++ b/packages/lang-server/src/location.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/src/service_url.ts
+++ b/packages/lang-server/src/service_url.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/src/symbols.ts
+++ b/packages/lang-server/src/symbols.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/src/token.ts
+++ b/packages/lang-server/src/token.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/src/usage.ts
+++ b/packages/lang-server/src/usage.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/src/workspace.ts
+++ b/packages/lang-server/src/workspace.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/test/completions.test.ts
+++ b/packages/lang-server/test/completions.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/test/context.test.ts
+++ b/packages/lang-server/test/context.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/test/definitions.test.ts
+++ b/packages/lang-server/test/definitions.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/test/diagnostics.test.ts
+++ b/packages/lang-server/test/diagnostics.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/test/location.test.ts
+++ b/packages/lang-server/test/location.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/test/service_url.test.ts
+++ b/packages/lang-server/test/service_url.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/test/symbols.test.ts
+++ b/packages/lang-server/test/symbols.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/test/token.test.ts
+++ b/packages/lang-server/test/token.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/test/usage.test.ts
+++ b/packages/lang-server/test/usage.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/test/workspace.test.ts
+++ b/packages/lang-server/test/workspace.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/jest.config.js
+++ b/packages/logging/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/src/internal/colors/index.ts
+++ b/packages/logging/src/internal/colors/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/src/internal/common.ts
+++ b/packages/logging/src/internal/common.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/src/internal/config.ts
+++ b/packages/logging/src/internal/config.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/src/internal/env.ts
+++ b/packages/logging/src/internal/env.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/src/internal/level.ts
+++ b/packages/logging/src/internal/level.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/src/internal/log-file.ts
+++ b/packages/logging/src/internal/log-file.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/src/internal/log-tags.ts
+++ b/packages/logging/src/internal/log-tags.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/src/internal/logger.ts
+++ b/packages/logging/src/internal/logger.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/src/internal/namespace.ts
+++ b/packages/logging/src/internal/namespace.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/src/internal/pino.ts
+++ b/packages/logging/src/internal/pino.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/src/internal/quickhash.ts
+++ b/packages/logging/src/internal/quickhash.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/test/console.ts
+++ b/packages/logging/test/console.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/test/index.test.ts
+++ b/packages/logging/test/index.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/test/internal/config.test.ts
+++ b/packages/logging/test/internal/config.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/test/internal/env.test.ts
+++ b/packages/logging/test/internal/env.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/test/internal/levels.test.ts
+++ b/packages/logging/test/internal/levels.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/test/internal/log-tags.test.ts
+++ b/packages/logging/test/internal/log-tags.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/test/internal/log_file.test.ts
+++ b/packages/logging/test/internal/log_file.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/test/internal/namespace.test.ts
+++ b/packages/logging/test/internal/namespace.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/test/internal/pino_logger.test.ts
+++ b/packages/logging/test/internal/pino_logger.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/logging/test/matchers.ts
+++ b/packages/logging/test/matchers.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/index.ts
+++ b/packages/lowerdash/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/jest.config.js
+++ b/packages/lowerdash/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/chunks.ts
+++ b/packages/lowerdash/src/chunks.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/collections/array.ts
+++ b/packages/lowerdash/src/collections/array.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/collections/asynciterable.ts
+++ b/packages/lowerdash/src/collections/asynciterable.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/collections/index.ts
+++ b/packages/lowerdash/src/collections/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/collections/iterable.ts
+++ b/packages/lowerdash/src/collections/iterable.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/collections/map.ts
+++ b/packages/lowerdash/src/collections/map.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/collections/set.ts
+++ b/packages/lowerdash/src/collections/set.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/collections/tree_map.ts
+++ b/packages/lowerdash/src/collections/tree_map.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/decorators.ts
+++ b/packages/lowerdash/src/decorators.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/functions/default_opts.ts
+++ b/packages/lowerdash/src/functions/default_opts.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/functions/index.ts
+++ b/packages/lowerdash/src/functions/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/functions/opts_validator.ts
+++ b/packages/lowerdash/src/functions/opts_validator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/hash.ts
+++ b/packages/lowerdash/src/hash.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/index.ts
+++ b/packages/lowerdash/src/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/multi_index.ts
+++ b/packages/lowerdash/src/multi_index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/objects.ts
+++ b/packages/lowerdash/src/objects.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/promises/array.ts
+++ b/packages/lowerdash/src/promises/array.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/promises/index.ts
+++ b/packages/lowerdash/src/promises/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/promises/object.ts
+++ b/packages/lowerdash/src/promises/object.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/promises/state.ts
+++ b/packages/lowerdash/src/promises/state.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/promises/timeout.ts
+++ b/packages/lowerdash/src/promises/timeout.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/regex.ts
+++ b/packages/lowerdash/src/regex.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/retry/index.ts
+++ b/packages/lowerdash/src/retry/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/retry/strategies/exponential_backoff.ts
+++ b/packages/lowerdash/src/retry/strategies/exponential_backoff.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/retry/strategies/index.ts
+++ b/packages/lowerdash/src/retry/strategies/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/retry/strategies/intervals.ts
+++ b/packages/lowerdash/src/retry/strategies/intervals.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/retry/strategies/none.ts
+++ b/packages/lowerdash/src/retry/strategies/none.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/retry/strategy.ts
+++ b/packages/lowerdash/src/retry/strategy.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/retry/with_retry.ts
+++ b/packages/lowerdash/src/retry/with_retry.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/stack.ts
+++ b/packages/lowerdash/src/stack.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/streams.ts
+++ b/packages/lowerdash/src/streams.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/strings.ts
+++ b/packages/lowerdash/src/strings.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/types.ts
+++ b/packages/lowerdash/src/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/validators.ts
+++ b/packages/lowerdash/src/validators.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/src/values.ts
+++ b/packages/lowerdash/src/values.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/chunks.test.ts
+++ b/packages/lowerdash/test/chunks.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/collections/array.test.ts
+++ b/packages/lowerdash/test/collections/array.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/collections/asynciterable.test.ts
+++ b/packages/lowerdash/test/collections/asynciterable.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/collections/iterable.test.ts
+++ b/packages/lowerdash/test/collections/iterable.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/collections/map.test.ts
+++ b/packages/lowerdash/test/collections/map.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/collections/set.test.ts
+++ b/packages/lowerdash/test/collections/set.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/collections/tree_map.test.ts
+++ b/packages/lowerdash/test/collections/tree_map.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/decorators.test.ts
+++ b/packages/lowerdash/test/decorators.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/functions/default_opts.test.ts
+++ b/packages/lowerdash/test/functions/default_opts.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/functions/opts_validators.test.ts
+++ b/packages/lowerdash/test/functions/opts_validators.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/hash.test.ts
+++ b/packages/lowerdash/test/hash.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/index.test.ts
+++ b/packages/lowerdash/test/index.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/max_counter.ts
+++ b/packages/lowerdash/test/max_counter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/multi_index.test.ts
+++ b/packages/lowerdash/test/multi_index.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/objects.test.ts
+++ b/packages/lowerdash/test/objects.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/promises/array.test.ts
+++ b/packages/lowerdash/test/promises/array.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/promises/object.test.ts
+++ b/packages/lowerdash/test/promises/object.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/promises/state.test.ts
+++ b/packages/lowerdash/test/promises/state.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/promises/timeout.test.ts
+++ b/packages/lowerdash/test/promises/timeout.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/regex.test.ts
+++ b/packages/lowerdash/test/regex.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/retry/strategies/exponential_backoff.test.ts
+++ b/packages/lowerdash/test/retry/strategies/exponential_backoff.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/retry/strategies/index.test.ts
+++ b/packages/lowerdash/test/retry/strategies/index.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/retry/strategies/intervals.test.ts
+++ b/packages/lowerdash/test/retry/strategies/intervals.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/retry/strategies/none.test.ts
+++ b/packages/lowerdash/test/retry/strategies/none.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/retry/with_retry.test.ts
+++ b/packages/lowerdash/test/retry/with_retry.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/stack.test.ts
+++ b/packages/lowerdash/test/stack.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/streams.test.ts
+++ b/packages/lowerdash/test/streams.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/strings.test.ts
+++ b/packages/lowerdash/test/strings.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/types.test.ts
+++ b/packages/lowerdash/test/types.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/validators.test.ts
+++ b/packages/lowerdash/test/validators.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/lowerdash/test/values.test.ts
+++ b/packages/lowerdash/test/values.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/e2e_test/adapter.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/e2e_test/credentials_store/adapter.ts
+++ b/packages/netsuite-adapter/e2e_test/credentials_store/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/e2e_test/jest_environment.ts
+++ b/packages/netsuite-adapter/e2e_test/jest_environment.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/e2e_test/mock_elements.ts
+++ b/packages/netsuite-adapter/e2e_test/mock_elements.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/index.ts
+++ b/packages/netsuite-adapter/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/jest.config.js
+++ b/packages/netsuite-adapter/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/scripts/types_generation/types_generator.py
+++ b/packages/netsuite-adapter/scripts/types_generation/types_generator.py
@@ -34,7 +34,7 @@ INNER_TYPE_NAME_TO_DEF = 'inner_type_name_to_def'
 TYPE_DEF = 'type_def'
 
 LICENSE_HEADER = '''/*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types.ts
+++ b/packages/netsuite-adapter/src/autogen/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/addressForm.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/addressForm.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/advancedpdftemplate.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/advancedpdftemplate.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/bankstatementparserplugin.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/bankstatementparserplugin.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/bundleinstallationscript.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/bundleinstallationscript.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/center.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/center.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/centercategory.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/centercategory.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/centerlink.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/centerlink.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/centertab.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/centertab.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/clientscript.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/clientscript.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/cmscontenttype.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/cmscontenttype.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/crmcustomfield.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/crmcustomfield.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/customglplugin.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/customglplugin.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/customlist.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/customlist.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/customrecordactionscript.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/customrecordactionscript.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/customrecordtype.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/customrecordtype.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/customsegment.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/customsegment.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/customtransactiontype.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/customtransactiontype.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/dataset.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/dataset.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/datasetbuilderplugin.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/datasetbuilderplugin.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/emailcaptureplugin.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/emailcaptureplugin.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/emailtemplate.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/emailtemplate.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/entitycustomfield.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/entitycustomfield.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/entryForm.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/entryForm.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/ficonnectivityplugin.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/ficonnectivityplugin.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/fiparserplugin.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/fiparserplugin.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/integration.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/integration.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/itemcustomfield.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/itemcustomfield.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/itemnumbercustomfield.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/itemnumbercustomfield.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/itemoptioncustomfield.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/itemoptioncustomfield.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/kpiscorecard.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/kpiscorecard.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/mapreducescript.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/mapreducescript.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/massupdatescript.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/massupdatescript.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/othercustomfield.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/othercustomfield.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/pluginimplementation.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/pluginimplementation.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/plugintype.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/plugintype.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/portlet.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/portlet.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/promotionsplugin.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/promotionsplugin.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/publisheddashboard.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/publisheddashboard.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/restlet.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/restlet.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/role.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/role.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/savedcsvimport.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/savedcsvimport.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/savedsearch.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/savedsearch.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/scheduledscript.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/scheduledscript.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/sdfinstallationscript.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/sdfinstallationscript.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/secret.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/secret.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/sspapplication.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/sspapplication.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/sublist.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/sublist.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/subtab.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/subtab.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/suitelet.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/suitelet.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/transactionForm.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/transactionForm.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/transactionbodycustomfield.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/transactionbodycustomfield.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/transactioncolumncustomfield.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/transactioncolumncustomfield.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/translationcollection.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/translationcollection.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/usereventscript.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/usereventscript.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/workbook.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/workbook.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/workbookbuilderplugin.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/workbookbuilderplugin.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/workflow.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/workflow.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/custom_types/workflowactionscript.ts
+++ b/packages/netsuite-adapter/src/autogen/types/custom_types/workflowactionscript.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/autogen/types/enums.ts
+++ b/packages/netsuite-adapter/src/autogen/types/enums.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validators/custom_types_invalid_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/custom_types_invalid_values.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validators/data_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/data_account_specific_values.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validators/dependencies.ts
+++ b/packages/netsuite-adapter/src/change_validators/dependencies.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validators/file_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/file_changes.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/immutable_changes.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validators/instance_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/instance_changes.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validators/remove_custom_types.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_custom_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validators/remove_customlist_item.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_customlist_item.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validators/remove_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_file_cabinet.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validators/safe_deploy.ts
+++ b/packages/netsuite-adapter/src/change_validators/safe_deploy.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validators/saved_search_move_environment.ts
+++ b/packages/netsuite-adapter/src/change_validators/saved_search_move_environment.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/change_validators/subinstances.ts
+++ b/packages/netsuite-adapter/src/change_validators/subinstances.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detector.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_record_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_record_type.ts
@@ -1,6 +1,6 @@
 
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/file_cabinet.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/file_cabinet.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/role.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/role.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/savedsearch.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/savedsearch.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/script.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/script.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/workflow.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/workflow.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/changes_detector/date_formats.ts
+++ b/packages/netsuite-adapter/src/changes_detector/date_formats.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/changes_detector/types.ts
+++ b/packages/netsuite-adapter/src/changes_detector/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/client/constants.ts
+++ b/packages/netsuite-adapter/src/client/constants.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/client/credentials.ts
+++ b/packages/netsuite-adapter/src/client/credentials.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/client/suiteapp_client/constants.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/constants.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/client/suiteapp_client/errors.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/errors.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/schemas.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/schemas.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/client/utils.ts
+++ b/packages/netsuite-adapter/src/client/utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/config.ts
+++ b/packages/netsuite-adapter/src/config.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/data_elements/custom_fields.ts
+++ b/packages/netsuite-adapter/src/data_elements/custom_fields.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/data_elements/data_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/data_elements.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/data_elements/multi_fields_identifiers.ts
+++ b/packages/netsuite-adapter/src/data_elements/multi_fields_identifiers.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/data_elements/types.ts
+++ b/packages/netsuite-adapter/src/data_elements/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/elements_source_index/types.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filter.ts
+++ b/packages/netsuite-adapter/src/filter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/account_specific_values.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/add_parent_folder.ts
+++ b/packages/netsuite-adapter/src/filters/add_parent_folder.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/author_information.ts
+++ b/packages/netsuite-adapter/src/filters/author_information.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/author_information/constants.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/constants.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/author_information/saved_searches.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/saved_searches.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/author_information/system_note.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/system_note.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/consistent_values.ts
+++ b/packages/netsuite-adapter/src/filters/consistent_values.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/convert_lists.ts
+++ b/packages/netsuite-adapter/src/filters/convert_lists.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/data_instances_attributes.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_attributes.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/data_instances_custom_fields.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_custom_fields.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/data_instances_diff.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_diff.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/data_instances_identifiers.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_identifiers.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/data_instances_null_fields.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_null_fields.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/data_instances_references.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/data_types_custom_fields.ts
+++ b/packages/netsuite-adapter/src/filters/data_types_custom_fields.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/hidden_fields.ts
+++ b/packages/netsuite-adapter/src/filters/hidden_fields.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/instance_references.ts
+++ b/packages/netsuite-adapter/src/filters/instance_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/internal_ids/constants.ts
+++ b/packages/netsuite-adapter/src/filters/internal_ids/constants.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/internal_ids/sdf_internal_ids.ts
+++ b/packages/netsuite-adapter/src/filters/internal_ids/sdf_internal_ids.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/internal_ids/suite_app_internal_ids.ts
+++ b/packages/netsuite-adapter/src/filters/internal_ids/suite_app_internal_ids.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/parse_saved_searchs.ts
+++ b/packages/netsuite-adapter/src/filters/parse_saved_searchs.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/remove_redundant_fields.ts
+++ b/packages/netsuite-adapter/src/filters/remove_redundant_fields.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
+++ b/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/replace_record_ref.ts
+++ b/packages/netsuite-adapter/src/filters/replace_record_ref.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/service_urls.ts
+++ b/packages/netsuite-adapter/src/filters/service_urls.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/filters/translation_converter.ts
+++ b/packages/netsuite-adapter/src/filters/translation_converter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/group_changes.ts
+++ b/packages/netsuite-adapter/src/group_changes.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/query.ts
+++ b/packages/netsuite-adapter/src/query.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/reference_dependencies.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/saved_search_parsing/parsed_saved_search.ts
+++ b/packages/netsuite-adapter/src/saved_search_parsing/parsed_saved_search.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/saved_search_parsing/saved_search_parser.ts
+++ b/packages/netsuite-adapter/src/saved_search_parsing/saved_search_parser.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/server_time.ts
+++ b/packages/netsuite-adapter/src/server_time.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/service_url/constant_urls.ts
+++ b/packages/netsuite-adapter/src/service_url/constant_urls.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/service_url/custom_field.ts
+++ b/packages/netsuite-adapter/src/service_url/custom_field.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/service_url/custom_record_type.ts
+++ b/packages/netsuite-adapter/src/service_url/custom_record_type.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/service_url/custom_transaction_type.ts
+++ b/packages/netsuite-adapter/src/service_url/custom_transaction_type.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/service_url/emailtemplate.ts
+++ b/packages/netsuite-adapter/src/service_url/emailtemplate.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/service_url/file_cabinet.ts
+++ b/packages/netsuite-adapter/src/service_url/file_cabinet.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/service_url/instances_urls.ts
+++ b/packages/netsuite-adapter/src/service_url/instances_urls.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/service_url/role.ts
+++ b/packages/netsuite-adapter/src/service_url/role.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/service_url/savedsearch.ts
+++ b/packages/netsuite-adapter/src/service_url/savedsearch.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/service_url/script.ts
+++ b/packages/netsuite-adapter/src/service_url/script.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/service_url/sublist.ts
+++ b/packages/netsuite-adapter/src/service_url/sublist.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/service_url/suiteapp_elements_url.ts
+++ b/packages/netsuite-adapter/src/service_url/suiteapp_elements_url.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/service_url/types.ts
+++ b/packages/netsuite-adapter/src/service_url/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/service_url/validation.ts
+++ b/packages/netsuite-adapter/src/service_url/validation.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/suiteapp_file_cabinet.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/types/field_types.ts
+++ b/packages/netsuite-adapter/src/types/field_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/src/types/file_cabinet_types.ts
+++ b/packages/netsuite-adapter/src/types/file_cabinet_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/change_validator.test.ts
+++ b/packages/netsuite-adapter/test/change_validator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/change_validators/account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/account_specific_values.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/change_validators/custom_types_invalid_values.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/custom_types_invalid_values.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/change_validators/data_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/data_account_specific_values.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/change_validators/dependencies.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/dependencies.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/change_validators/file_changes.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/file_changes.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/change_validators/immutable_changes.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/immutable_changes.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/change_validators/instance_changes.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/instance_changes.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/change_validators/remove_custom_types.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_custom_types.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/change_validators/remove_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_file_cabinet.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/change_validators/remove_list_item.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_list_item.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/change_validators/safe_deploy.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/safe_deploy.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/change_validators/saved_search_move_environment.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/saved_search_move_environment.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/change_validators/subinstances.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/subinstances.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/changes_detector/date_formats.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/date_formats.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/changes_detector/file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/file_cabinet.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/changes_detector/role.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/role.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/changes_detector/savedsearch.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/savedsearch.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/changes_detector/script.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/script.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/changes_detector/workflow.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/workflow.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/client/sdf_client.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/client/soap_client.test.ts
+++ b/packages/netsuite-adapter/test/client/soap_client.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/config.test.ts
+++ b/packages/netsuite-adapter/test/config.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/data_elements/data_elements.test.ts
+++ b/packages/netsuite-adapter/test/data_elements/data_elements.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/elements_source_index.test.ts
+++ b/packages/netsuite-adapter/test/elements_source_index.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/account_specific_value.test.ts
+++ b/packages/netsuite-adapter/test/filters/account_specific_value.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/add_parent_folder.test.ts
+++ b/packages/netsuite-adapter/test/filters/add_parent_folder.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/author_information/saved_searches.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/saved_searches.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/consistent_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/consistent_values.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/convert_lists.test.ts
+++ b/packages/netsuite-adapter/test/filters/convert_lists.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/data_instances_attributes.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_attributes.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/data_instances_custom_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_custom_fields.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/data_instances_diff.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_diff.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/data_instances_identifiers.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_identifiers.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/data_instances_null_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_null_fields.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/data_types_custom_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_types_custom_fields.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/hidden_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/hidden_fields.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/instance_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/instance_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/internal_ids/sdf_internal_ids.test.ts
+++ b/packages/netsuite-adapter/test/filters/internal_ids/sdf_internal_ids.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/internal_ids/suite_app_internal_ids.test.ts
+++ b/packages/netsuite-adapter/test/filters/internal_ids/suite_app_internal_ids.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/parse_saved_searches.test.ts
+++ b/packages/netsuite-adapter/test/filters/parse_saved_searches.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/remove_redundant_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/remove_redundant_fields.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/replace_record_ref.test.ts
+++ b/packages/netsuite-adapter/test/filters/replace_record_ref.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/service_urls.test.ts
+++ b/packages/netsuite-adapter/test/filters/service_urls.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/filters/translation_converter.test.ts
+++ b/packages/netsuite-adapter/test/filters/translation_converter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/group_changes.test.ts
+++ b/packages/netsuite-adapter/test/group_changes.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/query.test.ts
+++ b/packages/netsuite-adapter/test/query.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/reference_dependencies.test.ts
+++ b/packages/netsuite-adapter/test/reference_dependencies.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/saved_search_definition.ts
+++ b/packages/netsuite-adapter/test/saved_search_definition.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/saved_search_parser.test.ts
+++ b/packages/netsuite-adapter/test/saved_search_parser.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/service_url/constant_urls.test.ts
+++ b/packages/netsuite-adapter/test/service_url/constant_urls.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/service_url/custom_field.test.ts
+++ b/packages/netsuite-adapter/test/service_url/custom_field.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/service_url/custom_record_type.test.ts
+++ b/packages/netsuite-adapter/test/service_url/custom_record_type.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/service_url/custom_transaction_type.test.ts
+++ b/packages/netsuite-adapter/test/service_url/custom_transaction_type.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/service_url/emailtemplate.test.ts
+++ b/packages/netsuite-adapter/test/service_url/emailtemplate.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/service_url/file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/service_url/file_cabinet.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/service_url/role.test.ts
+++ b/packages/netsuite-adapter/test/service_url/role.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/service_url/saved_search.test.ts
+++ b/packages/netsuite-adapter/test/service_url/saved_search.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/service_url/script.test.ts
+++ b/packages/netsuite-adapter/test/service_url/script.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/service_url/sublist.test.ts
+++ b/packages/netsuite-adapter/test/service_url/sublist.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/service_url/suiteapp_elements.test.ts
+++ b/packages/netsuite-adapter/test/service_url/suiteapp_elements.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/suiteapp_file_cabinet.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/types.test.ts
+++ b/packages/netsuite-adapter/test/types.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/test/utils.ts
+++ b/packages/netsuite-adapter/test/utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/netsuite-adapter/types/suitecloud-cli.d.ts
+++ b/packages/netsuite-adapter/types/suitecloud-cli.d.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/jest-dynalite-config.js
+++ b/packages/persistent-pool/jest-dynalite-config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/jest.config.js
+++ b/packages/persistent-pool/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/src/index.ts
+++ b/packages/persistent-pool/src/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/src/lib/dynamodb/dynamodb_repo.ts
+++ b/packages/persistent-pool/src/lib/dynamodb/dynamodb_repo.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/src/lib/dynamodb/utils.ts
+++ b/packages/persistent-pool/src/lib/dynamodb/utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/src/lib/renewed_lease.ts
+++ b/packages/persistent-pool/src/lib/renewed_lease.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/src/types.ts
+++ b/packages/persistent-pool/src/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/test/lib/dynamodb/dynamodb_repo.e2e.test.ts
+++ b/packages/persistent-pool/test/lib/dynamodb/dynamodb_repo.e2e.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/test/lib/dynamodb/dynamodb_repo.test.ts
+++ b/packages/persistent-pool/test/lib/dynamodb/dynamodb_repo.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/test/lib/dynamodb/environment/index.ts
+++ b/packages/persistent-pool/test/lib/dynamodb/environment/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/test/lib/dynamodb/environment/types.ts
+++ b/packages/persistent-pool/test/lib/dynamodb/environment/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/test/lib/dynamodb/utils.test.ts
+++ b/packages/persistent-pool/test/lib/dynamodb/utils.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/test/lib/dynamodb/utils.ts
+++ b/packages/persistent-pool/test/lib/dynamodb/utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/test/lib/renewed_lease.test.ts
+++ b/packages/persistent-pool/test/lib/renewed_lease.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/test/mock_repo.ts
+++ b/packages/persistent-pool/test/mock_repo.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/test/types.ts
+++ b/packages/persistent-pool/test/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/test/utils/async_to_array.ts
+++ b/packages/persistent-pool/test/utils/async_to_array.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/test/utils/promise_series.ts
+++ b/packages/persistent-pool/test/utils/promise_series.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/test/utils/random_string.ts
+++ b/packages/persistent-pool/test/utils/random_string.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/test/utils/repeat.ts
+++ b/packages/persistent-pool/test/utils/repeat.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/persistent-pool/test/utils/timing.ts
+++ b/packages/persistent-pool/test/utils/timing.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/e2e_test/adapter.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/e2e_test/credentials_store/adapter.ts
+++ b/packages/salesforce-adapter/e2e_test/credentials_store/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
+++ b/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/e2e_test/jest_environment.ts
+++ b/packages/salesforce-adapter/e2e_test/jest_environment.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/e2e_test/setup.ts
+++ b/packages/salesforce-adapter/e2e_test/setup.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/e2e_test/workflow.test.ts
+++ b/packages/salesforce-adapter/e2e_test/workflow.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/index.ts
+++ b/packages/salesforce-adapter/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/jest.config.js
+++ b/packages/salesforce-adapter/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/prettier.config.js
+++ b/packages/salesforce-adapter/prettier.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/change_validators/custom_object_instances.ts
+++ b/packages/salesforce-adapter/src/change_validators/custom_object_instances.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
+++ b/packages/salesforce-adapter/src/change_validators/multiple_deafults.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/change_validators/package.ts
+++ b/packages/salesforce-adapter/src/change_validators/package.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/change_validators/picklist_promote.ts
+++ b/packages/salesforce-adapter/src/change_validators/picklist_promote.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/change_validators/picklist_standard_field.ts
+++ b/packages/salesforce-adapter/src/change_validators/picklist_standard_field.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/change_validators/profile_map_keys.ts
+++ b/packages/salesforce-adapter/src/change_validators/profile_map_keys.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/change_validators/standard_field_label.ts
+++ b/packages/salesforce-adapter/src/change_validators/standard_field_label.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/change_validators/unknown_field.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_field.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/change_validators/validate_only_flag.ts
+++ b/packages/salesforce-adapter/src/change_validators/validate_only_flag.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/client/types.ts
+++ b/packages/salesforce-adapter/src/client/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/config_change.ts
+++ b/packages/salesforce-adapter/src/config_change.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/config_validation.ts
+++ b/packages/salesforce-adapter/src/config_validation.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/deprecated_config.ts
+++ b/packages/salesforce-adapter/src/deprecated_config.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/elements_url_retreiver/elements_url_retreiver.ts
+++ b/packages/salesforce-adapter/src/elements_url_retreiver/elements_url_retreiver.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/elements_url_retreiver/lightining_url_resolvers.ts
+++ b/packages/salesforce-adapter/src/elements_url_retreiver/lightining_url_resolvers.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/fetch_profile/data_management.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/data_management.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filter.ts
+++ b/packages/salesforce-adapter/src/filter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/add_missing_ids.ts
+++ b/packages/salesforce-adapter/src/filters/add_missing_ids.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/animation_rules.ts
+++ b/packages/salesforce-adapter/src/filters/animation_rules.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/author_information/data_instances.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/data_instances.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/author_information/sharing_rules.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/sharing_rules.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/convert_lists.ts
+++ b/packages/salesforce-adapter/src/filters/convert_lists.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/convert_types.ts
+++ b/packages/salesforce-adapter/src/filters/convert_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/cpq/custom_script.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/custom_script.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/cpq/hide_read_only_values.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/hide_read_only_values.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/cpq/lookup_fields.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/lookup_fields.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/custom_feed_filter.ts
+++ b/packages/salesforce-adapter/src/filters/custom_feed_filter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/custom_object_split.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_split.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
+++ b/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/elements_url.ts
+++ b/packages/salesforce-adapter/src/filters/elements_url.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/extra_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/extra_dependencies.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/flow.ts
+++ b/packages/salesforce-adapter/src/filters/flow.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/foreign_key_references.ts
+++ b/packages/salesforce-adapter/src/filters/foreign_key_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/global_value_sets.ts
+++ b/packages/salesforce-adapter/src/filters/global_value_sets.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/layouts.ts
+++ b/packages/salesforce-adapter/src/filters/layouts.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/profile_instance_split.ts
+++ b/packages/salesforce-adapter/src/filters/profile_instance_split.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/profile_paths.ts
+++ b/packages/salesforce-adapter/src/filters/profile_paths.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/profile_permissions.ts
+++ b/packages/salesforce-adapter/src/filters/profile_permissions.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/reference_annotations.ts
+++ b/packages/salesforce-adapter/src/filters/reference_annotations.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
+++ b/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
+++ b/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/saml_initiation_method.ts
+++ b/packages/salesforce-adapter/src/filters/saml_initiation_method.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/settings_type.ts
+++ b/packages/salesforce-adapter/src/filters/settings_type.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/standard_value_sets.ts
+++ b/packages/salesforce-adapter/src/filters/standard_value_sets.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/static_resource_file_ext.ts
+++ b/packages/salesforce-adapter/src/filters/static_resource_file_ext.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/territory.ts
+++ b/packages/salesforce-adapter/src/filters/territory.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/topics_for_objects.ts
+++ b/packages/salesforce-adapter/src/filters/topics_for_objects.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/trim_keys.ts
+++ b/packages/salesforce-adapter/src/filters/trim_keys.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/value_set.ts
+++ b/packages/salesforce-adapter/src/filters/value_set.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/value_to_static_file.ts
+++ b/packages/salesforce-adapter/src/filters/value_to_static_file.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/workflow.ts
+++ b/packages/salesforce-adapter/src/filters/workflow.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/filters/xml_attributes.ts
+++ b/packages/salesforce-adapter/src/filters/xml_attributes.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/group_changes.ts
+++ b/packages/salesforce-adapter/src/group_changes.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/transformers/missing_fields.ts
+++ b/packages/salesforce-adapter/src/transformers/missing_fields.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/transformers/salesforce_types.ts
+++ b/packages/salesforce-adapter/src/transformers/salesforce_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/adapter.creator.test.ts
+++ b/packages/salesforce-adapter/test/adapter.creator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/adapter.ts
+++ b/packages/salesforce-adapter/test/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/change_validators/custom_field_type.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/custom_field_type.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/change_validators/custom_object_instances.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/custom_object_instances.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/multiple_defaults.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/change_validators/package.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/package.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/change_validators/picklist_promote.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/picklist_promote.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/change_validators/picklist_standard_field.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/picklist_standard_field.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/change_validators/profile_map_keys.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/profile_map_keys.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/change_validators/standard_field_label.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/standard_field_label.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/change_validators/unknown_field.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/unknown_field.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/change_validators/validate_only_flag.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/validate_only_flag.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/client.ts
+++ b/packages/salesforce-adapter/test/client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/config_change.test.ts
+++ b/packages/salesforce-adapter/test/config_change.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/connection.ts
+++ b/packages/salesforce-adapter/test/connection.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/deprecated_config.test.ts
+++ b/packages/salesforce-adapter/test/deprecated_config.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/elements_url_retreiver.test.ts
+++ b/packages/salesforce-adapter/test/elements_url_retreiver.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/fetch_profile/data_management.test.ts
+++ b/packages/salesforce-adapter/test/fetch_profile/data_management.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
+++ b/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_missing_ids.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/animation_rules.test.ts
+++ b/packages/salesforce-adapter/test/filters/animation_rules.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/author_information/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/author_information/custom_objects.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/author_information/data_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/author_information/data_instances.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/author_information/sharing_rules.test.ts
+++ b/packages/salesforce-adapter/test/filters/author_information/sharing_rules.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/convert_lists.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_lists.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/convert_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_maps.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/convert_types.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_types.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/cpq/custom_script.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/custom_script.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/cpq/fields_with_context_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/fields_with_context_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/cpq/hide_read_only_values.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/hide_read_only_values.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/cpq/lookup_fields.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/lookup_fields.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/custom_feed_filter.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_feed_filter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/custom_settings_filter.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_settings_filter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/elements_url.test.ts
+++ b/packages/salesforce-adapter/test/filters/elements_url.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/extra_dependencies.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/filters.test.ts
+++ b/packages/salesforce-adapter/test/filters/filters.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/flow.test.ts
+++ b/packages/salesforce-adapter/test/filters/flow.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/foreign_key_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/foreign_key_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/global_value_sets.test.ts
+++ b/packages/salesforce-adapter/test/filters/global_value_sets.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/layouts.test.ts
+++ b/packages/salesforce-adapter/test/filters/layouts.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/profile_instance_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_instance_split.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/profile_paths.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_paths.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/profile_permissions.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_permissions.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/reference_annotations.test.ts
+++ b/packages/salesforce-adapter/test/filters/reference_annotations.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/remove_fields_and_values.test.ts
+++ b/packages/salesforce-adapter/test/filters/remove_fields_and_values.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/replace_instance_field_values.test.ts
+++ b/packages/salesforce-adapter/test/filters/replace_instance_field_values.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/saml_initiation_method.test.ts
+++ b/packages/salesforce-adapter/test/filters/saml_initiation_method.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/settings_type.test.ts
+++ b/packages/salesforce-adapter/test/filters/settings_type.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/standard_value_sets.test.ts
+++ b/packages/salesforce-adapter/test/filters/standard_value_sets.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/static_resource_file_ext.test.ts
+++ b/packages/salesforce-adapter/test/filters/static_resource_file_ext.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/territory.test.ts
+++ b/packages/salesforce-adapter/test/filters/territory.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/topics_for_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/topics_for_objects.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/trim_keys.test.ts
+++ b/packages/salesforce-adapter/test/filters/trim_keys.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/value_set.test.ts
+++ b/packages/salesforce-adapter/test/filters/value_set.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/value_to_static_file.test.ts
+++ b/packages/salesforce-adapter/test/filters/value_to_static_file.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/workflow.test.ts
+++ b/packages/salesforce-adapter/test/filters/workflow.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/filters/xml_attributes.test.ts
+++ b/packages/salesforce-adapter/test/filters/xml_attributes.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/group_changes.test.ts
+++ b/packages/salesforce-adapter/test/group_changes.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/salesforce-adapter/test/utils.ts
+++ b/packages/salesforce-adapter/test/utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/e2e_test/adapter.test.ts
+++ b/packages/stripe-adapter/e2e_test/adapter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/e2e_test/adapter.ts
+++ b/packages/stripe-adapter/e2e_test/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/e2e_test/credentials_store/adapter.ts
+++ b/packages/stripe-adapter/e2e_test/credentials_store/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/e2e_test/jest_environment.ts
+++ b/packages/stripe-adapter/e2e_test/jest_environment.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/index.ts
+++ b/packages/stripe-adapter/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/src/adapter.ts
+++ b/packages/stripe-adapter/src/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/src/adapter_creator.ts
+++ b/packages/stripe-adapter/src/adapter_creator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/src/auth.ts
+++ b/packages/stripe-adapter/src/auth.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/src/change_validator.ts
+++ b/packages/stripe-adapter/src/change_validator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/src/client/client.ts
+++ b/packages/stripe-adapter/src/client/client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/src/client/connection.ts
+++ b/packages/stripe-adapter/src/client/connection.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/src/constants.ts
+++ b/packages/stripe-adapter/src/constants.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/src/filter.ts
+++ b/packages/stripe-adapter/src/filter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/src/filters/field_references.ts
+++ b/packages/stripe-adapter/src/filters/field_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/test/adapter.test.ts
+++ b/packages/stripe-adapter/test/adapter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/test/adapter_creator.test.ts
+++ b/packages/stripe-adapter/test/adapter_creator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/test/change_validator.test.ts
+++ b/packages/stripe-adapter/test/change_validator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/test/filters/field_references.test.ts
+++ b/packages/stripe-adapter/test/filters/field_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/stripe-adapter/test/utils.ts
+++ b/packages/stripe-adapter/test/utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/test-utils/index.ts
+++ b/packages/test-utils/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/test-utils/jest.config.js
+++ b/packages/test-utils/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/test-utils/src/mock.ts
+++ b/packages/test-utils/src/mock.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/test-utils/src/promise.ts
+++ b/packages/test-utils/src/promise.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/test-utils/test/mock.test.ts
+++ b/packages/test-utils/test/mock.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/test-utils/test/promise.test.ts
+++ b/packages/test-utils/test/promise.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/vscode/e2e_test/extension.test.ts
+++ b/packages/vscode/e2e_test/extension.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/vscode/jest.config.js
+++ b/packages/vscode/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/vscode/src/adapters.ts
+++ b/packages/vscode/src/adapters.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/vscode/src/commands.ts
+++ b/packages/vscode/src/commands.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/vscode/src/events.ts
+++ b/packages/vscode/src/events.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/vscode/src/output.ts
+++ b/packages/vscode/src/output.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/vscode/src/providers.ts
+++ b/packages/vscode/src/providers.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/index.ts
+++ b/packages/workato-adapter/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/adapter_creator.ts
+++ b/packages/workato-adapter/src/adapter_creator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/auth.ts
+++ b/packages/workato-adapter/src/auth.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/change_validator.ts
+++ b/packages/workato-adapter/src/change_validator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/client/client.ts
+++ b/packages/workato-adapter/src/client/client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/client/connection.ts
+++ b/packages/workato-adapter/src/client/connection.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/client/pagination.ts
+++ b/packages/workato-adapter/src/client/pagination.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/config.ts
+++ b/packages/workato-adapter/src/config.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/constants.ts
+++ b/packages/workato-adapter/src/constants.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filter.ts
+++ b/packages/workato-adapter/src/filter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filters/cross_service/netsuite/element_index.ts
+++ b/packages/workato-adapter/src/filters/cross_service/netsuite/element_index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filters/cross_service/netsuite/recipe_block_types.ts
+++ b/packages/workato-adapter/src/filters/cross_service/netsuite/recipe_block_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filters/cross_service/netsuite/reference_finder.ts
+++ b/packages/workato-adapter/src/filters/cross_service/netsuite/reference_finder.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filters/cross_service/recipe_block_types.ts
+++ b/packages/workato-adapter/src/filters/cross_service/recipe_block_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filters/cross_service/recipe_references.ts
+++ b/packages/workato-adapter/src/filters/cross_service/recipe_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filters/cross_service/reference_finders.ts
+++ b/packages/workato-adapter/src/filters/cross_service/reference_finders.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filters/cross_service/salesforce/element_index.ts
+++ b/packages/workato-adapter/src/filters/cross_service/salesforce/element_index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filters/cross_service/salesforce/recipe_block_types.ts
+++ b/packages/workato-adapter/src/filters/cross_service/salesforce/recipe_block_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filters/cross_service/salesforce/reference_finder.ts
+++ b/packages/workato-adapter/src/filters/cross_service/salesforce/reference_finder.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filters/cross_service/zuora_billing/element_index.ts
+++ b/packages/workato-adapter/src/filters/cross_service/zuora_billing/element_index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filters/cross_service/zuora_billing/recipe_block_types.ts
+++ b/packages/workato-adapter/src/filters/cross_service/zuora_billing/recipe_block_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filters/cross_service/zuora_billing/reference_finder.ts
+++ b/packages/workato-adapter/src/filters/cross_service/zuora_billing/reference_finder.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filters/field_references.ts
+++ b/packages/workato-adapter/src/filters/field_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/src/filters/service_url.ts
+++ b/packages/workato-adapter/src/filters/service_url.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/test/adapter_creator.test.ts
+++ b/packages/workato-adapter/test/adapter_creator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/test/change_validator.test.ts
+++ b/packages/workato-adapter/test/change_validator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/test/client/connection.test.ts
+++ b/packages/workato-adapter/test/client/connection.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/test/client/pagination.test.ts
+++ b/packages/workato-adapter/test/client/pagination.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/test/filters/field_references.test.ts
+++ b/packages/workato-adapter/test/filters/field_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/test/filters/recipe_references.test.ts
+++ b/packages/workato-adapter/test/filters/recipe_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workato-adapter/test/filters/service_url.test.ts
+++ b/packages/workato-adapter/test/filters/service_url.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/jest.config.js
+++ b/packages/workspace/jest.config.js
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/element_adapter_rename.ts
+++ b/packages/workspace/src/element_adapter_rename.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/errors.ts
+++ b/packages/workspace/src/errors.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/expressions.ts
+++ b/packages/workspace/src/expressions.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/merger/index.ts
+++ b/packages/workspace/src/merger/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/merger/internal/common.ts
+++ b/packages/workspace/src/merger/internal/common.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/merger/internal/instances.ts
+++ b/packages/workspace/src/merger/internal/instances.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/merger/internal/object_types.ts
+++ b/packages/workspace/src/merger/internal/object_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/merger/internal/primitives.ts
+++ b/packages/workspace/src/merger/internal/primitives.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/merger/internal/variables.ts
+++ b/packages/workspace/src/merger/internal/variables.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/dump.ts
+++ b/packages/workspace/src/parser/dump.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/functions.ts
+++ b/packages/workspace/src/parser/functions.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/index.ts
+++ b/packages/workspace/src/parser/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/internal/dump.ts
+++ b/packages/workspace/src/parser/internal/dump.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/internal/functions.ts
+++ b/packages/workspace/src/parser/internal/functions.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/internal/native/consumers/blocks.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/blocks.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/internal/native/consumers/top_level.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/top_level.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/internal/native/consumers/values.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/values.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/internal/native/errors.ts
+++ b/packages/workspace/src/parser/internal/native/errors.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/internal/native/helpers.ts
+++ b/packages/workspace/src/parser/internal/native/helpers.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/internal/native/parse.ts
+++ b/packages/workspace/src/parser/internal/native/parse.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/internal/native/types.ts
+++ b/packages/workspace/src/parser/internal/native/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/internal/types.ts
+++ b/packages/workspace/src/parser/internal/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/language.ts
+++ b/packages/workspace/src/parser/language.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/parse.ts
+++ b/packages/workspace/src/parser/parse.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/source_map.ts
+++ b/packages/workspace/src/parser/source_map.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/parser/types.ts
+++ b/packages/workspace/src/parser/types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/serializer/index.ts
+++ b/packages/workspace/src/serializer/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/config/workspace_config_types.ts
+++ b/packages/workspace/src/workspace/config/workspace_config_types.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/config_source.ts
+++ b/packages/workspace/src/workspace/config_source.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/dir_store.ts
+++ b/packages/workspace/src/workspace/dir_store.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/elements_source.ts
+++ b/packages/workspace/src/workspace/elements_source.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/errors.ts
+++ b/packages/workspace/src/workspace/errors.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/nacl_files/addition_wrapper.ts
+++ b/packages/workspace/src/workspace/nacl_files/addition_wrapper.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/nacl_files/index.ts
+++ b/packages/workspace/src/workspace/nacl_files/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/nacl_files/multi_env/projections.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/projections.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_file.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_file.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/reference_indexes.ts
+++ b/packages/workspace/src/workspace/reference_indexes.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/remote_map.ts
+++ b/packages/workspace/src/workspace/remote_map.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/state/index.ts
+++ b/packages/workspace/src/workspace/state/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/state/state.ts
+++ b/packages/workspace/src/workspace/state/state.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/static_files/cache.ts
+++ b/packages/workspace/src/workspace/static_files/cache.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/static_files/common.ts
+++ b/packages/workspace/src/workspace/static_files/common.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/static_files/functions.ts
+++ b/packages/workspace/src/workspace/static_files/functions.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/static_files/index.ts
+++ b/packages/workspace/src/workspace/static_files/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/static_files/source.ts
+++ b/packages/workspace/src/workspace/static_files/source.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/src/workspace/workspace_config_source.ts
+++ b/packages/workspace/src/workspace/workspace_config_source.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/common/helpers.ts
+++ b/packages/workspace/test/common/helpers.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/common/nacl_file_source.ts
+++ b/packages/workspace/test/common/nacl_file_source.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/common/state.ts
+++ b/packages/workspace/test/common/state.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/core/expressions.test.ts
+++ b/packages/workspace/test/core/expressions.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/merger.test.ts
+++ b/packages/workspace/test/merger.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/parser/dump.test.ts
+++ b/packages/workspace/test/parser/dump.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/parser/errors.test.ts
+++ b/packages/workspace/test/parser/errors.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/parser/functions.test.ts
+++ b/packages/workspace/test/parser/functions.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/parser/internal/devaluate.ts
+++ b/packages/workspace/test/parser/internal/devaluate.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/parser/internal/source_map.test.ts
+++ b/packages/workspace/test/parser/internal/source_map.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/serializer/serializer.test.ts
+++ b/packages/workspace/test/serializer/serializer.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/utils.ts
+++ b/packages/workspace/test/utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/adapter_config.test.ts
+++ b/packages/workspace/test/workspace/adapter_config.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/adapters_config.test.ts
+++ b/packages/workspace/test/workspace/adapters_config.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/config_source.test.ts
+++ b/packages/workspace/test/workspace/config_source.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/element_adapter_rename.test.ts
+++ b/packages/workspace/test/workspace/element_adapter_rename.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/elements_source.test.ts
+++ b/packages/workspace/test/workspace/elements_source.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/multi_env/projections.test.ts
+++ b/packages/workspace/test/workspace/multi_env/projections.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/multi_env/routers.test.ts
+++ b/packages/workspace/test/workspace/multi_env/routers.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/nacl_files/addition_wrapper.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/addition_wrapper.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/nacl_files/elements_cache.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/elements_cache.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/nacl_files/parsed_nacl_files_cache.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/parsed_nacl_files_cache.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/path_index.test.ts
+++ b/packages/workspace/test/workspace/path_index.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/reference_indexes.test.ts
+++ b/packages/workspace/test/workspace/reference_indexes.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/remote_map.test.ts
+++ b/packages/workspace/test/workspace/remote_map.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/state.test.ts
+++ b/packages/workspace/test/workspace/state.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/static_files/common.test.ts
+++ b/packages/workspace/test/workspace/static_files/common.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/static_files/functions.test.ts
+++ b/packages/workspace/test/workspace/static_files/functions.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/static_files/source.test.ts
+++ b/packages/workspace/test/workspace/static_files/source.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/index.ts
+++ b/packages/zendesk-support-adapter/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-support-adapter/src/adapter_creator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/auth.ts
+++ b/packages/zendesk-support-adapter/src/auth.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/change_validator.ts
+++ b/packages/zendesk-support-adapter/src/change_validator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/client/client.ts
+++ b/packages/zendesk-support-adapter/src/client/client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/client/connection.ts
+++ b/packages/zendesk-support-adapter/src/client/connection.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/client/pagination.ts
+++ b/packages/zendesk-support-adapter/src/client/pagination.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/constants.ts
+++ b/packages/zendesk-support-adapter/src/constants.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/deployment.ts
+++ b/packages/zendesk-support-adapter/src/deployment.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/errors.ts
+++ b/packages/zendesk-support-adapter/src/errors.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/filter.ts
+++ b/packages/zendesk-support-adapter/src/filter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/filters/business_hours_schedule.ts
+++ b/packages/zendesk-support-adapter/src/filters/business_hours_schedule.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/filters/default_deploy.ts
+++ b/packages/zendesk-support-adapter/src/filters/default_deploy.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/filters/reorder/organization_field.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/organization_field.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/filters/reorder/ticket_form.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/ticket_form.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/filters/reorder/user_field.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/user_field.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-support-adapter/src/filters/unordered_lists.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/filters/view.ts
+++ b/packages/zendesk-support-adapter/src/filters/view.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/src/filters/workspace.ts
+++ b/packages/zendesk-support-adapter/src/filters/workspace.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/test/adapter_creator.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter_creator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/test/change_validator.test.ts
+++ b/packages/zendesk-support-adapter/test/change_validator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/test/client/connection.test.ts
+++ b/packages/zendesk-support-adapter/test/client/connection.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/test/errors.test.ts
+++ b/packages/zendesk-support-adapter/test/errors.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/test/filters/business_hours_schedule.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/business_hours_schedule.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/test/filters/field_references.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/field_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/test/filters/reorder/ticket_form.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/ticket_form.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/unordered_lists.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/test/filters/view.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/view.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zendesk-support-adapter/test/filters/workspace.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/workspace.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/e2e_test/adapter.test.ts
+++ b/packages/zuora-billing-adapter/e2e_test/adapter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/e2e_test/adapter.ts
+++ b/packages/zuora-billing-adapter/e2e_test/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/e2e_test/credentials_store/adapter.ts
+++ b/packages/zuora-billing-adapter/e2e_test/credentials_store/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/e2e_test/jest_environment.ts
+++ b/packages/zuora-billing-adapter/e2e_test/jest_environment.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/index.ts
+++ b/packages/zuora-billing-adapter/index.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/adapter.ts
+++ b/packages/zuora-billing-adapter/src/adapter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/adapter_creator.ts
+++ b/packages/zuora-billing-adapter/src/adapter_creator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/auth.ts
+++ b/packages/zuora-billing-adapter/src/auth.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/change_validator.ts
+++ b/packages/zuora-billing-adapter/src/change_validator.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/client/client.ts
+++ b/packages/zuora-billing-adapter/src/client/client.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/client/connection.ts
+++ b/packages/zuora-billing-adapter/src/client/connection.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/client/pagination.ts
+++ b/packages/zuora-billing-adapter/src/client/pagination.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/config.ts
+++ b/packages/zuora-billing-adapter/src/config.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/constants.ts
+++ b/packages/zuora-billing-adapter/src/constants.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/element_utils.ts
+++ b/packages/zuora-billing-adapter/src/element_utils.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/filter.ts
+++ b/packages/zuora-billing-adapter/src/filter.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/filters/field_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/field_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/finance_information_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/filters/object_def_split.ts
+++ b/packages/zuora-billing-adapter/src/filters/object_def_split.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/filters/object_defs.ts
+++ b/packages/zuora-billing-adapter/src/filters/object_defs.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/filters/object_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/object_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/filters/unordered_lists.ts
+++ b/packages/zuora-billing-adapter/src/filters/unordered_lists.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/transformers/billing_settings.ts
+++ b/packages/zuora-billing-adapter/src/transformers/billing_settings.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/src/transformers/standard_objects.ts
+++ b/packages/zuora-billing-adapter/src/transformers/standard_objects.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/test/adapter.test.ts
+++ b/packages/zuora-billing-adapter/test/adapter.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/test/adapter_creator.test.ts
+++ b/packages/zuora-billing-adapter/test/adapter_creator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/test/change_validator.test.ts
+++ b/packages/zuora-billing-adapter/test/change_validator.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/test/config.test.ts
+++ b/packages/zuora-billing-adapter/test/config.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/test/element_utils.test.ts
+++ b/packages/zuora-billing-adapter/test/element_utils.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/test/filters/field_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/field_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/test/filters/finance_information_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/finance_information_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/test/filters/object_defs.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/object_defs.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/test/filters/object_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/object_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/unordered_lists.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/test/filters/workflow_and_task_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/workflow_and_task_references.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/test/transformers/billing_settings.test.ts
+++ b/packages/zuora-billing-adapter/test/transformers/billing_settings.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with

--- a/packages/zuora-billing-adapter/test/transformers/standard_objects.test.ts
+++ b/packages/zuora-billing-adapter/test/transformers/standard_objects.test.ts
@@ -1,5 +1,5 @@
 /*
-*                      Copyright 2021 Salto Labs Ltd.
+*                      Copyright 2022 Salto Labs Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with


### PR DESCRIPTION
Update all file header's year to 2022

---

The year is 2022 and not 2021 anymore

---
_Release Notes_: 
None

---
_User Notifications_: 
None
