### PR TITLE
(SALTO-1862) fixed escape from forward slash before a closing quote creates a parser error

### DIFF
--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -64,7 +64,7 @@ export const rules: Record<string, moo.Rules> = {
   string: {
     [TOKEN_TYPES.REFERENCE]: { match: /\$\{[ \t]*[\d\w.]+[ \t]*\}/, value: s => s.slice(2, -1).trim() },
     [TOKEN_TYPES.DOUBLE_QUOTES]: { match: '"', pop: 1 },
-    [TOKEN_TYPES.CONTENT]: { match: /[^\\](?=")|[^\r\n]+?[^\\](?=\$\{|"|\n)/s, lineBreaks: false },
+    [TOKEN_TYPES.CONTENT]: { match: /(?:[^"\\\r\n]|\\.)+?(?="|\r|\n|\$\{)/, lineBreaks: false },
     [TOKEN_TYPES.NEWLINE]: { match: /[\r\n]+/, lineBreaks: true, pop: 1 },
   },
   multilineString: {

--- a/packages/workspace/test/parser/errors.test.ts
+++ b/packages/workspace/test/parser/errors.test.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+
 import { PrimitiveType, PrimitiveTypes, InstanceElement, ObjectType, ElemID } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { parse, ParseResult } from '../../src/parser'
@@ -1058,12 +1059,14 @@ describe('parsing errors', () => {
       })
     })
     describe('when the string is not terminated due to an escape char', () => {
+      /* eslint-disable no-useless-escape */
       const nacl = `
       type nowhere.man {
         sitting = "in his no-where land\\\"
         making = "all his nowhere plans"
       }
       `
+      /* eslint-enable no-useless-escape */
       let res: ParseResult
       beforeAll(async () => {
         res = await parse(Buffer.from(nacl), 'file.nacl', {})

--- a/packages/workspace/test/parser/errors.test.ts
+++ b/packages/workspace/test/parser/errors.test.ts
@@ -1057,6 +1057,33 @@ describe('parsing errors', () => {
         expect(element.annotations.making).toEqual('all his nowhere plans')
       })
     })
+    describe('when the string is not terminated due to an escape char', () => {
+      const nacl = `
+      type nowhere.man {
+        sitting = "in his no-where land\\\"
+        making = "all his nowhere plans"
+      }
+      `
+      let res: ParseResult
+      beforeAll(async () => {
+        res = await parse(Buffer.from(nacl), 'file.nacl', {})
+      })
+      it('should throw an error', () => {
+        expect(res.errors).toHaveLength(1)
+        expect(res.errors[0].subject).toEqual({
+          start: { line: 3, col: 19, byte: 44 },
+          end: { line: 3, col: 42, byte: 67 },
+          filename: 'file.nacl',
+        })
+        expect(res.errors[0].message).toBe('Unterminated string literal')
+        expect(res.errors[0].summary).toBe('Unterminated string literal')
+      })
+      it('should parse items after the unterminated string', async () => {
+        expect(res.elements).toHaveLength(1)
+        const element = (await awu(res.elements).toArray())[0] as ObjectType
+        expect(element.annotations.making).toEqual('all his nowhere plans')
+      })
+    })
   })
   describe('function definition errors', () => {
     describe('unknown function name', () => {

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -201,7 +201,13 @@ describe('Salto parser', () => {
       type salesforce.references {
         toVar = var.name3
         toVal = salesforce.test.instance.inst.name
-      }       `
+      }       
+      
+      type salesforce.escapedDashBeforeQuote {
+        str = "you can't run away \\\\"
+      }
+      
+      `
     beforeAll(async () => {
       const parsed = await parse(Buffer.from(body), 'none', functions)
       elements = await awu(parsed.elements).filter(element => !isContainerType(element))
@@ -214,7 +220,7 @@ describe('Salto parser', () => {
 
     describe('parse result', () => {
       it('should have all types', () => {
-        expect(elements.length).toBe(21)
+        expect(elements.length).toBe(22)
         expect(genericTypes.length).toBe(2)
       })
     })
@@ -686,6 +692,17 @@ describe('Salto parser', () => {
 
       it('should parse references to variables as VariableExpressions', () => {
         expect(refObj.annotations.toVar).toBeInstanceOf(VariableExpression)
+      })
+    })
+
+    describe('escape quote', () => {
+      let escapeObj: ObjectType
+      beforeAll(() => {
+        escapeObj = elements[21] as ObjectType
+      })
+
+      it('should parsed the double escaped string', () => {
+        expect(escapeObj.annotations.str).toEqual('you can\'t run away \\')
       })
     })
   })


### PR DESCRIPTION
The regex used by lexer identified the end of a content token by looking a head until a closing char (`\r` `\n` `${` or a `"`) that is not proceeded by a `\` char. As a result, if any of them was preceded by an escaped `\\` was not identified as a closing char resulting an a parse error.

The fix is a better regex which consumes every char after a '\' 

---

_NA_

---
_Release Notes_: 
_Fixed parsing error when a forward slash is escaped before a quotation mark_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
