### PR TITLE
SALTO-1854: Remove getChangeElement

### DIFF
--- a/packages/adapter-api/src/change.ts
+++ b/packages/adapter-api/src/change.ts
@@ -71,16 +71,6 @@ export const getAllChangeData = <T>(change: Change<T>): T[] => (
   ].filter(isDefined)
 )
 
-/**
- * @deprecated
- */
-export const getChangeElement = getChangeData
-
-/**
- * @deprecated
- */
-export const getAllChangeElements = getAllChangeData
-
 export const isInstanceChange = <T extends Change<unknown>>(change: T):
   change is T & Change<InstanceElement> => (
     isInstanceElement(getChangeData(change))

--- a/packages/netsuite-adapter/src/change_validators/custom_types_invalid_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/custom_types_invalid_values.ts
@@ -19,7 +19,7 @@ import {
   Change,
   ChangeError,
   ChangeValidator,
-  getChangeElement,
+  getChangeData,
   InstanceElement,
   isAdditionOrModificationChange,
   isInstanceChange,
@@ -62,7 +62,7 @@ const getInvalidValuesChangeErrors = (
   }
 
   return instanceChanges[typeName].map(change => {
-    const instance = getChangeElement(change)
+    const instance = getChangeData(change)
     if (_.get(instance.value, path) !== value
       || (isModificationChange(change) && _.get(change.data.before.value, path) === value)) {
       return undefined
@@ -82,8 +82,8 @@ const changeValidator: ChangeValidator = async changes => {
     changes
       .filter(isAdditionOrModificationChange)
       .filter(isInstanceChange)
-      .filter(change => isCustomType(getChangeElement(change).refType.elemID)),
-    change => getChangeElement(change).elemID.typeName
+      .filter(change => isCustomType(getChangeData(change).refType.elemID)),
+    change => getChangeData(change).elemID.typeName
   )
 
   return invalidValues.flatMap(


### PR DESCRIPTION
Removed the deprecated `getChangeElement` and `getAllChangeElements`

---

_Additional context for reviewer_

---

_Release Notes_: 
API: Removed the deprecated `getChangeElement` and `getAllChangeElements`

---

