### PR TITLE
SALTO-1796: Add type for trackHistory annotation

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -186,6 +186,7 @@ export const FIELD_ANNOTATIONS = {
   VALUE_SET: 'valueSet',
   DEFAULT_VALUE: 'defaultValue',
   FORMULA_TREAT_BLANKS_AS: 'formulaTreatBlanksAs',
+  TRACK_HISTORY: 'trackHistory',
   CREATABLE: 'createable',
   UPDATEABLE: 'updateable',
   // indicates whether a field is queryable by SOQL (default true)

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -405,6 +405,7 @@ export class Types {
     [FIELD_ANNOTATIONS.TRACK_TRENDING]: BuiltinTypes.BOOLEAN,
     [FIELD_ANNOTATIONS.TRACK_FEED_HISTORY]: BuiltinTypes.BOOLEAN,
     [FIELD_ANNOTATIONS.DEPRECATED]: BuiltinTypes.BOOLEAN,
+    [FIELD_ANNOTATIONS.TRACK_HISTORY]: BuiltinTypes.BOOLEAN,
   }
 
   // Type mapping for custom objects


### PR DESCRIPTION
The track history annotation exists on all fields of custom objects that have enableHistory = true.
Its type should be boolean.

When this type was not defined, deploying changes to the trackHistory value would not do anything

---

Note that when the annotation type did not exist, we would not include the annotation value in our request to salesforce, so the deploy would seem successful, but in fact nothing would be deployed.
Having the annotation type defined is sufficient to make the code deploy the annotation value, so this fixes the issue in deployment and not just the type issue.

---
_Release Notes_: 
Salesforce Adapter:
- Fix issue with the `trackHistory` annotation not working when deployed

---
_User Notifications_: 
Salesforce Adapter workspaces:
- On the next fetch, all `trackHistory` values will change type from a string to a boolean and an annotation type will be added to all field types in the fieldTypes.nacl file
