### PR TITLE
SALTO-1778-Support-screen-deployment

### DIFF
--- a/packages/adapter-components/src/deployment/deployment.ts
+++ b/packages/adapter-components/src/deployment/deployment.ts
@@ -22,6 +22,8 @@ import { DeploymentRequestsByAction } from '../config/request'
 import { ResponseValue } from '../client'
 import { OPERATION_TO_ANNOTATION } from './annotations'
 
+const FIELD_PATH_DELIMITER = '.'
+
 const filterIrrelevantValues = async (
   instance: InstanceElement,
   action: ActionName
@@ -70,7 +72,13 @@ export const deployChange = async (
 
   const urlVarsValues = {
     ...instance.value,
-    ..._.mapValues(endpoint.urlParamsToFields ?? {}, fieldName => instance.value[fieldName]),
+    ..._.mapValues(
+      endpoint.urlParamsToFields ?? {},
+      fieldName => _.get(
+        { ...instance.value, ...instance.annotations },
+        fieldName.split(FIELD_PATH_DELIMITER)
+      )
+    ),
     ...(additionalUrlVars ?? {}),
   }
   const url = replaceUrlParams(endpoint.url, urlVarsValues)

--- a/packages/adapter-components/src/deployment/deployment.ts
+++ b/packages/adapter-components/src/deployment/deployment.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { ActionName, Change, getChangeData, InstanceElement } from '@salto-io/adapter-api'
-import { transformElement } from '@salto-io/adapter-utils'
+import { resolvePath, transformElement } from '@salto-io/adapter-utils'
 import { replaceUrlParams } from '../elements/request_parameters'
 import { HTTPWriteClientInterface } from '../client/http_client'
 import { DeploymentRequestsByAction } from '../config/request'
@@ -74,9 +74,9 @@ export const deployChange = async (
     ...instance.value,
     ..._.mapValues(
       endpoint.urlParamsToFields ?? {},
-      fieldName => _.get(
-        { ...instance.value, ...instance.annotations },
-        fieldName.split(FIELD_PATH_DELIMITER)
+      fieldName => resolvePath(
+        instance,
+        instance.elemID.createNestedID(...fieldName.split(FIELD_PATH_DELIMITER))
       )
     ),
     ...(additionalUrlVars ?? {}),

--- a/packages/adapter-components/test/deployment/deployment.test.ts
+++ b/packages/adapter-components/test/deployment/deployment.test.ts
@@ -54,7 +54,7 @@ describe('deployChange', () => {
         url: '/test/endpoint/{instanceId}',
         method: 'delete',
         urlParamsToFields: {
-          instanceId: 'id',
+          instanceId: 'obj.id',
         },
       },
     }
@@ -82,14 +82,14 @@ describe('deployChange', () => {
       status: 200,
       data: {},
     })
-    instance.value.id = 1
+    instance.value.obj = { id: 1 }
     await deployChange(
       toChange({ before: instance }),
       httpClient,
       endpoint
     )
 
-    expect(instance.value.id).toBe(1)
+    expect(instance.value.obj.id).toBe(1)
     expect(httpClient.delete).toHaveBeenCalledWith(expect.objectContaining({
       url: '/test/endpoint/1',
     }))

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -513,11 +513,11 @@ export const restoreChangeElement = async (
   )
 )
 
-export const resolveChangeElement = <T extends ChangeDataType = ChangeDataType>(
-  change: Change<T>,
+export const resolveChangeElement = <T extends Change<ChangeDataType> = Change<ChangeDataType>>(
+  change: T,
   getLookUpName: GetLookupNameFunc,
   resolveValuesFunc = resolveValues,
-): Promise<Change<T>> => applyFunctionToChangeData(
+): Promise<T> => applyFunctionToChangeData(
     change,
     changeData => resolveValuesFunc(changeData, getLookUpName)
   )

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { FetchResult, AdapterOperations, DeployResult, InstanceElement, TypeMap, isObjectType, FetchOptions, DeployOptions, Change, isInstanceChange } from '@salto-io/adapter-api'
-import { config as configUtils, elements as elementUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { config as configUtils, elements as elementUtils, client as clientUtils, deployment as deploymentUtils } from '@salto-io/adapter-components'
 import { applyFunctionToChangeData, logDuration } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import JiraClient from './client/client'
@@ -220,6 +220,9 @@ export default class JiraAdapter implements AdapterOperations {
 
   // eslint-disable-next-line class-methods-use-this
   get deployModifiers(): AdapterOperations['deployModifiers'] {
-    return { changeValidator }
+    return {
+      changeValidator,
+      dependencyChanger: deploymentUtils.dependency.removeStandaloneFieldDependency,
+    }
   }
 }

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -29,6 +29,8 @@ import issueTypeSchemeReferences from './filters/issue_type_schemas/issue_type_s
 import issueTypeSchemeFilter from './filters/issue_type_schemas/issue_type_scheme'
 import sharePermissionFilter from './filters/share_permission'
 import boardFilter from './filters/board'
+import screenFilter from './filters/screen/screen'
+import screenableTabFilter from './filters/screen/screenable_tab'
 import hiddenValuesInListsFilter from './filters/hidden_value_in_lists'
 import projectFilter from './filters/project'
 import defaultInstancesDeployFilter from './filters/default_instances_deploy'
@@ -58,6 +60,8 @@ export const DEFAULT_FILTERS = [
   fieldStructureFilter,
   fieldTypeReferencesFilter,
   fieldDeploymentFilter,
+  screenFilter,
+  screenableTabFilter,
   referenceBySelfLinkFilter,
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -839,6 +839,31 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         },
       ],
     },
+    deployRequests: {
+      add: {
+        url: '/rest/api/3/screens/{screenId}/tabs',
+        method: 'post',
+        urlParamsToFields: {
+          screenId: '_parent.0.id',
+        },
+      },
+      modify: {
+        url: '/rest/api/3/screens/{screenId}/tabs/{tabId}',
+        method: 'put',
+        urlParamsToFields: {
+          screenId: '_parent.0.id',
+          tabId: 'id',
+        },
+      },
+      remove: {
+        url: '/rest/api/3/screens/{screenId}/tabs/{tabId}',
+        method: 'delete',
+        urlParamsToFields: {
+          screenId: '_parent.0.id',
+          tabId: 'id',
+        },
+      },
+    },
   },
   ScreenSchemes: {
     request: {

--- a/packages/jira-adapter/src/filters/screen/fields.ts
+++ b/packages/jira-adapter/src/filters/screen/fields.ts
@@ -1,0 +1,52 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, Element, Field, isInstanceElement, isObjectType, ListType, Values } from '@salto-io/adapter-api'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+
+const log = logger(module)
+
+export const covertFields = (
+  elements: Element[],
+  typeName: string,
+  fieldsFieldName: string,
+): void => {
+  const type = elements.filter(isObjectType).find(objType => objType.elemID.name === typeName)
+
+  if (type === undefined) {
+    log.warn(`${typeName} type was not found`)
+  } else {
+    type.fields[fieldsFieldName] = new Field(
+      type,
+      fieldsFieldName,
+      new ListType(BuiltinTypes.STRING)
+    )
+  }
+  elements
+    .filter(isInstanceElement)
+    .filter(instance => instance.elemID.typeName === typeName)
+    .forEach(instance => {
+      instance.value[fieldsFieldName] = instance.value[fieldsFieldName]
+        ?.filter((field: Values) => {
+          if (field.id === undefined) {
+            log.warn(`Received ${fieldsFieldName} item without id ${safeJsonStringify(field)} in instance ${instance.elemID.getFullName()}`)
+            return false
+          }
+          return true
+        })
+        .map(({ id }: Values) => id)
+    })
+}

--- a/packages/jira-adapter/src/filters/screen/screen.ts
+++ b/packages/jira-adapter/src/filters/screen/screen.ts
@@ -1,0 +1,152 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { AdditionChange, BuiltinTypes, CORE_ANNOTATIONS, Field, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isModificationChange, isObjectType, ListType, ModificationChange, ReferenceExpression, Values } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { defaultDeployChange, deployChanges } from '../../deployment'
+import { FilterCreator } from '../../filter'
+import JiraClient from '../../client/client'
+import { JiraConfig } from '../../config'
+
+const { awu } = collections.asynciterable
+
+const SCREEN_TYPE_NAME = 'Screen'
+
+const log = logger(module)
+
+const verifyTabsResolved = (
+  instance: InstanceElement
+): void => instance.value.tabs?.forEach((tab: ReferenceExpression, index: number) => {
+  if (tab.value === undefined) {
+    throw new Error(`Received unresolved reference in tab ${index} of ${instance.elemID.getFullName()}`)
+  }
+})
+
+
+const deployTabsOrder = async (
+  change: ModificationChange<InstanceElement> | AdditionChange<InstanceElement>,
+  client: JiraClient
+): Promise<void> => {
+  verifyTabsResolved(change.data.after)
+  const tabsAfter = change.data.after.value.tabs
+    ?.map((tab: ReferenceExpression) => tab.value.value.id) ?? []
+
+  if (isModificationChange(change)) {
+    verifyTabsResolved(change.data.before)
+  }
+  const tabsBefore = isModificationChange(change)
+    ? change.data.before.value.tabs?.map((tab: ReferenceExpression) => tab.value.value.id) ?? []
+    : []
+
+  if (tabsAfter.length <= 1 || _.isEqual(tabsAfter, tabsBefore)) {
+    return
+  }
+
+  const instance = getChangeData(change)
+  // This has to be sequential because when you re-position a tab from X to 0,
+  // all the positions of the tabs between 0 and X are incremented by 1
+  await awu(tabsAfter).forEach(
+    (id, index) => client.post({
+      url: `/rest/api/3/screens/${instance.value.id}/tabs/${id}/move/${index}`,
+      data: {},
+    })
+  )
+}
+
+const deployScreen = async (
+  change: ModificationChange<InstanceElement> | AdditionChange<InstanceElement>,
+  client: JiraClient,
+  config: JiraConfig
+): Promise<void> => {
+  const nameAfter = change.data.after.value.name
+  const nameBefore = isModificationChange(change)
+    ? change.data.before.value.name
+    : undefined
+  await defaultDeployChange({
+    change,
+    client,
+    apiDefinitions: config.apiDefinitions,
+    fieldsToIgnore: nameAfter === nameBefore
+      // If we try to deploy a screen with the same name,
+      // we get an error that the name is already in use
+      ? ['tabs', 'name']
+      : ['tabs'],
+  })
+
+  await deployTabsOrder(change, client)
+}
+
+const filter: FilterCreator = ({ config, client }) => ({
+  onFetch: async elements => {
+    const screenType = elements
+      .filter(isObjectType)
+      .find(
+        type => type.elemID.name === SCREEN_TYPE_NAME
+      )
+    if (screenType === undefined) {
+      log.warn(`${SCREEN_TYPE_NAME} type was not found`)
+    } else {
+      screenType.fields.tabs.annotations[CORE_ANNOTATIONS.CREATABLE] = true
+      screenType.fields.tabs.annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+
+      screenType.fields.availableFields = new Field(screenType, 'availableFields', new ListType(BuiltinTypes.STRING))
+    }
+
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === SCREEN_TYPE_NAME)
+      .forEach(instance => {
+        instance.value.availableFields = instance.value.availableFields
+          ?.filter((field: Values) => {
+            if (field.id === undefined) {
+              log.warn(`Received available field without id ${safeJsonStringify(field)} in instance ${instance.elemID.getFullName()}`)
+              return false
+            }
+            return true
+          })
+          .map(({ id }: Values) => id)
+      })
+  },
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && isAdditionOrModificationChange(change)
+        && getChangeData(change).elemID.typeName === SCREEN_TYPE_NAME
+    )
+
+
+    const deployResult = await deployChanges(
+      relevantChanges
+        .filter(isInstanceChange)
+        .filter(isAdditionOrModificationChange),
+      async change => deployScreen(
+        change,
+        client,
+        config
+      )
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/screen/screenable_tab.ts
+++ b/packages/jira-adapter/src/filters/screen/screenable_tab.ts
@@ -1,0 +1,161 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { AdditionChange, BuiltinTypes, CORE_ANNOTATIONS, Field, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isModificationChange, isObjectType, ListType, ModificationChange, Values } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { getParents, resolveChangeElement } from '@salto-io/adapter-utils'
+import { defaultDeployChange, deployChanges } from '../../deployment'
+import { FilterCreator } from '../../filter'
+import JiraClient from '../../client/client'
+import { JiraConfig } from '../../config'
+import { getLookUpName } from '../../reference_mapping'
+
+const { awu } = collections.asynciterable
+
+const SCREEN_TAB_TYPE_NAME = 'ScreenableTab'
+
+const log = logger(module)
+
+const deployTabFields = async (
+  change: ModificationChange<InstanceElement> | AdditionChange<InstanceElement>,
+  client: JiraClient
+): Promise<void> => {
+  const resolvedChange = await resolveChangeElement(change, getLookUpName)
+
+  const fieldsAfter = resolvedChange.data.after.value.fields ?? []
+  const fieldsBefore = isModificationChange(resolvedChange)
+    ? resolvedChange.data.before.value.fields ?? []
+    : []
+
+  const fieldsAfterSet = new Set(fieldsAfter)
+  const fieldsBeforeSet = new Set(fieldsBefore)
+
+  const addedFields = Array.from(fieldsAfter).filter(field => !fieldsBeforeSet.has(field))
+  const removedFields = Array.from(fieldsBefore).filter(field => !fieldsAfterSet.has(field))
+
+  const instance = getChangeData(resolvedChange)
+  const instanceParents = getParents(instance)
+  if (instanceParents?.[0]?.id === undefined || instanceParents.length > 1) {
+    throw new Error('Cannot deploy tab fields without a parent screen')
+  }
+
+  const screenId = getParents(instance)[0].id
+  const tabId = instance.value.id
+
+  await Promise.all(addedFields.map(id => client.post({
+    url: `/rest/api/3/screens/${screenId}/tabs/${tabId}/fields`,
+    data: {
+      fieldId: id,
+    },
+  })))
+
+  await Promise.all(removedFields.map(id => client.delete({
+    url: `/rest/api/3/screens/${screenId}/tabs/${tabId}/fields/${id}`,
+  })))
+
+  if (!_.isEqual(fieldsBefore, fieldsAfter) && fieldsAfter.length > 1) {
+    await client.post({
+      url: `/rest/api/3/screens/${screenId}/tabs/${tabId}/fields/${fieldsAfter[0]}/move`,
+      data: {
+        position: 'First',
+      },
+    })
+
+    await awu(fieldsAfter.slice(1)).forEach(async (fieldId, index) => {
+      await client.post({
+        url: `/rest/api/3/screens/${screenId}/tabs/${tabId}/fields/${fieldId}/move`,
+        data: {
+          after: fieldsAfter[index],
+        },
+      })
+    })
+  }
+}
+
+const deployScreenTab = async (
+  change: ModificationChange<InstanceElement> | AdditionChange<InstanceElement>,
+  client: JiraClient,
+  config: JiraConfig
+): Promise<void> => {
+  const nameAfter = change.data.after.value.name
+  const nameBefore = isModificationChange(change)
+    ? change.data.before.value.name
+    : undefined
+  await defaultDeployChange({
+    change,
+    client,
+    apiDefinitions: config.apiDefinitions,
+    fieldsToIgnore: nameAfter === nameBefore
+      // If we try to deploy a screen tab with the same name,
+      // we get an error that the name is already in use
+      ? ['fields', 'name']
+      : ['fields'],
+  })
+  await deployTabFields(change, client)
+}
+
+const filter: FilterCreator = ({ config, client }) => ({
+  onFetch: async elements => {
+    const types = elements.filter(isObjectType)
+
+    const screenTabType = types
+      .find(
+        type => type.elemID.name === SCREEN_TAB_TYPE_NAME
+      )
+    if (screenTabType === undefined) {
+      log.warn(`${SCREEN_TAB_TYPE_NAME} type was not found`)
+    } else {
+      screenTabType.fields.fields = new Field(screenTabType, 'fields', new ListType(BuiltinTypes.STRING), {
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+    }
+
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === SCREEN_TAB_TYPE_NAME)
+      .forEach(instance => {
+        instance.value.fields = instance.value.fields?.map(({ id }: Values) => id)
+      })
+  },
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && isAdditionOrModificationChange(change)
+        && getChangeData(change).elemID.typeName === SCREEN_TAB_TYPE_NAME
+    )
+
+    const deployResult = await deployChanges(
+      relevantChanges
+        .filter(isInstanceChange)
+        .filter(isAdditionOrModificationChange),
+      async change => deployScreenTab(
+        change,
+        client,
+        config
+      )
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -166,6 +166,16 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
     serializationStrategy: 'id',
     target: { type: 'NotificationScheme' },
   },
+  {
+    src: { field: 'availableFields', parentTypes: ['Screen'] },
+    serializationStrategy: 'id',
+    target: { type: 'Field' },
+  },
+  {
+    src: { field: 'fields', parentTypes: ['ScreenableTab'] },
+    serializationStrategy: 'id',
+    target: { type: 'Field' },
+  },
 ]
 
 const lookupNameFuncs: GetLookupNameFunc[] = [

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -32,6 +32,7 @@ jest.mock('@salto-io/adapter-components', () => {
   return {
     ...actual,
     deployment: {
+      ...actual.deployment,
       changeValidators: actual.deployment.changeValidators,
       deployChange: jest.fn().mockImplementation(actual.elements.swagger.deployChange),
     },

--- a/packages/jira-adapter/test/filters/screen/screen.test.ts
+++ b/packages/jira-adapter/test/filters/screen/screen.test.ts
@@ -1,0 +1,196 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { deployment, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import { JIRA } from '../../../src/constants'
+import { mockClient } from '../../utils'
+import screenFilter from '../../../src/filters/screen/screen'
+import { Filter } from '../../../src/filter'
+import JiraClient from '../../../src/client/client'
+import { DEFAULT_CONFIG } from '../../../src/config'
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn(),
+    },
+  }
+})
+
+describe('screenFilter', () => {
+  let screenType: ObjectType
+  let screenTabType: ObjectType
+  let filter: Filter
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let client: JiraClient
+  beforeEach(async () => {
+    const { client: cli, paginator, connection } = mockClient()
+    client = cli
+    mockConnection = connection
+
+    filter = screenFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    })
+    screenTabType = new ObjectType({
+      elemID: new ElemID(JIRA, 'ScreenableTab'),
+    })
+    screenType = new ObjectType({
+      elemID: new ElemID(JIRA, 'Screen'),
+      fields: {
+        tabs: { refType: new ListType(screenTabType) },
+      },
+    })
+  })
+
+  describe('onFetch', () => {
+    it('should add deployment annotation to tabs', async () => {
+      await filter.onFetch?.([screenType])
+      expect(screenType.fields.tabs.annotations)
+        .toEqual({
+          [CORE_ANNOTATIONS.CREATABLE]: true,
+          [CORE_ANNOTATIONS.UPDATABLE]: true,
+        })
+    })
+
+    it('should convert the available fields list to a list of ids', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        screenType,
+        {
+          availableFields: [
+            { id: 'id1' },
+            { id: 'id2' },
+          ],
+        },
+      )
+      await filter.onFetch?.([instance])
+      expect(instance.value.availableFields).toEqual(['id1', 'id2'])
+    })
+  })
+
+  describe('deploy', () => {
+    const deployChangeMock = deployment.deployChange as jest.MockedFunction<
+      typeof deployment.deployChange
+    >
+    it('should return irrelevant changes in leftoverChanges', async () => {
+      const res = await filter.deploy?.([
+        toChange({ after: screenType }),
+        toChange({ before: new InstanceElement('instance1', screenType) }),
+        toChange({
+          before: new InstanceElement('instance2', new ObjectType({ elemID: new ElemID(JIRA, 'someType') })),
+          after: new InstanceElement('instance2', new ObjectType({ elemID: new ElemID(JIRA, 'someType') })),
+        }),
+      ])
+      expect(res?.leftoverChanges).toHaveLength(3)
+      expect(res?.deployResult).toEqual({ appliedChanges: [], errors: [] })
+    })
+
+    it('should call deployChange and ignore tabs', async () => {
+      const change = toChange({
+        before: new InstanceElement('instance2', screenType),
+        after: new InstanceElement('instance2', screenType, { name: 'name2' }),
+      })
+      await filter.deploy?.([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        change,
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.Screen.deployRequests,
+        ['tabs'],
+        undefined
+      )
+    })
+
+    it('should call deployChange and ignore tabs and names of were not changed', async () => {
+      const change = toChange({
+        before: new InstanceElement('instance2', screenType),
+        after: new InstanceElement('instance2', screenType),
+      })
+      await filter.deploy?.([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        change,
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.Screen.deployRequests,
+        ['tabs', 'name'],
+        undefined
+      )
+    })
+
+    it('should call endpoints to reorder tabs', async () => {
+      const after = new InstanceElement(
+        'instance1',
+        screenType,
+        {
+          tabs: [
+            new ReferenceExpression(
+              screenTabType.elemID.createNestedID('instance', 'inst2'),
+              new InstanceElement('inst2', screenTabType, { id: 'id2' }),
+            ),
+            new ReferenceExpression(
+              screenTabType.elemID.createNestedID('instance', 'inst1'),
+              new InstanceElement('inst1', screenTabType, { id: 'id1' }),
+            ),
+          ],
+        }
+      )
+      deployChangeMock.mockResolvedValue({ id: 'screenId' })
+
+      const change = toChange({ after })
+      await filter.deploy?.([change])
+      expect(mockConnection.post).toHaveBeenCalledWith(
+        '/rest/api/3/screens/screenId/tabs/id2/move/0',
+        {},
+        undefined,
+      )
+
+      expect(mockConnection.post).toHaveBeenCalledWith(
+        '/rest/api/3/screens/screenId/tabs/id1/move/1',
+        {},
+        undefined,
+      )
+    })
+
+    it('should not call re-order endpoints if tabs were not changed', async () => {
+      const instance = new InstanceElement(
+        'instance1',
+        screenType,
+        {
+          tabs: [
+            new ReferenceExpression(
+              screenTabType.elemID.createNestedID('instance', 'inst1'),
+              new InstanceElement('inst1', screenTabType, { id: 'id1' }),
+            ),
+            new ReferenceExpression(
+              screenTabType.elemID.createNestedID('instance', 'inst2'),
+              new InstanceElement('inst2', screenTabType, { id: 'id2' }),
+            ),
+          ],
+        }
+      )
+
+      const change = toChange({ before: instance, after: instance })
+      await filter.deploy?.([change])
+      expect(mockConnection.post).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/screen/screenable_tab.test.ts
+++ b/packages/jira-adapter/test/filters/screen/screenable_tab.test.ts
@@ -1,0 +1,229 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, ObjectType, toChange } from '@salto-io/adapter-api'
+import { deployment, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import { JIRA } from '../../../src/constants'
+import { mockClient } from '../../utils'
+import screenableTabFilter from '../../../src/filters/screen/screenable_tab'
+import { Filter } from '../../../src/filter'
+import JiraClient from '../../../src/client/client'
+import { DEFAULT_CONFIG } from '../../../src/config'
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn(),
+    },
+  }
+})
+
+describe('screenableTabFilter', () => {
+  let screenTabType: ObjectType
+  let filter: Filter
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let client: JiraClient
+  beforeEach(async () => {
+    const { client: cli, paginator, connection } = mockClient()
+    client = cli
+    mockConnection = connection
+
+    filter = screenableTabFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    })
+    screenTabType = new ObjectType({
+      elemID: new ElemID(JIRA, 'ScreenableTab'),
+      fields: {
+        fields: {
+          refType: new ListType(BuiltinTypes.STRING),
+        },
+      },
+    })
+  })
+
+  describe('onFetch', () => {
+    it('should add deployment annotation to fields', async () => {
+      await filter.onFetch?.([screenTabType])
+      expect(screenTabType.fields.fields.annotations)
+        .toEqual({
+          [CORE_ANNOTATIONS.CREATABLE]: true,
+          [CORE_ANNOTATIONS.UPDATABLE]: true,
+        })
+    })
+
+    it('should convert the fields list to a list of ids', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        screenTabType,
+        {
+          fields: [
+            { id: 'id1' },
+            { id: 'id2' },
+          ],
+        },
+      )
+      await filter.onFetch?.([instance])
+      expect(instance.value.fields).toEqual(['id1', 'id2'])
+    })
+  })
+
+  describe('deploy', () => {
+    const deployChangeMock = deployment.deployChange as jest.MockedFunction<
+      typeof deployment.deployChange
+    >
+    it('should return irrelevant changes in leftoverChanges', async () => {
+      const res = await filter.deploy?.([
+        toChange({ after: screenTabType }),
+        toChange({ before: new InstanceElement('instance1', screenTabType) }),
+        toChange({
+          before: new InstanceElement('instance2', new ObjectType({ elemID: new ElemID(JIRA, 'someType') })),
+          after: new InstanceElement('instance2', new ObjectType({ elemID: new ElemID(JIRA, 'someType') })),
+        }),
+      ])
+      expect(res?.leftoverChanges).toHaveLength(3)
+      expect(res?.deployResult).toEqual({ appliedChanges: [], errors: [] })
+    })
+
+    it('should call deployChange and ignore fields', async () => {
+      const change = toChange({
+        before: new InstanceElement('instance2', screenTabType),
+        after: new InstanceElement('instance2', screenTabType, { name: 'name2' }),
+      })
+      await filter.deploy?.([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        change,
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.ScreenableTab.deployRequests,
+        ['fields'],
+        undefined
+      )
+    })
+
+    it('should call deployChange and ignore fields and names of were not changed', async () => {
+      const change = toChange({
+        before: new InstanceElement('instance2', screenTabType),
+        after: new InstanceElement('instance2', screenTabType),
+      })
+      await filter.deploy?.([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        change,
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.ScreenableTab.deployRequests,
+        ['fields', 'name'],
+        undefined
+      )
+    })
+
+    describe('deploying fields', () => {
+      beforeEach(async () => {
+        const before = new InstanceElement(
+          'instance1',
+          screenTabType,
+          {
+            id: 'tabId',
+            fields: [
+              'id1',
+              'id3',
+            ],
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [{ id: 'screenId' }],
+          },
+        )
+        const after = new InstanceElement(
+          'instance1',
+          screenTabType,
+          {
+            id: 'tabId',
+            fields: [
+              'id2',
+              'id1',
+            ],
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [{ id: 'screenId' }],
+          },
+        )
+
+        await filter.deploy?.([toChange({ before, after })])
+      })
+      it('should call endpoints to add fields', async () => {
+        expect(mockConnection.post).toHaveBeenCalledWith(
+          '/rest/api/3/screens/screenId/tabs/tabId/fields',
+          {
+            fieldId: 'id2',
+          },
+          undefined,
+        )
+      })
+
+      it('should call endpoints to remove fields', async () => {
+        expect(mockConnection.delete).toHaveBeenCalledWith(
+          '/rest/api/3/screens/screenId/tabs/tabId/fields/id3',
+          undefined,
+        )
+      })
+
+      it('should call endpoints to re-order fields', async () => {
+        expect(mockConnection.post).toHaveBeenCalledWith(
+          '/rest/api/3/screens/screenId/tabs/tabId/fields/id2/move',
+          {
+            position: 'First',
+          },
+          undefined,
+        )
+
+        expect(mockConnection.post).toHaveBeenCalledWith(
+          '/rest/api/3/screens/screenId/tabs/tabId/fields/id1/move',
+          {
+            after: 'id2',
+          },
+          undefined,
+        )
+      })
+    })
+
+    it('should not call re-order if fields were not changed', async () => {
+      const instance = new InstanceElement(
+        'instance1',
+        screenTabType,
+        {
+          id: 'tabId',
+          fields: [
+            'id1',
+            'id2',
+          ],
+        },
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: { value: { id: 'screenId' } },
+        },
+      )
+
+      await filter.deploy?.([toChange({ before: instance, after: instance })])
+      expect(mockConnection.post).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Added support for deploy screen and its tabs

Only the last commit is relevant
This PR is build on https://github.com/salto-io/salto/pull/2598

---

- Added support for deploying tabs order in screen
- Added support for deploying fields in screen tab
- Added support in urlParamsToFields to point to inner values

---
_Release Notes_: 
None

---
_User Notifications_: 
None