### PR TITLE
SALTO-1287 netsuite - add required dependencies

### DIFF
--- a/packages/lowerdash/src/values.ts
+++ b/packages/lowerdash/src/values.ts
@@ -19,3 +19,16 @@ export const isDefined = <T>(val: T | undefined | void): val is T => val !== und
 
 export const isPlainObject = (val: unknown): val is object => _.isPlainObject(val)
 export const isPlainRecord = (val: unknown): val is Record<string, unknown> => _.isPlainObject(val)
+
+export const lookupValue = (blob: unknown, lookupFunc: (val: unknown) => boolean): boolean => {
+  if (lookupFunc(blob)) {
+    return true
+  }
+  if (_.isArray(blob)) {
+    return _.some(blob, item => lookupValue(item, lookupFunc))
+  }
+  if (isPlainRecord(blob)) {
+    return _.some(Object.values(blob), item => lookupValue(item, lookupFunc))
+  }
+  return false
+}

--- a/packages/lowerdash/src/values.ts
+++ b/packages/lowerdash/src/values.ts
@@ -20,7 +20,10 @@ export const isDefined = <T>(val: T | undefined | void): val is T => val !== und
 export const isPlainObject = (val: unknown): val is object => _.isPlainObject(val)
 export const isPlainRecord = (val: unknown): val is Record<string, unknown> => _.isPlainObject(val)
 
-export const lookupValue = (blob: unknown, lookupFunc: (val: unknown) => boolean): boolean => {
+export const lookupValue = (
+  blob: unknown,
+  lookupFunc: (val: unknown) => boolean | void
+): boolean => {
   if (lookupFunc(blob)) {
     return true
   }

--- a/packages/lowerdash/src/values.ts
+++ b/packages/lowerdash/src/values.ts
@@ -28,10 +28,10 @@ export const lookupValue = (
     return true
   }
   if (_.isArray(blob)) {
-    return _.some(blob, item => lookupValue(item, lookupFunc))
+    return blob.some(item => lookupValue(item, lookupFunc))
   }
   if (isPlainRecord(blob)) {
-    return _.some(Object.values(blob), item => lookupValue(item, lookupFunc))
+    return Object.values(blob).some(item => lookupValue(item, lookupFunc))
   }
   return false
 }

--- a/packages/lowerdash/test/values.test.ts
+++ b/packages/lowerdash/test/values.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { isDefined, isPlainObject, isPlainRecord } from '../src/values'
+import { isDefined, isPlainObject, isPlainRecord, lookupValue } from '../src/values'
 
 describe('isDefined', () => {
   describe('with undefined value', () => {
@@ -68,5 +68,14 @@ describe('isRecord', () => {
   it('should return false for array', () => {
     expect(isPlainRecord([])).toBeFalsy()
     expect(isPlainRecord([{ a: 'a', b: ['c', 'd'] }])).toBeFalsy()
+  })
+})
+
+describe('lookupValue', () => {
+  it('should return false', () => {
+    expect(lookupValue({ a: 'a', b: ['c', 'd'] }, val => val === 'e')).toBeFalsy()
+  })
+  it('should return true', () => {
+    expect(lookupValue({ a: 'a', b: ['c', 'd'] }, val => val === 'd')).toBeTruthy()
   })
 })

--- a/packages/netsuite-adapter/src/client/manifest_utils.ts
+++ b/packages/netsuite-adapter/src/client/manifest_utils.ts
@@ -1,0 +1,163 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { collections, values, strings } from '@salto-io/lowerdash'
+import { Value } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import xmlParser from 'fast-xml-parser'
+import _ from 'lodash'
+import { SCRIPT_ID, WORKFLOW } from '../constants'
+import { CustomizationInfo } from './types'
+import { ATTRIBUTE_PREFIX } from './constants'
+
+const { makeArray } = collections.array
+const { isDefined, lookupValue } = values
+const { matchAll } = strings
+const log = logger(module)
+
+const TEXT_ATTRIBUTE = '#text'
+const REQUIRED_ATTRIBUTE = '@_required'
+const INVALID_DEPENDENCIES = ['ADVANCEDEXPENSEMANAGEMENT', 'SUBSCRIPTIONBILLING', 'WMSSYSTEM', 'BILLINGACCOUNTS']
+const REFERENCED_OBJECT_REGEX = new RegExp(`${SCRIPT_ID}=(?<${SCRIPT_ID}>[a-z0-9_]+(\\.[a-z0-9_]+)*)`, 'g')
+
+type RequiredDependency = {
+  typeName: string
+  dependency: string
+  value?: Value
+}
+
+type RequiredDependencyWithCondition = (
+  RequiredDependency & {
+  condition: 'byPath'
+  path: string[]
+}) | (
+  RequiredDependency & {
+  condition?: 'fullLookup' | 'byValue'
+})
+
+const REQUIRED_FEATURES: RequiredDependencyWithCondition[] = [
+  {
+    typeName: WORKFLOW,
+    dependency: 'EXPREPORTS',
+    value: 'STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP',
+  },
+]
+
+const getRequiredFeatures = (customizationInfos: CustomizationInfo[]): string[] =>
+  REQUIRED_FEATURES.filter(
+    feature => customizationInfos
+      .some(custInfo => {
+        const { typeName, value } = feature
+        if (typeName !== custInfo.typeName) {
+          return false
+        }
+        if (_.isUndefined(value)) {
+          return true
+        }
+        switch (feature.condition) {
+          case 'byPath':
+            return _.get(custInfo.values, feature.path) === value
+          case 'byValue':
+            return lookupValue(custInfo.values, val => _.isEqual(val, value))
+          default:
+            return lookupValue(custInfo.values,
+              val => _.isEqual(val, value)
+              || (_.isString(val) && _.isString(value) && val.includes(value)))
+        }
+      })
+  ).map(({ dependency }) => dependency)
+
+const getRequiredObjects = (customizationInfos: CustomizationInfo[]): string[] =>
+  _.uniq(customizationInfos.flatMap(custInfo => {
+    const objName = custInfo.values[ATTRIBUTE_PREFIX + SCRIPT_ID]
+    const requiredObjects: string[] = []
+    lookupValue(custInfo.values, val => {
+      if (!_.isString(val)) {
+        return
+      }
+
+      requiredObjects.push(...Array.from(matchAll(val, REFERENCED_OBJECT_REGEX))
+        .map(r => r.groups)
+        .filter(isDefined)
+        .map(group => group[SCRIPT_ID])
+        .filter(scriptId => scriptId !== objName
+          && !scriptId.startsWith(`${objName}.`)))
+    })
+    return requiredObjects
+  }))
+
+const fixDependenciesObject = (dependencies: Value): void => {
+  dependencies.features = dependencies.features ?? {}
+  dependencies.features.feature = dependencies.features.feature ?? []
+  dependencies.objects = dependencies.objects ?? {}
+  dependencies.objects.object = dependencies.objects.object ?? []
+}
+
+const addRequiredDependencies = (
+  dependencies: Value,
+  customizationInfos: CustomizationInfo[]
+): void => {
+  const requiredFeatures = getRequiredFeatures(customizationInfos)
+    .map(feature => ({ [REQUIRED_ATTRIBUTE]: 'true', [TEXT_ATTRIBUTE]: feature }))
+  const requiredObjects = getRequiredObjects(customizationInfos)
+  if (requiredFeatures.length === 0 && requiredObjects.length === 0) {
+    return
+  }
+
+  const { features, objects } = dependencies
+  features.feature = [
+    // remove required features that are set to "required=false"
+    ..._.differenceBy(
+      makeArray(features.feature),
+      requiredFeatures,
+      item => item[TEXT_ATTRIBUTE]
+    ),
+    ...requiredFeatures,
+  ]
+  objects.object = _.union(objects.object, requiredObjects)
+}
+
+const cleanInvalidDependencies = (dependencies: Value): void => {
+  // This is done due to an SDF bug described in SALTO-1107.
+  // This function should be removed once the bug is fixed.
+  dependencies.features.feature = makeArray(dependencies.features.feature)
+    .filter(item => !INVALID_DEPENDENCIES.includes(item[TEXT_ATTRIBUTE]))
+}
+
+export const fixManifest = (
+  manifestContent: string,
+  customizationInfos: CustomizationInfo[]
+): string => {
+  const manifestXml = xmlParser.parse(manifestContent, { ignoreAttributes: false })
+
+  if (!_.isPlainObject(manifestXml.manifest?.dependencies)) {
+    log.warn('manifest.xml is missing dependencies tag')
+    return manifestContent
+  }
+
+  const { dependencies } = manifestXml.manifest
+  fixDependenciesObject(dependencies)
+  cleanInvalidDependencies(dependencies)
+  addRequiredDependencies(dependencies, customizationInfos)
+
+  // eslint-disable-next-line new-cap
+  const fixedDependencies = new xmlParser.j2xParser({
+    ignoreAttributes: false,
+    format: true,
+  }).parse({ dependencies })
+  return manifestContent.replace(
+    new RegExp('<dependencies>.*</dependencies>\\n?', 'gs'), fixedDependencies
+  )
+}

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -259,6 +259,7 @@ const addRequiredDependencies = (
   customizationInfos: CustomizationInfo[]
 ): void => {
   const requiredFeatures = getRequiredFeatures(customizationInfos)
+    .map(feature => ({ [REQUIRED_ATTRIBUTE]: 'true', [TEXT_ATTRIBUTE]: feature }))
   const requiredObjects = getRequiredObjects(customizationInfos)
   if (requiredFeatures.length === 0 && requiredObjects.length === 0) {
     return
@@ -266,8 +267,13 @@ const addRequiredDependencies = (
 
   const { features, objects } = dependencies
   features.feature = _.union(
-    features.feature,
-    requiredFeatures.map(feature => ({ [REQUIRED_ATTRIBUTE]: 'true', [TEXT_ATTRIBUTE]: feature }))
+    // remove required features that are set to "required=false"
+    _.differenceBy(
+      makeArray(features.feature),
+      requiredFeatures,
+      item => item[TEXT_ATTRIBUTE]
+    ),
+    requiredFeatures
   )
   objects.object = _.union(objects.object, requiredObjects)
 }

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -912,7 +912,7 @@ export default class SdfClient {
     const manifestContent = (await readFile(manifestPath)).toString()
     const manifestXml = xmlParser.parse(manifestContent, { ignoreAttributes: false })
 
-    if (!_.isPlainObject(manifestXml.manifest.dependencies)) {
+    if (!_.isPlainObject(manifestXml.manifest?.dependencies)) {
       log.warn('manifest.xml is missing dependencies tag')
       return
     }

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { collections, decorators, objects as lowerdashObjects, promises, values, strings } from '@salto-io/lowerdash'
+import { collections, decorators, objects as lowerdashObjects, promises, values } from '@salto-io/lowerdash'
 import { Values, AccountId, Value } from '@salto-io/adapter-api'
 import { mkdirp, readDir, readFile, writeFile, rm, rename } from '@salto-io/file'
 import { logger } from '@salto-io/logging'
@@ -34,8 +34,6 @@ import shellQuote from 'shell-quote'
 import {
   APPLICATION_ID,
   FILE_CABINET_PATH_SEPARATOR,
-  SCRIPT_ID,
-  WORKFLOW,
 } from '../constants'
 import {
   DEFAULT_FETCH_ALL_TYPES_AT_ONCE, DEFAULT_COMMAND_TIMEOUT_IN_MINUTES,
@@ -53,11 +51,11 @@ import {
   isCustomTypeInfo, isFileCustomizationInfo, isFolderCustomizationInfo, isTemplateCustomTypeInfo,
   mergeTypeToInstances,
 } from './utils'
+import { fixManifest } from './manifest_utils'
 
 const { makeArray } = collections.array
 const { withLimitedConcurrency } = promises.array
-const { isDefined, lookupValue } = values
-const { matchAll } = strings
+const { isDefined } = values
 const { concatObjects } = lowerdashObjects
 const log = logger(module)
 
@@ -98,34 +96,6 @@ const ADDITIONAL_FILE_PATTERN = '.template.'
 export const MINUTE_IN_MILLISECONDS = 1000 * 60
 const SINGLE_OBJECT_RETRIES = 3
 const READ_CONCURRENCY = 100
-
-const TEXT_ATTRIBUTE = '#text'
-const REQUIRED_ATTRIBUTE = '@_required'
-const INVALID_DEPENDENCIES = ['ADVANCEDEXPENSEMANAGEMENT', 'SUBSCRIPTIONBILLING', 'WMSSYSTEM', 'BILLINGACCOUNTS']
-const REFERENCED_OBJECT_REGEX = new RegExp(`${SCRIPT_ID}=(?<${SCRIPT_ID}>[a-z0-9_]+(\\.[a-z0-9_]+)*)`, 'g')
-
-type RequiredDependency = {
-  typeName: string
-  dependency: string
-  value?: Value
-}
-
-type RequiredDependencyWithCondition = (
-  RequiredDependency & {
-  condition: 'byPath'
-  path: string[]
-}) | (
-  RequiredDependency & {
-  condition?: 'fullLookup' | 'byValue'
-})
-
-const REQUIRED_FEATURES: RequiredDependencyWithCondition[] = [
-  {
-    typeName: WORKFLOW,
-    dependency: 'EXPREPORTS',
-    value: 'STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP',
-  },
-]
 
 const baseExecutionPath = os.tmpdir()
 
@@ -205,87 +175,6 @@ type ObjectsChunk = {
   ids: string[]
   index: number
   total: number
-}
-
-const getRequiredFeatures = (customizationInfos: CustomizationInfo[]): string[] =>
-  REQUIRED_FEATURES.filter(
-    feature => customizationInfos
-      .some(custInfo => {
-        const { typeName, value } = feature
-        if (typeName !== custInfo.typeName) {
-          return false
-        }
-        if (_.isUndefined(value)) {
-          return true
-        }
-        switch (feature.condition) {
-          case 'byPath':
-            return _.get(custInfo.values, feature.path) === value
-          case 'byValue':
-            return lookupValue(custInfo.values, val => _.isEqual(val, value))
-          default:
-            return lookupValue(custInfo.values,
-              val => _.isEqual(val, value)
-              || (_.isString(val) && _.isString(value) && val.includes(value)))
-        }
-      })
-  ).map(({ dependency }) => dependency)
-
-const getRequiredObjects = (customizationInfos: CustomizationInfo[]): string[] =>
-  _.uniq(customizationInfos.flatMap(custInfo => {
-    const objName = custInfo.values[ATTRIBUTE_PREFIX + SCRIPT_ID]
-    const requiredObjects: string[] = []
-    lookupValue(custInfo.values, val => {
-      if (!_.isString(val)) {
-        return
-      }
-
-      requiredObjects.push(...Array.from(matchAll(val, REFERENCED_OBJECT_REGEX))
-        .map(r => r.groups)
-        .filter(isDefined)
-        .map(group => group[SCRIPT_ID])
-        .filter(scriptId => scriptId !== objName
-          && !scriptId.startsWith(`${objName}.`)))
-    })
-    return requiredObjects
-  }))
-
-const fixDependenciesObject = (dependencies: Value): void => {
-  dependencies.features = dependencies.features ?? {}
-  dependencies.features.feature = dependencies.features.feature ?? []
-  dependencies.objects = dependencies.objects ?? {}
-  dependencies.objects.object = dependencies.objects.object ?? []
-}
-
-const addRequiredDependencies = (
-  dependencies: Value,
-  customizationInfos: CustomizationInfo[]
-): void => {
-  const requiredFeatures = getRequiredFeatures(customizationInfos)
-    .map(feature => ({ [REQUIRED_ATTRIBUTE]: 'true', [TEXT_ATTRIBUTE]: feature }))
-  const requiredObjects = getRequiredObjects(customizationInfos)
-  if (requiredFeatures.length === 0 && requiredObjects.length === 0) {
-    return
-  }
-
-  const { features, objects } = dependencies
-  features.feature = [
-    // remove required features that are set to "required=false"
-    ..._.differenceBy(
-      makeArray(features.feature),
-      requiredFeatures,
-      item => item[TEXT_ATTRIBUTE]
-    ),
-    ...requiredFeatures,
-  ]
-  objects.object = _.union(objects.object, requiredObjects)
-}
-
-const cleanInvalidDependencies = (dependencies: Value): void => {
-  // This is done due to an SDF bug described in SALTO-1107.
-  // This function should be removed once the bug is fixed.
-  dependencies.features.feature = makeArray(dependencies.features.feature)
-    .filter(item => !INVALID_DEPENDENCIES.includes(item[TEXT_ATTRIBUTE]))
 }
 
 export default class SdfClient {
@@ -915,27 +804,7 @@ export default class SdfClient {
   ): Promise<void> {
     const manifestPath = osPath.join(projectPath, 'src', 'manifest.xml')
     const manifestContent = (await readFile(manifestPath)).toString()
-    const manifestXml = xmlParser.parse(manifestContent, { ignoreAttributes: false })
-
-    if (!_.isPlainObject(manifestXml.manifest?.dependencies)) {
-      log.warn('manifest.xml is missing dependencies tag')
-      return
-    }
-
-    const { dependencies } = manifestXml.manifest
-    fixDependenciesObject(dependencies)
-    cleanInvalidDependencies(dependencies)
-    addRequiredDependencies(dependencies, customizationInfos)
-
-    // eslint-disable-next-line new-cap
-    const fixedDependencies = new xmlParser.j2xParser({
-      ignoreAttributes: false,
-      format: true,
-    }).parse({ dependencies })
-    const fixedManifestContent = manifestContent.replace(
-      new RegExp('<dependencies>.*</dependencies>\\n?', 'gs'), fixedDependencies
-    )
-    await writeFile(manifestPath, fixedManifestContent)
+    await writeFile(manifestPath, fixManifest(manifestContent, customizationInfos))
   }
 
   private async runDeployCommands(

--- a/packages/netsuite-adapter/src/reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/reference_dependencies.ts
@@ -21,8 +21,7 @@ import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
 import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
 import wu from 'wu'
 import {
-  CUSTOM_RECORD_TYPE, CUSTOM_SEGMENT, DATASET, NETSUITE, TRANSACTION_COLUMN_CUSTOM_FIELD,
-  TRANSACTION_BODY_CUSTOM_FIELD, WORKBOOK,
+  CUSTOM_RECORD_TYPE, CUSTOM_SEGMENT, DATASET, NETSUITE, WORKBOOK,
 } from './constants'
 
 const { awu } = collections.asynciterable
@@ -117,10 +116,6 @@ export const getRequiredReferencedInstances = (
         return getReferencedInstance(instance.value.recordtype, CUSTOM_RECORD_TYPE)
       case WORKBOOK:
         return getReferencedInstance(instance.value.dependencies?.dependency, DATASET)
-      case TRANSACTION_COLUMN_CUSTOM_FIELD:
-        return getReferencedInstance(instance.value.sourcefrom) // might reference a lot of types
-      case TRANSACTION_BODY_CUSTOM_FIELD:
-        return getReferencedInstance(instance.value.sourcefrom) // might reference a lot of types
       default:
         return undefined
     }

--- a/packages/netsuite-adapter/test/client/manifest_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/manifest_utils.test.ts
@@ -1,0 +1,196 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { WORKFLOW } from '../../src/constants'
+import { fixManifest } from '../../src/client/manifest_utils'
+import { CustomizationInfo } from '../../src/client/types'
+
+describe('manifest.xml utils', () => {
+  const custInfos: CustomizationInfo[] = [
+    {
+      typeName: 'someType',
+      values: {
+        key: '__STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP__',
+        ref: '[scriptid=somescriptid]',
+      },
+    },
+    {
+      typeName: WORKFLOW,
+      values: {
+        key: '__STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP__',
+        ref: '[scriptid=secondscriptid]',
+      },
+    },
+  ]
+
+  it('should return with no dependencies tag', () => {
+    const manifest = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
+<projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
+<frameworkversion>1.0</frameworkversion>
+</manifest>`
+    expect(fixManifest(manifest, custInfos)).toEqual(manifest)
+  })
+  it('should fix empty dependencies tag', () => {
+    const manifest = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
+<projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
+<frameworkversion>1.0</frameworkversion>
+<dependencies>
+  <files>
+    <file>/SuiteScripts/clientScript_2_0.js</file>
+  </files>
+</dependencies>
+</manifest>`
+    const fixedManifest = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
+<projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
+<frameworkversion>1.0</frameworkversion>
+<dependencies>
+  <files>
+    <file>/SuiteScripts/clientScript_2_0.js</file>
+  </files>
+  <features>
+    <feature required="true">EXPREPORTS</feature>
+  </features>
+  <objects>
+    <object>somescriptid</object>
+    <object>secondscriptid</object>
+  </objects>
+</dependencies>
+</manifest>`
+    expect(fixManifest(manifest, custInfos)).toEqual(fixedManifest)
+  })
+  it('should remove invalid dependencies', () => {
+    const manifest = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
+<projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
+<frameworkversion>1.0</frameworkversion>
+<dependencies>
+  <features>
+    <feature required="true">ADVANCEDEXPENSEMANAGEMENT</feature>
+    <feature required="true">SFA</feature>
+    <feature required="true">MULTICURRENCYVENDOR</feature>
+    <feature required="true">ACCOUNTING</feature>
+    <feature required="true">SUBSCRIPTIONBILLING</feature>
+    <feature required="true">ADDRESSCUSTOMIZATION</feature>
+    <feature required="true">WMSSYSTEM</feature>
+    <feature required="true">SUBSIDIARIES</feature>
+    <feature required="true">RECEIVABLES</feature>
+    <feature required="true">BILLINGACCOUNTS</feature>
+  </features>
+  <objects>
+    <object>custentity2edited</object>
+    <object>custentity13</object>
+    <object>custentity_14</object>
+    <object>custentity10</object>
+    <object>custentitycust_active</object>
+    <object>custentity11</object>
+    <object>custentity_slt_tax_reg</object>
+  </objects>
+  <files>
+    <file>/SuiteScripts/clientScript_2_0.js</file>
+  </files>
+</dependencies>
+</manifest>`
+    const fixedManifest = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
+<projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
+<frameworkversion>1.0</frameworkversion>
+<dependencies>
+  <features>
+    <feature required="true">SFA</feature>
+    <feature required="true">MULTICURRENCYVENDOR</feature>
+    <feature required="true">ACCOUNTING</feature>
+    <feature required="true">ADDRESSCUSTOMIZATION</feature>
+    <feature required="true">SUBSIDIARIES</feature>
+    <feature required="true">RECEIVABLES</feature>
+  </features>
+  <objects>
+    <object>custentity2edited</object>
+    <object>custentity13</object>
+    <object>custentity_14</object>
+    <object>custentity10</object>
+    <object>custentitycust_active</object>
+    <object>custentity11</object>
+    <object>custentity_slt_tax_reg</object>
+  </objects>
+  <files>
+    <file>/SuiteScripts/clientScript_2_0.js</file>
+  </files>
+</dependencies>
+</manifest>`
+    expect(fixManifest(manifest, []))
+      .toEqual(fixedManifest)
+  })
+  it('should add required dependencies to manifest.xml', () => {
+    const manifest = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
+<projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
+<frameworkversion>1.0</frameworkversion>
+<dependencies>
+  <features>
+    <feature required="true">ADVANCEDEXPENSEMANAGEMENT</feature>
+    <feature required="true">SFA</feature>
+    <feature required="true">MULTICURRENCYVENDOR</feature>
+    <feature required="true">ACCOUNTING</feature>
+    <feature required="true">SUBSCRIPTIONBILLING</feature>
+    <feature required="true">ADDRESSCUSTOMIZATION</feature>
+    <feature required="true">WMSSYSTEM</feature>
+    <feature required="true">SUBSIDIARIES</feature>
+    <feature required="true">RECEIVABLES</feature>
+    <feature required="true">BILLINGACCOUNTS</feature>
+  </features>
+  <objects>
+    <object>custentity2edited</object>
+    <object>custentity13</object>
+    <object>custentity_14</object>
+    <object>custentity10</object>
+    <object>custentitycust_active</object>
+    <object>custentity11</object>
+    <object>custentity_slt_tax_reg</object>
+  </objects>
+  <files>
+    <file>/SuiteScripts/clientScript_2_0.js</file>
+  </files>
+</dependencies>
+</manifest>`
+    const fixedManifest = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
+<projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
+<frameworkversion>1.0</frameworkversion>
+<dependencies>
+  <features>
+    <feature required="true">SFA</feature>
+    <feature required="true">MULTICURRENCYVENDOR</feature>
+    <feature required="true">ACCOUNTING</feature>
+    <feature required="true">ADDRESSCUSTOMIZATION</feature>
+    <feature required="true">SUBSIDIARIES</feature>
+    <feature required="true">RECEIVABLES</feature>
+    <feature required="true">EXPREPORTS</feature>
+  </features>
+  <objects>
+    <object>custentity2edited</object>
+    <object>custentity13</object>
+    <object>custentity_14</object>
+    <object>custentity10</object>
+    <object>custentitycust_active</object>
+    <object>custentity11</object>
+    <object>custentity_slt_tax_reg</object>
+    <object>somescriptid</object>
+    <object>secondscriptid</object>
+  </objects>
+  <files>
+    <file>/SuiteScripts/clientScript_2_0.js</file>
+  </files>
+</dependencies>
+</manifest>`
+    expect(fixManifest(manifest, custInfos))
+      .toEqual(fixedManifest)
+  })
+})

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -102,17 +102,14 @@ const MOCK_MANIFEST_WITH_REQUIRED_DEPENDENCIES = `<manifest projecttype="ACCOUNT
 <frameworkversion>1.0</frameworkversion>
 <dependencies>
   <features>
-    <feature required="true">ADVANCEDEXPENSEMANAGEMENT</feature>
     <feature required="true">SFA</feature>
     <feature required="true">MULTICURRENCYVENDOR</feature>
     <feature required="true">ACCOUNTING</feature>
-    <feature required="true">SUBSCRIPTIONBILLING</feature>
     <feature required="true">ADDRESSCUSTOMIZATION</feature>
-    <feature required="true">WMSSYSTEM</feature>
     <feature required="true">SUBSIDIARIES</feature>
     <feature required="true">RECEIVABLES</feature>
-    <feature required="true">BILLINGACCOUNTS</feature>
-  <feature required="true">EXPREPORTS</feature></features>
+    <feature required="true">EXPREPORTS</feature>
+  </features>
   <objects>
     <object>custentity2edited</object>
     <object>custentity13</object>
@@ -121,6 +118,7 @@ const MOCK_MANIFEST_WITH_REQUIRED_DEPENDENCIES = `<manifest projecttype="ACCOUNT
     <object>custentitycust_active</object>
     <object>custentity11</object>
     <object>custentity_slt_tax_reg</object>
+    <object>somescriptid</object>
   </objects>
   <files>
     <file>/SuiteScripts/clientScript_2_0.js</file>
@@ -1398,7 +1396,10 @@ describe('netsuite client', () => {
       const workflowScriptId = 'workflow2'
       const workflowCustInfo: CustomTypeInfo = {
         typeName: WORKFLOW,
-        values: { key: '__STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP__' },
+        values: {
+          key: '__STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP__',
+          ref: '[scriptid=somescriptid]',
+        },
         scriptId: workflowScriptId,
       }
 

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -20,7 +20,7 @@ import { buildNetsuiteQuery, notQuery } from '../../src/query'
 import mockClient, { DUMMY_CREDENTIALS } from './sdf_client'
 import {
   APPLICATION_ID,
-  FILE_CABINET_PATH_SEPARATOR, INSTALLED_SUITEAPPS,
+  FILE_CABINET_PATH_SEPARATOR, INSTALLED_SUITEAPPS, WORKFLOW,
 } from '../../src/constants'
 import SdfClient, {
   ATTRIBUTES_FILE_SUFFIX,
@@ -82,6 +82,37 @@ const MOCK_MANIFEST_VALID_DEPENDENCIES = `<manifest projecttype="ACCOUNTCUSTOMIZ
     <feature required="true">SUBSIDIARIES</feature>
     <feature required="true">RECEIVABLES</feature>
   </features>
+  <objects>
+    <object>custentity2edited</object>
+    <object>custentity13</object>
+    <object>custentity_14</object>
+    <object>custentity10</object>
+    <object>custentitycust_active</object>
+    <object>custentity11</object>
+    <object>custentity_slt_tax_reg</object>
+  </objects>
+  <files>
+    <file>/SuiteScripts/clientScript_2_0.js</file>
+  </files>
+</dependencies>
+</manifest>`
+
+const MOCK_MANIFEST_WITH_REQUIRED_DEPENDENCIES = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
+<projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
+<frameworkversion>1.0</frameworkversion>
+<dependencies>
+  <features>
+    <feature required="true">ADVANCEDEXPENSEMANAGEMENT</feature>
+    <feature required="true">SFA</feature>
+    <feature required="true">MULTICURRENCYVENDOR</feature>
+    <feature required="true">ACCOUNTING</feature>
+    <feature required="true">SUBSCRIPTIONBILLING</feature>
+    <feature required="true">ADDRESSCUSTOMIZATION</feature>
+    <feature required="true">WMSSYSTEM</feature>
+    <feature required="true">SUBSIDIARIES</feature>
+    <feature required="true">RECEIVABLES</feature>
+    <feature required="true">BILLINGACCOUNTS</feature>
+  <feature required="true">EXPREPORTS</feature></features>
   <objects>
     <object>custentity2edited</object>
     <object>custentity13</object>
@@ -1360,6 +1391,19 @@ describe('netsuite client', () => {
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(3, addDependenciesCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(4, deployProjectCommandMatcher)
+    })
+
+    it('should add required dependencies to manifest.xml', async () => {
+      mockExecuteAction.mockResolvedValue({ isSuccess: () => true })
+      const workflowScriptId = 'workflow2'
+      const workflowCustInfo: CustomTypeInfo = {
+        typeName: WORKFLOW,
+        values: { key: '__STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP__' },
+        scriptId: workflowScriptId,
+      }
+
+      await client.deploy([workflowCustInfo])
+      expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('manifest.xml'), MOCK_MANIFEST_WITH_REQUIRED_DEPENDENCIES)
     })
   })
 })

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -20,7 +20,7 @@ import { buildNetsuiteQuery, notQuery } from '../../src/query'
 import mockClient, { DUMMY_CREDENTIALS } from './sdf_client'
 import {
   APPLICATION_ID,
-  FILE_CABINET_PATH_SEPARATOR, INSTALLED_SUITEAPPS, WORKFLOW,
+  FILE_CABINET_PATH_SEPARATOR, INSTALLED_SUITEAPPS,
 } from '../../src/constants'
 import SdfClient, {
   ATTRIBUTES_FILE_SUFFIX,
@@ -90,35 +90,6 @@ const MOCK_MANIFEST_VALID_DEPENDENCIES = `<manifest projecttype="ACCOUNTCUSTOMIZ
     <object>custentitycust_active</object>
     <object>custentity11</object>
     <object>custentity_slt_tax_reg</object>
-  </objects>
-  <files>
-    <file>/SuiteScripts/clientScript_2_0.js</file>
-  </files>
-</dependencies>
-</manifest>`
-
-const MOCK_MANIFEST_WITH_REQUIRED_DEPENDENCIES = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
-<projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
-<frameworkversion>1.0</frameworkversion>
-<dependencies>
-  <features>
-    <feature required="true">SFA</feature>
-    <feature required="true">MULTICURRENCYVENDOR</feature>
-    <feature required="true">ACCOUNTING</feature>
-    <feature required="true">ADDRESSCUSTOMIZATION</feature>
-    <feature required="true">SUBSIDIARIES</feature>
-    <feature required="true">RECEIVABLES</feature>
-    <feature required="true">EXPREPORTS</feature>
-  </features>
-  <objects>
-    <object>custentity2edited</object>
-    <object>custentity13</object>
-    <object>custentity_14</object>
-    <object>custentity10</object>
-    <object>custentitycust_active</object>
-    <object>custentity11</object>
-    <object>custentity_slt_tax_reg</object>
-    <object>somescriptid</object>
   </objects>
   <files>
     <file>/SuiteScripts/clientScript_2_0.js</file>
@@ -1389,22 +1360,6 @@ describe('netsuite client', () => {
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(3, addDependenciesCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(4, deployProjectCommandMatcher)
-    })
-
-    it('should add required dependencies to manifest.xml', async () => {
-      mockExecuteAction.mockResolvedValue({ isSuccess: () => true })
-      const workflowScriptId = 'workflow2'
-      const workflowCustInfo: CustomTypeInfo = {
-        typeName: WORKFLOW,
-        values: {
-          key: '__STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP__',
-          ref: '[scriptid=somescriptid]',
-        },
-        scriptId: workflowScriptId,
-      }
-
-      await client.deploy([workflowCustInfo])
-      expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('manifest.xml'), MOCK_MANIFEST_WITH_REQUIRED_DEPENDENCIES)
     })
   })
 })

--- a/packages/netsuite-adapter/test/reference_dependencies.test.ts
+++ b/packages/netsuite-adapter/test/reference_dependencies.test.ts
@@ -16,7 +16,6 @@
 import { BuiltinTypes, ElemID, InstanceElement, ObjectType, ReferenceExpression, StaticFile } from '@salto-io/adapter-api'
 import {
   CUSTOM_RECORD_TYPE, CUSTOM_SEGMENT, DATASET, ENTITY_CUSTOM_FIELD, FILE, PATH, SCRIPT_ID, WORKBOOK,
-  TRANSACTION_COLUMN_CUSTOM_FIELD, TRANSACTION_BODY_CUSTOM_FIELD,
 } from '../src/constants'
 import { customTypes, fileCabinetTypes } from '../src/types'
 import {
@@ -104,22 +103,6 @@ describe('reference dependencies', () => {
         },
       })
 
-    const transactionColumnCustomFieldInstance = new InstanceElement('instance',
-      customTypes[TRANSACTION_COLUMN_CUSTOM_FIELD], {
-        [SCRIPT_ID]: 'custcol_my_script_id',
-        sourcefrom: new ReferenceExpression(
-          instance.elemID, 'val', instance
-        ),
-      })
-
-    const transactionBodyCustomFieldInstance = new InstanceElement('instance',
-      customTypes[TRANSACTION_BODY_CUSTOM_FIELD], {
-        [SCRIPT_ID]: 'custbody_my_script_id',
-        sourcefrom: new ReferenceExpression(
-          instance.elemID, 'val', instance
-        ),
-      })
-
     it('should not add dependencies that are not required', async () => {
       const result = getRequiredReferencedInstances([instanceWithManyRefs])
       expect(result).toEqual([instanceWithManyRefs])
@@ -140,19 +123,9 @@ describe('reference dependencies', () => {
       expect(result).toEqual([workbookInstance, datasetInstance])
     })
 
-    it('should add dependency of TRANSACTION_COLUMN_CUSTOM_FIELD', async () => {
-      const result = getRequiredReferencedInstances([transactionColumnCustomFieldInstance])
-      expect(result).toEqual([transactionColumnCustomFieldInstance, instance])
-    })
-
-    it('should add dependency of TRANSACTION_BODY_CUSTOM_FIELD', async () => {
-      const result = getRequiredReferencedInstances([transactionBodyCustomFieldInstance])
-      expect(result).toEqual([transactionBodyCustomFieldInstance, instance])
-    })
-
     it('should not add dependencies that already exist', async () => {
       const input = [customRecordTypeInstance, customSegmentInstance, workbookInstance,
-        datasetInstance, transactionColumnCustomFieldInstance, instance]
+        datasetInstance, instance]
       const result = getRequiredReferencedInstances(input)
       expect(result).toEqual(input)
     })


### PR DESCRIPTION
Some feature dependencies are not added automatically to the manifest and fail the deploy 

---
_Release Notes_: 
Netsuite Adapter:
- add missing features & objects dependencies to `manifest.xml` on SDF deploy

