### PR TITLE
SALTO-1778-Added-support-for-deploying-issue-type-screen-scheme

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -31,6 +31,7 @@ import sharePermissionFilter from './filters/share_permission'
 import boardFilter from './filters/board'
 import screenFilter from './filters/screen/screen'
 import screenableTabFilter from './filters/screen/screenable_tab'
+import issueTypeScreenSchemeFilter from './filters/issue_type_screen_scheme'
 import hiddenValuesInListsFilter from './filters/hidden_value_in_lists'
 import projectFilter from './filters/project'
 import defaultInstancesDeployFilter from './filters/default_instances_deploy'
@@ -62,6 +63,7 @@ export const DEFAULT_FILTERS = [
   fieldDeploymentFilter,
   screenFilter,
   screenableTabFilter,
+  issueTypeScreenSchemeFilter,
   referenceBySelfLinkFilter,
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,

--- a/packages/jira-adapter/src/filters/issue_type_screen_scheme.ts
+++ b/packages/jira-adapter/src/filters/issue_type_screen_scheme.ts
@@ -88,6 +88,9 @@ const deployDefaultMapping = async (
   const defaultAfter = change.data.after.value.issueTypeMappings
     ?.find((mapping: Values) => mapping.issueTypeId === DEFAULT_ISSUE_TYPE)
 
+  if (defaultAfter?.screenSchemeId === undefined) {
+    throw new Error(`instance ${getChangeData(change).elemID.getFullName()} must have a default screen scheme`)
+  }
 
   const instance = getChangeData(change)
   if (defaultBefore?.screenSchemeId !== defaultAfter?.screenSchemeId) {

--- a/packages/jira-adapter/src/filters/issue_type_screen_scheme.ts
+++ b/packages/jira-adapter/src/filters/issue_type_screen_scheme.ts
@@ -1,0 +1,173 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, getChangeData, InstanceElement, isInstanceChange, isModificationChange, isObjectType, ModificationChange, Values } from '@salto-io/adapter-api'
+import { resolveChangeElement } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { getLookUpName } from '../reference_mapping'
+import JiraClient from '../client/client'
+import { JiraConfig } from '../config'
+import { defaultDeployChange, deployChanges } from '../deployment'
+import { FilterCreator } from '../filter'
+
+const ISSUE_TYPE_SCREEN_SCHEME_NAME = 'IssueTypeScreenScheme'
+const ISSUE_TYPE_SCREEN_SCHEME_ITEM_NAME = 'IssueTypeScreenSchemeItem'
+
+const log = logger(module)
+
+const DEFAULT_ISSUE_TYPE = 'default'
+
+const deployIssueTypeMappings = async (
+  change: ModificationChange<InstanceElement>,
+  client: JiraClient,
+): Promise<void> => {
+  const afterItemsMap = _.keyBy(
+    change.data.after.value.issueTypeMappings ?? [],
+    (mapping: Values) => mapping.issueTypeId
+  )
+
+  const beforeItemsMap = _.keyBy(
+    change.data.before.value.issueTypeMappings ?? [],
+    (mapping: Values) => mapping.issueTypeId
+  )
+
+  const itemsToAdd = (change.data.after.value.issueTypeMappings ?? [])
+    .filter((mapping: Values) =>
+      mapping.issueTypeId !== DEFAULT_ISSUE_TYPE
+      && (beforeItemsMap[mapping.issueTypeId] === undefined
+        || !_.isEqual(beforeItemsMap[mapping.issueTypeId], mapping)
+      ))
+
+  const itemsToRemove = (change.data.before.value.issueTypeMappings ?? [])
+    .filter((mapping: Values) =>
+      mapping.issueTypeId !== DEFAULT_ISSUE_TYPE
+      && (afterItemsMap[mapping.issueTypeId] === undefined
+        || !_.isEqual(afterItemsMap[mapping.issueTypeId], mapping)
+      ))
+
+  const instance = getChangeData(change)
+
+  if (itemsToRemove.length > 0) {
+    await client.post({
+      url: `/rest/api/3/issuetypescreenscheme/${instance.value.id}/mapping/remove`,
+      data: {
+        issueTypeIds: itemsToRemove.map((mapping: Values) => mapping.issueTypeId),
+      },
+    })
+  }
+
+  if (itemsToAdd.length > 0) {
+    await client.put({
+      url: `/rest/api/3/issuetypescreenscheme/${instance.value.id}/mapping`,
+      data: {
+        issueTypeMappings: itemsToAdd,
+      },
+    })
+  }
+}
+
+const deployDefaultMapping = async (
+  change: ModificationChange<InstanceElement>,
+  client: JiraClient,
+): Promise<void> => {
+  const defaultBefore = change.data.before.value.issueTypeMappings
+    ?.find((mapping: Values) => mapping.issueTypeId === DEFAULT_ISSUE_TYPE)
+  const defaultAfter = change.data.after.value.issueTypeMappings
+    ?.find((mapping: Values) => mapping.issueTypeId === DEFAULT_ISSUE_TYPE)
+
+
+  const instance = getChangeData(change)
+  if (defaultBefore?.screenSchemeId !== defaultAfter?.screenSchemeId) {
+    await client.put({
+      url: `/rest/api/3/issuetypescreenscheme/${instance.value.id}/mapping/default`,
+      data: {
+        screenSchemeId: defaultAfter?.screenSchemeId,
+      },
+    })
+  }
+}
+
+const deployIssueTypeScreenSchema = async (
+  change: ModificationChange<InstanceElement>,
+  client: JiraClient,
+  config: JiraConfig,
+): Promise<void> => {
+  await defaultDeployChange({
+    change,
+    client,
+    apiDefinitions: config.apiDefinitions,
+    fieldsToIgnore: ['issueTypeMappings'],
+  })
+  await deployIssueTypeMappings(change, client)
+  await deployDefaultMapping(change, client)
+}
+
+const filter: FilterCreator = ({ config, client }) => ({
+  onFetch: async elements => {
+    const types = elements.filter(isObjectType)
+    const issueTypeScreenSchemaType = types
+      .find(element => element.elemID.name === ISSUE_TYPE_SCREEN_SCHEME_NAME)
+
+    if (issueTypeScreenSchemaType === undefined) {
+      log.warn(`${ISSUE_TYPE_SCREEN_SCHEME_NAME} type was not found`)
+    } else {
+      issueTypeScreenSchemaType.fields.issueTypeMappings
+        .annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+    }
+
+    const issueTypeScreenSchemaItemType = types
+      .find(element => element.elemID.name === ISSUE_TYPE_SCREEN_SCHEME_ITEM_NAME)
+
+    if (issueTypeScreenSchemaItemType === undefined) {
+      log.warn(`${ISSUE_TYPE_SCREEN_SCHEME_ITEM_NAME} type was not found`)
+    } else {
+      issueTypeScreenSchemaItemType.fields.issueTypeId
+        .annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+
+      issueTypeScreenSchemaItemType.fields.screenSchemeId
+        .annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+    }
+  },
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && isModificationChange(change)
+        && getChangeData(change).elemID.typeName === ISSUE_TYPE_SCREEN_SCHEME_NAME
+    )
+
+    const deployResult = await deployChanges(
+      relevantChanges
+        .filter(isInstanceChange)
+        .filter(isModificationChange),
+      async change => deployIssueTypeScreenSchema(
+        await resolveChangeElement(
+          change,
+          getLookUpName
+        ),
+        client,
+        config
+      )
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/test/filters/issue_type_screen_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_screen_scheme.test.ts
@@ -244,5 +244,24 @@ describe('issueTypeScreenScheme', () => {
       await filter.deploy?.([toChange({ before: beforeInstance, after: afterInstance })])
       expect(mockConnection.post).not.toHaveBeenCalled()
     })
+
+    it('should throw an error if no default item exist', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        issueTypeScreenSchemeType,
+        {
+          name: 'name2',
+          id: 'id',
+          issueTypeMappings: [
+            { issueTypeId: 'issueTypeId1', screenSchemeId: 'screenSchemeId1' },
+            { issueTypeId: 'issueTypeId2', screenSchemeId: 'screenSchemeId2' },
+          ],
+        }
+      )
+
+      const result = await filter.deploy?.([toChange({ before: instance, after: instance })])
+      expect(result?.deployResult?.appliedChanges).toEqual([])
+      expect(result?.deployResult?.errors).toHaveLength(1)
+    })
   })
 })

--- a/packages/jira-adapter/test/filters/issue_type_screen_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_screen_scheme.test.ts
@@ -1,0 +1,248 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, ObjectType, toChange } from '@salto-io/adapter-api'
+import { deployment, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import { JIRA } from '../../src/constants'
+import { mockClient } from '../utils'
+import issueTypeScreenSchemeFilter from '../../src/filters/issue_type_screen_scheme'
+import { Filter } from '../../src/filter'
+import JiraClient from '../../src/client/client'
+import { DEFAULT_CONFIG } from '../../src/config'
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn(),
+    },
+  }
+})
+
+describe('issueTypeScreenScheme', () => {
+  let issueTypeScreenSchemeType: ObjectType
+  let issueTypeScreenSchemeItemType: ObjectType
+  let filter: Filter
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let client: JiraClient
+  beforeEach(async () => {
+    const { client: cli, paginator, connection } = mockClient()
+    client = cli
+    mockConnection = connection
+
+    filter = issueTypeScreenSchemeFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    })
+    issueTypeScreenSchemeItemType = new ObjectType({
+      elemID: new ElemID(JIRA, 'IssueTypeScreenSchemeItem'),
+      fields: {
+        issueTypeId: { refType: BuiltinTypes.STRING },
+        screenSchemeId: { refType: BuiltinTypes.STRING },
+      },
+    })
+    issueTypeScreenSchemeType = new ObjectType({
+      elemID: new ElemID(JIRA, 'IssueTypeScreenScheme'),
+      fields: {
+        issueTypeMappings: { refType: new ListType(issueTypeScreenSchemeItemType) },
+      },
+    })
+  })
+
+  describe('onFetch', () => {
+    it('add the deployment annotation to issueTypeMappings', async () => {
+      await filter.onFetch?.([issueTypeScreenSchemeType])
+      expect(issueTypeScreenSchemeType.fields.issueTypeMappings.annotations)
+        .toEqual({ [CORE_ANNOTATIONS.UPDATABLE]: true })
+    })
+
+    it('add the deployment annotation to issueTypeScreenSchemeItemType', async () => {
+      await filter.onFetch?.([issueTypeScreenSchemeItemType])
+      expect(issueTypeScreenSchemeItemType.fields.issueTypeId.annotations)
+        .toEqual({ [CORE_ANNOTATIONS.UPDATABLE]: true })
+      expect(issueTypeScreenSchemeItemType.fields.screenSchemeId.annotations)
+        .toEqual({ [CORE_ANNOTATIONS.UPDATABLE]: true })
+    })
+  })
+
+  describe('deploy', () => {
+    it('should return irrelevant changes in leftoverChanges', async () => {
+      const res = await filter.deploy?.([
+        toChange({ after: issueTypeScreenSchemeType }),
+        toChange({ after: new InstanceElement('instance1', issueTypeScreenSchemeType) }),
+        toChange({
+          before: new InstanceElement('instance2', new ObjectType({ elemID: new ElemID(JIRA, 'someType') })),
+          after: new InstanceElement('instance2', new ObjectType({ elemID: new ElemID(JIRA, 'someType') })),
+        }),
+      ])
+      expect(res?.leftoverChanges).toHaveLength(3)
+      expect(res?.deployResult).toEqual({ appliedChanges: [], errors: [] })
+    })
+
+    describe('When deploying a change', () => {
+      const deployChangeMock = deployment.deployChange as jest.MockedFunction<
+        typeof deployment.deployChange
+      >
+      let change: Change<InstanceElement>
+
+      beforeEach(async () => {
+        const beforeInstance = new InstanceElement(
+          'instance',
+          issueTypeScreenSchemeType,
+          {
+            name: 'name1',
+            id: 'id',
+            issueTypeMappings: [
+              { issueTypeId: 'default', screenSchemeId: 'screenSchemeDefaultId' },
+              { issueTypeId: 'issueTypeId1', screenSchemeId: 'screenSchemeId1' },
+              { issueTypeId: 'issueTypeId2', screenSchemeId: 'screenSchemeId2' },
+            ],
+          }
+        )
+
+        const afterInstance = new InstanceElement(
+          'instance',
+          issueTypeScreenSchemeType,
+          {
+            name: 'name2',
+            id: 'id',
+            issueTypeMappings: [
+              { issueTypeId: 'default', screenSchemeId: 'screenSchemeDefaultId2' },
+              { issueTypeId: 'issueTypeId1', screenSchemeId: 'screenSchemeId12' },
+              { issueTypeId: 'issueTypeId3', screenSchemeId: 'screenSchemeId3' },
+            ],
+          }
+        )
+
+        change = toChange({ before: beforeInstance, after: afterInstance })
+
+        await filter.deploy?.([change])
+      })
+      it('should call deployChange and ignore issueTypeMappings', () => {
+        expect(deployChangeMock).toHaveBeenCalledWith(
+          change,
+          client,
+          DEFAULT_CONFIG.apiDefinitions.types.IssueTypeScreenScheme.deployRequests,
+          ['issueTypeMappings'],
+          undefined
+        )
+      })
+
+      it('should call the endpoint to remove the removed and modified items', () => {
+        expect(mockConnection.post).toHaveBeenCalledWith(
+          '/rest/api/3/issuetypescreenscheme/id/mapping/remove',
+          {
+            issueTypeIds: [
+              'issueTypeId1',
+              'issueTypeId2',
+            ],
+          },
+          undefined,
+        )
+      })
+
+      it('should call the endpoint to add the added and modified items', () => {
+        expect(mockConnection.put).toHaveBeenCalledWith(
+          '/rest/api/3/issuetypescreenscheme/id/mapping',
+          {
+            issueTypeMappings: [
+              { issueTypeId: 'issueTypeId1', screenSchemeId: 'screenSchemeId12' },
+              { issueTypeId: 'issueTypeId3', screenSchemeId: 'screenSchemeId3' },
+            ],
+          },
+          undefined,
+        )
+      })
+
+      it('should call the endpoint to update the default item', () => {
+        expect(mockConnection.put).toHaveBeenCalledWith(
+          '/rest/api/3/issuetypescreenscheme/id/mapping/default',
+          {
+            screenSchemeId: 'screenSchemeDefaultId2',
+          },
+          undefined,
+        )
+      })
+    })
+
+    it('should not call the new items endpoint if there are no new or modified items', async () => {
+      const beforeInstance = new InstanceElement(
+        'instance',
+        issueTypeScreenSchemeType,
+        {
+          name: 'name1',
+          id: 'id',
+          issueTypeMappings: [
+            { issueTypeId: 'default', screenSchemeId: 'screenSchemeDefaultId' },
+            { issueTypeId: 'issueTypeId1', screenSchemeId: 'screenSchemeId1' },
+            { issueTypeId: 'issueTypeId2', screenSchemeId: 'screenSchemeId2' },
+          ],
+        }
+      )
+
+      const afterInstance = new InstanceElement(
+        'instance',
+        issueTypeScreenSchemeType,
+        {
+          name: 'name2',
+          id: 'id',
+          issueTypeMappings: [
+            { issueTypeId: 'default', screenSchemeId: 'screenSchemeDefaultId' },
+            { issueTypeId: 'issueTypeId1', screenSchemeId: 'screenSchemeId1' },
+          ],
+        }
+      )
+
+      await filter.deploy?.([toChange({ before: beforeInstance, after: afterInstance })])
+      expect(mockConnection.put).not.toHaveBeenCalled()
+    })
+
+    it('should not call the remove items endpoint if there are no removed or modified items', async () => {
+      const beforeInstance = new InstanceElement(
+        'instance',
+        issueTypeScreenSchemeType,
+        {
+          name: 'name1',
+          id: 'id',
+          issueTypeMappings: [
+            { issueTypeId: 'default', screenSchemeId: 'screenSchemeDefaultId' },
+            { issueTypeId: 'issueTypeId1', screenSchemeId: 'screenSchemeId1' },
+          ],
+        }
+      )
+
+      const afterInstance = new InstanceElement(
+        'instance',
+        issueTypeScreenSchemeType,
+        {
+          name: 'name2',
+          id: 'id',
+          issueTypeMappings: [
+            { issueTypeId: 'default', screenSchemeId: 'screenSchemeDefaultId' },
+            { issueTypeId: 'issueTypeId1', screenSchemeId: 'screenSchemeId1' },
+            { issueTypeId: 'issueTypeId2', screenSchemeId: 'screenSchemeId2' },
+          ],
+        }
+      )
+
+      await filter.deploy?.([toChange({ before: beforeInstance, after: afterInstance })])
+      expect(mockConnection.post).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Added support for deploying issue type screen scheme

Only last commit is relevant
This PR is build on https://github.com/salto-io/salto/pull/2598

---
_Release Notes_: 
None

---
_User Notifications_: 
None