### PR TITLE
SALTO-1778-field-configuration-deploy

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -19,7 +19,7 @@ import { config as configUtils, elements as elementUtils, client as clientUtils,
 import { applyFunctionToChangeData, logDuration } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import JiraClient from './client/client'
-import changeValidator from './change_validator'
+import changeValidator from './change_validators'
 import { JiraConfig, getApiDefinitions } from './config'
 import { FilterCreator, Filter, filtersRunner } from './filter'
 import fieldReferencesFilter from './filters/field_references'
@@ -32,6 +32,7 @@ import boardFilter from './filters/board'
 import screenFilter from './filters/screen/screen'
 import screenableTabFilter from './filters/screen/screenable_tab'
 import issueTypeScreenSchemeFilter from './filters/issue_type_screen_scheme'
+import fieldConfigurationFilter from './filters/field_configuration'
 import hiddenValuesInListsFilter from './filters/hidden_value_in_lists'
 import projectFilter from './filters/project'
 import defaultInstancesDeployFilter from './filters/default_instances_deploy'
@@ -64,6 +65,7 @@ export const DEFAULT_FILTERS = [
   screenFilter,
   screenableTabFilter,
   issueTypeScreenSchemeFilter,
+  fieldConfigurationFilter,
   referenceBySelfLinkFilter,
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,

--- a/packages/jira-adapter/src/change_validators/field_configuration.ts
+++ b/packages/jira-adapter/src/change_validators/field_configuration.ts
@@ -1,0 +1,64 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, compareSpecialValues, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isReferenceExpression, ModificationChange, SaltoErrorSeverity, Values } from '@salto-io/adapter-api'
+import { values } from '@salto-io/lowerdash'
+import _ from 'lodash'
+
+const getFieldId = (field: Values): string => (
+  isReferenceExpression(field.id) ? field.id.value.value.id : field.id
+)
+
+const getDiffFields = (change: ModificationChange<InstanceElement>): Values[] => {
+  const beforeIdToField = _.keyBy(
+    change.data.before.value.fields,
+    getFieldId,
+  )
+
+  return change.data.after.value.fields.filter(
+    (field: Values) => !_.isEqualWith(
+      field,
+      beforeIdToField[getFieldId(field)],
+      compareSpecialValues
+    )
+  )
+}
+
+export const unsupportedFieldConfigurationsValidator: ChangeValidator = async changes => (
+  changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === 'FieldConfiguration')
+    .map(change => {
+      const fields = isAdditionChange(change)
+        ? change.data.after.value.fields
+        : getDiffFields(change)
+
+      const unsupportedIds = fields
+        .filter((field: Values) =>
+          !isReferenceExpression(field.id)
+          || field.id.value.value.isLocked)
+        .map(getFieldId)
+
+      const { elemID } = getChangeData(change)
+      return unsupportedIds.length !== 0 ? {
+        elemID,
+        severity: 'Warning' as SaltoErrorSeverity,
+        message: `Salto can't deploy fields configuration of ${elemID.getFullName()} because they are either locked or team-managed`,
+        detailedMessage: `Salto can't deploy the configuration of fields: ${unsupportedIds.join(', ')}. If continuing, they will be omitted from the deployment`,
+      } : undefined
+    })
+    .filter(values.isDefined)
+)

--- a/packages/jira-adapter/src/change_validators/field_configuration.ts
+++ b/packages/jira-adapter/src/change_validators/field_configuration.ts
@@ -13,9 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { ChangeValidator, compareSpecialValues, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isReferenceExpression, ModificationChange, SaltoErrorSeverity, Values } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
-import _ from 'lodash'
 
 const getFieldId = (field: Values): string => (
   isReferenceExpression(field.id) ? field.id.value.value.id : field.id
@@ -53,12 +53,15 @@ export const unsupportedFieldConfigurationsValidator: ChangeValidator = async ch
         .map(getFieldId)
 
       const { elemID } = getChangeData(change)
-      return unsupportedIds.length !== 0 ? {
-        elemID,
-        severity: 'Warning' as SaltoErrorSeverity,
-        message: `Salto can't deploy fields configuration of ${elemID.getFullName()} because they are either locked or team-managed`,
-        detailedMessage: `Salto can't deploy the configuration of fields: ${unsupportedIds.join(', ')}. If continuing, they will be omitted from the deployment`,
-      } : undefined
+      if (unsupportedIds.length !== 0) {
+        return {
+          elemID,
+          severity: 'Warning' as SaltoErrorSeverity,
+          message: `Salto can't deploy fields configuration of ${elemID.getFullName()} because they are either locked or team-managed`,
+          detailedMessage: `Salto can't deploy the configuration of fields: ${unsupportedIds.join(', ')}. If continuing, they will be omitted from the deployment`,
+        }
+      }
+      return undefined
     })
     .filter(values.isDefined)
 )

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -16,6 +16,7 @@
 import { ChangeValidator } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
 import { createChangeValidator } from '@salto-io/adapter-utils'
+import { unsupportedFieldConfigurationsValidator } from './field_configuration'
 
 const {
   deployTypesNotSupportedValidator,
@@ -23,6 +24,7 @@ const {
 
 const validators: ChangeValidator[] = [
   deployTypesNotSupportedValidator,
+  unsupportedFieldConfigurationsValidator,
 ]
 
 export default createChangeValidator(validators)

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -15,11 +15,10 @@
 */
 import _ from 'lodash'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ListType } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ListType, ObjectType } from '@salto-io/adapter-api'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
 import { JIRA } from './constants'
 
-const { createClientConfigType } = clientUtils
 const { createUserFetchConfigType, createSwaggerAdapterApiConfigType } = configUtils
 
 const DEFAULT_ID_FIELDS = ['name']
@@ -28,6 +27,9 @@ const FIELDS_TO_OMIT: configUtils.FieldToOmitType[] = [
 ]
 
 type JiraClientConfig = clientUtils.ClientBaseConfig<clientUtils.ClientRateLimitConfig>
+  & {
+    fieldConfigurationItemsDeploymentLimit: number
+  }
 
 type JiraFetchConfig = configUtils.UserFetchConfig
 type JiraApiConfig = Omit<configUtils.AdapterSwaggerApiConfig, 'swagger'> & {
@@ -159,11 +161,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   },
   Field: {
     transformation: {
-      // fieldsToHide: [
-      //   {
-      //     fieldName: 'id',
-      //   },
-      // ],
+      fieldsToHide: [
+        {
+          fieldName: 'id',
+        },
+      ],
       idFields: ['id'],
       fieldTypeOverrides: [
         { fieldName: 'contexts', fieldType: 'list<CustomFieldContext>' },
@@ -1417,7 +1419,7 @@ export const DEFAULT_INCLUDE_ENDPOINTS: string[] = [
 ]
 
 export type JiraConfig = {
-  client?: JiraClientConfig
+  client: JiraClientConfig
   fetch: JiraFetchConfig
   apiDefinitions: JiraApiConfig
 }
@@ -1447,21 +1449,33 @@ const apiDefinitionsType = createMatchingObjectType<Partial<JiraApiConfig>>({
 })
 
 export const DEFAULT_CONFIG: JiraConfig = {
+  client: {
+  // Jira does not allow more items in a single request than this
+    fieldConfigurationItemsDeploymentLimit: 100,
+  },
   fetch: {
     includeTypes: DEFAULT_INCLUDE_ENDPOINTS,
   },
   apiDefinitions: DEFAULT_API_DEFINITIONS,
 }
 
+const createClientConfigType = (): ObjectType => {
+  const configType = clientUtils.createClientConfigType(JIRA)
+  configType.fields.FieldConfigurationItemsDeploymentLimit = new Field(
+    configType, 'FieldConfigurationItemsDeploymentLimit', BuiltinTypes.NUMBER
+  )
+  return configType
+}
+
 export const configType = createMatchingObjectType<Partial<JiraConfig>>({
   elemID: new ElemID(JIRA),
   fields: {
-    client: { refType: createClientConfigType(JIRA) },
+    client: { refType: createClientConfigType() },
     fetch: { refType: createUserFetchConfigType(JIRA) },
     apiDefinitions: { refType: apiDefinitionsType },
   },
   annotations: {
-    [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, 'apiDefinitions'),
+    [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, ['apiDefinitions', 'client']),
   },
 })
 
@@ -1475,5 +1489,3 @@ export const getApiDefinitions = (config: JiraApiConfig): {
     jira: { ...baseConfig, swagger: config.jiraSwagger },
   }
 }
-
-export type FilterContext = Pick<JiraConfig, 'fetch' | 'apiDefinitions'>

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -114,7 +114,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       url: '/rest/api/3/field/search',
       paginationField: 'startAt',
       queryParams: {
-        expand: 'searcherKey',
+        expand: 'searcherKey,isLocked',
       },
       recurseInto: [
         {
@@ -159,11 +159,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   },
   Field: {
     transformation: {
-      fieldsToHide: [
-        {
-          fieldName: 'id',
-        },
-      ],
+      // fieldsToHide: [
+      //   {
+      //     fieldName: 'id',
+      //   },
+      // ],
       idFields: ['id'],
       fieldTypeOverrides: [
         { fieldName: 'contexts', fieldType: 'list<CustomFieldContext>' },
@@ -292,12 +292,27 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     transformation: {
       fieldTypeOverrides: [
         { fieldName: 'fields', fieldType: 'list<FieldConfigurationItem>' },
+        { fieldName: 'id', fieldType: 'number' },
       ],
       fieldsToHide: [
         {
           fieldName: 'id',
         },
       ],
+    },
+    deployRequests: {
+      add: {
+        url: '/rest/api/3/fieldconfiguration',
+        method: 'post',
+      },
+      modify: {
+        url: '/rest/api/3/fieldconfiguration/{id}',
+        method: 'put',
+      },
+      remove: {
+        url: '/rest/api/3/fieldconfiguration/{id}',
+        method: 'delete',
+      },
     },
   },
   PageBeanFieldConfigurationItem: {

--- a/packages/jira-adapter/src/filters/field_configuration.ts
+++ b/packages/jira-adapter/src/filters/field_configuration.ts
@@ -1,0 +1,112 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, CORE_ANNOTATIONS, getChangeData, InstanceElement, isInstanceChange, isObjectType, isReferenceExpression, isRemovalChange, Values } from '@salto-io/adapter-api'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { defaultDeployChange, deployChanges } from '../deployment'
+import { FilterCreator } from '../filter'
+
+const FIELD_CONFIGURATION_TYPE_NAME = 'FieldConfiguration'
+const FIELD_CONFIGURATION_ITEM_TYPE_NAME = 'FieldConfigurationItem'
+
+const log = logger(module)
+
+// Jira does not allow more items in a single request than this
+const MAX_ITEMS_IN_REQUEST = 100
+
+const deployFieldConfigurationItems = async (
+  change: Change<InstanceElement>,
+  client: clientUtils.HTTPWriteClientInterface,
+): Promise<void> => {
+  const instance = getChangeData(change)
+  const fields = (instance.value.fields ?? [])
+    .filter((fieldConf: Values) => isReferenceExpression(fieldConf.id))
+    .filter((fieldConf: Values) => !fieldConf.id.value.value.isLocked)
+    .map((fieldConf: Values) => ({ ...fieldConf, id: fieldConf.id.value.value.id }))
+
+  if (fields.length === 0) {
+    return
+  }
+
+  await Promise.all(
+    _.chunk(fields, MAX_ITEMS_IN_REQUEST).map(async fieldsChunk =>
+      client.put({
+        url: `/rest/api/3/fieldconfiguration/${instance.value.id}/fields`,
+        data: {
+          fieldConfigurationItems: fieldsChunk,
+        },
+      }))
+  )
+}
+
+const filter: FilterCreator = ({ config, client }) => ({
+  onFetch: async elements => {
+    const types = elements.filter(isObjectType)
+
+    const fieldConfigurationType = types
+      .find(type => type.elemID.name === FIELD_CONFIGURATION_TYPE_NAME)
+
+    if (fieldConfigurationType === undefined) {
+      log.warn(`${FIELD_CONFIGURATION_TYPE_NAME} type not found`)
+    } else {
+      fieldConfigurationType.fields.fields.annotations[CORE_ANNOTATIONS.CREATABLE] = true
+      fieldConfigurationType.fields.fields.annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+    }
+
+    const fieldConfigurationItemType = types
+      .find(type => type.elemID.name === FIELD_CONFIGURATION_ITEM_TYPE_NAME)
+
+    if (fieldConfigurationItemType === undefined) {
+      log.warn(`${FIELD_CONFIGURATION_ITEM_TYPE_NAME} type not found`)
+    } else {
+      ['id', 'description', 'isHidden', 'isRequired', 'renderer'].forEach(fieldName => {
+        fieldConfigurationItemType.fields[fieldName].annotations[CORE_ANNOTATIONS.CREATABLE] = true
+        fieldConfigurationItemType.fields[fieldName].annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+      })
+    }
+  },
+
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && getChangeData(change).elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME
+        && !isRemovalChange(change)
+    )
+
+
+    const deployResult = await deployChanges(
+      relevantChanges as Change<InstanceElement>[],
+      async change => {
+        await defaultDeployChange({
+          change,
+          client,
+          apiDefinitions: config.apiDefinitions,
+          fieldsToIgnore: ['fields'],
+        })
+        await deployFieldConfigurationItems(change, client)
+      }
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/field_configuration.ts
+++ b/packages/jira-adapter/src/filters/field_configuration.ts
@@ -13,24 +13,24 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, CORE_ANNOTATIONS, getChangeData, InstanceElement, isInstanceChange, isObjectType, isReferenceExpression, isRemovalChange, Values } from '@salto-io/adapter-api'
+import { Change, getChangeData, InstanceElement, isInstanceChange, isObjectType, isReferenceExpression, isRemovalChange, Values } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { defaultDeployChange, deployChanges } from '../deployment'
 import { FilterCreator } from '../filter'
+import { setDeploymentAnnotations } from '../utils'
+import { JiraConfig } from '../config'
 
 const FIELD_CONFIGURATION_TYPE_NAME = 'FieldConfiguration'
 const FIELD_CONFIGURATION_ITEM_TYPE_NAME = 'FieldConfigurationItem'
 
 const log = logger(module)
 
-// Jira does not allow more items in a single request than this
-const MAX_ITEMS_IN_REQUEST = 100
-
 const deployFieldConfigurationItems = async (
   change: Change<InstanceElement>,
   client: clientUtils.HTTPWriteClientInterface,
+  config: JiraConfig
 ): Promise<void> => {
   const instance = getChangeData(change)
   const fields = (instance.value.fields ?? [])
@@ -43,7 +43,7 @@ const deployFieldConfigurationItems = async (
   }
 
   await Promise.all(
-    _.chunk(fields, MAX_ITEMS_IN_REQUEST).map(async fieldsChunk =>
+    _.chunk(fields, config.client.fieldConfigurationItemsDeploymentLimit).map(async fieldsChunk =>
       client.put({
         url: `/rest/api/3/fieldconfiguration/${instance.value.id}/fields`,
         data: {
@@ -63,8 +63,7 @@ const filter: FilterCreator = ({ config, client }) => ({
     if (fieldConfigurationType === undefined) {
       log.warn(`${FIELD_CONFIGURATION_TYPE_NAME} type not found`)
     } else {
-      fieldConfigurationType.fields.fields.annotations[CORE_ANNOTATIONS.CREATABLE] = true
-      fieldConfigurationType.fields.fields.annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+      setDeploymentAnnotations(fieldConfigurationType, 'fields')
     }
 
     const fieldConfigurationItemType = types
@@ -74,8 +73,7 @@ const filter: FilterCreator = ({ config, client }) => ({
       log.warn(`${FIELD_CONFIGURATION_ITEM_TYPE_NAME} type not found`)
     } else {
       ['id', 'description', 'isHidden', 'isRequired', 'renderer'].forEach(fieldName => {
-        fieldConfigurationItemType.fields[fieldName].annotations[CORE_ANNOTATIONS.CREATABLE] = true
-        fieldConfigurationItemType.fields[fieldName].annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+        setDeploymentAnnotations(fieldConfigurationItemType, fieldName)
       })
     }
   },
@@ -98,7 +96,7 @@ const filter: FilterCreator = ({ config, client }) => ({
           apiDefinitions: config.apiDefinitions,
           fieldsToIgnore: ['fields'],
         })
-        await deployFieldConfigurationItems(change, client)
+        await deployFieldConfigurationItems(change, client, config)
       }
     )
 

--- a/packages/jira-adapter/src/filters/fields/constants.ts
+++ b/packages/jira-adapter/src/filters/fields/constants.ts
@@ -13,18 +13,4 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, ObjectType, Element, isObjectType } from '@salto-io/adapter-api'
-
 export const FIELD_TYPE_NAME = 'Field'
-
-export const setDeploymentAnnotations = (contextType: ObjectType, fieldName: string): void => {
-  if (contextType.fields[fieldName] !== undefined) {
-    contextType.fields[fieldName].annotations[CORE_ANNOTATIONS.CREATABLE] = true
-    contextType.fields[fieldName].annotations[CORE_ANNOTATIONS.UPDATABLE] = true
-  }
-}
-
-export const findObject = (elements: Element[], name: string): ObjectType | undefined =>
-  elements.filter(isObjectType).find(
-    element => element.elemID.name === name
-  )

--- a/packages/jira-adapter/src/filters/fields/context_options.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options.ts
@@ -20,7 +20,7 @@ import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { getLookUpName } from '../../reference_mapping'
-import { setDeploymentAnnotations } from './utils'
+import { setDeploymentAnnotations } from '../../utils'
 
 const log = logger(module)
 

--- a/packages/jira-adapter/src/filters/fields/contexts.ts
+++ b/packages/jira-adapter/src/filters/fields/contexts.ts
@@ -24,7 +24,7 @@ import JiraClient from '../../client/client'
 import { setContextOptions, setOptionTypeDeploymentAnnotations } from './context_options'
 import { setDefaultValueTypeDeploymentAnnotations } from './default_values'
 import { setContextField } from './issues_and_projects'
-import { setDeploymentAnnotations } from './utils'
+import { setDeploymentAnnotations } from '../../utils'
 
 const { awu } = collections.asynciterable
 

--- a/packages/jira-adapter/src/filters/fields/default_values.ts
+++ b/packages/jira-adapter/src/filters/fields/default_values.ts
@@ -19,7 +19,7 @@ import { client as clientUtils } from '@salto-io/adapter-components'
 import { resolveChangeElement } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { getLookUpName } from '../../reference_mapping'
-import { setDeploymentAnnotations } from './utils'
+import { setDeploymentAnnotations } from '../../utils'
 
 const EDITABLE_FIELD_NAMES = [
   'type',

--- a/packages/jira-adapter/src/filters/fields/field_deployment_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_deployment_filter.ts
@@ -15,19 +15,19 @@
 */
 import { Change, Element, getChangeData, InstanceElement, isInstanceChange, isObjectType, isRemovalChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { FilterContext } from '../../config'
 import JiraClient from '../../client/client'
 import { FilterCreator } from '../../filter'
 import { deployContexts, setContextDeploymentAnnotations } from './contexts'
 import { updateDefaultValues } from './default_values'
 import { defaultDeployChange, deployChanges } from '../../deployment'
-import { FIELD_TYPE_NAME } from './utils'
+import { FIELD_TYPE_NAME } from './constants'
+import { JiraConfig } from '../../config'
 
 
 const deployField = async (
   change: Change<InstanceElement>,
   client: JiraClient,
-  config: FilterContext,
+  config: JiraConfig,
 ): Promise<void> => {
   await defaultDeployChange({ change, client, apiDefinitions: config.apiDefinitions, fieldsToIgnore: ['contexts'] })
 

--- a/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
@@ -17,7 +17,8 @@ import { BuiltinTypes, Element, Field, InstanceElement, isInstanceElement, ListT
 import { naclCase } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { FilterCreator } from '../../filter'
-import { FIELD_TYPE_NAME, findObject } from './utils'
+import { findObject } from '../../utils'
+import { FIELD_TYPE_NAME } from './constants'
 
 
 const addTypeValue = (instance: InstanceElement): void => {

--- a/packages/jira-adapter/src/filters/fields/field_type_references_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_type_references_filter.ts
@@ -18,7 +18,8 @@ import { GetLookupNameFunc, naclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { FilterCreator } from '../../filter'
-import { FIELD_TYPE_NAME, findObject } from './utils'
+import { findObject } from '../../utils'
+import { FIELD_TYPE_NAME } from './constants'
 
 const log = logger(module)
 

--- a/packages/jira-adapter/src/filters/screen/screen.ts
+++ b/packages/jira-adapter/src/filters/screen/screen.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { AdditionChange, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isModificationChange, isObjectType, ModificationChange, ReferenceExpression } from '@salto-io/adapter-api'
+import { AdditionChange, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isModificationChange, ModificationChange, ReferenceExpression } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { defaultDeployChange, deployChanges } from '../../deployment'
@@ -21,6 +21,7 @@ import { FilterCreator } from '../../filter'
 import JiraClient from '../../client/client'
 import { JiraConfig } from '../../config'
 import { covertFields } from './fields'
+import { findObject, setDeploymentAnnotations } from '../../utils'
 
 const { awu } = collections.asynciterable
 
@@ -90,14 +91,9 @@ const deployScreen = async (
 
 const filter: FilterCreator = ({ config, client }) => ({
   onFetch: async elements => {
-    const screenType = elements
-      .filter(isObjectType)
-      .find(
-        type => type.elemID.name === SCREEN_TYPE_NAME
-      )
+    const screenType = findObject(elements, SCREEN_TYPE_NAME)
     if (screenType !== undefined) {
-      screenType.fields.tabs.annotations[CORE_ANNOTATIONS.CREATABLE] = true
-      screenType.fields.tabs.annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+      setDeploymentAnnotations(screenType, 'tabs')
     }
 
     covertFields(elements, SCREEN_TYPE_NAME, 'availableFields')

--- a/packages/jira-adapter/src/filters/workflow/workflow.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow.ts
@@ -13,9 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, Element, Field, isInstanceElement, isObjectType, ListType, MapType } from '@salto-io/adapter-api'
+import { BuiltinTypes, Element, Field, isInstanceElement, ListType, MapType } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
+import { findObject } from '../../utils'
 import { FilterCreator } from '../../filter'
 import { postFunctionType, types as postFunctionTypes } from './post_functions_types'
 import { isWorkflowInstance, Rules, Status, Validator, Workflow } from './types'
@@ -123,20 +124,19 @@ const transformWorkflowInstance = (workflowValues: Workflow): void => {
 // This filter transforms the workflow values structure so it will fit its deployment endpoint
 const filter: FilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
-    const types = elements.filter(isObjectType)
-    const workflowType = types.find(element => element.elemID.name === WORKFLOW_TYPE_NAME)
+    const workflowType = findObject(elements, WORKFLOW_TYPE_NAME)
     if (workflowType !== undefined) {
       delete workflowType.fields.id
     }
 
-    const workflowStatusType = types.find(element => element.elemID.name === 'WorkflowStatus')
+    const workflowStatusType = findObject(elements, 'WorkflowStatus')
     if (workflowStatusType === undefined) {
       log.warn('WorkflowStatus type was not received in fetch')
     } else {
       workflowStatusType.fields.properties = new Field(workflowStatusType, 'properties', new MapType(BuiltinTypes.STRING))
     }
 
-    const workflowRulesType = types.find(element => element.elemID.name === 'WorkflowRules')
+    const workflowRulesType = findObject(elements, 'WorkflowRules')
 
     if (workflowRulesType === undefined) {
       log.warn('WorkflowRules type was not received in fetch')

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -176,6 +176,11 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
     serializationStrategy: 'id',
     target: { type: 'Field' },
   },
+  {
+    src: { field: 'id', parentTypes: ['FieldConfigurationItem'] },
+    serializationStrategy: 'id',
+    target: { type: 'Field' },
+  },
 ]
 
 const lookupNameFuncs: GetLookupNameFunc[] = [

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -13,12 +13,16 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { filterUtils } from '@salto-io/adapter-components'
-import JiraClient from './client/client'
-import { JiraConfig } from './config'
+import { CORE_ANNOTATIONS, ObjectType, Element, isObjectType } from '@salto-io/adapter-api'
 
-export const { filtersRunner } = filterUtils
+export const setDeploymentAnnotations = (contextType: ObjectType, fieldName: string): void => {
+  if (contextType.fields[fieldName] !== undefined) {
+    contextType.fields[fieldName].annotations[CORE_ANNOTATIONS.CREATABLE] = true
+    contextType.fields[fieldName].annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+  }
+}
 
-export type Filter = filterUtils.Filter
-
-export type FilterCreator = filterUtils.FilterCreator<JiraClient, JiraConfig>
+export const findObject = (elements: Element[], name: string): ObjectType | undefined =>
+  elements.filter(isObjectType).find(
+    element => element.elemID.name === name
+  )

--- a/packages/jira-adapter/system_config_doc.md
+++ b/packages/jira-adapter/system_config_doc.md
@@ -2,54 +2,141 @@
 ## Default Configuration
 ```hcl
 jira {
-  fetch = {
-    includeTypes = [
-      "rest__api__3__application_properties@uuuuuub",
-      "rest__api__3__applicationrole",
-      "AttachmentSettings",
-      "Configuration",
-      "rest__api__3__configuration__timetracking__list",
-      "PageBeanDashboard",
-      "PageBeanField",
-      "PageBeanFieldConfigurationDetails",
-      "PageBeanFieldConfigurationScheme",
-      "PageBeanFieldConfigurationIssueTypeItem",
-      "PageBeanFilterDetails",
-      "IssueTypeDetails",
-      "IssueLinkTypes",
-      "SecuritySchemes",
-      "PageBeanIssueTypeScheme",
-      "PageBeanIssueTypeSchemeMapping",
-      "PageBeanIssueTypeScreenScheme",
-      "PageBeanIssueTypeScreenSchemeItem",
-      "PageBeanNotificationScheme",
-      "Permissions",
-      "PermissionSchemes",
-      "rest__api__3__priority",
-      "rest__api__3__projectCategory",
-      "PageBeanProject",
-      "rest__api__3__project__type",
-      "rest__api__3__resolution",
-      "rest__api__3__role",
-      "PageBeanScreen",
-      "PageBeanScreenScheme",
-      "rest__api__3__status",
-      "rest__api__3__statuscategory",
-      "PageBeanWorkflow",
-      "PageBeanWorkflowScheme",
-      "ServerInformation",
-      "agile__1_0__board@uuvuu",
-    ]
-  }
   apiDefinitions = {
     platformSwagger = {
       url = "https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json"
+      typeNameOverrides = [
+        {
+          originalName = "FilterDetails"
+          newName = "Filter"
+        },
+        {
+          originalName = "IssueTypeDetails"
+          newName = "IssueType"
+        },
+        {
+          originalName = "StatusDetails"
+          newName = "Status"
+        },
+        {
+          originalName = "rest__api__3__application_properties@uuuuuub"
+          newName = "ApplicationProperties"
+        },
+        {
+          originalName = "rest__api__3__applicationrole"
+          newName = "ApplicationRoles"
+        },
+        {
+          originalName = "rest__api__3__configuration__timetracking__list"
+          newName = "TimeTrackingProviders"
+        },
+        {
+          originalName = "PageBeanDashboard"
+          newName = "Dashboards"
+        },
+        {
+          originalName = "PageBeanField"
+          newName = "Fields"
+        },
+        {
+          originalName = "PageBeanFieldConfigurationDetails"
+          newName = "FieldConfigurations"
+        },
+        {
+          originalName = "FieldConfigurationDetails"
+          newName = "FieldConfiguration"
+        },
+        {
+          originalName = "PageBeanFieldConfigurationScheme"
+          newName = "FieldsConfigurationScheme"
+        },
+        {
+          originalName = "PageBeanFieldConfigurationIssueTypeItem"
+          newName = "FieldsConfigurationIssueTypeItem"
+        },
+        {
+          originalName = "PageBeanFilterDetails"
+          newName = "Filters"
+        },
+        {
+          originalName = "PageBeanIssueTypeScheme"
+          newName = "IssueTypeSchemes"
+        },
+        {
+          originalName = "PageBeanIssueTypeSchemeMapping"
+          newName = "IssueTypeSchemeMappings"
+        },
+        {
+          originalName = "PageBeanIssueTypeScreenScheme"
+          newName = "IssueTypeScreenSchemes"
+        },
+        {
+          originalName = "PageBeanIssueTypeScreenSchemeItem"
+          newName = "IssueTypeScreenSchemeItems"
+        },
+        {
+          originalName = "PageBeanNotificationScheme"
+          newName = "NotificationSchemes"
+        },
+        {
+          originalName = "rest__api__3__priority"
+          newName = "Priorities"
+        },
+        {
+          originalName = "rest__api__3__projectCategory"
+          newName = "ProjectCategories"
+        },
+        {
+          originalName = "PageBeanProject"
+          newName = "Projects"
+        },
+        {
+          originalName = "rest__api__3__project__type"
+          newName = "ProjectTypes"
+        },
+        {
+          originalName = "rest__api__3__resolution"
+          newName = "Resolutions"
+        },
+        {
+          originalName = "rest__api__3__role"
+          newName = "Roles"
+        },
+        {
+          originalName = "PageBeanScreen"
+          newName = "Screens"
+        },
+        {
+          originalName = "PageBeanScreenScheme"
+          newName = "ScreenSchemes"
+        },
+        {
+          originalName = "rest__api__3__status"
+          newName = "Statuses"
+        },
+        {
+          originalName = "rest__api__3__statuscategory"
+          newName = "StatusCategories"
+        },
+        {
+          originalName = "PageBeanWorkflow"
+          newName = "Workflows"
+        },
+        {
+          originalName = "PageBeanWorkflowScheme"
+          newName = "WorkflowSchemes"
+        },
+      ]
     }
     jiraSwagger = {
       url = "https://developer.atlassian.com/cloud/jira/software/swagger.v3.json"
       typeNameOverrides = [
         {
-          originalName = "agile__1_0__board_values@uuvuuu"
+          originalName = "agile__1_0__board@uuvuu"
+          newName = "Boards"
+        },
+        {
+          originalName = "Boards_values"
           newName = "Board"
         },
       ]
@@ -74,12 +161,12 @@ jira {
           isSingleton = true
         }
       }
-      PageBeanDashboard = {
+      Dashboards = {
         request = {
           url = "/rest/api/3/dashboard/search"
           paginationField = "startAt"
           queryParams = {
-            expand = "description,owner,viewUrl,favouritedCount,sharePermissions"
+            expand = "description,owner,sharePermissions"
           }
         }
       }
@@ -108,6 +195,11 @@ jira {
               fieldName = "id"
             },
           ]
+          fieldsToOmit = [
+            {
+              fieldName = "isFavourite"
+            },
+          ]
         }
         deployRequests = {
           add = {
@@ -124,12 +216,12 @@ jira {
           }
         }
       }
-      PageBeanField = {
+      Fields = {
         request = {
           url = "/rest/api/3/field/search"
           paginationField = "startAt"
           queryParams = {
-            expand = "key,searcherKey"
+            expand = "searcherKey,isLocked"
           }
           recurseInto = [
             {
@@ -259,6 +351,13 @@ jira {
         }
       }
       ApplicationProperty = {
+        transformation = {
+          fieldsToOmit = [
+            {
+              fieldName = "key"
+            },
+          ]
+        }
         deployRequests = {
           modify = {
             url = "/rest/api/3/application-properties/{id}"
@@ -296,12 +395,34 @@ jira {
           ]
         }
       }
+      CustomFieldContextOption = {
+        transformation = {
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+        }
+      }
       CustomFieldContext = {
         transformation = {
           fieldTypeOverrides = [
             {
               fieldName = "options"
               fieldType = "list<CustomFieldContextOption>"
+            },
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "id"
+            },
+          ]
+          fieldsToOmit = [
+            {
+              fieldName = "isGlobalContext"
+            },
+            {
+              fieldName = "isAnyIssueType"
             },
           ]
         }
@@ -332,7 +453,7 @@ jira {
           paginationField = "startAt"
         }
       }
-      PageBeanFieldConfigurationDetails = {
+      FieldConfigurations = {
         request = {
           url = "/rest/api/3/fieldconfiguration"
           paginationField = "startAt"
@@ -350,12 +471,16 @@ jira {
           ]
         }
       }
-      FieldConfigurationDetails = {
+      FieldConfiguration = {
         transformation = {
           fieldTypeOverrides = [
             {
               fieldName = "fields"
               fieldType = "list<FieldConfigurationItem>"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
             },
           ]
           fieldsToHide = [
@@ -364,6 +489,20 @@ jira {
             },
           ]
         }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/fieldconfiguration"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/fieldconfiguration/{id}"
+            method = "put"
+          }
+          remove = {
+            url = "/rest/api/3/fieldconfiguration/{id}"
+            method = "delete"
+          }
+        }
       }
       PageBeanFieldConfigurationItem = {
         request = {
@@ -371,13 +510,13 @@ jira {
           paginationField = "startAt"
         }
       }
-      PageBeanFieldConfigurationScheme = {
+      FieldsConfigurationScheme = {
         request = {
           url = "/rest/api/3/fieldconfigurationscheme"
           paginationField = "startAt"
           recurseInto = [
             {
-              type = "PageBeanFieldConfigurationIssueTypeItem"
+              type = "FieldsConfigurationIssueTypeItem"
               toField = "items"
               context = [
                 {
@@ -404,7 +543,7 @@ jira {
           ]
         }
       }
-      PageBeanFieldConfigurationIssueTypeItem = {
+      FieldsConfigurationIssueTypeItem = {
         request = {
           url = "/rest/api/3/fieldconfigurationscheme/mapping?fieldConfigurationSchemeId={schemeId}"
           paginationField = "startAt"
@@ -419,11 +558,11 @@ jira {
           ]
         }
       }
-      PageBeanFilterDetails = {
+      Filters = {
         request = {
           url = "/rest/api/3/filter/search"
           queryParams = {
-            expand = "description,owner,jql,searchUrl,viewUrl,sharePermissions,subscriptions"
+            expand = "description,owner,jql,sharePermissions,subscriptions"
           }
           paginationField = "startAt"
           recurseInto = [
@@ -440,7 +579,7 @@ jira {
           ]
         }
       }
-      FilterDetails = {
+      Filter = {
         transformation = {
           fieldTypeOverrides = [
             {
@@ -469,14 +608,14 @@ jira {
           }
         }
       }
-      PageBeanIssueTypeScheme = {
+      IssueTypeSchemes = {
         request = {
           url = "/rest/api/3/issuetypescheme"
           paginationField = "startAt"
           recurseInto = [
             {
-              type = "PageBeanIssueTypeSchemeMapping"
-              toField = "issueTypes"
+              type = "IssueTypeSchemeMappings"
+              toField = "issueTypeIds"
               context = [
                 {
                   name = "schemeId"
@@ -500,15 +639,11 @@ jira {
         transformation = {
           fieldTypeOverrides = [
             {
-              fieldName = "issueTypes"
+              fieldName = "issueTypeIds"
               fieldType = "list<IssueTypeSchemeMapping>"
             },
           ]
-          fieldsToHide = [
-            {
-              fieldName = "id"
-            },
-          ]
+          serviceIdField = "issueTypeSchemeId"
         }
         deployRequests = {
           add = {
@@ -518,20 +653,14 @@ jira {
           modify = {
             url = "/rest/api/3/issuetypescheme/{issueTypeSchemeId}"
             method = "put"
-            urlParamsToFields = {
-              issueTypeSchemeId = "id"
-            }
           }
           remove = {
             url = "/rest/api/3/issuetypescheme/{issueTypeSchemeId}"
             method = "delete"
-            urlParamsToFields = {
-              issueTypeSchemeId = "id"
-            }
           }
         }
       }
-      PageBeanIssueTypeSchemeMapping = {
+      IssueTypeSchemeMappings = {
         request = {
           url = "/rest/api/3/issuetypescheme/mapping?issueTypeSchemeId={schemeId}"
           paginationField = "startAt"
@@ -546,14 +675,14 @@ jira {
           ]
         }
       }
-      PageBeanIssueTypeScreenScheme = {
+      IssueTypeScreenSchemes = {
         request = {
           url = "/rest/api/3/issuetypescreenscheme"
           paginationField = "startAt"
           recurseInto = [
             {
-              type = "PageBeanIssueTypeScreenSchemeItem"
-              toField = "items"
+              type = "IssueTypeScreenSchemeItems"
+              toField = "issueTypeMappings"
               context = [
                 {
                   name = "schemeId"
@@ -568,7 +697,7 @@ jira {
         transformation = {
           fieldTypeOverrides = [
             {
-              fieldName = "items"
+              fieldName = "issueTypeMappings"
               fieldType = "list<IssueTypeScreenSchemeItem>"
             },
           ]
@@ -603,7 +732,7 @@ jira {
           }
         }
       }
-      PageBeanIssueTypeScreenSchemeItem = {
+      IssueTypeScreenSchemeItems = {
         request = {
           url = "/rest/api/3/issuetypescreenscheme/mapping?issueTypeScreenSchemeId={schemeId}"
           paginationField = "startAt"
@@ -618,7 +747,7 @@ jira {
           ]
         }
       }
-      PageBeanNotificationScheme = {
+      NotificationSchemes = {
         request = {
           url = "/rest/api/3/notificationscheme"
           queryParams = {
@@ -636,8 +765,18 @@ jira {
         request = {
           url = "/rest/api/3/permissionscheme"
           queryParams = {
-            expand = "all"
+            expand = "permissions,user"
           }
+        }
+      }
+      PermissionHolder = {
+        transformation = {
+          fieldTypeOverrides = [
+            {
+              fieldName = "user"
+              fieldType = "User"
+            },
+          ]
         }
       }
       PermissionGrant = {
@@ -691,7 +830,7 @@ jira {
           ]
         }
       }
-      PageBeanProject = {
+      Projects = {
         request = {
           url = "/rest/api/3/project/search"
           queryParams = {
@@ -717,6 +856,7 @@ jira {
                   fromField = "id"
                 },
               ]
+              isSingle = true
             },
             {
               type = "PermissionScheme"
@@ -727,6 +867,7 @@ jira {
                   fromField = "id"
                 },
               ]
+              isSingle = true
             },
             {
               type = "NotificationScheme"
@@ -737,6 +878,7 @@ jira {
                   fromField = "id"
                 },
               ]
+              isSingle = true
             },
             {
               type = "PageBeanIssueTypeScreenSchemesProjects"
@@ -747,6 +889,7 @@ jira {
                   fromField = "id"
                 },
               ]
+              isSingle = true
             },
             {
               type = "PageBeanFieldConfigurationSchemeProjects"
@@ -757,6 +900,7 @@ jira {
                   fromField = "id"
                 },
               ]
+              isSingle = true
             },
           ]
         }
@@ -778,33 +922,59 @@ jira {
             },
           ]
         }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/projectCategory"
+            method = "post"
+          }
+          modify = {
+            url = "/rest/api/3/projectCategory/{id}"
+            method = "put"
+          }
+          remove = {
+            url = "/rest/api/3/projectCategory/{id}"
+            method = "delete"
+          }
+        }
       }
       Project = {
         transformation = {
           fieldTypeOverrides = [
+            {
+              fieldName = "projectKeys"
+              fieldType = "List<string>"
+            },
+            {
+              fieldName = "entityId"
+              fieldType = "string"
+            },
+            {
+              fieldName = "leadAccountId"
+              fieldType = "string"
+            },
             {
               fieldName = "components"
               fieldType = "list<ComponentWithIssueCount>"
             },
             {
               fieldName = "workflowScheme"
-              fieldType = "list<WorkflowSchemeAssociations>"
+              fieldType = "WorkflowScheme"
             },
             {
               fieldName = "permissionScheme"
-              fieldType = "list<PermissionScheme>"
+              fieldType = "PermissionScheme"
             },
             {
               fieldName = "notificationScheme"
-              fieldType = "list<NotificationScheme>"
+              fieldType = "NotificationScheme"
             },
             {
               fieldName = "issueTypeScreenScheme"
-              fieldType = "list<IssueTypeScreenSchemesProjects>"
+              fieldType = "IssueTypeScreenScheme"
             },
             {
               fieldName = "fieldConfigurationScheme"
-              fieldType = "list<FieldConfigurationSchemeProjects>"
+              fieldType = "FieldConfigurationScheme"
             },
           ]
           fieldsToHide = [
@@ -894,7 +1064,7 @@ jira {
           url = "/rest/api/3/fieldconfigurationscheme/project?projectId={projectId}"
         }
       }
-      PageBeanScreen = {
+      Screens = {
         request = {
           url = "/rest/api/3/screens"
           paginationField = "startAt"
@@ -1009,19 +1179,44 @@ jira {
             },
           ]
         }
+        deployRequests = {
+          add = {
+            url = "/rest/api/3/screens/{screenId}/tabs"
+            method = "post"
+            urlParamsToFields = {
+              screenId = "_parent.0.id"
+            }
+          }
+          modify = {
+            url = "/rest/api/3/screens/{screenId}/tabs/{tabId}"
+            method = "put"
+            urlParamsToFields = {
+              screenId = "_parent.0.id"
+              tabId = "id"
+            }
+          }
+          remove = {
+            url = "/rest/api/3/screens/{screenId}/tabs/{tabId}"
+            method = "delete"
+            urlParamsToFields = {
+              screenId = "_parent.0.id"
+              tabId = "id"
+            }
+          }
+        }
       }
-      PageBeanScreenScheme = {
+      ScreenSchemes = {
         request = {
           url = "/rest/api/3/screenscheme"
           paginationField = "startAt"
         }
       }
-      rest__api__3__status = {
+      Statuses = {
         transformation = {
           dataField = "."
         }
       }
-      PageBeanWorkflow = {
+      Workflows = {
         request = {
           url = "/rest/api/3/workflow/search"
           paginationField = "startAt"
@@ -1068,10 +1263,25 @@ jira {
       }
       Workflow = {
         transformation = {
+          fieldTypeOverrides = [
+            {
+              fieldName = "name"
+              fieldType = "string"
+            },
+            {
+              fieldName = "entityId"
+              fieldType = "string"
+            },
+          ]
           idFields = [
             "id.name",
           ]
           serviceIdField = "entityId"
+          fieldsToHide = [
+            {
+              fieldName = "entityId"
+            },
+          ]
           fieldsToOmit = [
             {
               fieldName = "created"
@@ -1092,7 +1302,7 @@ jira {
           }
         }
       }
-      PageBeanWorkflowScheme = {
+      WorkflowSchemes = {
         request = {
           url = "/rest/api/3/workflowscheme"
           paginationField = "startAt"
@@ -1116,7 +1326,7 @@ jira {
           ]
         }
       }
-      StatusDetails = {
+      Status = {
         transformation = {
           fieldsToHide = [
             {
@@ -1148,12 +1358,23 @@ jira {
           }
         }
       }
-      IssueTypeDetails = {
+      IssueType = {
         request = {
           url = "/rest/api/3/issuetype"
         }
         transformation = {
           dataField = "."
+          fieldTypeOverrides = [
+            {
+              fieldName = "untranslatedName"
+              fieldType = "string"
+            },
+          ]
+          fieldsToOmit = [
+            {
+              fieldName = "subtask"
+            },
+          ]
           fieldsToHide = [
             {
               fieldName = "id"
@@ -1185,7 +1406,7 @@ jira {
           isSingleton = true
         }
       }
-      agile__1_0__board@uuvuu = {
+      Boards = {
         request = {
           url = "/rest/agile/1.0/board"
           paginationField = "startAt"
@@ -1202,6 +1423,7 @@ jira {
                   fromField = "id"
                 },
               ]
+              isSingle = true
             },
           ]
         }
@@ -1211,7 +1433,11 @@ jira {
           fieldTypeOverrides = [
             {
               fieldName = "config"
-              fieldType = "list<agile__1_0__board___boardId___configuration@uuvuuuu_00123_00125uu>"
+              fieldType = "agile__1_0__board___boardId___configuration@uuvuuuu_00123_00125uu"
+            },
+            {
+              fieldName = "filterId"
+              fieldType = "string"
             },
           ]
           fieldsToHide = [

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -19,7 +19,7 @@ import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { mockFunction } from '@salto-io/test-utils'
 import JiraClient from '../src/client/client'
 import { adapter as adapterCreator } from '../src/adapter_creator'
-import { DEFAULT_INCLUDE_ENDPOINTS, DEFAULT_API_DEFINITIONS } from '../src/config'
+import { DEFAULT_CONFIG } from '../src/config'
 import { JIRA } from '../src/constants'
 import { createCredentialsInstance, createConfigInstance } from './utils'
 
@@ -55,10 +55,7 @@ describe('adapter', () => {
     adapter = adapterCreator.operations({
       elementsSource,
       credentials: createCredentialsInstance({ baseUrl: 'http:/jira.net', user: 'u', token: 't' }),
-      config: createConfigInstance({
-        apiDefinitions: DEFAULT_API_DEFINITIONS,
-        fetch: { includeTypes: DEFAULT_INCLUDE_ENDPOINTS },
-      }),
+      config: createConfigInstance(DEFAULT_CONFIG),
     })
   })
   describe('deploy', () => {

--- a/packages/jira-adapter/test/adapter_creator.test.ts
+++ b/packages/jira-adapter/test/adapter_creator.test.ts
@@ -19,7 +19,7 @@ import { ObjectType, InstanceElement, AccountId, ReadOnlyElementsSource, Adapter
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { adapter } from '../src/adapter_creator'
 import JiraAdapter from '../src/adapter'
-import { JiraConfig, DEFAULT_API_DEFINITIONS, DEFAULT_INCLUDE_ENDPOINTS } from '../src/config'
+import { JiraConfig, DEFAULT_CONFIG } from '../src/config'
 import { createCredentialsInstance, createConfigInstance } from './utils'
 
 describe('adapter creator', () => {
@@ -74,10 +74,6 @@ describe('adapter creator', () => {
   describe('create adapter', () => {
     let elementsSource: ReadOnlyElementsSource
     let credentialsInstance: InstanceElement
-    const defaultConfig: JiraConfig = {
-      apiDefinitions: DEFAULT_API_DEFINITIONS,
-      fetch: { includeTypes: DEFAULT_INCLUDE_ENDPOINTS },
-    }
     beforeEach(() => {
       elementsSource = buildElementsSourceFromElements([])
       credentialsInstance = createCredentialsInstance({ baseUrl: 'url', user: 'u', token: 't' })
@@ -86,7 +82,7 @@ describe('adapter creator', () => {
       let result: AdapterOperations
       beforeEach(() => {
         const configWithExtraValue = {
-          ...defaultConfig,
+          ...DEFAULT_CONFIG,
           extraValue: true,
         }
         result = adapter.operations({
@@ -114,7 +110,7 @@ describe('adapter creator', () => {
           elementsSource,
           credentials: credentialsInstance,
           config: createConfigInstance({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             fetch: undefined,
           } as unknown as JiraConfig),
         })).toThrow()
@@ -127,7 +123,7 @@ describe('adapter creator', () => {
           elementsSource,
           credentials: credentialsInstance,
           config: createConfigInstance({
-            ...defaultConfig,
+            ...DEFAULT_CONFIG,
             apiDefinitions: { typeDefaults: 2 },
           } as unknown as JiraConfig),
         })).toThrow()

--- a/packages/jira-adapter/test/change_validators/change_validator.test.ts
+++ b/packages/jira-adapter/test/change_validators/change_validator.test.ts
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 import { toChange, ObjectType, ElemID } from '@salto-io/adapter-api'
-import changeValidator from '../src/change_validator'
-import { JIRA } from '../src/constants'
+import changeValidator from '../../src/change_validators'
+import { JIRA } from '../../src/constants'
 
 describe('change validator creator', () => {
   describe('checkDeploymentAnnotationsValidator', () => {

--- a/packages/jira-adapter/test/change_validators/field_configuration.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_configuration.test.ts
@@ -1,0 +1,104 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { unsupportedFieldConfigurationsValidator } from '../../src/change_validators/field_configuration'
+import { JIRA } from '../../src/constants'
+
+describe('unsupportedFieldConfigurationsValidator', () => {
+  let type: ObjectType
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    type = new ObjectType({ elemID: new ElemID(JIRA, 'FieldConfiguration') })
+    instance = new InstanceElement('instance', type)
+  })
+  it('should return an error if id is not a reference', async () => {
+    instance.value.fields = [{
+      id: 'id',
+    }]
+
+    expect(await unsupportedFieldConfigurationsValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Warning',
+        message: `Salto can't deploy fields configuration of ${instance.elemID.getFullName()} because they are either locked or team-managed`,
+        detailedMessage: 'Salto can\'t deploy the configuration of fields: id. If continuing, they will be omitted from the deployment',
+      },
+    ])
+  })
+
+  it('should return an error if id is a reference to a locked field', async () => {
+    instance.value.fields = [{
+      id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'inst'), {
+        value: {
+          id: 'inst',
+          isLocked: true,
+        },
+      }),
+    }]
+
+    expect(await unsupportedFieldConfigurationsValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Warning',
+        message: `Salto can't deploy fields configuration of ${instance.elemID.getFullName()} because they are either locked or team-managed`,
+        detailedMessage: 'Salto can\'t deploy the configuration of fields: inst. If continuing, they will be omitted from the deployment',
+      },
+    ])
+  })
+
+  it('should not return an error if field configuration is valid', async () => {
+    instance.value.fields = [{
+      id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'inst'), {
+        value: {
+          id: 'inst',
+        },
+      }),
+    }]
+
+    expect(await unsupportedFieldConfigurationsValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([])
+  })
+
+  it('should not return an error if an invalid field config was not changed', async () => {
+    instance.value.fields = [{
+      id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'inst'), {
+        value: {
+          id: 'inst',
+          isLocked: true,
+        },
+      }),
+    }]
+
+    expect(await unsupportedFieldConfigurationsValidator([
+      toChange({
+        before: instance,
+        after: instance,
+      }),
+    ])).toEqual([])
+  })
+})

--- a/packages/jira-adapter/test/filters/field_configuration.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration.test.ts
@@ -1,0 +1,198 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { filterUtils, client as clientUtils, deployment } from '@salto-io/adapter-components'
+import { resolveChangeElement } from '@salto-io/adapter-utils'
+import { MockInterface } from '@salto-io/test-utils'
+import _ from 'lodash'
+import { getLookUpName } from '../../src/references'
+import JiraClient from '../../src/client/client'
+import { DEFAULT_CONFIG } from '../../src/config'
+import { JIRA } from '../../src/constants'
+import fieldConfigurationFilter from '../../src/filters/field_configuration'
+import { mockClient } from '../utils'
+
+const { deployChange } = deployment
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn(),
+    },
+  }
+})
+
+describe('fieldConfigurationFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let fieldConfigurationType: ObjectType
+  let fieldConfigurationItemType: ObjectType
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let mockCli: JiraClient
+
+  beforeEach(async () => {
+    const { client, paginator, connection } = mockClient()
+    mockConnection = connection
+    mockCli = client
+
+    filter = fieldConfigurationFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    }) as typeof filter
+
+    fieldConfigurationItemType = new ObjectType({
+      elemID: new ElemID(JIRA, 'FieldConfigurationItem'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+        description: { refType: BuiltinTypes.STRING },
+        isHidden: { refType: BuiltinTypes.BOOLEAN },
+        isRequired: { refType: BuiltinTypes.BOOLEAN },
+        renderer: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    fieldConfigurationType = new ObjectType({
+      elemID: new ElemID(JIRA, 'FieldConfiguration'),
+      fields: {
+        fields: { refType: new ListType(fieldConfigurationItemType) },
+      },
+    })
+  })
+
+  describe('onFetch', () => {
+    it('should add deployment annotations to FieldConfiguration', async () => {
+      await filter.onFetch([fieldConfigurationType])
+      expect(fieldConfigurationType.fields.fields.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+    })
+
+    it('should add deployment annotations to FieldConfigurationItem', async () => {
+      await filter.onFetch([fieldConfigurationItemType])
+      expect(fieldConfigurationItemType.fields.id.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(fieldConfigurationItemType.fields.description.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(fieldConfigurationItemType.fields.isHidden.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(fieldConfigurationItemType.fields.isRequired.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(fieldConfigurationItemType.fields.renderer.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+    })
+  })
+
+  describe('deploy', () => {
+    const supportedFields = _.range(0, 150).map(i => ({
+      id: new ReferenceExpression(
+        new ElemID(JIRA, 'Field', 'instance', `supported${i}`),
+        {
+          value: {
+            id: `supported${i}`,
+          },
+        }
+      ),
+    }))
+
+    let instance: InstanceElement
+    let change: Change<InstanceElement>
+
+    beforeEach(async () => {
+      instance = new InstanceElement(
+        'instance',
+        fieldConfigurationType,
+        {
+          name: 'name',
+          id: 1,
+          fields: [
+            {
+              id: 'notSupported1',
+            },
+            {
+              id: new ReferenceExpression(
+                new ElemID(JIRA, 'Field', 'instance', 'notSupported2'),
+                {
+                  value: {
+                    id: 'notSupported2',
+                    isLocked: true,
+                  },
+                }
+              ),
+            },
+            ...supportedFields,
+          ],
+        }
+      )
+
+      change = toChange({ before: instance, after: instance })
+    })
+
+    it('should deploy regular fields using deployChange', async () => {
+      await filter.deploy([change])
+      expect(deployChange).toHaveBeenCalledWith(
+        await resolveChangeElement(change, getLookUpName),
+        mockCli,
+        DEFAULT_CONFIG.apiDefinitions.types.FieldConfiguration.deployRequests,
+        ['fields'],
+        undefined,
+      )
+    })
+
+    it('should deploy supported fields configuration in chunks', async () => {
+      await filter.deploy([change])
+      expect(mockConnection.put).toHaveBeenCalledWith(
+        '/rest/api/3/fieldconfiguration/1/fields',
+        {
+          fieldConfigurationItems: supportedFields.slice(0, 100)
+            .map(field => ({ ...field, id: field.id.value.value.id })),
+        },
+        undefined,
+      )
+      expect(mockConnection.put).toHaveBeenCalledWith(
+        '/rest/api/3/fieldconfiguration/1/fields',
+        {
+          fieldConfigurationItems: supportedFields.slice(100, supportedFields.length)
+            .map(field => ({ ...field, id: field.id.value.value.id })),
+        },
+        undefined,
+      )
+    })
+
+    it('should not deploy fields configuration if empty', async () => {
+      delete instance.value.fields
+      await filter.deploy([change])
+      expect(mockConnection.put).not.toHaveBeenCalledWith()
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/field_configuration.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration.test.ts
@@ -18,7 +18,7 @@ import { filterUtils, client as clientUtils, deployment } from '@salto-io/adapte
 import { resolveChangeElement } from '@salto-io/adapter-utils'
 import { MockInterface } from '@salto-io/test-utils'
 import _ from 'lodash'
-import { getLookUpName } from '../../src/references'
+import { getLookUpName } from '../../src/reference_mapping'
 import JiraClient from '../../src/client/client'
 import { DEFAULT_CONFIG } from '../../src/config'
 import { JIRA } from '../../src/constants'


### PR DESCRIPTION
Added support for deploying field configuration

Only the last commit is relevant
This PR is build on https://github.com/salto-io/salto/pull/2598

---

- Added support for deploying field configuration items
- Added change validator when trying to deploy a change validator that is read-only or team-managed

---
_Release Notes_: 
None

---
_User Notifications_: 
None