### PR TITLE
SALTO-1778-field-configuration-scheme-deploy

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -33,6 +33,7 @@ import screenFilter from './filters/screen/screen'
 import screenableTabFilter from './filters/screen/screenable_tab'
 import issueTypeScreenSchemeFilter from './filters/issue_type_screen_scheme'
 import fieldConfigurationFilter from './filters/field_configuration'
+import fieldConfigurationSchemeFilter from './filters/field_configurations_scheme'
 import hiddenValuesInListsFilter from './filters/hidden_value_in_lists'
 import projectFilter from './filters/project'
 import defaultInstancesDeployFilter from './filters/default_instances_deploy'
@@ -66,6 +67,7 @@ export const DEFAULT_FILTERS = [
   screenableTabFilter,
   issueTypeScreenSchemeFilter,
   fieldConfigurationFilter,
+  fieldConfigurationSchemeFilter,
   referenceBySelfLinkFilter,
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -345,6 +345,20 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         },
       ],
     },
+    deployRequests: {
+      add: {
+        url: '/rest/api/3/fieldconfigurationscheme',
+        method: 'post',
+      },
+      modify: {
+        url: '/rest/api/3/fieldconfigurationscheme/{id}',
+        method: 'put',
+      },
+      remove: {
+        url: '/rest/api/3/fieldconfigurationscheme/{id}',
+        method: 'delete',
+      },
+    },
   },
 
   FieldsConfigurationIssueTypeItem: {

--- a/packages/jira-adapter/src/diff.ts
+++ b/packages/jira-adapter/src/diff.ts
@@ -13,6 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { Values } from '@salto-io/adapter-api'
+
 export const getDiffIds = (
   beforeIds: string[],
   afterIds: string[],
@@ -26,5 +28,24 @@ export const getDiffIds = (
   return {
     addedIds: Array.from(afterIds).filter(id => !beforeIdsSet.has(id)),
     removedIds: Array.from(beforeIds).filter(id => !afterIdsSet.has(id)),
+  }
+}
+
+export const getDiffObjects = (
+  beforeObjects: Values[],
+  afterObjects: Values[],
+  idField: string,
+): {
+  addedObjects: Values[]
+  modifiedObjects: Values[]
+  removedObjects: Values[]
+ } => {
+  const beforeIds = new Set(beforeObjects.map(obj => obj[idField]))
+  const afterIds = new Set(afterObjects.map(obj => obj[idField]))
+
+  return {
+    addedObjects: afterObjects.filter(obj => !beforeIds.has(obj[idField])),
+    removedObjects: beforeObjects.filter(obj => !afterIds.has(obj[idField])),
+    modifiedObjects: afterObjects.filter(obj => beforeIds.has(obj[idField])),
   }
 }

--- a/packages/jira-adapter/src/filters/field_configurations_scheme.ts
+++ b/packages/jira-adapter/src/filters/field_configurations_scheme.ts
@@ -1,0 +1,144 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isModificationChange, isObjectType, Value, Values } from '@salto-io/adapter-api'
+import { resolveChangeElement } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { getLookUpName } from '../reference_mapping'
+import JiraClient from '../client/client'
+import { JiraConfig } from '../config'
+import { defaultDeployChange, deployChanges } from '../deployment'
+import { FilterCreator } from '../filter'
+
+const FIELD_CONFIG_SCHEME_NAME = 'FieldConfigurationScheme'
+const FIELD_CONFIG_SCHEME_ITEM_NAME = 'FieldConfigurationIssueTypeItem'
+
+const log = logger(module)
+
+const deployFieldConfigSchemeItems = async (
+  change: Change<InstanceElement>,
+  client: JiraClient,
+): Promise<void> => {
+  const resolvedChange = await resolveChangeElement(change, getLookUpName)
+
+  const afterIds = new Set(isAdditionOrModificationChange(resolvedChange)
+    ? resolvedChange.data.after.value.items?.map((item: Values) => item.issueTypeId) ?? []
+    : [])
+
+
+  const itemsToAdd = isAdditionOrModificationChange(resolvedChange)
+    ? resolvedChange.data.after.value.items ?? []
+    : []
+
+  const itemsToRemove = isModificationChange(resolvedChange)
+    ? resolvedChange.data.before.value.items
+      ?.map((item: Values) => item.issueTypeId)
+      .filter(
+        (issueTypeId: Value) => !afterIds.has(issueTypeId)
+      ) ?? []
+    : []
+
+  const instance = getChangeData(change)
+  if (itemsToAdd.length > 0) {
+    await client.put({
+      url: `/rest/api/3/fieldconfigurationscheme/${instance.value.id}/mapping`,
+      data: {
+        mappings: itemsToAdd,
+      },
+    })
+  }
+
+  if (itemsToRemove.length > 0) {
+    await client.post({
+      url: `/rest/api/3/fieldconfigurationscheme/${instance.value.id}/mapping/delete`,
+      data: {
+        issueTypeIds: itemsToRemove,
+      },
+    })
+  }
+}
+
+const deployFieldConfigScheme = async (
+  change: Change<InstanceElement>,
+  client: JiraClient,
+  config: JiraConfig,
+): Promise<void> => {
+  await defaultDeployChange({
+    change,
+    client,
+    apiDefinitions: config.apiDefinitions,
+    fieldsToIgnore: ['items'],
+  })
+  await deployFieldConfigSchemeItems(change, client)
+}
+
+const filter: FilterCreator = ({ config, client }) => ({
+  onFetch: async elements => {
+    const types = elements.filter(isObjectType)
+    const fieldConfigurationSchemeType = types.find(
+      type => type.elemID.name === FIELD_CONFIG_SCHEME_NAME
+    )
+
+    if (fieldConfigurationSchemeType === undefined) {
+      log.warn(`${FIELD_CONFIG_SCHEME_NAME} type not found`)
+    } else {
+      fieldConfigurationSchemeType.fields.items.annotations[CORE_ANNOTATIONS.CREATABLE] = true
+      fieldConfigurationSchemeType.fields.items.annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+    }
+
+    const fieldConfigurationIssueTypeItemType = types.find(
+      type => type.elemID.name === FIELD_CONFIG_SCHEME_ITEM_NAME
+    )
+
+    if (fieldConfigurationIssueTypeItemType === undefined) {
+      log.warn(`${FIELD_CONFIG_SCHEME_ITEM_NAME} type not found`)
+    } else {
+      fieldConfigurationIssueTypeItemType.fields.issueTypeId
+        .annotations[CORE_ANNOTATIONS.CREATABLE] = true
+      fieldConfigurationIssueTypeItemType.fields.issueTypeId
+        .annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+
+      fieldConfigurationIssueTypeItemType.fields.fieldConfigurationId
+        .annotations[CORE_ANNOTATIONS.CREATABLE] = true
+      fieldConfigurationIssueTypeItemType.fields.fieldConfigurationId
+        .annotations[CORE_ANNOTATIONS.UPDATABLE] = true
+    }
+  },
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && isAdditionOrModificationChange(change)
+        && getChangeData(change).elemID.typeName === FIELD_CONFIG_SCHEME_NAME
+    )
+
+    const deployResult = await deployChanges(
+      relevantChanges.filter(isInstanceChange),
+      async change => deployFieldConfigScheme(
+        change,
+        client,
+        config
+      )
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/test/filters/field_configurations_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/field_configurations_scheme.test.ts
@@ -1,0 +1,249 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, ObjectType, toChange } from '@salto-io/adapter-api'
+import { deployment, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import { JIRA } from '../../src/constants'
+import { mockClient } from '../utils'
+import fieldConfigurationsSchemeFilter from '../../src/filters/field_configurations_scheme'
+import { Filter } from '../../src/filter'
+import JiraClient from '../../src/client/client'
+import { DEFAULT_CONFIG } from '../../src/config'
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn(),
+    },
+  }
+})
+
+describe('field_configurations_scheme', () => {
+  let fieldConfigSchemeType: ObjectType
+  let fieldConfigIssueTypeItemType: ObjectType
+  let filter: Filter
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  beforeEach(async () => {
+    const { client, paginator, connection } = mockClient()
+    mockConnection = connection
+
+    filter = fieldConfigurationsSchemeFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    })
+
+    fieldConfigIssueTypeItemType = new ObjectType({
+      elemID: new ElemID(JIRA, 'FieldConfigurationIssueTypeItem'),
+      fields: {
+        issueTypeId: { refType: BuiltinTypes.STRING },
+        fieldConfigurationId: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    fieldConfigSchemeType = new ObjectType({
+      elemID: new ElemID(JIRA, 'FieldConfigurationScheme'),
+      fields: {
+        items: { refType: new ListType(fieldConfigIssueTypeItemType) },
+      },
+    })
+  })
+
+  describe('onFetch', () => {
+    it('should add deployment annotations to FieldConfigurationScheme', async () => {
+      await filter.onFetch?.([fieldConfigSchemeType])
+      expect(fieldConfigSchemeType.fields.items.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+    })
+
+    it('should add deployment annotations to FieldConfigurationIssueTypeItem', async () => {
+      await filter.onFetch?.([fieldConfigIssueTypeItemType])
+      expect(fieldConfigIssueTypeItemType.fields.issueTypeId.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      await filter.onFetch?.([fieldConfigIssueTypeItemType])
+      expect(fieldConfigIssueTypeItemType.fields.fieldConfigurationId.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+    })
+  })
+
+  describe('deploy', () => {
+    it('should return irrelevant changes in leftoverChanges', async () => {
+      const res = await filter.deploy?.([
+        toChange({ after: fieldConfigSchemeType }),
+        toChange({ before: new InstanceElement('instance1', fieldConfigSchemeType) }),
+        toChange({ after: new InstanceElement('instance1', fieldConfigIssueTypeItemType) }),
+      ])
+      expect(res?.leftoverChanges).toHaveLength(3)
+      expect(res?.deployResult).toEqual({ appliedChanges: [], errors: [] })
+    })
+
+    describe('When deploying a change', () => {
+      const deployChangeMock = deployment.deployChange as jest.MockedFunction<
+        typeof deployment.deployChange
+      >
+      let change: Change<InstanceElement>
+
+      beforeEach(async () => {
+        const beforeInstance = new InstanceElement(
+          'instance',
+          fieldConfigSchemeType,
+          {
+            name: 'name',
+            items: [
+              {
+                issueTypeId: '1',
+                fieldConfigurationId: '1',
+              },
+              {
+                issueTypeId: '2',
+                fieldConfigurationId: '2',
+              },
+            ],
+          }
+        )
+
+        const afterInstance = new InstanceElement(
+          'instance',
+          fieldConfigSchemeType,
+          {
+            id: '1',
+            name: 'name',
+            items: [
+              {
+                issueTypeId: '1',
+                fieldConfigurationId: '1',
+              },
+              {
+                issueTypeId: '3',
+                fieldConfigurationId: '3',
+              },
+            ],
+          }
+        )
+
+        change = toChange({ before: beforeInstance, after: afterInstance })
+
+        await filter.deploy?.([change])
+      })
+      it('should call deployChange and ignore items', () => {
+        expect(deployChangeMock).toHaveBeenCalledWith(
+          change,
+          expect.any(JiraClient),
+          expect.any(Object),
+          ['items'],
+          undefined
+        )
+      })
+
+      it('should call the endpoint to add the new items', () => {
+        expect(mockConnection.put).toHaveBeenCalledWith(
+          '/rest/api/3/fieldconfigurationscheme/1/mapping',
+          {
+            mappings: [
+              {
+                issueTypeId: '1',
+                fieldConfigurationId: '1',
+              },
+              {
+                issueTypeId: '3',
+                fieldConfigurationId: '3',
+              },
+            ],
+          },
+          undefined,
+        )
+      })
+
+      it('should call the endpoint to remove the removed items', () => {
+        expect(mockConnection.post).toHaveBeenCalledWith(
+          '/rest/api/3/fieldconfigurationscheme/1/mapping/delete',
+          {
+            issueTypeIds: ['2'],
+          },
+          undefined,
+        )
+      })
+    })
+
+    it('should not call the new items endpoint of there are no new items', async () => {
+      const beforeInstance = new InstanceElement(
+        'instance',
+        fieldConfigSchemeType,
+        {
+          items: [
+            {
+              issueTypeId: '1',
+              fieldConfigurationId: '1',
+            },
+            {
+              issueTypeId: '2',
+              fieldConfigurationId: '2',
+            },
+          ],
+        }
+      )
+
+      const afterInstance = new InstanceElement(
+        'instance',
+        fieldConfigSchemeType,
+      )
+
+      await filter.deploy?.([toChange({ before: beforeInstance, after: afterInstance })])
+      expect(mockConnection.put).not.toHaveBeenCalledWith()
+    })
+
+    it('should not call the remove items endpoint of there are no removed items', async () => {
+      const beforeInstance = new InstanceElement(
+        'instance',
+        fieldConfigSchemeType,
+      )
+
+      const afterInstance = new InstanceElement(
+        'instance',
+        fieldConfigSchemeType,
+        {
+          items: [
+            {
+              issueTypeId: '1',
+              fieldConfigurationId: '1',
+            },
+            {
+              issueTypeId: '2',
+              fieldConfigurationId: '2',
+            },
+            {
+              issueTypeId: '3',
+              fieldConfigurationId: '3',
+            },
+          ],
+        }
+      )
+
+      await filter.deploy?.([toChange({ before: beforeInstance, after: afterInstance })])
+      expect(mockConnection.post).not.toHaveBeenCalledWith()
+    })
+  })
+})


### PR DESCRIPTION
Added support for deploying field configuration schemes

Only the last commit is relevant
This PR is build on https://github.com/salto-io/salto/pull/2598

---
_Release Notes_: 
None

---
_User Notifications_: 
None