### PR TITLE
Revert "SALTO-1833: Retrieve normalized namespace for ts modules"

### DIFF
--- a/packages/logging/jest.config.js
+++ b/packages/logging/jest.config.js
@@ -26,7 +26,7 @@ module.exports = deepMerge(
     ],
     coverageThreshold: {
       global: {
-        branches: 98,
+        branches: 100,
         functions: 100,
         lines: 100,
         statements: 100,

--- a/packages/logging/src/internal/namespace.ts
+++ b/packages/logging/src/internal/namespace.ts
@@ -16,7 +16,7 @@
 import path from 'path'
 import { stack } from '@salto-io/lowerdash'
 import { safe as safeColors } from './colors'
-import quickHash, { MAX_HASH, MIN_HASH } from './quickhash'
+import quickHash, { MIN_HASH, MAX_HASH } from './quickhash'
 
 // Partial of ES6 Module
 export type LoggingModule = {
@@ -32,9 +32,7 @@ const parentDir = (numLevels: number): string => path.normalize(
   path.join(__dirname, ...Array(numLevels).fill('..'))
 )
 
-const MONOREPO_PACKAGES_DIRNAME = module.filename?.endsWith('.ts')
-  ? parentDir(3)
-  : parentDir(4)
+const MONOREPO_PACKAGES_DIRNAME = parentDir(4)
 
 const usableNamespaceColors = safeColors.map(c => c.hexString)
 
@@ -65,7 +63,7 @@ const fromFilename = (
 ): Namespace => path.relative(MONOREPO_PACKAGES_DIRNAME, filename)
   .replace(/.*:/, '') // remove 'var/task/webpack:' prefix
   .replace(/^\//, '') // remove '/' prefix
-  .replace(/^([^/]+)\/(dist\/src|dist|src)/, '$1') // remove src or dist/src directory
+  .replace(/dist\/((src)\/)?/, '')
   .replace(/\.[^.]+$/, '') // remove extension
   .replace(/\/{2}/g, '/') // normalize double slashes to single
 
@@ -106,9 +104,4 @@ export const namespaceNormalizer = (
 
   // last resort - not very meaningful
   return uniteNamespaceFragments(String(id))
-}
-
-
-export const exportedForTesting = {
-  MONOREPO_PACKAGES_DIRNAME,
 }

--- a/packages/logging/test/internal/namespace.test.ts
+++ b/packages/logging/test/internal/namespace.test.ts
@@ -13,9 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { exportedForTesting, namespaceNormalizer, toHexColor } from '../../src/internal/namespace'
-
-const { MONOREPO_PACKAGES_DIRNAME } = exportedForTesting
+import {
+  toHexColor, namespaceNormalizer,
+} from '../../src/internal/namespace'
 
 describe('namespace', () => {
   describe('toHexColor', () => {
@@ -38,10 +38,6 @@ describe('namespace', () => {
         it('should return the correct namespace', () => {
           expect(normalizeNamespace(module))
             .toEqual('logging/test/internal/namespace.test')
-        })
-        it('should return the correct namespace for typescript module', () => {
-          expect(normalizeNamespace({ id: `${MONOREPO_PACKAGES_DIRNAME}/test-package/src/path/to/module.ts` }))
-            .toEqual('test-package/path/to/module')
         })
         it('should return the correct namespace with extra fragments', () => {
           expect(normalizeNamespace(module, ['foo', 'bar']))


### PR DESCRIPTION
Reverts salto-io/salto#2590