### PR TITLE
SALTO-1542: Added workspace cache update command

### DIFF
--- a/packages/cli/src/commands/workspace.ts
+++ b/packages/cli/src/commands/workspace.ts
@@ -124,6 +124,34 @@ const wsCleanDef = createWorkspaceCommand({
   action: cleanAction,
 })
 
+type CacheUpdateArgs = {}
+export const cacheUpdateAction: WorkspaceCommandAction<CacheUpdateArgs> = async ({
+  workspace,
+  output,
+}) => {
+  outputLine('Updating workspace cache', output)
+  await workspace.flush()
+  return CliExitCode.Success
+}
+
+const cacheUpdateDef = createWorkspaceCommand({
+  properties: {
+    name: 'update',
+    description: 'Update the workspace cache',
+  },
+  action: cacheUpdateAction,
+})
+
+const cacheGroupDef = createCommandGroupDef({
+  properties: {
+    name: 'cache',
+    description: 'Commands for workspace cache administration',
+  },
+  subCommands: [
+    cacheUpdateDef,
+  ],
+})
+
 // Group definition
 const wsGroupDef = createCommandGroupDef({
   properties: {
@@ -132,6 +160,7 @@ const wsGroupDef = createCommandGroupDef({
   },
   subCommands: [
     wsCleanDef,
+    cacheGroupDef,
   ],
 })
 

--- a/packages/cli/test/commands/workspace.test.ts
+++ b/packages/cli/test/commands/workspace.test.ts
@@ -16,7 +16,7 @@
 import * as core from '@salto-io/core'
 import * as callbacks from '../../src/callbacks'
 import * as mocks from '../mocks'
-import { cleanAction } from '../../src/commands/workspace'
+import { cleanAction, cacheUpdateAction } from '../../src/commands/workspace'
 import { CliExitCode } from '../../src/types'
 
 jest.mock('@salto-io/core', () => ({
@@ -28,7 +28,6 @@ jest.mock('@salto-io/core', () => ({
 describe('workspace command group', () => {
   let cliArgs: mocks.MockCliArgs
   let output: mocks.MockCliOutput
-  let cliCommandArgs: mocks.MockCommandArgs
 
   beforeEach(async () => {
     cliArgs = mocks.mockCliArgs()
@@ -37,6 +36,7 @@ describe('workspace command group', () => {
 
   describe('clean command', () => {
     const commandName = 'clean'
+    let cliCommandArgs: mocks.MockCommandArgs
 
     beforeEach(async () => {
       cliCommandArgs = mocks.mockCliCommandArgs(commandName, cliArgs)
@@ -208,6 +208,32 @@ describe('workspace command group', () => {
         })
         expect(output.stdout.content.search('Starting to clean')).toBeGreaterThan(0)
         expect(output.stdout.content.search('Finished cleaning')).toBeGreaterThan(0)
+      })
+    })
+  })
+
+  describe('cache command group', () => {
+    describe('cache update command', () => {
+      const commandName = 'update'
+      let cliCommandArgs: mocks.MockCommandArgs
+      let workspace: mocks.MockWorkspace
+      let result: CliExitCode
+
+      beforeEach(async () => {
+        cliCommandArgs = mocks.mockCliCommandArgs(commandName, cliArgs)
+        workspace = mocks.mockWorkspace({})
+        result = await cacheUpdateAction({
+          ...cliCommandArgs,
+          input: {},
+          workspace,
+        })
+      })
+
+      it('should flush the workspace', () => {
+        expect(workspace.flush).toHaveBeenCalled()
+      })
+      it('should return success', () => {
+        expect(result).toEqual(CliExitCode.Success)
       })
     })
   })


### PR DESCRIPTION
Added a command for updating the workspace cache.
This only loads the workspace and flushes it
the actual updating is a side effect of the load and flush

---

The workspace clean command that used to expose this option does not anymore, adding as a separate command

---
_Release Notes_: 
CLI
- Added `salto workspace cache update` administrative command to allow updating the workspace cache

---
_User Notifications_: 
_None_
