### PR TITLE
Fix cli e2e failing on newly created accounts

### DIFF
--- a/packages/cli/e2e_test/multi_env.test.ts
+++ b/packages/cli/e2e_test/multi_env.test.ts
@@ -49,9 +49,9 @@ const SALESFORCE_SERVICE_NAME = 'salesforce'
 // const ALTERNATIVE_SALESFORCE_ACCOUNT_NAME = 'e2esalesforce'
 
 describe.each([
-  SALESFORCE_SERVICE_NAME,
-  // ALTERNATIVE_SALESFORCE_ACCOUNT_NAME,
-])('.add($accountName)', accountName => {
+  [SALESFORCE_SERVICE_NAME],
+  // [ALTERNATIVE_SALESFORCE_ACCOUNT_NAME],
+])('cli e2e multi env with account name %s', accountName => {
   const accounts = accountName === SALESFORCE_SERVICE_NAME ? undefined : [accountName]
   jest.setTimeout(15 * 60 * 1000)
 


### PR DESCRIPTION
The cli e2e expects there to be static resources in one of the tests
but it does not create anything with a static resource, so in new accounts it fails

Added a test that adds an instance with a static resource and does not delete it until teardown

Also fixed issue where jest.each was not provided with parameters in the correct structure

---

~Did not test locally yet, what are the odds this works?~ edit: it didn't

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
