### PR TITLE
added env flag to dummy adapter config

### DIFF
--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -28,7 +28,8 @@ export const configType = new ObjectType({
       [CORE_ANNOTATIONS.DEFAULT]: defValue,
     },
   })),
-  extraNaclPath: { refType: BuiltinTypes.STRING } },
+  extraNaclPath: { refType: BuiltinTypes.STRING },
+  generateEnvName: { refType: BuiltinTypes.STRING } },
 })
 
 export const adapter: Adapter = {

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -67,6 +67,7 @@ export type GeneratorParams = {
     listLengthStd: number
     useOldProfiles: boolean
     extraNaclPath?: string
+    generateEnvName? : string
 }
 
 export const defaultParams: Omit<GeneratorParams, 'extraNaclPath'> = {
@@ -615,7 +616,7 @@ export const generateElements = async (
 
 
   const generateEnvElements = (): Element[] => {
-    const envID = process.env.SALTO_ENV
+    const envID = params.generateEnvName ?? process.env.SALTO_ENV
     if (envID === undefined) return []
     const PrimWithHiddenAnnos = new PrimitiveType({
       elemID: new ElemID('dummy', 'PrimWithAnnos'),

--- a/packages/dummy-adapter/test/adapter_creator.test.ts
+++ b/packages/dummy-adapter/test/adapter_creator.test.ts
@@ -22,7 +22,7 @@ import DummyAdapter from '../src/adapter'
 describe('adapter creator', () => {
   it('should return a config containing all of the generator params', () => {
     const config = adapter.configType as ObjectType
-    expect(Object.keys(config?.fields)).toEqual([...Object.keys(defaultParams), 'extraNaclPath'])
+    expect(Object.keys(config?.fields)).toEqual([...Object.keys(defaultParams), 'extraNaclPath', 'generateEnvName'])
   })
   it('should return an empty creds type', () => {
     expect(Object.keys(adapter.authenticationMethods.basic.credentialsType.fields)).toHaveLength(0)


### PR DESCRIPTION
_added env flag to dummy adapter config_

---

_Exposed the SALTO_ENV flag which is used to modify the adapter output via the adapter config as well_

---
_Release Notes_: 
_NA_

---
_User Notifications_: 
_NA_
