### PR TITLE
SALTO-1888: Update macos version on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
 
   test_cli_mac:
     macos:
-      xcode: 11.3.0
+      xcode: 13.2.1
 
     steps:
       - set_s3_pkg_urls


### PR DESCRIPTION
The version we have been using has been deprecated and [is being removed tomorrow](https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions)

---

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
