### PR TITLE
SALTO-1890: Add ability to disable specific change validators in salesforce

### DIFF
--- a/packages/adapter-utils/test/change_validator.test.ts
+++ b/packages/adapter-utils/test/change_validator.test.ts
@@ -25,7 +25,6 @@ describe('change_validator', () => {
   let changes: ReadonlyArray<Change>
   let adapterConfig: InstanceElement
   let errors: ChangeError[]
-  let result: ReadonlyArray<ChangeError>
 
   beforeEach(async () => {
     errors = [
@@ -47,17 +46,44 @@ describe('change_validator', () => {
       mockFunction<ChangeValidator>().mockResolvedValue(errors.slice(1)),
     ]
     changes = [toChange({ after: testElem })]
-    const mainValidator = createChangeValidator(mockValidators)
-    result = await mainValidator(changes, adapterConfig)
   })
 
-  it('should call all validators', () => {
-    mockValidators.forEach(
-      validator => expect(validator).toHaveBeenCalledWith(changes, adapterConfig)
-    )
+  describe('with active validators', () => {
+    let result: ReadonlyArray<ChangeError>
+    beforeEach(async () => {
+      const mainValidator = createChangeValidator(mockValidators)
+      result = await mainValidator(changes, adapterConfig)
+    })
+    it('should call all validators', () => {
+      mockValidators.forEach(
+        validator => expect(validator).toHaveBeenCalledWith(changes, adapterConfig)
+      )
+    })
+    it('should return errors from all validators', () => {
+      expect(result).toEqual(errors)
+    })
   })
 
-  it('should return errors from all validators', () => {
-    expect(result).toEqual(errors)
+  describe('with disabled validators', () => {
+    let disabledError: ChangeError
+    let disabledValidator: jest.MockedFunction<ChangeValidator>
+    let result: ReadonlyArray<ChangeError>
+    beforeEach(async () => {
+      disabledError = {
+        elemID: testElem.elemID,
+        severity: 'Error',
+        message: 'test3',
+        detailedMessage: 'test3',
+      }
+      disabledValidator = mockFunction<ChangeValidator>().mockResolvedValue([disabledError])
+      const mainValidator = createChangeValidator(mockValidators, [disabledValidator])
+      result = await mainValidator(changes, adapterConfig)
+    })
+    it('should call disabled validator', () => {
+      expect(disabledValidator).toHaveBeenCalled()
+    })
+    it('should not return error from disabled validator', () => {
+      expect(result).not.toContainEqual(disabledError)
+    })
   })
 })

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -252,5 +252,5 @@ For more details see the DeployOptions section in the [salesforce documentation 
 | standardFieldLabel                                          | true                      | Disallow changing a label of a standard field
 | profileMapKeys                                              | true                      | Ensure proper structure of profiles before deploying
 | multipleDefaults                                            | true                      | Check for multiple default values in picklists and other places where only one default is allowed
-| picklistPromote                                             | true                      | Promoting picklist value-set to global cannot be done with the API
+| picklistPromote                                             | true                      | Disallow promoting picklist value-set to global since it cannot be done with the API
 | validateOnlyFlag                                            | true                      | Disallow deploying data records in a validation only deploy

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -116,6 +116,7 @@ salesforce {
 | maxItemsInRetrieveRequest                                | 2500                          | Limits the max number of requested items a single retrieve request
 | [fetch](#fetch-configuration-options)                    |                               | Fetch configuration 
 | [client](#client-configuration-options)                  | {} (no overrides)             | Configuration relating to the client used to interact with salesforce
+| [validators](#validator-configuration-options)           | {} (all enabled)              | Configuration for choosing which validators will be applied to deploy plans
 
 ## Fetch configuration options
 
@@ -229,9 +230,9 @@ For more details see the DeployOptions section in the [salesforce documentation 
 
 | Name                                                        | Default when undefined                           | Description
 | ------------------------------------------------------------| -------------------------------------------------| -----------
-| maxAttempts                                                    | `3`                                              | Max attempts to deploy data instances
-| retryDelay                                                        | `1000`                                | Delay (in millis) between each retry
-| retryableFailures                                                        | `FIELD_CUSTOM_VALIDATION_EXCEPTION, UNABLE_TO_LOCK_ROW`                                | Error messages for which to retry
+| maxAttempts                                                 | `3`                                              | Max attempts to deploy data instances
+| retryDelay                                                  | `1000`                                           | Delay (in millis) between each retry
+| retryableFailures                                           | `FIELD_CUSTOM_VALIDATION_EXCEPTION, UNABLE_TO_LOCK_ROW` | Error messages for which to retry
 | 
 
 ### Read metadata chunk size
@@ -239,3 +240,17 @@ For more details see the DeployOptions section in the [salesforce documentation 
 | ------------------------------------------------------------| -------------------------------------------------| -----------
 | default                                                     | `10`                                             | Default value for chunk size in readMetadata
 | overrides                                                   | Profile and PermissionSet are set to 1           | Chunk size for specific metadata types
+
+## Validator Configuration Options
+| Name                                                        | Default when undefined    | Description
+| ------------------------------------------------------------| ------------------------- | -----------
+| managedPackage                                              | true                      | Disallow changes to objects and fields that are part of a managed package
+| picklistStandardField                                       | true                      | It is forbidden to modify a picklist on a standard field. Only StandardValueSet is allowed
+| customObjectInstances                                       | true                      | Validate permissions of creating / update data records
+| unknownField                                                | true                      | Disallow deploying an unknown field type
+| customFieldType                                             | true                      | Ensure the type given to a custom field is a valid type for custom fields
+| standardFieldLabel                                          | true                      | Disallow changing a label of a standard field
+| profileMapKeys                                              | true                      | Ensure proper structure of profiles before deploying
+| multipleDefaults                                            | true                      | Check for multiple default values in picklists and other places where only one default is allowed
+| picklistPromote                                             | true                      | Promoting picklist value-set to global cannot be done with the API
+| validateOnlyFlag                                            | true                      | Disallow deploying data records in a validation only deploy

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -179,7 +179,7 @@ export const adapter: Adapter = {
 
       deploy: salesforceAdapter.deploy.bind(salesforceAdapter),
       deployModifiers: {
-        changeValidator: createChangeValidator(config),
+        changeValidator: createChangeValidator(config.validators),
         getChangeGroupIds,
       },
     }

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -26,7 +26,7 @@ import profileMapKeysValidator from './change_validators/profile_map_keys'
 import multipleDefaultsValidator from './change_validators/multiple_deafults'
 import picklistPromoteValidator from './change_validators/picklist_promote'
 import validateOnlyFlagValidator from './change_validators/validate_only_flag'
-import { SalesforceConfig, ChangeValidatorName } from './types'
+import { ChangeValidatorName, ChangeValidatorConfig } from './types'
 
 export const changeValidators: Record<ChangeValidatorName, ChangeValidator> = {
   managedPackage: packageValidator,
@@ -42,10 +42,10 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidator> = {
 }
 
 
-const createSalesforceChangeValidator = (config: SalesforceConfig): ChangeValidator => {
+const createSalesforceChangeValidator = (config?: ChangeValidatorConfig): ChangeValidator => {
   const [activeValidators, disabledValidators] = _.partition(
     Object.entries(changeValidators),
-    ([name]) => config.validators?.[name as ChangeValidatorName] ?? true,
+    ([name]) => config?.[name as ChangeValidatorName] ?? true,
   )
   return createChangeValidator(
     activeValidators.map(([_name, validator]) => validator),

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import _ from 'lodash'
 import { ChangeValidator } from '@salto-io/adapter-api'
 import { createChangeValidator } from '@salto-io/adapter-utils'
 import packageValidator from './change_validators/package'
@@ -25,18 +26,30 @@ import profileMapKeysValidator from './change_validators/profile_map_keys'
 import multipleDefaultsValidator from './change_validators/multiple_deafults'
 import picklistPromoteValidator from './change_validators/picklist_promote'
 import validateOnlyFlagValidator from './change_validators/validate_only_flag'
+import { SalesforceConfig, ChangeValidatorName } from './types'
 
-const changeValidators: ChangeValidator[] = [
-  packageValidator,
-  picklistStandardFieldValidator,
-  customObjectInstancesValidator,
-  unknownFieldValidator,
-  customFieldTypeValidator,
-  standardFieldLabelValidator,
-  profileMapKeysValidator,
-  multipleDefaultsValidator,
-  picklistPromoteValidator,
-  validateOnlyFlagValidator,
-]
+export const changeValidators: Record<ChangeValidatorName, ChangeValidator> = {
+  managedPackage: packageValidator,
+  picklistStandardField: picklistStandardFieldValidator,
+  customObjectInstances: customObjectInstancesValidator,
+  unknownField: unknownFieldValidator,
+  customFieldType: customFieldTypeValidator,
+  standardFieldLabel: standardFieldLabelValidator,
+  profileMapKeys: profileMapKeysValidator,
+  multipleDefaults: multipleDefaultsValidator,
+  picklistPromote: picklistPromoteValidator,
+  validateOnlyFlag: validateOnlyFlagValidator,
+}
 
-export default createChangeValidator(changeValidators)
+
+const createSalesforceChangeValidator = (config: SalesforceConfig): ChangeValidator => {
+  const [activeValidators, disabledValidators] = _.partition(
+    Object.entries(changeValidators),
+    ([name]) => config.validators?.[name as ChangeValidatorName] ?? true,
+  )
+  return createChangeValidator(
+    activeValidators.map(([_name, validator]) => validator),
+    disabledValidators.map(([_name, validator]) => validator),
+  )
+}
+export default createSalesforceChangeValidator

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -64,6 +64,20 @@ export type OptionalFeatures = {
   authorInformation?: boolean
 }
 
+export type ChangeValidatorName = (
+  'managedPackage'
+  | 'picklistStandardField'
+  | 'customObjectInstances'
+  | 'unknownField'
+  | 'customFieldType'
+  | 'standardFieldLabel'
+  | 'profileMapKeys'
+  | 'multipleDefaults'
+  | 'picklistPromote'
+  | 'validateOnlyFlag'
+)
+export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
+
 type ObjectIdSettings = {
   objectsRegex: string
   idFields: string[]
@@ -195,6 +209,7 @@ export type SalesforceConfig = {
   [MAX_ITEMS_IN_RETRIEVE_REQUEST]?: number
   [USE_OLD_PROFILES]?: boolean
   [CLIENT_CONFIG]?: SalesforceClientConfig
+  validators?: ChangeValidatorConfig
 }
 
 type DataManagementConfigSuggestions = {
@@ -442,6 +457,22 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
   },
 })
 
+const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig>({
+  elemID: new ElemID(constants.SALESFORCE, 'changeValidatorConfig'),
+  fields: {
+    managedPackage: { refType: BuiltinTypes.BOOLEAN },
+    picklistStandardField: { refType: BuiltinTypes.BOOLEAN },
+    customObjectInstances: { refType: BuiltinTypes.BOOLEAN },
+    unknownField: { refType: BuiltinTypes.BOOLEAN },
+    customFieldType: { refType: BuiltinTypes.BOOLEAN },
+    standardFieldLabel: { refType: BuiltinTypes.BOOLEAN },
+    profileMapKeys: { refType: BuiltinTypes.BOOLEAN },
+    multipleDefaults: { refType: BuiltinTypes.BOOLEAN },
+    picklistPromote: { refType: BuiltinTypes.BOOLEAN },
+    validateOnlyFlag: { refType: BuiltinTypes.BOOLEAN },
+  },
+})
+
 const fetchConfigType = createMatchingObjectType<FetchParameters>({
   elemID: new ElemID(constants.SALESFORCE, 'fetchConfig'),
   fields: {
@@ -453,7 +484,7 @@ const fetchConfigType = createMatchingObjectType<FetchParameters>({
   },
 })
 
-export const configType = new ObjectType({
+export const configType = createMatchingObjectType<SalesforceConfig>({
   elemID: configID,
   fields: {
     [FETCH_CONFIG]: {
@@ -508,14 +539,8 @@ export const configType = new ObjectType({
     [CLIENT_CONFIG]: {
       refType: clientConfigType,
     },
-    [METADATA_TYPES_SKIPPED_LIST]: {
-      refType: new ListType(BuiltinTypes.STRING),
-    },
-    [INSTANCES_REGEX_SKIPPED_LIST]: {
-      refType: new ListType(BuiltinTypes.STRING),
-    },
-    [DATA_MANAGEMENT]: {
-      refType: dataManagementType,
+    validators: {
+      refType: changeValidatorConfigType,
     },
   },
 })

--- a/packages/salesforce-adapter/test/change_validator.test.ts
+++ b/packages/salesforce-adapter/test/change_validator.test.ts
@@ -1,0 +1,61 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ChangeValidator } from '@salto-io/adapter-api'
+import { createChangeValidator } from '@salto-io/adapter-utils'
+import createSalesforceChangeValidator, { changeValidators } from '../src/change_validator'
+
+jest.mock('@salto-io/adapter-utils', () => {
+  const actual = jest.requireActual('@salto-io/adapter-utils')
+  return {
+    ...actual,
+    createChangeValidator: jest.fn().mockImplementation(actual.createChangeValidator),
+  }
+})
+
+describe('createSalesforceChangeValidator', () => {
+  afterEach(() => {
+    (createChangeValidator as jest.MockedFunction<typeof createChangeValidator>).mockClear()
+  })
+
+  describe('with no validator config', () => {
+    let validator: ChangeValidator
+    beforeEach(() => {
+      validator = createSalesforceChangeValidator()
+    })
+    it('should create a validator', () => {
+      expect(validator).toBeDefined()
+    })
+    it('should create a validator will all internal validators enabled', () => {
+      expect(createChangeValidator).toHaveBeenCalledWith(Object.values(changeValidators), [])
+    })
+  })
+
+  describe('with a disabled validator config', () => {
+    let validator: ChangeValidator
+    beforeEach(() => {
+      validator = createSalesforceChangeValidator({ customFieldType: false })
+    })
+    it('should create a validator', () => {
+      expect(validator).toBeDefined()
+    })
+    it('should put the disabled validator in the disabled list', () => {
+      const enabledValidators = Object.values(_.omit(changeValidators, 'customFieldType'))
+      const disabledValidators = [changeValidators.customFieldType]
+      expect(createChangeValidator).toHaveBeenCalledWith(enabledValidators, disabledValidators)
+    })
+  })
+})


### PR DESCRIPTION
Ideally this should be a core ability, but this is a first step towards that.
This adds a section to the salesforce adapter configuration that allows disabling a validator by name

---

Still need to add tests and documentation

---
_Release Notes_: 
Salesforce adapter:
- Added `validators` section in the configuration to allow disabling specific change validators

---
_User Notifications_: 
_None_
