### PR TITLE
SALTO-1864: fixed ETIMEDOUT error

### DIFF
--- a/packages/adapter-components/package.json
+++ b/packages/adapter-components/package.json
@@ -35,7 +35,7 @@
     "@salto-io/adapter-utils": "0.3.8",
     "@salto-io/logging": "0.3.8",
     "@salto-io/lowerdash": "0.3.8",
-    "axios": "^0.21.1",
+    "axios": "^0.21.3",
     "axios-retry": "^3.1.9",
     "bottleneck": "^2.19.5",
     "lodash": "^4.17.21",

--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -70,6 +70,9 @@ export class HTTPError extends Error {
   }
 }
 
+export class TimeoutError extends Error {
+}
+
 const isMethodWithData = (params: ClientParams): params is ClientDataParams =>
   'data' in params
 
@@ -195,6 +198,9 @@ export abstract class AdapterHTTPClient<
       }
     } catch (e) {
       log.warn(`failed to ${method} ${url} ${queryParams}: ${e}, stack: ${e.stack}, data: ${safeJsonStringify(e?.response?.data)}`)
+      if (e.code === 'ETIMEDOUT') {
+        throw new TimeoutError(`Failed to ${method} ${url} with error: ${e}`)
+      }
       if (e.response !== undefined) {
         throw new HTTPError(`Failed to ${method} ${url} with error: ${e}`, e.response)
       }

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -31,6 +31,7 @@ import {
 import { findDataField, FindNestedFieldFunc } from '../field_finder'
 import { computeGetArgs as defaultComputeGetArgs, ComputeGetArgsFunc } from '../request_parameters'
 import { getElementsWithContext } from '../element_getter'
+import { TimeoutError } from '../../client/http_client'
 
 const { makeArray } = collections.array
 const { toArrayAsync, awu } = collections.asynciterable
@@ -424,7 +425,9 @@ const getInstancesForType = async (params: GetEntriesParams): Promise<InstanceEl
     })
   } catch (e) {
     log.warn(`Could not fetch ${typeName}: ${e}. %s`, e.stack)
-    if (e instanceof UnauthorizedError || e instanceof InvalidTypeConfig) {
+    if (e instanceof UnauthorizedError
+      || e instanceof InvalidTypeConfig
+      || e instanceof TimeoutError) {
       throw e
     }
     return []

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "@salto-io/zendesk-support-adapter": "0.3.8",
     "@salto-io/zuora-billing-adapter": "0.3.8",
     "async-lock": "^1.2.4",
-    "axios": "^0.21.1",
+    "axios": "^0.21.3",
     "fs-extra": "^9.1.0",
     "glob": "^7.1.6",
     "levelup": "^4.4.0",

--- a/packages/jira-adapter/package.json
+++ b/packages/jira-adapter/package.json
@@ -45,7 +45,7 @@
     "@types/lodash": "^4.14.168",
     "@typescript-eslint/eslint-plugin": "4.22.1",
     "@typescript-eslint/parser": "4.22.1",
-    "axios": "^0.21.1",
+    "axios": "^0.21.3",
     "axios-mock-adapter": "^1.19.0",
     "eslint": "^6.2.2",
     "eslint-config-airbnb": "18.0.1",

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -39,7 +39,7 @@
     "@salto-io/suitecloud-cli": "1.3.2-salto-1",
     "ajv": "^7.1.1",
     "async-lock": "^1.2.4",
-    "axios": "^0.21.1",
+    "axios": "^0.21.3",
     "bottleneck": "^2.19.5",
     "crypto": "^1.0.1",
     "fast-xml-parser": "^3.15.0",

--- a/packages/stripe-adapter/package.json
+++ b/packages/stripe-adapter/package.json
@@ -38,7 +38,7 @@
     "@salto-io/e2e-credentials-store": "0.3.8",
     "@salto-io/logging": "0.3.8",
     "@salto-io/lowerdash": "0.3.8",
-    "axios": "^0.21.1",
+    "axios": "^0.21.3",
     "axios-retry": "^3.1.9",
     "lodash": "^4.17.21"
   },
@@ -47,7 +47,7 @@
     "@types/lodash": "^4.14.168",
     "@typescript-eslint/eslint-plugin": "4.22.1",
     "@typescript-eslint/parser": "4.22.1",
-    "axios": "^0.21.1",
+    "axios": "^0.21.3",
     "axios-mock-adapter": "^1.19.0",
     "eslint": "^6.2.2",
     "eslint-config-airbnb": "18.0.1",

--- a/packages/workato-adapter/package.json
+++ b/packages/workato-adapter/package.json
@@ -44,7 +44,7 @@
     "@types/mime-types": "^2.1.0",
     "@typescript-eslint/eslint-plugin": "4.22.1",
     "@typescript-eslint/parser": "4.22.1",
-    "axios": "^0.21.1",
+    "axios": "^0.21.3",
     "axios-mock-adapter": "^1.19.0",
     "eslint": "^6.2.2",
     "eslint-config-airbnb": "18.0.1",

--- a/packages/zendesk-support-adapter/package.json
+++ b/packages/zendesk-support-adapter/package.json
@@ -43,7 +43,7 @@
     "@types/lodash": "^4.14.168",
     "@typescript-eslint/eslint-plugin": "4.22.1",
     "@typescript-eslint/parser": "4.22.1",
-    "axios": "^0.21.1",
+    "axios": "^0.21.3",
     "axios-mock-adapter": "^1.19.0",
     "eslint": "^6.2.2",
     "eslint-config-airbnb": "18.0.1",

--- a/packages/zuora-billing-adapter/package.json
+++ b/packages/zuora-billing-adapter/package.json
@@ -46,7 +46,7 @@
     "@types/lodash": "^4.14.168",
     "@typescript-eslint/eslint-plugin": "4.22.1",
     "@typescript-eslint/parser": "4.22.1",
-    "axios": "^0.21.1",
+    "axios": "^0.21.3",
     "axios-mock-adapter": "^1.19.0",
     "eslint": "^6.2.2",
     "eslint-config-airbnb": "18.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2241,11 +2241,11 @@
   integrity sha512-PJJ/jvb5Gor8DWvXN3e75njfQyYNRz0PaFSZ3br9GfHM9N2FxvuJ/E/ytcQePJOLzHlvgFSsIJIvfUMUxWTbnA==
 
 "@types/moxios@^0.4.10":
-  version "0.4.12"
-  resolved "https://registry.yarnpkg.com/@types/moxios/-/moxios-0.4.12.tgz#c55882ab85a6e7687597a74ec201b366eb608b3e"
-  integrity sha512-/wi8KjB0Lj5sa6XvGToi89rNybR20fk3KmhPsX/g1JqC8f8I/C4Yd9QgU692ReqJprUoYEzQl9rElyhabhNY1g==
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/@types/moxios/-/moxios-0.4.14.tgz#38ed0cdedeb6abcb5a4e087e3e2be2d2a036a052"
+  integrity sha512-YUfHi11hgmu7+nRoPf7wzNOuqNgMjCT8Sui3KB+HjKWYwixCgyTcSeLLPXfR4f1BTlPC5xrrEIRCWffh/3aJ6A==
   dependencies:
-    axios "^0.21.1"
+    axios "^0.24.0"
 
 "@types/nearley@^2.11.0":
   version "2.11.1"
@@ -3203,12 +3203,19 @@ axios-retry@^3.1.9:
   dependencies:
     is-retry-allowed "^1.1.0"
 
-axios@^0.21.1:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
-  integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
+axios@^0.21.3:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
+
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
+  dependencies:
+    follow-redirects "^1.14.4"
 
 axobject-query@^2.0.2:
   version "2.1.2"
@@ -5754,10 +5761,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.14.0:
-  version "1.14.5"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
-  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
+follow-redirects@^1.14.0, follow-redirects@^1.14.4:
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Fixed a bug where we would sometimes get ETIMEDOUT error when fetching from Jira which would cause some elements to not be returned from fetch

---

- It looks `axios-retry` covers `ETIMEDOUT` but there was a bug in our current axios package which would cause the axios-retry to not work at all. The bug was fixed in axios 0.21.3 (https://github.com/axios/axios/releases?q=21.3&expanded=true the interceptor thing) so I upgraded the package and it seems to work 

- Changed to throw an exception and fail the whole fetch if we still got ETIMEDOUT after the retries

---
_Release Notes_: 
None

---
_User Notifications_: 
None