### PR TITLE
SALTO-1778-workflow-bug

### DIFF
--- a/packages/adapter-components/src/deployment/change_validators/deploy_types_not_supported.ts
+++ b/packages/adapter-components/src/deployment/change_validators/deploy_types_not_supported.ts
@@ -23,6 +23,6 @@ export const deployTypesNotSupportedValidator: ChangeValidator = async changes =
       elemID: objectType.elemID,
       severity: 'Error',
       message: `Deployment of non-instance elements is not supported in adapter ${objectType.elemID.adapter}`,
-      detailedMessage: `Salto does not support deployment of ${objectType.elemID.getFullName()}`,
+      detailedMessage: `Deployment of ${objectType.elemID.getFullName()} is not supported`,
     }))
 )

--- a/packages/adapter-components/test/deployment/change_validators/deploy_types_not_supported.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/deploy_types_not_supported.test.ts
@@ -27,7 +27,7 @@ describe('deployTypesNotSupportedValidator', () => {
       elemID: type.elemID,
       severity: 'Error',
       message: `Deployment of non-instance elements is not supported in adapter ${type.elemID.adapter}`,
-      detailedMessage: `Salto does not support deployment of ${type.elemID.getFullName()}`,
+      detailedMessage: `Deployment of ${type.elemID.getFullName()} is not supported`,
     }])
   })
 })

--- a/packages/core/src/core/plan/change_validators/check_deployment_annotations.ts
+++ b/packages/core/src/core/plan/change_validators/check_deployment_annotations.ts
@@ -25,7 +25,7 @@ const { OPERATION_TO_ANNOTATION } = deployment
 const ERROR_MESSAGE = (id: ElemID): string => `The change of ${id.getFullName()} is not supported and will be omitted from deploy`
 
 const detailedErrorMessage = (action: Change['action'], path: ElemID): string =>
-  `Salto does not support "${action}" of ${path.getFullName()}`
+  `"${action}" operation on ${path.getFullName()} is not supported`
 
 const isDeploymentSupported = (element: Element, action: Change['action']): boolean =>
   element.annotations[OPERATION_TO_ANNOTATION[action]]

--- a/packages/core/test/core/plan/change_validators/check_deployment_annotations.test.ts
+++ b/packages/core/test/core/plan/change_validators/check_deployment_annotations.test.ts
@@ -71,7 +71,7 @@ describe('checkDeploymentAnnotationsValidator', () => {
       elemID: instance.elemID,
       severity: 'Error',
       message: `The change of ${type.elemID.getFullName()} is not supported and will be omitted from deploy`,
-      detailedMessage: `Salto does not support "add" of ${instance.elemID.getFullName()}`,
+      detailedMessage: `"add" operation on ${instance.elemID.getFullName()} is not supported`,
     }])
   })
 
@@ -85,7 +85,7 @@ describe('checkDeploymentAnnotationsValidator', () => {
       elemID: instance.elemID,
       severity: 'Warning',
       message: `The change of ${type.fields.notUpdatableField.elemID.getFullName()} is not supported and will be omitted from deploy`,
-      detailedMessage: `Salto does not support "modify" of ${instance.elemID.createNestedID('notUpdatableField').getFullName()}`,
+      detailedMessage: `"modify" operation on ${instance.elemID.createNestedID('notUpdatableField').getFullName()} is not supported`,
     }])
   })
 
@@ -99,7 +99,7 @@ describe('checkDeploymentAnnotationsValidator', () => {
       elemID: instance.elemID,
       severity: 'Warning',
       message: `The change of ${type.fields.notUpdatableField.elemID.getFullName()} is not supported and will be omitted from deploy`,
-      detailedMessage: `Salto does not support "modify" of ${instance.elemID.createNestedID('inner', 'notUpdatableField').getFullName()}`,
+      detailedMessage: `"modify" operation on ${instance.elemID.createNestedID('inner', 'notUpdatableField').getFullName()} is not supported`,
     }])
   })
 

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -17,6 +17,7 @@ import { ChangeValidator } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
 import { createChangeValidator } from '@salto-io/adapter-utils'
 import { unsupportedFieldConfigurationsValidator } from './field_configuration'
+import { workflowValidator } from './workflow'
 
 const {
   deployTypesNotSupportedValidator,
@@ -25,6 +26,7 @@ const {
 const validators: ChangeValidator[] = [
   deployTypesNotSupportedValidator,
   unsupportedFieldConfigurationsValidator,
+  workflowValidator,
 ]
 
 export default createChangeValidator(validators)

--- a/packages/jira-adapter/src/change_validators/workflow.ts
+++ b/packages/jira-adapter/src/change_validators/workflow.ts
@@ -1,0 +1,55 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isAdditionChange, isInstanceChange, SaltoErrorSeverity } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { resolveValues } from '@salto-io/adapter-utils'
+import { UNDEPLOYALBE_POST_FUNCTION_TYPES, UNDEPLOYALBE_VALIDATOR_TYPES } from '../filters/workflow/workflow'
+import { isWorkflowInstance, WorkflowInstance } from '../filters/workflow/types'
+import { getLookUpName } from '../reference_mapping'
+
+const { awu } = collections.asynciterable
+
+const doesHaveUndeployableTypes = (instance: WorkflowInstance): boolean => {
+  const doesContainUndeployablePostFunction = instance.value.transitions?.some(transition =>
+    transition.rules?.postFunctions?.some(
+      postFunction => UNDEPLOYALBE_POST_FUNCTION_TYPES.includes(postFunction.type ?? ''),
+    )) ?? false
+
+  const doesContainUndeployableValidator = instance.value.transitions?.some(transition =>
+    transition.rules?.validators?.some(
+      validator => UNDEPLOYALBE_VALIDATOR_TYPES.includes(validator.type ?? ''),
+    )) ?? false
+
+  return doesContainUndeployablePostFunction || doesContainUndeployableValidator
+}
+
+export const workflowValidator: ChangeValidator = async changes => (
+  awu(changes)
+    .filter(isInstanceChange)
+    .filter(isAdditionChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === 'Workflow')
+    .map(instance => resolveValues(instance, getLookUpName))
+    .filter(isWorkflowInstance)
+    .filter(doesHaveUndeployableTypes)
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Warning' as SaltoErrorSeverity,
+      message: `Salto does not support deploying script-runner configuration in the instance ${instance.elemID.getFullName()}`,
+      detailedMessage: 'Salto does not support deploying script-runner (com.onresolve.jira.groovy.groovyrunner) configuration. If continuing, they will be omitted from the deployment',
+    }))
+    .toArray()
+)

--- a/packages/jira-adapter/src/change_validators/workflow.ts
+++ b/packages/jira-adapter/src/change_validators/workflow.ts
@@ -22,18 +22,18 @@ import { getLookUpName } from '../reference_mapping'
 
 const { awu } = collections.asynciterable
 
-const doesHaveUndeployableTypes = (instance: WorkflowInstance): boolean => {
+const hasUndeployableTypes = (instance: WorkflowInstance): boolean => {
   const doesContainUndeployablePostFunction = instance.value.transitions?.some(transition =>
     transition.rules?.postFunctions?.some(
       postFunction => UNDEPLOYALBE_POST_FUNCTION_TYPES.includes(postFunction.type ?? ''),
     )) ?? false
 
-  const doesContainUndeployableValidator = instance.value.transitions?.some(transition =>
+  const containsUndeployableValidator = instance.value.transitions?.some(transition =>
     transition.rules?.validators?.some(
       validator => UNDEPLOYALBE_VALIDATOR_TYPES.includes(validator.type ?? ''),
     )) ?? false
 
-  return doesContainUndeployablePostFunction || doesContainUndeployableValidator
+  return doesContainUndeployablePostFunction || containsUndeployableValidator
 }
 
 export const workflowValidator: ChangeValidator = async changes => (
@@ -44,12 +44,12 @@ export const workflowValidator: ChangeValidator = async changes => (
     .filter(instance => instance.elemID.typeName === 'Workflow')
     .map(instance => resolveValues(instance, getLookUpName))
     .filter(isWorkflowInstance)
-    .filter(doesHaveUndeployableTypes)
+    .filter(hasUndeployableTypes)
     .map(instance => ({
       elemID: instance.elemID,
       severity: 'Warning' as SaltoErrorSeverity,
-      message: `Salto does not support deploying script-runner configuration in the instance ${instance.elemID.getFullName()}`,
-      detailedMessage: 'Salto does not support deploying script-runner (com.onresolve.jira.groovy.groovyrunner) configuration. If continuing, they will be omitted from the deployment',
+      message: `Deploying script-runner configuration in the instance ${instance.elemID.getFullName()} is not supported.`,
+      detailedMessage: 'Deploying script-runner (com.onresolve.jira.groovy.groovyrunner) configuration is not supported. If continuing, they will be omitted from the deployment',
     }))
     .toArray()
 )

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -73,10 +73,12 @@ const postFunctionConfigurationSchema = Joi.object({
 }).unknown(true)
 
 export type Validator = {
+  type?: string
   configuration?: ValidatorConfiguration
 }
 
 const validatorSchema = Joi.object({
+  type: Joi.string().optional(),
   configuration: validatorConfigurationSchema.optional(),
 }).unknown(true)
 
@@ -138,8 +140,10 @@ const workflowSchema = Joi.object({
   statuses: Joi.array().items(statusSchema).optional(),
 }).unknown(true)
 
+export type WorkflowInstance = InstanceElement & { value: InstanceElement['value'] & Workflow }
+
 export const isWorkflowInstance = (instance: InstanceElement)
-: instance is InstanceElement & { value: InstanceElement['value'] & Workflow } => {
+: instance is WorkflowInstance => {
   const { error } = workflowSchema.validate(instance.value)
   if (error !== undefined) {
     log.warn(`Received an invalid workflow: ${error.message}`)

--- a/packages/jira-adapter/src/filters/workflow/workflow.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow.ts
@@ -13,19 +13,32 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, Element, Field, isInstanceElement, ListType, MapType } from '@salto-io/adapter-api'
+import { AdditionChange, BuiltinTypes, Element, Field, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isInstanceElement, ListType, MapType, toChange } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
+import { resolveValues } from '@salto-io/adapter-utils'
 import { findObject } from '../../utils'
 import { FilterCreator } from '../../filter'
 import { postFunctionType, types as postFunctionTypes } from './post_functions_types'
-import { isWorkflowInstance, Rules, Status, Validator, Workflow } from './types'
+import { isWorkflowInstance, Rules, Status, Validator, Workflow, WorkflowInstance } from './types'
 import { validatorType, types as validatorTypes } from './validators_types'
+import JiraClient from '../../client/client'
+import { JiraConfig } from '../../config'
+import { getLookUpName } from '../../reference_mapping'
+import { defaultDeployChange, deployChanges } from '../../deployment'
 
 const log = logger(module)
 
+export const UNDEPLOYALBE_VALIDATOR_TYPES = [
+  'com.onresolve.jira.groovy.groovyrunner__script-workflow-validators',
+]
+
+export const UNDEPLOYALBE_POST_FUNCTION_TYPES = [
+  'com.onresolve.jira.groovy.groovyrunner__script-postfunction',
+]
+
 // Taken from https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-workflows/#api-rest-api-3-workflow-post
-const SUPPORTED_POST_FUNCTIONS_TYPES = [
+const FETCHED_POST_FUNCTIONS_TYPES = [
   'FireIssueEventFunction',
   'AssignToCurrentUserFunction',
   'AssignToLeadFunction',
@@ -37,14 +50,16 @@ const SUPPORTED_POST_FUNCTIONS_TYPES = [
   'TriggerWebhookFunction',
   'UpdateIssueCustomFieldPostFunction',
   'UpdateIssueFieldFunction',
+  ...UNDEPLOYALBE_POST_FUNCTION_TYPES,
 ]
 
-const SUPPORTED_ONLY_INITIAL_POST_FUNCTION = [
+const FETCHED_ONLY_INITIAL_POST_FUNCTION = [
   'UpdateIssueStatusFunction',
   'CreateCommentFunction',
   'IssueStoreFunction',
-  ...SUPPORTED_POST_FUNCTIONS_TYPES,
+  ...FETCHED_POST_FUNCTIONS_TYPES,
 ]
+
 
 const WORKFLOW_TYPE_NAME = 'Workflow'
 
@@ -72,8 +87,8 @@ const transformPostFunctions = (rules: Rules, transitionType?: string): void => 
 
     rules.postFunctions = rules.postFunctions?.filter(
       postFunction => (transitionType === 'initial'
-        ? SUPPORTED_ONLY_INITIAL_POST_FUNCTION.includes(postFunction.type ?? '')
-        : SUPPORTED_POST_FUNCTIONS_TYPES.includes(postFunction.type ?? '')),
+        ? FETCHED_ONLY_INITIAL_POST_FUNCTION.includes(postFunction.type ?? '')
+        : FETCHED_POST_FUNCTIONS_TYPES.includes(postFunction.type ?? '')),
     )
 }
 
@@ -121,8 +136,73 @@ const transformWorkflowInstance = (workflowValues: Workflow): void => {
     .forEach(transition => transformRules(transition.rules as Rules, transition.type))
 }
 
+/**
+ * When creating a workflow, the initial transition is always created
+ * with an extra PermissionValidator with CREATE_ISSUES permission key.
+ * Currently the API does not allow us to remove it but we can at least make sure to
+ * not create an additional one if one validator like that is already appears in the nacl.
+ */
+const removeCreateIssuePermissionValidator = (instance: WorkflowInstance): void => {
+  instance.value.transitions
+    ?.filter(transition => transition.type === 'initial')
+    .forEach(transition => {
+      const createIssuePermissionValidatorIndex = _.findLastIndex(
+        transition.rules?.validators ?? [],
+        validator => _.isEqual(
+          validator,
+          {
+            type: 'PermissionValidator',
+            configuration: {
+              permissionKey: 'CREATE_ISSUES',
+            },
+          },
+        ),
+      )
+
+      _.pullAt(
+        transition.rules?.validators ?? [],
+        createIssuePermissionValidatorIndex,
+      )
+    })
+}
+
+const removeUnsupportedRules = (instance: WorkflowInstance): void => {
+  instance.value.transitions
+    ?.forEach(transition => {
+      if (transition.rules?.postFunctions !== undefined) {
+        transition.rules.postFunctions = transition.rules.postFunctions.filter(
+          postFunction => !UNDEPLOYALBE_POST_FUNCTION_TYPES.includes(postFunction.type ?? ''),
+        )
+      }
+
+      if (transition.rules?.validators !== undefined) {
+        transition.rules.validators = transition.rules.validators.filter(
+          validator => !UNDEPLOYALBE_VALIDATOR_TYPES.includes(validator.type ?? ''),
+        )
+      }
+    })
+}
+
+const deployWorkflow = async (
+  change: AdditionChange<InstanceElement>,
+  client: JiraClient,
+  config: JiraConfig,
+): Promise<void> => {
+  const instance = await resolveValues(getChangeData(change), getLookUpName)
+  if (isWorkflowInstance(instance)) {
+    removeCreateIssuePermissionValidator(instance)
+    removeUnsupportedRules(instance)
+  }
+  await defaultDeployChange({
+    change: toChange({ after: instance }),
+    client,
+    apiDefinitions: config.apiDefinitions,
+  })
+  getChangeData(change).value.entityId = instance.value.entityId
+}
+
 // This filter transforms the workflow values structure so it will fit its deployment endpoint
-const filter: FilterCreator = () => ({
+const filter: FilterCreator = ({ config, client }) => ({
   onFetch: async (elements: Element[]) => {
     const workflowType = findObject(elements, WORKFLOW_TYPE_NAME)
     if (workflowType !== undefined) {
@@ -155,6 +235,27 @@ const filter: FilterCreator = () => ({
       .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
       .filter(isWorkflowInstance)
       .forEach(instance => transformWorkflowInstance(instance.value))
+  },
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && isAdditionChange(change)
+        && getChangeData(change).elemID.typeName === 'Workflow'
+    )
+
+
+    const deployResult = await deployChanges(
+      relevantChanges
+        .filter(isInstanceChange)
+        .filter(isAdditionChange),
+      async change => deployWorkflow(change, client, config)
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
   },
 })
 

--- a/packages/jira-adapter/test/change_validators/change_validator.test.ts
+++ b/packages/jira-adapter/test/change_validators/change_validator.test.ts
@@ -32,13 +32,13 @@ describe('change validator creator', () => {
           elemID: new ElemID(JIRA, 'obj'),
           severity: 'Error',
           message: 'Deployment of non-instance elements is not supported in adapter jira',
-          detailedMessage: 'Salto does not support deployment of jira.obj',
+          detailedMessage: 'Deployment of jira.obj is not supported',
         },
         {
           elemID: new ElemID(JIRA, 'obj2'),
           severity: 'Error',
           message: 'Deployment of non-instance elements is not supported in adapter jira',
-          detailedMessage: 'Salto does not support deployment of jira.obj2',
+          detailedMessage: 'Deployment of jira.obj2 is not supported',
         },
       ])
     })

--- a/packages/jira-adapter/test/change_validators/workflow.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflow.test.ts
@@ -44,8 +44,8 @@ describe('workflowValidator', () => {
       {
         elemID: instance.elemID,
         severity: 'Warning',
-        message: `Salto does not support deploying script-runner configuration in the instance ${instance.elemID.getFullName()}`,
-        detailedMessage: 'Salto does not support deploying script-runner (com.onresolve.jira.groovy.groovyrunner) configuration. If continuing, they will be omitted from the deployment',
+        message: `Deploying script-runner configuration in the instance ${instance.elemID.getFullName()} is not supported.`,
+        detailedMessage: 'Deploying script-runner (com.onresolve.jira.groovy.groovyrunner) configuration is not supported. If continuing, they will be omitted from the deployment',
       },
     ])
   })
@@ -69,8 +69,8 @@ describe('workflowValidator', () => {
       {
         elemID: instance.elemID,
         severity: 'Warning',
-        message: `Salto does not support deploying script-runner configuration in the instance ${instance.elemID.getFullName()}`,
-        detailedMessage: 'Salto does not support deploying script-runner (com.onresolve.jira.groovy.groovyrunner) configuration. If continuing, they will be omitted from the deployment',
+        message: `Deploying script-runner configuration in the instance ${instance.elemID.getFullName()} is not supported.`,
+        detailedMessage: 'Deploying script-runner (com.onresolve.jira.groovy.groovyrunner) configuration is not supported. If continuing, they will be omitted from the deployment',
       },
     ])
   })

--- a/packages/jira-adapter/test/change_validators/workflow.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflow.test.ts
@@ -1,0 +1,124 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { workflowValidator } from '../../src/change_validators/workflow'
+import { JIRA } from '../../src/constants'
+
+describe('workflowValidator', () => {
+  let type: ObjectType
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    type = new ObjectType({ elemID: new ElemID(JIRA, 'Workflow') })
+    instance = new InstanceElement('instance', type)
+  })
+  it('should return an error if there is a non-deployable post function', async () => {
+    instance.value.transitions = [{
+      rules: {
+        postFunctions: [
+          {
+            type: 'com.onresolve.jira.groovy.groovyrunner__script-postfunction',
+          },
+        ],
+      },
+    }]
+
+    expect(await workflowValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Warning',
+        message: `Salto does not support deploying script-runner configuration in the instance ${instance.elemID.getFullName()}`,
+        detailedMessage: 'Salto does not support deploying script-runner (com.onresolve.jira.groovy.groovyrunner) configuration. If continuing, they will be omitted from the deployment',
+      },
+    ])
+  })
+
+  it('should return an error if there is a non-deployable validator', async () => {
+    instance.value.transitions = [{
+      rules: {
+        validators: [
+          {
+            type: 'com.onresolve.jira.groovy.groovyrunner__script-workflow-validators',
+          },
+        ],
+      },
+    }]
+
+    expect(await workflowValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Warning',
+        message: `Salto does not support deploying script-runner configuration in the instance ${instance.elemID.getFullName()}`,
+        detailedMessage: 'Salto does not support deploying script-runner (com.onresolve.jira.groovy.groovyrunner) configuration. If continuing, they will be omitted from the deployment',
+      },
+    ])
+  })
+
+  it('should not return an error if workflow is valid', async () => {
+    instance.value.transitions = [{
+      rules: {
+        postFunctions: [
+          {
+            type: 'other',
+          },
+          {
+            val: 'val',
+          },
+        ],
+        validators: [
+          {
+            type: 'other',
+          },
+          {
+            val: 'val',
+          },
+        ],
+      },
+    }]
+
+    expect(await workflowValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([])
+  })
+
+  it('should not return an error if there are no transitions', async () => {
+    expect(await workflowValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([])
+  })
+  it('should not return an error if there are no rules', async () => {
+    instance.value.transitions = [{
+      val: 'val',
+    }]
+    expect(await workflowValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([])
+  })
+})

--- a/packages/jira-adapter/test/filters/workflow.test.ts
+++ b/packages/jira-adapter/test/filters/workflow.test.ts
@@ -18,7 +18,7 @@ import { deployment, filterUtils } from '@salto-io/adapter-components'
 import JiraClient from '../../src/client/client'
 import { DEFAULT_CONFIG } from '../../src/config'
 import { JIRA } from '../../src/constants'
-import workflowFilter from '../../src/filters/workflow/workflow'
+import workflowFilter, { INITIAL_VALIDATOR } from '../../src/filters/workflow/workflow'
 import { mockClient } from '../utils'
 import { EXPECTED_POST_FUNCTIONS, WITH_PERMISSION_VALIDATORS, WITH_POST_FUNCTIONS, WITH_SCRIPT_RUNNERS, WITH_UNSUPPORTED_POST_FUNCTIONS, WITH_VALIDATORS } from './workflow_values'
 
@@ -424,12 +424,7 @@ describe('workflowFilter', () => {
                   type: 'initial',
                   rules: {
                     validators: [
-                      {
-                        type: 'PermissionValidator',
-                        configuration: {
-                          permissionKey: 'CREATE_ISSUES',
-                        },
-                      },
+                      INITIAL_VALIDATOR,
                       {
                         type: 'PreviousStatusValidator',
                         configuration: {

--- a/packages/jira-adapter/test/filters/workflow.test.ts
+++ b/packages/jira-adapter/test/filters/workflow.test.ts
@@ -13,252 +13,165 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import { filterUtils } from '@salto-io/adapter-components'
+import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { deployment, filterUtils } from '@salto-io/adapter-components'
+import JiraClient from '../../src/client/client'
+import { DEFAULT_CONFIG } from '../../src/config'
 import { JIRA } from '../../src/constants'
 import workflowFilter from '../../src/filters/workflow/workflow'
-import { mockClient, getDefaultAdapterConfig } from '../utils'
-import { EXPECTED_POST_FUNCTIONS, WITH_POST_FUNCTIONS, WITH_UNSUPPORTED_POST_FUNCTIONS, WITH_VALIDATORS } from './workflow_values'
+import { mockClient } from '../utils'
+import { EXPECTED_POST_FUNCTIONS, WITH_PERMISSION_VALIDATORS, WITH_POST_FUNCTIONS, WITH_SCRIPT_RUNNERS, WITH_UNSUPPORTED_POST_FUNCTIONS, WITH_VALIDATORS } from './workflow_values'
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn(),
+    },
+  }
+})
 
 describe('workflowFilter', () => {
-  let filter: filterUtils.FilterWith<'onFetch'>
+  let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
   let workflowType: ObjectType
+  let client: JiraClient
   beforeEach(async () => {
     workflowType = new ObjectType({ elemID: new ElemID(JIRA, 'Workflow') })
 
-    const { client, paginator } = mockClient()
+    const { client: cli, paginator } = mockClient()
+    client = cli
     filter = workflowFilter({
       client,
       paginator,
-      config: await getDefaultAdapterConfig(),
+      config: DEFAULT_CONFIG,
     }) as typeof filter
   })
 
-  it('should delete the id field in Workflow type', async () => {
-    const workflowIdType = new ObjectType({
-      elemID: new ElemID(JIRA, 'WorkflowId'),
-      fields: {
-        entityId: {
-          refType: BuiltinTypes.STRING,
-        },
-        name: {
-          refType: BuiltinTypes.STRING,
-        },
-      },
-    })
-    workflowType.fields.id = new Field(workflowType, 'id', workflowIdType)
-    await filter.onFetch([workflowType])
-    expect(workflowType.fields.id).toBeUndefined()
-  })
-
-  it('should set the properties field in WorkflowStatus', async () => {
-    const workflowStatusType = new ObjectType({
-      elemID: new ElemID(JIRA, 'WorkflowStatus'),
-    })
-    await filter.onFetch([workflowStatusType])
-    expect(workflowStatusType.fields.properties).toBeDefined()
-  })
-
-  it('should replace conditionsTree with conditions in WorkflowRules', async () => {
-    const workflowRulesType = new ObjectType({
-      elemID: new ElemID(JIRA, 'WorkflowRules'),
-      fields: {
-        conditionsTree: {
-          refType: BuiltinTypes.STRING,
-        },
-      },
-    })
-    await filter.onFetch([workflowRulesType])
-    expect(workflowRulesType.fields.conditionsTree).toBeUndefined()
-    expect(workflowRulesType.fields.conditions).toBeDefined()
-  })
-
-  it('should replace postFunctions and validators types and and return the new types', async () => {
-    const workflowRulesType = new ObjectType({
-      elemID: new ElemID(JIRA, 'WorkflowRules'),
-      fields: {
-        conditionsTree: {
-          refType: BuiltinTypes.STRING,
-        },
-        postFunctions: {
-          refType: BuiltinTypes.STRING,
-        },
-        validators: {
-          refType: BuiltinTypes.STRING,
-        },
-      },
-    })
-    const elements = [workflowRulesType]
-    await filter.onFetch(elements)
-    expect(elements.length).toBeGreaterThan(1)
-    expect((await workflowRulesType.fields.postFunctions.getType()).elemID.getFullName()).toBe('List<jira.PostFunction>')
-    expect((await workflowRulesType.fields.validators.getType()).elemID.getFullName()).toBe('List<jira.Validator>')
-  })
-
-  it('should split the id value to entityId and name in Workflow instances', async () => {
-    const instance = new InstanceElement(
-      'instance',
-      workflowType,
-      {
-        id: {
-          entityId: 'id',
-          name: 'name',
-        },
-      }
-    )
-    await filter.onFetch([instance])
-    expect(instance.value).toEqual({
-      entityId: 'id',
-      name: 'name',
-    })
-  })
-
-  it('should remove additionalProperties and issueEditable from statuses', async () => {
-    const instance = new InstanceElement(
-      'instance',
-      workflowType,
-      {
-        statuses: [
-          {
-            properties: {
-              additionalProperties: {
-                'jira.issue.editable': 'true',
-                issueEditable: true,
-              },
-            },
+  describe('onFetch', () => {
+    it('should delete the id field in Workflow type', async () => {
+      const workflowIdType = new ObjectType({
+        elemID: new ElemID(JIRA, 'WorkflowId'),
+        fields: {
+          entityId: {
+            refType: BuiltinTypes.STRING,
           },
-          {
-            properties: {
-              additionalProperties: {
-                'jira.issue.editable': 'false',
-                issueEditable: false,
-              },
-            },
+          name: {
+            refType: BuiltinTypes.STRING,
           },
-          {},
-        ],
-      }
-    )
-    await filter.onFetch([instance])
-    expect(instance.value.statuses).toEqual([
-      {
-        properties: {
-          'jira.issue.editable': 'true',
         },
-      },
-      {
-        properties: {
-          'jira.issue.editable': 'false',
-        },
-      },
-      {},
-    ])
-  })
+      })
+      workflowType.fields.id = new Field(workflowType, 'id', workflowIdType)
+      await filter.onFetch([workflowType])
+      expect(workflowType.fields.id).toBeUndefined()
+    })
 
-  it('should replace conditionsTree with conditions', async () => {
-    const instance = new InstanceElement(
-      'instance',
-      workflowType,
-      {
-        transitions: [
-          {
-            rules: {
-              conditionsTree: 'conditionsTree',
-            },
+    it('should set the properties field in WorkflowStatus', async () => {
+      const workflowStatusType = new ObjectType({
+        elemID: new ElemID(JIRA, 'WorkflowStatus'),
+      })
+      await filter.onFetch([workflowStatusType])
+      expect(workflowStatusType.fields.properties).toBeDefined()
+    })
+
+    it('should replace conditionsTree with conditions in WorkflowRules', async () => {
+      const workflowRulesType = new ObjectType({
+        elemID: new ElemID(JIRA, 'WorkflowRules'),
+        fields: {
+          conditionsTree: {
+            refType: BuiltinTypes.STRING,
           },
-        ],
-      }
-    )
-    await filter.onFetch([instance])
-    expect(instance.value.transitions).toEqual([
-      {
-        rules: {
-          conditions: 'conditionsTree',
         },
-      },
-    ])
-  })
+      })
+      await filter.onFetch([workflowRulesType])
+      expect(workflowRulesType.fields.conditionsTree).toBeUndefined()
+      expect(workflowRulesType.fields.conditions).toBeDefined()
+    })
 
-  describe('post functions', () => {
-    it('should remove name from post functions', async () => {
+    it('should replace postFunctions and validators types and and return the new types', async () => {
+      const workflowRulesType = new ObjectType({
+        elemID: new ElemID(JIRA, 'WorkflowRules'),
+        fields: {
+          conditionsTree: {
+            refType: BuiltinTypes.STRING,
+          },
+          postFunctions: {
+            refType: BuiltinTypes.STRING,
+          },
+          validators: {
+            refType: BuiltinTypes.STRING,
+          },
+        },
+      })
+      const elements = [workflowRulesType]
+      await filter.onFetch(elements)
+      expect(elements.length).toBeGreaterThan(1)
+      expect((await workflowRulesType.fields.postFunctions.getType()).elemID.getFullName()).toBe('List<jira.PostFunction>')
+      expect((await workflowRulesType.fields.validators.getType()).elemID.getFullName()).toBe('List<jira.Validator>')
+    })
+
+    it('should split the id value to entityId and name in Workflow instances', async () => {
       const instance = new InstanceElement(
         'instance',
         workflowType,
-        WITH_POST_FUNCTIONS
+        {
+          id: {
+            entityId: 'id',
+            name: 'name',
+          },
+        }
       )
       await filter.onFetch([instance])
-      expect(instance.value.transitions).toEqual([
-        EXPECTED_POST_FUNCTIONS,
-      ])
+      expect(instance.value).toEqual({
+        entityId: 'id',
+        name: 'name',
+      })
     })
 
-    it('should remove unsupported post functions', async () => {
+    it('should remove additionalProperties and issueEditable from statuses', async () => {
       const instance = new InstanceElement(
         'instance',
         workflowType,
-        WITH_UNSUPPORTED_POST_FUNCTIONS
-      )
-      await filter.onFetch([instance])
-      expect(instance.value.transitions).toEqual([
         {
-          type: 'initial',
-          rules: {
-            postFunctions: [
-              { type: 'AssignToCurrentUserFunction' },
-              { type: 'UpdateIssueStatusFunction' },
-            ],
-          },
-        },
-        {
-          type: 'global',
-          rules: {
-            postFunctions: [
-              { type: 'AssignToCurrentUserFunction' },
-            ],
-          },
-        },
-      ])
-    })
-  })
-
-  describe('validators', () => {
-    it('should remove name', async () => {
-      const instance = new InstanceElement(
-        'instance',
-        workflowType,
-        WITH_VALIDATORS,
-      )
-      await filter.onFetch([instance])
-      expect(instance.value.transitions).toEqual([
-        {
-          rules: {
-            validators: [
-              {
-                type: 'ParentStatusValidator',
-                configuration: {
-                  parentStatuses: [{
-                    id: '1',
-                  }],
+          statuses: [
+            {
+              properties: {
+                additionalProperties: {
+                  'jira.issue.editable': 'true',
+                  issueEditable: true,
                 },
               },
-              {
-                type: 'PreviousStatusValidator',
-                configuration: {
-                  previousStatus: {
-                    id: '1',
-                  },
+            },
+            {
+              properties: {
+                additionalProperties: {
+                  'jira.issue.editable': 'false',
+                  issueEditable: false,
                 },
               },
-              {
-                type: 'PreviousStatusValidator',
-              },
-            ],
+            },
+            {},
+          ],
+        }
+      )
+      await filter.onFetch([instance])
+      expect(instance.value.statuses).toEqual([
+        {
+          properties: {
+            'jira.issue.editable': 'true',
           },
         },
+        {
+          properties: {
+            'jira.issue.editable': 'false',
+          },
+        },
+        {},
       ])
     })
 
-    it('should rename fields to fieldIds', async () => {
+    it('should replace conditionsTree with conditions', async () => {
       const instance = new InstanceElement(
         'instance',
         workflowType,
@@ -266,15 +179,7 @@ describe('workflowFilter', () => {
           transitions: [
             {
               rules: {
-                validators: [
-                  {
-                    type: 'ParentStatusValidator',
-                    configuration: {
-                      fields: ['1'],
-                      field: '1',
-                    },
-                  },
-                ],
+                conditionsTree: 'conditionsTree',
               },
             },
           ],
@@ -284,21 +189,171 @@ describe('workflowFilter', () => {
       expect(instance.value.transitions).toEqual([
         {
           rules: {
-            validators: [
-              {
-                type: 'ParentStatusValidator',
-                configuration: {
-                  fieldIds: ['1'],
-                  fieldId: '1',
-                },
-              },
-            ],
+            conditions: 'conditionsTree',
           },
         },
       ])
     })
 
-    it('should convert windowsDays to number', async () => {
+    describe('post functions', () => {
+      it('should remove name from post functions', async () => {
+        const instance = new InstanceElement(
+          'instance',
+          workflowType,
+          WITH_POST_FUNCTIONS
+        )
+        await filter.onFetch([instance])
+        expect(instance.value.transitions).toEqual([
+          EXPECTED_POST_FUNCTIONS,
+        ])
+      })
+
+      it('should remove unsupported post functions', async () => {
+        const instance = new InstanceElement(
+          'instance',
+          workflowType,
+          WITH_UNSUPPORTED_POST_FUNCTIONS
+        )
+        await filter.onFetch([instance])
+        expect(instance.value.transitions).toEqual([
+          {
+            type: 'initial',
+            rules: {
+              postFunctions: [
+                { type: 'AssignToCurrentUserFunction' },
+                { type: 'UpdateIssueStatusFunction' },
+              ],
+            },
+          },
+          {
+            type: 'global',
+            rules: {
+              postFunctions: [
+                { type: 'AssignToCurrentUserFunction' },
+              ],
+            },
+          },
+        ])
+      })
+    })
+
+    describe('validators', () => {
+      it('should remove name', async () => {
+        const instance = new InstanceElement(
+          'instance',
+          workflowType,
+          WITH_VALIDATORS,
+        )
+        await filter.onFetch([instance])
+        expect(instance.value.transitions).toEqual([
+          {
+            rules: {
+              validators: [
+                {
+                  type: 'ParentStatusValidator',
+                  configuration: {
+                    parentStatuses: [{
+                      id: '1',
+                    }],
+                  },
+                },
+                {
+                  type: 'PreviousStatusValidator',
+                  configuration: {
+                    previousStatus: {
+                      id: '1',
+                    },
+                  },
+                },
+                {
+                  type: 'PreviousStatusValidator',
+                },
+              ],
+            },
+          },
+        ])
+      })
+
+      it('should rename fields to fieldIds', async () => {
+        const instance = new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            transitions: [
+              {
+                rules: {
+                  validators: [
+                    {
+                      type: 'ParentStatusValidator',
+                      configuration: {
+                        fields: ['1'],
+                        field: '1',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          }
+        )
+        await filter.onFetch([instance])
+        expect(instance.value.transitions).toEqual([
+          {
+            rules: {
+              validators: [
+                {
+                  type: 'ParentStatusValidator',
+                  configuration: {
+                    fieldIds: ['1'],
+                    fieldId: '1',
+                  },
+                },
+              ],
+            },
+          },
+        ])
+      })
+
+      it('should convert windowsDays to number', async () => {
+        const instance = new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            transitions: [
+              {
+                rules: {
+                  validators: [
+                    {
+                      type: 'ParentStatusValidator',
+                      configuration: {
+                        windowsDays: '1',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          }
+        )
+        await filter.onFetch([instance])
+        expect(instance.value.transitions).toEqual([
+          {
+            rules: {
+              validators: [
+                {
+                  type: 'ParentStatusValidator',
+                  configuration: {
+                    windowsDays: 1,
+                  },
+                },
+              ],
+            },
+          },
+        ])
+      })
+    })
+
+    it('should not convert invalid workflow', async () => {
       const instance = new InstanceElement(
         'instance',
         workflowType,
@@ -306,6 +361,7 @@ describe('workflowFilter', () => {
           transitions: [
             {
               rules: {
+                postFunctions: 'invalid',
                 validators: [
                   {
                     type: 'ParentStatusValidator',
@@ -323,11 +379,12 @@ describe('workflowFilter', () => {
       expect(instance.value.transitions).toEqual([
         {
           rules: {
+            postFunctions: 'invalid',
             validators: [
               {
                 type: 'ParentStatusValidator',
                 configuration: {
-                  windowsDays: 1,
+                  windowsDays: '1',
                 },
               },
             ],
@@ -337,43 +394,212 @@ describe('workflowFilter', () => {
     })
   })
 
-  it('should not convert invalid workflow', async () => {
-    const instance = new InstanceElement(
-      'instance',
-      workflowType,
-      {
-        transitions: [
-          {
-            rules: {
-              postFunctions: 'invalid',
-              validators: [
+  describe('deploy', () => {
+    const deployChangeMock = deployment.deployChange as jest.MockedFunction<
+      typeof deployment.deployChange
+    >
+
+    beforeEach(() => {
+      deployChangeMock.mockClear()
+    })
+    it('should remove the last PermissionValidator with permissionKey CREATE_ISSUES', async () => {
+      const change = toChange({
+        after: new InstanceElement(
+          'instance',
+          workflowType,
+          WITH_PERMISSION_VALIDATORS
+        ),
+      })
+
+      await filter.deploy([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        toChange({
+          after: new InstanceElement(
+            'instance',
+            workflowType,
+            {
+              transitions: [
                 {
-                  type: 'ParentStatusValidator',
-                  configuration: {
-                    windowsDays: '1',
+                  type: 'initial',
+                  rules: {
+                    validators: [
+                      {
+                        type: 'PermissionValidator',
+                        configuration: {
+                          permissionKey: 'CREATE_ISSUES',
+                        },
+                      },
+                      {
+                        type: 'PreviousStatusValidator',
+                        configuration: {
+                          previousStatus: {
+                            id: '1',
+                            name: 'name',
+                          },
+                        },
+                      },
+                      {
+                        type: 'PermissionValidator',
+                        configuration: {
+                          permissionKey: 'OTHER',
+                        },
+                      },
+                    ],
                   },
                 },
               ],
-            },
-          },
-        ],
-      }
-    )
-    await filter.onFetch([instance])
-    expect(instance.value.transitions).toEqual([
-      {
-        rules: {
-          postFunctions: 'invalid',
-          validators: [
+            }
+          ),
+        }),
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.Workflow.deployRequests,
+        [],
+        undefined
+      )
+    })
+
+    it('should remove the undeployable post functions and validators', async () => {
+      const change = toChange({
+        after: new InstanceElement(
+          'instance',
+          workflowType,
+          WITH_SCRIPT_RUNNERS
+        ),
+      })
+
+      await filter.deploy([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        toChange({
+          after: new InstanceElement(
+            'instance',
+            workflowType,
             {
-              type: 'ParentStatusValidator',
-              configuration: {
-                windowsDays: '1',
+              transitions: [
+                {
+                  rules: {
+                    validators: [
+                      {
+                        type: 'other',
+                      },
+                      {
+                        val: 'val',
+                      },
+                    ],
+                    postFunctions: [
+                      {
+                        type: 'other',
+                      },
+                      {
+                        val: 'val',
+                      },
+                    ],
+                  },
+                },
+              ],
+            }
+          ),
+        }),
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.Workflow.deployRequests,
+        [],
+        undefined
+      )
+    })
+
+    it('should not change the values if there are no transitions', async () => {
+      const change = toChange({
+        after: new InstanceElement(
+          'instance',
+          workflowType,
+          {}
+        ),
+      })
+
+      await filter.deploy([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        toChange({
+          after: new InstanceElement(
+            'instance',
+            workflowType,
+            {},
+          ),
+        }),
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.Workflow.deployRequests,
+        [],
+        undefined
+      )
+    })
+
+    it('should not change the values if there are no rules', async () => {
+      const change = toChange({
+        after: new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            transitions: [
+              {
+                type: 'initial',
               },
+            ],
+          }
+        ),
+      })
+
+      await filter.deploy([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        toChange({
+          after: new InstanceElement(
+            'instance',
+            workflowType,
+            {
+              transitions: [
+                {
+                  type: 'initial',
+                },
+              ],
             },
-          ],
-        },
-      },
-    ])
+          ),
+        }),
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.Workflow.deployRequests,
+        [],
+        undefined
+      )
+    })
+
+    it('should not change the values if values are not a valid workflow', async () => {
+      const change = toChange({
+        after: new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            transitions: 2,
+          }
+        ),
+      })
+
+      await filter.deploy([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        toChange({
+          after: new InstanceElement(
+            'instance',
+            workflowType,
+            {
+              transitions: 2,
+            },
+          ),
+        }),
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.Workflow.deployRequests,
+        [],
+        undefined
+      )
+    })
   })
 })

--- a/packages/jira-adapter/test/filters/workflow_values.ts
+++ b/packages/jira-adapter/test/filters/workflow_values.ts
@@ -13,6 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { INITIAL_VALIDATOR } from '../../src/filters/workflow/workflow'
+
 export const WITH_POST_FUNCTIONS = {
   transitions: [
     {
@@ -160,12 +162,7 @@ export const WITH_PERMISSION_VALIDATORS = {
       type: 'initial',
       rules: {
         validators: [
-          {
-            type: 'PermissionValidator',
-            configuration: {
-              permissionKey: 'CREATE_ISSUES',
-            },
-          },
+          INITIAL_VALIDATOR,
           {
             type: 'PreviousStatusValidator',
             configuration: {
@@ -175,12 +172,7 @@ export const WITH_PERMISSION_VALIDATORS = {
               },
             },
           },
-          {
-            type: 'PermissionValidator',
-            configuration: {
-              permissionKey: 'CREATE_ISSUES',
-            },
-          },
+          INITIAL_VALIDATOR,
           {
             type: 'PermissionValidator',
             configuration: {

--- a/packages/jira-adapter/test/filters/workflow_values.ts
+++ b/packages/jira-adapter/test/filters/workflow_values.ts
@@ -153,3 +153,73 @@ export const WITH_VALIDATORS = {
     },
   ],
 }
+
+export const WITH_PERMISSION_VALIDATORS = {
+  transitions: [
+    {
+      type: 'initial',
+      rules: {
+        validators: [
+          {
+            type: 'PermissionValidator',
+            configuration: {
+              permissionKey: 'CREATE_ISSUES',
+            },
+          },
+          {
+            type: 'PreviousStatusValidator',
+            configuration: {
+              previousStatus: {
+                id: '1',
+                name: 'name',
+              },
+            },
+          },
+          {
+            type: 'PermissionValidator',
+            configuration: {
+              permissionKey: 'CREATE_ISSUES',
+            },
+          },
+          {
+            type: 'PermissionValidator',
+            configuration: {
+              permissionKey: 'OTHER',
+            },
+          },
+        ],
+      },
+    },
+  ],
+}
+
+export const WITH_SCRIPT_RUNNERS = {
+  transitions: [
+    {
+      rules: {
+        validators: [
+          {
+            type: 'com.onresolve.jira.groovy.groovyrunner__script-workflow-validators',
+          },
+          {
+            type: 'other',
+          },
+          {
+            val: 'val',
+          },
+        ],
+        postFunctions: [
+          {
+            type: 'com.onresolve.jira.groovy.groovyrunner__script-postfunction',
+          },
+          {
+            type: 'other',
+          },
+          {
+            val: 'val',
+          },
+        ],
+      },
+    },
+  ],
+}

--- a/packages/zendesk-support-adapter/test/change_validator.test.ts
+++ b/packages/zendesk-support-adapter/test/change_validator.test.ts
@@ -34,13 +34,13 @@ describe('change validator creator', () => {
           elemID: new ElemID(ZENDESK_SUPPORT, 'obj'),
           severity: 'Error',
           message: 'Deployment of non-instance elements is not supported in adapter zendesk_support',
-          detailedMessage: 'Salto does not support deployment of zendesk_support.obj',
+          detailedMessage: 'Deployment of zendesk_support.obj is not supported',
         },
         {
           elemID: new ElemID(ZENDESK_SUPPORT, 'obj2'),
           severity: 'Error',
           message: 'Deployment of non-instance elements is not supported in adapter zendesk_support',
-          detailedMessage: 'Salto does not support deployment of zendesk_support.obj2',
+          detailedMessage: 'Deployment of zendesk_support.obj2 is not supported',
         },
       ])
     })


### PR DESCRIPTION
Fixed two issues in workflow deployment
- When creating a workflow it automatically adds an additional `PermissionValidator` with `permissionKey` of `CREATE_ISSUES`  to the initial transition so if it's already in the NaCl I remove it to not create duplicate validators

- Jira does not support deploying script runners config so I removed it from the nacl on deploy and added a changed validator

---
_Release Notes_: 
None

---
_User Notifications_: 
None