### PR TITLE
SALTO-1882 Mock missed swagger calls in jira unittests

### DIFF
--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -28,16 +28,16 @@ const { generateTypes, getAllInstances, loadSwagger } = elements.swagger
 
 jest.mock('@salto-io/adapter-components', () => {
   const actual = jest.requireActual('@salto-io/adapter-components')
+  // only including relevant functions
   return {
     ...actual,
     deployment: {
-      ...actual.deployment,
+      changeValidators: actual.deployment.changeValidators,
       deployChange: jest.fn().mockImplementation(actual.elements.swagger.deployChange),
     },
     elements: {
-      ...actual.elements,
       swagger: {
-        ...actual.elements.swagger,
+        flattenAdditionalProperties: actual.elements.swagger.flattenAdditionalProperties,
         generateTypes: jest.fn().mockImplementation(() => { throw new Error('generateTypes called without a mock') }),
         getAllInstances: jest.fn().mockImplementation(() => { throw new Error('getAllInstances called without a mock') }),
         loadSwagger: jest.fn().mockImplementation(() => { throw new Error('loadSwagger called without a mock') }),


### PR DESCRIPTION
Looks like we started making network calls due to a recent change to load swaggers before `generateTypes` ([here](https://github.com/salto-io/salto/pull/2527/files#diff-c0e6fe5ff7328c339f0fcaaad6e26e11196075822b41173debf3667cd0a83de3R92))


---
_Release Notes_: 
None

---
_User Notifications_: 
None