### PR TITLE
SALTO-1882: Stripe UTs will no longer require internet access

### DIFF
--- a/packages/stripe-adapter/test/adapter.test.ts
+++ b/packages/stripe-adapter/test/adapter.test.ts
@@ -171,7 +171,7 @@ describe('stripe swagger adapter', () => {
         },
       },
     }
-    mockedAdapterComponents.elements.swagger.generateTypes.mockReturnValue(mockTypes)
+    mockedAdapterComponents.elements.swagger.generateTypes.mockImplementation(async () => mockTypes)
 
     const mockAxiosAdapter = new MockAdapter(axios, { delayResponse: 1, onNoMatch: 'throwException' });
     (mockReplies as MockReply[]).forEach(({ url, params, response }) => {

--- a/packages/stripe-adapter/test/adapter.test.ts
+++ b/packages/stripe-adapter/test/adapter.test.ts
@@ -171,7 +171,7 @@ describe('stripe swagger adapter', () => {
         },
       },
     }
-    mockedAdapterComponents.elements.swagger.generateTypes.mockImplementation(async () => mockTypes)
+    mockedAdapterComponents.elements.swagger.generateTypes.mockResolvedValue(mockTypes)
 
     const mockAxiosAdapter = new MockAdapter(axios, { delayResponse: 1, onNoMatch: 'throwException' });
     (mockReplies as MockReply[]).forEach(({ url, params, response }) => {


### PR DESCRIPTION
Stripe UTs parsed the actual swagger as part of the UTs which was slow and required internet.

---

_Release Notes_: 
_None_

---

_User Notifications_: 
_None_
