### PR TITLE
SALTO-1895: Omit base element changes from deploy plan when their inner value has ChangeError

### DIFF
--- a/packages/core/src/core/plan/filter.ts
+++ b/packages/core/src/core/plan/filter.ts
@@ -213,7 +213,9 @@ export const filterInvalidChanges = async (
     .toArray()
 
   const invalidChanges = changeErrors.filter(v => v.severity === 'Error')
-  const nodeElemIdsToOmit = new Set(invalidChanges.map(change => change.elemID.getFullName()))
+  const nodeElemIdsToOmit = new Set(
+    invalidChanges.map(change => change.elemID.createBaseID().parent.getFullName())
+  )
   const validAfterElementsMap = await createValidAfterElementsMap(invalidChanges)
   const { validDiffGraph, dependencyErrors } = buildValidDiffGraph(
     nodeElemIdsToOmit,

--- a/packages/core/test/core/plan/filter.test.ts
+++ b/packages/core/test/core/plan/filter.test.ts
@@ -258,16 +258,8 @@ describe('filterInvalidChanges', () => {
     expect(planResult.changeErrors.filter(err => !isDependencyError(err))).toHaveLength(1)
     expect(planResult.changeErrors.filter(err => isDependencyError(err))).toHaveLength(0)
     expect(planResult.changeErrors[0].severity).toEqual('Error')
-    expect(planResult.changeErrors[0].elemID.isEqual(seatsId))
-      .toBeTruthy()
-    expect(planResult.size).toBe(1)
-    const planItem = getFirstPlanItem(planResult)
-    expect(planItem.items.size).toBe(1)
-    const [change] = planItem.changes()
-    expect(change.action).toEqual('modify')
-    const changeInstance = getChangeData(change)
-    expect(changeInstance).toBeInstanceOf(InstanceElement)
-    expect(changeInstance.elemID).toEqual(saltoEmployeeInstance.elemID)
+    expect(planResult.changeErrors[0].elemID.isEqual(seatsId)).toBeTruthy()
+    expect(planResult.size).toBe(0)
   })
 
   it('should have onRemove change errors', async () => {


### PR DESCRIPTION
_Release Notes_: 
Omit type/field/instance change from the deploy plan when its inner value has ChangeError

---
_User Notifications_: 
None