### PR TITLE
SALTO-1778: Added references to workflow scheme

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -23,6 +23,7 @@ import { createIssueTypeSchemeValues } from './issueTypeScheme'
 import { createIssueTypeScreenSchemeValues } from './issueTypeScreenScheme'
 import { createScreenValues } from './screen'
 import { createWorkflowValues } from './workflow'
+import { createWorkflowSchemeValues } from './workflowScheme'
 
 export const createInstances = (fetchedElements: Element[]): InstanceElement[] => {
   const randomString = `createdByOssE2e${String(Date.now()).substring(6)}`
@@ -70,11 +71,7 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[] =
   const workflowScheme = new InstanceElement(
     randomString,
     findType('WorkflowScheme', fetchedElements),
-    {
-      name: randomString,
-      description: randomString,
-      defaultWorkflow: 'classic default workflow',
-    },
+    createWorkflowSchemeValues(randomString, fetchedElements),
   )
 
   const screenScheme = new InstanceElement(

--- a/packages/jira-adapter/e2e_test/instances/workflowScheme.ts
+++ b/packages/jira-adapter/e2e_test/instances/workflowScheme.ts
@@ -1,0 +1,33 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Values, Element, ElemID } from '@salto-io/adapter-api'
+import { createReference } from '../utils'
+import { JIRA } from '../../src/constants'
+
+export const createWorkflowSchemeValues = (
+  name: string,
+  allElements: Element[],
+): Values => ({
+  name,
+  description: name,
+  defaultWorkflow: createReference(new ElemID(JIRA, 'Workflow', 'instance', 'jira'), allElements),
+  items: [
+    {
+      issueType: createReference(new ElemID(JIRA, 'IssueType', 'instance', 'Bug'), allElements),
+      workflow: createReference(new ElemID(JIRA, 'Workflow', 'instance', 'jira'), allElements),
+    },
+  ],
+})

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -37,6 +37,7 @@ import hiddenValuesInListsFilter from './filters/hidden_value_in_lists'
 import projectFilter from './filters/project'
 import defaultInstancesDeployFilter from './filters/default_instances_deploy'
 import workflowFilter from './filters/workflow/workflow'
+import workflowSchemeFilter from './filters/workflow_scheme'
 import fieldStructureFilter from './filters/fields/field_structure_filter'
 import fieldDeploymentFilter from './filters/fields/field_deployment_filter'
 import fieldTypeReferencesFilter from './filters/fields/field_type_references_filter'
@@ -54,6 +55,7 @@ const log = logger(module)
 
 export const DEFAULT_FILTERS = [
   workflowFilter,
+  workflowSchemeFilter,
   issueTypeSchemeReferences,
   issueTypeSchemeFilter,
   sharePermissionFilter,

--- a/packages/jira-adapter/src/filters/field_references.ts
+++ b/packages/jira-adapter/src/filters/field_references.ts
@@ -26,6 +26,7 @@ const filter: FilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
     await referenceUtils.addReferences({
       elements,
+      fieldsToGroupBy: ['id', 'name'],
       defs: referencesRules,
       isEqualValue: (lhs, rhs) => _.toString(lhs) === _.toString(rhs),
     })

--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -69,7 +69,9 @@ const filter: FilterCreator = ({ config, client }) => ({
         }
       )
 
-      delete workflowSchemeType.fields.issueTypeMappings
+      if (workflowSchemeType.fields.issueTypeMappings !== undefined) {
+        delete workflowSchemeType.fields.issueTypeMappings
+      }
 
       elements.push(workflowSchemeItemType)
     }

--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -1,0 +1,148 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, Field, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, ListType, ObjectType } from '@salto-io/adapter-api'
+import { elements as elementUtils } from '@salto-io/adapter-components'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { applyFunctionToChangeData, resolveValues } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { getLookUpName } from '../reference_mapping'
+import { findObject } from '../utils'
+import { FilterCreator } from '../filter'
+import { JIRA } from '../constants'
+import { defaultDeployChange, deployChanges } from '../deployment'
+
+const { awu } = collections.asynciterable
+
+const WORKFLOW_SCHEME_TYPE = 'WorkflowScheme'
+const WORKFLOW_SCHEME_ITEM_TYPE = 'WorkflowSchemeItem'
+
+const log = logger(module)
+
+const filter: FilterCreator = ({ config, client }) => ({
+  onFetch: async elements => {
+    const workflowSchemeType = findObject(elements, WORKFLOW_SCHEME_TYPE)
+    if (workflowSchemeType === undefined) {
+      log.warn(`${WORKFLOW_SCHEME_TYPE} type not found`)
+    } else {
+      const workflowSchemeItemType = new ObjectType({
+        elemID: new ElemID(JIRA, WORKFLOW_SCHEME_ITEM_TYPE),
+        fields: {
+          issueType: {
+            refType: BuiltinTypes.STRING,
+            annotations: {
+              [CORE_ANNOTATIONS.CREATABLE]: true,
+              [CORE_ANNOTATIONS.UPDATABLE]: true,
+            },
+          },
+          workflow: {
+            refType: BuiltinTypes.STRING,
+            annotations: {
+              [CORE_ANNOTATIONS.CREATABLE]: true,
+              [CORE_ANNOTATIONS.UPDATABLE]: true,
+            },
+          },
+        },
+        path: [JIRA, elementUtils.TYPES_PATH, WORKFLOW_SCHEME_ITEM_TYPE],
+      })
+
+      workflowSchemeType.fields.items = new Field(
+        workflowSchemeType,
+        'items',
+        new ListType(workflowSchemeItemType),
+        {
+          [CORE_ANNOTATIONS.CREATABLE]: true,
+          [CORE_ANNOTATIONS.UPDATABLE]: true,
+        }
+      )
+
+      delete workflowSchemeType.fields.issueTypeMappings
+
+      elements.push(workflowSchemeItemType)
+    }
+
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === WORKFLOW_SCHEME_TYPE)
+      .filter(instance => instance.value.issueTypeMappings !== undefined)
+      .forEach(instance => {
+        instance.value.items = Object.entries(instance.value.issueTypeMappings
+          .additionalProperties ?? {}).map(([issueType, workflow]) => ({ workflow, issueType }))
+        delete instance.value.issueTypeMappings
+      })
+  },
+
+  preDeploy: async changes => (
+    awu(changes)
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === WORKFLOW_SCHEME_TYPE)
+      .forEach(change => applyFunctionToChangeData<Change<InstanceElement>>(
+        change,
+        async instance => {
+          if (instance.value.items !== undefined) {
+            const resolvedInstance = await resolveValues(instance, getLookUpName)
+            instance.value.issueTypeMappings = _(resolvedInstance.value.items)
+              .keyBy(mapping => mapping.issueType)
+              .mapValues(mapping => mapping.workflow)
+              .value()
+          }
+          return instance
+        }
+      ))
+  ),
+
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && isAdditionOrModificationChange(change)
+        && getChangeData(change).elemID.typeName === WORKFLOW_SCHEME_TYPE
+    )
+
+
+    const deployResult = await deployChanges(
+      relevantChanges
+        .filter(isInstanceChange)
+        .filter(isAdditionOrModificationChange),
+      async change => defaultDeployChange({
+        change,
+        client,
+        apiDefinitions: config.apiDefinitions,
+        fieldsToIgnore: ['items'],
+      })
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+
+  onDeploy: async changes => (
+    awu(changes)
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === WORKFLOW_SCHEME_TYPE)
+      .forEach(change => applyFunctionToChangeData<Change<InstanceElement>>(
+        change,
+        async instance => {
+          delete instance.value.issueTypeMappings
+          return instance
+        }
+      ))
+  ),
+})
+
+export default filter

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -210,6 +210,21 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
     serializationStrategy: 'id',
     target: { type: 'Screen' },
   },
+  {
+    src: { field: 'defaultWorkflow', parentTypes: ['WorkflowScheme'] },
+    serializationStrategy: 'name',
+    target: { type: 'Workflow' },
+  },
+  {
+    src: { field: 'workflow', parentTypes: ['WorkflowSchemeItem'] },
+    serializationStrategy: 'name',
+    target: { type: 'Workflow' },
+  },
+  {
+    src: { field: 'issueType', parentTypes: ['WorkflowSchemeItem'] },
+    serializationStrategy: 'id',
+    target: { type: 'IssueType' },
+  },
 ]
 
 const lookupNameFuncs: GetLookupNameFunc[] = [

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -1,0 +1,208 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { deployment } from '@salto-io/adapter-components'
+import { JIRA } from '../../src/constants'
+import { mockClient } from '../utils'
+import workflowSchemeFilter from '../../src/filters/workflow_scheme'
+import { Filter } from '../../src/filter'
+import { DEFAULT_CONFIG } from '../../src/config'
+import JiraClient from '../../src/client/client'
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn(),
+    },
+  }
+})
+
+describe('workflowScheme', () => {
+  let workflowSchemeType: ObjectType
+  let filter: Filter
+  let client: JiraClient
+  beforeEach(async () => {
+    const { client: cli, paginator } = mockClient()
+    client = cli
+
+    filter = workflowSchemeFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    })
+    workflowSchemeType = new ObjectType({
+      elemID: new ElemID(JIRA, 'WorkflowScheme'),
+    })
+  })
+
+  describe('onFetch', () => {
+    it('replace field issueTypeMappings with items', async () => {
+      workflowSchemeType.fields.issueTypeMappings = new Field(workflowSchemeType, 'issueTypeMappings', BuiltinTypes.STRING)
+      await filter.onFetch?.([workflowSchemeType])
+      expect(workflowSchemeType.fields.issueTypeMappings).toBeUndefined()
+      expect(workflowSchemeType.fields.items).toBeDefined()
+      expect(workflowSchemeType.fields.items.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+    })
+
+    it('replace value of issueTypeMappings with items', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowSchemeType,
+        {
+          issueTypeMappings: {
+            additionalProperties: {
+              1234: 'workflow name',
+            },
+          },
+        }
+      )
+      await filter.onFetch?.([instance])
+      expect(instance.value).toEqual({
+        items: [
+          {
+            issueType: '1234',
+            workflow: 'workflow name',
+          },
+        ],
+      })
+    })
+
+    it('do nothing if there are no issueTypeMappings', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowSchemeType,
+        {
+          val: 1,
+        }
+      )
+      await filter.onFetch?.([instance])
+      expect(instance.value).toEqual({
+        val: 1,
+      })
+    })
+  })
+
+  describe('preDeploy', () => {
+    it('add issueTypeMappings to instance', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowSchemeType,
+        {
+          items: [
+            {
+              issueType: 1234,
+              workflow: 'workflow name',
+            },
+          ],
+        }
+      )
+      await filter.preDeploy?.([toChange({ after: instance })])
+      expect(instance.value).toEqual({
+        items: [
+          {
+            issueType: 1234,
+            workflow: 'workflow name',
+          },
+        ],
+        issueTypeMappings: {
+          1234: 'workflow name',
+        },
+      })
+    })
+
+    it('should do nothing if there are no items', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowSchemeType,
+        {
+          val: 1,
+        }
+      )
+      await filter.preDeploy?.([toChange({ after: instance })])
+      expect(instance.value).toEqual({
+        val: 1,
+      })
+    })
+  })
+
+  describe('deploy', () => {
+    const deployChangeMock = deployment.deployChange as jest.MockedFunction<
+        typeof deployment.deployChange
+      >
+    it('ignore items when deploying', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowSchemeType,
+        {
+          items: [
+            {
+              issueType: 1234,
+              workflow: 'workflow name',
+            },
+          ],
+          issueTypeMappings: {
+            1234: 'workflow name',
+          },
+        }
+      )
+
+      const change = toChange({ after: instance })
+      await filter.deploy?.([change])
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        change,
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.WorkflowScheme.deployRequests,
+        ['items'],
+        undefined
+      )
+    })
+  })
+
+  describe('onDeploy', () => {
+    it('should remove issueTypeMappings', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowSchemeType,
+        {
+          items: [
+            {
+              issueType: 1234,
+              workflow: 'workflow name',
+            },
+          ],
+          issueTypeMappings: {
+            1234: 'workflow name',
+          },
+        }
+      )
+      await filter.onDeploy?.([toChange({ after: instance })])
+      expect(instance.value).toEqual({
+        items: [
+          {
+            issueType: 1234,
+            workflow: 'workflow name',
+          },
+        ],
+      })
+    })
+  })
+})


### PR DESCRIPTION
Added references to workflow scheme

---

The structure workflow scheme is changed from 

from
```
jira.WorkflowScheme "1801BugWorkflowScheme" {
  name = "1801BugWorkflowScheme"
  description = "this is a description!1@"
  defaultWorkflow = "Software Simplified Workflow for Project LIORCOMP"
  issueTypeMappings = {
    additionalProperties = {
      "10000" = "Software Simplified Workflow for Project TP3"
      "10005" = "Lior's Test Workflow"
      "10006" = "Software Simplified Workflow for Project TP3"
      "10007" = "Software Simplified Workflow for Project LIORCOMP"
      "10008" = "jira"
    }
  }
}
```

to
```
jira.WorkflowScheme "1801BugWorkflowScheme" {
  name = "1801BugWorkflowScheme"
  description = "this is a description!1@"
  defaultWorkflow = jira.Workflow.instance.Software_Simplified_Workflow_for_Project_LIORCOMP@s
  items = [
    {
      workflow = jira.Workflow.instance.Software_Simplified_Workflow_for_Project_TP3@s
      issueType = jira.IssueType.instance.Epic
    },
    {
      workflow = jira.Workflow.instance.Lior_s_Test_Workflow@tss
      issueType = jira.IssueType.instance.Task
    },
    {
      workflow = jira.Workflow.instance.Software_Simplified_Workflow_for_Project_TP3@s
      issueType = jira.IssueType.instance.Sub_task@b
    },
    {
      workflow = jira.Workflow.instance.Software_Simplified_Workflow_for_Project_LIORCOMP@s
      issueType = jira.IssueType.instance.Story
    },
    {
      workflow = jira.Workflow.instance.jira
      issueType = jira.IssueType.instance.Bug
    },
  ]
}
```

---
_Release Notes_: 
None

---
_User Notifications_: 
None