### PR TITLE
SALTO-1904: add custom fields references in zendesk

### DIFF
--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -228,8 +228,12 @@ export const addReferences = async <
 export const generateLookupFunc = <
   T extends string,
   GenericFieldReferenceDefinition extends FieldReferenceDefinition<T>
->(defs: GenericFieldReferenceDefinition[]): GetLookupNameFunc => {
-  const resolverFinder = generateReferenceResolverFinder(defs)
+>(
+    defs: GenericFieldReferenceDefinition[],
+    fieldReferenceResolverCreator?: (def: GenericFieldReferenceDefinition) =>
+      FieldReferenceResolver<T>,
+  ): GetLookupNameFunc => {
+  const resolverFinder = generateReferenceResolverFinder(defs, fieldReferenceResolverCreator)
 
   const determineLookupStrategy = async (args: GetLookupNameFuncArgs):
     Promise<ReferenceSerializationStrategy | undefined> => {

--- a/packages/adapter-components/test/references/field_references.test.ts
+++ b/packages/adapter-components/test/references/field_references.test.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, BuiltinTypes, isInstanceElement, ListType, createRefToElmWithValue, Field } from '@salto-io/adapter-api'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
 import { addReferences, generateLookupFunc } from '../../src/references/field_references'
-import { FieldReferenceDefinition } from '../../src/references/reference_mapping'
+import { FieldReferenceDefinition, FieldReferenceResolver, ReferenceSerializationStrategy, ReferenceSerializationStrategyLookup, ReferenceSerializationStrategyName } from '../../src/references/reference_mapping'
 import { ContextValueMapperFunc, ContextFunc, neighborContextGetter } from '../../src/references'
 
 const ADAPTER_NAME = 'myAdapter'
@@ -420,6 +420,49 @@ describe('Field references', () => {
       })
 
       expect(res).toEqual({ id: 2, name: 'name' })
+    })
+    it('should resolve using custom resolver if given', async () => {
+      type CustomFieldReferenceDefinition = FieldReferenceDefinition<never> & {
+        customSerializationStrategy?: 'realId'
+      }
+      const CustomReferenceSerializationStrategyLookup: Record<
+        'realId' | ReferenceSerializationStrategyName, ReferenceSerializationStrategy
+      > = {
+        ...ReferenceSerializationStrategyLookup,
+        realId: {
+          serialize: ({ ref }) => ref.value.value.realId,
+          lookup: val => val,
+        },
+      }
+      class CustomFieldReferenceResolver extends FieldReferenceResolver<never> {
+        constructor(def: CustomFieldReferenceDefinition) {
+          super({ src: def.src })
+          this.serializationStrategy = CustomReferenceSerializationStrategyLookup[
+            def.customSerializationStrategy ?? def.serializationStrategy ?? 'fullValue'
+          ]
+          this.target = def.target
+            ? { ...def.target, lookup: this.serializationStrategy.lookup }
+            : undefined
+        }
+      }
+      const customLookupNameFunc = generateLookupFunc(
+        [{
+          src: { field: 'refValue' },
+          customSerializationStrategy: 'realId',
+          target: { type: 'typeWithDifferentIdField' },
+        } as CustomFieldReferenceDefinition],
+        defs => new CustomFieldReferenceResolver(defs),
+      )
+      const res = await customLookupNameFunc({
+        ref: new ReferenceExpression(
+          new ElemID('adapter', 'obj', 'instance', 'instance'),
+          new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'obj') }), { realId: 2 }),
+        ),
+        field: new Field(new ObjectType({ elemID: new ElemID('adapter', 'obj2') }), 'refValue', BuiltinTypes.NUMBER),
+        path: new ElemID('adapter', 'somePath'),
+      })
+
+      expect(res).toEqual(2)
     })
   })
   describe('failure modes', () => {

--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -33,7 +33,8 @@ import { API_DEFINITIONS_CONFIG, ZendeskConfig } from './config'
 import { ZENDESK_SUPPORT } from './constants'
 import createChangeValidator from './change_validator'
 import { paginate } from './client/pagination'
-import fieldReferencesFilter, { fieldNameToTypeMappingDefs } from './filters/field_references'
+import fieldReferencesFilter, { fieldNameToTypeMappingDefs,
+  ZendeskSupportFieldReferenceResolver } from './filters/field_references'
 import unorderedListsFilter from './filters/unordered_lists'
 import viewFilter from './filters/view'
 import workspaceFilter from './filters/workspace'
@@ -149,7 +150,10 @@ export default class ZendeskAdapter implements AdapterOperations {
       })) as Change<InstanceElement>[]
 
     const runner = await this.createFiltersRunner()
-    const lookupFunc = referencesUtils.generateLookupFunc(fieldNameToTypeMappingDefs)
+    const lookupFunc = referencesUtils.generateLookupFunc(
+      fieldNameToTypeMappingDefs,
+      defs => new ZendeskSupportFieldReferenceResolver(defs)
+    )
     const resolvedChanges = await awu(changesToDeploy)
       .map(change => resolveChangeElement(change, lookupFunc))
       .toArray()

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -63,7 +63,7 @@ const ZendeskSupportReferenceSerializationStrategyLookup: Record<
   ...referenceUtils.ReferenceSerializationStrategyLookup,
   customFields: {
     serialize: ({ ref }) => (isInstanceElement(ref.value)
-      ? CUSTOM_FIELDS_PREFIX.concat(ref.value.value.id?.toString())
+      ? `${CUSTOM_FIELDS_PREFIX}${ref.value.value.id?.toString()}`
       : ref.value),
     lookup: val => ((_.isString(val) && val.startsWith(CUSTOM_FIELDS_PREFIX))
       ? val.slice(CUSTOM_FIELDS_PREFIX.length)
@@ -83,13 +83,15 @@ export const contextStrategyLookup: Record<
   parentValue: neighborContextFunc({ contextFieldName: 'value', levelsUp: 2, contextValueMapper: getValueLookupType }),
 }
 
-type ZendeskSupportFieldReferenceDefinition = referenceUtils
-  .FieldReferenceDefinition<ReferenceContextStrategyName> & {
+type ZendeskSupportFieldReferenceDefinition = referenceUtils.FieldReferenceDefinition<
+  ReferenceContextStrategyName
+> & {
   zendeskSupportSerializationStrategy?: ZendeskSupportReferenceSerializationStrategyName
 }
 
-export class ZendeskSupportFieldReferenceResolver extends referenceUtils
-  .FieldReferenceResolver<ReferenceContextStrategyName> {
+export class ZendeskSupportFieldReferenceResolver extends referenceUtils.FieldReferenceResolver<
+  ReferenceContextStrategyName
+> {
   constructor(def: ZendeskSupportFieldReferenceDefinition) {
     super({ src: def.src })
     this.serializationStrategy = ZendeskSupportReferenceSerializationStrategyLookup[

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -234,12 +234,12 @@ export const fieldNameToTypeMappingDefs: ZendeskSupportFieldReferenceDefinition[
   },
 
   {
-    src: { field: 'id', parentTypes: ['view__restriction'] },
+    src: { field: 'id', parentTypes: ['view__restriction', 'macro__restriction'] },
     serializationStrategy: 'id',
     target: { typeContext: 'neighborType' },
   },
   {
-    src: { field: 'ids', parentTypes: ['view__restriction'] },
+    src: { field: 'ids', parentTypes: ['view__restriction', 'macro__restriction'] },
     serializationStrategy: 'id',
     target: { typeContext: 'neighborType' },
   },


### PR DESCRIPTION
_Add custom fields references in zendesk_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Zendesk-Support Adapter_
* Add references to custom ticket fields in views and macros

---
_User Notifications_: 
_Add references to custom ticket fields in views and macros_
