### PR TITLE
SALTO-1778: added change validator for screen tabs

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -17,6 +17,7 @@ import { ChangeValidator } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
 import { createChangeValidator } from '@salto-io/adapter-utils'
 import { unsupportedFieldConfigurationsValidator } from './field_configuration'
+import { screenValidator } from './screen'
 import { workflowValidator } from './workflow'
 
 const {
@@ -27,6 +28,7 @@ const validators: ChangeValidator[] = [
   deployTypesNotSupportedValidator,
   unsupportedFieldConfigurationsValidator,
   workflowValidator,
+  screenValidator,
 ]
 
 export default createChangeValidator(validators)

--- a/packages/jira-adapter/src/change_validators/screen.ts
+++ b/packages/jira-adapter/src/change_validators/screen.ts
@@ -1,0 +1,47 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SaltoErrorSeverity, Values } from '@salto-io/adapter-api'
+import { collections, values } from '@salto-io/lowerdash'
+import { resolveValues } from '@salto-io/adapter-utils'
+import { getLookUpName } from '../reference_mapping'
+
+const { awu } = collections.asynciterable
+
+export const screenValidator: ChangeValidator = async changes => (
+  awu(changes)
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === 'Screen')
+    .map(async instance => {
+      const resolvedInstance = await resolveValues(instance, getLookUpName)
+
+      const usedFields = (Object.values(resolvedInstance.value.tabs ?? {}) as Values[])
+        .flatMap(tab => tab.fields ?? [])
+
+      if (usedFields.length !== new Set(usedFields).size) {
+        return {
+          elemID: instance.elemID,
+          severity: 'Error' as SaltoErrorSeverity,
+          message: `A field can only be used once in the tabs of screen ${instance.elemID.getFullName()}`,
+          detailedMessage: 'The field cannot be used more than once in the same screen instance',
+        }
+      }
+      return undefined
+    })
+    .filter(values.isDefined)
+    .toArray()
+)

--- a/packages/jira-adapter/src/change_validators/screen.ts
+++ b/packages/jira-adapter/src/change_validators/screen.ts
@@ -40,7 +40,7 @@ export const screenValidator: ChangeValidator = async changes => (
         return {
           elemID: instance.elemID,
           severity: 'Error' as SaltoErrorSeverity,
-          message: 'The field cannot be used more than once in the same screen instance',
+          message: 'Fields cannot be used more than once in the same screen instance',
           detailedMessage: `The ${duplicateFields.length > 1 ? 'fields' : 'field'} ${duplicateFields.join(', ')} can only be used once in the tabs of screen ${instance.elemID.getFullName()}`,
         }
       }

--- a/packages/jira-adapter/test/change_validators/screen.test.ts
+++ b/packages/jira-adapter/test/change_validators/screen.test.ts
@@ -33,6 +33,8 @@ describe('screenValidator', () => {
           '1',
           '2',
           '1',
+          '2',
+          '3',
         ],
       },
     }
@@ -45,8 +47,8 @@ describe('screenValidator', () => {
       {
         elemID: instance.elemID,
         severity: 'Error',
-        message: `A field can only be used once in the tabs of screen ${instance.elemID.getFullName()}`,
-        detailedMessage: 'The field cannot be used more than once in the same screen instance',
+        message: 'The field cannot be used more than once in the same screen instance',
+        detailedMessage: `The fields 1, 2 can only be used once in the tabs of screen ${instance.elemID.getFullName()}`,
       },
     ])
   })
@@ -78,8 +80,8 @@ describe('screenValidator', () => {
       {
         elemID: instance.elemID,
         severity: 'Error',
-        message: `A field can only be used once in the tabs of screen ${instance.elemID.getFullName()}`,
-        detailedMessage: 'The field cannot be used more than once in the same screen instance',
+        message: 'The field cannot be used more than once in the same screen instance',
+        detailedMessage: `The field 1 can only be used once in the tabs of screen ${instance.elemID.getFullName()}`,
       },
     ])
   })

--- a/packages/jira-adapter/test/change_validators/screen.test.ts
+++ b/packages/jira-adapter/test/change_validators/screen.test.ts
@@ -47,7 +47,7 @@ describe('screenValidator', () => {
       {
         elemID: instance.elemID,
         severity: 'Error',
-        message: 'The field cannot be used more than once in the same screen instance',
+        message: 'Fields cannot be used more than once in the same screen instance',
         detailedMessage: `The fields 1, 2 can only be used once in the tabs of screen ${instance.elemID.getFullName()}`,
       },
     ])
@@ -80,7 +80,7 @@ describe('screenValidator', () => {
       {
         elemID: instance.elemID,
         severity: 'Error',
-        message: 'The field cannot be used more than once in the same screen instance',
+        message: 'Fields cannot be used more than once in the same screen instance',
         detailedMessage: `The field 1 can only be used once in the tabs of screen ${instance.elemID.getFullName()}`,
       },
     ])

--- a/packages/jira-adapter/test/change_validators/screen.test.ts
+++ b/packages/jira-adapter/test/change_validators/screen.test.ts
@@ -1,0 +1,124 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { screenValidator } from '../../src/change_validators/screen'
+import { JIRA } from '../../src/constants'
+
+describe('screenValidator', () => {
+  let type: ObjectType
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    type = new ObjectType({ elemID: new ElemID(JIRA, 'Screen') })
+    instance = new InstanceElement('instance', type)
+  })
+  it('should return an error if the same tab has the same field more then once', async () => {
+    instance.value.tabs = {
+      tab: {
+        name: 'tab',
+        fields: [
+          '1',
+          '2',
+          '1',
+        ],
+      },
+    }
+
+    expect(await screenValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: `A field can only be used once in the tabs of screen ${instance.elemID.getFullName()}`,
+        detailedMessage: 'The field cannot be used more than once in the same screen instance',
+      },
+    ])
+  })
+
+  it('should return an error if the two tabs has the same field', async () => {
+    instance.value.tabs = {
+      tab: {
+        name: 'tab',
+        fields: [
+          '1',
+          '2',
+        ],
+      },
+
+      tab2: {
+        name: 'tab2',
+        fields: [
+          '1',
+          '3',
+        ],
+      },
+    }
+
+    expect(await screenValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: `A field can only be used once in the tabs of screen ${instance.elemID.getFullName()}`,
+        detailedMessage: 'The field cannot be used more than once in the same screen instance',
+      },
+    ])
+  })
+
+  it('should not return an error if there is no common field in the screen tabs', async () => {
+    instance.value.tabs = {
+      tab: {
+        name: 'tab',
+        fields: [
+          '4',
+          '2',
+        ],
+      },
+
+      tab2: {
+        name: 'tab2',
+        fields: [
+          '1',
+          '3',
+        ],
+      },
+
+      tab3: {
+        name: 'tab3',
+      },
+    }
+
+    expect(await screenValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([])
+  })
+
+  it('should not return an error if there are no tabs', async () => {
+    expect(await screenValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([])
+  })
+})


### PR DESCRIPTION
Added change validator to validate that the same tab is not used more than once in screen tabs (since Jira does not support that)

---
_Release Notes_: 
None

---
_User Notifications_: 
None