### PR TITLE
SALTO-1739: Add support for "retry-after" header

### DIFF
--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import axios, { AxiosError, AxiosBasicCredentials } from 'axios'
-import axiosRetry from 'axios-retry'
+import axiosRetry, { isNetworkOrIdempotentRequestError } from 'axios-retry'
 import { AccountId } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { ClientRetryConfig } from './config'
@@ -55,6 +55,7 @@ type AuthenticatedAPIConnection = APIConnection & {
 export type RetryOptions = {
   retries: number
   retryDelay?: (retryCount: number, error: AxiosError) => number
+  retryCondition?: (error: AxiosError) => boolean
 }
 
 type LoginFunc<TCredentials> = (creds: TCredentials) => Promise<AuthenticatedAPIConnection>
@@ -70,14 +71,26 @@ export type ConnectionCreator<TCredentials> = (
 export const createRetryOptions = (retryOptions: Required<ClientRetryConfig>): RetryOptions => ({
   retries: retryOptions.maxAttempts,
   retryDelay: (retryCount, err) => {
+    // Although the standard is 'Retry-After' is seems that some servers
+    // returns 'retry-after' so just in case we lowercase the headers
+    const retryAfterHeaderValue = _.mapKeys(
+      err.response?.headers ?? {},
+      (_val, key) => key.toLowerCase()
+    )['retry-after']
+    const retryDelay = retryAfterHeaderValue !== undefined
+      ? parseInt(retryAfterHeaderValue, 10) * 1000
+      : retryOptions.retryDelay
+
     log.warn('Failed to run client call to %s for reason: %s (%s). Retrying in %ds (attempt %d).',
       err.config.url,
       err.code,
       err.message,
-      retryOptions.retryDelay / 1000,
+      retryDelay / 1000,
       retryCount)
-    return retryOptions.retryDelay
+    return retryDelay
   },
+  retryCondition: err => isNetworkOrIdempotentRequestError(err)
+    || err.response?.status === 429,
 })
 
 type ConnectionParams<TCredentials> = {

--- a/packages/adapter-components/test/client/http_connection.test.ts
+++ b/packages/adapter-components/test/client/http_connection.test.ts
@@ -97,12 +97,39 @@ describe('client_http_connection', () => {
           url: 'url',
         },
       } as AxiosError)).toBe(10000)
+
+      expect(retryOptions.retryDelay?.(1, {
+        response: {
+          headers: {
+            'retry-after': '10',
+          },
+        },
+        code: 'code',
+        config: {
+          url: 'url',
+        },
+      } as AxiosError)).toBe(10000)
     })
 
-    it('should use the input detail when retry-after header when available', () => {
+    it('should use the input delay when retry-after header is not available', () => {
       expect(retryOptions.retryDelay?.(1, {
         response: {
           headers: {},
+          status: 429,
+        },
+        code: 'code',
+        config: {
+          url: 'url',
+        },
+      } as AxiosError)).toBe(100)
+    })
+
+    it('should use the input delay when retry-after header is invalid', () => {
+      expect(retryOptions.retryDelay?.(1, {
+        response: {
+          headers: {
+            'Retry-After': 'invalid',
+          },
         },
         code: 'code',
         config: {

--- a/packages/adapter-components/test/client/http_connection.test.ts
+++ b/packages/adapter-components/test/client/http_connection.test.ts
@@ -13,9 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import axios from 'axios'
+import axios, { AxiosError } from 'axios'
 import MockAdapter from 'axios-mock-adapter'
-import { validateCredentials, axiosConnection, UnauthorizedError } from '../../src/client'
+import { RetryOptions } from '../../src/client/http_connection'
+import { validateCredentials, axiosConnection, UnauthorizedError, createRetryOptions } from '../../src/client'
 import { createConnection, BASE_URL } from './common'
 
 describe('client_http_connection', () => {
@@ -68,6 +69,46 @@ describe('client_http_connection', () => {
           credValidateFunc: async () => { throw new Error('aaa') },
         })) },
       )).rejects.toThrow(new Error('Login failed with error: Error: aaa'))
+    })
+  })
+  describe('createRetryOptions', () => {
+    let retryOptions: RetryOptions
+
+    beforeEach(() => {
+      retryOptions = createRetryOptions({ maxAttempts: 3, retryDelay: 100 })
+    })
+    it('should retry error code 429', () => {
+      expect(retryOptions.retryCondition?.({
+        response: {
+          status: 429,
+        },
+      } as AxiosError)).toBeTruthy()
+    })
+
+    it('should use the retry-after header when available', () => {
+      expect(retryOptions.retryDelay?.(1, {
+        response: {
+          headers: {
+            'Retry-After': '10',
+          },
+        },
+        code: 'code',
+        config: {
+          url: 'url',
+        },
+      } as AxiosError)).toBe(10000)
+    })
+
+    it('should use the input detail when retry-after header when available', () => {
+      expect(retryOptions.retryDelay?.(1, {
+        response: {
+          headers: {},
+        },
+        code: 'code',
+        config: {
+          url: 'url',
+        },
+      } as AxiosError)).toBe(100)
     })
   })
 })


### PR DESCRIPTION
Added support for waiting the time that was returned in the "retry-after" header in the response before retrying a request in the simple adapter HTTP client

---
_Release Notes_: 
None

---
_User Notifications_: 
None