### PR TITLE
SALTO-1908: added support for deploying active workflow schemes

### DIFF
--- a/packages/jira-adapter/src/filters/default_instances_deploy.ts
+++ b/packages/jira-adapter/src/filters/default_instances_deploy.ts
@@ -21,7 +21,9 @@ const filter: FilterCreator = ({ client, config }) => ({
   deploy: async changes => {
     const deployResult = await deployChanges(
       changes.filter(isInstanceChange),
-      change => defaultDeployChange({ change, client, apiDefinitions: config.apiDefinitions })
+      async change => {
+        await defaultDeployChange({ change, client, apiDefinitions: config.apiDefinitions })
+      },
     )
 
     return {

--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -252,7 +252,9 @@ const filter: FilterCreator = ({ config, client }) => ({
         change,
         async instance => {
           delete instance.value.issueTypeMappings
-          delete instance.value.updateDraftIfNeeded
+          if (isModificationChange(change)) {
+            delete instance.value.updateDraftIfNeeded
+          }
           return instance
         }
       ))

--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -13,24 +13,107 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, Field, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, ListType, ObjectType } from '@salto-io/adapter-api'
-import { elements as elementUtils } from '@salto-io/adapter-components'
+import { BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, Field, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isModificationChange, ListType, ObjectType, Values } from '@salto-io/adapter-api'
+import { elements as elementUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { applyFunctionToChangeData, resolveValues } from '@salto-io/adapter-utils'
+import { applyFunctionToChangeData, resolveValues, safeJsonStringify } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { getLookUpName } from '../reference_mapping'
 import { findObject } from '../utils'
 import { FilterCreator } from '../filter'
 import { JIRA } from '../constants'
 import { defaultDeployChange, deployChanges } from '../deployment'
+import JiraClient from '../client/client'
+import { JiraConfig } from '../config'
 
 const { awu } = collections.asynciterable
 
 const WORKFLOW_SCHEME_TYPE = 'WorkflowScheme'
 const WORKFLOW_SCHEME_ITEM_TYPE = 'WorkflowSchemeItem'
 
+export const MAX_TASK_CHECKS = 60
+const TASK_CHECK_INTERVAL_MILLI = 1000
+
 const log = logger(module)
+
+function validateTaskResponse(
+  response: clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>
+): asserts response is clientUtils.Response<clientUtils.ResponseValue & { self: string }> {
+  if (Array.isArray(response.data) || !_.isString(response.data.self)) {
+    log.warn(`Received unexpected response from when attempted to publish workflow scheme: ${safeJsonStringify(response.data, undefined, 2)}`)
+    throw new Error('Failed to publish workflow scheme draft')
+  }
+}
+
+const waitForWorkflowSchemePublish = async (
+  taskResponse: clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>,
+  client: JiraClient,
+  checksLeft: number,
+): Promise<void> => {
+  validateTaskResponse(taskResponse)
+
+  if (taskResponse.data.result !== undefined) {
+    if (taskResponse.data.status !== 'COMPLETE') {
+      log.warn(`Failed to publish workflow scheme draft: ${safeJsonStringify(taskResponse.data, undefined, 2)}`)
+      throw new Error('Failed to publish workflow scheme draft')
+    }
+    return
+  }
+
+  if (checksLeft === 0) {
+    log.warn(`Publish draft operation did not finish, last response: ${safeJsonStringify(taskResponse.data, undefined, 2)}`)
+    throw new Error('Failed to publish workflow scheme draft')
+  }
+
+  await new Promise(resolve => {
+    setTimeout(resolve, TASK_CHECK_INTERVAL_MILLI)
+  })
+
+  await waitForWorkflowSchemePublish(
+    await client.getSinglePage({ url: taskResponse.data.self }),
+    client,
+    checksLeft - 1,
+  )
+}
+
+const publishDraft = async (
+  change: Change<InstanceElement>,
+  client: JiraClient,
+  statusMigrations?: Values[]
+): Promise<void> => {
+  const response = await client.post({
+    url: `/rest/api/3/workflowscheme/${getChangeData(change).value.id}/draft/publish`,
+    data: statusMigrations !== undefined
+      ? {
+        statusMappings: statusMigrations,
+      }
+      : {},
+  })
+
+  await waitForWorkflowSchemePublish(response, client, MAX_TASK_CHECKS)
+}
+
+const deployWorkflowScheme = async (
+  change: Change<InstanceElement>,
+  client: JiraClient,
+  config: JiraConfig,
+): Promise<void> => {
+  const instance = getChangeData(change)
+  const { statusMigrations } = (await resolveValues(instance, getLookUpName)).value
+  delete instance.value.statusMigrations
+
+  const response = await defaultDeployChange({
+    change,
+    client,
+    apiDefinitions: config.apiDefinitions,
+    fieldsToIgnore: ['items'],
+  })
+
+  if (isModificationChange(change) && !Array.isArray(response) && response?.draft) {
+    await publishDraft(change, client, statusMigrations)
+  }
+}
 
 const filter: FilterCreator = ({ config, client }) => ({
   onFetch: async elements => {
@@ -73,7 +156,35 @@ const filter: FilterCreator = ({ config, client }) => ({
         delete workflowSchemeType.fields.issueTypeMappings
       }
 
-      elements.push(workflowSchemeItemType)
+      const statusMigrationType = new ObjectType({
+        elemID: new ElemID(JIRA, 'StatusMigration'),
+        fields: {
+          issueTypeId: {
+            refType: BuiltinTypes.STRING,
+            annotations: { [CORE_ANNOTATIONS.UPDATABLE]: true },
+          },
+          statusId: {
+            refType: BuiltinTypes.STRING,
+            annotations: { [CORE_ANNOTATIONS.UPDATABLE]: true },
+          },
+          newStatusId: {
+            refType: BuiltinTypes.STRING,
+            annotations: { [CORE_ANNOTATIONS.UPDATABLE]: true },
+          },
+        },
+        path: [JIRA, elementUtils.TYPES_PATH, 'StatusMigration'],
+      })
+
+      workflowSchemeType.fields.statusMigrations = new Field(
+        workflowSchemeType,
+        'statusMigrations',
+        new ListType(statusMigrationType),
+        {
+          [CORE_ANNOTATIONS.UPDATABLE]: true,
+        }
+      )
+
+      elements.push(workflowSchemeItemType, statusMigrationType)
     }
 
     elements
@@ -101,6 +212,11 @@ const filter: FilterCreator = ({ config, client }) => ({
               .mapValues(mapping => mapping.workflow)
               .value()
           }
+
+          if (isModificationChange(change)) {
+            instance.value.updateDraftIfNeeded = true
+          }
+
           return instance
         }
       ))
@@ -119,12 +235,7 @@ const filter: FilterCreator = ({ config, client }) => ({
       relevantChanges
         .filter(isInstanceChange)
         .filter(isAdditionOrModificationChange),
-      async change => defaultDeployChange({
-        change,
-        client,
-        apiDefinitions: config.apiDefinitions,
-        fieldsToIgnore: ['items'],
-      })
+      async change => deployWorkflowScheme(change, client, config),
     )
 
     return {
@@ -141,6 +252,7 @@ const filter: FilterCreator = ({ config, client }) => ({
         change,
         async instance => {
           delete instance.value.issueTypeMappings
+          delete instance.value.updateDraftIfNeeded
           return instance
         }
       ))

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -230,6 +230,21 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
     serializationStrategy: 'id',
     target: { type: 'IssueType' },
   },
+  {
+    src: { field: 'statusId', parentTypes: ['StatusMigration'] },
+    serializationStrategy: 'id',
+    target: { type: 'Status' },
+  },
+  {
+    src: { field: 'newStatusId', parentTypes: ['StatusMigration'] },
+    serializationStrategy: 'id',
+    target: { type: 'Status' },
+  },
+  {
+    src: { field: 'issueTypeId', parentTypes: ['StatusMigration'] },
+    serializationStrategy: 'id',
+    target: { type: 'IssueType' },
+  },
 ]
 
 const lookupNameFuncs: GetLookupNameFunc[] = [

--- a/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
@@ -296,7 +296,7 @@ describe('issueTypeScheme', () => {
       const res = await filter.deploy?.(
         [toChange({ before: beforeInstance, after: afterInstance })]
       )
-      expect(res?.deployResult.errors).toEqual([new Error('Failed to delete /rest/api/3/issuetypescheme/1/issuetype/1 with error: Error: some error')])
+      expect(res?.deployResult.errors).toEqual([new Error('Deployment of jira.IssueTypeScheme.instance.instance failed: Error: Failed to delete /rest/api/3/issuetypescheme/1/issuetype/1 with error: Error: some error')])
       expect(res?.deployResult.appliedChanges).toEqual([])
     })
   })

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -14,10 +14,12 @@
 * limitations under the License.
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
-import { deployment } from '@salto-io/adapter-components'
+import { deployment, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import _ from 'lodash'
 import { JIRA } from '../../src/constants'
 import { mockClient } from '../utils'
-import workflowSchemeFilter from '../../src/filters/workflow_scheme'
+import workflowSchemeFilter, { MAX_TASK_CHECKS } from '../../src/filters/workflow_scheme'
 import { Filter } from '../../src/filter'
 import { DEFAULT_CONFIG } from '../../src/config'
 import JiraClient from '../../src/client/client'
@@ -37,9 +39,11 @@ describe('workflowScheme', () => {
   let workflowSchemeType: ObjectType
   let filter: Filter
   let client: JiraClient
+  let connection: MockInterface<clientUtils.APIConnection>
   beforeEach(async () => {
-    const { client: cli, paginator } = mockClient()
+    const { client: cli, paginator, connection: conn } = mockClient()
     client = cli
+    connection = conn
 
     filter = workflowSchemeFilter({
       client,
@@ -52,6 +56,13 @@ describe('workflowScheme', () => {
   })
 
   describe('onFetch', () => {
+    it('should add statusMigrations', async () => {
+      await filter.onFetch?.([workflowSchemeType])
+      expect(workflowSchemeType.fields.statusMigrations).toBeDefined()
+      expect(workflowSchemeType.fields.statusMigrations.annotations).toEqual({
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+    })
     it('replace field issueTypeMappings with items', async () => {
       workflowSchemeType.fields.issueTypeMappings = new Field(workflowSchemeType, 'issueTypeMappings', BuiltinTypes.STRING)
       await filter.onFetch?.([workflowSchemeType])
@@ -129,6 +140,19 @@ describe('workflowScheme', () => {
       })
     })
 
+    it('add updateDraftIfNeeded to instance if modification', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowSchemeType,
+        {
+        }
+      )
+      await filter.preDeploy?.([toChange({ before: instance, after: instance })])
+      expect(instance.value).toEqual({
+        updateDraftIfNeeded: true,
+      })
+    })
+
     it('should do nothing if there are no items', async () => {
       const instance = new InstanceElement(
         'instance',
@@ -148,6 +172,11 @@ describe('workflowScheme', () => {
     const deployChangeMock = deployment.deployChange as jest.MockedFunction<
         typeof deployment.deployChange
       >
+
+    beforeEach(() => {
+      deployChangeMock.mockClear()
+      jest.spyOn(global, 'setTimeout').mockImplementation((cb: TimerHandler) => (_.isFunction(cb) ? cb() : undefined))
+    })
     it('ignore items when deploying', async () => {
       const instance = new InstanceElement(
         'instance',
@@ -174,6 +203,186 @@ describe('workflowScheme', () => {
         ['items'],
         undefined
       )
+    })
+
+    it('when draft should call publish draft', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowSchemeType,
+        {
+          id: '1',
+          items: [
+            {
+              issueType: 1234,
+              workflow: 'workflow name',
+            },
+          ],
+          issueTypeMappings: {
+            1234: 'workflow name',
+          },
+          statusMigrations: [
+            {
+              issueTypeId: '1',
+              statusId: '2',
+              newStatusId: '3',
+            },
+          ],
+        }
+      )
+
+      deployChangeMock.mockResolvedValue({ draft: true })
+      connection.post.mockResolvedValue({
+        status: 200,
+        data: {
+          self: 'taskUrl',
+        },
+      })
+
+      connection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          self: 'taskUrl',
+          result: 'done',
+          status: 'COMPLETE',
+        },
+      })
+
+      await filter.deploy?.([toChange({ before: instance, after: instance })])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        toChange({ before: instance, after: instance }),
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.WorkflowScheme.deployRequests,
+        ['items'],
+        undefined
+      )
+
+      expect(connection.post).toHaveBeenCalledWith(
+        '/rest/api/3/workflowscheme/1/draft/publish',
+        {
+          statusMappings: [
+            {
+              issueTypeId: '1',
+              statusId: '2',
+              newStatusId: '3',
+            },
+          ],
+        },
+        undefined
+      )
+
+      expect(connection.get).toHaveBeenCalledWith(
+        'taskUrl',
+        undefined
+      )
+
+      expect(instance.value.statusMigrations).toBeUndefined()
+    })
+
+    it('when return error if publish draft failed', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowSchemeType,
+        {
+          id: '1',
+          items: [
+            {
+              issueType: 1234,
+              workflow: 'workflow name',
+            },
+          ],
+          issueTypeMappings: {
+            1234: 'workflow name',
+          },
+        }
+      )
+
+      deployChangeMock.mockResolvedValue({ draft: true })
+      connection.post.mockResolvedValue({
+        status: 200,
+        data: {
+          self: 'taskUrl',
+          result: 'done',
+          status: 'FAIL',
+        },
+      })
+
+      const res = await filter.deploy?.([toChange({ before: instance, after: instance })])
+      expect(res?.deployResult.appliedChanges).toEqual([])
+      expect(res?.deployResult.errors).toHaveLength(1)
+    })
+
+    it('when throw if publish draft did not finish after max tries', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowSchemeType,
+        {
+          id: '1',
+          items: [
+            {
+              issueType: 1234,
+              workflow: 'workflow name',
+            },
+          ],
+          issueTypeMappings: {
+            1234: 'workflow name',
+          },
+        }
+      )
+
+      deployChangeMock.mockResolvedValue({ draft: true })
+      connection.post.mockResolvedValue({
+        status: 200,
+        data: {
+          self: 'taskUrl',
+        },
+      })
+
+      connection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          self: 'taskUrl',
+        },
+      })
+
+      const res = await filter.deploy?.([toChange({ before: instance, after: instance })])
+
+      expect(connection.get).toHaveBeenCalledTimes(MAX_TASK_CHECKS)
+
+      expect(res?.deployResult.appliedChanges).toEqual([])
+      expect(res?.deployResult.errors).toHaveLength(1)
+    })
+
+    it('when response is invalid should return an error', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowSchemeType,
+        {
+          id: '1',
+          items: [
+            {
+              issueType: 1234,
+              workflow: 'workflow name',
+            },
+          ],
+          issueTypeMappings: {
+            1234: 'workflow name',
+          },
+        }
+      )
+
+      deployChangeMock.mockResolvedValue({ draft: true })
+      connection.post.mockResolvedValue({
+        status: 200,
+        data: {
+          self: 2,
+        },
+      })
+
+      const res = await filter.deploy?.([toChange({ before: instance, after: instance })])
+
+      expect(res?.deployResult.appliedChanges).toEqual([])
+      expect(res?.deployResult.errors).toHaveLength(1)
     })
   })
 
@@ -203,6 +412,18 @@ describe('workflowScheme', () => {
           },
         ],
       })
+    })
+
+    it('should remove updateDraftIfNeeded', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowSchemeType,
+        {
+          updateDraftIfNeeded: true,
+        }
+      )
+      await filter.onDeploy?.([toChange({ after: instance })])
+      expect(instance.value).toEqual({})
     })
   })
 })

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -422,7 +422,7 @@ describe('workflowScheme', () => {
           updateDraftIfNeeded: true,
         }
       )
-      await filter.onDeploy?.([toChange({ after: instance })])
+      await filter.onDeploy?.([toChange({ before: instance, after: instance })])
       expect(instance.value).toEqual({})
     })
   })


### PR DESCRIPTION
Added support for deploying an active workflow scheme.

---

When updating an active workflow scheme it creates the changes in a draft and then we need to publish the drat.
The publish draft API is async, meaning we need to send one request to start the publishing and then check it's status repeatedly with another request.
Also, when publishing workflow scheme draft. The changes might not be backward compatible with the previous workflow scheme (if in the new workflow scheme we removed some issue statuses). So Jira allows us to pass how we want to migrate the used issue statuses so I also added `statusMigrations` field.

---
_Release Notes_: 
None

---
_User Notifications_: 
None