### PR TITLE
SALTO-1778: added check when context does not exist in a field

### DIFF
--- a/packages/jira-adapter/test/filters/fields/field_structure.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_structure.test.ts
@@ -65,6 +65,10 @@ describe('fields_structure', () => {
             contextId: 'id1',
             value: 'someValue',
           },
+          {
+            contextId: 'id2',
+            value: 'someValue',
+          },
         ],
         contextIssueTypes: [
           {
@@ -75,6 +79,10 @@ describe('fields_structure', () => {
             contextId: 'id1',
             issueTypeId: '2',
           },
+          {
+            contextId: 'id2',
+            issueTypeId: '2',
+          },
         ],
         contextProjects: [
           {
@@ -83,6 +91,10 @@ describe('fields_structure', () => {
           },
           {
             contextId: 'id1',
+            projectId: '4',
+          },
+          {
+            contextId: 'id2',
             projectId: '4',
           },
         ],
@@ -104,7 +116,7 @@ describe('fields_structure', () => {
     })
   })
 
-  it('should transform options to map and add postions and cascadingOptions', async () => {
+  it('should transform options to map and add positions and cascadingOptions', async () => {
     const instance = new InstanceElement(
       'instance',
       fieldType,


### PR DESCRIPTION
I encountered a case where the API returns a context default entry for a context that does not exist on the field. I fixed the code to not crash in that case and to ignore the context default entry. I don't think this context default has any effect on the account (it is also not visible in the UI)

---
_Release Notes_: 
None

---
_User Notifications_: 
None