### PR TITLE
SALTO-1915: Fixed plan of fields with built in function names

### DIFF
--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -20,7 +20,7 @@ import {
   ChangeValidator, Change, ChangeError, DependencyChanger, ChangeGroupIdFunction, getChangeData,
   isAdditionOrRemovalChange, isFieldChange, ReadOnlyElementsSource, ElemID, isVariable,
   Value, isReferenceExpression, compareSpecialValues, BuiltinTypesByFullName, isAdditionChange,
-  isModificationChange, isRemovalChange, InstanceElement, PlaceholderObjectType, isElement,
+  isModificationChange, isRemovalChange, InstanceElement, PlaceholderObjectType,
 } from '@salto-io/adapter-api'
 import { DataNodeMap, DiffNode, DiffGraph, Group, GroupDAG, DAG } from '@salto-io/dag'
 import { logger } from '@salto-io/logging'
@@ -249,12 +249,16 @@ const addDifferentElements = (
     const allFieldNames = [...Object.keys(beforeFields), ...Object.keys(afterFields)]
     await Promise.all(allFieldNames.map(
       fieldName => addNodeIfDifferent(
-        // We check `isElement` and don't just do `beforeFields[fieldName]`
+        // We check `hasOwnProperty` and don't just do `beforeFields[fieldName]`
         // because fieldName might be a builtin function name such as
         // `toString` and in that case `beforeFields[fieldName]` will
         // unexpectedly return a function
-        isElement(beforeFields[fieldName]) ? beforeFields[fieldName] : undefined,
-        isElement(afterFields[fieldName]) ? afterFields[fieldName] : undefined
+        Object.prototype.hasOwnProperty.call(beforeFields, fieldName)
+          ? beforeFields[fieldName]
+          : undefined,
+        Object.prototype.hasOwnProperty.call(afterFields, fieldName)
+          ? afterFields[fieldName]
+          : undefined
       )
     ))
   }

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -20,7 +20,7 @@ import {
   ChangeValidator, Change, ChangeError, DependencyChanger, ChangeGroupIdFunction, getChangeData,
   isAdditionOrRemovalChange, isFieldChange, ReadOnlyElementsSource, ElemID, isVariable,
   Value, isReferenceExpression, compareSpecialValues, BuiltinTypesByFullName, isAdditionChange,
-  isModificationChange, isRemovalChange, InstanceElement, PlaceholderObjectType,
+  isModificationChange, isRemovalChange, InstanceElement, PlaceholderObjectType, isElement,
 } from '@salto-io/adapter-api'
 import { DataNodeMap, DiffNode, DiffGraph, Group, GroupDAG, DAG } from '@salto-io/dag'
 import { logger } from '@salto-io/logging'
@@ -248,7 +248,14 @@ const addDifferentElements = (
     const afterFields = (isObjectType(afterElement)) ? afterElement.fields : {}
     const allFieldNames = [...Object.keys(beforeFields), ...Object.keys(afterFields)]
     await Promise.all(allFieldNames.map(
-      fieldName => addNodeIfDifferent(beforeFields[fieldName], afterFields[fieldName])
+      fieldName => addNodeIfDifferent(
+        // We check `isElement` and don't just do `beforeFields[fieldName]`
+        // because fieldName might be a builtin function name such as
+        // `toString` and in that case `beforeFields[fieldName]` will
+        // unexpectedly return a function
+        isElement(beforeFields[fieldName]) ? beforeFields[fieldName] : undefined,
+        isElement(afterFields[fieldName]) ? afterFields[fieldName] : undefined
+      )
     ))
   }
   const isSpecialId = (id: string): boolean => (BuiltinTypesByFullName[id] !== undefined

--- a/packages/core/test/core/plan/plan.test.ts
+++ b/packages/core/test/core/plan/plan.test.ts
@@ -225,4 +225,19 @@ describe('getPlan', () => {
     })
     expect(plan.size).toBe(0)
   })
+
+  it('should work for new type with a built-in function name', async () => {
+    const type = new ObjectType({
+      elemID: new ElemID('adapter', 'type'),
+      fields: {
+        toString: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    const plan = await getPlan({
+      before: createElementSource([]),
+      after: createElementSource([type]),
+    })
+    expect(plan.size).toBe(1)
+  })
 })


### PR DESCRIPTION
Plan calc throws "Cannot read property 'getFullName' of undefined" if a type have a field with a name of a built in function (such as `toString`)

The bug was that we expected `beforeFields[fieldName]` to be either `undefined` or `Field` but when `fieldName` is `toString`, `beforeFields[fieldName]` is a function

---
_Release Notes_: 

Core:
- Fixed bug of fields with built-in function names (e.g., `toString`)

---
_User Notifications_: 
None