### PR TITLE
SALTO-1791 Remove restrictions impacted by custom objects and fields

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -39,6 +39,7 @@ import profilePermissionsFilter from './filters/profile_permissions'
 import convertListsFilter from './filters/convert_lists'
 import convertTypeFilter from './filters/convert_types'
 import removeFieldsAndValuesFilter from './filters/remove_fields_and_values'
+import removeRestrictionAnnotationsFilter from './filters/remove_restriction_annotations'
 import standardValueSetFilter from './filters/standard_value_sets'
 import flowFilter from './filters/flow'
 import addMissingIdsFilter from './filters/add_missing_ids'
@@ -94,6 +95,7 @@ export const DEFAULT_FILTERS = [
   // customObjectsInstancesFilter depends on customObjectsFilter
   customObjectsInstancesFilter,
   removeFieldsAndValuesFilter,
+  removeRestrictionAnnotationsFilter,
   // addMissingIdsFilter should run after customObjectsFilter
   addMissingIdsFilter,
   layoutFilter,

--- a/packages/salesforce-adapter/src/filters/remove_restriction_annotations.ts
+++ b/packages/salesforce-adapter/src/filters/remove_restriction_annotations.ts
@@ -44,16 +44,15 @@ export const makeFilter = (
       relevantFields.forEach(fieldName => {
         const field = type.fields[fieldName]
         if (field !== undefined && field.annotations[CORE_ANNOTATIONS.RESTRICTION] !== undefined) {
-          field.annotations[CORE_ANNOTATIONS.RESTRICTION] = undefined
+          delete field.annotations[CORE_ANNOTATIONS.RESTRICTION]
         }
       })
     }
 
-    await awu(elements).filter(isObjectType).filter(
-      async type => typeNameToFieldMapping[
-        await metadataType(type)
-      ] !== undefined
-    ).forEach(removeRestrictionsFromTypeFields)
+    await awu(elements)
+      .filter(isObjectType)
+      .filter(async type => typeNameToFieldMapping[await metadataType(type)] !== undefined)
+      .forEach(removeRestrictionsFromTypeFields)
   },
 })
 

--- a/packages/salesforce-adapter/src/filters/remove_restriction_annotations.ts
+++ b/packages/salesforce-adapter/src/filters/remove_restriction_annotations.ts
@@ -1,0 +1,60 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { isObjectType, Element, ObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { FilterCreator } from '../filter'
+import { metadataType } from '../transformers/transformer'
+
+const { awu } = collections.asynciterable
+
+const FIELDS_TO_REMOVE_RESTRICTION_FROM_BY_TYPE: Record<string, string[]> = {
+  AccessControlPolicy: ['targetEntity'],
+  AnimationRule: ['sobjectType', 'targetField'],
+  PlatformEventChannelMember: ['selectedEntity'],
+  RestrictionRule: ['targetEntity'],
+  AppProfileActionOverride: ['pageOrSobjectType'],
+  QueueSobject: ['sobjectType'],
+}
+
+/**
+ * Remove _restriction annotation values from types that are impacted by custom objects.
+ * Note: This is a short-term solution - once SALTO-1381 is implemented, we should
+ * convert the builtin _restriction annotation to hidden (with _hidden_value=true),
+ * and hide all the values on upgrade.
+ */
+export const makeFilter = (
+  typeNameToFieldMapping: Record<string, string[]>,
+): FilterCreator => () => ({
+  onFetch: async (elements: Element[]) => {
+    const removeRestrictionsFromTypeFields = async (type: ObjectType): Promise<void> => {
+      const relevantFields = typeNameToFieldMapping[await metadataType(type)]
+      relevantFields.forEach(fieldName => {
+        const field = type.fields[fieldName]
+        if (field !== undefined && field.annotations[CORE_ANNOTATIONS.RESTRICTION] !== undefined) {
+          field.annotations[CORE_ANNOTATIONS.RESTRICTION] = undefined
+        }
+      })
+    }
+
+    await awu(elements).filter(isObjectType).filter(
+      async type => typeNameToFieldMapping[
+        await metadataType(type)
+      ] !== undefined
+    ).forEach(removeRestrictionsFromTypeFields)
+  },
+})
+
+export default makeFilter(FIELDS_TO_REMOVE_RESTRICTION_FROM_BY_TYPE)

--- a/packages/salesforce-adapter/src/filters/remove_restriction_annotations.ts
+++ b/packages/salesforce-adapter/src/filters/remove_restriction_annotations.ts
@@ -23,10 +23,12 @@ const { awu } = collections.asynciterable
 const FIELDS_TO_REMOVE_RESTRICTION_FROM_BY_TYPE: Record<string, string[]> = {
   AccessControlPolicy: ['targetEntity'],
   AnimationRule: ['sobjectType', 'targetField'],
-  PlatformEventChannelMember: ['selectedEntity'],
-  RestrictionRule: ['targetEntity'],
   AppProfileActionOverride: ['pageOrSobjectType'],
+  PlatformEventChannelMember: ['selectedEntity'],
+  ProfileActionOverride: ['pageOrSobjectType'],
   QueueSobject: ['sobjectType'],
+  RestrictionRule: ['targetEntity'],
+  Territory2RuleItem: ['field'],
 }
 
 /**

--- a/packages/salesforce-adapter/test/filters/remove_restriction_annotations.test.ts
+++ b/packages/salesforce-adapter/test/filters/remove_restriction_annotations.test.ts
@@ -83,18 +83,20 @@ describe('remove restriction annotations filter', () => {
     it('should not remove restriction for unrelated fields', () => {
       const testType = testElements[0] as ObjectType
       expect(testType.fields.unrelated).toBeDefined()
-      expect(testType.fields.unrelated.annotations[CORE_ANNOTATIONS.RESTRICTION]).toBeDefined()
+      expect(testType.fields.unrelated.annotations).toHaveProperty(CORE_ANNOTATIONS.RESTRICTION)
       const unrelatedType = testElements[1] as ObjectType
       expect(unrelatedType.fields.targetField).toBeDefined()
-      expect(
-        unrelatedType.fields.targetField.annotations[CORE_ANNOTATIONS.RESTRICTION]
-      ).toBeDefined()
+      expect(unrelatedType.fields.targetField.annotations).toHaveProperty(
+        CORE_ANNOTATIONS.RESTRICTION
+      )
     })
 
     it('should remove annotation for related fields', () => {
       const testType = testElements[0] as ObjectType
       expect(testType.fields.targetField).toBeDefined()
-      expect(testType.fields.targetField.annotations[CORE_ANNOTATIONS.RESTRICTION]).toBeUndefined()
+      expect(testType.fields.targetField.annotations).not.toHaveProperty(
+        CORE_ANNOTATIONS.RESTRICTION
+      )
     })
   })
 })

--- a/packages/salesforce-adapter/test/filters/remove_restriction_annotations.test.ts
+++ b/packages/salesforce-adapter/test/filters/remove_restriction_annotations.test.ts
@@ -1,0 +1,100 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, BuiltinTypes, Element, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { makeFilter } from '../../src/filters/remove_restriction_annotations'
+import * as constants from '../../src/constants'
+import { FilterWith } from '../../src/filter'
+import mockClient from '../client'
+import { defaultFilterContext } from '../utils'
+
+describe('remove restriction annotations filter', () => {
+  const mockObjId = new ElemID(constants.SALESFORCE, 'AnimationRule')
+  const mockType = new ObjectType({
+    elemID: mockObjId,
+    fields: {
+      unrelated: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          _restriction: { values: ['a'] },
+        },
+      },
+      targetField: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          _restriction: { values: ['a'] },
+        },
+      },
+    },
+    annotations: {
+      [constants.METADATA_TYPE]: 'AnimationRule',
+    },
+  })
+  const mockUnrelatedType = new ObjectType({
+    elemID: mockObjId,
+    fields: {
+      unrelated: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          _restriction: { values: ['a'] },
+        },
+      },
+      targetField: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          _restriction: { values: ['a'] },
+        },
+      },
+    },
+    annotations: {
+      [constants.METADATA_TYPE]: 'somethingElse',
+    },
+  })
+
+  const { client } = mockClient()
+  const filter = makeFilter({
+    AnimationRule: ['sobjectType', 'targetField'],
+  })({ client, config: defaultFilterContext }) as FilterWith<'onFetch'>
+
+  let testElements: Element[]
+
+  beforeEach(() => {
+    testElements = [
+      mockType.clone(),
+      mockUnrelatedType.clone(),
+    ]
+  })
+
+  describe('on fetch', () => {
+    beforeEach(() => filter.onFetch(testElements))
+
+    it('should not remove restriction for unrelated fields', () => {
+      const testType = testElements[0] as ObjectType
+      expect(testType.fields.unrelated).toBeDefined()
+      expect(testType.fields.unrelated.annotations[CORE_ANNOTATIONS.RESTRICTION]).toBeDefined()
+      const unrelatedType = testElements[1] as ObjectType
+      expect(unrelatedType.fields.targetField).toBeDefined()
+      expect(
+        unrelatedType.fields.targetField.annotations[CORE_ANNOTATIONS.RESTRICTION]
+      ).toBeDefined()
+    })
+
+    it('should remove annotation for related fields', () => {
+      const testType = testElements[0] as ObjectType
+      expect(testType.fields.targetField).toBeDefined()
+      expect(testType.fields.targetField.annotations[CORE_ANNOTATIONS.RESTRICTION]).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
Remove `_restriction` values in salesforce types that may be impacted by addition/removal of custom objects and fields, to avoid unintentional changes in that annotation that may result in unexpected deploy plans (and sometimes failures).

Ideally these would be hidden rather than removed, but we don't have a good way to apply hidden changes related to builtin annotation types on existing workspaces - once we do, this will be replaced by the improved approach.

---

Will wait with merging until the corresponding noise-reduction PR is merged

---
_Release Notes_: 

_Salesforce Adapter_:
* Remove `_restriction` annotation values for specific fields under `AccessControlPolicy`, `AnimationRule`, `PlatformEventChannelMember`, `RestrictionRule`, `AppProfileActionOverride`, `QueueSobject`, `ProfileActionOverride`, `Territory2RuleItem`

---
_User Notifications_: 
Removing annotation values under
```
salesforce.AccessControlPolicy.field.targetEntity._restriction
salesforce.AnimationRule.field.sobjectType._restriction
salesforce.AnimationRule.field.targetField._restriction
salesforce.PlatformEventChannelMember.field.selectedEntity._restriction
salesforce.RestrictionRule.field.targetEntity._restriction
salesforce.AppProfileActionOverride.field.pageOrSobjectType._restriction
salesforce.QueueSobject.field.sobjectType._restriction
salesforce.ProfileActionOverride.field.pageOrSobjectType._restriction
salesforce.Territory2RuleItem.field.field._restriction

```