### PR TITLE
SALTO-1913: separated field and contexts to different instances

### DIFF
--- a/packages/adapter-components/src/elements/index.ts
+++ b/packages/adapter-components/src/elements/index.ts
@@ -21,6 +21,7 @@ import { computeGetArgs, simpleGetArgs } from './request_parameters'
 import { RECORDS_PATH, TYPES_PATH, SUBTYPES_PATH } from './constants'
 import { findDataField, returnFullEntry, FindNestedFieldFunc } from './field_finder'
 import { filterTypes } from './type_elements'
+import { getInstanceName } from './instance_elements'
 
 export {
   ducktype,
@@ -31,4 +32,5 @@ export {
   findDataField, returnFullEntry, FindNestedFieldFunc,
   RECORDS_PATH, TYPES_PATH, SUBTYPES_PATH,
   filterTypes,
+  getInstanceName,
 }

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -38,6 +38,17 @@ export type InstanceCreationParams = {
   normalized?: boolean
 }
 
+export const getInstanceName = (
+  instanceValues: Values,
+  idFields: string[],
+): string | undefined => {
+  const nameParts = idFields.map(field => _.get(instanceValues, field))
+  if (nameParts.includes(undefined)) {
+    log.warn(`could not find id for entry - expected id fields ${idFields}, available fields ${Object.keys(instanceValues)}`)
+  }
+  return nameParts.every(part => part !== undefined && part !== '') ? nameParts.map(String).join('_') : undefined
+}
+
 /**
  * Generate an instance for a single entry returned for a given type.
  *
@@ -83,11 +94,7 @@ export const toBasicInstance = async ({
     transformationDefaultConfig,
   )
 
-  const nameParts = idFields.map(field => _.get(entry, field))
-  if (nameParts.includes(undefined)) {
-    log.warn(`could not find id for entry - expected id fields ${idFields}, available fields ${Object.keys(entry)}`)
-  }
-  const name = nameParts.every(part => part !== undefined && part !== '') ? nameParts.map(String).join('_') : defaultName
+  const name = getInstanceName(entry, idFields) ?? defaultName
 
   const fileNameParts = (fileNameFields !== undefined
     ? fileNameFields.map(field => _.get(entry, field))

--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -95,18 +95,15 @@ describe('Jira E2E', () => {
           },
         })
 
-        const appliedChange = res.appliedChanges[0]
-        if (appliedChange === undefined) {
-          return res
-        }
-
-        const appliedInstance = getChangeData(appliedChange)
-        instances
-          .flatMap(getParents)
-          .filter(parent => parent.elemID.isEqual(appliedInstance.elemID))
-          .forEach(parent => {
-            parent.resValue = appliedInstance
-          })
+        res.appliedChanges.forEach(appliedChange => {
+          const appliedInstance = getChangeData(appliedChange)
+          instances
+            .flatMap(getParents)
+            .filter(parent => parent.elemID.isEqual(appliedInstance.elemID))
+            .forEach(parent => {
+              parent.resValue = appliedInstance
+            })
+        })
         return res
       }).toArray()
     })

--- a/packages/jira-adapter/e2e_test/instances/field.ts
+++ b/packages/jira-adapter/e2e_test/instances/field.ts
@@ -35,54 +35,53 @@ const p1Option = {
   position: 0,
 }
 
-export const createFieldValues = (name: string, allElements: Element[]): Values => ({
+export const createFieldValues = (name: string): Values => ({
   name,
   description: 'desc!',
   searcherKey: 'com.atlassian.jira.plugin.system.customfieldtypes:cascadingselectsearcher',
-  contexts: {
-    'CustomConfigurationScheme_for_CustomSelectList@s': {
-      name: 'CustomConfigurationScheme for CustomSelectList',
-      options: {
-        p1: p1Option,
-        p2: {
-          value: 'p2',
+  type: 'com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect',
+})
+
+export const createContextValues = (name: string, allElements: Element[]): Values => ({
+  name,
+  options: {
+    p1: p1Option,
+    p2: {
+      value: 'p2',
+      disabled: false,
+      cascadingOptions: {
+        c22: {
+          value: 'c22',
           disabled: false,
-          cascadingOptions: {
-            c22: {
-              value: 'c22',
-              disabled: false,
-              position: 0,
-            },
-          },
-          position: 1,
-        },
-        p3: {
-          value: 'p3',
-          disabled: true,
-          position: 2,
-        },
-        p4: {
-          value: 'p4',
-          disabled: false,
-          position: 3,
+          position: 0,
         },
       },
-      defaultValue: {
-        type: 'option.cascading',
-        optionId: new ReferenceExpression(
-          new ElemID(JIRA, 'Field', 'instance', name, 'contexts', 'CustomConfigurationScheme_for_CustomSelectList@s', 'options', 'p1'),
-          p1Option
-        ),
-        cascadingOptionId: new ReferenceExpression(
-          new ElemID(JIRA, 'Field', 'instance', name, 'contexts', 'CustomConfigurationScheme_for_CustomSelectList@s', 'options', 'p1', 'cascadingOptions', 'c11'),
-          p1Option.cascadingOptions.c11
-        ),
-      },
-      issueTypeIds: [
-        createReference(new ElemID(JIRA, 'IssueType', 'instance', 'Epic'), allElements),
-        createReference(new ElemID(JIRA, 'IssueType', 'instance', 'Story'), allElements),
-      ],
+      position: 1,
+    },
+    p3: {
+      value: 'p3',
+      disabled: true,
+      position: 2,
+    },
+    p4: {
+      value: 'p4',
+      disabled: false,
+      position: 3,
     },
   },
-  type: 'com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect',
+  defaultValue: {
+    type: 'option.cascading',
+    optionId: new ReferenceExpression(
+      new ElemID(JIRA, 'Field', 'instance', name, 'contexts', 'CustomConfigurationScheme_for_CustomSelectList@s', 'options', 'p1'),
+      p1Option
+    ),
+    cascadingOptionId: new ReferenceExpression(
+      new ElemID(JIRA, 'Field', 'instance', name, 'contexts', 'CustomConfigurationScheme_for_CustomSelectList@s', 'options', 'p1', 'cascadingOptions', 'c11'),
+      p1Option.cascadingOptions.c11
+    ),
+  },
+  issueTypeIds: [
+    createReference(new ElemID(JIRA, 'IssueType', 'instance', 'Epic'), allElements),
+    createReference(new ElemID(JIRA, 'IssueType', 'instance', 'Story'), allElements),
+  ],
 })

--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -13,11 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, Element, ElemID } from '@salto-io/adapter-api'
+import { InstanceElement, Element, ElemID, CORE_ANNOTATIONS, ReferenceExpression } from '@salto-io/adapter-api'
+import { naclCase } from '@salto-io/adapter-utils'
 import { JIRA } from '../../src/constants'
 import { createReference, findType } from '../utils'
 import { createBoardValues } from './board'
-import { createFieldValues } from './field'
+import { createContextValues, createFieldValues } from './field'
 import { createFieldConfigurationSchemeValues } from './fieldConfigurationScheme'
 import { createIssueTypeSchemeValues } from './issueTypeScheme'
 import { createIssueTypeScreenSchemeValues } from './issueTypeScreenScheme'
@@ -41,7 +42,15 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[] =
   const field = new InstanceElement(
     randomString,
     findType('Field', fetchedElements),
-    createFieldValues(randomString, fetchedElements),
+    createFieldValues(randomString),
+  )
+
+  const fieldContext = new InstanceElement(
+    naclCase(`${randomString}_${randomString}`),
+    findType('CustomFieldContext', fetchedElements),
+    createContextValues(randomString, fetchedElements),
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(field.elemID, field)] }
   )
 
   const workflow = new InstanceElement(
@@ -141,6 +150,7 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[] =
   return [
     issueType,
     field,
+    fieldContext,
     screen,
     workflow,
     dashboard,

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -42,6 +42,7 @@ import workflowFilter from './filters/workflow/workflow'
 import workflowSchemeFilter from './filters/workflow_scheme'
 import fieldStructureFilter from './filters/fields/field_structure_filter'
 import fieldDeploymentFilter from './filters/fields/field_deployment_filter'
+import contextDeploymentFilter from './filters/fields/context_deployment_filter'
 import fieldTypeReferencesFilter from './filters/fields/field_type_references_filter'
 import avatarsFilter from './filters/avatars'
 import { JIRA } from './constants'
@@ -69,6 +70,7 @@ export const DEFAULT_FILTERS = [
   fieldStructureFilter,
   fieldTypeReferencesFilter,
   fieldDeploymentFilter,
+  contextDeploymentFilter,
   screenFilter,
   issueTypeScreenSchemeFilter,
   fieldConfigurationFilter,

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -166,7 +166,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
           fieldName: 'id',
         },
       ],
-      idFields: ['id'],
       fieldTypeOverrides: [
         { fieldName: 'contexts', fieldType: 'list<CustomFieldContext>' },
         { fieldName: 'contextDefaults', fieldType: 'list<CustomFieldContextDefaultValue>' },
@@ -254,12 +253,16 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       add: {
         url: '/rest/api/3/field/{fieldId}/context',
         method: 'post',
+        urlParamsToFields: {
+          fieldId: '_parent.0.id',
+        },
       },
       modify: {
         url: '/rest/api/3/field/{fieldId}/context/{contextId}',
         method: 'put',
         urlParamsToFields: {
           contextId: 'id',
+          fieldId: '_parent.0.id',
         },
       },
       remove: {
@@ -267,6 +270,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         method: 'delete',
         urlParamsToFields: {
           contextId: 'id',
+          fieldId: '_parent.0.id',
         },
       },
     },

--- a/packages/jira-adapter/src/deployment.ts
+++ b/packages/jira-adapter/src/deployment.ts
@@ -80,11 +80,11 @@ export const deployChanges = async <T extends Change<ChangeDataType>>(
         await deployChangeFunc(change)
         return change
       } catch (err) {
-        const errorMessage = `Deployment of ${getChangeData(change).elemID.getFullName()} failed: ${err}`
+        err.message = `Deployment of ${getChangeData(change).elemID.getFullName()} failed: ${err}`
         if (err instanceof clientUtils.HTTPError && 'errorMessages' in err.response.data) {
-          return new Error(`${errorMessage}. ${err.response.data.errorMessages}`)
+          err.message = `${err.message}. ${err.response.data.errorMessages}`
         }
-        return new Error(errorMessage)
+        return err
       }
     })
   )

--- a/packages/jira-adapter/src/filters/fields/constants.ts
+++ b/packages/jira-adapter/src/filters/fields/constants.ts
@@ -14,3 +14,4 @@
 * limitations under the License.
 */
 export const FIELD_TYPE_NAME = 'Field'
+export const FIELD_CONTEXT_TYPE_NAME = 'CustomFieldContext'

--- a/packages/jira-adapter/src/filters/fields/constants.ts
+++ b/packages/jira-adapter/src/filters/fields/constants.ts
@@ -15,3 +15,5 @@
 */
 export const FIELD_TYPE_NAME = 'Field'
 export const FIELD_CONTEXT_TYPE_NAME = 'CustomFieldContext'
+export const FIELD_CONTEXT_DEFAULT_TYPE_NAME = 'CustomFieldContextDefaultValue'
+export const FIELD_CONTEXT_OPTION_TYPE_NAME = 'CustomFieldContextOption'

--- a/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
@@ -1,0 +1,56 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, getChangeData, isInstanceChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../../filter'
+import { deployContextChange, setContextDeploymentAnnotations } from './contexts'
+import { deployChanges } from '../../deployment'
+import { FIELD_CONTEXT_TYPE_NAME } from './constants'
+import { findObject } from '../../utils'
+
+const log = logger(module)
+
+const filter: FilterCreator = ({ client, config }) => ({
+  onFetch: async (elements: Element[]) => {
+    const fieldContextType = findObject(elements, FIELD_CONTEXT_TYPE_NAME)
+    if (fieldContextType === undefined) {
+      log.warn(`Could not find type ${FIELD_CONTEXT_TYPE_NAME}`)
+    } else {
+      await setContextDeploymentAnnotations(fieldContextType)
+    }
+  },
+
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && getChangeData(change).elemID.typeName === FIELD_CONTEXT_TYPE_NAME
+    )
+
+    const deployResult = await deployChanges(
+      relevantChanges.filter(isInstanceChange),
+      change => deployContextChange(change, client, config.apiDefinitions)
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/fields/context_options.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options.ts
@@ -15,7 +15,7 @@
 */
 import { AdditionChange, Change, getChangeData, InstanceElement, isAdditionChange, isMapType, isObjectType, isRemovalChange, ModificationChange, ObjectType, Value, Values } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
-import { naclCase, resolveValues } from '@salto-io/adapter-utils'
+import { getParents, naclCase, resolveValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
@@ -173,7 +173,6 @@ const reorderContextOptions = async (
 
 export const setContextOptions = async (
   contextChange: Change<InstanceElement>,
-  parentField: InstanceElement,
   client: clientUtils.HTTPWriteClientInterface,
 ): Promise<void> => {
   if (isRemovalChange(contextChange)) {
@@ -187,7 +186,9 @@ export const setContextOptions = async (
     option => option.optionId !== undefined || option.parentValue === undefined
   )
 
-  const url = `/rest/api/3/field/${parentField.value.id}/context/${getChangeData(contextChange).value.id}/option`
+  const fieldId = getParents(getChangeData(contextChange))[0].value.value.id
+
+  const url = `/rest/api/3/field/${fieldId}/context/${getChangeData(contextChange).value.id}/option`
   await updateContextOptions({
     addedOptions: addedWithParentId,
     modifiedOptions: modified,

--- a/packages/jira-adapter/src/filters/fields/contexts.ts
+++ b/packages/jira-adapter/src/filters/fields/contexts.ts
@@ -69,8 +69,8 @@ export const deployContextChange = async (
     throw err
   }
 
-  await setContextField(change, 'issueTypeIds', 'issuetype', client)
-  await setContextField(change, 'projectIds', 'project', client)
+  await setContextField({ contextChange: change, fieldName: 'issueTypeIds', endpoint: 'issuetype', client })
+  await setContextField({ contextChange: change, fieldName: 'projectIds', endpoint: 'project', client })
   await setContextOptions(change, client)
   await updateDefaultValues(change, client)
 }

--- a/packages/jira-adapter/src/filters/fields/contexts.ts
+++ b/packages/jira-adapter/src/filters/fields/contexts.ts
@@ -13,73 +13,23 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { AdditionChange, Change, getChangeData, InstanceElement, isAdditionChange, isMapType, isModificationChange, isObjectType, ModificationChange, ObjectType, toChange, Value, Values } from '@salto-io/adapter-api'
-import { collections } from '@salto-io/lowerdash'
-import _ from 'lodash'
-import { config } from '@salto-io/adapter-components'
+import { AdditionChange, Change, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionChange, isMapType, isObjectType, isRemovalChange, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { config, client as clientUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { defaultDeployChange } from '../../deployment'
 import JiraClient from '../../client/client'
 import { setContextOptions, setOptionTypeDeploymentAnnotations } from './context_options'
-import { setDefaultValueTypeDeploymentAnnotations } from './default_values'
+import { setDefaultValueTypeDeploymentAnnotations, updateDefaultValues } from './default_values'
 import { setContextField } from './issues_and_projects'
 import { setDeploymentAnnotations } from '../../utils'
-
-const { awu } = collections.asynciterable
 
 const FIELDS_TO_IGNORE = ['defaultValue', 'options']
 
 const log = logger(module)
 
-const toContextInstance = (
-  context: Values,
-  contextType: ObjectType,
-): InstanceElement =>
-  new InstanceElement(context.id, contextType, context)
 
-const getContextChanges = (
-  change: ModificationChange<InstanceElement> | AdditionChange<InstanceElement>,
-  contextType: ObjectType
-): Change<InstanceElement>[] => {
-  const instance = getChangeData(change)
-  if (isAdditionChange(change)) {
-    return Object.values(instance.value.contexts ?? {}).map(
-      (context: Value) => toChange({
-        after: toContextInstance(context, contextType),
-      })
-    )
-  }
-
-  const afterContexts = _.values(change.data.after.value.contexts ?? {})
-  const beforeContexts = _.values(change.data.before.value.contexts ?? {})
-  const afterContextsById = _.keyBy(afterContexts, context => context.id)
-  const beforeContextsById = _.keyBy(beforeContexts, context => context.id)
-
-  const removeChanges = beforeContexts
-    .filter(context => !(context.id in afterContextsById))
-    .map(context => toChange({
-      before: toContextInstance(context, contextType),
-    }))
-
-  const addedChanges = afterContexts
-    .filter(context => !(context.id in beforeContextsById))
-    .map(context => toChange({
-      after: toContextInstance(context, contextType),
-    }))
-
-  const modifiedChanges = afterContexts
-    .filter(context => context.id in beforeContextsById)
-    .map(context => toChange({
-      before: toContextInstance(beforeContextsById[context.id], contextType),
-      after: toContextInstance(context, contextType),
-    }))
-
-  return [...removeChanges, ...modifiedChanges, ...addedChanges]
-}
-
-
-const getContextType = async (fieldType: ObjectType):
+export const getContextType = async (fieldType: ObjectType):
 Promise<ObjectType> => {
   const contextMapType = await fieldType.fields.contexts.getType()
   if (!isMapType(contextMapType)) {
@@ -94,28 +44,38 @@ Promise<ObjectType> => {
   return contextType
 }
 
-const deployContextChange = async (
+export const deployContextChange = async (
   change: Change<InstanceElement>,
-  parentField: InstanceElement,
   client: JiraClient,
   apiDefinitions: config.AdapterApiConfig,
 ): Promise<void> => {
-  await defaultDeployChange({
-    change,
-    client,
-    apiDefinitions,
-    // 'issueTypeIds', 'projectIds' can be deployed in the same endpoint as create
-    // but for modify there are different endpoints for them
-    fieldsToIgnore: isAdditionChange(change) ? FIELDS_TO_IGNORE : [...FIELDS_TO_IGNORE, 'issueTypeIds', 'projectIds'],
-    additionalUrlVars: { fieldId: parentField.value.id },
-  })
+  try {
+    await defaultDeployChange({
+      change,
+      client,
+      apiDefinitions,
+      // 'issueTypeIds', 'projectIds' can be deployed in the same endpoint as create
+      // but for modify there are different endpoints for them
+      fieldsToIgnore: isAdditionChange(change) ? FIELDS_TO_IGNORE : [...FIELDS_TO_IGNORE, 'issueTypeIds', 'projectIds'],
+    })
+  } catch (err) {
+    if (isRemovalChange(change)
+      && err instanceof clientUtils.HTTPError
+      && Array.isArray(err.response.data.errorMessages)
+      && err.response.data.errorMessages.includes('The custom field was not found.')
+    ) {
+      return
+    }
+    throw err
+  }
 
-  await setContextField(change, 'issueTypeIds', 'issuetype', parentField, client)
-  await setContextField(change, 'projectIds', 'project', parentField, client)
-  await setContextOptions(change, parentField, client)
+  await setContextField(change, 'issueTypeIds', 'issuetype', client)
+  await setContextField(change, 'projectIds', 'project', client)
+  await setContextOptions(change, client)
+  await updateDefaultValues(change, client)
 }
 
-const getContexts = async (
+export const getContexts = async (
   fieldChange: AdditionChange<InstanceElement>,
   contextType: ObjectType,
   client: JiraClient,
@@ -126,43 +86,20 @@ const getContexts = async (
     log.warn(`Received unexpected response from Jira when querying contexts for instance ${getChangeData(fieldChange).elemID.getFullName()}: ${safeJsonStringify(resp.data.values)}`)
     throw new Error(`Received unexpected response from Jira when querying contexts for instance ${getChangeData(fieldChange).elemID.getFullName()}`)
   }
-  return resp.data.values.map(values => new InstanceElement(values.id, contextType, values))
+  return resp.data.values.map(values => new InstanceElement(
+    values.id,
+    contextType,
+    values,
+    undefined,
+    {
+      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(fieldInstance.elemID, fieldInstance)],
+    }
+  ))
 }
-
-export const deployContexts = async (
-  fieldChange: ModificationChange<InstanceElement> | AdditionChange<InstanceElement>,
-  client: JiraClient,
-  apiDefinitions: config.AdapterApiConfig,
-): Promise<void> => {
-  const contextType = await getContextType(await getChangeData(fieldChange).getType())
-  // When creating a field, it is created with a default context,
-  // in addition to what is in the NaCl so we need to delete it
-  const removalContextsChanges = isAdditionChange(fieldChange)
-    ? (await getContexts(fieldChange, contextType, client))
-      .map(instance => toChange({ before: instance }))
-    : []
-
-  const fieldInstance = getChangeData(fieldChange)
-
-  const contextChanges = [
-    ...removalContextsChanges,
-    ...getContextChanges(fieldChange, contextType),
-  ]
-  await awu(contextChanges).filter(contextChange => (
-    !isModificationChange(contextChange)
-    || !contextChange.data.before.isEqual(contextChange.data.after)
-  )).forEach(async contextChange => {
-    await deployContextChange(contextChange, fieldInstance, client, apiDefinitions)
-  })
-}
-
 
 export const setContextDeploymentAnnotations = async (
-  fieldType: ObjectType,
+  contextType: ObjectType,
 ): Promise<void> => {
-  setDeploymentAnnotations(fieldType, 'contexts')
-  const contextType = await getContextType(fieldType)
-
   await setDefaultValueTypeDeploymentAnnotations(contextType)
   setDeploymentAnnotations(contextType, 'projectIds')
   setDeploymentAnnotations(contextType, 'issueTypeIds')

--- a/packages/jira-adapter/src/filters/fields/field_deployment_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_deployment_filter.ts
@@ -15,6 +15,7 @@
 */
 import { Change, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
 import JiraClient from '../../client/client'
 import { FilterCreator } from '../../filter'
 import { deployContextChange, getContexts, getContextType } from './contexts'
@@ -22,6 +23,7 @@ import { defaultDeployChange, deployChanges } from '../../deployment'
 import { FIELD_TYPE_NAME } from './constants'
 import { JiraConfig } from '../../config'
 
+const { awu } = collections.asynciterable
 
 const deployField = async (
   change: Change<InstanceElement>,
@@ -38,11 +40,11 @@ const deployField = async (
       .map(instance => toChange({ before: instance }))
     : []
 
-  await Promise.all(removalContextsChanges.map(contextChange => deployContextChange(
+  await awu(removalContextsChanges).forEach(contextChange => deployContextChange(
     contextChange,
     client,
     config.apiDefinitions
-  )))
+  ))
 }
 
 const filter: FilterCreator = ({ client, config }) => ({

--- a/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
@@ -245,7 +245,8 @@ const filter: FilterCreator = ({ config }) => ({
             config,
           ))
 
-        delete instance.value.contexts
+        instance.value.contexts = contexts
+          .map((context: InstanceElement) => new ReferenceExpression(context.elemID, context))
 
         elements.push(...contexts)
       })

--- a/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
@@ -48,45 +48,64 @@ const addDefaultValuesToContexts = (
   delete instance.value.contextDefaults
 }
 
+const addPropertyToContexts = (
+  {
+    instance,
+    idToContext,
+    allPropertiesFieldName,
+    propertyFieldName,
+    isGlobalFieldName,
+    destinationFieldName,
+  }: {
+    instance: InstanceElement
+    idToContext: Record<string, Values>
+    allPropertiesFieldName: string
+    propertyFieldName: string
+    isGlobalFieldName: string
+    destinationFieldName: string
+  }
+): void => {
+  (instance.value[allPropertiesFieldName] ?? [])
+    .filter((property: Values) => !property[isGlobalFieldName])
+    .forEach((property: Values) => {
+      if (idToContext[property.contextId] === undefined) {
+        log.warn(`Context with id ${property.contextId} not found in instance ${instance.elemID.getFullName()} when assigning ${destinationFieldName}`)
+        return
+      }
+      if (idToContext[property.contextId][destinationFieldName] === undefined) {
+        idToContext[property.contextId][destinationFieldName] = []
+      }
+      idToContext[property.contextId][destinationFieldName].push(property[propertyFieldName])
+    })
+
+  delete instance.value[allPropertiesFieldName]
+}
+
 const addIssueTypesToContexts = (
   instance: InstanceElement,
   idToContext: Record<string, Values>
-): void => {
-  (instance.value.contextIssueTypes ?? [])
-    .filter((issueType: Values) => !issueType.isAnyIssueType)
-    .forEach((issueType: Values) => {
-      if (idToContext[issueType.contextId] === undefined) {
-        log.warn(`Context with id ${issueType.contextId} not found in instance ${instance.elemID.getFullName()} when assigning issue types`)
-        return
-      }
-      if (idToContext[issueType.contextId].issueTypeIds === undefined) {
-        idToContext[issueType.contextId].issueTypeIds = []
-      }
-      idToContext[issueType.contextId].issueTypeIds.push(issueType.issueTypeId)
-    })
-
-  delete instance.value.contextIssueTypes
-}
+): void =>
+  addPropertyToContexts({
+    instance,
+    idToContext,
+    allPropertiesFieldName: 'contextIssueTypes',
+    propertyFieldName: 'issueTypeId',
+    isGlobalFieldName: 'isAnyIssueType',
+    destinationFieldName: 'issueTypeIds',
+  })
 
 const addProjectsToContexts = (
   instance: InstanceElement,
   idToContext: Record<string, Values>
-): void => {
-  (instance.value.contextProjects ?? [])
-    .filter((project: Values) => !project.isGlobalContext)
-    .forEach((project: Values) => {
-      if (idToContext[project.contextId] === undefined) {
-        log.warn(`Context with id ${project.contextId} not found in instance ${instance.elemID.getFullName()} when assigning projects`)
-        return
-      }
-      if (idToContext[project.contextId].projectIds === undefined) {
-        idToContext[project.contextId].projectIds = []
-      }
-      idToContext[project.contextId].projectIds.push(project.projectId)
-    })
-
-  delete instance.value.contextProjects
-}
+): void =>
+  addPropertyToContexts({
+    instance,
+    idToContext,
+    allPropertiesFieldName: 'contextProjects',
+    propertyFieldName: 'projectId',
+    isGlobalFieldName: 'isGlobalContext',
+    destinationFieldName: 'projectIds',
+  })
 
 const addCascadingOptionsToOptions = (instance: InstanceElement): void => {
   instance.value.contexts

--- a/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
@@ -192,16 +192,15 @@ const filter: FilterCreator = ({ config }) => ({
     const fieldContextDefaultValueType = types[FIELD_CONTEXT_DEFAULT_TYPE_NAME]
     const fieldContextOptionType = types[FIELD_CONTEXT_OPTION_TYPE_NAME]
 
-    if (fieldType === undefined
-      || fieldContextType === undefined
-      || fieldContextDefaultValueType === undefined
-      || fieldContextOptionType === undefined) {
-      const missingTypes = [
-        fieldType === undefined ? FIELD_TYPE_NAME : undefined,
-        fieldContextType === undefined ? FIELD_CONTEXT_TYPE_NAME : undefined,
-        fieldContextDefaultValueType === undefined ? FIELD_CONTEXT_DEFAULT_TYPE_NAME : undefined,
-        fieldContextOptionType === undefined ? FIELD_CONTEXT_OPTION_TYPE_NAME : undefined,
-      ].filter(values.isDefined)
+
+    const missingTypes = [
+      fieldType === undefined ? FIELD_TYPE_NAME : undefined,
+      fieldContextType === undefined ? FIELD_CONTEXT_TYPE_NAME : undefined,
+      fieldContextDefaultValueType === undefined ? FIELD_CONTEXT_DEFAULT_TYPE_NAME : undefined,
+      fieldContextOptionType === undefined ? FIELD_CONTEXT_OPTION_TYPE_NAME : undefined,
+    ].filter(values.isDefined)
+
+    if (missingTypes.length) {
       log.warn(`Missing types for field structure filter: ${missingTypes.join(', ')}, skipping`)
       return
     }

--- a/packages/jira-adapter/src/filters/fields/issues_and_projects.ts
+++ b/packages/jira-adapter/src/filters/fields/issues_and_projects.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { Change, getChangeData, InstanceElement, isModificationChange } from '@salto-io/adapter-api'
-import { resolveChangeElement } from '@salto-io/adapter-utils'
+import { getParents, resolveChangeElement } from '@salto-io/adapter-utils'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { getLookUpName } from '../../reference_mapping'
 import { getDiffIds } from '../../diff'
@@ -24,7 +24,6 @@ export const setContextField = async (
   contextChange: Change<InstanceElement>,
   fieldName: string,
   endpoint: string,
-  parentField: InstanceElement,
   client: clientUtils.HTTPWriteClientInterface
 ): Promise<void> => {
   const resolvedChange = await resolveChangeElement(contextChange, getLookUpName)
@@ -42,9 +41,11 @@ export const setContextField = async (
     contextInstance.value[fieldName] ?? []
   )
 
+  const fieldId = getParents(contextInstance)[0].id
+
   if (addedIds.length !== 0) {
     await client.put({
-      url: `/rest/api/3/field/${parentField.value.id}/context/${contextInstance.value.id}/${endpoint}`,
+      url: `/rest/api/3/field/${fieldId}/context/${contextInstance.value.id}/${endpoint}`,
       data: {
         [fieldName]: addedIds,
       },
@@ -53,7 +54,7 @@ export const setContextField = async (
 
   if (removedIds.length !== 0) {
     await client.post({
-      url: `/rest/api/3/field/${parentField.value.id}/context/${contextInstance.value.id}/${endpoint}/remove`,
+      url: `/rest/api/3/field/${fieldId}/context/${contextInstance.value.id}/${endpoint}/remove`,
       data: {
         [fieldName]: removedIds,
       },

--- a/packages/jira-adapter/src/filters/fields/issues_and_projects.ts
+++ b/packages/jira-adapter/src/filters/fields/issues_and_projects.ts
@@ -20,12 +20,17 @@ import { getLookUpName } from '../../reference_mapping'
 import { getDiffIds } from '../../diff'
 
 // Works for issuesIds and projectsIds
-export const setContextField = async (
-  contextChange: Change<InstanceElement>,
-  fieldName: string,
-  endpoint: string,
+export const setContextField = async ({
+  contextChange,
+  fieldName,
+  endpoint,
+  client,
+}: {
+  contextChange: Change<InstanceElement>
+  fieldName: string
+  endpoint: string
   client: clientUtils.HTTPWriteClientInterface
-): Promise<void> => {
+}): Promise<void> => {
   const resolvedChange = await resolveChangeElement(contextChange, getLookUpName)
   if (!isModificationChange(resolvedChange)) {
     // In create the issue types and projects ids are created

--- a/packages/jira-adapter/system_config_doc.md
+++ b/packages/jira-adapter/system_config_doc.md
@@ -310,9 +310,6 @@ jira {
               fieldName = "id"
             },
           ]
-          idFields = [
-            "id",
-          ]
           fieldTypeOverrides = [
             {
               fieldName = "contexts"

--- a/packages/jira-adapter/test/filters/fields/context_options.test.ts
+++ b/packages/jira-adapter/test/filters/fields/context_options.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, InstanceElement, MapType, ObjectType, toChange } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, MapType, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import { setContextOptions, setOptionTypeDeploymentAnnotations } from '../../../src/filters/fields/context_options'
@@ -51,11 +51,15 @@ describe('context options', () => {
             position: 1,
           },
         ],
+      },
+      undefined,
+      {
+        [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parentField.elemID, parentField)],
       })
     })
 
     it('if change is removal, should do nothing', async () => {
-      await setContextOptions(toChange({ before: contextInstance }), parentField, client)
+      await setContextOptions(toChange({ before: contextInstance }), client)
       expect(client.post).not.toHaveBeenCalled()
       expect(client.put).not.toHaveBeenCalled()
       expect(client.delete).not.toHaveBeenCalled()
@@ -83,7 +87,6 @@ describe('context options', () => {
         })
         await setContextOptions(
           toChange({ after: contextInstance }),
-          parentField,
           client
         )
       })
@@ -111,7 +114,6 @@ describe('context options', () => {
       })
       await expect(setContextOptions(
         toChange({ after: contextInstance }),
-        parentField,
         client
       )).rejects.toThrow()
     })
@@ -160,7 +162,6 @@ describe('context options', () => {
         })
         await setContextOptions(
           toChange({ before: contextInstance, after: contextInstanceAfter }),
-          parentField,
           client
         )
       })

--- a/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
@@ -1,0 +1,143 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, MapType, ObjectType, toChange } from '@salto-io/adapter-api'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { mockClient } from '../../utils'
+import { DEFAULT_CONFIG } from '../../../src/config'
+import { JIRA } from '../../../src/constants'
+import contextDeploymentFilter from '../../../src/filters/fields/context_deployment_filter'
+import JiraClient from '../../../src/client/client'
+import * as contexts from '../../../src/filters/fields/contexts'
+import { FIELD_CONTEXT_TYPE_NAME } from '../../../src/filters/fields/constants'
+
+
+describe('fieldContextDeployment', () => {
+  let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let contextType: ObjectType
+  let optionType: ObjectType
+  let defaultValueType: ObjectType
+
+  let client: JiraClient
+  let paginator: clientUtils.Paginator
+  const deployContextChangeMock = jest.spyOn(contexts, 'deployContextChange')
+
+  beforeEach(() => {
+    deployContextChangeMock.mockClear()
+
+    const mockCli = mockClient()
+    client = mockCli.client
+    paginator = mockCli.paginator
+
+    filter = contextDeploymentFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    }) as typeof filter
+
+    optionType = new ObjectType({
+      elemID: new ElemID(JIRA, 'CustomFieldContextOption'),
+      fields: {
+        value: { refType: BuiltinTypes.STRING },
+        optionId: { refType: BuiltinTypes.STRING },
+        disabled: { refType: BuiltinTypes.STRING },
+        position: { refType: BuiltinTypes.NUMBER },
+      },
+    })
+
+    defaultValueType = new ObjectType({
+      elemID: new ElemID(JIRA, 'CustomFieldContextDefaultValue'),
+      fields: {
+        type: { refType: BuiltinTypes.STRING },
+      },
+    })
+
+    contextType = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME),
+      fields: {
+        options: { refType: new MapType(optionType) },
+        defaultValue: { refType: defaultValueType },
+        projectIds: { refType: new ListType(BuiltinTypes.STRING) },
+        issueTypeIds: { refType: new ListType(BuiltinTypes.STRING) },
+      },
+    })
+  })
+
+  describe('onFetch', () => {
+    it('should add deployment annotations to context type', async () => {
+      await filter.onFetch([contextType])
+
+      expect(contextType.fields.projectIds.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(contextType.fields.issueTypeIds.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(contextType.fields.options.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(optionType.fields.value.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(optionType.fields.optionId.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(optionType.fields.disabled.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(optionType.fields.position.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(contextType.fields.defaultValue.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+
+      expect(defaultValueType.fields.type.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+    })
+  })
+  it('should call deployContextChange', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      contextType,
+      {},
+    )
+
+    const change = toChange({ after: instance })
+    await filter.deploy([change])
+    expect(deployContextChangeMock).toHaveBeenCalledWith(
+      change,
+      client,
+      DEFAULT_CONFIG.apiDefinitions,
+    )
+  })
+})

--- a/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
@@ -88,7 +88,7 @@ describe('fields_deployment', () => {
       change,
       client,
       DEFAULT_CONFIG.apiDefinitions.types.Field.deployRequests,
-      [],
+      ['contexts'],
       undefined,
     )
   })

--- a/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
@@ -13,15 +13,16 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ListType, MapType, ObjectType, toChange } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, MapType, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import { deployment, filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
 import { mockClient } from '../../utils'
 import { DEFAULT_CONFIG } from '../../../src/config'
 import { JIRA } from '../../../src/constants'
 import fieldsDeploymentFilter from '../../../src/filters/fields/field_deployment_filter'
 import JiraClient from '../../../src/client/client'
 import * as contexts from '../../../src/filters/fields/contexts'
-import * as defaultValues from '../../../src/filters/fields/default_values'
+import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
 
 
 jest.mock('@salto-io/adapter-components', () => {
@@ -36,167 +37,155 @@ jest.mock('@salto-io/adapter-components', () => {
 })
 
 describe('fields_deployment', () => {
-  let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let filter: filterUtils.FilterWith<'deploy'>
   let fieldType: ObjectType
+  let contextType: ObjectType
+
   const deployChangeMock = deployment.deployChange as jest.MockedFunction<
     typeof deployment.deployChange
   >
   let client: JiraClient
   let paginator: clientUtils.Paginator
-  const deployContextsMock = jest.spyOn(contexts, 'deployContexts').mockResolvedValue()
-  const updateDefaultValuesMock = jest.spyOn(defaultValues, 'updateDefaultValues').mockResolvedValue()
+  const deployContextChangeMock = jest.spyOn(contexts, 'deployContextChange')
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+
   beforeEach(() => {
     deployChangeMock.mockClear()
-    deployContextsMock.mockClear()
-    updateDefaultValuesMock.mockClear()
+    deployContextChangeMock.mockClear()
 
     const mockCli = mockClient()
     client = mockCli.client
     paginator = mockCli.paginator
+    mockConnection = mockCli.connection
+
     filter = fieldsDeploymentFilter({
       client,
       paginator,
       config: DEFAULT_CONFIG,
     }) as typeof filter
 
+    contextType = new ObjectType({
+      elemID: new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME),
+    })
+
     fieldType = new ObjectType({
-      elemID: new ElemID(JIRA, 'Field'),
+      elemID: new ElemID(JIRA, FIELD_TYPE_NAME),
+      fields: {
+        contexts: { refType: new MapType(contextType) },
+      },
     })
   })
-  it('should call deployChange for all the fields expect contexts', async () => {
+  it('should call deployChange', async () => {
     const instance = new InstanceElement(
       'instance',
       fieldType,
       {},
     )
 
-    const change = toChange({ before: instance, after: instance })
+    const change = toChange({ after: instance })
     await filter.deploy([change])
     expect(deployChangeMock).toHaveBeenCalledWith(
       change,
       client,
       DEFAULT_CONFIG.apiDefinitions.types.Field.deployRequests,
-      ['contexts'],
+      [],
       undefined,
     )
   })
 
-  it('should call updateDefaultValues and deployContexts if change is not removal', async () => {
+  it('if an addition should remove default context', async () => {
     const instance = new InstanceElement(
       'instance',
       fieldType,
-      {},
+      {
+        id: 'field_1',
+      },
     )
 
-    const change = toChange({ before: instance, after: instance })
+    mockConnection.get.mockImplementation(async url => ({
+      status: 200,
+      data: {
+        values: url === '/rest/api/3/field/field_1/contexts'
+          ? [{ id: '4' }]
+          : [],
+      },
+    }))
+
+
+    const change = toChange({ after: instance })
+
     await filter.deploy([change])
 
-    expect(deployContextsMock).toHaveBeenCalledWith(
-      change,
+    expect(deployContextChangeMock).toHaveBeenCalledWith(
+      toChange({
+        before: new InstanceElement(
+          '4',
+          contextType,
+          {
+            id: '4',
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(instance.elemID, instance)],
+          }
+        ),
+      }),
       client,
-      DEFAULT_CONFIG.apiDefinitions
-    )
-
-    expect(updateDefaultValuesMock).toHaveBeenCalledWith(
-      change,
-      client,
+      DEFAULT_CONFIG.apiDefinitions,
     )
   })
 
-  it('should not call updateDefaultValues and deployContexts if change is removal', async () => {
+  it('should throw if contexts is not a map', async () => {
+    fieldType.fields.contexts = new Field(fieldType, 'contexts', BuiltinTypes.STRING)
+
     const instance = new InstanceElement(
       'instance',
       fieldType,
-      {},
+      {
+        id: 'field_1',
+      },
     )
 
-    const change = toChange({ before: instance })
-    await filter.deploy([change])
+    mockConnection.get.mockImplementation(async url => ({
+      status: 200,
+      data: {
+        values: url === '/rest/api/3/field/field_1/contexts'
+          ? [{ id: '4' }]
+          : [],
+      },
+    }))
 
-    expect(deployContextsMock).not.toHaveBeenCalled()
-    expect(updateDefaultValuesMock).not.toHaveBeenCalled()
+
+    const change = toChange({ after: instance })
+
+    const res = await filter.deploy([change])
+    expect(res.deployResult.errors).toHaveLength(1)
   })
 
-  it('should add the appropriate deployment annotations to the type', async () => {
-    const optionType = new ObjectType({
-      elemID: new ElemID(JIRA, 'CustomFieldContextOption'),
-      fields: {
-        value: { refType: BuiltinTypes.STRING },
-        optionId: { refType: BuiltinTypes.STRING },
-        disabled: { refType: BuiltinTypes.STRING },
-        position: { refType: BuiltinTypes.NUMBER },
+  it('should throw if contexts inner type is not an object type', async () => {
+    fieldType.fields.contexts = new Field(fieldType, 'contexts', new MapType(BuiltinTypes.STRING))
+
+    const instance = new InstanceElement(
+      'instance',
+      fieldType,
+      {
+        id: 'field_1',
       },
-    })
+    )
 
-    const defaultValueType = new ObjectType({
-      elemID: new ElemID(JIRA, 'CustomFieldContextDefaultValue'),
-      fields: {
-        type: { refType: BuiltinTypes.STRING },
+    mockConnection.get.mockImplementation(async url => ({
+      status: 200,
+      data: {
+        values: url === '/rest/api/3/field/field_1/contexts'
+          ? [{ id: '4' }]
+          : [],
       },
-    })
+    }))
 
-    const contextType = new ObjectType({
-      elemID: new ElemID(JIRA, 'CustomFieldContext'),
-      fields: {
-        options: { refType: new MapType(optionType) },
-        defaultValue: { refType: defaultValueType },
-        projectIds: { refType: new ListType(BuiltinTypes.STRING) },
-        issueTypeIds: { refType: new ListType(BuiltinTypes.STRING) },
-      },
-    })
 
-    fieldType.fields.contexts = new Field(fieldType, 'contexts', new MapType(contextType))
+    const change = toChange({ after: instance })
 
-    await filter.onFetch([fieldType])
-
-    expect(fieldType.fields.contexts.annotations).toEqual({
-      [CORE_ANNOTATIONS.CREATABLE]: true,
-      [CORE_ANNOTATIONS.UPDATABLE]: true,
-    })
-
-    expect(contextType.fields.projectIds.annotations).toEqual({
-      [CORE_ANNOTATIONS.CREATABLE]: true,
-      [CORE_ANNOTATIONS.UPDATABLE]: true,
-    })
-
-    expect(contextType.fields.issueTypeIds.annotations).toEqual({
-      [CORE_ANNOTATIONS.CREATABLE]: true,
-      [CORE_ANNOTATIONS.UPDATABLE]: true,
-    })
-
-    expect(contextType.fields.options.annotations).toEqual({
-      [CORE_ANNOTATIONS.CREATABLE]: true,
-      [CORE_ANNOTATIONS.UPDATABLE]: true,
-    })
-
-    expect(optionType.fields.value.annotations).toEqual({
-      [CORE_ANNOTATIONS.CREATABLE]: true,
-      [CORE_ANNOTATIONS.UPDATABLE]: true,
-    })
-
-    expect(optionType.fields.optionId.annotations).toEqual({
-      [CORE_ANNOTATIONS.CREATABLE]: true,
-      [CORE_ANNOTATIONS.UPDATABLE]: true,
-    })
-
-    expect(optionType.fields.disabled.annotations).toEqual({
-      [CORE_ANNOTATIONS.CREATABLE]: true,
-      [CORE_ANNOTATIONS.UPDATABLE]: true,
-    })
-
-    expect(optionType.fields.position.annotations).toEqual({
-      [CORE_ANNOTATIONS.CREATABLE]: true,
-      [CORE_ANNOTATIONS.UPDATABLE]: true,
-    })
-
-    expect(contextType.fields.defaultValue.annotations).toEqual({
-      [CORE_ANNOTATIONS.CREATABLE]: true,
-      [CORE_ANNOTATIONS.UPDATABLE]: true,
-    })
-
-    expect(defaultValueType.fields.type.annotations).toEqual({
-      [CORE_ANNOTATIONS.CREATABLE]: true,
-      [CORE_ANNOTATIONS.UPDATABLE]: true,
-    })
+    const res = await filter.deploy([change])
+    expect(res.deployResult.errors).toHaveLength(1)
   })
 })

--- a/packages/jira-adapter/test/filters/fields/field_structure.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_structure.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { mockClient } from '../../utils'
 import { DEFAULT_CONFIG } from '../../../src/config'
@@ -59,7 +59,10 @@ describe('fields_structure', () => {
       fieldContextDefaultValueType,
       fieldContextOptionType,
     ])
-    expect(instance.value).toEqual({ type: 'someType' })
+    expect(instance.value).toEqual({
+      type: 'someType',
+      contexts: [],
+    })
   })
 
   it('should add the defaults, issue types and projects to the contexts', async () => {
@@ -127,6 +130,9 @@ describe('fields_structure', () => {
     expect(fieldInstance.value).toEqual(
       {
         name: 'name',
+        contexts: [
+          new ReferenceExpression(contextInstance.elemID, contextInstance),
+        ],
       },
     )
     expect(contextInstance.value).toEqual(

--- a/packages/jira-adapter/test/filters/fields/field_structure.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_structure.test.ts
@@ -122,7 +122,8 @@ describe('fields_structure', () => {
       fieldContextOptionType,
     ]
     await filter.onFetch(elements)
-    const [contextInstance, fieldInstance] = elements as InstanceElement[]
+    const fieldInstance = elements[0] as InstanceElement
+    const contextInstance = elements[elements.length - 1] as InstanceElement
     expect(fieldInstance.value).toEqual(
       {
         name: 'name',
@@ -198,7 +199,7 @@ describe('fields_structure', () => {
       fieldContextDefaultValueType,
     ]
     await filter.onFetch(elements)
-    const [contextInstance] = elements as InstanceElement[]
+    const contextInstance = elements[elements.length - 1] as InstanceElement
     expect(contextInstance.value).toEqual({
       name: 'name',
       id: 'id1',

--- a/packages/jira-adapter/test/filters/fields/field_structure.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_structure.test.ts
@@ -23,6 +23,9 @@ import fieldsStructureFilter from '../../../src/filters/fields/field_structure_f
 describe('fields_structure', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
   let fieldType: ObjectType
+  let fieldContextType: ObjectType
+  let fieldContextDefaultValueType: ObjectType
+  let fieldContextOptionType: ObjectType
   beforeEach(() => {
     const { client, paginator } = mockClient()
     filter = fieldsStructureFilter({
@@ -34,6 +37,10 @@ describe('fields_structure', () => {
     fieldType = new ObjectType({
       elemID: new ElemID(JIRA, 'Field'),
     })
+
+    fieldContextType = new ObjectType({ elemID: new ElemID(JIRA, 'CustomFieldContext') })
+    fieldContextDefaultValueType = new ObjectType({ elemID: new ElemID(JIRA, 'CustomFieldContextDefaultValue') })
+    fieldContextOptionType = new ObjectType({ elemID: new ElemID(JIRA, 'CustomFieldContextOption') })
   })
   it('should replace schema.custom with type', async () => {
     const instance = new InstanceElement(
@@ -45,7 +52,13 @@ describe('fields_structure', () => {
         },
       }
     )
-    await filter.onFetch([instance])
+    await filter.onFetch([
+      instance,
+      fieldType,
+      fieldContextType,
+      fieldContextDefaultValueType,
+      fieldContextOptionType,
+    ])
     expect(instance.value).toEqual({ type: 'someType' })
   })
 
@@ -54,6 +67,7 @@ describe('fields_structure', () => {
       'instance',
       fieldType,
       {
+        name: 'name',
         contexts: [
           {
             name: 'name',
@@ -63,6 +77,10 @@ describe('fields_structure', () => {
         contextDefaults: [
           {
             contextId: 'id1',
+            value: 'someValue',
+          },
+          {
+            contextId: 'id2',
             value: 'someValue',
           },
         ],
@@ -75,6 +93,10 @@ describe('fields_structure', () => {
             contextId: 'id1',
             issueTypeId: '2',
           },
+          {
+            contextId: 'id2',
+            issueTypeId: '2',
+          },
         ],
         contextProjects: [
           {
@@ -85,26 +107,47 @@ describe('fields_structure', () => {
             contextId: 'id1',
             projectId: '4',
           },
+          {
+            contextId: 'id2',
+            projectId: '4',
+          },
         ],
       }
     )
-    await filter.onFetch([instance])
-    expect(instance.value).toEqual({
-      contexts: {
-        name: {
-          name: 'name',
-          id: 'id1',
-          defaultValue: {
-            value: 'someValue',
-          },
-          issueTypeIds: ['1', '2'],
-          projectIds: ['3', '4'],
-        },
+    const elements = [
+      instance,
+      fieldType,
+      fieldContextType,
+      fieldContextDefaultValueType,
+      fieldContextOptionType,
+    ]
+    await filter.onFetch(elements)
+    const [contextInstance, fieldInstance] = elements as InstanceElement[]
+    expect(fieldInstance.value).toEqual(
+      {
+        name: 'name',
       },
-    })
+    )
+    expect(contextInstance.value).toEqual(
+      {
+        name: 'name',
+        id: 'id1',
+        defaultValue: {
+          value: 'someValue',
+        },
+        issueTypeIds: [
+          '1',
+          '2',
+        ],
+        projectIds: [
+          '3',
+          '4',
+        ],
+      },
+    )
   })
 
-  it('should transform options to map and add postions and cascadingOptions', async () => {
+  it('should transform options to map and add positions and cascadingOptions', async () => {
     const instance = new InstanceElement(
       'instance',
       fieldType,
@@ -147,46 +190,50 @@ describe('fields_structure', () => {
         ],
       }
     )
-    await filter.onFetch([instance])
-    expect(instance.value).toEqual({
-      contexts: {
-        name: {
-          name: 'name',
-          id: 'id1',
-          options: {
-            someValue: {
-              id: '1',
-              value: 'someValue',
+    const elements = [
+      instance,
+      fieldType,
+      fieldContextType,
+      fieldContextOptionType,
+      fieldContextDefaultValueType,
+    ]
+    await filter.onFetch(elements)
+    const [contextInstance] = elements as InstanceElement[]
+    expect(contextInstance.value).toEqual({
+      name: 'name',
+      id: 'id1',
+      options: {
+        someValue: {
+          id: '1',
+          value: 'someValue',
+          position: 0,
+          cascadingOptions: {
+            someValue3: {
+              id: '3',
+              value: 'someValue3',
               position: 0,
-              cascadingOptions: {
-                someValue3: {
-                  id: '3',
-                  value: 'someValue3',
-                  position: 0,
-                },
-                someValue4: {
-                  id: '4',
-                  value: 'someValue4',
-                  position: 1,
-                },
-              },
             },
-            someValue2: {
-              id: '2',
-              value: 'someValue2',
+            someValue4: {
+              id: '4',
+              value: 'someValue4',
               position: 1,
-              cascadingOptions: {
-                someValue5: {
-                  id: '5',
-                  value: 'someValue5',
-                  position: 0,
-                },
-                someValue6: {
-                  id: '6',
-                  value: 'someValue6',
-                  position: 1,
-                },
-              },
+            },
+          },
+        },
+        someValue2: {
+          id: '2',
+          value: 'someValue2',
+          position: 1,
+          cascadingOptions: {
+            someValue5: {
+              id: '5',
+              value: 'someValue5',
+              position: 0,
+            },
+            someValue6: {
+              id: '6',
+              value: 'someValue6',
+              position: 1,
             },
           },
         },
@@ -195,10 +242,6 @@ describe('fields_structure', () => {
   })
 
   it('should add the new fields to the Field type', async () => {
-    const fieldContextType = new ObjectType({ elemID: new ElemID(JIRA, 'CustomFieldContext') })
-    const fieldContextDefaultValueType = new ObjectType({ elemID: new ElemID(JIRA, 'CustomFieldContextDefaultValue') })
-    const fieldContextOptionType = new ObjectType({ elemID: new ElemID(JIRA, 'CustomFieldContextOption') })
-
     fieldType.fields.contextDefaults = new Field(fieldType, 'contextDefaults', BuiltinTypes.STRING)
     fieldType.fields.contextProjects = new Field(fieldType, 'contextProjects', BuiltinTypes.STRING)
     fieldType.fields.contextIssueTypes = new Field(fieldType, 'contextIssueTypes', BuiltinTypes.STRING)

--- a/packages/jira-adapter/test/filters/fields/issues_and_projects.test.ts
+++ b/packages/jira-adapter/test/filters/fields/issues_and_projects.test.ts
@@ -66,7 +66,7 @@ describe('issues and projects', () => {
         after: contextAfter,
       })
 
-      await setContextField(contextChange, 'projectIds', 'projects', client)
+      await setContextField({ contextChange, fieldName: 'projectIds', endpoint: 'projects', client })
 
       expect(client.put).toHaveBeenCalledWith({
         url: '/rest/api/3/field/1/context/2/projects',

--- a/packages/jira-adapter/test/filters/fields/issues_and_projects.test.ts
+++ b/packages/jira-adapter/test/filters/fields/issues_and_projects.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import { JIRA } from '../../../src/constants'
@@ -46,6 +46,10 @@ describe('issues and projects', () => {
             '3',
             '4',
           ],
+        },
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(field.elemID, field)],
         }
       )
     })
@@ -62,7 +66,7 @@ describe('issues and projects', () => {
         after: contextAfter,
       })
 
-      await setContextField(contextChange, 'projectIds', 'projects', field, client)
+      await setContextField(contextChange, 'projectIds', 'projects', client)
 
       expect(client.put).toHaveBeenCalledWith({
         url: '/rest/api/3/field/1/context/2/projects',


### PR DESCRIPTION
Separated contexts in fields to different instances to break the circle in https://salto-io.atlassian.net/browse/SALTO-1913
Also changed the id of a field to be its name and not id to be env friendly

---
_Release Notes_: 
None

---
_User Notifications_: 
None