### PR TITLE
SALTO-1921: fix log elem id collision bug

### DIFF
--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -24,6 +24,7 @@ const log = logger(module)
 
 const MAX_BREAKDOWN_ELEMENTS = 10
 const MAX_BREAKDOWN_DETAILS_ELEMENTS = 3
+const MAX_INSTANCES_WITH_COLLIDING_ELEM_ID_TO_LOG = 20
 
 export const groupInstancesByTypeAndElemID = async (
   instances: InstanceElement[],
@@ -75,10 +76,12 @@ const logInstancesWithCollidingElemID = async (
     Object.entries(elemIDtoInstances).forEach(([elemID, elemIDInstances]) => {
       const relevantInstanceValues = elemIDInstances
         .map(instance => _.pickBy(instance.value, val => !_.isEmpty(val)))
-      const relevantInstanceValuesStr = relevantInstanceValues
-        .map(instValues => safeJsonStringify(instValues, undefined, 2)).join('\n')
-      log.debug(`Omitted instances of type ${type} with colliding ElemID ${elemID} with values - 
-  ${relevantInstanceValuesStr}`)
+      log.debug(`Omitted instances of type ${type} with colliding ElemID ${elemID} with values:\n`)
+      relevantInstanceValues
+        .slice(0, MAX_INSTANCES_WITH_COLLIDING_ELEM_ID_TO_LOG)
+        .forEach(instValues => {
+          log.debug(`${safeJsonStringify(instValues, undefined, 2)}\n`)
+        })
     })
   })
 }

--- a/packages/zendesk-support-adapter/src/filters/collision_errors.ts
+++ b/packages/zendesk-support-adapter/src/filters/collision_errors.ts
@@ -25,7 +25,7 @@ import { API_DEFINITIONS_CONFIG } from '../config'
  */
 const filterCreator: FilterCreator = ({ config }) => ({
   onFetch: async (elements: Element[]) => {
-    const collistionWarnings = await getAndLogCollisionWarnings({
+    const collisionWarnings = await getAndLogCollisionWarnings({
       adapterName: ZENDESK_SUPPORT,
       configurationName: 'service',
       instances: getInstancesWithCollidingElemID(elements.filter(isInstanceElement)),
@@ -38,7 +38,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
       ).idFields,
       idFieldsName: 'idFields',
     })
-    return { errors: collistionWarnings }
+    return { errors: collisionWarnings }
   },
 })
 


### PR DESCRIPTION
_fix log Elem id collision bug_

---

_Additional context for reviewer_
Datadog [link](https://app.datadoghq.com/logs?query=env%3Aproduction%20%22Invalid%20string%20length%22%20%22RangeError%3A%20Invalid%20string%20length%22&agg_m=count&agg_q=%40email%2Chost&agg_t=count&cols=core_host%2Ccore_service&event=AQAAAX5zYnT4gVjtZAAAAABBWDV6WW53SkFBQUZmRUpIUVJYT1h3QUI&index=%2A&messageDisplay=inline&panel=%7B%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22email%22%2C%22value%22%3A%22jordan_leclaire%40discovery.com%22%7D%2C%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22tag%22%2C%22path%22%3A%22host%22%2C%22value%22%3A%22i-096a3a11e49c7dd34%22%7D%5D%2C%22timeRange%22%3A%7B%22from%22%3A1642613330000%2C%22to%22%3A1642613350000%2C%22live%22%3Afalse%7D%2C%22queryString%22%3A%22%40email%3Ajordan_leclaire%40discovery.com%20host%3Ai-096a3a11e49c7dd34%22%2C%22queryId%22%3A%22a%22%7D&stream_sort=desc&viz=timeseries&from_ts=1642612494000&to_ts=1642613694000&live=false)

---
_Release Notes_: 
_Zendesk_support_adapter_:
* Fix bug in logging when there are collided element ids

---
_User Notifications_: 
_None_
