### PR TITLE
SALTO-1921 avoid logging serialized values inside reference expressions

### DIFF
--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { InstanceElement, SaltoError } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
-import { safeJsonStringify } from './utils'
+import { safeJsonStringify, referenceExpressionStringifyReplacer } from './utils'
 
 const { groupByAsync } = collections.asynciterable
 const log = logger(module)
@@ -65,7 +65,6 @@ export const getInstancesWithCollidingElemID = (instances: InstanceElement[]): I
     .filter(groupedInstances => groupedInstances.length > 1)
     .flat()
 
-
 const logInstancesWithCollidingElemID = async (
   typeToElemIDtoInstances: Record<string, Record<string, InstanceElement[]>>
 ): Promise<void> => {
@@ -76,7 +75,7 @@ const logInstancesWithCollidingElemID = async (
       const relevantInstanceValues = elemIDInstances
         .map(instance => _.pickBy(instance.value, val => !_.isEmpty(val)))
       const relevantInstanceValuesStr = relevantInstanceValues
-        .map(instValues => safeJsonStringify(instValues, undefined, 2)).join('\n')
+        .map(instValues => safeJsonStringify(instValues, referenceExpressionStringifyReplacer, 2)).join('\n')
       log.debug(`Omitted instances of type ${type} with colliding ElemID ${elemID} with values - 
   ${relevantInstanceValuesStr}`)
     })

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -868,8 +868,16 @@ export const createDefaultInstanceFromType = async (name: string, objectType: Ob
   return instance
 }
 
+type Replacer = (key: string, value: Value) => Value
+
+export const referenceExpressionStringifyReplacer: Replacer = (_key, value) => (
+  isReferenceExpression(value)
+    ? `ReferenceExpression(${value.elemID.getFullName()}, ${value.value ? '<omitted>' : '<no value>'})`
+    : value
+)
+
 export const safeJsonStringify = (value: Value,
-  replacer?: (key: string, value: Value) => Value,
+  replacer?: Replacer,
   space?: string | number): string =>
   safeStringify(value, replacer, space)
 

--- a/packages/adapter-utils/test/collisions.test.ts
+++ b/packages/adapter-utils/test/collisions.test.ts
@@ -13,14 +13,18 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { getAndLogCollisionWarnings, getInstancesWithCollidingElemID } from '../src/collisions'
 
 describe('collisions', () => {
   const instType = new ObjectType({
     elemID: new ElemID('salto', 'obj'),
   })
-  const instance = new InstanceElement('test', instType, { title: 'test' })
+  const instance = new InstanceElement(
+    'test',
+    instType,
+    { title: 'test', ref: new ReferenceExpression(new ElemID('salto', 'something'), 'some value') },
+  )
   const collidedInstance = new InstanceElement('test', instType, { title: 'test', val: 'val' })
   const differentInstance = new InstanceElement('test1', instType, { title: 'test1' })
   describe('getInstancesWithCollidingElemID', () => {

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -32,6 +32,7 @@ import {
   flatValues, mapKeysRecursive, createDefaultInstanceFromType, applyInstancesDefaults,
   restoreChangeElement, RestoreValuesFunc, getAllReferencedIds, applyFunctionToChangeData,
   transformElement, toObjectType, getParents, resolveTypeShallow,
+  referenceExpressionStringifyReplacer,
 } from '../src/utils'
 import { buildElementsSourceFromElements } from '../src/element_source'
 
@@ -2063,6 +2064,43 @@ describe('Test utils.ts', () => {
       const regJSON = JSON.stringify(obj)
       it('should serialize to the same result JSON.stringify', () => {
         expect(saltoJSON).toEqual(regJSON)
+      })
+    })
+    describe('with reference replacer', () => {
+      let inst: InstanceElement
+      beforeAll(() => {
+        const elemID = new ElemID('salto', 'obj')
+        inst = new InstanceElement(
+          'test2',
+          new ObjectType({ elemID }),
+          {
+            title: 'test',
+            refWithVal: new ReferenceExpression(new ElemID('a', 'b'), 'something'),
+            refWithoutVal: new ReferenceExpression(new ElemID('c', 'd')),
+          },
+        )
+      })
+      it('should replace the reference expression object with a serialized representation', () => {
+        const res = safeJsonStringify(inst, referenceExpressionStringifyReplacer, 2)
+        expect(res).not.toEqual(safeJsonStringify(inst))
+        expect(res).toEqual(`{
+  "elemID": {
+    "adapter": "salto",
+    "typeName": "obj",
+    "idType": "instance",
+    "nameParts": [
+      "test2"
+    ]
+  },
+  "annotations": {},
+  "annotationRefTypes": {},
+  "value": {
+    "title": "test",
+    "refWithVal": "ReferenceExpression(a.b, <omitted>)",
+    "refWithoutVal": "ReferenceExpression(c.d, <no value>)"
+  },
+  "refType": "ReferenceExpression(salto.obj, <omitted>)"
+}`)
       })
     })
   })


### PR DESCRIPTION
This can be combined with some chunking mechanism like the one started in https://github.com/salto-io/salto/pull/2681, but I think regardless we should avoid logging values inside reference expressions as these can be very large.
For now only omitting these in a log we know is problematic, but I think we should consider using this replacer everywhere.

---

_Release Notes_: 
(same as https://github.com/salto-io/salto/pull/2681)
_Zendesk_support adapter_:
* Fix bug in logging when there are collided element ids


---
_User Notifications_: 
None