### PR TITLE
SALTO-1927: removed fields in trash from field configuration

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -73,7 +73,7 @@ export const DEFAULT_FILTERS = [
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,
   fieldReferencesFilter,
-  // Most run after fieldReferencesFilter
+  // Must run after fieldReferencesFilter
   fieldConfigurationTrashedFieldsFilter,
   hiddenValuesInListsFilter,
   // Must be last

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -32,6 +32,7 @@ import boardFilter from './filters/board'
 import screenFilter from './filters/screen/screen'
 import issueTypeScreenSchemeFilter from './filters/issue_type_screen_scheme'
 import fieldConfigurationFilter from './filters/field_configuration'
+import fieldConfigurationTrashedFieldsFilter from './filters/field_configuration_trashed_fields'
 import fieldConfigurationSchemeFilter from './filters/field_configurations_scheme'
 import hiddenValuesInListsFilter from './filters/hidden_value_in_lists'
 import projectFilter from './filters/project'
@@ -72,6 +73,8 @@ export const DEFAULT_FILTERS = [
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,
   fieldReferencesFilter,
+  // Most run after fieldReferencesFilter
+  fieldConfigurationTrashedFieldsFilter,
   hiddenValuesInListsFilter,
   // Must be last
   defaultInstancesDeployFilter,

--- a/packages/jira-adapter/src/change_validators/field_configuration.ts
+++ b/packages/jira-adapter/src/change_validators/field_configuration.ts
@@ -47,9 +47,7 @@ export const unsupportedFieldConfigurationsValidator: ChangeValidator = async ch
         : getDiffFields(change)
 
       const unsupportedIds = fields
-        .filter((field: Values) =>
-          !isReferenceExpression(field.id)
-          || field.id.value.value.isLocked)
+        .filter((field: Values) => field.id.value.value.isLocked)
         .map(getFieldId)
 
       const { elemID } = getChangeData(change)
@@ -57,7 +55,7 @@ export const unsupportedFieldConfigurationsValidator: ChangeValidator = async ch
         return {
           elemID,
           severity: 'Warning' as SaltoErrorSeverity,
-          message: `Salto can't deploy fields configuration of ${elemID.getFullName()} because they are either locked or team-managed`,
+          message: `Salto can't deploy fields configuration of ${elemID.getFullName()} because they are locked`,
           detailedMessage: `Salto can't deploy the configuration of fields: ${unsupportedIds.join(', ')}. If continuing, they will be omitted from the deployment`,
         }
       }

--- a/packages/jira-adapter/src/filters/field_configuration_trashed_fields.ts
+++ b/packages/jira-adapter/src/filters/field_configuration_trashed_fields.ts
@@ -1,0 +1,31 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { isInstanceElement, isReferenceExpression, Values } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+
+const filter: FilterCreator = () => ({
+  onFetch: async elements => {
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === 'FieldConfiguration')
+      .forEach(instance => {
+        instance.value.fields = instance.value.fields
+          && instance.value.fields.filter((field: Values) => isReferenceExpression(field.id))
+      })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/field_configuration_trashed_fields.ts
+++ b/packages/jira-adapter/src/filters/field_configuration_trashed_fields.ts
@@ -20,8 +20,13 @@ import { FilterCreator } from '../filter'
 
 const log = logger(module)
 
-const filter: FilterCreator = () => ({
+const filter: FilterCreator = ({ config }) => ({
   onFetch: async elements => {
+    if (!config.fetch.includeTypes.includes('Fields')) {
+      log.warn('Fields is not included in the fetch list so we cannot know what fields is in trash. Skipping the field_configuration_trashed_fields')
+      return
+    }
+
     elements
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === 'FieldConfiguration')

--- a/packages/jira-adapter/test/change_validators/field_configuration.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_configuration.test.ts
@@ -25,24 +25,6 @@ describe('unsupportedFieldConfigurationsValidator', () => {
     type = new ObjectType({ elemID: new ElemID(JIRA, 'FieldConfiguration') })
     instance = new InstanceElement('instance', type)
   })
-  it('should return an error if id is not a reference', async () => {
-    instance.value.fields = [{
-      id: 'id',
-    }]
-
-    expect(await unsupportedFieldConfigurationsValidator([
-      toChange({
-        after: instance,
-      }),
-    ])).toEqual([
-      {
-        elemID: instance.elemID,
-        severity: 'Warning',
-        message: `Salto can't deploy fields configuration of ${instance.elemID.getFullName()} because they are either locked or team-managed`,
-        detailedMessage: 'Salto can\'t deploy the configuration of fields: id. If continuing, they will be omitted from the deployment',
-      },
-    ])
-  })
 
   it('should return an error if id is a reference to a locked field', async () => {
     instance.value.fields = [{
@@ -62,7 +44,7 @@ describe('unsupportedFieldConfigurationsValidator', () => {
       {
         elemID: instance.elemID,
         severity: 'Warning',
-        message: `Salto can't deploy fields configuration of ${instance.elemID.getFullName()} because they are either locked or team-managed`,
+        message: `Salto can't deploy fields configuration of ${instance.elemID.getFullName()} because they are locked`,
         detailedMessage: 'Salto can\'t deploy the configuration of fields: inst. If continuing, they will be omitted from the deployment',
       },
     ])

--- a/packages/jira-adapter/test/filters/field_configuration_trashed_fields.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration_trashed_fields.test.ts
@@ -67,6 +67,40 @@ describe('fieldConfigurationTrashedFieldsFilter', () => {
       })
     })
 
+    it('should do nothing of fields are not fetched', async () => {
+      const { client, paginator } = mockClient()
+      filter = fieldConfigurationTrashedFieldsFilter({
+        client,
+        paginator,
+        config: {
+          ...DEFAULT_CONFIG,
+          fetch: {
+            includeTypes: DEFAULT_CONFIG.fetch.includeTypes.filter(type => type !== 'Fields'),
+          },
+        },
+      }) as typeof filter
+
+      const instance = new InstanceElement(
+        'instance',
+        fieldConfigurationType,
+        {
+          fields: [
+            {
+              id: '2',
+            },
+          ],
+        }
+      )
+      await filter.onFetch([instance])
+      expect(instance.value).toEqual({
+        fields: [
+          {
+            id: '2',
+          },
+        ],
+      })
+    })
+
     it('should do nothing of there are no fields', async () => {
       const instance = new InstanceElement(
         'instance',

--- a/packages/jira-adapter/test/filters/field_configuration_trashed_fields.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration_trashed_fields.test.ts
@@ -1,0 +1,84 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { DEFAULT_CONFIG } from '../../src/config'
+import { JIRA } from '../../src/constants'
+import fieldConfigurationTrashedFieldsFilter from '../../src/filters/field_configuration_trashed_fields'
+import { mockClient } from '../utils'
+
+
+describe('fieldConfigurationTrashedFieldsFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let fieldConfigurationType: ObjectType
+
+  beforeEach(async () => {
+    const { client, paginator } = mockClient()
+
+    filter = fieldConfigurationTrashedFieldsFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    }) as typeof filter
+
+
+    fieldConfigurationType = new ObjectType({
+      elemID: new ElemID(JIRA, 'FieldConfiguration'),
+      fields: {},
+    })
+  })
+
+  describe('onFetch', () => {
+    it('should remove fields that are not references', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        fieldConfigurationType,
+        {
+          fields: [
+            {
+              id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'field1')),
+            },
+            {
+              id: '2',
+            },
+          ],
+        }
+      )
+      await filter.onFetch([instance])
+      expect(instance.value).toEqual({
+        fields: [
+          {
+            id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'field1')),
+          },
+        ],
+      })
+    })
+
+    it('should do nothing of there are no fields', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        fieldConfigurationType,
+        {
+          name: 'name',
+        }
+      )
+      await filter.onFetch([instance])
+      expect(instance.value).toEqual({
+        name: 'name',
+      })
+    })
+  })
+})


### PR DESCRIPTION
Removed fields in trash from the fields configuration instances since we don't fetch them, they are not deployable, and they are not visible in the UI

---
_Release Notes_: 
None

---
_User Notifications_: 
None