### PR TITLE
SALTO-1928 support settings instances in selectors

### DIFF
--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -179,11 +179,14 @@ export class ElemID {
       .join(ElemID.NAMESPACE_SEPARATOR)
   }
 
-  getFullNameParts(): string[] {
+  getFullNameParts(includeConfigPart = false): string[] {
     const nameParts = this.fullNameParts()
-    return this.fullNameParts()
-      // If the last part of the name is empty we can omit it
-      .filter((part, idx) => idx !== nameParts.length - 1 || part !== ElemID.CONFIG_NAME)
+    return this.fullNameParts().filter((part, idx) => (
+      idx !== nameParts.length - 1
+      // If the last part of the name is empty we can omit it, unless explicitly specified
+      || part !== ElemID.CONFIG_NAME
+      || includeConfigPart
+    ))
   }
 
   isConfig(): boolean {

--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -57,7 +57,7 @@ const match = (elemId: ElemID, selector: ElementSelector, includeNested = false)
   && selector.typeNameSelector.test(elemId.typeName)
   && ((selector.idTypeSelector === elemId.idType) || (includeNested && selector.idTypeSelector === 'type' && elemId.createTopLevelParentID().parent.idType === 'type'))
   && testNames(
-    elemId.getFullNameParts().slice(ElemID.NUM_ELEM_ID_NON_NAME_PARTS),
+    elemId.getFullNameParts(true).slice(ElemID.NUM_ELEM_ID_NON_NAME_PARTS),
     selector.nameSelectors ?? [],
     includeNested
   )
@@ -210,8 +210,12 @@ const createTopLevelSelector = (selector: ElementSelector): ElementSelector => {
 }
 
 const createSameDepthSelector = (selector: ElementSelector, elemID: ElemID): ElementSelector =>
-  createElementSelector(selector.origin.split(ElemID.NAMESPACE_SEPARATOR).slice(0,
-    elemID.getFullNameParts().length).join(ElemID.NAMESPACE_SEPARATOR), selector.caseInsensitive)
+  createElementSelector(
+    selector.origin
+      .split(ElemID.NAMESPACE_SEPARATOR)
+      .slice(0, elemID.getFullNameParts(true).length)
+      .join(ElemID.NAMESPACE_SEPARATOR), selector.caseInsensitive
+  )
 
 const isElementPossiblyParentOfSearchedElement = (
   selectors: ElementSelector[], testId: ElemID
@@ -283,7 +287,7 @@ export const selectElementIdsByTraversal = async ({
 
   const subElementIDs = new Set<string>()
   const selectFromSubElements: WalkOnFunc = ({ path }) => {
-    if (path.getFullNameParts().length <= 1) {
+    if (path.getFullNameParts(true).length <= 1) {
       return WALK_NEXT_STEP.RECURSE
     }
 
@@ -294,7 +298,7 @@ export const selectElementIdsByTraversal = async ({
       }
     }
     const stillRelevantSelectors = selectors.filter(selector =>
-      selector.origin.split(ElemID.NAMESPACE_SEPARATOR).length > path.getFullNameParts().length)
+      selector.origin.split(ElemID.NAMESPACE_SEPARATOR).length > path.getFullNameParts(true).length)
     if (stillRelevantSelectors.length === 0) {
       return WALK_NEXT_STEP.SKIP
     }

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -169,11 +169,15 @@ describe('element selector', () => {
       new ElemID('salesforce', 'sometype', 'instance', 'A', 'B'),
       new ElemID('salesforce', 'sometype', 'instance', 'A', 'B', 'C'),
       new ElemID('salesforce', 'othertype', 'instance', 'NotA'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config', 'B'),
     ]
-    const selectedElements = await selectElements(
+    expect(await selectElements(
       { elements, selectors: ['salesforce.*.instance.A'] }
-    )
-    expect(selectedElements).toEqual([elements[0]])
+    )).toEqual([elements[0]])
+    expect(await selectElements(
+      { elements, selectors: ['salesforce.*.instance._config'] }
+    )).toEqual([elements[4]])
   })
 
   it('should select also nested elements when includeNested is true and name selectors length is 1', async () => {
@@ -182,11 +186,15 @@ describe('element selector', () => {
       new ElemID('salesforce', 'sometype', 'instance', 'A', 'B'),
       new ElemID('salesforce', 'sometype', 'instance', 'A', 'B', 'C'),
       new ElemID('salesforce', 'othertype', 'instance', 'NotA'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config', 'B'),
     ]
-    const selectedElements = await selectElements(
+    expect(await selectElements(
       { elements, selectors: ['salesforce.*.instance.A'], includeNested: true }
-    )
-    expect(selectedElements).toEqual([elements[0], elements[1], elements[2]])
+    )).toEqual([elements[0], elements[1], elements[2]])
+    expect(await selectElements(
+      { elements, selectors: ['salesforce.*.instance._config'], includeNested: true }
+    )).toEqual([elements[4], elements[5]])
   })
 
   it('should select fields and attributes when includeNested is true', async () => {
@@ -208,11 +216,15 @@ describe('element selector', () => {
       new ElemID('salesforce', 'sometype', 'instance', 'A', 'B'),
       new ElemID('salesforce', 'sometype', 'instance', 'A', 'B', 'C'),
       new ElemID('salesforce', 'othertype', 'instance', 'NotA', 'B'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config', 'B'),
     ]
-    const selectedElements = await selectElements(
+    expect(await selectElements(
       { elements, selectors: ['salesforce.*.instance.A.*'] }
-    )
-    expect(selectedElements).toEqual([elements[1]])
+    )).toEqual([elements[1]])
+    expect(await selectElements(
+      { elements, selectors: ['salesforce.*.instance._config.*'] }
+    )).toEqual([elements[5]])
   })
 
   it('should select also nested elements when includeNested is true and name selectors length is 2', async () => {
@@ -221,11 +233,15 @@ describe('element selector', () => {
       new ElemID('salesforce', 'sometype', 'instance', 'A', 'B'),
       new ElemID('salesforce', 'sometype', 'instance', 'A', 'B', 'C'),
       new ElemID('salesforce', 'othertype', 'instance', 'NotA', 'B'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config'),
+      new ElemID('salesforce', 'othertype', 'instance', '_config', 'B'),
     ]
-    const selectedElements = await selectElements(
+    expect(await selectElements(
       { elements, selectors: ['salesforce.*.instance.A.*'], includeNested: true }
-    )
-    expect(selectedElements).toEqual([elements[1], elements[2]])
+    )).toEqual([elements[1], elements[2]])
+    expect(await selectElements(
+      { elements, selectors: ['salesforce.*.instance._config.*'], includeNested: true }
+    )).toEqual([elements[5]])
   })
 
   it('should handle asterisks alongside partial names in type', async () => {


### PR DESCRIPTION
Settings instances have special elem ids with instance name `_config`. These were not supported correctly in element selectors.

---
_Release Notes_: 
_Core_:
* Support settings instances in element selectors

_CLI_:
* Allow finding settings instances in `salto element list` and other commands

---
_User Notifications_: 
None