### PR TITLE
SALTO-1925: remove domain from url prefixes

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -82,7 +82,7 @@ export abstract class AdapterHTTPClient<
 > extends AdapterClientBase<TRateLimitConfig>
   implements HTTPReadClientInterface, HTTPWriteClientInterface {
   protected readonly conn: Connection<TCredentials>
-  private readonly credentials: TCredentials
+  protected readonly credentials: TCredentials
 
   constructor(
     clientName: string,

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -41,6 +41,7 @@ import workflowSchemeFilter from './filters/workflow_scheme'
 import fieldStructureFilter from './filters/fields/field_structure_filter'
 import fieldDeploymentFilter from './filters/fields/field_deployment_filter'
 import fieldTypeReferencesFilter from './filters/fields/field_type_references_filter'
+import avatarsFilter from './filters/avatars'
 import { JIRA } from './constants'
 import { removeScopedObjects } from './client/pagination'
 
@@ -54,6 +55,7 @@ const { createPaginator, getWithOffsetAndLimit } = clientUtils
 const log = logger(module)
 
 export const DEFAULT_FILTERS = [
+  avatarsFilter,
   workflowFilter,
   workflowSchemeFilter,
   issueTypeSchemeReferences,

--- a/packages/jira-adapter/src/client/client.ts
+++ b/packages/jira-adapter/src/client/client.ts
@@ -53,6 +53,10 @@ export default class JiraClient extends clientUtils.AdapterHTTPClient<
     )
   }
 
+  public get baseUrl(): string {
+    return this.credentials.baseUrl
+  }
+
   public async getSinglePage(
     args: clientUtils.ClientBaseParams,
   ): Promise<clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>> {

--- a/packages/jira-adapter/src/filters/avatars.ts
+++ b/packages/jira-adapter/src/filters/avatars.ts
@@ -1,0 +1,92 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, Field, isInstanceElement, isObjectType } from '@salto-io/adapter-api'
+import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { FilterCreator } from '../filter'
+
+const AVATAR_URLS_FIELD = 'avatarUrls'
+const ICON_URL_FIELD = 'iconUrl'
+
+const AVATAR_ID_FIELD = 'avatarId'
+
+const AVATAR_ID_PATTERN = new RegExp('/rest/api/\\d+/universal_avatar/view/type/\\w+/avatar/(\\d+)')
+
+const removeDomainPrefix = (url: string, baseUrl: string): string => {
+  // This is to make sure the url will always have '/' in the end
+  const fixedBaseUrl = new URL(baseUrl).href
+  return url.startsWith(fixedBaseUrl) ? url.slice(fixedBaseUrl.length - 1) : url
+}
+
+const filter: FilterCreator = ({ client }) => ({
+  onFetch: async elements => {
+    elements
+      .filter(isObjectType)
+      .forEach(type => {
+        if ([AVATAR_URLS_FIELD, ICON_URL_FIELD].some(name => type.fields[name] !== undefined)) {
+          type.fields[AVATAR_ID_FIELD] = new Field(type, AVATAR_ID_FIELD, BuiltinTypes.NUMBER)
+        }
+      })
+
+    elements
+      .filter(isInstanceElement)
+      .forEach(element => {
+        walkOnElement({
+          element,
+          func: ({ value }) => {
+            const objValues = isInstanceElement(value) ? value.value : value
+
+            if (!_.isPlainObject(objValues)) {
+              return WALK_NEXT_STEP.RECURSE
+            }
+
+            let url: string | undefined
+            if (objValues[ICON_URL_FIELD] !== undefined) {
+              objValues[ICON_URL_FIELD] = removeDomainPrefix(
+                objValues[ICON_URL_FIELD],
+                client.baseUrl
+              )
+              url = objValues[ICON_URL_FIELD]
+            }
+
+            if (!_.isEmpty(objValues[AVATAR_URLS_FIELD] ?? {})) {
+              objValues[AVATAR_URLS_FIELD] = _.mapValues(
+                objValues[AVATAR_URLS_FIELD],
+                avatarUrl => removeDomainPrefix(avatarUrl, client.baseUrl)
+              );
+              [url] = Object.values(objValues[AVATAR_URLS_FIELD])
+            }
+
+            if (url !== undefined && objValues[AVATAR_ID_FIELD] === undefined) {
+              const match = AVATAR_ID_PATTERN.exec(url)
+              if (match !== null) {
+                objValues[AVATAR_ID_FIELD] = parseInt(match[1], 10)
+              }
+            }
+
+            if (objValues[AVATAR_ID_FIELD] !== undefined) {
+              delete objValues[AVATAR_URLS_FIELD]
+              delete objValues[ICON_URL_FIELD]
+            }
+
+            return WALK_NEXT_STEP.RECURSE
+          },
+        })
+      })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/avatars.ts
+++ b/packages/jira-adapter/src/filters/avatars.ts
@@ -32,6 +32,9 @@ const removeDomainPrefix = (url: string, baseUrl: string): string => {
 }
 
 const filter: FilterCreator = ({ client }) => ({
+  // There is no need to revert the changes of iconUrl and avatarUrls
+  // pre deploy because they are not deployable
+  // (and we already have a change validator for undeployable changes)
   onFetch: async elements => {
     elements
       .filter(isObjectType)

--- a/packages/jira-adapter/test/filters/avatars.test.ts
+++ b/packages/jira-adapter/test/filters/avatars.test.ts
@@ -1,0 +1,202 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { mockClient } from '../utils'
+import avatarsFilter from '../../src/filters/avatars'
+import { Filter } from '../../src/filter'
+import { DEFAULT_CONFIG } from '../../src/config'
+import { JIRA } from '../../src/constants'
+
+describe('avatarsFilter', () => {
+  let filter: Filter
+  let type: ObjectType
+  beforeEach(async () => {
+    const { client, paginator } = mockClient()
+
+    filter = avatarsFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    })
+
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, 'type'),
+    })
+  })
+
+  describe('onFetch', () => {
+    it('should add the avatarId field if there is iconUrl field', async () => {
+      type.fields.iconUrl = new Field(type, 'iconUrl', BuiltinTypes.STRING)
+      await filter.onFetch?.([type])
+      expect(type.fields.avatarId).toBeDefined()
+    })
+
+    it('should add the avatarId field if there is avatarUrls field', async () => {
+      type.fields.avatarUrls = new Field(type, 'avatarUrls', BuiltinTypes.STRING)
+      await filter.onFetch?.([type])
+      expect(type.fields.avatarId).toBeDefined()
+    })
+
+    it('should do nothing if there are not avatar fields', async () => {
+      await filter.onFetch?.([type])
+      expect(type.fields.avatarId).toBeUndefined()
+    })
+
+    it('should extract id from url', async () => {
+      const iconInstance = new InstanceElement(
+        'instance',
+        type,
+        {
+          iconUrl: 'https://ori-salto-test.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium',
+        }
+      )
+
+      const avatarsInstance = new InstanceElement(
+        'instance',
+        type,
+        {
+          avatarUrls: {
+            '48x48': 'https://ori-salto-test.atlassian.net/rest/api/3/universal_avatar/view/type/project/avatar/10303',
+            '24x24': 'https://ori-salto-test.atlassian.net/rest/api/3/universal_avatar/view/type/project/avatar/10303?size=small',
+            '16x16': 'https://ori-salto-test.atlassian.net/rest/api/3/universal_avatar/view/type/project/avatar/10303?size=xsmall',
+            '32x32': 'https://ori-salto-test.atlassian.net/rest/api/3/universal_avatar/view/type/project/avatar/10303?size=medium',
+          },
+        }
+      )
+
+      await filter.onFetch?.([iconInstance, avatarsInstance])
+
+      expect(iconInstance.value).toEqual({
+        avatarId: 10303,
+      })
+
+      expect(avatarsInstance.value).toEqual({
+        avatarId: 10303,
+      })
+    })
+
+    it('if url does not contain an id should remove the domain prefix', async () => {
+      const iconInstance = new InstanceElement(
+        'instance',
+        type,
+        {
+          iconUrl: 'https://ori-salto-test.atlassian.net/images/icons/priorities/low.svg?size=medium',
+        }
+      )
+
+      const avatarsInstance = new InstanceElement(
+        'instance',
+        type,
+        {
+          avatarUrls: {
+            '48x48': 'https://ori-salto-test.atlassian.net/images/icons/priorities/low.svg',
+            '24x24': 'https://ori-salto-test.atlassian.net/images/icons/priorities/low.svg?size=small',
+            '16x16': 'https://ori-salto-test.atlassian.net/images/icons/priorities/low.svg?size=xsmall',
+            '32x32': 'https://ori-salto-test.atlassian.net/images/icons/priorities/low.svg?size=medium',
+          },
+        }
+      )
+
+      await filter.onFetch?.([iconInstance, avatarsInstance])
+
+      expect(iconInstance.value).toEqual({
+        iconUrl: '/images/icons/priorities/low.svg?size=medium',
+      })
+
+      expect(avatarsInstance.value).toEqual({
+        avatarUrls: {
+          '48x48': '/images/icons/priorities/low.svg',
+          '24x24': '/images/icons/priorities/low.svg?size=small',
+          '16x16': '/images/icons/priorities/low.svg?size=xsmall',
+          '32x32': '/images/icons/priorities/low.svg?size=medium',
+        },
+      })
+    })
+
+    it('if url does not start with the domain prefix should not change it', async () => {
+      const iconInstance = new InstanceElement(
+        'instance',
+        type,
+        {
+          iconUrl: 'https://other/images/icons/priorities/low.svg?size=medium',
+        }
+      )
+
+      const avatarsInstance = new InstanceElement(
+        'instance',
+        type,
+        {
+          avatarUrls: {
+            '48x48': 'https://other/images/icons/priorities/low.svg',
+            '24x24': 'https://other/images/icons/priorities/low.svg?size=small',
+            '16x16': 'https://other/images/icons/priorities/low.svg?size=xsmall',
+            '32x32': 'https://other/images/icons/priorities/low.svg?size=medium',
+          },
+        }
+      )
+
+      await filter.onFetch?.([iconInstance, avatarsInstance])
+
+      expect(iconInstance.value).toEqual({
+        iconUrl: 'https://other/images/icons/priorities/low.svg?size=medium',
+      })
+
+      expect(avatarsInstance.value).toEqual({
+        avatarUrls: {
+          '48x48': 'https://other/images/icons/priorities/low.svg',
+          '24x24': 'https://other/images/icons/priorities/low.svg?size=small',
+          '16x16': 'https://other/images/icons/priorities/low.svg?size=xsmall',
+          '32x32': 'https://other/images/icons/priorities/low.svg?size=medium',
+        },
+      })
+    })
+
+    it('if instance already have avatarId should not replace it', async () => {
+      const iconInstance = new InstanceElement(
+        'instance',
+        type,
+        {
+          iconUrl: 'https://ori-salto-test.atlassian.net/images/icons/priorities/low.svg?size=medium',
+          avatarId: 1,
+        }
+      )
+
+      const avatarsInstance = new InstanceElement(
+        'instance',
+        type,
+        {
+          avatarUrls: {
+            '48x48': 'https://ori-salto-test.atlassian.net/images/icons/priorities/low.svg',
+            '24x24': 'https://ori-salto-test.atlassian.net/images/icons/priorities/low.svg?size=small',
+            '16x16': 'https://ori-salto-test.atlassian.net/images/icons/priorities/low.svg?size=xsmall',
+            '32x32': 'https://ori-salto-test.atlassian.net/images/icons/priorities/low.svg?size=medium',
+          },
+          avatarId: 1,
+        }
+      )
+
+      await filter.onFetch?.([iconInstance, avatarsInstance])
+
+      expect(iconInstance.value).toEqual({
+        avatarId: 1,
+      })
+
+      expect(avatarsInstance.value).toEqual({
+        avatarId: 1,
+      })
+    })
+  })
+})


### PR DESCRIPTION
Remove the domain prefix of the current env from the URLs of avatars

---

If the URL contains the id of the avatar we replace the URL with the ID. Otherwise, we remove the domain name prefix from the URL if exists

---
_Release Notes_: 
None

---
_User Notifications_: 
None