### PR TITLE
Removed base64 icon from projectType

### DIFF
--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -629,6 +629,9 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   ProjectType: {
     transformation: {
       idFields: ['key'],
+      fieldsToOmit: [
+        { fieldName: 'icon' },
+      ],
     },
   },
   Projects: {


### PR DESCRIPTION
Removed from `ProjectType` a base64 value of a SVG icon

---
_Release Notes_: 
None

---
_User Notifications_: 
None