### PR TITLE
SALTO-1933: added support deploying project components

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { FetchResult, AdapterOperations, DeployResult, InstanceElement, TypeMap, isObjectType, FetchOptions, DeployOptions, Change, isInstanceChange } from '@salto-io/adapter-api'
-import { config as configUtils, elements as elementUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { config as configUtils, elements as elementUtils, client as clientUtils, deployment } from '@salto-io/adapter-components'
 import { applyFunctionToChangeData, logDuration } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import JiraClient from './client/client'
@@ -36,6 +36,7 @@ import fieldConfigurationTrashedFieldsFilter from './filters/field_configuration
 import fieldConfigurationSchemeFilter from './filters/field_configurations_scheme'
 import hiddenValuesInListsFilter from './filters/hidden_value_in_lists'
 import projectFilter from './filters/project'
+import projectComponentFilter from './filters/project_component'
 import defaultInstancesDeployFilter from './filters/default_instances_deploy'
 import workflowFilter from './filters/workflow/workflow'
 import workflowSchemeFilter from './filters/workflow_scheme'
@@ -64,6 +65,7 @@ export const DEFAULT_FILTERS = [
   sharePermissionFilter,
   boardFilter,
   projectFilter,
+  projectComponentFilter,
   fieldStructureFilter,
   fieldTypeReferencesFilter,
   fieldDeploymentFilter,
@@ -233,6 +235,7 @@ export default class JiraAdapter implements AdapterOperations {
   get deployModifiers(): AdapterOperations['deployModifiers'] {
     return {
       changeValidator,
+      dependencyChanger: deployment.dependency.removeStandaloneFieldDependency,
     }
   }
 }

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -777,7 +777,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     transformation: {
       fieldTypeOverrides: [
         { fieldName: 'issueCount', fieldType: 'number' },
-        { fieldName: 'project', fieldType: 'Project' },
         { fieldName: 'leadAccountId', fieldType: 'string' },
         { fieldName: 'componentBean', fieldType: 'ProjectComponent' },
       ],

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -723,7 +723,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'projectKeys', fieldType: 'List<string>' },
         { fieldName: 'entityId', fieldType: 'string' },
         { fieldName: 'leadAccountId', fieldType: 'string' },
-        { fieldName: 'components', fieldType: 'list<ComponentWithIssueCount>' },
+        { fieldName: 'components', fieldType: 'list<ProjectComponent>' },
         { fieldName: 'workflowScheme', fieldType: 'WorkflowScheme' },
         { fieldName: 'permissionScheme', fieldType: 'PermissionScheme' },
         { fieldName: 'notificationScheme', fieldType: 'NotificationScheme' },
@@ -734,6 +734,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       fieldsToHide: [
         {
           fieldName: 'id',
+        },
+      ],
+      standaloneFields: [
+        {
+          fieldName: 'components',
         },
       ],
     },
@@ -768,13 +773,41 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       fieldsToOmit: [{ fieldName: 'projectIds' }],
     },
   },
-  ComponentWithIssueCount: {
+  ProjectComponent: {
     transformation: {
+      fieldTypeOverrides: [
+        { fieldName: 'issueCount', fieldType: 'number' },
+        { fieldName: 'project', fieldType: 'Project' },
+        { fieldName: 'leadAccountId', fieldType: 'string' },
+        { fieldName: 'componentBean', fieldType: 'ProjectComponent' },
+      ],
+      fieldsToHide: [
+        { fieldName: 'id' },
+      ],
       fieldsToOmit: [
         { fieldName: 'issueCount' },
-        { fieldName: 'id' },
         { fieldName: 'projectId' },
+        { fieldName: 'project' },
+        { fieldName: 'realAssignee' },
+        { fieldName: 'isAssigneeTypeValid' },
+        { fieldName: 'realAssigneeType' },
+        { fieldName: 'assignee' },
+        { fieldName: 'componentBean' },
       ],
+    },
+    deployRequests: {
+      add: {
+        url: '/rest/api/3/component',
+        method: 'post',
+      },
+      modify: {
+        url: '/rest/api/3/component/{id}',
+        method: 'put',
+      },
+      remove: {
+        url: '/rest/api/3/component/{id}',
+        method: 'delete',
+      },
     },
   },
   NotificationScheme: {
@@ -1361,6 +1394,10 @@ export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
       {
         originalName: 'PageBeanProject',
         newName: 'Projects',
+      },
+      {
+        originalName: 'ComponentWithIssueCount',
+        newName: 'ProjectComponent',
       },
       {
         originalName: 'rest__api__3__project__type',

--- a/packages/jira-adapter/src/filters/project.ts
+++ b/packages/jira-adapter/src/filters/project.ts
@@ -27,6 +27,12 @@ const log = logger(module)
 
 const PROJECT_TYPE_NAME = 'Project'
 
+const WORKFLOW_SCHEME_FIELD = 'workflowScheme'
+const COMPONENTS_FIELD = 'components'
+const ISSUE_TYPE_SCREEN_SCHEME_FIELD = 'issueTypeScreenScheme'
+const FIELD_CONFIG_SCHEME_FIELD = 'fieldConfigurationScheme'
+const ISSUE_TYPE_SCHEME = 'issueTypeScheme'
+
 const deployScheme = async (
   instance: InstanceElement,
   client: JiraClient,
@@ -50,10 +56,10 @@ const deployProjectSchemes = async (
 ): Promise<void> => {
   const instance = await resolveValues(getChangeData(projectChange), getLookUpName)
 
-  await deployScheme(instance, client, 'workflowScheme', 'workflowSchemeId')
-  await deployScheme(instance, client, 'issueTypeScreenScheme', 'issueTypeScreenSchemeId')
-  await deployScheme(instance, client, 'fieldConfigurationScheme', 'fieldConfigurationSchemeId')
-  await deployScheme(instance, client, 'issueTypeScheme', 'issueTypeSchemeId')
+  await deployScheme(instance, client, WORKFLOW_SCHEME_FIELD, 'workflowSchemeId')
+  await deployScheme(instance, client, ISSUE_TYPE_SCREEN_SCHEME_FIELD, 'issueTypeScreenSchemeId')
+  await deployScheme(instance, client, FIELD_CONFIG_SCHEME_FIELD, 'fieldConfigurationSchemeId')
+  await deployScheme(instance, client, ISSUE_TYPE_SCHEME, 'issueTypeSchemeId')
 }
 
 /**
@@ -65,11 +71,11 @@ const filter: FilterCreator = ({ config, client }) => ({
     if (projectType === undefined) {
       log.debug(`${PROJECT_TYPE_NAME} type not found`)
     } else {
-      setDeploymentAnnotations(projectType, 'workflowScheme')
-      setDeploymentAnnotations(projectType, 'issueTypeScreenScheme')
-      setDeploymentAnnotations(projectType, 'fieldConfigurationScheme')
-      setDeploymentAnnotations(projectType, 'issueTypeScheme')
-      setDeploymentAnnotations(projectType, 'components')
+      setDeploymentAnnotations(projectType, WORKFLOW_SCHEME_FIELD)
+      setDeploymentAnnotations(projectType, ISSUE_TYPE_SCREEN_SCHEME_FIELD)
+      setDeploymentAnnotations(projectType, FIELD_CONFIG_SCHEME_FIELD)
+      setDeploymentAnnotations(projectType, ISSUE_TYPE_SCHEME)
+      setDeploymentAnnotations(projectType, COMPONENTS_FIELD)
     }
 
     elements
@@ -79,14 +85,14 @@ const filter: FilterCreator = ({ config, client }) => ({
         instance.value.leadAccountId = instance.value.lead?.accountId
         delete instance.value.lead
 
-        instance.value.workflowScheme = instance.value.workflowScheme?.workflowScheme
-          ?.id?.toString()
-        instance.value.issueTypeScreenScheme = instance.value.issueTypeScreenScheme
-          ?.issueTypeScreenScheme?.id
-        instance.value.fieldConfigurationScheme = instance.value.fieldConfigurationScheme
-          ?.fieldConfigurationScheme?.id
-        instance.value.issueTypeScheme = instance.value.issueTypeScheme
-          ?.issueTypeScheme?.id
+        instance.value[WORKFLOW_SCHEME_FIELD] = instance
+          .value[WORKFLOW_SCHEME_FIELD]?.[WORKFLOW_SCHEME_FIELD]?.id?.toString()
+        instance.value.issueTypeScreenScheme = instance
+          .value[ISSUE_TYPE_SCREEN_SCHEME_FIELD]?.[ISSUE_TYPE_SCREEN_SCHEME_FIELD]?.id
+        instance.value.fieldConfigurationScheme = instance
+          .value[FIELD_CONFIG_SCHEME_FIELD]?.[FIELD_CONFIG_SCHEME_FIELD]?.id
+        instance.value[ISSUE_TYPE_SCHEME] = instance
+          .value[ISSUE_TYPE_SCHEME]?.[ISSUE_TYPE_SCHEME]?.id
 
         instance.value.notificationScheme = instance.value.notificationScheme?.id?.toString()
         instance.value.permissionScheme = instance.value.permissionScheme?.id?.toString()
@@ -110,8 +116,12 @@ const filter: FilterCreator = ({ config, client }) => ({
           client,
           apiDefinitions: config.apiDefinitions,
           fieldsToIgnore: isModificationChange(change)
-            ? ['components', 'workflowScheme', 'issueTypeScreenScheme', 'fieldConfigurationScheme', 'issueTypeScheme']
-            : ['components'],
+            ? [COMPONENTS_FIELD,
+              WORKFLOW_SCHEME_FIELD,
+              ISSUE_TYPE_SCREEN_SCHEME_FIELD,
+              FIELD_CONFIG_SCHEME_FIELD,
+              ISSUE_TYPE_SCHEME]
+            : [COMPONENTS_FIELD],
         })
         if (isModificationChange(change)) {
           await deployProjectSchemes(change, client)

--- a/packages/jira-adapter/src/filters/project_component.ts
+++ b/packages/jira-adapter/src/filters/project_component.ts
@@ -1,0 +1,100 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, Element, getChangeData, InstanceElement, isInstanceChange, isInstanceElement, isRemovalChange } from '@salto-io/adapter-api'
+import { getParents } from '@salto-io/adapter-utils'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { defaultDeployChange, deployChanges } from '../deployment'
+import { FilterCreator } from '../filter'
+
+const PROJECT_COMPONENT_TYPE_NAME = 'ProjectComponent'
+
+const filter: FilterCreator = ({ client, config }) => ({
+  onFetch: async (elements: Element[]) => {
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === PROJECT_COMPONENT_TYPE_NAME)
+      .forEach(instance => {
+        const leadAccountId = instance.value.lead?.accountId
+        if (leadAccountId !== undefined) {
+          instance.value.leadAccountId = leadAccountId
+          delete instance.value.lead
+        }
+      })
+  },
+
+  preDeploy: async changes => {
+    changes
+      .filter(isInstanceChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === PROJECT_COMPONENT_TYPE_NAME)
+      .forEach(instance => {
+        const projectKey = getParents(instance)[0]?.value?.value?.key
+        if (projectKey !== undefined) {
+          instance.value.project = projectKey
+        }
+      })
+  },
+
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && getChangeData(change).elemID.typeName === PROJECT_COMPONENT_TYPE_NAME
+        && isRemovalChange(change)
+    )
+
+
+    const deployResult = await deployChanges(
+      relevantChanges as Change<InstanceElement>[],
+      async change => {
+        try {
+          await defaultDeployChange({
+            change,
+            client,
+            apiDefinitions: config.apiDefinitions,
+          })
+        } catch (err) {
+          if (err instanceof clientUtils.HTTPError
+            && Array.isArray(err.response.data.errorMessages)
+            && err.response.data.errorMessages
+              .includes(`The component with id ${getChangeData(change).value.id} does not exist.`)
+          ) {
+            return
+          }
+          throw err
+        }
+      }
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+
+  onDeploy: async changes => {
+    changes
+      .filter(isInstanceChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === PROJECT_COMPONENT_TYPE_NAME)
+      .forEach(instance => {
+        delete instance.value.project
+      })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/project_component.ts
+++ b/packages/jira-adapter/src/filters/project_component.ts
@@ -17,10 +17,13 @@ import { Change, Element, getChangeData, InstanceElement, isInstanceChange, isIn
 import { getParents } from '@salto-io/adapter-utils'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
+import { logger } from '@salto-io/logging'
 import { defaultDeployChange, deployChanges } from '../deployment'
 import { FilterCreator } from '../filter'
 
 const PROJECT_COMPONENT_TYPE_NAME = 'ProjectComponent'
+
+const log = logger(module)
 
 const filter: FilterCreator = ({ client, config }) => ({
   onFetch: async (elements: Element[]) => {
@@ -73,6 +76,7 @@ const filter: FilterCreator = ({ client, config }) => ({
             && err.response.data.errorMessages
               .includes(`The component with id ${getChangeData(change).value.id} does not exist.`)
           ) {
+            log.debug(`When attempting to delete component ${getChangeData(change).elemID.getFullName}, received an error that it is already deleted`)
             return
           }
           throw err

--- a/packages/jira-adapter/test/filters/project.test.ts
+++ b/packages/jira-adapter/test/filters/project.test.ts
@@ -61,6 +61,7 @@ describe('projectFilter', () => {
         issueTypeScreenScheme: { refType: BuiltinTypes.STRING },
         fieldConfigurationScheme: { refType: BuiltinTypes.STRING },
         issueTypeScheme: { refType: BuiltinTypes.STRING },
+        components: { refType: BuiltinTypes.STRING },
       },
     })
 
@@ -125,6 +126,13 @@ describe('projectFilter', () => {
       })
     })
 
+    it('should add the deployment annotations to the components', () => {
+      expect(type.fields.components.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
+    })
+
     it('should set the leadAccountId', async () => {
       expect(instance.value.leadAccountId).toEqual('1')
     })
@@ -163,7 +171,7 @@ describe('projectFilter', () => {
         change,
         client,
         DEFAULT_CONFIG.apiDefinitions.types.Project.deployRequests,
-        ['workflowScheme', 'issueTypeScreenScheme', 'fieldConfigurationScheme', 'issueTypeScheme'],
+        ['components', 'workflowScheme', 'issueTypeScreenScheme', 'fieldConfigurationScheme', 'issueTypeScheme'],
         undefined
       )
     })

--- a/packages/jira-adapter/test/filters/project_component.test.ts
+++ b/packages/jira-adapter/test/filters/project_component.test.ts
@@ -1,0 +1,151 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { filterUtils, client as clientUtils, deployment } from '@salto-io/adapter-components'
+import { DEFAULT_CONFIG } from '../../src/config'
+import JiraClient from '../../src/client/client'
+import { JIRA } from '../../src/constants'
+import projectComponentFilter from '../../src/filters/project_component'
+import { mockClient } from '../utils'
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn(),
+    },
+  }
+})
+
+describe('projectComponentFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'deploy' | 'onDeploy'>
+  let instance: InstanceElement
+  let client: JiraClient
+  let type: ObjectType
+  const deployChangeMock = deployment.deployChange as jest.MockedFunction<
+    typeof deployment.deployChange
+  >
+
+  beforeEach(async () => {
+    const { client: cli, paginator } = mockClient()
+    client = cli
+
+    filter = projectComponentFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    }) as typeof filter
+
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, 'ProjectComponent'),
+    })
+
+    instance = new InstanceElement(
+      'instance',
+      type,
+    )
+  })
+
+  describe('onFetch', () => {
+    it('should add leadAccountId', async () => {
+      instance.value = {
+        lead: {
+          accountId: '1',
+        },
+      }
+      await filter.onFetch([type, instance])
+      expect(instance.value).toEqual({
+        leadAccountId: '1',
+      })
+    })
+
+    it('should do nothing if there is not leadAccountId', async () => {
+      instance.value = {
+        other: 'other',
+      }
+      await filter.onFetch([type, instance])
+      expect(instance.value).toEqual({
+        other: 'other',
+      })
+    })
+  })
+
+  describe('deploy', () => {
+    it('should ignore instance not being exist error on removal', async () => {
+      instance.value.id = '1'
+      deployChangeMock.mockImplementation(async () => {
+        throw new clientUtils.HTTPError('message', {
+          status: 404,
+          data: {
+            errorMessages: ['The component with id 1 does not exist.'],
+          },
+        })
+      })
+      const change = toChange({ before: instance })
+      const res = await filter.deploy([change])
+
+      expect(res.deployResult.errors).toHaveLength(0)
+    })
+
+    it('should throw for other errors', async () => {
+      instance.value.id = '1'
+      deployChangeMock.mockImplementation(async () => {
+        throw new clientUtils.HTTPError('message', {
+          status: 404,
+          data: {
+            errorMessages: ['Other'],
+          },
+        })
+      })
+      const change = toChange({ before: instance })
+      const res = await filter.deploy([change])
+
+      expect(res.deployResult.errors).toHaveLength(1)
+    })
+  })
+
+  describe('preDeploy', () => {
+    it('should add project value', async () => {
+      instance.annotations[CORE_ANNOTATIONS.PARENT] = [
+        new ReferenceExpression(
+          new ElemID(JIRA, 'Project', 'instance', 'parent'),
+          {
+            value: {
+              key: 'projectKey',
+            },
+          }
+        ),
+      ]
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.project).toEqual('projectKey')
+    })
+
+    it('should do nothing if there is no parent', async () => {
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.project).toBeUndefined()
+    })
+  })
+
+  describe('onDeploy', () => {
+    it('should convert the id to string', async () => {
+      instance.value.project = 'key'
+      await filter.onDeploy([toChange({ after: instance })])
+      expect(instance.value.project).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
Moved project component to a standalone field, removed redundant values in it, and made it deployable

---
_Release Notes_: 
None

---
_User Notifications_: 
None