### PR TITLE
SALTO-1941 define field as map

### DIFF
--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -122,6 +122,9 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
     transformation: {
       sourceTypeName: 'organizations__organizations',
       fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
+      fieldTypeOverrides: [
+        { fieldName: 'organization_fields', fieldType: 'map<unknown>' },
+      ],
     },
     deployRequests: {
       add: {

--- a/packages/zendesk-support-adapter/system_config_doc.md
+++ b/packages/zendesk-support-adapter/system_config_doc.md
@@ -168,6 +168,12 @@ zendesk_support {
               fieldType = "number"
             },
           ]
+          fieldTypeOverrides = [
+            {
+              fieldName = "organization_fields"
+              fieldType = "map<unknown>"
+            },
+          ]
         }
         deployRequests = {
           add = {


### PR DESCRIPTION
Fix type for field with dynamic keys.

Note: I think we are still generating the subtype even though we are not using it - ~maybe for now we should remove it manually?~ I will try to add a PR in a few days that removes "orphan" subtypes.

---
_Release Notes_: 
Zendesk adapter:
* Change type for organization fields

---
_User Notifications_: 
Zendesk adapter:
* Change type for organization fields (I believe this is not currently tracked)