### PR TITLE
SALTO-1940: fixed listUnresolvedReference with circular dependencies

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -1228,11 +1228,13 @@ export const loadWorkspace = async (
         ids: ElemID[], visitedIds: Set<string>, elementsArray: Element[] = [],
       ): Promise<{ completed: string[]; missing: string[] }> => {
         const newIds = ids.filter(id => !visitedIds.has(id.getFullName()))
-        newIds.map(id => id.getFullName()).forEach(id => visitedIds.add(id))
 
         if (newIds.length === 0) {
           return { completed: [], missing: [] }
         }
+
+        newIds.map(id => id.getFullName()).forEach(id => visitedIds.add(id))
+
         const getCompletionElem = async (id: ElemID): Promise<Element | undefined> => {
           const rootElem = await (await elementsImpl(true, completeFromEnv))
             .get(id.createTopLevelParentID().parent)


### PR DESCRIPTION
listUnresolvedReference would get into an infinite recursion if there were a circular references in the completeFrom env (which is a valid case if the adapter defined a dependency changer to resolve the cycle)

---
_Release Notes_: 
Core:
- Fixed bug in `listUnresolvedReference` with `completeFrom` when there is a circular references in the `completeFrom` env

---
_User Notifications_: 
None