### PR TITLE
Fixed log level

### DIFF
--- a/packages/adapter-components/src/client/pagination.ts
+++ b/packages/adapter-components/src/client/pagination.ts
@@ -114,7 +114,7 @@ export const traverseRequests: (
     })
 
     if (response.status !== 200) {
-      log.error(`error getting result for ${url}: %s %o %o`, response.status, response.statusText, response.data)
+      log.warn(`error getting result for ${url}: %s %o %o`, response.status, response.statusText, response.data)
       break
     }
 


### PR DESCRIPTION
Changed the log level in paginator when the response is not 200 from error to warning, so if the adapter client suppressed some kind of status code (in Jira 404 is suppressed), in won't be logged as an error anyway.
If the request did fail, `getSinglePage` in line 111 will throw an error that will be logged somewhere else. 

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
