### PR TITLE
SALTO-1894: add ElemIdGetter to zendesk

### DIFF
--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -41,6 +41,11 @@ const StandardBuiltinTypes = {
     primitive: PrimitiveTypes.STRING,
     annotations: { [CORE_ANNOTATIONS.SERVICE_ID]: true },
   }),
+  SERVICE_ID_NUMBER: new PrimitiveType({
+    elemID: new ElemID(GLOBAL_ADAPTER, 'serviceid_number'),
+    primitive: PrimitiveTypes.NUMBER,
+    annotations: { [CORE_ANNOTATIONS.SERVICE_ID]: true },
+  }),
   JSON: new PrimitiveType({
     elemID: new ElemID(GLOBAL_ADAPTER, 'json'),
     primitive: PrimitiveTypes.STRING,
@@ -148,11 +153,6 @@ export const BuiltinTypes = {
     annotations: {
       [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
     },
-  }),
-  SERVICE_ID_NUMBER: new PrimitiveType({
-    elemID: new ElemID(GLOBAL_ADAPTER, 'serviceid_number'),
-    primitive: PrimitiveTypes.NUMBER,
-    annotations: { [CORE_ANNOTATIONS.SERVICE_ID]: true },
   }),
 }
 

--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -149,6 +149,11 @@ export const BuiltinTypes = {
       [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
     },
   }),
+  SERVICE_ID_NUMBER: new PrimitiveType({
+    elemID: new ElemID(GLOBAL_ADAPTER, 'serviceid_number'),
+    primitive: PrimitiveTypes.NUMBER,
+    annotations: { [CORE_ANNOTATIONS.SERVICE_ID]: true },
+  }),
 }
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
+++ b/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { InstanceElement, isObjectType, isInstanceElement, ReferenceExpression, ObjectType, Element, createRefToElmWithValue, isListType, ListType, TypeElement } from '@salto-io/adapter-api'
+import { InstanceElement, isObjectType, isInstanceElement, ReferenceExpression, ObjectType, Element, createRefToElmWithValue, isListType, ListType, TypeElement, ElemIdGetter } from '@salto-io/adapter-api'
 import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { StandaloneFieldConfigType, TransformationConfig, TransformationDefaultConfig } from '../../config'
@@ -62,6 +62,7 @@ const addFieldTypeAndInstances = async ({
   instances,
   transformationConfigByType,
   transformationDefaultConfig,
+  getElemIdFunc,
 }: {
   adapterName: string
   typeName: string
@@ -70,6 +71,7 @@ const addFieldTypeAndInstances = async ({
   instances: InstanceElement[]
   transformationConfigByType: Record<string, TransformationConfig>
   transformationDefaultConfig: TransformationDefaultConfig
+  getElemIdFunc?: ElemIdGetter
 }): Promise<Element[]> => {
   if (type.fields[fieldName] === undefined) {
     log.info('type %s field %s does not exist (maybe it is not populated by any of the instances), not extracting field', type.elemID.name, fieldName)
@@ -123,6 +125,7 @@ const addFieldTypeAndInstances = async ({
         nestName: true,
         transformationConfigByType,
         transformationDefaultConfig,
+        getElemIdFunc,
       })
       if (fieldInstance === undefined) {
         // cannot happen
@@ -154,11 +157,13 @@ export const extractStandaloneFields = async ({
   transformationConfigByType,
   transformationDefaultConfig,
   adapterName,
+  getElemIdFunc,
 }: {
   elements: Element[]
   transformationConfigByType: Record<string, TransformationConfig>
   transformationDefaultConfig: TransformationDefaultConfig
   adapterName: string
+  getElemIdFunc?: ElemIdGetter
 }): Promise<void> => {
   const allTypes = _.keyBy(elements.filter(isObjectType), e => e.elemID.name)
   const allInstancesbyType = _.groupBy(
@@ -196,6 +201,7 @@ export const extractStandaloneFields = async ({
           instances,
           transformationConfigByType,
           transformationDefaultConfig,
+          getElemIdFunc,
         }))
       })
     })

--- a/packages/adapter-components/src/elements/ducktype/type_elements.ts
+++ b/packages/adapter-components/src/elements/ducktype/type_elements.ts
@@ -21,7 +21,7 @@ import {
 import { pathNaclCase, naclCase } from '@salto-io/adapter-utils'
 import { DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, getConfigWithDefault } from '../../config'
 import { TYPES_PATH, SUBTYPES_PATH } from '../constants'
-import { hideFields } from '../type_elements'
+import { hideFields, markServiceIdField } from '../type_elements'
 
 const ID_SEPARATOR = '__'
 
@@ -224,13 +224,17 @@ export const generateType = ({
     )
 
   // mark fields as hidden based on config
-  const { fieldsToHide } = getConfigWithDefault(
+  const { fieldsToHide, serviceIdField } = getConfigWithDefault(
     transformationConfigByType[naclName],
     transformationDefaultConfig,
   )
 
   if (Array.isArray(fieldsToHide)) {
     hideFields(fieldsToHide, fields, typeName)
+  }
+
+  if (serviceIdField) {
+    markServiceIdField(serviceIdField, fields, typeName)
   }
 
   const type = new ObjectType({

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  InstanceElement, Values, ObjectType, ReferenceExpression, CORE_ANNOTATIONS, ElemID,
+  InstanceElement, Values, ObjectType, ReferenceExpression, CORE_ANNOTATIONS, ElemID, ElemIdGetter, OBJECT_SERVICE_ID, OBJECT_NAME, toServiceIdsString,
 } from '@salto-io/adapter-api'
 import { pathNaclCase, naclCase, transformValues, TransformFunc } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -36,6 +36,7 @@ export type InstanceCreationParams = {
   nestName?: boolean
   parent?: InstanceElement
   normalized?: boolean
+  getElemIdFunc?: ElemIdGetter
 }
 
 export const getInstanceName = (
@@ -63,6 +64,7 @@ export const toBasicInstance = async ({
   nestName,
   parent,
   defaultName,
+  getElemIdFunc,
 }: InstanceCreationParams): Promise<InstanceElement> => {
   const omitFields: TransformFunc = ({ value, field }) => {
     if (field !== undefined) {
@@ -88,7 +90,7 @@ export const toBasicInstance = async ({
   })
 
   const {
-    idFields, fileNameFields,
+    idFields, fileNameFields, serviceIdField,
   } = getConfigWithDefault(
     transformationConfigByType[type.elemID.name],
     transformationDefaultConfig,
@@ -103,10 +105,22 @@ export const toBasicInstance = async ({
     ? fileNameParts.join('_')
     : undefined))
 
-  const naclName = naclCase(
+  const desiredName = naclCase(
     parent && nestName ? `${parent.elemID.name}${ID_SEPARATOR}${name}` : String(name)
   )
   const adapterName = type.elemID.adapter
+  const naclName = getElemIdFunc && serviceIdField
+    ? getElemIdFunc(
+      adapterName,
+      {
+        [serviceIdField]: entry[serviceIdField],
+        [OBJECT_SERVICE_ID]: toServiceIdsString({
+          [OBJECT_NAME]: type.elemID.getFullName(),
+        }),
+      },
+      desiredName
+    ).name
+    : desiredName
   const filePath = type.isSettings
     ? [
       adapterName,

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import {
   InstanceElement, Values, ObjectType, ReferenceExpression, CORE_ANNOTATIONS, ElemID,
-  ElemIdGetter, OBJECT_SERVICE_ID, OBJECT_NAME, toServiceIdsString,
+  ElemIdGetter, OBJECT_SERVICE_ID, OBJECT_NAME, toServiceIdsString, ServiceIds,
 } from '@salto-io/adapter-api'
 import { pathNaclCase, naclCase, transformValues, TransformFunc } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -50,6 +50,15 @@ export const getInstanceName = (
   }
   return nameParts.every(part => part !== undefined && part !== '') ? nameParts.map(String).join('_') : undefined
 }
+
+const createServiceIds = (
+  entry: Values, serviceIdField: string, type: ObjectType
+): ServiceIds => ({
+  [serviceIdField]: entry[serviceIdField],
+  [OBJECT_SERVICE_ID]: toServiceIdsString({
+    [OBJECT_NAME]: type.elemID.getFullName(),
+  }),
+})
 
 /**
  * Generate an instance for a single entry returned for a given type.
@@ -111,16 +120,7 @@ export const toBasicInstance = async ({
   )
   const adapterName = type.elemID.adapter
   const naclName = getElemIdFunc && serviceIdField
-    ? getElemIdFunc(
-      adapterName,
-      {
-        [serviceIdField]: entry[serviceIdField],
-        [OBJECT_SERVICE_ID]: toServiceIdsString({
-          [OBJECT_NAME]: type.elemID.getFullName(),
-        }),
-      },
-      desiredName
-    ).name
+    ? getElemIdFunc(adapterName, createServiceIds(entry, serviceIdField, type), desiredName).name
     : desiredName
   const filePath = type.isSettings
     ? [

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -15,7 +15,8 @@
 */
 import _ from 'lodash'
 import {
-  InstanceElement, Values, ObjectType, ReferenceExpression, CORE_ANNOTATIONS, ElemID, ElemIdGetter, OBJECT_SERVICE_ID, OBJECT_NAME, toServiceIdsString,
+  InstanceElement, Values, ObjectType, ReferenceExpression, CORE_ANNOTATIONS, ElemID,
+  ElemIdGetter, OBJECT_SERVICE_ID, OBJECT_NAME, toServiceIdsString,
 } from '@salto-io/adapter-api'
 import { pathNaclCase, naclCase, transformValues, TransformFunc } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'

--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -16,7 +16,7 @@
 */
 import _ from 'lodash'
 import { FieldDefinition, Field, CORE_ANNOTATIONS, TypeElement, isObjectType, isContainerType,
-  getDeepInnerType, ObjectType, BuiltinTypes, createRestriction, createRefToElmWithValue, PrimitiveType, LIST_ID_PREFIX, GENERIC_ID_PREFIX, GENERIC_ID_SUFFIX, MAP_ID_PREFIX, ListType, MapType, isEqualElements } from '@salto-io/adapter-api'
+  getDeepInnerType, ObjectType, BuiltinTypes, createRestriction, createRefToElmWithValue, PrimitiveType, LIST_ID_PREFIX, GENERIC_ID_PREFIX, GENERIC_ID_SUFFIX, MAP_ID_PREFIX, ListType, MapType, isEqualElements, isPrimitiveType, PrimitiveTypes } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { values, collections } from '@salto-io/lowerdash'
 import { FieldToHideType, FieldTypeOverrideType, getTypeTransformationConfig } from '../config/transformation'
@@ -52,6 +52,30 @@ export const hideFields = (
   })
 }
 
+/**
+ * Change field type to be service_id if it match the specified configuration.
+ */
+export const markServiceIdField = (
+  fieldName: string,
+  typeFields: Record<string, FieldDefinition>,
+  typeName: string,
+): void => {
+  const field = typeFields[fieldName]
+  if (field === undefined) {
+    log.warn('field %s.%s not found, cannot mark it as service_id', typeName, fieldName)
+    return
+  }
+  log.debug('Mark field %s.%s as service_id', typeName, fieldName)
+  if (!isPrimitiveType(field.refType)) {
+    log.warn('field %s.%s type is not primitive, cannot mark it as service_id', typeName, fieldName)
+    return
+  }
+  if (field.refType.primitive === PrimitiveTypes.NUMBER) {
+    field.refType = BuiltinTypes.SERVICE_ID_NUMBER
+  } else {
+    field.refType = BuiltinTypes.SERVICE_ID
+  }
+}
 
 export const filterTypes = async (
   adapterName: string,

--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -37,7 +37,9 @@ export const hideFields = (
   typeName: string,
 ): void => {
   fieldsToHide.forEach(({ fieldName, fieldType }) => {
-    const field = typeFields[fieldName]
+    const field = Object.prototype.hasOwnProperty.call(typeFields, fieldName)
+      ? typeFields[fieldName]
+      : undefined
     if (field === undefined) {
       log.warn('field %s.%s not found, cannot hide it', typeName, fieldName)
       return
@@ -60,7 +62,9 @@ export const markServiceIdField = (
   typeFields: Record<string, FieldDefinition>,
   typeName: string,
 ): void => {
-  const field = typeFields[fieldName]
+  const field = Object.prototype.hasOwnProperty.call(typeFields, fieldName)
+    ? typeFields[fieldName]
+    : undefined
   if (field === undefined) {
     log.warn('field %s.%s not found, cannot mark it as service_id', typeName, fieldName)
     return
@@ -70,10 +74,18 @@ export const markServiceIdField = (
     log.warn('field %s.%s type is not primitive, cannot mark it as service_id', typeName, fieldName)
     return
   }
-  if (field.refType.primitive === PrimitiveTypes.NUMBER) {
-    field.refType = BuiltinTypes.SERVICE_ID_NUMBER
-  } else {
-    field.refType = BuiltinTypes.SERVICE_ID
+  switch (field.refType.primitive) {
+    case (PrimitiveTypes.NUMBER):
+      field.refType = BuiltinTypes.SERVICE_ID_NUMBER
+      return
+    case (PrimitiveTypes.STRING):
+      field.refType = BuiltinTypes.SERVICE_ID
+      return
+    default:
+      log.warn(
+        'Failed to mark field %s.%s as service id, since its primitive type id (%d) is not supported',
+        typeName, fieldName, field.refType.primitive
+      )
   }
 }
 

--- a/packages/adapter-components/test/elements/ducktype/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/instance_elements.test.ts
@@ -326,5 +326,35 @@ describe('ducktype_instance_elements', () => {
       })
       expect(inst).toBeUndefined()
     })
+    it('should use elemIdGetter ', async () => {
+      const instanceName = 'test'
+      const inst = await toInstance({
+        type,
+        transformationConfigByType: {
+          bla: {
+            idFields: ['name'],
+            serviceIdField: 'id',
+          },
+        },
+        transformationDefaultConfig: {
+          idFields: ['somethingElse'],
+        },
+        defaultName: 'abc',
+        entry,
+        getElemIdFunc: (adapterName, serviceIds, name) => {
+          if (Number(serviceIds.id) === entry.id) {
+            return new ElemID(adapterName, type.elemID.typeName, 'instance', instanceName)
+          }
+          return new ElemID(adapterName, type.elemID.typeName, 'instance', name)
+        },
+      })
+      expect(inst).toBeDefined()
+      expect(inst?.isEqual(new InstanceElement(
+        instanceName,
+        type,
+        entry,
+      ))).toBeTruthy()
+      expect(inst?.path).toEqual([ADAPTER_NAME, RECORDS_PATH, 'bla', instanceName])
+    })
   })
 })

--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -15,8 +15,8 @@
 */
 import _ from 'lodash'
 import {
-  FetchResult, AdapterOperations, DeployResult, Element, DeployModifiers,
-  FetchOptions, DeployOptions, Change, isInstanceChange, InstanceElement, getChangeData,
+  FetchResult, AdapterOperations, DeployResult, Element, DeployModifiers, FetchOptions,
+  DeployOptions, Change, isInstanceChange, InstanceElement, getChangeData, ElemIdGetter,
 } from '@salto-io/adapter-api'
 import {
   client as clientUtils,
@@ -84,6 +84,8 @@ export interface ZendeskAdapterParams {
   filterCreators?: FilterCreator[]
   client: ZendeskClient
   config: ZendeskConfig
+  // callback function to get an existing elemId or create a new one by the ServiceIds values
+  getElemIdFunc?: ElemIdGetter
 }
 
 export default class ZendeskAdapter implements AdapterOperations {
@@ -91,13 +93,16 @@ export default class ZendeskAdapter implements AdapterOperations {
   private client: ZendeskClient
   private paginator: clientUtils.Paginator
   private userConfig: ZendeskConfig
+  private getElemIdFunc?: ElemIdGetter
 
   public constructor({
     filterCreators = DEFAULT_FILTERS,
     client,
+    getElemIdFunc,
     config,
   }: ZendeskAdapterParams) {
     this.userConfig = config
+    this.getElemIdFunc = getElemIdFunc
     this.client = client
     this.paginator = createPaginator({
       client: this.client,
@@ -129,6 +134,7 @@ export default class ZendeskAdapter implements AdapterOperations {
       nestedFieldFinder: findDataField,
       computeGetArgs,
       typeDefaults: this.userConfig.apiDefinitions.typeDefaults,
+      getElemIdFunc: this.getElemIdFunc,
     })
   }
 

--- a/packages/zendesk-support-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-support-adapter/src/adapter_creator.ts
@@ -107,6 +107,7 @@ export const adapter: Adapter = {
         config: config[CLIENT_CONFIG],
       }),
       config,
+      getElemIdFunc: context.getElemIdFunc,
     })
   },
   validateCredentials: async config => validateCredentials(

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -26,6 +26,7 @@ const {
 
 export const DEFAULT_ID_FIELDS = ['name']
 export const DEFAULT_FILENAME_FIELDS = ['name']
+export const DEFAULT_SERVICE_ID_FIELD = 'id'
 export const FIELDS_TO_OMIT: configUtils.FieldToOmitType[] = [
   { fieldName: 'extended_input_schema' },
   { fieldName: 'extended_output_schema' },
@@ -1436,6 +1437,7 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
         fileNameFields: DEFAULT_FILENAME_FIELDS,
         fieldsToOmit: FIELDS_TO_OMIT,
         fieldsToHide: FIELDS_TO_HIDE,
+        serviceIdField: DEFAULT_SERVICE_ID_FIELD,
       },
     },
     types: DEFAULT_TYPES,

--- a/packages/zendesk-support-adapter/test/resolve_changes.test.ts
+++ b/packages/zendesk-support-adapter/test/resolve_changes.test.ts
@@ -103,6 +103,7 @@ describe('resolveChanges', () => {
       fields: {
         id: { refType: BuiltinTypes.NUMBER },
         title: { refType: BuiltinTypes.STRING },
+        default_custom_field_option: { refType: BuiltinTypes.STRING },
         custom_field_options: { refType: new ListType(ticketFieldOptionType) },
       },
     })
@@ -189,6 +190,9 @@ describe('resolveChanges', () => {
         id: 100,
         title: 'tf1',
         type: 'tagger',
+        default_custom_field_option: new ReferenceExpression(
+          ticketFieldOption1Instance.elemID, ticketFieldOption1Instance
+        ),
         custom_field_options: [
           new ReferenceExpression(ticketFieldOption1Instance.elemID, ticketFieldOption1Instance),
         ],
@@ -271,10 +275,12 @@ describe('resolveChanges', () => {
         },
       },
     )
-    const resolvedChanges = await awu([toChange({ after: automationInstance })])
+    const resolvedChanges = await awu(
+      [automationInstance, ticketFieldInstance].map(inst => toChange({ after: inst }))
+    )
       .map(change => resolveChangeElement(change, lookupFunc))
       .toArray()
-    expect(resolvedChanges).toHaveLength(1)
+    expect(resolvedChanges).toHaveLength(2)
     expect(getChangeData(resolvedChanges[0]).value).toEqual({
       id: 2,
       title: 'Test',
@@ -288,6 +294,15 @@ describe('resolveChanges', () => {
           { field: 'custom_fields_100', operator: 'is', value: 'v123' },
         ],
       },
+    })
+    expect(getChangeData(resolvedChanges[1]).value).toEqual({
+      id: 100,
+      title: 'tf1',
+      type: 'tagger',
+      default_custom_field_option: 'v1',
+      custom_field_options: [
+        { id: 1001, name: 'option1', value: 'v1' },
+      ],
     })
   })
 })


### PR DESCRIPTION
_add ElemIdGetter to zendesk_

---

_Additional context for reviewer_

- [x] write tests

---
_Release Notes_: 
_Zendesk_support adapter_
* renaming element name in the service would modify the element

---
_User Notifications_: 
_None_
