### PR TITLE
SALTO-1946: removed isLocked when not locked

### DIFF
--- a/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
@@ -226,6 +226,10 @@ const filter: FilterCreator = ({ config }) => ({
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === FIELD_TYPE_NAME)
       .forEach(instance => {
+        if (instance.value.isLocked === false) {
+          delete instance.value.isLocked
+        }
+
         addTypeValue(instance)
 
         const idToContext = _.keyBy(instance.value.contexts ?? [], context => context.id)

--- a/packages/jira-adapter/test/filters/fields/field_structure.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_structure.test.ts
@@ -65,6 +65,47 @@ describe('fields_structure', () => {
     })
   })
 
+  it('should remove isLocked if not locked', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      fieldType,
+      {
+        isLocked: false,
+      }
+    )
+    await filter.onFetch([
+      instance,
+      fieldType,
+      fieldContextType,
+      fieldContextDefaultValueType,
+      fieldContextOptionType,
+    ])
+    expect(instance.value).toEqual({
+      contexts: [],
+    })
+  })
+
+  it('should not remove isLocked if locked', async () => {
+    const instance = new InstanceElement(
+      'instance',
+      fieldType,
+      {
+        isLocked: true,
+      }
+    )
+    await filter.onFetch([
+      instance,
+      fieldType,
+      fieldContextType,
+      fieldContextDefaultValueType,
+      fieldContextOptionType,
+    ])
+    expect(instance.value).toEqual({
+      isLocked: true,
+      contexts: [],
+    })
+  })
+
   it('should add the defaults, issue types and projects to the contexts', async () => {
     const instance = new InstanceElement(
       'instance',


### PR DESCRIPTION
Removed isLocked from fields when it is false to remove the redundant change validator warning about this value not being deployable

---
_Release Notes_: 
None

---
_User Notifications_: 
None