### PR TITLE
SALTO-1957: fixed issues with adding and removing values from the default issueTypeScheme

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/field.ts
+++ b/packages/jira-adapter/e2e_test/instances/field.ts
@@ -15,7 +15,7 @@
 */
 import { ElemID, Values, Element, ReferenceExpression } from '@salto-io/adapter-api'
 import { createReference } from '../utils'
-import { JIRA } from '../../src/constants'
+import { ISSUE_TYPE_NAME, JIRA } from '../../src/constants'
 
 const p1Option = {
   value: 'p1',
@@ -81,7 +81,7 @@ export const createContextValues = (name: string, allElements: Element[]): Value
     ),
   },
   issueTypeIds: [
-    createReference(new ElemID(JIRA, 'IssueType', 'instance', 'Epic'), allElements),
-    createReference(new ElemID(JIRA, 'IssueType', 'instance', 'Story'), allElements),
+    createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Epic'), allElements),
+    createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Story'), allElements),
   ],
 })

--- a/packages/jira-adapter/e2e_test/instances/fieldConfigurationScheme.ts
+++ b/packages/jira-adapter/e2e_test/instances/fieldConfigurationScheme.ts
@@ -15,7 +15,7 @@
 */
 import { Values, Element, ElemID } from '@salto-io/adapter-api'
 import { createReference } from '../utils'
-import { JIRA } from '../../src/constants'
+import { ISSUE_TYPE_NAME, JIRA } from '../../src/constants'
 
 export const createFieldConfigurationSchemeValues = (
   name: string,
@@ -29,7 +29,7 @@ export const createFieldConfigurationSchemeValues = (
       fieldConfigurationId: createReference(new ElemID(JIRA, 'FieldConfiguration', 'instance', 'Default_Field_Configuration@s'), allElements),
     },
     {
-      issueTypeId: createReference(new ElemID(JIRA, 'IssueType', 'instance', 'Bug'), allElements),
+      issueTypeId: createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Bug'), allElements),
       fieldConfigurationId: createReference(new ElemID(JIRA, 'FieldConfiguration', 'instance', 'Default_Field_Configuration@s'), allElements),
     },
   ],

--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -15,7 +15,7 @@
 */
 import { InstanceElement, Element, ElemID, CORE_ANNOTATIONS, ReferenceExpression } from '@salto-io/adapter-api'
 import { naclCase } from '@salto-io/adapter-utils'
-import { JIRA } from '../../src/constants'
+import { ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, JIRA } from '../../src/constants'
 import { createReference, findType } from '../utils'
 import { createBoardValues } from './board'
 import { createContextValues, createFieldValues } from './field'
@@ -31,7 +31,7 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[] =
 
   const issueType = new InstanceElement(
     randomString,
-    findType('IssueType', fetchedElements),
+    findType(ISSUE_TYPE_NAME, fetchedElements),
     {
       description: randomString,
       name: randomString,
@@ -134,7 +134,7 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[] =
 
   const issueTypeScheme = new InstanceElement(
     randomString,
-    findType('IssueTypeScheme', fetchedElements),
+    findType(ISSUE_TYPE_SCHEMA_NAME, fetchedElements),
     createIssueTypeSchemeValues(randomString, fetchedElements),
   )
 

--- a/packages/jira-adapter/e2e_test/instances/issueTypeScheme.ts
+++ b/packages/jira-adapter/e2e_test/instances/issueTypeScheme.ts
@@ -15,16 +15,16 @@
 */
 import { Values, Element, ElemID } from '@salto-io/adapter-api'
 import { createReference } from '../utils'
-import { JIRA } from '../../src/constants'
+import { ISSUE_TYPE_NAME, JIRA } from '../../src/constants'
 
 export const createIssueTypeSchemeValues = (
   name: string,
   allElements: Element[],
 ): Values => ({
   name,
-  defaultIssueTypeId: createReference(new ElemID(JIRA, 'IssueType', 'instance', 'Bug'), allElements),
+  defaultIssueTypeId: createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Bug'), allElements),
   issueTypeIds: [
-    createReference(new ElemID(JIRA, 'IssueType', 'instance', 'Bug'), allElements),
-    createReference(new ElemID(JIRA, 'IssueType', 'instance', 'Epic'), allElements),
+    createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Bug'), allElements),
+    createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Epic'), allElements),
   ],
 })

--- a/packages/jira-adapter/e2e_test/instances/issueTypeScreenScheme.ts
+++ b/packages/jira-adapter/e2e_test/instances/issueTypeScreenScheme.ts
@@ -15,7 +15,7 @@
 */
 import { Values, Element, ElemID } from '@salto-io/adapter-api'
 import { createReference } from '../utils'
-import { JIRA } from '../../src/constants'
+import { ISSUE_TYPE_NAME, JIRA } from '../../src/constants'
 
 export const createIssueTypeScreenSchemeValues = (
   name: string,
@@ -29,7 +29,7 @@ export const createIssueTypeScreenSchemeValues = (
       screenSchemeId: createReference(new ElemID(JIRA, 'ScreenScheme', 'instance', 'Default_Screen_Scheme@s'), allElements),
     },
     {
-      issueTypeId: createReference(new ElemID(JIRA, 'IssueType', 'instance', 'Bug'), allElements),
+      issueTypeId: createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Bug'), allElements),
       screenSchemeId: createReference(new ElemID(JIRA, 'ScreenScheme', 'instance', 'Default_Screen_Scheme@s'), allElements),
     },
   ],

--- a/packages/jira-adapter/e2e_test/instances/workflowScheme.ts
+++ b/packages/jira-adapter/e2e_test/instances/workflowScheme.ts
@@ -15,7 +15,7 @@
 */
 import { Values, Element, ElemID } from '@salto-io/adapter-api'
 import { createReference } from '../utils'
-import { JIRA } from '../../src/constants'
+import { ISSUE_TYPE_NAME, JIRA } from '../../src/constants'
 
 export const createWorkflowSchemeValues = (
   name: string,
@@ -26,7 +26,7 @@ export const createWorkflowSchemeValues = (
   defaultWorkflow: createReference(new ElemID(JIRA, 'Workflow', 'instance', 'jira'), allElements),
   items: [
     {
-      issueType: createReference(new ElemID(JIRA, 'IssueType', 'instance', 'Bug'), allElements),
+      issueType: createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Bug'), allElements),
       workflow: createReference(new ElemID(JIRA, 'Workflow', 'instance', 'jira'), allElements),
     },
   ],

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -18,6 +18,7 @@ import { deployment } from '@salto-io/adapter-components'
 import { createChangeValidator } from '@salto-io/adapter-utils'
 import { unsupportedFieldConfigurationsValidator } from './field_configuration_unsupported_fields'
 import { defaultFieldConfigurationValidator } from './default_field_configuration'
+import { issueTypeSchemeValidator } from './issue_type_scheme'
 import { screenValidator } from './screen'
 import { workflowValidator } from './workflow'
 
@@ -31,6 +32,7 @@ const validators: ChangeValidator[] = [
   defaultFieldConfigurationValidator,
   workflowValidator,
   screenValidator,
+  issueTypeSchemeValidator,
 ]
 
 export default createChangeValidator(validators)

--- a/packages/jira-adapter/src/change_validators/issue_type_scheme.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_scheme.ts
@@ -54,6 +54,11 @@ export const issueTypeSchemeValidator: ChangeValidator = async changes => {
     // fetch and the user can't delete them because they are hidden
     .map(change => getChangeData(change).value.id)
 
+  // We should also check in the element source if the issue was deleted
+  // in case the changes of the issueType deletion and the issueTypeScheme
+  // were deployed in two separate deployments (doesn't supposed to happen,
+  // unless there was some unexpected error in the original deployment that
+  // contains both of them). See SALTO-1981
   const deletedIdsSet = new Set(deletedIds)
 
   if (removedIdsFromDefaultScheme.every(id => deletedIdsSet.has(id))) {

--- a/packages/jira-adapter/src/change_validators/issue_type_scheme.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_scheme.ts
@@ -1,0 +1,63 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isInstanceChange, isModificationChange, isRemovalChange, SaltoErrorSeverity } from '@salto-io/adapter-api'
+import { resolveChangeElement } from '@salto-io/adapter-utils'
+import { getLookUpName } from '../reference_mapping'
+import { getDiffIds } from '../diff'
+
+
+export const issueTypeSchemeValidator: ChangeValidator = async changes => {
+  const instanceChanges = changes
+    .filter(isInstanceChange)
+
+  const defaultIssueTypeSchemeChange = instanceChanges
+    .filter(isModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === 'IssueTypeScheme')
+    .find(change => getChangeData(change).value.isDefault)
+
+  if (defaultIssueTypeSchemeChange === undefined) {
+    return []
+  }
+
+  const resolvedDefaultSchemeChange = await resolveChangeElement(
+    defaultIssueTypeSchemeChange,
+    getLookUpName,
+  )
+  const { removedIds: removedIdsFromDefaultScheme } = getDiffIds(
+    resolvedDefaultSchemeChange.data.before.value.issueTypeIds ?? [],
+    resolvedDefaultSchemeChange.data.after.value.issueTypeIds ?? []
+  )
+
+  const deletedIds = instanceChanges
+    .filter(isRemovalChange)
+    .filter(change => getChangeData(change).elemID.typeName === 'IssueType')
+    .map(change => getChangeData(change).value.id)
+
+  const deletedIdsSet = new Set(deletedIds)
+
+  if (removedIdsFromDefaultScheme.every(id => deletedIdsSet.has(id))) {
+    return []
+  }
+
+  const { elemID } = getChangeData(resolvedDefaultSchemeChange)
+
+  return [{
+    elemID,
+    severity: 'Error' as SaltoErrorSeverity,
+    message: 'Cannot remove issue types from default issue type scheme',
+    detailedMessage: `Removing issue types from the default issue type scheme ${elemID.getFullName()} is not supported`,
+  }]
+}

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ListType, ObjectType } from '@salto-io/adapter-api'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
-import { JIRA } from './constants'
+import { ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, JIRA } from './constants'
 
 const { createUserFetchConfigType, createSwaggerAdapterApiConfigType } = configUtils
 
@@ -737,7 +737,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'notificationScheme', fieldType: 'NotificationScheme' },
         { fieldName: 'issueTypeScreenScheme', fieldType: 'IssueTypeScreenScheme' },
         { fieldName: 'fieldConfigurationScheme', fieldType: 'FieldConfigurationScheme' },
-        { fieldName: 'issueTypeScheme', fieldType: 'IssueTypeScheme' },
+        { fieldName: 'issueTypeScheme', fieldType: ISSUE_TYPE_SCHEMA_NAME },
       ],
       fieldsToHide: [
         {
@@ -1318,7 +1318,7 @@ export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
       },
       {
         originalName: 'IssueTypeDetails',
-        newName: 'IssueType',
+        newName: ISSUE_TYPE_NAME,
       },
       {
         originalName: 'StatusDetails',
@@ -1477,7 +1477,7 @@ export const DEFAULT_INCLUDE_ENDPOINTS: string[] = [
   'FieldsConfigurationScheme',
   'FieldsConfigurationIssueTypeItem',
   'Filters',
-  'IssueType',
+  ISSUE_TYPE_NAME,
   'IssueLinkTypes',
   'SecuritySchemes',
   'IssueTypeSchemes',

--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -14,3 +14,5 @@
 * limitations under the License.
 */
 export const JIRA = 'jira'
+export const ISSUE_TYPE_SCHEMA_NAME = 'IssueTypeScheme'
+export const ISSUE_TYPE_NAME = 'IssueType'

--- a/packages/jira-adapter/src/diff.ts
+++ b/packages/jira-adapter/src/diff.ts
@@ -16,18 +16,18 @@
 import { Values } from '@salto-io/adapter-api'
 
 export const getDiffIds = (
-  beforeIds: string[],
-  afterIds: string[],
+  beforeIds: string[] | undefined,
+  afterIds: string[] | undefined,
 ): {
   addedIds: string[]
   removedIds: string[]
  } => {
-  const beforeIdsSet = new Set(beforeIds)
-  const afterIdsSet = new Set(afterIds)
+  const beforeIdsSet = new Set(beforeIds ?? [])
+  const afterIdsSet = new Set(afterIds ?? [])
 
   return {
-    addedIds: Array.from(afterIds).filter(id => !beforeIdsSet.has(id)),
-    removedIds: Array.from(beforeIds).filter(id => !afterIdsSet.has(id)),
+    addedIds: Array.from(afterIds ?? []).filter(id => !beforeIdsSet.has(id)),
+    removedIds: Array.from(beforeIds ?? []).filter(id => !afterIdsSet.has(id)),
   }
 }
 

--- a/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme.ts
+++ b/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme.ts
@@ -24,8 +24,8 @@ import { JiraConfig } from '../../config'
 import { defaultDeployChange, deployChanges } from '../../deployment'
 import { FilterCreator } from '../../filter'
 import { getDiffIds } from '../../diff'
+import { ISSUE_TYPE_SCHEMA_NAME } from '../../constants'
 
-const ISSUE_TYPE_SCHEMA_NAME = 'IssueTypeScheme'
 const MAX_CONCURRENT_PROMISES = 20
 
 const log = logger(module)
@@ -53,17 +53,13 @@ const deployNewAndDeletedIssueTypeIds = async (
     }
   }
 
-  if (!instance.value.isDefault) {
-    await promises.array.withLimitedConcurrency(
-      Array.from(removedIds).map(id => () =>
-        client.delete({
-          url: `/rest/api/3/issuetypescheme/${instance.value.id}/issuetype/${id}`,
-        })),
-      MAX_CONCURRENT_PROMISES,
-    )
-  } else if (removedIds.length > 0) {
-    log.info('Removing issue types from default issue type scheme is not supported')
-  }
+  await promises.array.withLimitedConcurrency(
+    Array.from(removedIds).map(id => () =>
+      client.delete({
+        url: `/rest/api/3/issuetypescheme/${instance.value.id}/issuetype/${id}`,
+      })),
+    MAX_CONCURRENT_PROMISES,
+  )
 }
 
 const deployIssueTypeIdsOrder = async (

--- a/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme_references.ts
+++ b/packages/jira-adapter/src/filters/issue_type_schemas/issue_type_scheme_references.ts
@@ -14,11 +14,13 @@
 * limitations under the License.
 */
 import { Element, InstanceElement, isInstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { ISSUE_TYPE_SCHEMA_NAME } from '../../constants'
 import { FilterCreator } from '../../filter'
 
 const filter: FilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
-    const isIssueTypeScheme = (element: Element): boolean => element.elemID.typeName === 'IssueTypeScheme'
+    const isIssueTypeScheme = (element: Element): boolean =>
+      element.elemID.typeName === ISSUE_TYPE_SCHEMA_NAME
     const setReferences = (scheme: InstanceElement): void => {
       type IssueTypeMapping = { issueTypeId: ReferenceExpression }
       scheme.value.issueTypeIds = scheme.value.issueTypeIds

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -16,6 +16,7 @@
 import { isReferenceExpression } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
+import { ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME } from './constants'
 import { getFieldsLookUpName } from './filters/fields/field_type_references_filter'
 
 
@@ -23,7 +24,7 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
   {
     src: { field: 'issueTypeId', parentTypes: ['IssueTypeScreenSchemeItem', 'FieldConfigurationIssueTypeItem'] },
     serializationStrategy: 'id',
-    target: { type: 'IssueType' },
+    target: { type: ISSUE_TYPE_NAME },
   },
   {
     src: { field: 'fieldConfigurationId', parentTypes: ['FieldConfigurationIssueTypeItem'] },
@@ -36,14 +37,14 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
     target: { type: 'ScreenScheme' },
   },
   {
-    src: { field: 'defaultIssueTypeId', parentTypes: ['IssueTypeScheme'] },
+    src: { field: 'defaultIssueTypeId', parentTypes: [ISSUE_TYPE_SCHEMA_NAME] },
     serializationStrategy: 'id',
-    target: { type: 'IssueType' },
+    target: { type: ISSUE_TYPE_NAME },
   },
   {
-    src: { field: 'issueTypeIds', parentTypes: ['IssueTypeScheme', 'CustomFieldContext'] },
+    src: { field: 'issueTypeIds', parentTypes: [ISSUE_TYPE_SCHEMA_NAME, 'CustomFieldContext'] },
     serializationStrategy: 'id',
-    target: { type: 'IssueType' },
+    target: { type: ISSUE_TYPE_NAME },
   },
   {
     src: { field: 'projectIds', parentTypes: ['CustomFieldContext'] },
@@ -158,7 +159,7 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
   {
     src: { field: 'issueTypeScheme', parentTypes: ['Project'] },
     serializationStrategy: 'id',
-    target: { type: 'IssueTypeScheme' },
+    target: { type: ISSUE_TYPE_SCHEMA_NAME },
   },
   {
     src: { field: 'permissionScheme', parentTypes: ['Project'] },
@@ -223,7 +224,7 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
   {
     src: { field: 'issueType', parentTypes: ['WorkflowSchemeItem'] },
     serializationStrategy: 'id',
-    target: { type: 'IssueType' },
+    target: { type: ISSUE_TYPE_NAME },
   },
   {
     src: { field: 'statusId', parentTypes: ['StatusMigration'] },
@@ -238,7 +239,7 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
   {
     src: { field: 'issueTypeId', parentTypes: ['StatusMigration'] },
     serializationStrategy: 'id',
-    target: { type: 'IssueType' },
+    target: { type: ISSUE_TYPE_NAME },
   },
   {
     src: { field: 'fieldId', parentTypes: ['BoardConfiguration_estimation'] },

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -20,7 +20,7 @@ import { mockFunction } from '@salto-io/test-utils'
 import JiraClient from '../src/client/client'
 import { adapter as adapterCreator } from '../src/adapter_creator'
 import { DEFAULT_CONFIG } from '../src/config'
-import { JIRA } from '../src/constants'
+import { ISSUE_TYPE_NAME, JIRA } from '../src/constants'
 import { createCredentialsInstance, createConfigInstance } from './utils'
 
 
@@ -93,7 +93,10 @@ describe('adapter', () => {
     it('should call deployChange with the resolved elements', async () => {
       const referencedInstance = new InstanceElement(
         'referenced',
-        new ObjectType({ elemID: new ElemID(JIRA, 'IssueType'), fields: { id: { refType: BuiltinTypes.STRING } } }),
+        new ObjectType({
+          elemID: new ElemID(JIRA, ISSUE_TYPE_NAME),
+          fields: { id: { refType: BuiltinTypes.STRING } },
+        }),
         { id: '3' }
       )
       await adapter.deploy({

--- a/packages/jira-adapter/test/change_validators/issue_type_scheme.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_scheme.test.ts
@@ -1,0 +1,81 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement, Change, getChangeData } from '@salto-io/adapter-api'
+import { issueTypeSchemeValidator } from '../../src/change_validators/issue_type_scheme'
+import { JIRA } from '../../src/constants'
+
+describe('issueTypeSchemeValidator', () => {
+  let issueTypeSchemeChange: Change
+  let issueTypeChange: Change
+
+  beforeEach(() => {
+    const issueTypeSchemeType = new ObjectType({ elemID: new ElemID(JIRA, 'IssueTypeScheme') })
+    const issueType = new ObjectType({ elemID: new ElemID(JIRA, 'IssueType') })
+
+    issueTypeSchemeChange = toChange({
+      before: new InstanceElement(
+        'instance',
+        issueTypeSchemeType,
+        {
+          isDefault: true,
+          issueTypeIds: [
+            '1',
+            '2',
+            '3',
+          ],
+        }
+      ),
+
+      after: new InstanceElement(
+        'instance',
+        issueTypeSchemeType,
+        {
+          isDefault: true,
+          issueTypeIds: [
+            '1',
+            '2',
+          ],
+        }
+      ),
+    })
+
+    issueTypeChange = toChange({
+      before: new InstanceElement(
+        'instance',
+        issueType,
+        {
+          id: '3',
+        }
+      ),
+    })
+  })
+
+  it('should return an error if an issue type was removed from the list without being deleted', async () => {
+    expect(await issueTypeSchemeValidator([issueTypeSchemeChange])).toEqual([
+      {
+        elemID: getChangeData(issueTypeSchemeChange).elemID,
+        severity: 'Error',
+        message: 'Cannot remove issue types from default issue type scheme',
+        detailedMessage: `Removing issue types from the default issue type scheme ${getChangeData(issueTypeSchemeChange).elemID.getFullName()} is not supported`,
+      },
+    ])
+  })
+
+  it('should not return an error if an issue type was removed from the list and was deleted', async () => {
+    expect(await issueTypeSchemeValidator([issueTypeSchemeChange, issueTypeChange]))
+      .toEqual([])
+  })
+})

--- a/packages/jira-adapter/test/change_validators/issue_type_scheme.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_type_scheme.test.ts
@@ -15,15 +15,15 @@
 */
 import { toChange, ObjectType, ElemID, InstanceElement, Change, getChangeData } from '@salto-io/adapter-api'
 import { issueTypeSchemeValidator } from '../../src/change_validators/issue_type_scheme'
-import { JIRA } from '../../src/constants'
+import { ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, JIRA } from '../../src/constants'
 
 describe('issueTypeSchemeValidator', () => {
   let issueTypeSchemeChange: Change
   let issueTypeChange: Change
 
   beforeEach(() => {
-    const issueTypeSchemeType = new ObjectType({ elemID: new ElemID(JIRA, 'IssueTypeScheme') })
-    const issueType = new ObjectType({ elemID: new ElemID(JIRA, 'IssueType') })
+    const issueTypeSchemeType = new ObjectType({ elemID: new ElemID(JIRA, ISSUE_TYPE_SCHEMA_NAME) })
+    const issueType = new ObjectType({ elemID: new ElemID(JIRA, ISSUE_TYPE_NAME) })
 
     issueTypeSchemeChange = toChange({
       before: new InstanceElement(

--- a/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
@@ -188,7 +188,7 @@ describe('issueTypeScheme', () => {
       })
     })
 
-    it('should not call the new issue type ids endpoint of there are no new ids', async () => {
+    it('should not call the new issue type ids endpoint if there are no new ids', async () => {
       const beforeInstance = new InstanceElement(
         'instance',
         type,
@@ -215,6 +215,64 @@ describe('issueTypeScheme', () => {
         expect.any(Object),
         undefined,
       )
+    })
+
+    it('should not call the new issue type ids endpoint if the scheme is the default scheme', async () => {
+      const beforeInstance = new InstanceElement(
+        'instance',
+        type,
+        {
+          id: '1',
+          name: 'name1',
+          issueTypeIds: ['1', '2'],
+          isDefault: true,
+        }
+      )
+
+      const afterInstance = new InstanceElement(
+        'instance',
+        type,
+        {
+          id: '1',
+          name: 'name2',
+          issueTypeIds: ['1', '2', '3'],
+          isDefault: true,
+        }
+      )
+
+      await filter.deploy?.([toChange({ before: beforeInstance, after: afterInstance })])
+      expect(mockConnection.put).not.toHaveBeenCalledWith(
+        '/rest/api/3/issuetypescheme/1/issuetype',
+        expect.any(Object),
+        undefined,
+      )
+    })
+
+    it('should not call the remove issue type ids endpoint if the scheme is the default scheme', async () => {
+      const beforeInstance = new InstanceElement(
+        'instance',
+        type,
+        {
+          id: '1',
+          name: 'name1',
+          issueTypeIds: ['1', '2', '3'],
+          isDefault: true,
+        }
+      )
+
+      const afterInstance = new InstanceElement(
+        'instance',
+        type,
+        {
+          id: '1',
+          name: 'name2',
+          issueTypeIds: ['1', '2'],
+          isDefault: true,
+        }
+      )
+
+      await filter.deploy?.([toChange({ before: beforeInstance, after: afterInstance })])
+      expect(mockConnection.delete).not.toHaveBeenCalled()
     })
 
     it('should not call the re-order endpoint of there are no changes in the ids', async () => {

--- a/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type_schemas/issue_type_scheme.test.ts
@@ -16,7 +16,7 @@
 import { BuiltinTypes, Change, CORE_ANNOTATIONS, ElemID, InstanceElement, ListType, ObjectType, toChange } from '@salto-io/adapter-api'
 import { deployment, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
-import { JIRA } from '../../../src/constants'
+import { ISSUE_TYPE_SCHEMA_NAME, JIRA } from '../../../src/constants'
 import { mockClient } from '../../utils'
 import issueTypeSchemeFilter from '../../../src/filters/issue_type_schemas/issue_type_scheme'
 import { Filter } from '../../../src/filter'
@@ -48,7 +48,7 @@ describe('issueTypeScheme', () => {
       config: DEFAULT_CONFIG,
     })
     type = new ObjectType({
-      elemID: new ElemID(JIRA, 'IssueTypeScheme'),
+      elemID: new ElemID(JIRA, ISSUE_TYPE_SCHEMA_NAME),
       fields: {
         issueTypeIds: { refType: new ListType(BuiltinTypes.STRING) },
       },
@@ -246,33 +246,6 @@ describe('issueTypeScheme', () => {
         expect.any(Object),
         undefined,
       )
-    })
-
-    it('should not call the remove issue type ids endpoint if the scheme is the default scheme', async () => {
-      const beforeInstance = new InstanceElement(
-        'instance',
-        type,
-        {
-          id: '1',
-          name: 'name1',
-          issueTypeIds: ['1', '2', '3'],
-          isDefault: true,
-        }
-      )
-
-      const afterInstance = new InstanceElement(
-        'instance',
-        type,
-        {
-          id: '1',
-          name: 'name2',
-          issueTypeIds: ['1', '2'],
-          isDefault: true,
-        }
-      )
-
-      await filter.deploy?.([toChange({ before: beforeInstance, after: afterInstance })])
-      expect(mockConnection.delete).not.toHaveBeenCalled()
     })
 
     it('should not call the re-order endpoint of there are no changes in the ids', async () => {

--- a/packages/jira-adapter/test/mock_elements.ts
+++ b/packages/jira-adapter/test/mock_elements.ts
@@ -24,7 +24,7 @@ import {
   ReferenceExpression,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
-import { JIRA } from '../src/constants'
+import { ISSUE_TYPE_SCHEMA_NAME, JIRA } from '../src/constants'
 
 const { ADDITIONAL_PROPERTIES_FIELD } = elementsUtils.swagger
 
@@ -59,7 +59,7 @@ const issueTypeSchemeMappingType = new ObjectType({
 })
 
 const issueTypeSchemeType = new ObjectType({
-  elemID: new ElemID(JIRA, 'IssueTypeScheme'),
+  elemID: new ElemID(JIRA, ISSUE_TYPE_SCHEMA_NAME),
   fields: {
     issueTypeIds: { refType: new ListType(issueTypeSchemeMappingType) },
   },


### PR DESCRIPTION
Fixed adding and removing issue types from the default issue type scheme

---

The default issueTypeScheme always contains all of the issueTypes. That creates two problems:

- When creating a new issueType and adding it to the list, we get an error on deploy because when we create the issueType it is automatically added to the default issue type scheme so when we call the endpoint to add it to the list we fail because it's already there. For that, we can just ignore the new ids if the scheme is the default scheme

- Removing an issue type from the default scheme is not supported, so if an issue type was removed from the list, we need to check if it was really deleted

---
_Release Notes_: 
None

---
_User Notifications_: 
None