### PR TITLE
SALTO-1860: removal changes on custom field options and variants should be done last

### DIFF
--- a/packages/zendesk-support-adapter/src/filters/custom_field_options/creator.ts
+++ b/packages/zendesk-support-adapter/src/filters/custom_field_options/creator.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import {
   Change, getChangeData, InstanceElement, isInstanceElement, Element,
-  isObjectType, Field, BuiltinTypes, ReferenceExpression,
+  isObjectType, Field, BuiltinTypes, ReferenceExpression, isRemovalChange,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { getParents } from '@salto-io/adapter-utils'
@@ -114,8 +114,9 @@ export const createCustomFieldOptionsFilterCreator = (
       change => getChangeData(change).elemID.typeName === parentTypeName,
     )
     if (parentChanges.length === 0) {
+      const [removalChanges, nonRemovalChanges] = _.partition(childrenChanges, isRemovalChange)
       const deployResult = await deployChanges(
-        childrenChanges,
+        [...nonRemovalChanges, ...removalChanges],
         async change => {
           await deployChange(change, client, config.apiDefinitions)
         }

--- a/packages/zendesk-support-adapter/src/filters/dynamic_content.ts
+++ b/packages/zendesk-support-adapter/src/filters/dynamic_content.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  Change, getChangeData, InstanceElement, isAdditionChange, isModificationChange,
+  Change, getChangeData, InstanceElement, isAdditionChange, isModificationChange, isRemovalChange,
 } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
@@ -71,8 +71,9 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
       change => getChangeData(change).elemID.typeName === DYNAMIC_CONTENT_ITEM_TYPE_NAME,
     )
     if (itemChanges.length === 0 || itemChanges.every(isModificationChange)) {
+      const [removalChanges, nonRemovalChanges] = _.partition(relevantChanges, isRemovalChange)
       const deployResult = await deployChanges(
-        relevantChanges,
+        [...nonRemovalChanges, ...removalChanges],
         async change => {
           await deployChange(change, client, config.apiDefinitions)
         }


### PR DESCRIPTION
_Removal changes on custom field options and variants should be done last_

---

_Additional context for reviewer_
Handles the case where we first try to remove the only variant(s) and then add them (we can't leave an item with no variants). Same thing applies to custom fields options

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
