### PR TITLE
SALTO-1961: fixed contexts field

### DIFF
--- a/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
@@ -19,13 +19,20 @@ import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../../filter'
 import { deployContextChange, setContextDeploymentAnnotations } from './contexts'
 import { deployChanges } from '../../deployment'
-import { FIELD_CONTEXT_TYPE_NAME } from './constants'
-import { findObject } from '../../utils'
+import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from './constants'
+import { findObject, setDeploymentAnnotations } from '../../utils'
 
 const log = logger(module)
 
 const filter: FilterCreator = ({ client, config }) => ({
   onFetch: async (elements: Element[]) => {
+    const fieldType = findObject(elements, FIELD_TYPE_NAME)
+    if (fieldType === undefined) {
+      log.warn(`Could not find type ${FIELD_TYPE_NAME}`)
+    } else {
+      setDeploymentAnnotations(fieldType, 'contexts')
+    }
+
     const fieldContextType = findObject(elements, FIELD_CONTEXT_TYPE_NAME)
     if (fieldContextType === undefined) {
       log.warn(`Could not find type ${FIELD_CONTEXT_TYPE_NAME}`)

--- a/packages/jira-adapter/src/filters/fields/contexts.ts
+++ b/packages/jira-adapter/src/filters/fields/contexts.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { AdditionChange, Change, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionChange, isMapType, isObjectType, isRemovalChange, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { AdditionChange, Change, CORE_ANNOTATIONS, getChangeData, InstanceElement, isAdditionChange, isListType, isObjectType, isRemovalChange, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
 import { config, client as clientUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
@@ -32,8 +32,8 @@ const log = logger(module)
 export const getContextType = async (fieldType: ObjectType):
 Promise<ObjectType> => {
   const contextMapType = await fieldType.fields.contexts.getType()
-  if (!isMapType(contextMapType)) {
-    throw new Error(`type of ${fieldType.fields.contexts.elemID.getFullName()} is not a map type`)
+  if (!isListType(contextMapType)) {
+    throw new Error(`type of ${fieldType.fields.contexts.elemID.getFullName()} is not a list type`)
   }
 
   const contextType = await contextMapType.getInnerType()

--- a/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
@@ -211,8 +211,6 @@ const filter: FilterCreator = ({ config }) => ({
     delete fieldType.fields.contextProjects
     delete fieldType.fields.contextIssueTypes
 
-    fieldType.fields.contexts = new Field(fieldType, 'contexts', new MapType(fieldContextType))
-
     fieldContextType.fields.projectIds = new Field(fieldContextType, 'projectIds', new ListType(BuiltinTypes.STRING))
     fieldContextType.fields.issueTypeIds = new Field(fieldContextType, 'issueTypeIds', new ListType(BuiltinTypes.STRING))
     fieldContextType.fields.defaultValue = new Field(fieldContextType, 'defaultValue', fieldContextDefaultValueType)

--- a/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
@@ -26,6 +26,7 @@ import { FIELD_CONTEXT_TYPE_NAME } from '../../../src/filters/fields/constants'
 
 describe('fieldContextDeployment', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let fieldType: ObjectType
   let contextType: ObjectType
   let optionType: ObjectType
   let defaultValueType: ObjectType
@@ -73,11 +74,23 @@ describe('fieldContextDeployment', () => {
         issueTypeIds: { refType: new ListType(BuiltinTypes.STRING) },
       },
     })
+
+    fieldType = new ObjectType({
+      elemID: new ElemID(JIRA, 'Field'),
+      fields: {
+        contexts: { refType: new ListType(contextType) },
+      },
+    })
   })
 
   describe('onFetch', () => {
     it('should add deployment annotations to context type', async () => {
-      await filter.onFetch([contextType])
+      await filter.onFetch([fieldType, contextType])
+
+      expect(fieldType.fields.contexts.annotations).toEqual({
+        [CORE_ANNOTATIONS.CREATABLE]: true,
+        [CORE_ANNOTATIONS.UPDATABLE]: true,
+      })
 
       expect(contextType.fields.projectIds.annotations).toEqual({
         [CORE_ANNOTATIONS.CREATABLE]: true,

--- a/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, MapType, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, InstanceElement, ListType, MapType, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import { deployment, filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
 import { mockClient } from '../../utils'
@@ -71,7 +71,7 @@ describe('fields_deployment', () => {
     fieldType = new ObjectType({
       elemID: new ElemID(JIRA, FIELD_TYPE_NAME),
       fields: {
-        contexts: { refType: new MapType(contextType) },
+        contexts: { refType: new ListType(contextType) },
       },
     })
   })


### PR DESCRIPTION
Added deployment annotation to field contexts so we won't get a warning when attempting to deploy it and fixed it's type (it was map when it was supposed to be list)

---
_Release Notes_: 
None

---
_User Notifications_: 
None