### PR TITLE
SALTO-1962: Replaced swaggers URL without our repo

### DIFF
--- a/packages/jira-adapter/README.md
+++ b/packages/jira-adapter/README.md
@@ -9,3 +9,8 @@ Salto supports authenticating with Atlassian Jira using a user email and an API 
 - Create a new token
 - Connect to Jira with the command 'salto service add jira' or 'salto service login jira'.
 - You will be asked to provide the Atlassian Base URL (e.g. https://acme.atlassian.net/), the user email, and the token you created.
+
+## Jira Swaggers
+
+The Jira adapter is heavily relying on the [Atlassian JIRA Cloud platform](https://developer.atlassian.com/cloud/jira/platform/rest/v3/) and [Atlassian JIRA Software Cloud](https://developer.atlassian.com/cloud/jira/software/rest) API swagger definitions.
+To make sure the adapter won't unexpectedly break due to a change in one of the swaggers. The adapter uses the swaggers [Jira Swaggers Repository](https://github.com/salto-io/jira-swaggers) which will contain the latest swagger version that this adapter was tested on.

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1309,7 +1309,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
 
 export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
   platformSwagger: {
-    url: 'https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json',
+    url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/main/platform-swagger.v3.json',
     typeNameOverrides: [
       {
         originalName: 'FilterDetails',
@@ -1438,7 +1438,7 @@ export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
     ],
   },
   jiraSwagger: {
-    url: 'https://developer.atlassian.com/cloud/jira/software/swagger.v3.json',
+    url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/main/software-swagger.v3.json',
     typeNameOverrides: [
       {
         originalName: 'rest__agile__1_0__board@uuuuvuu',

--- a/packages/jira-adapter/system_config_doc.md
+++ b/packages/jira-adapter/system_config_doc.md
@@ -4,7 +4,7 @@
 jira {
   apiDefinitions = {
     platformSwagger = {
-      url = "https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json"
+      url = "https://raw.githubusercontent.com/salto-io/jira-swaggers/main/platform-swagger.v3.json"
       typeNameOverrides = [
         {
           originalName = "FilterDetails"
@@ -133,7 +133,7 @@ jira {
       ]
     }
     jiraSwagger = {
-      url = "https://developer.atlassian.com/cloud/jira/software/swagger.v3.json"
+      url = "https://raw.githubusercontent.com/salto-io/jira-swaggers/main/software-swagger.v3.json"
       typeNameOverrides = [
         {
           originalName = "rest__agile__1_0__board@uuuuvuu"

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -215,13 +215,13 @@ describe('adapter', () => {
     })
     it('should generate types for the platform and the jira apis', () => {
       expect(loadSwagger).toHaveBeenCalledTimes(2)
-      expect(loadSwagger).toHaveBeenCalledWith('https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json')
-      expect(loadSwagger).toHaveBeenCalledWith('https://developer.atlassian.com/cloud/jira/software/swagger.v3.json')
+      expect(loadSwagger).toHaveBeenCalledWith('https://raw.githubusercontent.com/salto-io/jira-swaggers/main/platform-swagger.v3.json')
+      expect(loadSwagger).toHaveBeenCalledWith('https://raw.githubusercontent.com/salto-io/jira-swaggers/main/software-swagger.v3.json')
       expect(generateTypes).toHaveBeenCalledWith(
         JIRA,
         expect.objectContaining({
           swagger: expect.objectContaining({
-            url: 'https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json',
+            url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/main/platform-swagger.v3.json',
           }),
         }),
         undefined,
@@ -231,7 +231,7 @@ describe('adapter', () => {
         JIRA,
         expect.objectContaining({
           swagger: expect.objectContaining({
-            url: 'https://developer.atlassian.com/cloud/jira/software/swagger.v3.json',
+            url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/main/software-swagger.v3.json',
           }),
         }),
         undefined,


### PR DESCRIPTION
Replaced URL of Jira swagger with the URL of our repo

---
_Release Notes_: 
None

---
_User Notifications_: 
None