### PR TITLE
SALTO-1966: always have at least an empty type for any deployable instance

### DIFF
--- a/packages/adapter-components/src/config/ducktype.ts
+++ b/packages/adapter-components/src/config/ducktype.ts
@@ -104,3 +104,9 @@ export const validateFetchConfig = (
     throw Error(`Invalid type names in ${fetchConfigPath}: ${invalidIncludeTypes}`)
   }
 }
+
+export const getTransformationConfigByType = (typesConfig: Record<string, TypeDuckTypeConfig>):
+Record<string, DuckTypeTransformationConfig> => _.pickBy(
+  _.mapValues(typesConfig, def => def.transformation),
+  isDefined,
+)

--- a/packages/adapter-components/src/config/ducktype.ts
+++ b/packages/adapter-components/src/config/ducktype.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { ObjectType, BuiltinTypes, FieldDefinition } from '@salto-io/adapter-api'
 import { values as lowerDashValues } from '@salto-io/lowerdash'
 import { AdapterApiConfig, createAdapterApiConfigType, UserFetchConfig, TypeConfig, TypeDefaultsConfig } from './shared'
-import { TransformationConfig, TransformationDefaultConfig, createTransformationConfigTypes, validateTransoformationConfig } from './transformation'
+import { TransformationConfig, TransformationDefaultConfig, createTransformationConfigTypes, validateTransoformationConfig, getTransformationConfigByType } from './transformation'
 import { createRequestConfigs, validateRequestConfig } from './request'
 
 const { isDefined } = lowerDashValues
@@ -80,10 +80,7 @@ export const validateApiDefinitionConfig = (
   validateTransoformationConfig(
     apiDefinitionConfigPath,
     adapterApiConfig.typeDefaults.transformation,
-    _.pickBy(
-      _.mapValues(adapterApiConfig.types, typeDef => typeDef.transformation),
-      isDefined,
-    ),
+    getTransformationConfigByType(adapterApiConfig.types),
   )
 }
 
@@ -104,9 +101,3 @@ export const validateFetchConfig = (
     throw Error(`Invalid type names in ${fetchConfigPath}: ${invalidIncludeTypes}`)
   }
 }
-
-export const getTransformationConfigByType = (typesConfig: Record<string, TypeDuckTypeConfig>):
-Record<string, DuckTypeTransformationConfig> => _.pickBy(
-  _.mapValues(typesConfig, def => def.transformation),
-  isDefined,
-)

--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateApiDefinitionConfig as validateDuckTypeApiDefinitionConfig, validateFetchConfig as validateDuckTypeFetchConfig, DuckTypeUserFetchConfig } from './ducktype'
+export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateApiDefinitionConfig as validateDuckTypeApiDefinitionConfig, validateFetchConfig as validateDuckTypeFetchConfig, DuckTypeUserFetchConfig, getTransformationConfigByType } from './ducktype'
 export { createRequestConfigs, validateRequestConfig, FetchRequestConfig, DeployRequestConfig, UrlParams, DeploymentRequestsByAction, RecurseIntoCondition, isRecurseIntoConditionByField } from './request'
 export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig, createUserFetchConfigType } from './shared'
 export { mergeWithDefaultConfig } from './merge'

--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -13,9 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateApiDefinitionConfig as validateDuckTypeApiDefinitionConfig, validateFetchConfig as validateDuckTypeFetchConfig, DuckTypeUserFetchConfig, getTransformationConfigByType } from './ducktype'
+export { createDucktypeAdapterApiConfigType, AdapterDuckTypeApiConfig, DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig, validateApiDefinitionConfig as validateDuckTypeApiDefinitionConfig, validateFetchConfig as validateDuckTypeFetchConfig, DuckTypeUserFetchConfig } from './ducktype'
 export { createRequestConfigs, validateRequestConfig, FetchRequestConfig, DeployRequestConfig, UrlParams, DeploymentRequestsByAction, RecurseIntoCondition, isRecurseIntoConditionByField } from './request'
 export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig, createUserFetchConfigType } from './shared'
 export { mergeWithDefaultConfig } from './merge'
 export { createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, TypeNameOverrideConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig, validateFetchConfig as validateSwaggerFetchConfig } from './swagger'
-export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType } from './transformation'
+export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType, getTransformationConfigByType } from './transformation'

--- a/packages/adapter-components/src/config/swagger.ts
+++ b/packages/adapter-components/src/config/swagger.ts
@@ -18,7 +18,7 @@ import { ObjectType, ElemID, BuiltinTypes, CORE_ANNOTATIONS, FieldDefinition, Li
 import { types, values as lowerDashValues } from '@salto-io/lowerdash'
 import { AdapterApiConfig, createAdapterApiConfigType, TypeConfig, TypeDefaultsConfig, UserFetchConfig } from './shared'
 import { createRequestConfigs, validateRequestConfig } from './request'
-import { createTransformationConfigTypes, validateTransoformationConfig } from './transformation'
+import { createTransformationConfigTypes, getTransformationConfigByType, validateTransoformationConfig } from './transformation'
 import { findDuplicates } from './validation_utils'
 
 const { isDefined } = lowerDashValues
@@ -162,10 +162,7 @@ export const validateApiDefinitionConfig = (
   validateTransoformationConfig(
     apiDefinitionConfigPath,
     adapterApiConfig.typeDefaults.transformation,
-    _.pickBy(
-      _.mapValues(adapterApiConfig.types, typeDef => typeDef.transformation),
-      isDefined,
-    ),
+    getTransformationConfigByType(adapterApiConfig.types),
   )
   // TODO after loading the swagger and parsing the types,
   // add change suggestions for values that catch nothing

--- a/packages/adapter-components/src/config/transformation.ts
+++ b/packages/adapter-components/src/config/transformation.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { ElemID, ObjectType, BuiltinTypes, CORE_ANNOTATIONS,
   FieldDefinition, ListType, RestrictionAnnotationType } from '@salto-io/adapter-api'
-import { types } from '@salto-io/lowerdash'
+import { types, values } from '@salto-io/lowerdash'
 import { findDuplicates } from './validation_utils'
 import { getConfigWithDefault, TypeConfig, TypeDefaultsConfig } from './shared'
 
@@ -223,4 +223,10 @@ export const getTypeTransformationConfig = (
     typeConfig[typeName]?.transformation,
     typeDefaultConfig.transformation,
   )
+)
+
+export const getTransformationConfigByType = (typesConfig: Record<string, TypeConfig>):
+Record<string, TransformationConfig> => _.pickBy(
+  _.mapValues(typesConfig, def => def.transformation),
+  values.isDefined,
 )

--- a/packages/adapter-components/src/elements/ducktype/add_remaining_types.ts
+++ b/packages/adapter-components/src/elements/ducktype/add_remaining_types.ts
@@ -21,7 +21,10 @@ import { DATA_FIELD_ENTIRE_OBJECT } from '../../config/transformation'
 import { getTransformationConfigByType, TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig } from '../../config'
 
 /**
- * Adds the types that supposed to exist but weren't created since they had no instances
+ * Add empty object types for all types that can have instances in the workspace,
+ *  even if no instances will be created for them in the current fetch.
+ * This is needed because if instances are added / cloned from another environment,
+ *  they need to have a type in order to be deployed.
  *
  * Note: modifies the elements array in-place.
  */

--- a/packages/adapter-components/src/elements/ducktype/add_remaining_types.ts
+++ b/packages/adapter-components/src/elements/ducktype/add_remaining_types.ts
@@ -1,0 +1,56 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ElemID, isObjectType, ObjectType, Element } from '@salto-io/adapter-api'
+import { toNestedTypeName } from './type_elements'
+import { DATA_FIELD_ENTIRE_OBJECT } from '../../config/transformation'
+import { TypeDuckTypeConfig } from '../../config'
+
+export const addRemainingTypes = ({
+  elements, typesConfig, adapterName,
+}: {
+  elements: Element[]
+  typesConfig: Record<string, TypeDuckTypeConfig>
+  adapterName: string
+}): void => {
+  const sourceTypeNameToTypeName = _(typesConfig)
+    .pickBy(typeConfig => typeConfig.transformation?.sourceTypeName !== undefined)
+    .entries()
+    .map(([typeName, typeConfig]) => [typeConfig?.transformation?.sourceTypeName, typeName])
+    .fromPairs()
+    .value()
+  const typeNames = _(typesConfig)
+    .entries()
+    .flatMap(([typeName, typeConfig]) => {
+      const dataField = typeConfig.transformation?.dataField
+      const standAloneFields = typeConfig.transformation?.standaloneFields
+      const nestedFields = [
+        ...((dataField && dataField !== DATA_FIELD_ENTIRE_OBJECT) ? [dataField] : []),
+        ...(standAloneFields ?? []).map(field => field.fieldName),
+      ].map(fieldName => toNestedTypeName(typeName, fieldName))
+      return [typeName, ...nestedFields]
+    })
+    .map(typeName => sourceTypeNameToTypeName[typeName] ?? typeName)
+    .uniq()
+    .value()
+  const existingTypeNames = new Set(elements
+    .filter(isObjectType)
+    .map(e => e.elemID.typeName))
+  const typesToAdd = typeNames
+    .filter(typeName => !existingTypeNames.has(typeName))
+    .map(typeName => new ObjectType({ elemID: new ElemID(adapterName, typeName) }))
+  elements.push(...typesToAdd)
+}

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -29,6 +29,7 @@ import { getElementsWithContext } from '../element_getter'
 import { extractStandaloneFields } from './standalone_field_extractor'
 import { fixFieldTypes } from '../type_elements'
 import { shouldRecurseIntoEntry } from '../instance_elements'
+import { addRemainingTypes } from './add_remaining_types'
 
 const { makeArray } = collections.array
 const { toArrayAsync, awu } = collections.asynciterable
@@ -326,5 +327,9 @@ export const getAllElements = async ({
     typeDefaults,
     (val: string) => _.get(duckTypeTypeMap, val, BuiltinTypes.UNKNOWN),
   )
-  return [...Object.values(objectTypes), ...elements.filter(e => !isObjectType(e))]
+  const instancesAndTypes = [
+    ...Object.values(objectTypes), ...elements.filter(e => !isObjectType(e)),
+  ]
+  addRemainingTypes({ adapterName, elements: instancesAndTypes, typesConfig: types })
+  return instancesAndTypes
 }

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -330,6 +330,6 @@ export const getAllElements = async ({
   const instancesAndTypes = [
     ...Object.values(objectTypes), ...elements.filter(e => !isObjectType(e)),
   ]
-  addRemainingTypes({ adapterName, elements: instancesAndTypes, typesConfig: types })
+  addRemainingTypes({ adapterName, elements: instancesAndTypes, typesConfig: types, includeTypes })
   return instancesAndTypes
 }

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -330,6 +330,13 @@ export const getAllElements = async ({
   const instancesAndTypes = [
     ...Object.values(objectTypes), ...elements.filter(e => !isObjectType(e)),
   ]
-  addRemainingTypes({ adapterName, elements: instancesAndTypes, typesConfig: types, includeTypes })
+  addRemainingTypes({
+    adapterName,
+    elements: instancesAndTypes,
+    typesConfig: types,
+    includeTypes,
+    typeDefaultConfig: typeDefaults,
+    hideTypes,
+  })
   return instancesAndTypes
 }

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -21,7 +21,7 @@ import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
 import { Paginator, ResponseValue } from '../../client'
 import { generateType } from './type_elements'
 import { toInstance } from './instance_elements'
-import { TypeConfig, getConfigWithDefault } from '../../config'
+import { TypeConfig, getConfigWithDefault, getTransformationConfigByType } from '../../config'
 import { FindNestedFieldFunc } from '../field_finder'
 import { TypeDuckTypeDefaultsConfig, TypeDuckTypeConfig } from '../../config/ducktype'
 import { ComputeGetArgsFunc } from '../request_parameters'
@@ -92,10 +92,7 @@ const getEntriesForType = async (
     // escape "field" names that contain '.'
     .map(values => _.mapKeys(values, (_val, key) => naclCase(key)))
 
-  const transformationConfigByType = _.pickBy(
-    _.mapValues(typesConfig, def => def.transformation),
-    isDefined,
-  )
+  const transformationConfigByType = getTransformationConfigByType(typesConfig)
   const transformationDefaultConfig = typeDefaultConfig.transformation
 
   // types with dynamic fields will be associated with the dynamic_keys type
@@ -244,10 +241,7 @@ export const getTypeAndInstances = async ({
     getElemIdFunc,
   })
   const elements = [entries.type, ...entries.nestedTypes, ...entries.instances]
-  const transformationConfigByType = _.pickBy(
-    _.mapValues(typesConfig, def => def.transformation),
-    isDefined,
-  )
+  const transformationConfigByType = getTransformationConfigByType(typesConfig)
 
   // We currently don't support extracting standalone fields from the types we recursed into
   await extractStandaloneFields({

--- a/packages/adapter-components/src/elements/ducktype/type_elements.ts
+++ b/packages/adapter-components/src/elements/ducktype/type_elements.ts
@@ -24,7 +24,7 @@ import { DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, getC
 import { TYPES_PATH, SUBTYPES_PATH } from '../constants'
 import { hideFields, markServiceIdField } from '../type_elements'
 
-export const ID_SEPARATOR = '__'
+const ID_SEPARATOR = '__'
 
 export const toNestedTypeName = (parentName: string, nestedTypeName: string): string => (
   `${parentName}${ID_SEPARATOR}${nestedTypeName}`

--- a/packages/adapter-components/src/elements/ducktype/type_elements.ts
+++ b/packages/adapter-components/src/elements/ducktype/type_elements.ts
@@ -24,7 +24,7 @@ import { DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, getC
 import { TYPES_PATH, SUBTYPES_PATH } from '../constants'
 import { hideFields, markServiceIdField } from '../type_elements'
 
-const ID_SEPARATOR = '__'
+export const ID_SEPARATOR = '__'
 
 export const toNestedTypeName = (parentName: string, nestedTypeName: string): string => (
   `${parentName}${ID_SEPARATOR}${nestedTypeName}`

--- a/packages/adapter-components/test/elements/ducktype/add_remaining_types.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/add_remaining_types.test.ts
@@ -1,0 +1,103 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, InstanceElement, Element, BuiltinTypes } from '@salto-io/adapter-api'
+import { TypeDuckTypeConfig } from '../../../src/config'
+import { addRemainingTypes } from '../../../src/elements/ducktype/add_remaining_types'
+
+const ADAPTER_NAME = 'myAdapter'
+
+describe('add remaining types', () => {
+  const typesConfig: Record<string, TypeDuckTypeConfig> = {
+    folder: {
+      request: {
+        url: '/folders',
+      },
+      transformation: {
+        idFields: ['name'],
+        standaloneFields: [{ fieldName: 'subfolders' }],
+      },
+    },
+    file: {
+      request: {
+        url: '/files',
+        dependsOn: [
+          // id doesn't actually exist in the url so this configuration is not realistic
+          { pathParam: 'id', from: { type: 'folder', field: 'id' } },
+        ],
+      },
+    },
+    permission: {
+      request: {
+        url: '/permissions',
+        queryParams: {
+          folderId: 'abc',
+        },
+      },
+      transformation: {
+        dataField: '.',
+      },
+    },
+    workflow: {
+      request: {
+        url: '/workflows',
+      },
+      transformation: {
+        standaloneFields: [{ fieldName: 'flows' }],
+      },
+    },
+    subfolders: {
+      transformation: {
+        sourceTypeName: 'folder__subfolders',
+        dataField: 'value',
+      },
+    },
+  }
+  it('should create all the needed types if elements exist', () => {
+    const elements: Element[] = []
+    addRemainingTypes({ elements, typesConfig, adapterName: ADAPTER_NAME })
+    expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
+      'myAdapter.file',
+      'myAdapter.folder',
+      'myAdapter.permission',
+      'myAdapter.subfolders',
+      'myAdapter.subfolders__value',
+      'myAdapter.workflow',
+      'myAdapter.workflow__flows',
+    ])
+  })
+  it('should not remove existing types and instances', () => {
+    const fileType = new ObjectType({
+      elemID: new ElemID(ADAPTER_NAME, 'file'),
+      fields: { test: { refType: BuiltinTypes.STRING } },
+    })
+    const fileInstance = new InstanceElement('file1', fileType, { test: 'test1' })
+    const elements = [fileType, fileInstance]
+    addRemainingTypes({ elements, typesConfig, adapterName: ADAPTER_NAME })
+    expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
+      'myAdapter.file',
+      'myAdapter.file.instance.file1',
+      'myAdapter.folder',
+      'myAdapter.permission',
+      'myAdapter.subfolders',
+      'myAdapter.subfolders__value',
+      'myAdapter.workflow',
+      'myAdapter.workflow__flows',
+    ])
+    expect(elements.find(e => e.elemID.getFullName() === 'myAdapter.file')).toEqual(fileType)
+    expect(elements.find(e => e.elemID.getFullName() === 'myAdapter.file.instance.file1'))
+      .toEqual(fileInstance)
+  })
+})

--- a/packages/adapter-components/test/elements/ducktype/add_remaining_types.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/add_remaining_types.test.ts
@@ -14,12 +14,13 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, Element, BuiltinTypes } from '@salto-io/adapter-api'
-import { TypeDuckTypeConfig } from '../../../src/config'
+import { TypeDuckTypeConfig, TypeDuckTypeDefaultsConfig } from '../../../src/config'
 import { addRemainingTypes } from '../../../src/elements/ducktype/add_remaining_types'
 
 const ADAPTER_NAME = 'myAdapter'
 
 describe('add remaining types', () => {
+  const typeDefaultConfig: TypeDuckTypeDefaultsConfig = { transformation: { idFields: ['name'] } }
   const typesConfig: Record<string, TypeDuckTypeConfig> = {
     folder: {
       request: {
@@ -69,7 +70,14 @@ describe('add remaining types', () => {
   const includeTypes = ['dir', 'file', 'permission', 'workflow']
   it('should create all the needed types if elements exist', () => {
     const elements: Element[] = []
-    addRemainingTypes({ elements, typesConfig, adapterName: ADAPTER_NAME, includeTypes })
+    addRemainingTypes({
+      elements,
+      typesConfig,
+      adapterName: ADAPTER_NAME,
+      includeTypes,
+      typeDefaultConfig,
+      hideTypes: false,
+    })
     expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
       'myAdapter.file',
       'myAdapter.folder',
@@ -87,7 +95,14 @@ describe('add remaining types', () => {
     })
     const fileInstance = new InstanceElement('file1', fileType, { test: 'test1' })
     const elements = [fileType, fileInstance]
-    addRemainingTypes({ elements, typesConfig, adapterName: ADAPTER_NAME, includeTypes })
+    addRemainingTypes({
+      elements,
+      typesConfig,
+      adapterName: ADAPTER_NAME,
+      includeTypes,
+      typeDefaultConfig,
+      hideTypes: false,
+    })
     expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
       'myAdapter.file',
       'myAdapter.file.instance.file1',

--- a/packages/adapter-components/test/elements/ducktype/add_remaining_types.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/add_remaining_types.test.ts
@@ -28,6 +28,7 @@ describe('add remaining types', () => {
       transformation: {
         idFields: ['name'],
         standaloneFields: [{ fieldName: 'subfolders' }],
+        sourceTypeName: 'dir',
       },
     },
     file: {
@@ -65,9 +66,10 @@ describe('add remaining types', () => {
       },
     },
   }
+  const includeTypes = ['dir', 'file', 'permission', 'workflow']
   it('should create all the needed types if elements exist', () => {
     const elements: Element[] = []
-    addRemainingTypes({ elements, typesConfig, adapterName: ADAPTER_NAME })
+    addRemainingTypes({ elements, typesConfig, adapterName: ADAPTER_NAME, includeTypes })
     expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
       'myAdapter.file',
       'myAdapter.folder',
@@ -85,7 +87,7 @@ describe('add remaining types', () => {
     })
     const fileInstance = new InstanceElement('file1', fileType, { test: 'test1' })
     const elements = [fileType, fileInstance]
-    addRemainingTypes({ elements, typesConfig, adapterName: ADAPTER_NAME })
+    addRemainingTypes({ elements, typesConfig, adapterName: ADAPTER_NAME, includeTypes })
     expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
       'myAdapter.file',
       'myAdapter.file.instance.file1',

--- a/packages/adapter-components/test/elements/ducktype/transformer.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/transformer.test.ts
@@ -537,7 +537,7 @@ describe('ducktype_transformer', () => {
         types: typesConfig,
         typeDefaults: typeDefaultConfig,
       })
-      expect(res).toHaveLength(6)
+      expect(res).toHaveLength(8)
       expect(res.map(e => e.elemID.getFullName())).toEqual([
         'something.folder',
         'something.permission',
@@ -545,6 +545,8 @@ describe('ducktype_transformer', () => {
         'something.folder.instance.abc',
         'something.permission.instance.abc',
         'something.file.instance.abc',
+        'something.folder__subfolders',
+        'something.workflow',
       ])
       expect(transformer.getTypeAndInstances).toHaveBeenCalledTimes(3)
       expect(transformer.getTypeAndInstances).toHaveBeenCalledWith({

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -273,11 +273,8 @@ describe('adapter', () => {
           ),
           elementsSource: buildElementsSourceFromElements([]),
         }).fetch({ progressReporter: { reportProgress: () => null } })
-        expect(elements).toHaveLength(7)
-        expect(elements.filter(isObjectType)).toHaveLength(1)
-        expect(elements.filter(isInstanceElement)).toHaveLength(6)
-        expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
-          'workato.connection',
+        const intances = elements.filter(isInstanceElement)
+        expect(intances.map(e => e.elemID.getFullName()).sort()).toEqual([
           'workato.connection.instance.HTTP_connection_1@s',
           'workato.connection.instance.My_Gmail_connection@s',
           'workato.connection.instance.My_Google_sheets_connection@s',

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -273,14 +273,23 @@ describe('adapter', () => {
           ),
           elementsSource: buildElementsSourceFromElements([]),
         }).fetch({ progressReporter: { reportProgress: () => null } })
-        const intances = elements.filter(isInstanceElement)
-        expect(intances.map(e => e.elemID.getFullName()).sort()).toEqual([
+        expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
+          'workato.api_access_profile',
+          'workato.api_client',
+          'workato.api_collection',
+          'workato.api_endpoint',
+          'workato.connection',
           'workato.connection.instance.HTTP_connection_1@s',
           'workato.connection.instance.My_Gmail_connection@s',
           'workato.connection.instance.My_Google_sheets_connection@s',
           'workato.connection.instance.Test_NetSuite_account@s',
           'workato.connection.instance.dev2_sfdc_account@s',
           'workato.connection.instance.sfdev1',
+          'workato.folder',
+          'workato.property',
+          'workato.recipe',
+          'workato.recipe__code',
+          'workato.role',
         ])
       })
     })

--- a/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
@@ -74,7 +74,7 @@ export const createReorderFilterCreator = (
       { [orderFieldName]: instancesReferences },
       [ZENDESK_SUPPORT, RECORDS_PATH, typeName, typeNameNaclCase],
     )
-    // Those types are already exist since we added the empty version of them
+    // Those types already exist since we added the empty version of them
     //  via the add remaining types mechanism. So we first need to remove the old versions
     _.remove(elements, element => element.elemID.isEqual(type.elemID))
     elements.push(type, instance)

--- a/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
@@ -74,6 +74,8 @@ export const createReorderFilterCreator = (
       { [orderFieldName]: instancesReferences },
       [ZENDESK_SUPPORT, RECORDS_PATH, typeName, typeNameNaclCase],
     )
+    // Those types are already exist since we added the empty version of them
+    //  via the add remaining types mechanism. So we first need to remove the old versions
     _.remove(elements, element => element.elemID.isEqual(type.elemID))
     elements.push(type, instance)
   },

--- a/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
@@ -74,6 +74,7 @@ export const createReorderFilterCreator = (
       { [orderFieldName]: instancesReferences },
       [ZENDESK_SUPPORT, RECORDS_PATH, typeName, typeNameNaclCase],
     )
+    _.remove(elements, element => element.elemID.isEqual(type.elemID))
     elements.push(type, instance)
   },
   deploy: async (changes: Change<InstanceElement>[]) => {

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -558,7 +558,9 @@ describe('adapter', () => {
       })
       const { elements } = await operations
         .fetch({ progressReporter: { reportProgress: () => null } })
-      const instances = elements.filter(isInstanceElement)
+      const instances = elements
+        .filter(isInstanceElement)
+        .filter(inst => inst.elemID.typeName === 'group')
       expect(instances).toHaveLength(4)
       expect(instances.map(e => e.elemID.getFullName()).sort()).toEqual([
         'zendesk_support.group.instance.Support',
@@ -588,7 +590,9 @@ describe('adapter', () => {
       )
       const { elements: newElements } = await operations
         .fetch({ progressReporter: { reportProgress: () => null } })
-      const newInstances = newElements.filter(isInstanceElement)
+      const newInstances = newElements
+        .filter(isInstanceElement)
+        .filter(inst => inst.elemID.typeName === 'group')
       expect(newInstances.map(e => e.elemID.getFullName()).sort()).toEqual([
         'zendesk_support.group.instance.Support',
       ])

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -80,8 +80,8 @@ describe('adapter', () => {
           ),
           elementsSource: buildElementsSourceFromElements([]),
         }).fetch({ progressReporter: { reportProgress: () => null } })
-        expect(elements).toHaveLength(354)
-        expect(elements.filter(isObjectType)).toHaveLength(180)
+        expect(elements).toHaveLength(362)
+        expect(elements.filter(isObjectType)).toHaveLength(188)
         expect(elements.filter(isInstanceElement)).toHaveLength(174)
         expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
           'zendesk_support.account_setting',
@@ -124,6 +124,7 @@ describe('adapter', () => {
           'zendesk_support.app_installation__settings',
           'zendesk_support.app_installation__settings_objects',
           'zendesk_support.app_installations',
+          'zendesk_support.app_owned',
           'zendesk_support.apps_owned',
           'zendesk_support.automation',
           'zendesk_support.automation.instance.Close_ticket_4_days_after_status_is_set_to_solved@s',
@@ -147,6 +148,7 @@ describe('adapter', () => {
           'zendesk_support.business_hours_schedule_holiday',
           'zendesk_support.business_hours_schedule_holiday.instance.New_schedule_s__Holiday1@umuu',
           'zendesk_support.business_hours_schedule_holiday.instance.Schedule_3_s__Holi2@umuu',
+          'zendesk_support.business_hours_schedule_holiday__holidays',
           'zendesk_support.business_hours_schedules',
           'zendesk_support.custom_role',
           'zendesk_support.custom_role.instance.Advisor',
@@ -192,6 +194,7 @@ describe('adapter', () => {
           'zendesk_support.macro_action__values__list',
           'zendesk_support.macro_categories',
           'zendesk_support.macro_categories.instance',
+          'zendesk_support.macro_category',
           'zendesk_support.macro_definition',
           'zendesk_support.macro_definition.instance',
           'zendesk_support.macro_definition__actions',
@@ -200,6 +203,7 @@ describe('adapter', () => {
           'zendesk_support.macros_actions',
           'zendesk_support.macros_actions.instance',
           'zendesk_support.macros_definitions',
+          'zendesk_support.monitored_twitter_handle',
           'zendesk_support.monitored_twitter_handles',
           'zendesk_support.oauth_client',
           'zendesk_support.oauth_client.instance.c123',
@@ -256,12 +260,15 @@ describe('adapter', () => {
           'zendesk_support.routing_attribute_value.instance.Language__Spanish',
           'zendesk_support.routing_attribute_value.instance.Location__San_Francisco@uus',
           'zendesk_support.routing_attribute_value.instance.Location__Tel_Aviv@uus',
+          'zendesk_support.routing_attribute_value__attribute_values',
           'zendesk_support.routing_attribute_value__conditions',
           'zendesk_support.routing_attribute_value__conditions__all',
           'zendesk_support.routing_attributes',
+          'zendesk_support.sharing_agreement',
           'zendesk_support.sharing_agreements',
           'zendesk_support.sla_policies',
           'zendesk_support.sla_policies_definitions',
+          'zendesk_support.sla_policies_definitions__value',
           'zendesk_support.sla_policy',
           'zendesk_support.sla_policy.instance.SLA_501@s',
           'zendesk_support.sla_policy.instance.SLA_502@s',
@@ -431,6 +438,7 @@ describe('adapter', () => {
           'zendesk_support.webhooks__meta',
           'zendesk_support.workspace',
           'zendesk_support.workspace.instance.New_Workspace_123@s',
+          'zendesk_support.workspace__apps',
           'zendesk_support.workspace__conditions',
           'zendesk_support.workspace__conditions__all',
           'zendesk_support.workspace__conditions__any',
@@ -490,17 +498,20 @@ describe('adapter', () => {
           ),
           elementsSource: buildElementsSourceFromElements([]),
         }).fetch({ progressReporter: { reportProgress: () => null } })
-        expect(elements).toHaveLength(6)
-        expect(elements.filter(isObjectType)).toHaveLength(2)
-        expect(elements.filter(isInstanceElement)).toHaveLength(4)
-        expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
-          'zendesk_support.group',
-          'zendesk_support.group.instance.Support',
-          'zendesk_support.group.instance.Support2',
-          'zendesk_support.group.instance.Support4',
-          'zendesk_support.group.instance.Support5',
-          'zendesk_support.groups',
-        ])
+        const instances = elements.filter(isInstanceElement)
+        expect(instances).toHaveLength(8)
+        expect(instances.map(e => e.elemID.getFullName()).sort())
+          .toEqual([
+            'zendesk_support.group.instance.Support',
+            'zendesk_support.group.instance.Support2',
+            'zendesk_support.group.instance.Support4',
+            'zendesk_support.group.instance.Support5',
+            // The order element are always created on fetch
+            'zendesk_support.organization_field_order.instance',
+            'zendesk_support.ticket_form_order.instance',
+            'zendesk_support.user_field_order.instance',
+            'zendesk_support.workspace_order.instance',
+          ])
       })
     })
     it('should use elemIdGetter', async () => {


### PR DESCRIPTION
_always have at least an empty type for any deployable instance_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Zendesk_support adapter_
* always have at least an empty type for any deployable instance

_Workato adapter_
* always have at least an empty type for any deployable instance

---
_User Notifications_: 
_Zendesk - new empty instances will be added_
