### PR TITLE
[SALTO-1876] retry 400 errors on salesforce client

### DIFF
--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -150,7 +150,7 @@ describe('salesforce client', () => {
       expect(res).toEqual([])
     })
     it('writes the right things to log', () => {
-      expect(log).toHaveBeenCalledWith('failed to run SFDC call for reason: %s. נing in %ss.', 'something awful happened', 0.1)
+      expect(log).toHaveBeenCalledWith('failed to run SFDC call for reason: %s. Retrying in %ss.', 'something awful happened', 0.1)
     })
   })
 
@@ -159,19 +159,12 @@ describe('salesforce client', () => {
       const dodoScope = nock('http://dodo22')
         .post(/.*/)
         .times(1)
-        .reply(500, 'server error')
+        .reply(400, {})
         .post(/.*/)
         .reply(200, { 'a:Envelope': { 'a:Body': { a: { result: { metadataObjects: [] } } } } },
           headers)
-
-      try {
-        await client.listMetadataTypes()
-        throw new Error('client should have failed')
-      } catch (e) {
-        expect(e.message).toBe('server error')
-        expect(e.attempts).toBeUndefined()
-      }
-      expect(dodoScope.isDone()).toBeFalsy()
+      await client.listMetadataTypes()
+      expect(dodoScope.isDone()).toBeTruthy()
     })
     it('fails on first error without retries', async () => {
       const dodoScope = nock('http://dodo22')

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -113,6 +113,19 @@ describe('salesforce client', () => {
       log = jest.spyOn(logging, 'error')
     })
 
+    it('retries with 400 error', async () => {
+      const dodoScope = nock('http://dodo22')
+        .post(/.*/)
+        .times(1)
+        .reply(400, {})
+        .post(/.*/)
+        .reply(200, { 'a:Envelope': { 'a:Body': { a: { result: { metadataObjects: [] } } } } },
+          headers)
+      const res = await client.listMetadataTypes()
+      expect(dodoScope.isDone()).toBeTruthy()
+      expect(res).toEqual([])
+    })
+
     it('fails if max attempts was reached ', async () => {
       const dodoScope = nock('http://dodo22')
         .persist()
@@ -155,17 +168,6 @@ describe('salesforce client', () => {
   })
 
   describe('with other errors ', () => {
-    it('retries with 400 error', async () => {
-      const dodoScope = nock('http://dodo22')
-        .post(/.*/)
-        .times(1)
-        .reply(400, {})
-        .post(/.*/)
-        .reply(200, { 'a:Envelope': { 'a:Body': { a: { result: { metadataObjects: [] } } } } },
-          headers)
-      await client.listMetadataTypes()
-      expect(dodoScope.isDone()).toBeTruthy()
-    })
     it('fails on first error without retries', async () => {
       const dodoScope = nock('http://dodo22')
         .post(/.*/)


### PR DESCRIPTION
On some rare cases salesforce client fails with 400, and a retry would fix the failure, so we will retry on 400

---

_Additional context for reviewer_

---
_Release Notes_: 

---
_User Notifications_: 
