### PR TITLE
SALTO-1963 resolve references on plan

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -192,7 +192,7 @@ export type TemplatePart = string | Expression
   However, it's about 20 times better to use replace than to iterate over both strings.
   For this reason we first check a naive comparison, and then test with replace.
   */
-export const compareStringsIgnoreNewlineDifferences = (s1: string, s2: string): boolean =>
+const compareStringsIgnoreNewlineDifferences = (s1: string, s2: string): boolean =>
   (s1 === s2) || (s1.replace(/\r\n/g, '\n') === s2.replace(/\r\n/g, '\n'))
 
 export const compareSpecialValues = (

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -192,7 +192,7 @@ export type TemplatePart = string | Expression
   However, it's about 20 times better to use replace than to iterate over both strings.
   For this reason we first check a naive comparison, and then test with replace.
   */
-const compareStringsIgnoreNewlineDifferences = (s1: string, s2: string): boolean =>
+export const compareStringsIgnoreNewlineDifferences = (s1: string, s2: string): boolean =>
   (s1 === s2) || (s1.replace(/\r\n/g, '\n') === s2.replace(/\r\n/g, '\n'))
 
 export const compareSpecialValues = (

--- a/packages/core/test/core/plan/plan.test.ts
+++ b/packages/core/test/core/plan/plan.test.ts
@@ -338,6 +338,10 @@ describe('getPlan', () => {
   })
 
   it('when reference in instance changes but the value is the same should have a change in plan', async () => {
+    // This behavior works for fetch but it is not really the correct behavior for deploy:
+    // If there is no difference in the value to be deployed, it should not be a change in the plan
+    // (because nothing is actually going to change).
+    // We may want to change that in the future.
     const type = new ObjectType({
       elemID: new ElemID('adapter', 'type'),
       fields: {

--- a/packages/core/test/core/plan/plan.test.ts
+++ b/packages/core/test/core/plan/plan.test.ts
@@ -375,6 +375,9 @@ describe('getPlan', () => {
   })
 
   it('when reference in instance points to a whole element should have a change in plan', async () => {
+    // Ideally we would want to know if the adapter is going to resolve this element into its ID
+    // so we could tell if this is a real difference, but since we can't do that with the current
+    // design, we take the safer option and say this is always a change
     const type = new ObjectType({
       elemID: new ElemID('adapter', 'type'),
       fields: {


### PR DESCRIPTION
Fixing bug - In `core/src/core/plan/plan.ts` line 79 - the reference expressions are compared after resolving them, but in some cases the value doesn't change and the reference does change. For example - from `netsuite.a.instance.a.list.0.scriptid` to `netsuite.a.instance.a.list.somekey.scriptid`
It means that this change will be ignored and if it is the only change in an instance it won’t be written to the NaCl.

This PR is a fix to https://github.com/salto-io/salto/pull/2589 and its keeping the original behavior of references comparison, with a recursive comparison of nested references.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
