### PR TITLE
SALTO-1976: fixed deployment error message in Jira

### DIFF
--- a/packages/jira-adapter/src/deployment.ts
+++ b/packages/jira-adapter/src/deployment.ts
@@ -15,7 +15,7 @@
 */
 import { Change, ChangeDataType, DeployResult, getChangeData, InstanceElement, isAdditionChange } from '@salto-io/adapter-api'
 import { config, deployment, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { resolveChangeElement } from '@salto-io/adapter-utils'
+import { resolveChangeElement, safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import JiraClient from './client/client'
@@ -81,8 +81,18 @@ export const deployChanges = async <T extends Change<ChangeDataType>>(
         return change
       } catch (err) {
         err.message = `Deployment of ${getChangeData(change).elemID.getFullName()} failed: ${err}`
-        if (err instanceof clientUtils.HTTPError && 'errorMessages' in err.response.data) {
-          err.message = `${err.message}. ${err.response.data.errorMessages}`
+        if (err instanceof clientUtils.HTTPError && _.isPlainObject(err.response.data)) {
+          const errorMessages = [
+            ...(Array.isArray(err.response.data.errorMessages)
+              ? err.response.data.errorMessages
+              : []),
+            ...(_.isPlainObject(err.response.data.errors)
+              ? [safeJsonStringify(err.response.data.errors)]
+              : []),
+          ]
+          if (errorMessages.length > 0) {
+            err.message = `${err.message}. ${errorMessages.join(', ')}`
+          }
         }
         return err
       }

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -125,7 +125,7 @@ describe('adapter', () => {
         if (isRemovalChange(change)) {
           throw new Error('some error')
         }
-        throw new client.HTTPError('some error', { status: 400, data: { errorMessages: ['errorMessage'] } })
+        throw new client.HTTPError('some error', { status: 400, data: { errorMessages: ['errorMessage'], errors: { key: 'value' } } })
       })
 
       const deployRes = await adapter.deploy({
@@ -139,7 +139,7 @@ describe('adapter', () => {
       })
 
       expect(deployRes.errors).toEqual([
-        new Error('Deployment of jira.FieldConfigurationIssueTypeItem.instance.inst1 failed: Error: some error. errorMessage'),
+        new Error('Deployment of jira.FieldConfigurationIssueTypeItem.instance.inst1 failed: Error: some error. errorMessage, {"key":"value"}'),
         new Error('Deployment of jira.FieldConfigurationIssueTypeItem.instance.inst2 failed: Error: some error'),
       ])
     })


### PR DESCRIPTION
Fixed Jira deployment error message to contain also `errors` in the response if exists and not only `errorMessages`

---
_Release Notes_: 
None

---
_User Notifications_: 
None