### PR TITLE
SALTO-1971: changed field configuration fields from list to a map

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -31,6 +31,7 @@ import sharePermissionFilter from './filters/share_permission'
 import sortListsFilter from './filters/sort_lists'
 import boardFilter from './filters/board'
 import screenFilter from './filters/screen/screen'
+import mapListsFilter from './filters/map_lists'
 import issueTypeScreenSchemeFilter from './filters/issue_type_screen_scheme'
 import fieldConfigurationFilter from './filters/field_configuration'
 import fieldConfigurationTrashedFieldsFilter from './filters/field_configuration_trashed_fields'
@@ -84,6 +85,8 @@ export const DEFAULT_FILTERS = [
   fieldConfigurationTrashedFieldsFilter,
   // Must run after fieldReferencesFilter
   sortListsFilter,
+  // Must run after fieldReferencesFilter
+  mapListsFilter,
   hiddenValuesInListsFilter,
   // Must be last
   defaultInstancesDeployFilter,

--- a/packages/jira-adapter/src/change_validators/field_configuration_unsupported_fields.ts
+++ b/packages/jira-adapter/src/change_validators/field_configuration_unsupported_fields.ts
@@ -22,18 +22,19 @@ const getFieldId = (field: Values): string => (
 )
 
 const getDiffFields = (change: ModificationChange<InstanceElement>): Values[] => {
-  const beforeIdToField = _.keyBy(
-    change.data.before.value.fields,
-    getFieldId,
-  )
+  const beforeIdToField = _(change.data.before.value.fields)
+    .values()
+    .keyBy(getFieldId)
+    .value()
 
-  return change.data.after.value.fields.filter(
-    (field: Values) => !_.isEqualWith(
-      field,
-      beforeIdToField[getFieldId(field)],
-      compareSpecialValues
+  return (Object.values(change.data.after.value.fields ?? []) as Values[])
+    .filter(
+      (field: Values) => !_.isEqualWith(
+        field,
+        beforeIdToField[getFieldId(field)],
+        compareSpecialValues
+      )
     )
-  )
 }
 
 export const unsupportedFieldConfigurationsValidator: ChangeValidator = async changes => (
@@ -43,7 +44,7 @@ export const unsupportedFieldConfigurationsValidator: ChangeValidator = async ch
     .filter(change => getChangeData(change).elemID.typeName === 'FieldConfiguration')
     .map(change => {
       const fields = isAdditionChange(change)
-        ? change.data.after.value.fields
+        ? Object.values(change.data.after.value.fields ?? []) as Values[]
         : getDiffFields(change)
 
       const unsupportedIds = fields

--- a/packages/jira-adapter/src/filters/field_configuration.ts
+++ b/packages/jira-adapter/src/filters/field_configuration.ts
@@ -33,7 +33,7 @@ const deployFieldConfigurationItems = async (
   config: JiraConfig
 ): Promise<void> => {
   const instance = getChangeData(change)
-  const fields = (instance.value.fields ?? [])
+  const fields = (Object.values(instance.value.fields ?? []) as Values[])
     .filter((fieldConf: Values) => isReferenceExpression(fieldConf.id))
     .filter((fieldConf: Values) => !fieldConf.id.value.value.isLocked)
     .map((fieldConf: Values) => ({ ...fieldConf, id: fieldConf.id.value.value.id }))

--- a/packages/jira-adapter/src/filters/map_lists.ts
+++ b/packages/jira-adapter/src/filters/map_lists.ts
@@ -1,0 +1,93 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Field, isListType, isObjectType, MapType, Element, isInstanceElement } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { FilterCreator } from '../filter'
+
+const { awu } = collections.asynciterable
+
+const log = logger(module)
+
+type ListToMapDetails = {
+  typeName: string
+  fieldToMap: string
+  keyPath: string
+}
+
+const LIST_TO_MAPS_DETAILS: ListToMapDetails[] = [
+  {
+    typeName: 'FieldConfiguration',
+    fieldToMap: 'fields',
+    keyPath: 'id.elemID.name',
+  },
+]
+
+const replaceFieldTypes = async (elements: Element[]): Promise<void> => {
+  await awu(elements)
+    .filter(isObjectType)
+    .forEach(async type => {
+      await awu(LIST_TO_MAPS_DETAILS)
+        .filter(({ typeName }) => type.elemID.name === typeName)
+        .forEach(async ({ fieldToMap }) => {
+          const field = type.fields[fieldToMap]
+          if (field === undefined) {
+            log.warn(`${type.elemID.getFullName()} does not have ${fieldToMap} field`)
+            return
+          }
+
+          const fieldType = await field.getType()
+
+          if (isListType(fieldType)) {
+            type.fields[fieldToMap] = new Field(
+              type,
+              fieldToMap,
+              new MapType(await fieldType.getInnerType()),
+              field.annotations
+            )
+          } else {
+            log.warn(`${fieldToMap} in ${type.elemID.getFullName()} is not a list`)
+          }
+        })
+    })
+}
+
+const replaceFieldValues = (elements: Element[]): void => {
+  elements
+    .filter(isInstanceElement)
+    .forEach(instance => {
+      LIST_TO_MAPS_DETAILS
+        .filter(({ typeName }) => instance.elemID.typeName === typeName)
+        .forEach(({ fieldToMap, keyPath }) => {
+          if (!Array.isArray(instance.value[fieldToMap])) {
+            log.warn(`${fieldToMap} of ${instance.elemID.getFullName()} is not a list`)
+            return
+          }
+
+          instance.value[fieldToMap] = _.keyBy(instance.value[fieldToMap], keyPath)
+        })
+    })
+}
+
+const filter: FilterCreator = () => ({
+  onFetch: async elements => {
+    await replaceFieldTypes(elements)
+    replaceFieldValues(elements)
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/test/change_validators/default_field_configuration.test.ts
+++ b/packages/jira-adapter/test/change_validators/default_field_configuration.test.ts
@@ -28,7 +28,7 @@ describe('defaultFieldConfigurationValidator', () => {
       type,
       {
         isDefault: true,
-        fields: [],
+        fields: {},
       }
     )
   })

--- a/packages/jira-adapter/test/change_validators/field_configuration_unsupported_fields.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_configuration_unsupported_fields.test.ts
@@ -27,14 +27,16 @@ describe('unsupportedFieldConfigurationsValidator', () => {
   })
 
   it('should return an error if id is a reference to a locked field', async () => {
-    instance.value.fields = [{
-      id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'inst'), {
-        value: {
-          id: 'inst',
-          isLocked: true,
-        },
-      }),
-    }]
+    instance.value.fields = {
+      inst: {
+        id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'inst'), {
+          value: {
+            id: 'inst',
+            isLocked: true,
+          },
+        }),
+      },
+    }
 
     expect(await unsupportedFieldConfigurationsValidator([
       toChange({
@@ -51,13 +53,15 @@ describe('unsupportedFieldConfigurationsValidator', () => {
   })
 
   it('should not return an error if field configuration is valid', async () => {
-    instance.value.fields = [{
-      id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'inst'), {
-        value: {
-          id: 'inst',
-        },
-      }),
-    }]
+    instance.value.fields = {
+      inst: {
+        id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'inst'), {
+          value: {
+            id: 'inst',
+          },
+        }),
+      },
+    }
 
     expect(await unsupportedFieldConfigurationsValidator([
       toChange({
@@ -67,14 +71,16 @@ describe('unsupportedFieldConfigurationsValidator', () => {
   })
 
   it('should not return an error if an invalid field config was not changed', async () => {
-    instance.value.fields = [{
-      id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'inst'), {
-        value: {
-          id: 'inst',
-          isLocked: true,
-        },
-      }),
-    }]
+    instance.value.fields = {
+      inst: {
+        id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'inst'), {
+          value: {
+            id: 'inst',
+            isLocked: true,
+          },
+        }),
+      },
+    }
 
     expect(await unsupportedFieldConfigurationsValidator([
       toChange({

--- a/packages/jira-adapter/test/filters/map_lists.test.ts
+++ b/packages/jira-adapter/test/filters/map_lists.test.ts
@@ -1,0 +1,107 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, ElemID, Field, InstanceElement, isMapType, ListType, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { mockClient } from '../utils'
+import mapListsFilter from '../../src/filters/map_lists'
+import { Filter } from '../../src/filter'
+import { DEFAULT_CONFIG } from '../../src/config'
+import { JIRA } from '../../src/constants'
+
+describe('mapListsFilter', () => {
+  let filter: Filter
+  let type: ObjectType
+  beforeEach(async () => {
+    const { client, paginator } = mockClient()
+
+    filter = mapListsFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    })
+
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, 'FieldConfiguration'),
+      fields: {
+        fields: { refType: new ListType(BuiltinTypes.STRING) },
+      },
+    })
+  })
+
+  describe('onFetch', () => {
+    it('should change the field in type to map', async () => {
+      await filter.onFetch?.([type])
+      expect(isMapType(await type.fields.fields.getType())).toBeTruthy()
+    })
+
+    it('if field does not exists on type should do nothing', async () => {
+      delete type.fields.fields
+      await filter.onFetch?.([type])
+      expect(type.fields).toEqual({})
+    })
+
+    it('if field is not a list should do nothing', async () => {
+      type.fields.fields = new Field(
+        type,
+        'fields',
+        BuiltinTypes.STRING,
+      )
+      await filter.onFetch?.([type])
+      expect(isMapType(await type.fields.fields.getType())).toBeFalsy()
+    })
+
+    it('should change the value in instance to map', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        type,
+        {
+          fields: [
+            {
+              id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'name1')),
+            },
+            {
+              id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'name2')),
+            },
+          ],
+        }
+      )
+      await filter.onFetch?.([instance])
+      expect(instance.value).toEqual({
+        fields: {
+          name1: {
+            id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'name1')),
+          },
+          name2: {
+            id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'name2')),
+          },
+        },
+      })
+    })
+
+    it('if value in instance is not a list should do nothing', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        type,
+        {
+          fields: 'string',
+        }
+      )
+      await filter.onFetch?.([instance])
+      expect(instance.value).toEqual({
+        fields: 'string',
+      })
+    })
+  })
+})


### PR DESCRIPTION
Changed fields in `FieldConfiguraiton` to be a map where the key is the field name to reduce noise when comparing between envs

---
_Release Notes_: 
None

---
_User Notifications_: 
None