### PR TITLE
SALTO-1292: remove inconsistent interface from adapter-api change validator

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -69,10 +69,8 @@ export type DependencyError = ChangeError & {
 
 export const isDependencyError = (err: ChangeError): err is DependencyError => 'causeID' in err
 
-export type ChangeValidator = (
-  changes: ReadonlyArray<Change>,
-  deployConfig?: Readonly<InstanceElement>,
-) => Promise<ReadonlyArray<ChangeError>>
+export type ChangeValidator = (changes: ReadonlyArray<Change>) =>
+  Promise<ReadonlyArray<ChangeError>>
 
 export type DeployModifiers = {
   changeValidator?: ChangeValidator

--- a/packages/adapter-components/src/deployment/change_validators/skip_parents_of_skipped_instances.ts
+++ b/packages/adapter-components/src/deployment/change_validators/skip_parents_of_skipped_instances.ts
@@ -21,9 +21,9 @@ import { createChangeValidator, getParents } from '@salto-io/adapter-utils'
 export const createSkipParentsOfSkippedInstancesValidator = (
   changeValidators: ReadonlyArray<ChangeValidator>,
   disabledValidators?: ReadonlyArray<ChangeValidator>,
-): ChangeValidator => async (changes, adapterConfig) => {
+): ChangeValidator => async changes => {
   const changeValidator = createChangeValidator(changeValidators, disabledValidators)
-  const changeErrors = await changeValidator(changes, adapterConfig)
+  const changeErrors = await changeValidator(changes)
   const idToChange = Object.fromEntries(
     changes.map(change => [getChangeData(change).elemID.getFullName(), change])
   )
@@ -47,8 +47,8 @@ export const createSkipParentsOfSkippedInstancesValidator = (
     .map(ref => ({
       elemID: ref.elemID,
       severity: 'Error',
-      message: `${ref.elemID.getFullName()} depeneds on a skipped instance`,
-      detailedMessage: `${ref.elemID.getFullName()} depeneds on a skipped instance and therefore is also skipped`,
+      message: `${ref.elemID.getFullName()} depends on a skipped instance`,
+      detailedMessage: `${ref.elemID.getFullName()} depends on a skipped instance and therefore is also skipped`,
     }) as ChangeError)
     .value()
   return [...changeErrors, ...newChangeErrors]

--- a/packages/adapter-utils/src/change_validator.ts
+++ b/packages/adapter-utils/src/change_validator.ts
@@ -22,10 +22,10 @@ const log = logger(module)
 export const createChangeValidator = (
   changeValidators: ReadonlyArray<ChangeValidator>,
   disabledValidators?: ReadonlyArray<ChangeValidator>,
-): ChangeValidator => async (changes, adapterConfig) => {
+): ChangeValidator => async changes => {
   if (disabledValidators !== undefined) {
     const disabledErrors = _.flatten(await Promise.all(
-      disabledValidators.map(validator => validator(changes, adapterConfig))
+      disabledValidators.map(validator => validator(changes))
     ))
     disabledErrors.forEach(error => {
       log.info(
@@ -35,6 +35,6 @@ export const createChangeValidator = (
     })
   }
   return _.flatten(await Promise.all(
-    changeValidators.map(validator => validator(changes, adapterConfig))
+    changeValidators.map(validator => validator(changes))
   ))
 }

--- a/packages/adapter-utils/test/change_validator.test.ts
+++ b/packages/adapter-utils/test/change_validator.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { ChangeValidator, ChangeError, ObjectType, ElemID, Change, toChange, InstanceElement } from '@salto-io/adapter-api'
+import { ChangeValidator, ChangeError, ObjectType, ElemID, Change, toChange } from '@salto-io/adapter-api'
 import { mockFunction } from '@salto-io/test-utils'
 import { createChangeValidator } from '../src/change_validator'
 
@@ -23,7 +23,6 @@ describe('change_validator', () => {
 
   let mockValidators: jest.MockedFunction<ChangeValidator>[]
   let changes: ReadonlyArray<Change>
-  let adapterConfig: InstanceElement
   let errors: ChangeError[]
 
   beforeEach(async () => {
@@ -52,11 +51,11 @@ describe('change_validator', () => {
     let result: ReadonlyArray<ChangeError>
     beforeEach(async () => {
       const mainValidator = createChangeValidator(mockValidators)
-      result = await mainValidator(changes, adapterConfig)
+      result = await mainValidator(changes)
     })
     it('should call all validators', () => {
       mockValidators.forEach(
-        validator => expect(validator).toHaveBeenCalledWith(changes, adapterConfig)
+        validator => expect(validator).toHaveBeenCalledWith(changes)
       )
     })
     it('should return errors from all validators', () => {
@@ -77,7 +76,7 @@ describe('change_validator', () => {
       }
       disabledValidator = mockFunction<ChangeValidator>().mockResolvedValue([disabledError])
       const mainValidator = createChangeValidator(mockValidators, [disabledValidator])
-      result = await mainValidator(changes, adapterConfig)
+      result = await mainValidator(changes)
     })
     it('should call disabled validator', () => {
       expect(disabledValidator).toHaveBeenCalled()

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -44,7 +44,7 @@ import { defaultDependencyChangers } from './core/plan/plan'
 import { createRestoreChanges } from './core/restore'
 import { getAdapterChangeGroupIdFunctions } from './core/adapters/custom_group_key'
 import { createDiffChanges } from './core/diff'
-import { getChangeValidators, getAdaptersConfig } from './core/plan/change_validators'
+import getChangeValidators from './core/plan/change_validators'
 import { renameChecks, renameElement, updateStateElements } from './core/rename'
 
 export { cleanWorkspace } from './core/clean'
@@ -108,7 +108,6 @@ export const preview = async (
     dependencyChangers: defaultDependencyChangers.concat(getAdapterDependencyChangers(adapters)),
     customGroupIdFunctions: getAdapterChangeGroupIdFunctions(adapters),
     topLevelFilters: [shouldElementBeIncluded(accounts)],
-    adapterGetConfig: await getAdaptersConfig(adapters, workspace.accountConfig.bind(workspace)),
   })
 }
 

--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -174,7 +174,7 @@ const filterElementsSource = (
   }
 }
 
-export type AdapterConfigGetter = (
+type AdapterConfigGetter = (
   adapter: string, defaultValue?: InstanceElement
 ) => Promise<InstanceElement | undefined>
 

--- a/packages/core/src/core/plan/change_validators/index.ts
+++ b/packages/core/src/core/plan/change_validators/index.ts
@@ -14,16 +14,13 @@
 * limitations under the License.
 */
 
-import { AdapterOperations, ChangeValidator, InstanceElement } from '@salto-io/adapter-api'
+import { AdapterOperations, ChangeValidator } from '@salto-io/adapter-api'
 import { createChangeValidator } from '@salto-io/adapter-utils'
-import { promises } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { getAdapterChangeValidators, AdapterConfigGetter } from '../../adapters'
+import { getAdapterChangeValidators } from '../../adapters'
 import { changeValidator as unresolvedReferencesValidator } from './unresolved_references'
 import { checkDeploymentAnnotationsValidator } from './check_deployment_annotations'
 
-
-const { mapValuesAsync } = promises.object
 
 const DEFAULT_CHANGE_VALIDATORS = [
   unresolvedReferencesValidator,
@@ -37,19 +34,4 @@ Record<string, ChangeValidator> =>
     adapterValidator => createChangeValidator([...DEFAULT_CHANGE_VALIDATORS, adapterValidator])
   )
 
-const getAdaptersConfig = async (
-  adapters: Record<string, AdapterOperations>,
-  getConfig: AdapterConfigGetter,
-): Promise<Record<string, InstanceElement | undefined>> => {
-  const adaptersConfig = await mapValuesAsync(
-    adapters,
-    (_v, adapter) => getConfig(adapter)
-  )
-
-  return adaptersConfig
-}
-
-export {
-  getChangeValidators,
-  getAdaptersConfig,
-}
+export default getChangeValidators

--- a/packages/core/src/core/plan/filter.ts
+++ b/packages/core/src/core/plan/filter.ts
@@ -36,7 +36,6 @@ export const filterInvalidChanges = async (
   afterElements: ReadOnlyElementsSource,
   diffGraph: DiffGraph<ChangeDataType>,
   changeValidators: Record<string, ChangeValidator>,
-  adapterGetConfig?: Record<string, InstanceElement | undefined>,
 ): Promise<FilterResult> => {
   const createValidTopLevelElem = (beforeTopLevelElem: TopLevelElement,
     afterTopLevelElem: TopLevelElement, elemIdsToOmit: ElemID[]): Element | undefined => {
@@ -206,10 +205,7 @@ export const filterInvalidChanges = async (
 
   const changeErrors = await awu(changesByAdapter.entries())
     .filter(([adapter]) => adapter in changeValidators)
-    .flatMap(([adapter, changes]) => changeValidators[adapter](
-      changes,
-      adapterGetConfig?.[adapter],
-    ))
+    .flatMap(([adapter, changes]) => changeValidators[adapter](changes))
     .toArray()
 
   const invalidChanges = changeErrors.filter(v => v.severity === 'Error')

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -20,7 +20,7 @@ import {
   ChangeValidator, Change, ChangeError, DependencyChanger, ChangeGroupIdFunction, getChangeData,
   isAdditionOrRemovalChange, isFieldChange, ReadOnlyElementsSource, ElemID, isVariable,
   Value, isReferenceExpression, compareSpecialValues, BuiltinTypesByFullName, isAdditionChange,
-  isModificationChange, isRemovalChange, InstanceElement, PlaceholderObjectType,
+  isModificationChange, isRemovalChange, PlaceholderObjectType,
 } from '@salto-io/adapter-api'
 import { DataNodeMap, DiffNode, DiffGraph, Group, GroupDAG, DAG } from '@salto-io/dag'
 import { logger } from '@salto-io/logging'
@@ -426,7 +426,6 @@ type GetPlanParameters = {
   customGroupIdFunctions?: Record<string, ChangeGroupIdFunction>
   additionalResolveContext?: ReadonlyArray<Element>
   topLevelFilters?: IDFilter[]
-  adapterGetConfig?: Record<string, InstanceElement | undefined>
 }
 export const getPlan = async ({
   before,
@@ -435,7 +434,6 @@ export const getPlan = async ({
   dependencyChangers = defaultDependencyChangers,
   customGroupIdFunctions = {},
   topLevelFilters = [],
-  adapterGetConfig,
 }: GetPlanParameters): Promise<Plan> => {
   const numBeforeElements = await awu(await before.list()).length()
   const numAfterElements = await awu(await after.list()).length()
@@ -446,7 +444,7 @@ export const getPlan = async ({
       addNodeDependencies(dependencyChangers),
     )
     const filterResult = await filterInvalidChanges(
-      before, after, diffGraph, changeValidators, adapterGetConfig
+      before, after, diffGraph, changeValidators,
     )
     const customGroupKeys = await getCustomGroupIds(
       // We need to resolve the fileted graph again.

--- a/packages/core/test/core/plan/change_validators/index.test.ts
+++ b/packages/core/test/core/plan/change_validators/index.test.ts
@@ -13,10 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { AdapterOperations, ChangeValidator, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { AdapterOperations, ChangeValidator, ElemID, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import { mockFunction } from '@salto-io/test-utils'
 import { expressions } from '@salto-io/workspace'
-import { getChangeValidators } from '../../../../src/core/plan/change_validators'
+import getChangeValidators from '../../../../src/core/plan/change_validators'
 
 describe('getChangeValidators', () => {
   it('should call both the adapter change validators and the core change validators', async () => {
@@ -45,14 +45,10 @@ describe('getChangeValidators', () => {
       },
     })
     const changes = [toChange({ after: type })]
-    const configType = new ObjectType({
-      elemID: new ElemID('adapter', '_config'),
-    })
-    const adapterConfig = new InstanceElement('_config', configType)
-    const errors = await changesValidators.adapter(changes, adapterConfig)
+    const errors = await changesValidators.adapter(changes)
     expect(errors).toHaveLength(2)
     expect(errors[0].message).toBe('Element has unresolved references')
-    expect(adapterChangeValidator).toHaveBeenCalledWith(changes, adapterConfig)
+    expect(adapterChangeValidator).toHaveBeenCalledWith(changes)
     expect(errors[1].message).toBe('message')
   })
 })

--- a/packages/salesforce-adapter/index.ts
+++ b/packages/salesforce-adapter/index.ts
@@ -22,7 +22,6 @@ import { CustomObject as tCustomObject } from './src/client/types'
 
 export { default } from './src/adapter'
 export { adapter } from './src/adapter_creator'
-export { default as changeValidator } from './src/change_validator'
 export { default as SalesforceClient } from './src/client/client'
 export { UsernamePasswordCredentials, OauthAccessTokenCredentials } from './src/types'
 export { getAllInstances } from './src/filters/custom_objects_instances'

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -179,7 +179,7 @@ export const adapter: Adapter = {
 
       deploy: salesforceAdapter.deploy.bind(salesforceAdapter),
       deployModifiers: {
-        changeValidator: createChangeValidator(config.validators),
+        changeValidator: createChangeValidator(config),
         getChangeGroupIds,
       },
     }


### PR DESCRIPTION
PR #2439 added an interface to adapter-api change validators that was inconsistent and should not be used. it was relying on a config instance that was passed through a different code path than the one the adapter actually uses and as such was not validated or parsed by the adapter.

There is already an interface to get the adapter config in a change validator, so in this PR we remove the interface that should not exist and change the implementation of the one validator that used the old interface to use the correct interface instead

---

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
