### PR TITLE
SALTO-1559 more generated dependencies

### DIFF
--- a/packages/netsuite-adapter/test/filters/instance_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/instance_references.test.ts
@@ -363,15 +363,24 @@ describe('instance_references filter', () => {
         .toHaveLength(3)
       expect(instanceWithRefs.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES])
         .toEqual([
-          { reference: new ReferenceExpression(
-            customSegmentInstance.elemID.createNestedID(SCRIPT_ID)
-          ) },
-          { reference: new ReferenceExpression(
-            workflowInstance.elemID.createNestedID('workflowstates', 'workflowstate', '0', 'workflowactions', '0', 'setfieldvalueaction', '0', SCRIPT_ID)
-          ) },
-          { reference: new ReferenceExpression(
-            workflowInstance.elemID.createNestedID(SCRIPT_ID)
-          ) },
+          {
+            reference: new ReferenceExpression(
+              customSegmentInstance.elemID.createNestedID(SCRIPT_ID)
+            ),
+            occurrences: undefined,
+          },
+          {
+            reference: new ReferenceExpression(
+              workflowInstance.elemID.createNestedID(SCRIPT_ID)
+            ),
+            occurrences: undefined,
+          },
+          {
+            reference: new ReferenceExpression(
+              workflowInstance.elemID.createNestedID('workflowstates', 'workflowstate', '0', 'workflowactions', '0', 'setfieldvalueaction', '0', SCRIPT_ID)
+            ),
+            occurrences: undefined,
+          },
         ])
     })
 


### PR DESCRIPTION
- generate reference dependency when there is a reference of the form `[type=crmcustomfield, scriptid=cseg1]` and `cseg1` is not of type `crmcustomfield`
- use `extendGeneratedDependencies`

---

_Additional context for reviewer_
None

---
_Release Notes_: 
Netsuite-Adapter:
- generate reference dependency for references of the form `[type=crmcustomfield, scriptid=cseg1]` when `cseg1` is not of type `crmcustomfield` 

---
_User Notifications_: 
- NetSuite Adapter: more references in `_generated_dependencies` 