### PR TITLE
SALTO-1991: fixed fieldConfiguration deployment

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/fieldConfiguration.ts
+++ b/packages/jira-adapter/e2e_test/instances/fieldConfiguration.ts
@@ -1,0 +1,34 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Values, Element, ElemID } from '@salto-io/adapter-api'
+import { createReference } from '../utils'
+import { JIRA } from '../../src/constants'
+
+export const createFieldConfigurationValues = (
+  name: string,
+  allElements: Element[],
+): Values => ({
+  name,
+  description: name,
+  fields: {
+    Assignee: {
+      id: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee'), allElements),
+      description: 'For example operating system, software platform and/or hardware specifications (include as appropriate for the issue).',
+      isHidden: false,
+      isRequired: false,
+    },
+  },
+})

--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -19,6 +19,7 @@ import { ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, JIRA } from '../../src/constan
 import { createReference, findType } from '../utils'
 import { createBoardValues } from './board'
 import { createContextValues, createFieldValues } from './field'
+import { createFieldConfigurationValues } from './fieldConfiguration'
 import { createFieldConfigurationSchemeValues } from './fieldConfigurationScheme'
 import { createIssueTypeSchemeValues } from './issueTypeScheme'
 import { createIssueTypeScreenSchemeValues } from './issueTypeScreenScheme'
@@ -147,6 +148,12 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[] =
     },
   )
 
+  const fieldConfiguration = new InstanceElement(
+    randomString,
+    findType('FieldConfiguration', fetchedElements),
+    createFieldConfigurationValues(randomString, fetchedElements),
+  )
+
   return [
     issueType,
     field,
@@ -163,5 +170,6 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[] =
     issueLinkType,
     issueTypeScheme,
     projectRole,
+    fieldConfiguration,
   ]
 }

--- a/packages/jira-adapter/src/filters/field_configuration.ts
+++ b/packages/jira-adapter/src/filters/field_configuration.ts
@@ -91,7 +91,7 @@ const filter: FilterCreator = ({ config, client }) => ({
       relevantChanges as Change<InstanceElement>[],
       async change => {
         if (getChangeData(change).value.isDefault && isModificationChange(change)) {
-          log.warn(`Skipping default deploy for default ${FIELD_CONFIGURATION_TYPE_NAME} because it is not supported`)
+          log.info(`Skipping default deploy for default ${FIELD_CONFIGURATION_TYPE_NAME} because it is not supported`)
         } else {
           await defaultDeployChange({
             change,

--- a/packages/jira-adapter/src/filters/field_configuration.ts
+++ b/packages/jira-adapter/src/filters/field_configuration.ts
@@ -90,15 +90,15 @@ const filter: FilterCreator = ({ config, client }) => ({
     const deployResult = await deployChanges(
       relevantChanges as Change<InstanceElement>[],
       async change => {
-        if (!getChangeData(change).value.isDefault && isModificationChange(change)) {
+        if (getChangeData(change).value.isDefault && isModificationChange(change)) {
+          log.warn(`Skipping default deploy for default ${FIELD_CONFIGURATION_TYPE_NAME} because it is not supported`)
+        } else {
           await defaultDeployChange({
             change,
             client,
             apiDefinitions: config.apiDefinitions,
             fieldsToIgnore: ['fields'],
           })
-        } else {
-          log.warn(`Skipping default deploy for default ${FIELD_CONFIGURATION_TYPE_NAME} because it is not supported`)
         }
         await deployFieldConfigurationItems(change, client, config)
       }

--- a/packages/jira-adapter/test/filters/field_configuration.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration.test.ts
@@ -159,7 +159,7 @@ describe('fieldConfigurationFilter', () => {
       change = toChange({ before: instance, after: instance })
     })
 
-    it('should deploy regular fields using deployChange', async () => {
+    it('should deploy regular fields using deployChange in modification', async () => {
       await filter.deploy([change])
       expect(deployChange).toHaveBeenCalledWith(
         await resolveChangeElement(change, getLookUpName),
@@ -170,7 +170,18 @@ describe('fieldConfigurationFilter', () => {
       )
     })
 
-    it('should not deploy regular fields if is default', async () => {
+    it('should deploy regular fields using deployChange in creation', async () => {
+      await filter.deploy([toChange({ after: instance })])
+      expect(deployChange).toHaveBeenCalledWith(
+        await resolveChangeElement(toChange({ after: instance }), getLookUpName),
+        mockCli,
+        DEFAULT_CONFIG.apiDefinitions.types.FieldConfiguration.deployRequests,
+        ['fields'],
+        undefined,
+      )
+    })
+
+    it('should not deploy regular fields if is default and change is modification', async () => {
       instance.value.isDefault = true
       await filter.deploy([change])
       expect(deployChange).not.toHaveBeenCalled()


### PR DESCRIPTION
Fixed regression in FieldConfgiuration deployment

---

The condition [here](https://github.com/salto-io/salto/compare/main...alonstern:SALTO-1991?expand=1#diff-36059ffe65bf56a701ac1401981c8b25503bf1adcdb70fdf16254b71ecef532eL93) was wrong

---
_Release Notes_: 
None

---
_User Notifications_: 
None