### PR TITLE
SALTO-1990: Fixed saved search type

### DIFF
--- a/packages/netsuite-adapter/src/saved_search_parsing/parsed_saved_search.ts
+++ b/packages/netsuite-adapter/src/saved_search_parsing/parsed_saved_search.ts
@@ -251,7 +251,7 @@ export const savedsearchType = (): TypeAndInnerTypes => {
         refType: createRefToElmWithValue(new ListType(savedSearchReturnField)),
       },
       sort_columns: {
-        refType: createRefToElmWithValue(savedSearchSortColumns),
+        refType: new ListType(savedSearchSortColumns),
       },
       audience: {
         refType: createRefToElmWithValue(savedSearchAudience),


### PR DESCRIPTION
Fixed saved search type

---
_Release Notes_: 
Netsuite:
- Fixed `sort_columns` field type in `savedsearch` type

---
_User Notifications_: 
- The type of `sort_column` field in `savedsearch` type in Netsuite is going to change (the notifications won't alert this change, but it will affect the workspace on git). 