### PR TITLE
SALTO-1973: Added fetch for missing statuses

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -36,6 +36,7 @@ export type ClientOpts<
 export type ClientBaseParams = {
   url: string
   queryParams?: Record<string, string>
+  headers?: Record<string, string>
 }
 
 export type ClientDataParams = ClientBaseParams & {
@@ -172,21 +173,24 @@ export abstract class AdapterHTTPClient<
       throw new Error(`uninitialized ${this.clientName} client`)
     }
 
-    const { url, queryParams } = params
+    const { url, queryParams, headers } = params
     try {
-      const requestQueryParams = queryParams !== undefined && Object.keys(queryParams).length > 0
-        ? { params: queryParams }
+      const requestConfig = queryParams !== undefined || headers !== undefined
+        ? {
+          params: queryParams,
+          headers,
+        }
         : undefined
 
       const { data, status } = isMethodWithData(params)
         ? await this.apiClient[method](
           url,
           params.data,
-          requestQueryParams,
+          requestConfig,
         )
         : await this.apiClient[method](
           url,
-          requestQueryParams,
+          requestConfig,
         )
       log.debug('Received response for %s (%s) with status %d', url, safeJsonStringify({ url, queryParams }), status)
       log.trace('Full HTTP response for %s: %s', url, safeJsonStringify({

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import axios, { AxiosError, AxiosBasicCredentials } from 'axios'
+import axios, { AxiosError, AxiosBasicCredentials, AxiosRequestConfig } from 'axios'
 import axiosRetry, { isNetworkOrIdempotentRequestError } from 'axios-retry'
 import { AccountId } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
@@ -36,20 +36,15 @@ export type Response<T> = {
   statusText?: string
 }
 
-type RequestConfig = {
-  params?: Record<string, unknown>
-  headers?: Record<string, unknown>
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type APIConnection<T = any, S = any> = {
   // based on https://github.com/axios/axios/blob/f472e5da5fe76c72db703d6a0f5190e4ad31e642/index.d.ts#L140
-  get: (url: string, config?: RequestConfig) => Promise<Response<T>>
-  post: (url: string, data: S, config?: RequestConfig)
+  get: (url: string, config?: AxiosRequestConfig) => Promise<Response<T>>
+  post: (url: string, data: S, config?: AxiosRequestConfig)
     => Promise<Response<T>>
-  put: (url: string, data: S, config?: RequestConfig) => Promise<Response<T>>
-  delete: (url: string, config?: RequestConfig) => Promise<Response<T>>
-  patch: (url: string, data: S, config?: RequestConfig)
+  put: (url: string, data: S, config?: AxiosRequestConfig) => Promise<Response<T>>
+  delete: (url: string, config?: AxiosRequestConfig) => Promise<Response<T>>
+  patch: (url: string, data: S, config?: AxiosRequestConfig)
     => Promise<Response<T>>
 }
 

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -36,15 +36,20 @@ export type Response<T> = {
   statusText?: string
 }
 
+type RequestConfig = {
+  params?: Record<string, unknown>
+  headers?: Record<string, unknown>
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type APIConnection<T = any, S = any> = {
   // based on https://github.com/axios/axios/blob/f472e5da5fe76c72db703d6a0f5190e4ad31e642/index.d.ts#L140
-  get: (url: string, config?: { params: Record<string, unknown> }) => Promise<Response<T>>
-  post: (url: string, data: S, config?: { params: Record<string, unknown> })
+  get: (url: string, config?: RequestConfig) => Promise<Response<T>>
+  post: (url: string, data: S, config?: RequestConfig)
     => Promise<Response<T>>
-  put: (url: string, data: S, config?: { params: Record<string, unknown> }) => Promise<Response<T>>
-  delete: (url: string, config?: { params: Record<string, unknown> }) => Promise<Response<T>>
-  patch: (url: string, data: S, config?: { params: Record<string, unknown> })
+  put: (url: string, data: S, config?: RequestConfig) => Promise<Response<T>>
+  delete: (url: string, config?: RequestConfig) => Promise<Response<T>>
+  patch: (url: string, data: S, config?: RequestConfig)
     => Promise<Response<T>>
 }
 

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -38,6 +38,7 @@ jira {
 |---------------------------------------------------------------|--------------------------|------------
 | [retry](#retry-configuration-options)                         | `{}` (no overrides)      | Configuration for retrying on errors
 | [rateLimit](#rate-limit-configuration-options)                | `{}` (no overrides)      | Limits on the number of concurrent requests of different types
+| usePrivateAPI                                                 | true                     | Whether to use Jira Private API when fetching and deploying changes
 
 #### Client retry options
 

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -32,6 +32,7 @@ import sortListsFilter from './filters/sort_lists'
 import boardFilter from './filters/board'
 import screenFilter from './filters/screen/screen'
 import mapListsFilter from './filters/map_lists'
+import missingStatusesFilter from './filters/statuses/missing_statuses'
 import issueTypeScreenSchemeFilter from './filters/issue_type_screen_scheme'
 import fieldConfigurationFilter from './filters/field_configuration'
 import fieldConfigurationTrashedFieldsFilter from './filters/field_configuration_trashed_fields'
@@ -64,6 +65,7 @@ export const DEFAULT_FILTERS = [
   avatarsFilter,
   workflowFilter,
   workflowSchemeFilter,
+  missingStatusesFilter,
   issueTypeSchemeReferences,
   issueTypeSchemeFilter,
   sharePermissionFilter,

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -29,6 +29,7 @@ const FIELDS_TO_OMIT: configUtils.FieldToOmitType[] = [
 type JiraClientConfig = clientUtils.ClientBaseConfig<clientUtils.ClientRateLimitConfig>
   & {
     fieldConfigurationItemsDeploymentLimit: number
+    usePrivateAPI: boolean
   }
 
 type JiraFetchConfig = configUtils.UserFetchConfig
@@ -1539,6 +1540,7 @@ export const DEFAULT_CONFIG: JiraConfig = {
   client: {
   // Jira does not allow more items in a single request than this
     fieldConfigurationItemsDeploymentLimit: 100,
+    usePrivateAPI: true,
   },
   fetch: {
     includeTypes: DEFAULT_INCLUDE_ENDPOINTS,
@@ -1550,6 +1552,9 @@ const createClientConfigType = (): ObjectType => {
   const configType = clientUtils.createClientConfigType(JIRA)
   configType.fields.FieldConfigurationItemsDeploymentLimit = new Field(
     configType, 'FieldConfigurationItemsDeploymentLimit', BuiltinTypes.NUMBER
+  )
+  configType.fields.usePrivateAPI = new Field(
+    configType, 'usePrivateAPI', BuiltinTypes.BOOLEAN
   )
   return configType
 }

--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -16,3 +16,7 @@
 export const JIRA = 'jira'
 export const ISSUE_TYPE_SCHEMA_NAME = 'IssueTypeScheme'
 export const ISSUE_TYPE_NAME = 'IssueType'
+
+export const PRIVATE_API_HEADERS = {
+  'X-Atlassian-Token': 'no-check',
+}

--- a/packages/jira-adapter/src/filters/statuses/missing_statuses.ts
+++ b/packages/jira-adapter/src/filters/statuses/missing_statuses.ts
@@ -1,0 +1,125 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, InstanceElement, isInstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { naclCase, pathNaclCase, safeJsonStringify } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import Joi from 'joi'
+import { elements as elementUtils, config as configUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { findObject } from '../../utils'
+import { FilterCreator } from '../../filter'
+import { JIRA, PRIVATE_API_HEADERS } from '../../constants'
+import { JiraConfig } from '../../config'
+
+const STATUS_TYPE_NAME = 'Status'
+
+const log = logger(module)
+
+type Status = {
+  id: string
+  name: string
+  description?: string
+}
+
+const EXPECTED_RESULTS_SCHEME = Joi.array().items(Joi.object({
+  id: Joi.string(),
+  name: Joi.string(),
+  description: Joi.string().allow('').optional(),
+}).unknown(true))
+
+const isStatusesResponse = (responseValue: unknown): responseValue is Status[] => {
+  const { error } = EXPECTED_RESULTS_SCHEME.validate(responseValue)
+  if (error !== undefined) {
+    log.error(`Received an invalid response from statuses private API: ${error.message}, ${safeJsonStringify(responseValue)}`)
+    return false
+  }
+  return true
+}
+
+const createStatusInstance = (
+  statusValues: Status,
+  statusType: ObjectType,
+  config: JiraConfig
+): InstanceElement => {
+  const { idFields } = configUtils.getConfigWithDefault(
+    config.apiDefinitions.types[statusType.elemID.typeName].transformation,
+    config.apiDefinitions.typeDefaults.transformation
+  )
+  const statusName = naclCase(elementUtils.getInstanceName(statusValues, idFields)
+    ?? statusValues.id)
+
+  return new InstanceElement(
+    statusName,
+    statusType,
+    // iconURL seems to always be empty
+    _.omit(statusValues, 'iconURL'),
+    [
+      JIRA,
+      elementUtils.RECORDS_PATH,
+      STATUS_TYPE_NAME,
+      pathNaclCase(statusName),
+    ],
+  )
+}
+
+/**
+ * The public API for getting all the statuses returns only
+ * the statuses that are used in active workflows so we fetch
+ * the missing statuses using private API
+ */
+const filter: FilterCreator = ({ client, config }) => ({
+  onFetch: async (elements: Element[]) => {
+    if (!config.client.usePrivateAPI) {
+      log.debug('Skipping missing statuses filter because private API is not enabled')
+      return
+    }
+
+    const statusType = findObject(elements, 'Status')
+    if (statusType === undefined) {
+      log.warn(`${STATUS_TYPE_NAME} type not found, skipping missing_statuses filter`)
+      return
+    }
+
+    const existingIds = new Set(elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === STATUS_TYPE_NAME)
+      .map(instance => instance.value.id))
+
+
+    try {
+      const response = await client.getSinglePage({
+        url: '/rest/workflowDesigner/1.0/statuses',
+        headers: PRIVATE_API_HEADERS,
+      })
+      const statusesValues = response.data
+
+      if (!isStatusesResponse(statusesValues)) {
+        return
+      }
+
+
+      const missingStatuses = statusesValues
+        .filter(status => !existingIds.has(status.id))
+        .map(statusValues => createStatusInstance(statusValues, statusType, config))
+
+      elements.push(...missingStatuses)
+    } catch (err) {
+      log.error(`Received an error when using statuses private API: ${err.message}`)
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/test/filters/statuses/missing_statuses.test.ts
+++ b/packages/jira-adapter/test/filters/statuses/missing_statuses.test.ts
@@ -1,0 +1,124 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import _ from 'lodash'
+import { mockClient } from '../../utils'
+import missingStatusesFilter from '../../../src/filters/statuses/missing_statuses'
+import { Filter } from '../../../src/filter'
+import { DEFAULT_CONFIG, JiraConfig } from '../../../src/config'
+import { JIRA, PRIVATE_API_HEADERS } from '../../../src/constants'
+
+describe('missingStatusesFilter', () => {
+  let filter: Filter
+  let type: ObjectType
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let config: JiraConfig
+
+  beforeEach(async () => {
+    const { client, paginator, connection } = mockClient()
+    mockConnection = connection
+
+    config = _.cloneDeep(DEFAULT_CONFIG)
+    filter = missingStatusesFilter({
+      client,
+      paginator,
+      config,
+    })
+
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, 'Status'),
+    })
+  })
+
+  describe('onFetch', () => {
+    it('should do nothing if type is not found', async () => {
+      await filter.onFetch?.([])
+      expect(mockConnection.get).not.toHaveBeenCalled()
+    })
+
+    it('should do nothing if usePrivateAPI is false', async () => {
+      config.client.usePrivateAPI = false
+      await filter.onFetch?.([type])
+      expect(mockConnection.get).not.toHaveBeenCalled()
+    })
+
+    it('should do nothing if response is invalid', async () => {
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: 'invalid',
+      })
+
+      const elements = [type]
+      await filter.onFetch?.(elements)
+      expect(elements).toHaveLength(1)
+    })
+
+    it('should do nothing if request failed', async () => {
+      mockConnection.get.mockResolvedValue({
+        status: 400,
+        data: 'invalid',
+      })
+
+      const elements = [type]
+      await filter.onFetch?.(elements)
+      expect(elements).toHaveLength(1)
+    })
+
+    it('should add the missing statuses to elements', async () => {
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: [
+          {
+            id: '1',
+            name: 'Status1',
+            description: 'Description 1',
+          },
+          {
+            id: '2',
+            name: 'Status2',
+          },
+        ],
+      })
+
+      const instance = new InstanceElement(
+        'Status2',
+        type,
+        {
+          id: '2',
+          name: 'Status2',
+        },
+      )
+
+      const elements = [type, instance]
+      await filter.onFetch?.(elements)
+
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        '/rest/workflowDesigner/1.0/statuses',
+        {
+          headers: PRIVATE_API_HEADERS,
+        }
+      )
+
+      expect(elements.map(e => e.elemID.getFullName())).toEqual([
+        type.elemID.getFullName(),
+        instance.elemID.getFullName(),
+        new ElemID(JIRA, 'Status', 'instance', 'Status1').getFullName(),
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Jira public API for getting all the statuses returns only the statuses that are used in active workflows so we fetch the missing statuses using private API.
I also added a configuration option to turn off the usage of private API
 
---
_Release Notes_: 
None

---
_User Notifications_: 
None