### PR TITLE
SALTO-1985: changed to deploy removals first for projects

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { FetchResult, AdapterOperations, DeployResult, InstanceElement, TypeMap, isObjectType, FetchOptions, DeployOptions, Change, isInstanceChange, ElemIdGetter } from '@salto-io/adapter-api'
-import { config as configUtils, elements as elementUtils, client as clientUtils, deployment } from '@salto-io/adapter-components'
+import { config as configUtils, elements as elementUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { applyFunctionToChangeData, logDuration } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import JiraClient from './client/client'
@@ -51,6 +51,7 @@ import avatarsFilter from './filters/avatars'
 import userFilter from './filters/user'
 import { JIRA } from './constants'
 import { removeScopedObjects } from './client/pagination'
+import { dependencyChanger } from './dependency_changers'
 
 const {
   generateTypes,
@@ -253,7 +254,7 @@ export default class JiraAdapter implements AdapterOperations {
   get deployModifiers(): AdapterOperations['deployModifiers'] {
     return {
       changeValidator,
-      dependencyChanger: deployment.dependency.removeStandaloneFieldDependency,
+      dependencyChanger,
     }
   }
 }

--- a/packages/jira-adapter/src/dependency_changers/index.ts
+++ b/packages/jira-adapter/src/dependency_changers/index.ts
@@ -1,0 +1,30 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { DependencyChanger } from '@salto-io/adapter-api'
+import { deployment } from '@salto-io/adapter-components'
+import { collections } from '@salto-io/lowerdash'
+import { projectDependencyChanger } from './project'
+
+const { awu } = collections.asynciterable
+
+const DEPENDENCY_CHANGERS: DependencyChanger[] = [
+  deployment.dependency.removeStandaloneFieldDependency,
+  projectDependencyChanger,
+]
+
+export const dependencyChanger: DependencyChanger = async (
+  changes, deps
+) => awu(DEPENDENCY_CHANGERS).flatMap(changer => changer(changes, deps)).toArray()

--- a/packages/jira-adapter/src/dependency_changers/project.ts
+++ b/packages/jira-adapter/src/dependency_changers/project.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { Change, dependencyChange, DependencyChanger, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
-import { SetId } from '@salto-io/lowerdash/src/collections/set'
+import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 
 
@@ -22,7 +22,7 @@ export const projectDependencyChanger: DependencyChanger = async changes => {
   const projectChanges = Array.from(changes.entries())
     .map(([key, change]) => ({ key, change }))
     .filter(
-      (change): change is { key: SetId; change: Change<InstanceElement> } =>
+      (change): change is { key: collections.set.SetId; change: Change<InstanceElement> } =>
         isInstanceChange(change.change)
     )
     .filter(({ change }) => getChangeData(change).elemID.typeName === 'Project')

--- a/packages/jira-adapter/src/dependency_changers/project.ts
+++ b/packages/jira-adapter/src/dependency_changers/project.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, dependencyChange, DependencyChanger, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
+import { SetId } from '@salto-io/lowerdash/src/collections/set'
+import _ from 'lodash'
+
+
+export const projectDependencyChanger: DependencyChanger = async changes => {
+  const projectChanges = Array.from(changes.entries())
+    .map(([key, change]) => ({ key, change }))
+    .filter(
+      (change): change is { key: SetId; change: Change<InstanceElement> } =>
+        isInstanceChange(change.change)
+    )
+    .filter(({ change }) => getChangeData(change).elemID.typeName === 'Project')
+    .filter(({ change }) => getChangeData(change).value.key !== undefined)
+
+  const keyToProjects = _.groupBy(projectChanges, ({ change }) => getChangeData(change).value.key)
+
+  return Object.values(keyToProjects)
+    .flatMap(projectChangesGroup => {
+      const removalChanges = projectChangesGroup.filter(({ change }) => isRemovalChange(change))
+      const additionChanges = projectChangesGroup.filter(({ change }) => isAdditionChange(change))
+
+      return additionChanges.flatMap(
+        additionChange => removalChanges.map(
+          removalChange => dependencyChange(
+            'add',
+            additionChange.key,
+            removalChange.key,
+          )
+        )
+      )
+    })
+}

--- a/packages/jira-adapter/test/dependency_changers/index.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/index.test.ts
@@ -1,0 +1,60 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, toChange, dependencyChange } from '@salto-io/adapter-api'
+import { deployment } from '@salto-io/adapter-components'
+import { collections } from '@salto-io/lowerdash'
+import { JIRA } from '../../src/constants'
+import { dependencyChanger } from '../../src/dependency_changers'
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      dependency: {
+        ...actual.deployment.dependency,
+        removeStandaloneFieldDependency: jest.fn()
+          .mockResolvedValue([dependencyChange('add', 0, 1)]),
+      },
+    },
+  }
+})
+
+describe('dependencyChanger', () => {
+  let type: ObjectType
+  beforeEach(() => {
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, 'SomeType'),
+    })
+  })
+
+  it('should call its dependencies changers', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ after: type })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set()],
+    ])
+
+    const dependencyChanges = [...await dependencyChanger(inputChanges, inputDeps)]
+
+    expect(deployment.dependency.removeStandaloneFieldDependency).toHaveBeenCalled()
+    expect(dependencyChanges[0].action).toEqual('add')
+    expect(dependencyChanges[0].dependency.source).toEqual(0)
+    expect(dependencyChanges[0].dependency.target).toEqual(1)
+  })
+})

--- a/packages/jira-adapter/test/dependency_changers/project.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/project.test.ts
@@ -1,0 +1,68 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, InstanceElement, ElemID, toChange } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { projectDependencyChanger } from '../../src/dependency_changers/project'
+import { JIRA } from '../../src/constants'
+
+describe('projectDependencyChanger', () => {
+  let type: ObjectType
+  let instance: InstanceElement
+  beforeEach(() => {
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, 'Project'),
+    })
+    instance = new InstanceElement(
+      'inst',
+      type,
+      {
+        key: 'key',
+      },
+    )
+  })
+
+  it('should add dependency from the added to removed project with the same key', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ before: instance })],
+      [1, toChange({ after: instance })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set()],
+      [1, new Set()],
+    ])
+
+    const dependencyChanges = [...await projectDependencyChanger(inputChanges, inputDeps)]
+    expect(dependencyChanges).toHaveLength(1)
+    expect(dependencyChanges[0].action).toEqual('add')
+    expect(dependencyChanges[0].dependency.source).toEqual(1)
+    expect(dependencyChanges[0].dependency.target).toEqual(0)
+  })
+
+  it('should add no dependencies if there is no key', async () => {
+    delete instance.value.key
+    const inputChanges = new Map([
+      [0, toChange({ before: instance })],
+      [1, toChange({ after: instance })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set()],
+      [1, new Set()],
+    ])
+
+    const dependencyChanges = [...await projectDependencyChanger(inputChanges, inputDeps)]
+    expect(dependencyChanges).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Added dependency from additions to removals of projects with the same key

---

This is to prevent a scenario where for example with delete a project and create a project with the same key in the same deploy, but because we don't first remove the project and then add the new one, we get an error the the key is already in use

---
_Release Notes_: 
None

---
_User Notifications_: 
None