### PR TITLE
SALTO-1974, SALTO-1967: fixed changed validator message

### DIFF
--- a/packages/jira-adapter/src/change_validators/field_configuration_unsupported_fields.ts
+++ b/packages/jira-adapter/src/change_validators/field_configuration_unsupported_fields.ts
@@ -18,7 +18,7 @@ import { ChangeValidator, compareSpecialValues, getChangeData, InstanceElement, 
 import { values } from '@salto-io/lowerdash'
 
 const getFieldId = (field: Values): string => (
-  isReferenceExpression(field.id) ? field.id.value.value.id : field.id
+  isReferenceExpression(field.id) ? field.id.elemID.name : field.id
 )
 
 const getDiffFields = (change: ModificationChange<InstanceElement>): Values[] => {
@@ -57,7 +57,7 @@ export const unsupportedFieldConfigurationsValidator: ChangeValidator = async ch
           elemID,
           severity: 'Warning' as SaltoErrorSeverity,
           message: `Salto can't deploy fields configuration of ${elemID.getFullName()} because they are locked`,
-          detailedMessage: `Salto can't deploy the configuration of fields: ${unsupportedIds.join(', ')}. If continuing, they will be omitted from the deployment`,
+          detailedMessage: `Salto can't deploy the configuration of fields: ${unsupportedIds.join(', ')} because they are locked. If continuing, they will be omitted from the deployment`,
         }
       }
       return undefined

--- a/packages/jira-adapter/src/change_validators/field_configuration_unsupported_fields.ts
+++ b/packages/jira-adapter/src/change_validators/field_configuration_unsupported_fields.ts
@@ -17,21 +17,21 @@ import _ from 'lodash'
 import { ChangeValidator, compareSpecialValues, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isReferenceExpression, ModificationChange, SaltoErrorSeverity, Values } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
 
-const getFieldId = (field: Values): string => (
+const getFieldNaclRepr = (field: Values): string => (
   isReferenceExpression(field.id) ? field.id.elemID.name : field.id
 )
 
 const getDiffFields = (change: ModificationChange<InstanceElement>): Values[] => {
-  const beforeIdToField = _(change.data.before.value.fields)
+  const beforeReprToField = _(change.data.before.value.fields)
     .values()
-    .keyBy(getFieldId)
+    .keyBy(getFieldNaclRepr)
     .value()
 
   return (Object.values(change.data.after.value.fields ?? []) as Values[])
     .filter(
       (field: Values) => !_.isEqualWith(
         field,
-        beforeIdToField[getFieldId(field)],
+        beforeReprToField[getFieldNaclRepr(field)],
         compareSpecialValues
       )
     )
@@ -49,7 +49,7 @@ export const unsupportedFieldConfigurationsValidator: ChangeValidator = async ch
 
       const unsupportedIds = fields
         .filter((field: Values) => field.id.value.value.isLocked)
-        .map(getFieldId)
+        .map(getFieldNaclRepr)
 
       const { elemID } = getChangeData(change)
       if (unsupportedIds.length !== 0) {

--- a/packages/jira-adapter/test/change_validators/field_configuration_unsupported_fields.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_configuration_unsupported_fields.test.ts
@@ -29,7 +29,7 @@ describe('unsupportedFieldConfigurationsValidator', () => {
   it('should return an error if id is a reference to a locked field', async () => {
     instance.value.fields = {
       inst: {
-        id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'inst'), {
+        id: new ReferenceExpression(new ElemID(JIRA, 'Field', 'instance', 'instName'), {
           value: {
             id: 'inst',
             isLocked: true,
@@ -47,7 +47,7 @@ describe('unsupportedFieldConfigurationsValidator', () => {
         elemID: instance.elemID,
         severity: 'Warning',
         message: `Salto can't deploy fields configuration of ${instance.elemID.getFullName()} because they are locked`,
-        detailedMessage: 'Salto can\'t deploy the configuration of fields: inst. If continuing, they will be omitted from the deployment',
+        detailedMessage: 'Salto can\'t deploy the configuration of fields: instName because they are locked. If continuing, they will be omitted from the deployment',
       },
     ])
   })


### PR DESCRIPTION
Fixed `unsupportedFieldConfigurationsValidator` detailedMessage.

- Changed it to contain all information in the message (because in the SaaS we show only the detailedMessage)
- Replaced the ids in the message with the field instances names

---
_Release Notes_: 
None

---
_User Notifications_: 
None