### PR TITLE
Fetch From - Check for Errors and not Warnings, and only if fetching …

### DIFF
--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -39,7 +39,6 @@ const log = logger(module)
 
 export const MAX_DETAIL_CHANGES_TO_LOG = 100
 export const MAX_WORKSPACE_ERRORS_TO_LOG = 30
-const isError = (e: SaltoError): boolean => (e.severity === 'Error')
 
 export type LoadWorkspaceResult = {
   workspace: Workspace
@@ -94,13 +93,13 @@ export const validateWorkspace = async (
   if (!errors.hasErrors()) {
     return { status: 'Valid', errors: [] }
   }
-  if (wu.some(isError, errors.all())) {
-    return { status: 'Error', errors: groupRelatedErrors([...wu.filter(isError, errors.all())]) }
+  if (errors.hasErrors('Error')) {
+    return { status: 'Error', errors: groupRelatedErrors([...errors.all('Error')]) }
   }
 
   const relevantErrors = [...ignoreUnresolvedRefs
-    ? wu.filter(e => !isUnresolvedRefError(e), errors.all())
-    : errors.all()]
+    ? wu.filter(e => !isUnresolvedRefError(e), errors.all('Warning'))
+    : errors.all('Warning')]
 
   if (relevantErrors.length === 0) {
     return { status: 'Valid', errors: [] }

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -908,12 +908,14 @@ Moving the specified elements to common.
         workspace = mocks.mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementation(mockedList)
         // Should ignore unresolved reference errors
-        workspace.errors.mockResolvedValue(mocks.mockErrors([
-          new errors.UnresolvedReferenceValidationError({
+        workspace.errors.mockResolvedValue(new errors.Errors({
+          parse: [],
+          merge: [],
+          validation: [new errors.UnresolvedReferenceValidationError({
             elemID: new ElemID('test', 'src'),
             target: new ElemID('test', 'target'),
-          }),
-        ]))
+          })],
+        }))
         result = await listUnresolvedAction({
           ...mocks.mockCliCommandArgs(listUnresolvedName, cliArgs),
           input: {

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -295,13 +295,10 @@ export const elements = (): Element[] => {
   ]
 }
 
-export const mockErrors = (errors: SaltoError[]): wsErrors.Errors => ({
-  all: () => errors,
-  hasErrors: () => errors.length !== 0,
-  merge: [],
+export const mockErrors = (errors: SaltoError[]): wsErrors.Errors => new wsErrors.Errors({
   parse: [],
-  validation: errors.map(err => ({ elemID: new ElemID('test'), error: '', ...err })),
-  strings: () => errors.map(err => err.message),
+  merge: [],
+  validation: errors.map(err => ({ elemID: new ElemID('test'), error: err.message, ...err })),
 })
 
 // Mock interface does not handle template functions well

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -791,7 +791,7 @@ export const fetchChangesFromWorkspace = async (
     }`)
   }
   if (!fromState
-    && wu.some(err => err.severity === 'Error', (await otherWorkspace.errors()).all())) {
+    && (await otherWorkspace.errors()).hasErrors('Error')) {
     return createEmptyFetchChangeDueToError('Can not fetch from a workspace with errors.')
   }
 

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -790,8 +790,8 @@ export const fetchChangesFromWorkspace = async (
       differentConfig.map(config => config.elemID.adapter).join(', ')
     }`)
   }
-
-  if (await otherWorkspace.hasErrors(env)) {
+  if (!fromState
+    && wu.some(err => err.severity === 'Error', (await otherWorkspace.errors()).all())) {
     return createEmptyFetchChangeDueToError('Can not fetch from a workspace with errors.')
   }
 

--- a/packages/core/test/common/workspace.ts
+++ b/packages/core/test/common/workspace.ts
@@ -60,13 +60,10 @@ const mockEmptyConfigInstance = new InstanceElement(ElemID.CONFIG_NAME, mockEmpt
   sandbox: false,
 })
 
-export const mockErrors = (errors: SaltoError[]): wsErrors.Errors => ({
-  all: () => errors,
-  hasErrors: () => errors.length !== 0,
-  merge: [],
+export const mockErrors = (errors: SaltoError[]): wsErrors.Errors => new wsErrors.Errors({
   parse: [],
-  validation: errors.map(err => ({ elemID: new ElemID('test'), error: '', ...err })),
-  strings: () => errors.map(err => err.message),
+  merge: [],
+  validation: errors.map(err => ({ elemID: new ElemID('test'), error: err.message, ...err })),
 })
 
 export const mockWorkspace = ({

--- a/packages/core/test/common/workspace.ts
+++ b/packages/core/test/common/workspace.ts
@@ -16,7 +16,7 @@
 import { BuiltinTypes, Element, ElemID, InstanceElement, ObjectType, SaltoError, Value } from '@salto-io/adapter-api'
 import { mockFunction } from '@salto-io/test-utils'
 import * as workspace from '@salto-io/workspace'
-import { elementSource } from '@salto-io/workspace'
+import { elementSource, errors as wsErrors } from '@salto-io/workspace'
 import { mockState } from './state'
 
 const mockService = 'salto'
@@ -58,6 +58,15 @@ const mockEmptyConfigInstance = new InstanceElement(ElemID.CONFIG_NAME, mockEmpt
   password: 'test',
   token: 'test',
   sandbox: false,
+})
+
+export const mockErrors = (errors: SaltoError[]): wsErrors.Errors => ({
+  all: () => errors,
+  hasErrors: () => errors.length !== 0,
+  merge: [],
+  parse: [],
+  validation: errors.map(err => ({ elemID: new ElemID('test'), error: '', ...err })),
+  strings: () => errors.map(err => err.message),
 })
 
 export const mockWorkspace = ({
@@ -110,6 +119,7 @@ export const mockWorkspace = ({
     updateAccountConfig: jest.fn(),
     clear: jest.fn(),
     getElementIdsBySelectors: jest.fn(),
+    errors: jest.fn().mockImplementation(() => mockErrors(errors)),
     hasErrors: () => errors.length > 0,
     getValue: async (id: ElemID) => elements.find(e => e.elemID.getFullName() === id.getFullName()),
   } as unknown as workspace.Workspace


### PR DESCRIPTION
…not from the state

---
_Release Notes_: 
*Core*:
* Change the Fetch From Workspace pre-conditions check about Errors in the source Workspace to not fail from Warnings, and not check for Errors/Warnings at all if the Fetch is from the source's state

