### PR TITLE
SALTO-1958: changed swagger back to use main branch

### DIFF
--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1310,7 +1310,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
 
 export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
   platformSwagger: {
-    url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/platform-swagger.v3.json',
+    url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/main/platform-swagger.v3.json',
     typeNameOverrides: [
       {
         originalName: 'FilterDetails',
@@ -1439,7 +1439,7 @@ export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
     ],
   },
   jiraSwagger: {
-    url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/software-swagger.v3.json',
+    url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/main/software-swagger.v3.json',
     typeNameOverrides: [
       {
         originalName: 'agile__1_0__board@uuvuu',

--- a/packages/jira-adapter/system_config_doc.md
+++ b/packages/jira-adapter/system_config_doc.md
@@ -4,7 +4,7 @@
 jira {
   apiDefinitions = {
     platformSwagger = {
-      url = "https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/platform-swagger.v3.json"
+      url = "https://raw.githubusercontent.com/salto-io/jira-swaggers/main/platform-swagger.v3.json"
       typeNameOverrides = [
         {
           originalName = "FilterDetails"
@@ -133,7 +133,7 @@ jira {
       ]
     }
     jiraSwagger = {
-      url = "https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/software-swagger.v3.json"
+      url = "https://raw.githubusercontent.com/salto-io/jira-swaggers/main/software-swagger.v3.json"
       typeNameOverrides = [
         {
           originalName = "agile__1_0__board@uuvuu"

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -218,13 +218,13 @@ describe('adapter', () => {
     })
     it('should generate types for the platform and the jira apis', () => {
       expect(loadSwagger).toHaveBeenCalledTimes(2)
-      expect(loadSwagger).toHaveBeenCalledWith('https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/platform-swagger.v3.json')
-      expect(loadSwagger).toHaveBeenCalledWith('https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/software-swagger.v3.json')
+      expect(loadSwagger).toHaveBeenCalledWith('https://raw.githubusercontent.com/salto-io/jira-swaggers/main/platform-swagger.v3.json')
+      expect(loadSwagger).toHaveBeenCalledWith('https://raw.githubusercontent.com/salto-io/jira-swaggers/main/software-swagger.v3.json')
       expect(generateTypes).toHaveBeenCalledWith(
         JIRA,
         expect.objectContaining({
           swagger: expect.objectContaining({
-            url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/platform-swagger.v3.json',
+            url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/main/platform-swagger.v3.json',
           }),
         }),
         undefined,
@@ -234,7 +234,7 @@ describe('adapter', () => {
         JIRA,
         expect.objectContaining({
           swagger: expect.objectContaining({
-            url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/software-swagger.v3.json',
+            url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/main/software-swagger.v3.json',
           }),
         }),
         undefined,


### PR DESCRIPTION
Changed swagger back to use `main` branch in the jira-swaggers repo after it's been updated with the latest swagger

---
_Release Notes_: 
None

---
_User Notifications_: 
None