### PR TITLE
SALTO-2001: Added id to the name of duplicate instances

### DIFF
--- a/packages/adapter-components/src/elements/index.ts
+++ b/packages/adapter-components/src/elements/index.ts
@@ -21,7 +21,7 @@ import { computeGetArgs, simpleGetArgs } from './request_parameters'
 import { RECORDS_PATH, TYPES_PATH, SUBTYPES_PATH } from './constants'
 import { findDataField, returnFullEntry, FindNestedFieldFunc } from './field_finder'
 import { filterTypes } from './type_elements'
-import { getInstanceName } from './instance_elements'
+import { getInstanceName, generateInstanceNameFromConfig } from './instance_elements'
 
 export {
   ducktype,
@@ -33,4 +33,5 @@ export {
   RECORDS_PATH, TYPES_PATH, SUBTYPES_PATH,
   filterTypes,
   getInstanceName,
+  generateInstanceNameFromConfig,
 }

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -22,7 +22,7 @@ import { pathNaclCase, naclCase, transformValues, TransformFunc } from '@salto-i
 import { logger } from '@salto-io/logging'
 import { RECORDS_PATH } from './constants'
 import { TransformationConfig, TransformationDefaultConfig, getConfigWithDefault,
-  RecurseIntoCondition, isRecurseIntoConditionByField } from '../config'
+  RecurseIntoCondition, isRecurseIntoConditionByField, AdapterApiConfig } from '../config'
 
 const log = logger(module)
 
@@ -50,6 +50,19 @@ export const getInstanceName = (
   }
   return nameParts.every(part => part !== undefined && part !== '') ? nameParts.map(String).join('_') : undefined
 }
+
+export const generateInstanceNameFromConfig = (
+  values: Values,
+  typeName: string,
+  apiDefinitions: AdapterApiConfig
+): string | undefined => {
+  const { idFields } = getConfigWithDefault(
+    apiDefinitions.types[typeName]?.transformation ?? {},
+    apiDefinitions.typeDefaults.transformation
+  )
+  return getInstanceName(values, idFields)
+}
+
 
 const createServiceIds = (
   entry: Values, serviceIdField: string, type: ObjectType

--- a/packages/adapter-components/test/elements/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/instance_elements.test.ts
@@ -1,0 +1,60 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { generateInstanceNameFromConfig } from '../../src/elements/instance_elements'
+
+describe('generateInstanceNameFromConfig', () => {
+  it('should return the name of the instance based on the type config', () => {
+    expect(generateInstanceNameFromConfig(
+      {
+        name: 'name',
+        id: 'id',
+      },
+      'test',
+      {
+        typeDefaults: {
+          transformation: {
+            idFields: ['name'],
+          },
+        },
+        types: {
+          test: {
+            transformation: {
+              idFields: ['id'],
+            },
+          },
+        },
+      }
+    )).toBe('id')
+  })
+  it('should return the name of the type based on the type default when there is no type config', () => {
+    expect(generateInstanceNameFromConfig(
+      {
+        name: 'name',
+        id: 'id',
+      },
+      'test',
+      {
+        typeDefaults: {
+          transformation: {
+            idFields: ['name'],
+          },
+        },
+        types: {},
+      }
+    )).toBe('name')
+  })
+})

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -60,3 +60,4 @@ jira {
 | Name                                        | Default when undefined            | Description
 |---------------------------------------------|-----------------------------------|------------
 | includeTypes                                | []                                | List of types to fetch
+| fallbackToInternalId                        | false                             | Whether to add the internal ids to the instance name when the name is not unique among the instances of that type

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -57,6 +57,7 @@ jira {
 
 ## Fetch configuration options
 
-| Name                                        | Default when undefined          | Description
-|---------------------------------------------|---------------------------------|------------
-| includeTypes                                | []                              | List of types to fetch
+| Name                                        | Default when undefined            | Description
+|---------------------------------------------|-----------------------------------|------------
+| includeTypes                                | []                                | List of types to fetch
+| typesToFallbackToInternalId                 | ['Field', 'Status', 'Resolution'] | List of types to add their internal ids to the instance name when the name is not unique between the instances of that type

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -60,4 +60,3 @@ jira {
 | Name                                        | Default when undefined            | Description
 |---------------------------------------------|-----------------------------------|------------
 | includeTypes                                | []                                | List of types to fetch
-| typesToFallbackToInternalId                 | ['Field', 'Status', 'Resolution'] | List of types to add their internal ids to the instance name when the name is not unique between the instances of that type

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -65,6 +65,7 @@ const { createPaginator, getWithOffsetAndLimit } = clientUtils
 const log = logger(module)
 
 export const DEFAULT_FILTERS = [
+  // This should happen before any filter that creates new instances or references
   duplicateIdsFilter,
   avatarsFilter,
   workflowFilter,

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -44,6 +44,7 @@ import defaultInstancesDeployFilter from './filters/default_instances_deploy'
 import workflowFilter from './filters/workflow/workflow'
 import workflowPropertiesFilter from './filters/workflow/workflow_properties'
 import workflowSchemeFilter from './filters/workflow_scheme'
+import duplicateIdsFilter from './filters/duplicate_ids'
 import fieldStructureFilter from './filters/fields/field_structure_filter'
 import fieldDeploymentFilter from './filters/fields/field_deployment_filter'
 import contextDeploymentFilter from './filters/fields/context_deployment_filter'
@@ -64,6 +65,7 @@ const { createPaginator, getWithOffsetAndLimit } = clientUtils
 const log = logger(module)
 
 export const DEFAULT_FILTERS = [
+  duplicateIdsFilter,
   avatarsFilter,
   workflowFilter,
   workflowPropertiesFilter,

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -36,6 +36,7 @@ type JiraFetchConfig = configUtils.UserFetchConfig
 type JiraApiConfig = Omit<configUtils.AdapterSwaggerApiConfig, 'swagger'> & {
   platformSwagger: configUtils.AdapterSwaggerApiConfig['swagger']
   jiraSwagger: configUtils.AdapterSwaggerApiConfig['swagger']
+  fallbackToInternalId: boolean
 }
 
 // A list of custom field types that support options
@@ -1477,6 +1478,7 @@ export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
     },
   },
   types: DEFAULT_TYPE_CUSTOMIZATIONS,
+  fallbackToInternalId: true,
 }
 
 export const DEFAULT_INCLUDE_ENDPOINTS: string[] = [
@@ -1536,6 +1538,7 @@ const defaultApiDefinitionsType = createSwaggerAdapterApiConfigType({ adapter: J
 const apiDefinitionsType = createMatchingObjectType<Partial<JiraApiConfig>>({
   elemID: new ElemID(JIRA, 'apiDefinitions'),
   fields: {
+    fallbackToInternalId: { refType: BuiltinTypes.BOOLEAN },
     apiVersion: { refType: BuiltinTypes.STRING },
     typeDefaults: {
       refType: defaultApiDefinitionsType.fields.typeDefaults.refType,

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -32,12 +32,10 @@ type JiraClientConfig = clientUtils.ClientBaseConfig<clientUtils.ClientRateLimit
     usePrivateAPI: boolean
   }
 
-type JiraFetchConfig = configUtils.UserFetchConfig & {
-  typesToFallbackToInternalId?: string[]
-}
 type JiraApiConfig = Omit<configUtils.AdapterSwaggerApiConfig, 'swagger'> & {
   platformSwagger: configUtils.AdapterSwaggerApiConfig['swagger']
   jiraSwagger: configUtils.AdapterSwaggerApiConfig['swagger']
+  typesToFallbackToInternalId: string[]
 }
 
 // A list of custom field types that support options
@@ -1479,6 +1477,11 @@ export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
     },
   },
   types: DEFAULT_TYPE_CUSTOMIZATIONS,
+  typesToFallbackToInternalId: [
+    'Field',
+    'Status',
+    'Resolution',
+  ],
 }
 
 export const DEFAULT_INCLUDE_ENDPOINTS: string[] = [
@@ -1554,6 +1557,9 @@ const apiDefinitionsType = createMatchingObjectType<Partial<JiraApiConfig>>({
     supportedTypes: {
       refType: new ListType(BuiltinTypes.STRING),
     },
+    typesToFallbackToInternalId: {
+      refType: new ListType(BuiltinTypes.STRING),
+    },
   },
 })
 
@@ -1591,7 +1597,6 @@ const jiraDeployConfigType = new ObjectType({
 })
 
 const fetchConfigType = createUserFetchConfigType(JIRA)
-fetchConfigType.fields.typesToFallbackToInternalId = new Field(fetchConfigType, 'typesToFallbackToInternalId', new ListType(BuiltinTypes.STRING))
 
 export const configType = createMatchingObjectType<Partial<JiraConfig>>({
   elemID: new ElemID(JIRA),

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -32,11 +32,12 @@ type JiraClientConfig = clientUtils.ClientBaseConfig<clientUtils.ClientRateLimit
     usePrivateAPI: boolean
   }
 
-type JiraFetchConfig = configUtils.UserFetchConfig
+type JiraFetchConfig = configUtils.UserFetchConfig & {
+  typesToFallbackToInternalId?: string[]
+}
 type JiraApiConfig = Omit<configUtils.AdapterSwaggerApiConfig, 'swagger'> & {
   platformSwagger: configUtils.AdapterSwaggerApiConfig['swagger']
   jiraSwagger: configUtils.AdapterSwaggerApiConfig['swagger']
-  fallbackToInternalId: boolean
 }
 
 // A list of custom field types that support options
@@ -1478,7 +1479,6 @@ export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
     },
   },
   types: DEFAULT_TYPE_CUSTOMIZATIONS,
-  fallbackToInternalId: true,
 }
 
 export const DEFAULT_INCLUDE_ENDPOINTS: string[] = [
@@ -1538,7 +1538,6 @@ const defaultApiDefinitionsType = createSwaggerAdapterApiConfigType({ adapter: J
 const apiDefinitionsType = createMatchingObjectType<Partial<JiraApiConfig>>({
   elemID: new ElemID(JIRA, 'apiDefinitions'),
   fields: {
-    fallbackToInternalId: { refType: BuiltinTypes.BOOLEAN },
     apiVersion: { refType: BuiltinTypes.STRING },
     typeDefaults: {
       refType: defaultApiDefinitionsType.fields.typeDefaults.refType,
@@ -1591,12 +1590,15 @@ const jiraDeployConfigType = new ObjectType({
   },
 })
 
+const fetchConfigType = createUserFetchConfigType(JIRA)
+fetchConfigType.fields.typesToFallbackToInternalId = new Field(fetchConfigType, 'typesToFallbackToInternalId', new ListType(BuiltinTypes.STRING))
+
 export const configType = createMatchingObjectType<Partial<JiraConfig>>({
   elemID: new ElemID(JIRA),
   fields: {
     client: { refType: createClientConfigType() },
-    fetch: { refType: createUserFetchConfigType(JIRA) },
     deploy: { refType: jiraDeployConfigType },
+    fetch: { refType: fetchConfigType },
     apiDefinitions: { refType: apiDefinitionsType },
   },
   annotations: {

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1529,6 +1529,10 @@ type JiraDeployConfig = {
   forceDelete: boolean
 }
 
+type JiraFetchConfig = configUtils.UserFetchConfig & {
+  fallbackToInternalId?: boolean
+}
+
 export type JiraConfig = {
   client: JiraClientConfig
   fetch: JiraFetchConfig
@@ -1597,6 +1601,7 @@ const jiraDeployConfigType = new ObjectType({
 })
 
 const fetchConfigType = createUserFetchConfigType(JIRA)
+fetchConfigType.fields.fallbackToInternalId = new Field(fetchConfigType, 'fallbackToInternalId', BuiltinTypes.BOOLEAN)
 
 export const configType = createMatchingObjectType<Partial<JiraConfig>>({
   elemID: new ElemID(JIRA),

--- a/packages/jira-adapter/src/filter.ts
+++ b/packages/jira-adapter/src/filter.ts
@@ -13,12 +13,17 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { SaltoError } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import JiraClient from './client/client'
 import { JiraConfig } from './config'
 
 export const { filtersRunner } = filterUtils
 
-export type Filter = filterUtils.Filter
+export type FilterResult = {
+  errors?: SaltoError[]
+}
 
-export type FilterCreator = filterUtils.FilterCreator<JiraClient, JiraConfig>
+export type Filter = filterUtils.Filter<FilterResult>
+
+export type FilterCreator = filterUtils.FilterCreator<JiraClient, JiraConfig, FilterResult>

--- a/packages/jira-adapter/src/filters/duplicate_ids.ts
+++ b/packages/jira-adapter/src/filters/duplicate_ids.ts
@@ -61,7 +61,7 @@ const filter: FilterCreator = ({ config }) => ({
       .value())
 
     if (duplicateIds.size === 0) {
-      return
+      return {}
     }
 
     log.warn(`Found ${duplicateIds.size} duplicate instance names: ${Array.from(duplicateIds).join(', ')}`)
@@ -83,8 +83,21 @@ const filter: FilterCreator = ({ config }) => ({
         instance.annotations,
       ))
 
-    log.debug(`Replaced duplicate names with: ${Array.from(newInstances.map(instance => instance.elemID.name)).join(', ')}`)
+    const newNames = Array.from(newInstances.map(instance => instance.elemID.name))
+
+    log.debug(`Replaced duplicate names with: ${newNames.join(', ')}`)
     elements.push(...newInstances)
+
+    const isPlural = duplicateIds.size > 1
+
+    return {
+      errors: [
+        {
+          message: `The ${isPlural ? 'names' : 'name'} of ${Array.from(duplicateIds).join(', ')} ${isPlural ? 'are' : 'is'} not unique in the account, so the ids of the instances were added to their names, the new names are ${newNames.join(', ')}. However, that way Salto won't be able to identify that instances between envs are the same instance which will impact comparing and cloning elements between environments. It is strongly recommended to change the names of the instances to be unique in the account and then re-fetch with "Regenerate Salto IDs".`,
+          severity: 'Warning',
+        },
+      ],
+    }
   },
 })
 

--- a/packages/jira-adapter/src/filters/duplicate_ids.ts
+++ b/packages/jira-adapter/src/filters/duplicate_ids.ts
@@ -1,0 +1,77 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { naclCase } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { JiraConfig } from '../config'
+import { generateInstanceName } from '../utils'
+import { FilterCreator } from '../filter'
+
+const log = logger(module)
+
+const getInstanceName = (instance: InstanceElement, config: JiraConfig): string => {
+  const originalName = generateInstanceName(instance.value, instance.elemID.typeName, config)
+    ?? instance.elemID.name
+  return naclCase(`${originalName}_${instance.value.id}`)
+}
+
+/**
+ * Add id to the name of instances with duplicate names to prevent conflicts in the names
+ *
+ * This filter assumes the adapter does not split the same element into multiple files
+ */
+const filter: FilterCreator = ({ config }) => ({
+  onFetch: async elements => {
+    if (!config.apiDefinitions.fallbackToInternalId) {
+      return
+    }
+
+    const instances = elements.filter(isInstanceElement)
+    const duplicateIds = new Set(_(instances)
+      .countBy(instance => instance.elemID.getFullName())
+      .pickBy(count => count > 1)
+      .keys()
+      .value())
+
+    if (duplicateIds.size === 0) {
+      return
+    }
+
+    log.warn(`Found ${duplicateIds.size} duplicate instance names: ${Array.from(duplicateIds).join(', ')}`)
+
+    const duplicateInstances = _.remove(
+      elements,
+      element => duplicateIds.has(element.elemID.getFullName())
+        && isInstanceElement(element)
+        && element.value.id !== undefined
+    )
+
+    const newInstances = duplicateInstances
+      .filter(isInstanceElement)
+      .map(instance => new InstanceElement(
+        getInstanceName(instance, config),
+        instance.refType,
+        instance.value,
+        instance.path,
+        instance.annotations,
+      ))
+
+    elements.push(...newInstances)
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/duplicate_ids.ts
+++ b/packages/jira-adapter/src/filters/duplicate_ids.ts
@@ -20,18 +20,11 @@ import { logger } from '@salto-io/logging'
 import { elements as elementUtils } from '@salto-io/adapter-components'
 import { JiraConfig } from '../config'
 import { FilterCreator } from '../filter'
-import { FIELD_TYPE_NAME } from './fields/constants'
 
 const { generateInstanceNameFromConfig } = elementUtils
 
 
 const log = logger(module)
-
-const defaultTypesToFallbackToInternalId = [
-  FIELD_TYPE_NAME,
-  'Status',
-  'Resolution',
-]
 
 const getInstanceName = (instance: InstanceElement, config: JiraConfig): string => {
   const originalName = generateInstanceNameFromConfig(
@@ -51,8 +44,8 @@ const filter: FilterCreator = ({ config }) => ({
   onFetch: async elements => {
     const relevantInstances = elements
       .filter(isInstanceElement)
-      .filter(instance => (config.fetch.typesToFallbackToInternalId
-        ?? defaultTypesToFallbackToInternalId).includes(instance.elemID.typeName))
+      .filter(instance => config.apiDefinitions.typesToFallbackToInternalId
+        .includes(instance.elemID.typeName))
 
     const duplicateIds = new Set(_(relevantInstances)
       .countBy(instance => instance.elemID.getFullName())
@@ -93,7 +86,7 @@ const filter: FilterCreator = ({ config }) => ({
     return {
       errors: [
         {
-          message: `The ${isPlural ? 'names' : 'name'} of ${Array.from(duplicateIds).join(', ')} ${isPlural ? 'are' : 'is'} not unique in the account, so the ids of the instances were added to their names, the new names are ${newNames.join(', ')}. However, that way Salto won't be able to identify that instances between envs are the same instance which will impact comparing and cloning elements between environments. It is strongly recommended to change the names of the instances to be unique in the account and then re-fetch with "Regenerate Salto IDs".`,
+          message: `The ${isPlural ? 'names' : 'name'} of ${Array.from(duplicateIds).join(', ')} ${isPlural ? 'are' : 'is'} not unique in the account, so the ids of the instances were added to their names, the new names are ${newNames.join(', ')}. However, that way Salto will not be able to identify that instances between environments are the same instance which will impact comparing and cloning elements between environments. It is strongly recommended to change the names of the instances to be unique in the account and then re-fetch with "Regenerate Salto IDs".`,
           severity: 'Warning',
         },
       ],

--- a/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
@@ -167,30 +167,13 @@ const createContextInstance = (
   config: JiraConfig,
   getElemIdFunc?: ElemIdGetter,
 ): InstanceElement => {
-  const parentName = generateInstanceNameFromConfig(
-    parentField.value,
-    parentField.elemID.typeName,
-    config.apiDefinitions,
-  )
-
-  const naclCasedParentName = parentName !== undefined
-    ? naclCase(parentName)
-    : parentField.elemID.name
-
-  // This is a kinda hacky way to get the element name of the parent field
-  // (before the nacl case) if the id was added to it in the
-  // duplicate_ids filter.
-  const parentParts = naclCasedParentName !== parentField.elemID.name
-    ? [parentName, parentField.value.id]
-    : [(parentName ?? parentField.elemID.name)]
-
   const contextName = generateInstanceNameFromConfig(
     context,
     contextType.elemID.typeName,
     config.apiDefinitions
   ) ?? context.id
 
-  const defaultName = naclCase([...parentParts, contextName].join('_'))
+  const defaultName = naclCase([parentField.elemID.name, contextName].join('_'))
 
   const serviceIds = getServiceIds(context, contextType, config)
   const instanceName = getElemIdFunc && serviceIds

--- a/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
@@ -15,7 +15,7 @@
 */
 import { BuiltinTypes, CORE_ANNOTATIONS, Element, ElemIdGetter, Field, InstanceElement, isInstanceElement, isObjectType, ListType, MapType, ObjectType, OBJECT_NAME, OBJECT_SERVICE_ID, ReferenceExpression, ServiceIds, toServiceIdsString, Values } from '@salto-io/adapter-api'
 import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
-import { config as configUtils } from '@salto-io/adapter-components'
+import { config as configUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { values } from '@salto-io/lowerdash'
@@ -23,7 +23,8 @@ import { JIRA } from '../../constants'
 import { JiraConfig } from '../../config'
 import { FilterCreator } from '../../filter'
 import { FIELD_CONTEXT_DEFAULT_TYPE_NAME, FIELD_CONTEXT_OPTION_TYPE_NAME, FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from './constants'
-import { generateInstanceName } from '../../utils'
+
+const { generateInstanceNameFromConfig } = elementUtils
 
 const log = logger(module)
 
@@ -166,10 +167,10 @@ const createContextInstance = (
   config: JiraConfig,
   getElemIdFunc?: ElemIdGetter,
 ): InstanceElement => {
-  const parentName = generateInstanceName(
+  const parentName = generateInstanceNameFromConfig(
     parentField.value,
     parentField.elemID.typeName,
-    config,
+    config.apiDefinitions,
   )
 
   const naclCasedParentName = parentName !== undefined
@@ -183,8 +184,11 @@ const createContextInstance = (
     ? [parentName, parentField.value.id]
     : [(parentName ?? parentField.elemID.name)]
 
-  const contextName = generateInstanceName(context, contextType.elemID.typeName, config)
-    ?? context.id
+  const contextName = generateInstanceNameFromConfig(
+    context,
+    contextType.elemID.typeName,
+    config.apiDefinitions
+  ) ?? context.id
 
   const defaultName = naclCase([...parentParts, contextName].join('_'))
 

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -13,9 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, ObjectType, Element, isObjectType, Values } from '@salto-io/adapter-api'
-import { config as configUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { JiraConfig } from './config'
+import { CORE_ANNOTATIONS, ObjectType, Element, isObjectType } from '@salto-io/adapter-api'
 
 export const setDeploymentAnnotations = (contextType: ObjectType, fieldName: string): void => {
   if (contextType.fields[fieldName] !== undefined) {
@@ -28,15 +26,3 @@ export const findObject = (elements: Element[], name: string): ObjectType | unde
   elements.filter(isObjectType).find(
     element => element.elemID.name === name
   )
-
-export const generateInstanceName = (
-  values: Values,
-  typeName: string,
-  config: JiraConfig
-): string | undefined => {
-  const { idFields } = configUtils.getConfigWithDefault(
-    config.apiDefinitions.types[typeName].transformation,
-    config.apiDefinitions.typeDefaults.transformation
-  )
-  return elementUtils.getInstanceName(values, idFields)
-}

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -13,7 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, ObjectType, Element, isObjectType } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, ObjectType, Element, isObjectType, Values } from '@salto-io/adapter-api'
+import { config as configUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { JiraConfig } from './config'
 
 export const setDeploymentAnnotations = (contextType: ObjectType, fieldName: string): void => {
   if (contextType.fields[fieldName] !== undefined) {
@@ -26,3 +28,15 @@ export const findObject = (elements: Element[], name: string): ObjectType | unde
   elements.filter(isObjectType).find(
     element => element.elemID.name === name
   )
+
+export const generateInstanceName = (
+  values: Values,
+  typeName: string,
+  config: JiraConfig
+): string | undefined => {
+  const { idFields } = configUtils.getConfigWithDefault(
+    config.apiDefinitions.types[typeName].transformation,
+    config.apiDefinitions.typeDefaults.transformation
+  )
+  return elementUtils.getInstanceName(values, idFields)
+}

--- a/packages/jira-adapter/test/filters/duplicate_ids.test.ts
+++ b/packages/jira-adapter/test/filters/duplicate_ids.test.ts
@@ -1,0 +1,121 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { mockClient } from '../utils'
+import duplicateIdsFilter from '../../src/filters/duplicate_ids'
+import { Filter } from '../../src/filter'
+import { DEFAULT_CONFIG, JiraConfig } from '../../src/config'
+import { ISSUE_TYPE_NAME, JIRA } from '../../src/constants'
+
+describe('duplicateIdsFilter', () => {
+  let filter: Filter
+  let type: ObjectType
+  let config: JiraConfig
+  beforeEach(async () => {
+    const { client, paginator } = mockClient()
+
+    config = _.cloneDeep(DEFAULT_CONFIG)
+
+    filter = duplicateIdsFilter({
+      client,
+      paginator,
+      config,
+    })
+
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, ISSUE_TYPE_NAME),
+    })
+  })
+
+  describe('onFetch', () => {
+    it('should add id to duplicate instances name', async () => {
+      const dup1 = new InstanceElement(
+        'dup',
+        type,
+        {
+          id: '1',
+          name: 'dup',
+        }
+      )
+      const dup2 = new InstanceElement(
+        'dup',
+        type,
+        {
+          id: '2',
+        }
+      )
+
+      const notDup = new InstanceElement(
+        'notDup',
+        type,
+        {
+          id: '1',
+          name: 'notDup',
+        }
+      )
+
+      const elements = [notDup, dup1, dup2]
+      await filter.onFetch?.(elements)
+      expect(elements.map(e => e.elemID.name)).toEqual(['notDup', 'dup_1', 'dup_2'])
+    })
+
+    it('should do nothing if there is no id', async () => {
+      const dup1 = new InstanceElement(
+        'dup',
+        type,
+        {
+          name: 'dup',
+        }
+      )
+      const dup2 = new InstanceElement(
+        'dup',
+        type,
+        {
+          name: 'dup',
+        }
+      )
+
+      const elements = [dup1, dup2]
+      await filter.onFetch?.(elements)
+      expect(elements.map(e => e.elemID.name)).toEqual(['dup', 'dup'])
+    })
+  })
+
+  it('should do nothing if fallbackToInternalId is false', async () => {
+    config.apiDefinitions.fallbackToInternalId = false
+    const dup1 = new InstanceElement(
+      'dup',
+      type,
+      {
+        id: '1',
+        name: 'dup',
+      }
+    )
+    const dup2 = new InstanceElement(
+      'dup',
+      type,
+      {
+        id: '2',
+        name: 'dup',
+      }
+    )
+
+    const elements = [dup1, dup2]
+    await filter.onFetch?.(elements)
+    expect(elements.map(e => e.elemID.name)).toEqual(['dup', 'dup'])
+  })
+})

--- a/packages/jira-adapter/test/filters/duplicate_ids.test.ts
+++ b/packages/jira-adapter/test/filters/duplicate_ids.test.ts
@@ -29,6 +29,7 @@ describe('duplicateIdsFilter', () => {
     const { client, paginator } = mockClient()
 
     config = _.cloneDeep(DEFAULT_CONFIG)
+    config.fetch.typesToFallbackToInternalId = [ISSUE_TYPE_NAME]
 
     filter = duplicateIdsFilter({
       client,
@@ -95,8 +96,8 @@ describe('duplicateIdsFilter', () => {
     })
   })
 
-  it('should do nothing if fallbackToInternalId is false', async () => {
-    config.apiDefinitions.fallbackToInternalId = false
+  it('should do nothing if typesToFallbackToInternalId is empty', async () => {
+    config.fetch.typesToFallbackToInternalId = []
     const dup1 = new InstanceElement(
       'dup',
       type,

--- a/packages/jira-adapter/test/filters/duplicate_ids.test.ts
+++ b/packages/jira-adapter/test/filters/duplicate_ids.test.ts
@@ -19,7 +19,7 @@ import { mockClient } from '../utils'
 import duplicateIdsFilter from '../../src/filters/duplicate_ids'
 import { Filter } from '../../src/filter'
 import { DEFAULT_CONFIG, JiraConfig } from '../../src/config'
-import { ISSUE_TYPE_NAME, JIRA } from '../../src/constants'
+import { JIRA } from '../../src/constants'
 
 describe('duplicateIdsFilter', () => {
   let filter: Filter
@@ -29,7 +29,6 @@ describe('duplicateIdsFilter', () => {
     const { client, paginator } = mockClient()
 
     config = _.cloneDeep(DEFAULT_CONFIG)
-    config.fetch.typesToFallbackToInternalId = [ISSUE_TYPE_NAME]
 
     filter = duplicateIdsFilter({
       client,
@@ -38,7 +37,7 @@ describe('duplicateIdsFilter', () => {
     })
 
     type = new ObjectType({
-      elemID: new ElemID(JIRA, ISSUE_TYPE_NAME),
+      elemID: new ElemID(JIRA, 'Status'),
     })
   })
 
@@ -74,7 +73,7 @@ describe('duplicateIdsFilter', () => {
       expect(elements.map(e => e.elemID.name)).toEqual(['notDup', 'dup_1', 'dup_2'])
       expect(filterRes).toEqual({
         errors: [{
-          message: 'The name of jira.IssueType.instance.dup is not unique in the account, so the ids of the instances were added to their names, the new names are dup_1, dup_2. However, that way Salto won\'t be able to identify that instances between envs are the same instance which will impact comparing and cloning elements between environments. It is strongly recommended to change the names of the instances to be unique in the account and then re-fetch with "Regenerate Salto IDs".',
+          message: 'The name of jira.Status.instance.dup is not unique in the account, so the ids of the instances were added to their names, the new names are dup_1, dup_2. However, that way Salto will not be able to identify that instances between environments are the same instance which will impact comparing and cloning elements between environments. It is strongly recommended to change the names of the instances to be unique in the account and then re-fetch with "Regenerate Salto IDs".',
           severity: 'Warning',
         }],
       })
@@ -118,7 +117,7 @@ describe('duplicateIdsFilter', () => {
       expect(elements.map(e => e.elemID.name)).toEqual(['dupA_1', 'dupA_2', 'dupB_3', 'dupB_4'])
       expect(filterRes).toEqual({
         errors: [{
-          message: 'The names of jira.IssueType.instance.dupA, jira.IssueType.instance.dupB are not unique in the account, so the ids of the instances were added to their names, the new names are dupA_1, dupA_2, dupB_3, dupB_4. However, that way Salto won\'t be able to identify that instances between envs are the same instance which will impact comparing and cloning elements between environments. It is strongly recommended to change the names of the instances to be unique in the account and then re-fetch with "Regenerate Salto IDs".',
+          message: 'The names of jira.Status.instance.dupA, jira.Status.instance.dupB are not unique in the account, so the ids of the instances were added to their names, the new names are dupA_1, dupA_2, dupB_3, dupB_4. However, that way Salto will not be able to identify that instances between environments are the same instance which will impact comparing and cloning elements between environments. It is strongly recommended to change the names of the instances to be unique in the account and then re-fetch with "Regenerate Salto IDs".',
           severity: 'Warning',
         }],
       })
@@ -147,7 +146,7 @@ describe('duplicateIdsFilter', () => {
   })
 
   it('should do nothing if typesToFallbackToInternalId is empty', async () => {
-    config.fetch.typesToFallbackToInternalId = []
+    config.apiDefinitions.typesToFallbackToInternalId = []
     const dup1 = new InstanceElement(
       'dup',
       type,

--- a/packages/jira-adapter/test/filters/duplicate_ids.test.ts
+++ b/packages/jira-adapter/test/filters/duplicate_ids.test.ts
@@ -70,8 +70,58 @@ describe('duplicateIdsFilter', () => {
       )
 
       const elements = [notDup, dup1, dup2]
-      await filter.onFetch?.(elements)
+      const filterRes = await filter.onFetch?.(elements)
       expect(elements.map(e => e.elemID.name)).toEqual(['notDup', 'dup_1', 'dup_2'])
+      expect(filterRes).toEqual({
+        errors: [{
+          message: 'The name of jira.IssueType.instance.dup is not unique in the account, so the ids of the instances were added to their names, the new names are dup_1, dup_2. However, that way Salto won\'t be able to identify that instances between envs are the same instance which will impact comparing and cloning elements between environments. It is strongly recommended to change the names of the instances to be unique in the account and then re-fetch with "Regenerate Salto IDs".',
+          severity: 'Warning',
+        }],
+      })
+    })
+
+    it('should create the right warning message when there are multiple dups', async () => {
+      const dupA1 = new InstanceElement(
+        'dupA',
+        type,
+        {
+          id: '1',
+          name: 'dupA',
+        }
+      )
+      const dupA2 = new InstanceElement(
+        'dupA',
+        type,
+        {
+          id: '2',
+        }
+      )
+
+      const dupB1 = new InstanceElement(
+        'dupB',
+        type,
+        {
+          id: '3',
+          name: 'dupB',
+        }
+      )
+      const dupB2 = new InstanceElement(
+        'dupB',
+        type,
+        {
+          id: '4',
+        }
+      )
+
+      const elements = [dupA1, dupA2, dupB1, dupB2]
+      const filterRes = await filter.onFetch?.(elements)
+      expect(elements.map(e => e.elemID.name)).toEqual(['dupA_1', 'dupA_2', 'dupB_3', 'dupB_4'])
+      expect(filterRes).toEqual({
+        errors: [{
+          message: 'The names of jira.IssueType.instance.dupA, jira.IssueType.instance.dupB are not unique in the account, so the ids of the instances were added to their names, the new names are dupA_1, dupA_2, dupB_3, dupB_4. However, that way Salto won\'t be able to identify that instances between envs are the same instance which will impact comparing and cloning elements between environments. It is strongly recommended to change the names of the instances to be unique in the account and then re-fetch with "Regenerate Salto IDs".',
+          severity: 'Warning',
+        }],
+      })
     })
 
     it('should do nothing if there is no id', async () => {
@@ -116,7 +166,9 @@ describe('duplicateIdsFilter', () => {
     )
 
     const elements = [dup1, dup2]
-    await filter.onFetch?.(elements)
+    const filterRes = await filter.onFetch?.(elements)
     expect(elements.map(e => e.elemID.name)).toEqual(['dup', 'dup'])
+
+    expect(filterRes).toEqual({})
   })
 })

--- a/packages/jira-adapter/test/filters/fields/field_structure.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_structure.test.ts
@@ -324,6 +324,32 @@ describe('fields_structure', () => {
     })
   })
 
+  it('should create the right name for the context when the id was added to the field name', async () => {
+    const instance = new InstanceElement(
+      'instance_123',
+      fieldType,
+      {
+        name: 'instance',
+        id: '123',
+        contexts: [
+          {
+            name: 'name',
+          },
+        ],
+      }
+    )
+    const elements = [
+      instance,
+      fieldType,
+      fieldContextType,
+      fieldContextOptionType,
+      fieldContextDefaultValueType,
+    ]
+    await filter.onFetch(elements)
+    const contextInstance = elements[elements.length - 1] as InstanceElement
+    expect(contextInstance.elemID.name).toBe('instance_123_name')
+  })
+
   it('should add the new fields to the Field type', async () => {
     fieldType.fields.contextDefaults = new Field(fieldType, 'contextDefaults', BuiltinTypes.STRING)
     fieldType.fields.contextProjects = new Field(fieldType, 'contextProjects', BuiltinTypes.STRING)

--- a/packages/jira-adapter/test/filters/sort_lists.test.ts
+++ b/packages/jira-adapter/test/filters/sort_lists.test.ts
@@ -122,5 +122,11 @@ describe('sortListsFilter', () => {
       await filter.onFetch?.([instance])
       expect(instance.value).toEqual(sortedValues)
     })
+
+    it('should do nothing when field is undefined', async () => {
+      delete instance.value.permissions
+      await filter.onFetch?.([instance])
+      expect(instance.value).toEqual({})
+    })
   })
 })


### PR DESCRIPTION
JSM creates some duplicate records in the account, to deal with it we will add the id of the instance only to name of the duplicate instances in the account 

---
_Release Notes_: 
None

---
_User Notifications_: 
None