### PR TITLE
SALTO-2009 netsuite manifest dependency error

### DIFF
--- a/packages/netsuite-adapter/src/client/manifest_utils.ts
+++ b/packages/netsuite-adapter/src/client/manifest_utils.ts
@@ -93,9 +93,9 @@ const getRequiredFeatures = (customizationInfos: CustomizationInfo[]): string[] 
       })
   ).map(({ dependency }) => dependency)
 
-const getRequiredObjects = (customizationInfos: CustomizationInfo[]): string[] =>
-  _.uniq(customizationInfos.flatMap(custInfo => {
-    const objName = custInfo.values[ATTRIBUTE_PREFIX + SCRIPT_ID]
+const getRequiredObjects = (customizationInfos: CustomizationInfo[]): string[] => {
+  const objNames = customizationInfos.map(custInfo => custInfo.values[ATTRIBUTE_PREFIX + SCRIPT_ID])
+  return _.uniq(customizationInfos.flatMap(custInfo => {
     const requiredObjects: string[] = []
     lookupValue(custInfo.values, val => {
       if (!_.isString(val)) {
@@ -106,11 +106,12 @@ const getRequiredObjects = (customizationInfos: CustomizationInfo[]): string[] =
         .map(r => r.groups)
         .filter(isDefined)
         .map(group => group[SCRIPT_ID])
-        .filter(scriptId => scriptId !== objName
-          && !scriptId.startsWith(`${objName}.`)))
+        .filter(scriptId => objNames.every(objName => scriptId !== objName
+          && !scriptId.startsWith(`${objName}.`))))
     })
     return requiredObjects
   }))
+}
 
 const fixDependenciesObject = (dependencies: Value): void => {
   dependencies.features = dependencies.features ?? {}

--- a/packages/netsuite-adapter/test/client/manifest_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/manifest_utils.test.ts
@@ -22,6 +22,7 @@ describe('manifest.xml utils', () => {
     {
       typeName: 'someType',
       values: {
+        '@_scriptid': 'scriptid1',
         key: '__STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP__',
         ref: '[scriptid=somescriptid]',
       },
@@ -29,8 +30,11 @@ describe('manifest.xml utils', () => {
     {
       typeName: WORKFLOW,
       values: {
+        '@_scriptid': 'workflow1',
         key: '__STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP__',
         ref: '[scriptid=secondscriptid]',
+        ref2: '[scriptid=scriptid1]',
+        ref3: '[scriptid=workflow1.innerscriptid]',
       },
     },
   ]


### PR DESCRIPTION
objects shouldn’t be added to the manifest if they are in the project folder (and going to be deployed)

---
_Release Notes_: 
Netsuite Adapter:
- bug fix in adding object dependencies to `manifest.xml`

---
_User Notifications_: 
None