### PR TITLE
remove spamming log

### DIFF
--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -41,7 +41,6 @@ export const hideFields = (
       ? typeFields[fieldName]
       : undefined
     if (field === undefined) {
-      log.warn('field %s.%s not found, cannot hide it', typeName, fieldName)
       return
     }
     if (fieldType === undefined || fieldType === field.refType.elemID.name) {


### PR DESCRIPTION
_remove spamming log_

---

_Additional context for reviewer_
Some types don't have the default fields to hide and therefore our logs is spammed by this log message

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
