### PR TITLE
SALTO-2012: hide definition instances in zendesk

### DIFF
--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -49,6 +49,7 @@ import userFieldFilter from './filters/custom_field_options/user_field'
 import dynamicContentFilter from './filters/dynamic_content'
 import restrictionFilter from './filters/restriction'
 import organizationFieldFilter from './filters/organization_field'
+import hideDefinitionInstancesFilter from './filters/hide_definition_instances'
 import defaultDeployFilter from './filters/default_deploy'
 
 const log = logger(module)
@@ -73,6 +74,7 @@ export const DEFAULT_FILTERS = [
   dynamicContentFilter,
   restrictionFilter,
   organizationFieldFilter,
+  hideDefinitionInstancesFilter,
   fieldReferencesFilter,
   // unorderedListsFilter should run after fieldReferencesFilter
   unorderedListsFilter,

--- a/packages/zendesk-support-adapter/src/filters/hide_definition_instances.ts
+++ b/packages/zendesk-support-adapter/src/filters/hide_definition_instances.ts
@@ -1,0 +1,43 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  CORE_ANNOTATIONS, isObjectType,
+} from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+
+const DEFINITION_TYPE_NAMES = [
+  'macro_definition',
+  'macros_actions',
+  'trigger_definition',
+  'sla_policy_definition',
+  'routing_attribute_definition',
+]
+
+/**
+ * Hides the definition instances
+ */
+const filterCreator: FilterCreator = () => ({
+  onFetch: async elements => {
+    elements
+      .filter(isObjectType)
+      .filter(objType => DEFINITION_TYPE_NAMES.includes(objType.elemID.typeName))
+      .forEach(objType => {
+        objType.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
+      })
+  },
+})
+
+export default filterCreator

--- a/packages/zendesk-support-adapter/test/filters/hide_definition_instances.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/hide_definition_instances.test.ts
@@ -1,0 +1,65 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { DEFAULT_CONFIG } from '../../src/config'
+import ZendeskClient from '../../src/client/client'
+import { ZENDESK_SUPPORT } from '../../src/constants'
+import { paginate } from '../../src/client/pagination'
+import filterCreator from '../../src/filters/hide_definition_instances'
+import { FilterResult } from '../../src/filter'
+
+describe('hide definition instances', () => {
+  let client: ZendeskClient
+  type FilterType = filterUtils.FilterWith<'onFetch', FilterResult>
+  let filter: FilterType
+  const randomObjType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'obj') })
+  const triggerDefinitionObjType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'trigger_definition') })
+  const macrosActionsObjType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'macros_actions') })
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      }),
+      config: DEFAULT_CONFIG,
+    }) as FilterType
+  })
+
+  describe('onFetch', () => {
+    it('should change the hidden value annotation of the relevant types', async () => {
+      const elements = [randomObjType, triggerDefinitionObjType, macrosActionsObjType]
+        .map(e => e.clone())
+      await filter.onFetch(elements)
+      expect(elements.map(e => e.elemID.getFullName())).toEqual([
+        'zendesk_support.obj',
+        'zendesk_support.trigger_definition',
+        'zendesk_support.macros_actions',
+      ])
+      expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE])).toEqual([
+        undefined,
+        true,
+        true,
+      ])
+    })
+  })
+})


### PR DESCRIPTION
_hide definition instances in zendesk_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Zendesk_support adapter_
* Hide definition instances

---
_User Notifications_: 
_Hide definition instances in zendesk_
