### PR TITLE
Don't calculate cache invalidation if parsed files haven't been read yet

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -229,10 +229,10 @@ export const createMergeManager = async (flushables: Flushable[],
       || preChangeHash === cachePreChangeHash)
       && src1Changes.cacheValid && src2Changes.cacheValid
     if (!src1Changes.cacheValid) {
-      log.debug(`Invalid cache: ${cacheUpdate.src1Prefix}`)
+      log.debug(`Invalid cache: ${cacheUpdate.src1Prefix}. Prechange hash: ${src1Changes.preChangeHash}. Postchange hash: ${src1Changes.postChangeHash}`)
     }
     if (!src2Changes.cacheValid) {
-      log.debug(`Invalid cache: ${cacheUpdate.src2Prefix}`)
+      log.debug(`Invalid cache: ${cacheUpdate.src2Prefix}. Prechange hash: ${src2Changes.preChangeHash}. Postchange hash: ${src2Changes.postChangeHash}`)
     }
     if (!(preChangeHash === cachePreChangeHash)) {
       log.debug(`Invalid cache merge between ${cacheUpdate.src1Prefix} and ${cacheUpdate.src2Prefix}`)


### PR DESCRIPTION
Handled a case where parsed files weren't loaded yet, which caused a cache invalidation which was unnecessary. Users won't really notice this, but it can affect performance

---
There are all sorts of cases in which cache is invalidated even though there's no 
---
_Release Notes_: 
---
_User Notifications_:  