### PR TITLE
SALTO-1886 safe deploy SDF referenced deployed elements

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -362,7 +362,7 @@ describe('Netsuite adapter E2E with real account', () => {
               .toArray()
 
             expect(changeErrors.length).toBe(1)
-            const changeError = changeErrors.find(e => e.message === 'Continuing the deploy proccess will override changes made in the service to this element.')
+            const changeError = changeErrors.find(e => e.message === 'Continuing the deploy process will override changes made in the service to this element.')
             expect(changeError).toBeDefined()
           })
         })
@@ -418,7 +418,7 @@ describe('Netsuite adapter E2E with real account', () => {
               .toArray()
 
             expect(changeErrors.length).toBe(1)
-            const changeError = changeErrors.find(e => e.message === 'Continuing the deploy proccess will override changes made in the service to this element.')
+            const changeError = changeErrors.find(e => e.message === 'Continuing the deploy process will override changes made in the service to this element.')
             expect(changeError).toBeDefined()
           })
         })

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -33,7 +33,6 @@
     "@salto-io/adapter-api": "0.3.9",
     "@salto-io/adapter-components": "0.3.9",
     "@salto-io/adapter-utils": "0.3.9",
-    "@salto-io/workspace": "0.3.9",
     "@salto-io/file": "0.3.9",
     "@salto-io/logging": "0.3.9",
     "@salto-io/lowerdash": "0.3.9",

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -33,6 +33,7 @@
     "@salto-io/adapter-api": "0.3.9",
     "@salto-io/adapter-components": "0.3.9",
     "@salto-io/adapter-utils": "0.3.9",
+    "@salto-io/workspace": "0.3.9",
     "@salto-io/file": "0.3.9",
     "@salto-io/logging": "0.3.9",
     "@salto-io/lowerdash": "0.3.9",

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -107,7 +107,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
   private readonly fetchTarget?: NetsuiteQueryParameters
   private readonly skipList?: NetsuiteQueryParameters // old version
   private readonly useChangesDetection: boolean
-  private createFiltersRunner: () => Required<Filter>
+  private createFiltersRunner: (isPartial?: boolean) => Required<Filter>
   private elementsSourceIndex: LazyElementsSourceIndexes
 
 
@@ -173,12 +173,12 @@ export default class NetsuiteAdapter implements AdapterOperations {
      ?? config[DEPLOY_REFERENCED_ELEMENTS]
     this.warnStaleData = config[DEPLOY]?.[WARN_STALE_DATA]
     this.elementsSourceIndex = createElementsSourceIndex(this.elementsSource)
-    this.createFiltersRunner = () => filter.filtersRunner(
+    this.createFiltersRunner = isPartial => filter.filtersRunner(
       {
         client: this.client,
         elementsSourceIndex: this.elementsSourceIndex,
         elementsSource: this.elementsSource,
-        isPartial: this.fetchTarget !== undefined,
+        isPartial: isPartial ?? this.fetchTarget !== undefined,
       },
       filtersCreators,
     )
@@ -187,7 +187,8 @@ export default class NetsuiteAdapter implements AdapterOperations {
   public fetchByQuery: FetchByQueryFunc = async (
     fetchQuery: NetsuiteQuery,
     progressReporter: ProgressReporter,
-    useChangesDetection: boolean
+    useChangesDetection: boolean,
+    isPartial?: boolean
   ): Promise<FetchByQueryReturnType> => {
     const { customTypes, enums, fileCabinetTypes, fieldTypes } = getMetadataTypes()
     const {
@@ -260,7 +261,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       ...serverTimeElements,
     ]
 
-    await this.createFiltersRunner().onFetch(elements)
+    await this.createFiltersRunner(isPartial).onFetch(elements)
 
     return {
       failedToFetchAllAtOnce,

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -395,6 +395,8 @@ export default class NetsuiteAdapter implements AdapterOperations {
         withSuiteApp: this.client.isSuiteAppConfigured(),
         warnStaleData: this.warnStaleData ?? DEFAULT_WARN_STALE_DATA,
         fetchByQuery: this.fetchByQuery,
+        deployReferencedElements: this.deployReferencedElements
+          ?? DEFAULT_DEPLOY_REFERENCED_ELEMENTS,
       }),
       getChangeGroupIds: getChangeGroupIdsFunc(this.client.isSuiteAppConfigured()),
     }

--- a/packages/netsuite-adapter/src/change_validators/safe_deploy.ts
+++ b/packages/netsuite-adapter/src/change_validators/safe_deploy.ts
@@ -131,7 +131,7 @@ const toChangeWarning = (change: Change<InstanceElement>): ChangeError => (
   {
     elemID: getChangeData(change).elemID,
     severity: 'Warning',
-    message: 'Continuing the deploy proccess will override changes made in the service to this element.',
+    message: 'Continuing the deploy process will override changes made in the service to this element.',
     detailedMessage: `The element ${getChangeData(change).elemID.name}, which you are attempting to ${change.action}, has recently changed in the service.`,
   }
 )
@@ -141,7 +141,7 @@ const toAdditionalInstanceWarning = (
 ): ChangeError => ({
   elemID: referer.elemID,
   severity: 'Warning',
-  message: 'Continuing the deploy proccess will override changes made in the service to a referenced element.',
+  message: 'Continuing the deploy process will override changes made in the service to a referenced element.',
   detailedMessage: `The element ${instance.elemID.getFullName()}, which is ${dependency} in ${referer.elemID.name} and going to be deployed with it, has recently changed in the service.`,
 })
 

--- a/packages/netsuite-adapter/src/change_validators/safe_deploy.ts
+++ b/packages/netsuite-adapter/src/change_validators/safe_deploy.ts
@@ -37,7 +37,7 @@ export type FetchByQueryFunc = (
   fetchQuery: NetsuiteQuery,
   progressReporter: ProgressReporter,
   useChangesDetection: boolean,
-  isPartial?: boolean
+  isPartial: boolean
 ) => Promise<FetchByQueryReturnType>
 
 export type QueryChangeValidator = (

--- a/packages/netsuite-adapter/src/change_validators/safe_deploy.ts
+++ b/packages/netsuite-adapter/src/change_validators/safe_deploy.ts
@@ -19,7 +19,6 @@ import { isInstanceChange, InstanceElement, Element,
   getChangeData, ModificationChange,
   isRemovalChange, isModificationChange, isAdditionChange, AdditionChange, RemovalChange } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
-import { expressions, elementSource } from '@salto-io/workspace'
 import { buildNetsuiteQuery, convertToQueryParams, NetsuiteQuery, NetsuiteQueryParameters } from '../query'
 import { isCustomType, isFileCabinetInstance } from '../types'
 import { LAST_FETCH_TIME, PATH, SCRIPT_ID } from '../constants'
@@ -55,8 +54,6 @@ type AdditionalInstance = {
 
 const { awu } = collections.asynciterable
 const { isDefined } = values
-const { resolve } = expressions
-const { createInMemoryElementSource } = elementSource
 
 const getIdentifyingValue = async (instance: InstanceElement): Promise<string> => (
   instance.value[SCRIPT_ID] ?? instance.value[getTypeIdentifier(await instance.getType())]
@@ -99,9 +96,8 @@ const getMatchingServiceInstances = async (
 
   const fetchQuery = buildNetsuiteQuery(convertToQueryParams(fetchTarget))
   const { elements } = await fetchByQuery(fetchQuery, { reportProgress: () => null }, false)
-  const resolvedElements = await resolve(elements, createInMemoryElementSource(elements))
   return _.keyBy(
-    resolvedElements.filter(isInstanceElement).map(getInstanceToCompare),
+    elements.filter(isInstanceElement).map(getInstanceToCompare),
     element => element.elemID.getFullName()
   )
 }

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -27,7 +27,7 @@ import SuiteAppClient from './suiteapp_client/suiteapp_client'
 import { createSuiteAppFileCabinetOperations, SuiteAppFileCabinetOperations, DeployType } from '../suiteapp_file_cabinet'
 import { SavedSearchQuery, SystemInformation } from './suiteapp_client/types'
 import { GetCustomObjectsResult, ImportFileCabinetResult } from './types'
-import { getAllReferencedInstances, getRequiredReferencedInstances } from '../reference_dependencies'
+import { getReferencedInstances } from '../reference_dependencies'
 import { getLookUpName, toCustomizationInfo } from '../transformer'
 import { SDF_CHANGE_GROUP_ID, SUITEAPP_CREATING_FILES_GROUP_ID, SUITEAPP_CREATING_RECORDS_GROUP_ID, SUITEAPP_DELETING_FILES_GROUP_ID, SUITEAPP_DELETING_RECORDS_GROUP_ID, SUITEAPP_FILE_CABINET_GROUPS, SUITEAPP_UPDATING_FILES_GROUP_ID, SUITEAPP_UPDATING_RECORDS_GROUP_ID } from '../group_changes'
 import { DeployResult } from '../types'
@@ -101,22 +101,12 @@ export default class NetsuiteClient {
     return this.sdfClient.importFileCabinetContent(query)
   }
 
-  private static async getAllRequiredReferencedInstances(
-    changedInstances: ReadonlyArray<InstanceElement>,
-    deployReferencedElements: boolean,
-  ): Promise<ReadonlyArray<InstanceElement>> {
-    if (deployReferencedElements) {
-      return getAllReferencedInstances(changedInstances)
-    }
-    return getRequiredReferencedInstances(changedInstances)
-  }
-
   private async sdfDeploy(
     changes: ReadonlyArray<Change<InstanceElement>>,
     deployReferencedElements: boolean
   ): Promise<DeployResult> {
     const changedInstances = changes.map(getChangeData)
-    const customizationInfos = await awu(await NetsuiteClient.getAllRequiredReferencedInstances(
+    const customizationInfos = await awu(await getReferencedInstances(
       changedInstances,
       deployReferencedElements
     )).map(instance => resolveValues(instance, getLookUpName))

--- a/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
@@ -38,7 +38,7 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource):
   const customFieldsIndex: Record<string, InstanceElement[]> = {}
 
   const updateServiceIdIndex = async (element: InstanceElement): Promise<void> => {
-    const serviceIdRecords = await getInstanceServiceIdRecords(element)
+    const serviceIdRecords = await getInstanceServiceIdRecords(element, elementsSource)
     _.assign(serviceIdRecordsIndex, serviceIdRecords)
 
     const rawLastFetchTime = element.value[LAST_FETCH_TIME]

--- a/packages/netsuite-adapter/src/elements_source_index/types.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/types.ts
@@ -20,8 +20,11 @@ export type ElementsSourceValue = {
   elemID: ElemID
 }
 
+export type ServiceIdRecords = Record<string, { elemID: ElemID; serviceID: string }>
+
 export type ElementsSourceIndexes = {
   serviceIdsIndex: Record<string, ElementsSourceValue>
+  serviceIdRecordsIndex: ServiceIdRecords
   internalIdsIndex: Record<string, ElementsSourceValue>
   customFieldsIndex: Record<string, InstanceElement[]>
 }

--- a/packages/netsuite-adapter/src/reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/reference_dependencies.ts
@@ -21,6 +21,7 @@ import {
 import { transformElement, TransformFunc } from '@salto-io/adapter-utils'
 import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
 import wu from 'wu'
+import os from 'os'
 import {
   CUSTOM_RECORD_TYPE, CUSTOM_SEGMENT, DATASET, NETSUITE, WORKBOOK,
 } from './constants'
@@ -129,7 +130,16 @@ export const getRequiredReferencedInstances = (
     .map(getInstanceRequiredDependency)
     .filter(isDefined)
 
-  log.debug(`adding referenced instances:\n${requiredReferencedInstances.map(inst => inst.elemID.getFullName()).join('\n')}`)
+  log.debug(`adding referenced instances:${os.EOL}${requiredReferencedInstances.map(inst => inst.elemID.getFullName()).join('\n')}`)
 
   return Array.from(new Set(sourceInstances.concat(requiredReferencedInstances)))
 }
+
+export const getReferencedInstances = async (
+  instances: ReadonlyArray<InstanceElement>,
+  deployAllReferencedElements: boolean
+): Promise<ReadonlyArray<InstanceElement>> => (
+  deployAllReferencedElements
+    ? getAllReferencedInstances(instances)
+    : getRequiredReferencedInstances(instances)
+)

--- a/packages/netsuite-adapter/src/reference_dependencies.ts
+++ b/packages/netsuite-adapter/src/reference_dependencies.ts
@@ -72,7 +72,7 @@ export const findDependingInstancesFromRefs = async (
  * of deploy and writing them in the manifest.xml doesn't suffice.
  * Here we add automatically all of the referenced instances.
  */
-export const getAllReferencedInstances = async (
+const getAllReferencedInstances = async (
   sourceInstances: ReadonlyArray<InstanceElement>
 ): Promise<ReadonlyArray<InstanceElement>> => {
   const visited = new Set<string>(sourceInstances.map(inst => inst.elemID.getFullName()))
@@ -101,7 +101,7 @@ export const getAllReferencedInstances = async (
  * of deploy and writing them in the manifest.xml doesn't suffice.
  * Here we add manually all of the quirks we identified.
  */
-export const getRequiredReferencedInstances = (
+const getRequiredReferencedInstances = (
   sourceInstances: ReadonlyArray<InstanceElement>
 ): ReadonlyArray<InstanceElement> => {
   const getReferencedInstance = (value: Value, type?: string): InstanceElement | undefined => (

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -63,17 +63,15 @@ getChangeValidatorMock.mockImplementation(({}: {
 }) => (_changes: ReadonlyArray<Change>) => Promise.resolve([]))
 
 jest.mock('../src/reference_dependencies')
-const getAllReferencedInstancesMock = referenceDependenciesModule
-  .getAllReferencedInstances as jest.Mock
-getAllReferencedInstancesMock
-  .mockImplementation((sourceInstances: ReadonlyArray<InstanceElement>) => sourceInstances)
+const getReferencedInstancesMock = referenceDependenciesModule
+  .getReferencedInstances as jest.Mock
+getReferencedInstancesMock
+  .mockImplementation((
+    sourceInstances: ReadonlyArray<InstanceElement>,
+    _deployAllReferencedElements: boolean
+  ) => sourceInstances)
 
 jest.mock('../src/changes_detector/changes_detector')
-
-const getRequiredReferencedInstancesMock = referenceDependenciesModule
-  .getRequiredReferencedInstances as jest.Mock
-getRequiredReferencedInstancesMock
-  .mockImplementation((sourceInstances: ReadonlyArray<InstanceElement>) => sourceInstances)
 
 const onFetchMock = jest.fn().mockImplementation(async _arg => undefined)
 const firstDummyFilter: FilterCreator = () => ({
@@ -702,7 +700,7 @@ describe('Adapter', () => {
     })
 
     describe('deployReferencedElements', () => {
-      it('should call getAllReferencedInstances when deployReferencedElements is set to true', async () => {
+      it('should call getReferencedInstances with deployReferencedElements=true', async () => {
         const configWithDeployReferencedElements = {
           [TYPES_TO_SKIP]: [SAVED_SEARCH, TRANSACTION_FORM],
           [FETCH_ALL_TYPES_AT_ONCE]: true,
@@ -725,14 +723,12 @@ describe('Adapter', () => {
           },
         })
 
-        expect(getAllReferencedInstancesMock).toHaveBeenCalledTimes(1)
-        expect(getRequiredReferencedInstancesMock).not.toHaveBeenCalled()
+        expect(getReferencedInstancesMock).toHaveBeenCalledWith([instance], true)
       })
 
-      it('should call getRequiredReferencedInstances when deployReferencedElements is set to false', async () => {
+      it('should call getReferencedInstances with deployReferencedElements=false', async () => {
         await adapterAdd(instance)
-        expect(getRequiredReferencedInstancesMock).toHaveBeenCalledTimes(1)
-        expect(getAllReferencedInstancesMock).not.toHaveBeenCalled()
+        expect(getReferencedInstancesMock).toHaveBeenCalledWith([instance], false)
       })
     })
 

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -59,6 +59,7 @@ getChangeValidatorMock.mockImplementation(({}: {
   withSuiteApp: boolean
   warnStaleData: boolean
   fetchByQuery: FetchByQueryFunc
+  deployReferencedElements?: boolean
 }) => (_changes: ReadonlyArray<Change>) => Promise.resolve([]))
 
 jest.mock('../src/reference_dependencies')
@@ -758,6 +759,7 @@ describe('Adapter', () => {
           withSuiteApp: expect.anything(),
           warnStaleData: false,
           fetchByQuery: expect.anything(),
+          deployReferencedElements: expect.anything(),
         })
       })
 
@@ -784,6 +786,7 @@ describe('Adapter', () => {
           withSuiteApp: expect.anything(),
           warnStaleData: false,
           fetchByQuery: expect.anything(),
+          deployReferencedElements: expect.anything(),
         })
       })
 
@@ -810,6 +813,7 @@ describe('Adapter', () => {
           withSuiteApp: expect.anything(),
           warnStaleData: true,
           fetchByQuery: expect.anything(),
+          deployReferencedElements: expect.anything(),
         })
       })
     })

--- a/packages/netsuite-adapter/test/filters/author_information/saved_searches.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/saved_searches.test.ts
@@ -54,6 +54,7 @@ describe('netsuite saved searches author information tests', () => {
       client,
       elementsSourceIndex: { getIndexes: () => Promise.resolve({
         serviceIdsIndex: {},
+        serviceIdRecordsIndex: {},
         internalIdsIndex: {},
         customFieldsIndex: {},
       }) },
@@ -118,6 +119,7 @@ describe('netsuite saved searches author information tests', () => {
         client: clientWithoutSuiteApp,
         elementsSourceIndex: { getIndexes: () => Promise.resolve({
           serviceIdsIndex: {},
+          serviceIdRecordsIndex: {},
           internalIdsIndex: {},
           customFieldsIndex: {},
         }) },

--- a/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
@@ -73,6 +73,7 @@ describe('netsuite system note author information', () => {
       client,
       elementsSourceIndex: { getIndexes: () => Promise.resolve({
         serviceIdsIndex: {},
+        serviceIdRecordsIndex: {},
         internalIdsIndex: {},
         customFieldsIndex: {},
       }) },
@@ -178,6 +179,7 @@ describe('netsuite system note author information', () => {
         client: clientWithoutSuiteApp,
         elementsSourceIndex: { getIndexes: () => Promise.resolve({
           serviceIdsIndex: {},
+          serviceIdRecordsIndex: {},
           internalIdsIndex: {},
           customFieldsIndex: {},
         }) },

--- a/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
@@ -57,6 +57,7 @@ describe('data_instances_references', () => {
         elementsSourceIndex: {
           getIndexes: () => Promise.resolve({
             serviceIdsIndex: {},
+            serviceIdRecordsIndex: {},
             internalIdsIndex: {},
             customFieldsIndex: {},
           }),
@@ -82,6 +83,7 @@ describe('data_instances_references', () => {
         elementsSourceIndex: {
           getIndexes: () => Promise.resolve({
             serviceIdsIndex: {},
+            serviceIdRecordsIndex: {},
             internalIdsIndex: {},
             customFieldsIndex: {},
           }),
@@ -111,6 +113,7 @@ describe('data_instances_references', () => {
         elementsSourceIndex: {
           getIndexes: () => Promise.resolve({
             serviceIdsIndex: {},
+            serviceIdRecordsIndex: {},
             internalIdsIndex: {
               'firstType-1': { elemID: referencedInstance.elemID },
             },
@@ -143,6 +146,7 @@ describe('data_instances_references', () => {
         elementsSourceIndex: {
           getIndexes: () => Promise.resolve({
             serviceIdsIndex: {},
+            serviceIdRecordsIndex: {},
             internalIdsIndex: {},
             customFieldsIndex: {},
           }),
@@ -175,6 +179,7 @@ describe('data_instances_references', () => {
         elementsSourceIndex: {
           getIndexes: () => Promise.resolve({
             serviceIdsIndex: {},
+            serviceIdRecordsIndex: {},
             internalIdsIndex: {},
             customFieldsIndex: {},
           }),
@@ -208,6 +213,7 @@ describe('data_instances_references', () => {
         elementsSourceIndex: {
           getIndexes: () => Promise.resolve({
             serviceIdsIndex: {},
+            serviceIdRecordsIndex: {},
             internalIdsIndex: {},
             customFieldsIndex: {},
           }),

--- a/packages/netsuite-adapter/test/filters/data_types_custom_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_types_custom_fields.test.ts
@@ -37,6 +37,7 @@ describe('data_types_custom_fields', () => {
       elementsSourceIndex: {
         getIndexes: () => Promise.resolve({
           serviceIdsIndex: {},
+          serviceIdRecordsIndex: {},
           internalIdsIndex: {},
           customFieldsIndex: {},
         }),
@@ -91,6 +92,7 @@ describe('data_types_custom_fields', () => {
         elementsSourceIndex: {
           getIndexes: () => Promise.resolve({
             serviceIdsIndex: {},
+            serviceIdRecordsIndex: {},
             internalIdsIndex: {},
             customFieldsIndex: { Customer: [instance] },
           }),
@@ -114,6 +116,7 @@ describe('data_types_custom_fields', () => {
         elementsSourceIndex: {
           getIndexes: () => Promise.resolve({
             serviceIdsIndex: {},
+            serviceIdRecordsIndex: {},
             internalIdsIndex: {},
             customFieldsIndex: { Customer: [instance] },
           }),

--- a/packages/netsuite-adapter/test/filters/instance_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/instance_references.test.ts
@@ -42,7 +42,7 @@ describe('instance_references filter', () => {
     beforeEach(async () => {
       getIndexesMock.mockReset()
       getIndexesMock.mockResolvedValue({
-        serviceIdsIndex: {},
+        serviceIdRecordsIndex: {},
         internalIdsIndex: {},
       })
 
@@ -121,7 +121,7 @@ describe('instance_references filter', () => {
       }).onFetch?.([fileInstance, workflowInstance, instanceWithRefs])
 
       expect(instanceWithRefs.value.refToFilePath)
-        .toEqual(new ReferenceExpression(fileInstance.elemID.createNestedID(PATH)))
+        .toEqual(new ReferenceExpression(fileInstance.elemID.createNestedID(PATH), '/Templates/file.name'))
     })
 
     it('should replace scriptid references', async () => {
@@ -134,7 +134,7 @@ describe('instance_references filter', () => {
 
 
       expect(instanceWithRefs.value.refToScriptId)
-        .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID(SCRIPT_ID)))
+        .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID(SCRIPT_ID), 'top_level'))
     })
 
     it('should replace annotations references', async () => {
@@ -147,9 +147,9 @@ describe('instance_references filter', () => {
 
 
       expect(instanceWithRefs.annotations.refToFilePath)
-        .toEqual(new ReferenceExpression(fileInstance.elemID.createNestedID(PATH)))
+        .toEqual(new ReferenceExpression(fileInstance.elemID.createNestedID(PATH), '/Templates/file.name'))
       expect(instanceWithRefs.annotations.refToScriptId)
-        .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID(SCRIPT_ID)))
+        .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID(SCRIPT_ID), 'top_level'))
     })
 
     it('parent should reference the element itself', async () => {
@@ -175,7 +175,7 @@ describe('instance_references filter', () => {
 
 
       expect(instanceWithRefs.value.refToOneLevelNestedScriptId)
-        .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID('workflowstates', 'workflowstate', '0', SCRIPT_ID)))
+        .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID('workflowstates', 'workflowstate', '0', SCRIPT_ID), 'one_nesting'))
     })
 
     it('should replace scriptid with 2 nesting level references', async () => {
@@ -188,7 +188,7 @@ describe('instance_references filter', () => {
 
 
       expect(instanceWithRefs.value.refToTwoLevelNestedScriptId)
-        .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID('workflowstates', 'workflowstate', '0', 'workflowactions', '0', 'setfieldvalueaction', '0', SCRIPT_ID)))
+        .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID('workflowstates', 'workflowstate', '0', 'workflowactions', '0', 'setfieldvalueaction', '0', SCRIPT_ID), 'two_nesting'))
     })
 
     it('should replace inner scriptid references', async () => {
@@ -202,7 +202,7 @@ describe('instance_references filter', () => {
 
       expect(workflowInstance.value.workflowstates.workflowstate[0].workflowactions[0]
         .setfieldvalueaction[1].field)
-        .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID('workflowstates', 'workflowstate', '0', 'workflowactions', '0', 'setfieldvalueaction', '0', SCRIPT_ID)))
+        .toEqual(new ReferenceExpression(workflowInstance.elemID.createNestedID('workflowstates', 'workflowstate', '0', 'workflowactions', '0', 'setfieldvalueaction', '0', SCRIPT_ID), 'two_nesting'))
     })
 
     it('should replace type and scriptid references', async () => {
@@ -215,7 +215,7 @@ describe('instance_references filter', () => {
 
 
       expect(instanceWithRefs.value.refToCustomSegment)
-        .toEqual(new ReferenceExpression(customSegmentInstance.elemID.createNestedID(SCRIPT_ID)))
+        .toEqual(new ReferenceExpression(customSegmentInstance.elemID.createNestedID(SCRIPT_ID), 'cseg_1'))
     })
 
     it('should not replace scriptid references for non existing scriptid', async () => {
@@ -311,7 +311,7 @@ describe('instance_references filter', () => {
 
     it('should use elements source for creating the references with fetch is partial', async () => {
       getIndexesMock.mockResolvedValue({
-        serviceIdsIndex: {
+        serviceIdRecordsIndex: {
           '/Templates/instanceInElementsSource': { elemID: instanceInElementsSource.elemID.createNestedID(PATH) },
         },
         internalIdsIndex: {},
@@ -330,7 +330,7 @@ describe('instance_references filter', () => {
 
     it('should not use elements source for creating the references when fetch is not partial', async () => {
       getIndexesMock.mockResolvedValue({
-        serviceIdsIndex: {
+        serviceIdRecordsIndex: {
           '/Templates/instanceInElementsSource': { elemID: instanceInElementsSource.elemID.createNestedID(PATH) },
         },
         internalIdsIndex: {},

--- a/packages/netsuite-adapter/test/filters/internal_ids/sdf_internal_ids.test.ts
+++ b/packages/netsuite-adapter/test/filters/internal_ids/sdf_internal_ids.test.ts
@@ -64,6 +64,7 @@ describe('sdf internal ids tests', () => {
       client,
       elementsSourceIndex: { getIndexes: () => Promise.resolve({
         serviceIdsIndex: {},
+        serviceIdRecordsIndex: {},
         internalIdsIndex: {},
         customFieldsIndex: {},
       }) },
@@ -88,6 +89,7 @@ describe('sdf internal ids tests', () => {
         client: clientWithoutSuiteApp,
         elementsSourceIndex: { getIndexes: () => Promise.resolve({
           serviceIdsIndex: {},
+          serviceIdRecordsIndex: {},
           internalIdsIndex: {},
           customFieldsIndex: {},
         }) },
@@ -109,6 +111,7 @@ describe('sdf internal ids tests', () => {
         client: clientWithoutSuiteApp,
         elementsSourceIndex: { getIndexes: () => Promise.resolve({
           serviceIdsIndex: {},
+          serviceIdRecordsIndex: {},
           internalIdsIndex: {},
           customFieldsIndex: {},
         }) },
@@ -128,6 +131,7 @@ describe('sdf internal ids tests', () => {
         client: clientWithoutSuiteApp,
         elementsSourceIndex: { getIndexes: () => Promise.resolve({
           serviceIdsIndex: {},
+          serviceIdRecordsIndex: {},
           internalIdsIndex: {},
           customFieldsIndex: {},
         }) },

--- a/packages/netsuite-adapter/test/filters/parse_saved_searches.test.ts
+++ b/packages/netsuite-adapter/test/filters/parse_saved_searches.test.ts
@@ -34,6 +34,7 @@ describe('parse_saved_searches filter', () => {
     elementsSourceIndex: {
       getIndexes: () => Promise.resolve({
         serviceIdsIndex: {},
+        serviceIdRecordsIndex: {},
         internalIdsIndex: {},
         customFieldsIndex: {},
       }),
@@ -83,6 +84,7 @@ describe('parse_saved_searches filter', () => {
       elementsSourceIndex: {
         getIndexes: () => Promise.resolve({
           serviceIdsIndex: {},
+          serviceIdRecordsIndex: {},
           internalIdsIndex: {},
           customFieldsIndex: {},
         }),

--- a/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
@@ -38,6 +38,7 @@ describe('remove_unsupported_types', () => {
       client: { isSuiteAppConfigured: isSuiteAppConfiguredMock } as unknown as NetsuiteClient,
       elementsSourceIndex: { getIndexes: () => Promise.resolve({
         serviceIdsIndex: {},
+        serviceIdRecordsIndex: {},
         internalIdsIndex: {},
         customFieldsIndex: {},
       }) },

--- a/packages/netsuite-adapter/test/filters/service_urls.test.ts
+++ b/packages/netsuite-adapter/test/filters/service_urls.test.ts
@@ -44,6 +44,7 @@ describe('serviceUrls', () => {
       client,
       elementsSourceIndex: { getIndexes: () => Promise.resolve({
         serviceIdsIndex: {},
+        serviceIdRecordsIndex: {},
         internalIdsIndex: {},
         customFieldsIndex: {},
       }) },
@@ -58,6 +59,7 @@ describe('serviceUrls', () => {
       client,
       elementsSourceIndex: { getIndexes: () => Promise.resolve({
         serviceIdsIndex: {},
+        serviceIdRecordsIndex: {},
         internalIdsIndex: {},
         customFieldsIndex: {},
       }) },

--- a/packages/netsuite-adapter/test/reference_dependencies.test.ts
+++ b/packages/netsuite-adapter/test/reference_dependencies.test.ts
@@ -21,10 +21,7 @@ import { entitycustomfieldType } from '../src/autogen/types/custom_types/entityc
 import { workbookType } from '../src/autogen/types/custom_types/workbook'
 import { fileType } from '../src/types/file_cabinet_types'
 import { PATH, SCRIPT_ID } from '../src/constants'
-import {
-  getAllReferencedInstances,
-  getRequiredReferencedInstances,
-} from '../src/reference_dependencies'
+import { getReferencedInstances } from '../src/reference_dependencies'
 
 describe('reference dependencies', () => {
   const entitycustomfield = entitycustomfieldType().type
@@ -74,7 +71,7 @@ describe('reference dependencies', () => {
 
   describe('getAllReferencedInstances', () => {
     it('should return all depending instances', async () => {
-      const result = await getAllReferencedInstances([instanceWithManyRefs])
+      const result = await getReferencedInstances([instanceWithManyRefs], true)
       expect(result).toEqual([instanceWithManyRefs, dependsOn1Instance, fileInstance])
     })
   })
@@ -113,29 +110,29 @@ describe('reference dependencies', () => {
       })
 
     it('should not add dependencies that are not required', async () => {
-      const result = getRequiredReferencedInstances([instanceWithManyRefs])
+      const result = await getReferencedInstances([instanceWithManyRefs], false)
       expect(result).toEqual([instanceWithManyRefs])
     })
 
     it('should add CUSTOM_SEGMENT dependency of CUSTOM_RECORD_TYPE', async () => {
-      const result = getRequiredReferencedInstances([customRecordTypeInstance])
+      const result = await getReferencedInstances([customRecordTypeInstance], false)
       expect(result).toEqual([customRecordTypeInstance, customSegmentInstance])
     })
 
     it('should add CUSTOM_RECORD_TYPE dependency of CUSTOM_SEGMENT', async () => {
-      const result = getRequiredReferencedInstances([customSegmentInstance])
+      const result = await getReferencedInstances([customSegmentInstance], false)
       expect(result).toEqual([customSegmentInstance, customRecordTypeInstance])
     })
 
     it('should add DATASET dependency of WORKBOOK', async () => {
-      const result = getRequiredReferencedInstances([workbookInstance])
+      const result = await getReferencedInstances([workbookInstance], false)
       expect(result).toEqual([workbookInstance, datasetInstance])
     })
 
     it('should not add dependencies that already exist', async () => {
       const input = [customRecordTypeInstance, customSegmentInstance, workbookInstance,
         datasetInstance, instance]
-      const result = getRequiredReferencedInstances(input)
+      const result = await getReferencedInstances(input, false)
       expect(result).toEqual(input)
     })
 
@@ -148,8 +145,9 @@ describe('reference dependencies', () => {
           ),
         })
 
-      const result = getRequiredReferencedInstances(
-        [customRecordTypeInstance, customRecordTypeInstance2]
+      const result = await getReferencedInstances(
+        [customRecordTypeInstance, customRecordTypeInstance2],
+        false
       )
       expect(result)
         .toEqual([customRecordTypeInstance, customRecordTypeInstance2, customSegmentInstance])

--- a/packages/netsuite-adapter/tsconfig.json
+++ b/packages/netsuite-adapter/tsconfig.json
@@ -17,6 +17,7 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
+    { "path": "../workspace" },
     { "path": "../e2e-credentials-store" },
     { "path": "../file" },
     { "path": "../logging" },

--- a/packages/netsuite-adapter/tsconfig.json
+++ b/packages/netsuite-adapter/tsconfig.json
@@ -17,7 +17,6 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
-    { "path": "../workspace" },
     { "path": "../e2e-credentials-store" },
     { "path": "../file" },
     { "path": "../logging" },


### PR DESCRIPTION
For certain types, once we deploy them, SDF fails since it expects the referenced instances to be in the same deployed SDF project.
The hack in netsuite-adapter is to deploy the referenced instances in these specific cases although they are not in the plan.
The downside is that we deploy things to the customer that they are not aware of, and might override an element that has changed in the service and has an outdated version in the Workspace.

We should add these elements to the safe-deploy calculation.

---
_Release Notes_: 
Netsuite Adapter:
- add required/referenced elements to safe-deploy validation

---
_User Notifications_: 
None