### PR TITLE
SALTO-1997: fixed bug of hidden values with maps

### DIFF
--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -20,7 +20,7 @@ import { transformElement, TransformFunc, transformValues, applyFunctionToChange
 import { CORE_ANNOTATIONS, Element, isInstanceElement, isType, TypeElement, getField,
   DetailedChange, isRemovalChange, ElemID, isObjectType, ObjectType, Values,
   isRemovalOrModificationChange, isAdditionOrModificationChange, isElement, isField,
-  ReadOnlyElementsSource, ReferenceMap, isPrimitiveType, PrimitiveType, InstanceElement, Field, isModificationChange, ModificationChange, ReferenceExpression, isReferenceExpression } from '@salto-io/adapter-api'
+  ReadOnlyElementsSource, ReferenceMap, isPrimitiveType, PrimitiveType, InstanceElement, Field, isModificationChange, ModificationChange, ReferenceExpression, isReferenceExpression, MapType, getFieldType, isMapType } from '@salto-io/adapter-api'
 import { mergeElements, MergeResult } from '../merger'
 import { State } from './state'
 import { createAddChange, createRemoveChange } from './nacl_files/multi_env/projections'
@@ -198,7 +198,7 @@ export const removeHiddenFromElement = <T extends Element>(
   )
 
 const removeHiddenFromValues = (
-  type: ObjectType,
+  type: ObjectType | MapType,
   value: Values,
   pathID: ElemID,
   elementsSource: ReadOnlyElementsSource,
@@ -752,8 +752,8 @@ export const filterOutHiddenChanges = async (
       }
 
       const fieldType = changeType
-        && await (await getField(changeType, changePath, state))?.getType(state)
-      if (isObjectType(fieldType)) {
+        && await getFieldType(changeType, changePath, state)
+      if (isObjectType(fieldType) || isMapType(fieldType)) {
         const visible = await applyFunctionToChangeData(
           change,
           value => removeHiddenFromValues(

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -751,8 +751,7 @@ export const filterOutHiddenChanges = async (
         return { hidden: change }
       }
 
-      const fieldType = changeType
-        && await getFieldType(changeType, changePath, state)
+      const fieldType = changeType && await getFieldType(changeType, changePath, state)
       if (isObjectType(fieldType) || isMapType(fieldType)) {
         const visible = await applyFunctionToChangeData(
           change,


### PR DESCRIPTION
Fixed a bug with hidden values in maps values

---

There were two issues:
- We would not check inner values if the change was a change of map and not an object type
- `await (await getField(changeType, changePath, state))?.getType(state)` return the Map type and not the inner type also for values inside maps so we should use `getFieldType`

---
_Release Notes_: 
None

---
_User Notifications_: 
None