### PR TITLE
SALTO-1999: added elemIdGetter to Jira

### DIFF
--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -16,7 +16,7 @@
 */
 import _ from 'lodash'
 import { FieldDefinition, Field, CORE_ANNOTATIONS, TypeElement, isObjectType, isContainerType,
-  getDeepInnerType, ObjectType, BuiltinTypes, createRestriction, createRefToElmWithValue, PrimitiveType, LIST_ID_PREFIX, GENERIC_ID_PREFIX, GENERIC_ID_SUFFIX, MAP_ID_PREFIX, ListType, MapType, isEqualElements, isPrimitiveType, PrimitiveTypes } from '@salto-io/adapter-api'
+  getDeepInnerType, ObjectType, BuiltinTypes, createRestriction, createRefToElmWithValue, PrimitiveType, LIST_ID_PREFIX, GENERIC_ID_PREFIX, GENERIC_ID_SUFFIX, MAP_ID_PREFIX, ListType, MapType, isEqualElements, isPrimitiveType, PrimitiveTypes, isReferenceExpression } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { values, collections } from '@salto-io/lowerdash'
 import { FieldToHideType, FieldTypeOverrideType, getTypeTransformationConfig } from '../config/transformation'
@@ -69,21 +69,25 @@ export const markServiceIdField = (
     return
   }
   log.debug('Mark field %s.%s as service_id', typeName, fieldName)
-  if (!isPrimitiveType(field.refType)) {
+  const fieldType = isReferenceExpression(field.refType)
+    ? field.refType.value
+    : field.refType
+
+  if (!isPrimitiveType(fieldType)) {
     log.warn('field %s.%s type is not primitive, cannot mark it as service_id', typeName, fieldName)
     return
   }
-  switch (field.refType.primitive) {
+  switch (fieldType.primitive) {
     case (PrimitiveTypes.NUMBER):
-      field.refType = BuiltinTypes.SERVICE_ID_NUMBER
+      field.refType = createRefToElmWithValue(BuiltinTypes.SERVICE_ID_NUMBER)
       return
     case (PrimitiveTypes.STRING):
-      field.refType = BuiltinTypes.SERVICE_ID
+      field.refType = createRefToElmWithValue(BuiltinTypes.SERVICE_ID)
       return
     default:
       log.warn(
         'Failed to mark field %s.%s as service id, since its primitive type id (%d) is not supported',
-        typeName, fieldName, field.refType.primitive
+        typeName, fieldName, fieldType.primitive
       )
   }
 }

--- a/packages/adapter-components/src/filter_utils.ts
+++ b/packages/adapter-components/src/filter_utils.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { ElemIdGetter } from '@salto-io/adapter-api'
 import { filter } from '@salto-io/adapter-utils'
 import { Paginator } from './client'
 
@@ -26,6 +27,7 @@ export type FilterOpts<TClient, TContext> = {
   client: TClient
   paginator: Paginator
   config: TContext
+  getElemIdFunc?: ElemIdGetter
 }
 
 export type FilterCreator<

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -49,7 +49,12 @@ describe('swagger_type_elements', () => {
           ADAPTER_NAME,
           {
             swagger: { url },
-            typeDefaults: { transformation: { idFields: ['name'] } },
+            typeDefaults: {
+              transformation: {
+                idFields: ['name'],
+                serviceIdField: 'name',
+              },
+            },
             types: {},
           },
         )
@@ -62,7 +67,7 @@ describe('swagger_type_elements', () => {
           additionalProperties: 'Map<unknown>',
           category: 'myAdapter.Category',
           id: 'number',
-          name: 'string',
+          name: 'serviceid',
           photoUrls: 'List<string>',
           status: 'string',
           tags: 'List<myAdapter.Tag>',
@@ -149,7 +154,7 @@ describe('swagger_type_elements', () => {
         expect(location).toBeInstanceOf(ObjectType)
         expect(_.mapValues(location.fields, f => f.refType.elemID.name)).toEqual({
           additionalProperties: 'Map<unknown>',
-          name: 'string',
+          name: 'serviceid',
           // address is defined as anyOf combining primitive and object - should use unknown
           address: 'unknown',
         })

--- a/packages/adapter-components/test/elements/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/type_elements.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { FieldDefinition, BuiltinTypes, ObjectType, ElemID } from '@salto-io/adapter-api'
+import { FieldDefinition, BuiltinTypes, ObjectType, ElemID, createRefToElmWithValue } from '@salto-io/adapter-api'
 import { SUBTYPES_PATH, TYPES_PATH } from '../../src/elements/constants'
 import { filterTypes, hideFields, markServiceIdField } from '../../src/elements/type_elements'
 
@@ -117,7 +117,9 @@ describe('type_elements', () => {
           anotherField: { refType: BuiltinTypes.STRING },
         }
         markServiceIdField('id', typeFields, 'test')
-        expect(typeFields.id.refType).toEqual(BuiltinTypes.SERVICE_ID)
+        expect(typeFields.id.refType).toEqual(
+          createRefToElmWithValue(BuiltinTypes.SERVICE_ID)
+        )
       })
       it('should mark number', () => {
         const typeFields = {
@@ -125,7 +127,9 @@ describe('type_elements', () => {
           anotherField: { refType: BuiltinTypes.STRING },
         }
         markServiceIdField('id', typeFields, 'test')
-        expect(typeFields.id.refType).toEqual(BuiltinTypes.SERVICE_ID_NUMBER)
+        expect(typeFields.id.refType).toEqual(
+          createRefToElmWithValue(BuiltinTypes.SERVICE_ID_NUMBER)
+        )
       })
       it('should not mark boolean', () => {
         const typeFields = {

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { FetchResult, AdapterOperations, DeployResult, InstanceElement, TypeMap, isObjectType, FetchOptions, DeployOptions, Change, isInstanceChange } from '@salto-io/adapter-api'
+import { FetchResult, AdapterOperations, DeployResult, InstanceElement, TypeMap, isObjectType, FetchOptions, DeployOptions, Change, isInstanceChange, ElemIdGetter } from '@salto-io/adapter-api'
 import { config as configUtils, elements as elementUtils, client as clientUtils, deployment } from '@salto-io/adapter-components'
 import { applyFunctionToChangeData, logDuration } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -100,6 +100,7 @@ export interface JiraAdapterParams {
   filterCreators?: FilterCreator[]
   client: JiraClient
   config: JiraConfig
+  getElemIdFunc?: ElemIdGetter
 }
 
 type AdapterSwaggers = {
@@ -112,13 +113,16 @@ export default class JiraAdapter implements AdapterOperations {
   private client: JiraClient
   private userConfig: JiraConfig
   private paginator: clientUtils.Paginator
+  private getElemIdFunc?: ElemIdGetter
 
   public constructor({
     filterCreators = DEFAULT_FILTERS,
     client,
+    getElemIdFunc,
     config,
   }: JiraAdapterParams) {
     this.userConfig = config
+    this.getElemIdFunc = getElemIdFunc
     this.client = client
     const paginator = createPaginator({
       client: this.client,
@@ -131,6 +135,7 @@ export default class JiraAdapter implements AdapterOperations {
         client,
         paginator,
         config,
+        getElemIdFunc,
       }, filterCreators)
     )
   }
@@ -186,6 +191,7 @@ export default class JiraAdapter implements AdapterOperations {
       objectTypes: _.pickBy(allTypes, isObjectType),
       apiConfig: updatedApiDefinitionsConfig,
       fetchConfig: this.userConfig.fetch,
+      getElemIdFunc: this.getElemIdFunc,
     })
   }
 

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -97,6 +97,7 @@ export const adapter: Adapter = {
         config: config.client,
       }),
       config,
+      getElemIdFunc: context.getElemIdFunc,
     })
   },
   validateCredentials: async config => {

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1460,6 +1460,7 @@ export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
     transformation: {
       idFields: DEFAULT_ID_FIELDS,
       fieldsToOmit: FIELDS_TO_OMIT,
+      serviceIdField: 'id',
     },
   },
   types: DEFAULT_TYPE_CUSTOMIZATIONS,

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -48,6 +48,8 @@ const FIELD_TYPES_WITH_OPTIONS = [
   'com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes',
 ]
 
+const DEFAULT_SERVICE_ID_FIELD = 'id'
+
 const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   // Cloud platform API
   Configuration: {
@@ -1460,7 +1462,7 @@ export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
     transformation: {
       idFields: DEFAULT_ID_FIELDS,
       fieldsToOmit: FIELDS_TO_OMIT,
-      serviceIdField: 'id',
+      serviceIdField: DEFAULT_SERVICE_ID_FIELD,
     },
   },
   types: DEFAULT_TYPE_CUSTOMIZATIONS,

--- a/packages/jira-adapter/test/filters/fields/field_structure.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_structure.test.ts
@@ -195,6 +195,41 @@ describe('fields_structure', () => {
     )
   })
 
+  it('should use elemIdGetter when extracting the contexts', async () => {
+    const { client, paginator } = mockClient()
+    filter = fieldsStructureFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+      getElemIdFunc: () => new ElemID(JIRA, 'customName'),
+    }) as typeof filter
+
+    const instance = new InstanceElement(
+      'instance',
+      fieldType,
+      {
+        name: 'name',
+        contexts: [
+          {
+            name: 'name',
+            id: 'id1',
+          },
+        ],
+      }
+    )
+    const elements = [
+      instance,
+      fieldType,
+      fieldContextType,
+      fieldContextDefaultValueType,
+      fieldContextOptionType,
+    ]
+    await filter.onFetch(elements)
+    const contextInstance = elements[elements.length - 1] as InstanceElement
+
+    expect(contextInstance.elemID.name).toBe('customName')
+  })
+
   it('should transform options to map and add positions and cascadingOptions', async () => {
     const instance = new InstanceElement(
       'instance',


### PR DESCRIPTION
Using elemIdGetter in Jira to persist the element name after the first fetch

---
_Release Notes_: 
None

---
_User Notifications_: 
None