### PR TITLE
(SALTO-2025) show or hide instances when their type _hidden_value value is changed

### DIFF
--- a/packages/workspace/test/common/state.ts
+++ b/packages/workspace/test/common/state.ts
@@ -17,14 +17,14 @@ import { Element } from '@salto-io/adapter-api'
 import { State, buildInMemState } from '../../src/workspace/state'
 import { InMemoryRemoteMap } from '../../src/workspace/remote_map'
 import { createInMemoryElementSource } from '../../src/workspace/elements_source'
-import { Path, getElementsPathHints } from '../../src/workspace/path_index'
+import { Path } from '../../src/workspace/path_index'
 
 export const mockState = (
   elements: Element[] = [],
 ): State => (
   buildInMemState(async () => ({
     elements: createInMemoryElementSource(elements),
-    pathIndex: new InMemoryRemoteMap<Path[]>(getElementsPathHints(elements)),
+    pathIndex: new InMemoryRemoteMap<Path[]>(),
     accountsUpdateDate: new InMemoryRemoteMap(),
     saltoVersion: '0.0.1',
     saltoMetadata: new InMemoryRemoteMap(),

--- a/packages/workspace/test/common/state.ts
+++ b/packages/workspace/test/common/state.ts
@@ -17,14 +17,14 @@ import { Element } from '@salto-io/adapter-api'
 import { State, buildInMemState } from '../../src/workspace/state'
 import { InMemoryRemoteMap } from '../../src/workspace/remote_map'
 import { createInMemoryElementSource } from '../../src/workspace/elements_source'
-import { Path } from '../../src/workspace/path_index'
+import { Path, getElementsPathHints } from '../../src/workspace/path_index'
 
 export const mockState = (
   elements: Element[] = [],
 ): State => (
   buildInMemState(async () => ({
     elements: createInMemoryElementSource(elements),
-    pathIndex: new InMemoryRemoteMap<Path[]>(),
+    pathIndex: new InMemoryRemoteMap<Path[]>(getElementsPathHints(elements)),
     accountsUpdateDate: new InMemoryRemoteMap(),
     saltoVersion: '0.0.1',
     saltoMetadata: new InMemoryRemoteMap(),

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -642,8 +642,9 @@ describe('handleHiddenChanges', () => {
       path: ['this', 'is', 'path', 'to', 'hiddenObj'],
     })
     const inst = new InstanceElement('visi', obj, {}, ['this', 'is', 'path', 'to', 'inst'])
-    const hidden = new InstanceElement('hidden', hiddenObj, {}, ['this', 'is', 'path', 'to', 'hidden'])
-
+    const hidden1 = new InstanceElement('hidden', hiddenObj, { a: 1 }, ['this', 'is', 'path', 'to', 'hidden'])
+    const hidden2 = new InstanceElement('hidden', hiddenObj, { b: 2 }, ['this', 'is', 'path', 'to', 'hidden2'])
+    const hidden = new InstanceElement('hidden', hiddenObj, { a: 1, b: 2 })
     const state = mockState([obj, hiddenObj, inst, hidden])
     const visibleSource = createInMemoryElementSource([obj, hiddenObj, inst])
     describe('when the type\'s hidden_value values is changed to true', () => {
@@ -678,6 +679,8 @@ describe('handleHiddenChanges', () => {
         const hiddenObjClone = hiddenObj.clone()
         delete hiddenObjClone.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]
         await state.set(hiddenObjClone)
+        await state.overridePathIndex([obj, hiddenObj, inst, hidden1, hidden2])
+
         const fromHiddenChange = createRemoveChange(
           true,
           hiddenObj.elemID.createNestedID('attr', CORE_ANNOTATIONS.HIDDEN_VALUE)
@@ -689,10 +692,15 @@ describe('handleHiddenChanges', () => {
         )).visible
       })
       it('should create add changes with the instance value from the state', () => {
-        const addChange = changes
-          .find(c => c.id.getFullName() === hidden.elemID.getFullName()) as DetailedChange
-        expect(isAdditionChange(addChange)).toBeTruthy()
-        expect(addChange.path).toEqual(['this', 'is', 'path', 'to', 'hidden'])
+        const addChanges = changes
+          .filter(c => c.id.getFullName() === hidden.elemID.getFullName() && isAdditionChange(c))
+        expect(addChanges).toHaveLength(2)
+        expect(addChanges.map(c => c.path)).toEqual(
+          [
+            ['this', 'is', 'path', 'to', 'hidden'],
+            ['this', 'is', 'path', 'to', 'hidden2'],
+          ]
+        )
       })
     })
   })


### PR DESCRIPTION
…

_show or hide instances when their type _hidden_value value is changed_

---

_when an instance type _hidden_value value changes, the instance should be removed/shown in the nacls_

---
_Release Notes_: 
_Fixed merge errors after a _hidden_value value is change in a type that is used by instances._

---
_User Notifications_: 
_NA_
