### PR TITLE
SALTO-1998: changed workflow properties to a list of objects

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/workflow.ts
@@ -224,15 +224,17 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
   statuses: [
     {
       id: createReference(new ElemID(JIRA, 'Status', 'instance', 'Backlog'), allElements),
-      properties: {
-        'jira.issue.editable': 'true',
-      },
+      properties: [{
+        key: 'jira.issue.editable',
+        value: 'true',
+      }],
     },
     {
       id: createReference(new ElemID(JIRA, 'Status', 'instance', 'Done'), allElements),
-      properties: {
-        'jira.issue.editable': 'true',
-      },
+      properties: [{
+        key: 'jira.issue.editable',
+        value: 'true',
+      }],
     },
   ],
 })

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -42,6 +42,7 @@ import projectFilter from './filters/project'
 import projectComponentFilter from './filters/project_component'
 import defaultInstancesDeployFilter from './filters/default_instances_deploy'
 import workflowFilter from './filters/workflow/workflow'
+import workflowPropertiesFilter from './filters/workflow/workflow_properties'
 import workflowSchemeFilter from './filters/workflow_scheme'
 import fieldStructureFilter from './filters/fields/field_structure_filter'
 import fieldDeploymentFilter from './filters/fields/field_deployment_filter'
@@ -65,6 +66,7 @@ const log = logger(module)
 export const DEFAULT_FILTERS = [
   avatarsFilter,
   workflowFilter,
+  workflowPropertiesFilter,
   workflowSchemeFilter,
   missingStatusesFilter,
   issueTypeSchemeReferences,

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -19,6 +19,8 @@ import Joi from 'joi'
 
 const log = logger(module)
 
+export const WORKFLOW_TYPE_NAME = 'Workflow'
+
 type Id = {
   name?: string
   entityId?: string
@@ -30,23 +32,23 @@ const idSchema = Joi.object({
 }).unknown(true)
 
 type ConfigRef = {
-  id?: string | number
+  id?: unknown
   name?: string
 }
 
 const configRefSchema = Joi.object({
-  id: Joi.alternatives(Joi.number(), Joi.string()).optional(),
+  id: Joi.optional(),
   name: Joi.string().optional(),
 }).unknown(true)
 
 type ValidatorConfiguration = {
   windowsDays?: number | string
-  fieldId?: string
+  fieldId?: unknown
   parentStatuses?: ConfigRef[]
   previousStatus?: ConfigRef
   field?: string
   fields?: string[]
-  fieldIds?: string[]
+  fieldIds?: unknown[]
 }
 
 const validatorConfigurationSchema = Joi.object({
@@ -54,12 +56,12 @@ const validatorConfigurationSchema = Joi.object({
     Joi.number().integer(),
     Joi.string(),
   ).optional(),
-  fieldId: Joi.string().optional(),
+  fieldId: Joi.optional(),
   parentStatuses: Joi.array().items(configRefSchema).optional(),
   previousStatus: configRefSchema.optional(),
-  field: Joi.string().optional(),
+  field: Joi.optional(),
   fields: Joi.array().items(Joi.string()).optional(),
-  fieldIds: Joi.array().items(Joi.string()).optional(),
+  fieldIds: Joi.array().optional(),
 }).unknown(true)
 
 type PostFunctionConfiguration = {
@@ -121,7 +123,7 @@ export type Status = {
 }
 
 const statusSchema = Joi.object({
-  properties: Joi.object().optional(),
+  properties: Joi.alternatives(Joi.object(), Joi.array()).optional(),
 }).unknown(true)
 
 export type Workflow = {

--- a/packages/jira-adapter/src/filters/workflow/workflow.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow.ts
@@ -20,7 +20,7 @@ import { resolveValues } from '@salto-io/adapter-utils'
 import { findObject } from '../../utils'
 import { FilterCreator } from '../../filter'
 import { postFunctionType, types as postFunctionTypes } from './post_functions_types'
-import { isWorkflowInstance, Rules, Status, Validator, Workflow, WorkflowInstance } from './types'
+import { isWorkflowInstance, Rules, Status, Validator, Workflow, WorkflowInstance, WORKFLOW_TYPE_NAME } from './types'
 import { validatorType, types as validatorTypes } from './validators_types'
 import JiraClient from '../../client/client'
 import { JiraConfig } from '../../config'
@@ -67,8 +67,6 @@ export const INITIAL_VALIDATOR = {
   },
 }
 
-
-const WORKFLOW_TYPE_NAME = 'Workflow'
 
 const transformStatus = (status: Status): void => {
   status.properties = status.properties?.additionalProperties

--- a/packages/jira-adapter/src/filters/workflow/workflow_properties.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_properties.ts
@@ -31,9 +31,20 @@ const log = logger(module)
 
 const convertStatusesPropertiesToList = (instance: WorkflowInstance): void => {
   instance.value.statuses?.forEach(status => {
-    status.properties = status.properties
-      && Object.entries(status.properties)
+    if (status.properties !== undefined) {
+      status.properties = Object.entries(status.properties)
         .map(([key, value]) => ({ key, value }))
+    }
+  })
+}
+
+const convertStatusesPropertiesToMap = (instance: WorkflowInstance): void => {
+  instance.value.statuses?.forEach(status => {
+    if (status.properties !== undefined) {
+      status.properties = Object.fromEntries(
+        status.properties.map(({ key, value }: Values) => [key, value])
+      )
+    }
   })
 }
 
@@ -80,12 +91,7 @@ const filter: FilterCreator = () => ({
         await applyFunctionToChangeData<Change<WorkflowInstance>>(
           change,
           instance => {
-            instance.value.statuses?.forEach(status => {
-              status.properties = status.properties
-                && Object.fromEntries(
-                  status.properties.map(({ key, value }: Values) => [key, value])
-                )
-            })
+            convertStatusesPropertiesToMap(instance)
             return instance
           }
         )

--- a/packages/jira-adapter/src/filters/workflow/workflow_properties.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_properties.ts
@@ -1,0 +1,112 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, Change, CORE_ANNOTATIONS, Element, ElemID, Field, getChangeData, isInstanceChange, isInstanceElement, ListType, ObjectType, Values } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import { elements as elementUtils } from '@salto-io/adapter-components'
+import { findObject } from '../../utils'
+import { FilterCreator } from '../../filter'
+import { isWorkflowInstance, WorkflowInstance, WORKFLOW_TYPE_NAME } from './types'
+import { JIRA } from '../../constants'
+
+const STATUS_PROPERTY_TYPE_NAME = 'StatusProperty'
+
+const { awu } = collections.asynciterable
+
+const log = logger(module)
+
+const convertStatusesPropertiesToList = (instance: WorkflowInstance): void => {
+  instance.value.statuses?.forEach(status => {
+    status.properties = status.properties
+      && Object.entries(status.properties)
+        .map(([key, value]) => ({ key, value }))
+  })
+}
+
+
+const filter: FilterCreator = () => ({
+  onFetch: async (elements: Element[]) => {
+    const propertyType = new ObjectType({
+      elemID: new ElemID(JIRA, STATUS_PROPERTY_TYPE_NAME),
+      fields: {
+        key: {
+          refType: BuiltinTypes.STRING,
+          annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+        },
+        value: {
+          refType: BuiltinTypes.STRING,
+          annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+        },
+      },
+      path: [JIRA, elementUtils.TYPES_PATH, STATUS_PROPERTY_TYPE_NAME],
+    })
+
+    elements.push(propertyType)
+
+    const workflowStatusType = findObject(elements, 'WorkflowStatus')
+    if (workflowStatusType === undefined) {
+      log.warn('WorkflowStatus type was not received in fetch')
+    } else {
+      workflowStatusType.fields.properties = new Field(workflowStatusType, 'properties', new ListType(propertyType), { [CORE_ANNOTATIONS.REQUIRED]: true })
+    }
+
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
+      .filter(isWorkflowInstance)
+      .forEach(convertStatusesPropertiesToList)
+  },
+
+  preDeploy: async changes => {
+    await awu(changes)
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === WORKFLOW_TYPE_NAME)
+      .filter(change => isWorkflowInstance(getChangeData(change)))
+      .forEach(async change => {
+        await applyFunctionToChangeData<Change<WorkflowInstance>>(
+          change,
+          instance => {
+            instance.value.statuses?.forEach(status => {
+              status.properties = status.properties
+                && Object.fromEntries(
+                  status.properties.map(({ key, value }: Values) => [key, value])
+                )
+            })
+            return instance
+          }
+        )
+      })
+  },
+
+  onDeploy: async changes => {
+    await awu(changes)
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === WORKFLOW_TYPE_NAME)
+      .filter(change => isWorkflowInstance(getChangeData(change)))
+      .forEach(async change => {
+        await applyFunctionToChangeData<Change<WorkflowInstance>>(
+          change,
+          instance => {
+            convertStatusesPropertiesToList(instance)
+            return instance
+          }
+        )
+      })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/test/filters/workflow_properties.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_properties.test.ts
@@ -1,0 +1,179 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ListType, ObjectType, toChange } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import JiraClient from '../../src/client/client'
+import { DEFAULT_CONFIG } from '../../src/config'
+import { JIRA } from '../../src/constants'
+import workflowPropertiesFilter from '../../src/filters/workflow/workflow_properties'
+import { mockClient } from '../utils'
+
+describe('workflowPropertiesFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let workflowType: ObjectType
+  let workflowStatusType: ObjectType
+  let client: JiraClient
+  beforeEach(async () => {
+    workflowStatusType = new ObjectType({ elemID: new ElemID(JIRA, 'WorkflowStatus') })
+    workflowType = new ObjectType({
+      elemID: new ElemID(JIRA, 'Workflow'),
+      fields: {
+        statuses: { refType: new ListType(workflowStatusType) },
+      },
+    })
+
+    const { client: cli, paginator } = mockClient()
+    client = cli
+    filter = workflowPropertiesFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    }) as typeof filter
+  })
+
+  describe('onFetch', () => {
+    it('should set the properties field in WorkflowStatus', async () => {
+      const elements = [workflowStatusType]
+      await filter.onFetch(elements)
+      expect(workflowStatusType.fields.properties).toBeDefined()
+      expect(elements).toHaveLength(2)
+    })
+
+    it('should replace properties from map to list', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          statuses: [
+            {
+              properties: {
+                a: '1',
+                b: '2',
+              },
+            },
+            {
+              properties: {
+                c: '3',
+                d: '4',
+              },
+            },
+          ],
+        }
+      )
+      await filter.onFetch([instance])
+      expect(instance.value).toEqual({
+        statuses: [
+          {
+            properties: [
+              { key: 'a', value: '1' },
+              { key: 'b', value: '2' },
+            ],
+          },
+          {
+            properties: [
+              { key: 'c', value: '3' },
+              { key: 'd', value: '4' },
+            ],
+          },
+        ],
+      })
+    })
+  })
+
+  describe('preDeploy', () => {
+    it('should replace properties from list to map', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          statuses: [
+            {
+              properties: [
+                { key: 'a', value: '1' },
+                { key: 'b', value: '2' },
+              ],
+            },
+            {
+              properties: [
+                { key: 'c', value: '3' },
+                { key: 'd', value: '4' },
+              ],
+            },
+          ],
+        }
+      )
+      await filter.preDeploy?.([toChange({ after: instance })])
+      expect(instance.value).toEqual({
+        statuses: [
+          {
+            properties: {
+              a: '1',
+              b: '2',
+            },
+          },
+          {
+            properties: {
+              c: '3',
+              d: '4',
+            },
+          },
+        ],
+      })
+    })
+  })
+
+  describe('onDeploy', () => {
+    it('should replace properties from map to list', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          statuses: [
+            {
+              properties: {
+                a: '1',
+                b: '2',
+              },
+            },
+            {
+              properties: {
+                c: '3',
+                d: '4',
+              },
+            },
+          ],
+        }
+      )
+      await filter.onDeploy?.([toChange({ after: instance })])
+      expect(instance.value).toEqual({
+        statuses: [
+          {
+            properties: [
+              { key: 'a', value: '1' },
+              { key: 'b', value: '2' },
+            ],
+          },
+          {
+            properties: [
+              { key: 'c', value: '3' },
+              { key: 'd', value: '4' },
+            ],
+          },
+        ],
+      })
+    })
+  })
+})


### PR DESCRIPTION
Changed workflow statuses properties from a map to a list of objects with `key` and `value` because the key might contain `.` which isn't supported well by the parser

---
_Release Notes_: 
None

---
_User Notifications_: 
None