### PR TITLE
SALTO-1986: prevent omitting all options from fields and dynamic content items

### DIFF
--- a/packages/zendesk-support-adapter/src/change_validator.ts
+++ b/packages/zendesk-support-adapter/src/change_validator.ts
@@ -15,7 +15,12 @@
 */
 import { ChangeValidator } from '@salto-io/adapter-api'
 import { config as configUtils, deployment } from '@salto-io/adapter-components'
-import { accountSettingsValidator, duplicateCustomFieldOptionValuesValidator } from './change_validators'
+import {
+  accountSettingsValidator,
+  emptyCustomFieldOptionsValidator,
+  emptyVariantsValidator,
+  duplicateCustomFieldOptionValuesValidator,
+} from './change_validators'
 
 const {
   deployTypesNotSupportedValidator,
@@ -30,6 +35,8 @@ export default (
     deployTypesNotSupportedValidator,
     createCheckDeploymentBasedOnConfigValidator(apiConfig, typesDeployedViaParent),
     accountSettingsValidator,
+    emptyCustomFieldOptionsValidator,
+    emptyVariantsValidator,
     duplicateCustomFieldOptionValuesValidator,
   ]
   return createSkipParentsOfSkippedInstancesValidator(validators)

--- a/packages/zendesk-support-adapter/src/change_validators/empty_custom_field_options.ts
+++ b/packages/zendesk-support-adapter/src/change_validators/empty_custom_field_options.ts
@@ -17,6 +17,7 @@ import _ from 'lodash'
 import { ChangeValidator, getChangeData,
   isAdditionOrModificationChange, isInstanceElement } from '@salto-io/adapter-api'
 import { CUSTOM_FIELD_OPTIONS_FIELD_NAME } from '../filters/custom_field_options/creator'
+import { createEmptyFieldErrorMessage } from './utils'
 
 const RELEVANT_TYPES = ['ticket_field', 'user_field', 'organization_field']
 const RELEVANT_FIELD_TYPES = ['dropdown', 'tagger', 'multiselect']
@@ -35,8 +36,12 @@ export const emptyCustomFieldOptionsValidator: ChangeValidator = async changes =
         return [{
           elemID: instance.elemID,
           severity: 'Error',
-          message: `Can not change ${instance.elemID.getFullName()}' ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} to be empty`,
-          detailedMessage: `Can not change ${instance.elemID.getFullName()}' ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} to be empty`,
+          message: createEmptyFieldErrorMessage(
+            instance.elemID.getFullName(), CUSTOM_FIELD_OPTIONS_FIELD_NAME
+          ),
+          detailedMessage: createEmptyFieldErrorMessage(
+            instance.elemID.getFullName(), CUSTOM_FIELD_OPTIONS_FIELD_NAME
+          ),
         }]
       }
       return []

--- a/packages/zendesk-support-adapter/src/change_validators/empty_custom_field_options.ts
+++ b/packages/zendesk-support-adapter/src/change_validators/empty_custom_field_options.ts
@@ -1,0 +1,44 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ChangeValidator, getChangeData,
+  isAdditionOrModificationChange, isInstanceElement } from '@salto-io/adapter-api'
+import { CUSTOM_FIELD_OPTIONS_FIELD_NAME } from '../filters/custom_field_options/creator'
+
+const RELEVANT_TYPES = ['ticket_field', 'user_field', 'organization_field']
+const RELEVANT_FIELD_TYPES = ['dropdown', 'tagger', 'multiselect']
+
+export const emptyCustomFieldOptionsValidator: ChangeValidator = async changes => (
+  changes
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isInstanceElement)
+    .filter(instance => RELEVANT_TYPES.includes(instance.elemID.typeName))
+    .flatMap(instance => {
+      if (
+        RELEVANT_FIELD_TYPES.includes(instance.value.type)
+        && _.isEmpty(instance.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME])
+      ) {
+        return [{
+          elemID: instance.elemID,
+          severity: 'Error',
+          message: `Can not change ${instance.elemID.getFullName()}' ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} to be empty`,
+          detailedMessage: `Can not change ${instance.elemID.getFullName()}' ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} to be empty`,
+        }]
+      }
+      return []
+    })
+)

--- a/packages/zendesk-support-adapter/src/change_validators/empty_variants.ts
+++ b/packages/zendesk-support-adapter/src/change_validators/empty_variants.ts
@@ -17,6 +17,7 @@ import _ from 'lodash'
 import { ChangeValidator, getChangeData,
   isAdditionOrModificationChange, isInstanceElement } from '@salto-io/adapter-api'
 import { VARIANTS_FIELD_NAME, DYNAMIC_CONTENT_ITEM_TYPE_NAME } from '../filters/dynamic_content'
+import { createEmptyFieldErrorMessage } from './utils'
 
 export const emptyVariantsValidator: ChangeValidator = async changes => (
   changes
@@ -29,8 +30,10 @@ export const emptyVariantsValidator: ChangeValidator = async changes => (
         return [{
           elemID: instance.elemID,
           severity: 'Error',
-          message: `Can not change ${instance.elemID.getFullName()}' ${VARIANTS_FIELD_NAME} to be empty`,
-          detailedMessage: `Can not change ${instance.elemID.getFullName()}' ${VARIANTS_FIELD_NAME} to be empty`,
+          message: createEmptyFieldErrorMessage(instance.elemID.getFullName(), VARIANTS_FIELD_NAME),
+          detailedMessage: createEmptyFieldErrorMessage(
+            instance.elemID.getFullName(), VARIANTS_FIELD_NAME
+          ),
         }]
       }
       return []

--- a/packages/zendesk-support-adapter/src/change_validators/empty_variants.ts
+++ b/packages/zendesk-support-adapter/src/change_validators/empty_variants.ts
@@ -1,0 +1,38 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ChangeValidator, getChangeData,
+  isAdditionOrModificationChange, isInstanceElement } from '@salto-io/adapter-api'
+import { VARIANTS_FIELD_NAME, DYNAMIC_CONTENT_ITEM_TYPE_NAME } from '../filters/dynamic_content'
+
+export const emptyVariantsValidator: ChangeValidator = async changes => (
+  changes
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isInstanceElement)
+    .filter(instance => instance.elemID.typeName === DYNAMIC_CONTENT_ITEM_TYPE_NAME)
+    .flatMap(instance => {
+      if (_.isEmpty(instance.value[VARIANTS_FIELD_NAME])) {
+        return [{
+          elemID: instance.elemID,
+          severity: 'Error',
+          message: `Can not change ${instance.elemID.getFullName()}' ${VARIANTS_FIELD_NAME} to be empty`,
+          detailedMessage: `Can not change ${instance.elemID.getFullName()}' ${VARIANTS_FIELD_NAME} to be empty`,
+        }]
+      }
+      return []
+    })
+)

--- a/packages/zendesk-support-adapter/src/change_validators/index.ts
+++ b/packages/zendesk-support-adapter/src/change_validators/index.ts
@@ -15,3 +15,5 @@
 */
 export { accountSettingsValidator } from './account_settings'
 export { duplicateCustomFieldOptionValuesValidator } from './duplicate_option_values'
+export { emptyCustomFieldOptionsValidator } from './empty_custom_field_options'
+export { emptyVariantsValidator } from './empty_variants'

--- a/packages/zendesk-support-adapter/src/change_validators/utils.ts
+++ b/packages/zendesk-support-adapter/src/change_validators/utils.ts
@@ -1,0 +1,17 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+export const createEmptyFieldErrorMessage = (fullName: string, fieldName: string): string =>
+  `Can not change ${fullName}' ${fieldName} to be empty`

--- a/packages/zendesk-support-adapter/test/change_validators/empty_custom_field_options.test.ts
+++ b/packages/zendesk-support-adapter/test/change_validators/empty_custom_field_options.test.ts
@@ -1,0 +1,60 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { ZENDESK_SUPPORT } from '../../src/constants'
+import { emptyCustomFieldOptionsValidator } from '../../src/change_validators/empty_custom_field_options'
+import { CUSTOM_FIELD_OPTIONS_FIELD_NAME } from '../../src/filters/custom_field_options/creator'
+
+describe('emptyCustomFieldOptionsValidator', () => {
+  const userFieldType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'user_field') })
+  const userField = new InstanceElement(
+    'field1',
+    userFieldType,
+    { key: 'test1', title: 'test', type: 'dropdown', [CUSTOM_FIELD_OPTIONS_FIELD_NAME]: [] },
+  )
+  it('should return an error when we add field with no options', async () => {
+    const errors = await emptyCustomFieldOptionsValidator([
+      toChange({ after: userField }),
+    ])
+    expect(errors).toEqual([{
+      elemID: userField.elemID,
+      severity: 'Error',
+      message: `Can not change ${userField.elemID.getFullName()}' ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} to be empty`,
+      detailedMessage: `Can not change ${userField.elemID.getFullName()}' ${CUSTOM_FIELD_OPTIONS_FIELD_NAME} to be empty`,
+    }])
+  })
+  it('should not return an error when we remove a field', async () => {
+    const errors = await emptyCustomFieldOptionsValidator([
+      toChange({ before: userField }),
+    ])
+    expect(errors).toHaveLength(0)
+  })
+  it('should not return an error when there are options', async () => {
+    const clonedUserField = userField.clone()
+    const userFieldOption = new InstanceElement(
+      'option1',
+      new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'user_field__custom_field_options') }),
+      { name: 'v1', value: 'v1' },
+    )
+    clonedUserField.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME] = [
+      new ReferenceExpression(userFieldOption.elemID, userFieldOption),
+    ]
+    const errors = await emptyCustomFieldOptionsValidator([
+      toChange({ after: clonedUserField }),
+    ])
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/packages/zendesk-support-adapter/test/change_validators/empty_variants.test.ts
+++ b/packages/zendesk-support-adapter/test/change_validators/empty_variants.test.ts
@@ -1,0 +1,62 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { ZENDESK_SUPPORT } from '../../src/constants'
+import { emptyVariantsValidator } from '../../src/change_validators/empty_variants'
+import { VARIANTS_FIELD_NAME, DYNAMIC_CONTENT_ITEM_TYPE_NAME } from '../../src/filters/dynamic_content'
+
+describe('emptyVariantsValidator', () => {
+  const itemType = new ObjectType({
+    elemID: new ElemID(ZENDESK_SUPPORT, DYNAMIC_CONTENT_ITEM_TYPE_NAME),
+  })
+  const item = new InstanceElement(
+    'field1',
+    itemType,
+    { name: 'test1', [VARIANTS_FIELD_NAME]: [] },
+  )
+  it('should return an error when we add field with no options', async () => {
+    const errors = await emptyVariantsValidator([
+      toChange({ after: item }),
+    ])
+    expect(errors).toEqual([{
+      elemID: item.elemID,
+      severity: 'Error',
+      message: `Can not change ${item.elemID.getFullName()}' ${VARIANTS_FIELD_NAME} to be empty`,
+      detailedMessage: `Can not change ${item.elemID.getFullName()}' ${VARIANTS_FIELD_NAME} to be empty`,
+    }])
+  })
+  it('should not return an error when we remove a field', async () => {
+    const errors = await emptyVariantsValidator([
+      toChange({ before: item }),
+    ])
+    expect(errors).toHaveLength(0)
+  })
+  it('should not return an error when there are options', async () => {
+    const clonedItem = item.clone()
+    const variant = new InstanceElement(
+      'option1',
+      new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'dynamic_content_item__variants') }),
+      { content: 'test', locale_id: 1 },
+    )
+    clonedItem.value[VARIANTS_FIELD_NAME] = [
+      new ReferenceExpression(variant.elemID, variant),
+    ]
+    const errors = await emptyVariantsValidator([
+      toChange({ after: clonedItem }),
+    ])
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/packages/zendesk-support-adapter/test/change_validators/empty_variants.test.ts
+++ b/packages/zendesk-support-adapter/test/change_validators/empty_variants.test.ts
@@ -27,7 +27,7 @@ describe('emptyVariantsValidator', () => {
     itemType,
     { name: 'test1', [VARIANTS_FIELD_NAME]: [] },
   )
-  it('should return an error when we add field with no options', async () => {
+  it('should return an error when we add field with no variants', async () => {
     const errors = await emptyVariantsValidator([
       toChange({ after: item }),
     ])
@@ -38,13 +38,13 @@ describe('emptyVariantsValidator', () => {
       detailedMessage: `Can not change ${item.elemID.getFullName()}' ${VARIANTS_FIELD_NAME} to be empty`,
     }])
   })
-  it('should not return an error when we remove a field', async () => {
+  it('should not return an error when we remove an item', async () => {
     const errors = await emptyVariantsValidator([
       toChange({ before: item }),
     ])
     expect(errors).toHaveLength(0)
   })
-  it('should not return an error when there are options', async () => {
+  it('should not return an error when there are variants', async () => {
     const clonedItem = item.clone()
     const variant = new InstanceElement(
       'option1',


### PR DESCRIPTION
_Prevent omitting all options from fields and dynamic content items_

---

_Additional context for reviewer_
We can't leave a dropdown field with no options, or a dynamic content item with no variants

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
