### PR TITLE
SALTO-2016: added "forceDelete" deploy option

### DIFF
--- a/packages/jira-adapter/specific-cli-options.md
+++ b/packages/jira-adapter/specific-cli-options.md
@@ -1,0 +1,12 @@
+# Jira Specific CLI options
+
+| Name                           |  Description
+| -------------------------------| ------------------------
+| jira.deploy.forceDelete        |  Whether to allow deleting data that Salto won't be able to restore. Currently only relevant for deleting projects with issues
+
+
+### Example
+
+```bash
+salto deploy -C 'jira.deploy.forceDelete=true'
+```

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -250,10 +250,9 @@ export default class JiraAdapter implements AdapterOperations {
     }
   }
 
-  // eslint-disable-next-line class-methods-use-this
   get deployModifiers(): AdapterOperations['deployModifiers'] {
     return {
-      changeValidator,
+      changeValidator: changeValidator(this.client, this.userConfig),
       dependencyChanger,
     }
   }

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -61,17 +61,10 @@ function validateConfig(config: Values): asserts config is JiraConfig {
 }
 
 const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined): JiraConfig => {
-  const fullConfig = {
-    ...(config?.value ?? {}),
-    apiDefinitions: configUtils.mergeWithDefaultConfig(
-      DEFAULT_CONFIG.apiDefinitions,
-      config?.value.apiDefinitions
-    ),
-    client: configUtils.mergeWithDefaultConfig(
-      DEFAULT_CONFIG.client,
-      config?.value.client
-    ),
-  }
+  const fullConfig = configUtils.mergeWithDefaultConfig(
+    _.omit(DEFAULT_CONFIG, 'fetch'),
+    config?.value
+  )
   validateConfig(fullConfig)
 
   // Hack to make sure this is coupled with the type definition of JiraConfig
@@ -79,6 +72,7 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
     apiDefinitions: null,
     client: null,
     fetch: null,
+    deploy: null,
   }
   Object.keys(fullConfig)
     .filter(k => !Object.keys(adapterConfig).includes(k))

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -21,18 +21,27 @@ import { defaultFieldConfigurationValidator } from './default_field_configuratio
 import { issueTypeSchemeValidator } from './issue_type_scheme'
 import { screenValidator } from './screen'
 import { workflowValidator } from './workflow'
+import JiraClient from '../client/client'
+import { JiraConfig } from '../config'
+import { projectDeletionValidator } from './project_deletion'
 
 const {
   deployTypesNotSupportedValidator,
 } = deployment.changeValidators
 
-const validators: ChangeValidator[] = [
-  deployTypesNotSupportedValidator,
-  unsupportedFieldConfigurationsValidator,
-  defaultFieldConfigurationValidator,
-  workflowValidator,
-  screenValidator,
-  issueTypeSchemeValidator,
-]
 
-export default createChangeValidator(validators)
+export default (
+  client: JiraClient, config: JiraConfig
+): ChangeValidator => {
+  const validators: ChangeValidator[] = [
+    deployTypesNotSupportedValidator,
+    unsupportedFieldConfigurationsValidator,
+    defaultFieldConfigurationValidator,
+    workflowValidator,
+    screenValidator,
+    issueTypeSchemeValidator,
+    projectDeletionValidator(client, config),
+  ]
+
+  return createChangeValidator(validators)
+}

--- a/packages/jira-adapter/src/change_validators/project_deletion.ts
+++ b/packages/jira-adapter/src/change_validators/project_deletion.ts
@@ -1,0 +1,74 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, InstanceElement, isInstanceChange, isRemovalChange, SaltoErrorSeverity } from '@salto-io/adapter-api'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import JiraClient from '../client/client'
+import { JiraConfig } from '../config'
+
+const { awu } = collections.asynciterable
+
+const log = logger(module)
+
+const doesProjectHaveIssues = async (
+  instance: InstanceElement,
+  client: JiraClient
+): Promise<boolean> => {
+  try {
+    const response = await client.getSinglePage({
+      url: '/rest/api/3/search',
+      queryParams: {
+        jql: `project = "${instance.value.key}"`,
+        maxResults: '0',
+      },
+    })
+
+    if (Array.isArray(response.data) || response.data.total === undefined) {
+      log.error(`Received invalid response from Jira search API, ${safeJsonStringify(response.data, undefined, 2)}. Assuming project ${instance.elemID.getFullName()} has issues.`)
+      return true
+    }
+
+    log.debug(`Project ${instance.elemID.getFullName()} has ${response.data.total} issues.`)
+
+    return response.data.total !== 0
+  } catch (e) {
+    log.error(`Received an error Jira search API, ${e.message}. Assuming project ${instance.elemID.getFullName()} has issues.`)
+    return true
+  }
+}
+
+export const projectDeletionValidator: (client: JiraClient, config: JiraConfig) =>
+  ChangeValidator = (client, config) => async changes => {
+    if (config.deploy.forceDelete) {
+      log.info('Force delete is enabled, skipping project deletion validator')
+      return []
+    }
+
+    return awu(changes)
+      .filter(isInstanceChange)
+      .filter(isRemovalChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === 'Project')
+      .filter(instance => doesProjectHaveIssues(instance, client))
+      .map(instance => ({
+        elemID: instance.elemID,
+        severity: 'Error' as SaltoErrorSeverity,
+        message: 'Project has issues assigned to it.',
+        detailedMessage: `The project ${instance.elemID.getFullName()} has issues assigned to it. Deleting the project will also delete all its issues and Salto will not be able to restore the issues. If you are sure you want to delete the project use the "forceDelete" deploy option.`,
+      }))
+      .toArray()
+  }

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1509,9 +1509,14 @@ export const DEFAULT_INCLUDE_ENDPOINTS: string[] = [
   'Boards',
 ]
 
+type JiraDeployConfig = {
+  forceDelete: boolean
+}
+
 export type JiraConfig = {
   client: JiraClientConfig
   fetch: JiraFetchConfig
+  deploy: JiraDeployConfig
   apiDefinitions: JiraApiConfig
 }
 
@@ -1548,6 +1553,9 @@ export const DEFAULT_CONFIG: JiraConfig = {
   fetch: {
     includeTypes: DEFAULT_INCLUDE_ENDPOINTS,
   },
+  deploy: {
+    forceDelete: false,
+  },
   apiDefinitions: DEFAULT_API_DEFINITIONS,
 }
 
@@ -1562,11 +1570,19 @@ const createClientConfigType = (): ObjectType => {
   return configType
 }
 
+const jiraDeployConfigType = new ObjectType({
+  elemID: new ElemID(JIRA, 'DeployConfig'),
+  fields: {
+    forceDelete: { refType: BuiltinTypes.BOOLEAN },
+  },
+})
+
 export const configType = createMatchingObjectType<Partial<JiraConfig>>({
   elemID: new ElemID(JIRA),
   fields: {
     client: { refType: createClientConfigType() },
     fetch: { refType: createUserFetchConfigType(JIRA) },
+    deploy: { refType: jiraDeployConfigType },
     apiDefinitions: { refType: apiDefinitionsType },
   },
   annotations: {

--- a/packages/jira-adapter/test/change_validators/change_validator.test.ts
+++ b/packages/jira-adapter/test/change_validators/change_validator.test.ts
@@ -14,17 +14,21 @@
 * limitations under the License.
 */
 import { toChange, ObjectType, ElemID } from '@salto-io/adapter-api'
+import { DEFAULT_CONFIG } from '../../src/config'
+import { mockClient } from '../utils'
 import changeValidator from '../../src/change_validators'
 import { JIRA } from '../../src/constants'
 
 describe('change validator creator', () => {
   describe('checkDeploymentAnnotationsValidator', () => {
+    const { client } = mockClient()
+
     it('should not fail if there are no deploy changes', async () => {
-      expect(await changeValidator([])).toEqual([])
+      expect(await changeValidator(client, DEFAULT_CONFIG)([])).toEqual([])
     })
 
     it('should fail each change individually', async () => {
-      expect(await changeValidator([
+      expect(await changeValidator(client, DEFAULT_CONFIG)([
         toChange({ after: new ObjectType({ elemID: new ElemID(JIRA, 'obj') }) }),
         toChange({ before: new ObjectType({ elemID: new ElemID(JIRA, 'obj2') }) }),
       ])).toEqual([

--- a/packages/jira-adapter/test/change_validators/project_deletion.test.ts
+++ b/packages/jira-adapter/test/change_validators/project_deletion.test.ts
@@ -1,0 +1,154 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement, ChangeValidator } from '@salto-io/adapter-api'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import _ from 'lodash'
+import { mockClient } from '../utils'
+import { projectDeletionValidator } from '../../src/change_validators/project_deletion'
+import { DEFAULT_CONFIG, JiraConfig } from '../../src/config'
+import { JIRA } from '../../src/constants'
+
+describe('projectDeletionValidator', () => {
+  let type: ObjectType
+  let instance: InstanceElement
+  let config: JiraConfig
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let changeValidator: ChangeValidator
+
+  beforeEach(() => {
+    const { client, connection } = mockClient()
+    mockConnection = connection
+
+    mockConnection.get.mockResolvedValue({
+      status: 200,
+      data: {
+        total: 1,
+      },
+    })
+
+    config = _.cloneDeep(DEFAULT_CONFIG)
+
+    changeValidator = projectDeletionValidator(client, config)
+
+    type = new ObjectType({ elemID: new ElemID(JIRA, 'Project') })
+    instance = new InstanceElement(
+      'instance',
+      type,
+      {
+        key: 'KEY',
+      }
+    )
+  })
+  it('should return an error when removing a project with issue', async () => {
+    expect(await changeValidator([
+      toChange({
+        before: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: 'Project has issues assigned to it.',
+        detailedMessage: 'The project jira.Project.instance.instance has issues assigned to it. Deleting the project will also delete all its issues and Salto will not be able to restore the issues. If you are sure you want to delete the project use the "forceDelete" deploy option.',
+      },
+    ])
+
+    expect(mockConnection.get).toHaveBeenCalledWith(
+      '/rest/api/3/search',
+      {
+        params: {
+          jql: 'project = "KEY"',
+          maxResults: '0',
+        },
+      }
+    )
+  })
+
+  it('should not return an error when project does not have issues', async () => {
+    mockConnection.get.mockResolvedValue({
+      status: 200,
+      data: {
+        total: 0,
+      },
+    })
+
+    expect(await changeValidator([
+      toChange({
+        before: instance,
+      }),
+    ])).toEqual([])
+  })
+
+  it('should not return an error when forceDelete is on', async () => {
+    config.deploy.forceDelete = true
+
+    expect(await changeValidator([
+      toChange({
+        before: instance,
+      }),
+    ])).toEqual([])
+  })
+
+  it('should not return an error when not removal', async () => {
+    expect(await changeValidator([
+      toChange({
+        before: instance,
+        after: instance,
+      }),
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([])
+  })
+
+  it('should return an error when request throws an error', async () => {
+    mockConnection.get.mockRejectedValue(new Error('error'))
+
+    expect(await changeValidator([
+      toChange({
+        before: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: 'Project has issues assigned to it.',
+        detailedMessage: 'The project jira.Project.instance.instance has issues assigned to it. Deleting the project will also delete all its issues and Salto will not be able to restore the issues. If you are sure you want to delete the project use the "forceDelete" deploy option.',
+      },
+    ])
+  })
+
+  it('should return an error when response is invalid', async () => {
+    mockConnection.get.mockResolvedValue({
+      status: 200,
+      data: {},
+    })
+
+    expect(await changeValidator([
+      toChange({
+        before: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: 'Project has issues assigned to it.',
+        detailedMessage: 'The project jira.Project.instance.instance has issues assigned to it. Deleting the project will also delete all its issues and Salto will not be able to restore the issues. If you are sure you want to delete the project use the "forceDelete" deploy option.',
+      },
+    ])
+  })
+})


### PR DESCRIPTION
Added `forceDelete` deploy option that when is off, deploying projects with issues will be blocked because the issues can't be restored

---
_Release Notes_: 
None

---
_User Notifications_: 
None