### PR TITLE
SALTO-2049 netsuite - fix manifest appid error

### DIFF
--- a/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
@@ -19,8 +19,8 @@ import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { LAST_FETCH_TIME } from '../constants'
 import { getInstanceServiceIdRecords } from '../filters/instance_references'
-import { serviceId } from '../transformer'
 import { ElementsSourceIndexes, ElementsSourceValue, LazyElementsSourceIndexes, ServiceIdRecords } from './types'
+import { getServiceId } from '../transformer'
 import { getFieldInstanceTypes } from '../data_elements/custom_fields'
 
 const { awu } = collections.asynciterable
@@ -47,7 +47,7 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource):
     _.assign(
       serviceIdsIndex,
       _.isEmpty(serviceIdRecords)
-        ? { [serviceId(element)]: { lastFetchTime } }
+        ? { [getServiceId(element)]: { lastFetchTime } }
         : _.mapValues(serviceIdRecords, ({ elemID }) => ({ elemID, lastFetchTime }))
     )
   }

--- a/packages/netsuite-adapter/src/mapped_lists/utils.ts
+++ b/packages/netsuite-adapter/src/mapped_lists/utils.ts
@@ -24,7 +24,7 @@ import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { INDEX, LIST_MAPPED_BY_FIELD, SCRIPT_ID } from '../constants'
 import { listMappedByFieldMapping } from './mapping'
-import { CAPTURED_SERVICE_ID, captureServiceIdInfo } from '../service_id_info'
+import { captureServiceIdInfo } from '../service_id_info'
 
 const { awu } = collections.asynciterable
 const { makeArray } = collections.array
@@ -104,7 +104,7 @@ const getItemKey = (mapFieldValue: string, path?: ElemID): string => {
   }
 
   const serviceIdKey = naclCase(
-    serviceIdInfoList.map(serviceIdInfo => serviceIdInfo[CAPTURED_SERVICE_ID]).join('_')
+    serviceIdInfoList.map(serviceIdInfo => serviceIdInfo.serviceId).join('_')
   )
   log.debug(`extracting ${SCRIPT_ID} to use it as a key: '${mapFieldValue}' -> '${serviceIdKey}' (${path?.getFullName()})`)
   return serviceIdKey

--- a/packages/netsuite-adapter/src/service_id_info.ts
+++ b/packages/netsuite-adapter/src/service_id_info.ts
@@ -16,10 +16,10 @@
 import { values } from '@salto-io/lowerdash'
 import { SCRIPT_ID } from './constants'
 
-export const CAPTURED_SERVICE_ID = 'serviceId'
-export const CAPTURED_TYPE = 'type'
-export const CAPTURED_APPID = 'appid'
-export const CAPTURED_BUNDLEID = 'bundleid'
+const CAPTURED_SERVICE_ID = 'serviceId'
+const CAPTURED_TYPE = 'type'
+const CAPTURED_APPID = 'appid'
+const CAPTURED_BUNDLEID = 'bundleid'
 
 const TYPE_REGEX = `type=(?<${CAPTURED_TYPE}>[a-z_]+), `
 const APPID_REGEX = `appid=(?<${CAPTURED_APPID}>[a-z_\\.]+), `
@@ -33,10 +33,11 @@ const scriptIdReferenceRegex = new RegExp(`\\[(${BUNDLEID_REGEX})?(${APPID_REGEX
 const pathReferenceRegex = new RegExp(`^\\[(?<${CAPTURED_SERVICE_ID}>\\/.+)]$`)
 
 export type ServiceIdInfo = {
-  [CAPTURED_SERVICE_ID]: string
-  [CAPTURED_TYPE]?: string
-  [CAPTURED_APPID]?: string
-  [CAPTURED_BUNDLEID]?: string
+  serviceId: string
+  serviceIdType: 'path' | 'scriptid'
+  type?: string
+  appid?: string
+  bundleid?: string
   isFullMatch: boolean
 }
 
@@ -56,8 +57,12 @@ export const captureServiceIdInfo = (value: string): ServiceIdInfo[] => {
   const pathRefMatches = value.match(pathReferenceRegex)?.groups
   if (pathRefMatches !== undefined) {
     return [
-      { [CAPTURED_SERVICE_ID]: pathRefMatches[CAPTURED_SERVICE_ID],
-        isFullMatch: true }]
+      {
+        serviceId: pathRefMatches[CAPTURED_SERVICE_ID],
+        serviceIdType: 'path',
+        isFullMatch: true,
+      },
+    ]
   }
 
   const regexMatches = [scriptIdReferenceRegex.exec(value)]
@@ -70,10 +75,11 @@ export const captureServiceIdInfo = (value: string): ServiceIdInfo[] => {
   return scriptIdRefMatches.map(match => match?.groups)
     .filter(values.isDefined)
     .map(serviceIdRef => ({
-      [CAPTURED_SERVICE_ID]: serviceIdRef[CAPTURED_SERVICE_ID],
-      [CAPTURED_TYPE]: serviceIdRef[CAPTURED_TYPE],
-      [CAPTURED_APPID]: serviceIdRef[CAPTURED_APPID],
-      [CAPTURED_BUNDLEID]: serviceIdRef[CAPTURED_BUNDLEID],
+      serviceId: serviceIdRef[CAPTURED_SERVICE_ID],
+      serviceIdType: 'scriptid',
+      type: serviceIdRef[CAPTURED_TYPE],
+      appid: serviceIdRef[CAPTURED_APPID],
+      bundleid: serviceIdRef[CAPTURED_BUNDLEID],
       isFullMatch,
     }))
 }

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -265,7 +265,7 @@ export const toCustomizationInfo = async (
   return { typeName, values, scriptId } as CustomTypeInfo
 }
 
-export const serviceId = (instance: InstanceElement): string =>
+export const getServiceId = (instance: InstanceElement): string =>
   instance.value[isCustomType(instance.refType) ? SCRIPT_ID : PATH]
 
 const getScriptIdParts = (topLevelParent: InstanceElement, elemId: ElemID): string[] => {

--- a/packages/netsuite-adapter/test/client/manifest_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/manifest_utils.test.ts
@@ -35,6 +35,8 @@ describe('manifest.xml utils', () => {
         ref: '[scriptid=secondscriptid]',
         ref2: '[scriptid=scriptid1]',
         ref3: '[scriptid=workflow1.innerscriptid]',
+        ref4: '[appid=com.salto, scriptid=external_script_id]',
+        fileRef: '[/SuiteScripts/test.js]',
       },
     },
   ]


### PR DESCRIPTION
references to `[appid=com.someapp, scriptid=...]` should not be included in the manifest, as they causing an error - `The manifest contains a dependency on <scriptid> object, but it is not in the account.`

I also changed the keys in `ServiceIdInfo` type to literal strings instead of `[CONST_VALUE]` because its unnecessary.

---
_Release Notes_: 
Netsuite Adapter:
- fix bug in manifest.xml dependencies logic

---
_User Notifications_: 
None