### PR TITLE
(SALTO-1968) fixed changing type to hidden creates warnings

### DIFF
--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -842,6 +842,11 @@ export const handleHiddenChanges = async (
   state: State,
   visibleElementSource: ReadOnlyElementsSource,
 ): Promise<{visible: DetailedChange[]; hidden: DetailedChange[]}> => {
+  // The side effects here are going to be applied to the nacls, so only
+  // the visible part is needed. We filter it here and not with the rest
+  // of the changes in order to prevent remove changes (which are always
+  // sent to both the visible and hidden parts) from being applied to
+  // the state as well.
   const additionalNaclChanges = (await filterOutHiddenChanges(
     await getHiddenChangeNaclSideEffects(changes, state, visibleElementSource),
     state

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -473,9 +473,6 @@ export const loadWorkspace = async (
             .map(elem => toChange({ after: elem })).toArray()
           : []
 
-        const stateRemovedElementChanges = (workspaceChanges[envName] ?? createEmptyChangeSet())
-          .changes.filter(change => isRemovalChange(change)
-            && getChangeData(change).elemID.isTopLevel())
         // To preserve the old ws functionality - hidden values should be added to the workspace
         // cache only if their top level element is in the nacls, or they are marked as hidden
         // (SAAS-2639)
@@ -495,8 +492,7 @@ export const loadWorkspace = async (
 
         return {
           changes: stateChangesForExistingNaclElements
-            .concat(initHiddenElementsChanges)
-            .concat(stateRemovedElementChanges),
+            .concat(initHiddenElementsChanges),
           cacheValid,
           preChangeHash: partialStateChanges.preChangeHash
             ?? await stateToBuild.mergeManager.getHash(STATE_SOURCE_PREFIX + envName),

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -473,6 +473,13 @@ export const loadWorkspace = async (
             .map(elem => toChange({ after: elem })).toArray()
           : []
 
+        const stateRemovedElementChanges = await awu(
+          (workspaceChanges[envName] ?? createEmptyChangeSet())
+            .changes
+        ).filter(async change => isRemovalChange(change)
+            && getChangeData(change).elemID.isTopLevel()
+            && !await isHidden(getChangeData(change), state(envName))).toArray()
+
         // To preserve the old ws functionality - hidden values should be added to the workspace
         // cache only if their top level element is in the nacls, or they are marked as hidden
         // (SAAS-2639)
@@ -492,7 +499,8 @@ export const loadWorkspace = async (
 
         return {
           changes: stateChangesForExistingNaclElements
-            .concat(initHiddenElementsChanges),
+            .concat(initHiddenElementsChanges)
+            .concat(stateRemovedElementChanges),
           cacheValid,
           preChangeHash: partialStateChanges.preChangeHash
             ?? await stateToBuild.mergeManager.getHash(STATE_SOURCE_PREFIX + envName),

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -1667,7 +1667,7 @@ describe('workspace', () => {
       // of changes you get seems ok, you can just change numExpectedChanges
       expect(updateNaclFileResults).toEqual({
         naclFilesChangesCount: 23,
-        stateOnlyChangesCount: 20,
+        stateOnlyChangesCount: 19,
       })
     })
     it('should not cause parse errors', async () => {


### PR DESCRIPTION
_fixed changing type to hidden creates warnings_

The issue was caused since the hidden element was removed from the state cache as well as the workspace cache.

This was a result of the filter hidden changes function returning remove changes to both the state and the workspace, the function and flow was modified to direct remove changes just like regular changes. In addition to that, the `compateStateChanges` code was modify to account for cases in which remove changes to the workspace are a result of such change (which means they shouldn't be removed from the state)

_Release Notes_: 
_Fixed validation errors after a type `_hidden` annotation is changed to true._

---
_User Notifications_: 
_NA_
