### PR TITLE
SALTO-2055: fix routing attribute deploy

### DIFF
--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -52,6 +52,7 @@ import organizationFieldFilter from './filters/organization_field'
 import removeDefinitionInstancesFilter from './filters/remove_definition_instances'
 import hardcodedChannelFilter from './filters/hardcoded_channel'
 import usersFilter from './filters/user'
+import routingAttributeFilter from './filters/routing_attribute'
 import defaultDeployFilter from './filters/default_deploy'
 
 const log = logger(module)
@@ -83,6 +84,7 @@ export const DEFAULT_FILTERS = [
   hardcodedChannelFilter,
   fieldReferencesFilter,
   usersFilter,
+  routingAttributeFilter,
   // removeDefinitionInstancesFilter should be after hardcodedChannelFilter
   removeDefinitionInstancesFilter,
   // unorderedListsFilter should run after fieldReferencesFilter

--- a/packages/zendesk-support-adapter/src/filters/business_hours_schedule.ts
+++ b/packages/zendesk-support-adapter/src/filters/business_hours_schedule.ts
@@ -85,7 +85,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
     const deployResult = await deployChanges(
       scheduleChanges,
       async change => {
-        await deployChange(change, client, config.apiDefinitions)
+        await deployChange(change, client, config.apiDefinitions, ['holidays'])
         await deployIntervals(client, change)
       }
     )

--- a/packages/zendesk-support-adapter/src/filters/routing_attribute.ts
+++ b/packages/zendesk-support-adapter/src/filters/routing_attribute.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  Change, getChangeData, InstanceElement, isRemovalChange,
+} from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { deployChange, deployChanges } from '../deployment'
+
+const ROUTING_ATTRIBUTE_TYPE_NAME = 'routing_attribute'
+
+/**
+ * Deploys routing attribute
+ */
+const filterCreator: FilterCreator = ({ config, client }) => ({
+  deploy: async (changes: Change<InstanceElement>[]) => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change =>
+        (getChangeData(change).elemID.typeName === ROUTING_ATTRIBUTE_TYPE_NAME)
+        && !isRemovalChange(change),
+    )
+    const deployResult = await deployChanges(
+      relevantChanges,
+      async change => {
+        await deployChange(
+          change, client, config.apiDefinitions, ['values'],
+        )
+      },
+    )
+    return { deployResult, leftoverChanges }
+  },
+})
+
+export default filterCreator

--- a/packages/zendesk-support-adapter/test/filters/business_hours_schedule.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/business_hours_schedule.test.ts
@@ -78,7 +78,7 @@ describe('business hours schedule filter', () => {
       { action: 'add', data: { after: clonedSchedule } },
       expect.anything(),
       expect.anything(),
-      undefined
+      ['holidays']
     )
     expect(mockPut).toHaveBeenCalledTimes(1)
     expect(mockPut).toHaveBeenCalledWith({
@@ -110,7 +110,7 @@ describe('business hours schedule filter', () => {
       { action: 'modify', data: { before: clonedBeforeSchedule, after: clonedAfterSchedule } },
       expect.anything(),
       expect.anything(),
-      undefined
+      ['holidays']
     )
     expect(mockPut).toHaveBeenCalledTimes(1)
     expect(mockPut).toHaveBeenCalledWith({
@@ -138,7 +138,7 @@ describe('business hours schedule filter', () => {
       { action: 'remove', data: { before: clonedSchedule } },
       expect.anything(),
       expect.anything(),
-      undefined
+      ['holidays']
     )
     expect(mockPut).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)
@@ -165,7 +165,7 @@ describe('business hours schedule filter', () => {
       { action: 'modify', data: { before: clonedBeforeSchedule, after: clonedAfterSchedule } },
       expect.anything(),
       expect.anything(),
-      undefined
+      ['holidays']
     )
     expect(mockPut).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)
@@ -188,7 +188,7 @@ describe('business hours schedule filter', () => {
       { action: 'add', data: { after: clonedSchedule } },
       expect.anything(),
       expect.anything(),
-      undefined
+      ['holidays']
     )
     expect(mockPut).toHaveBeenCalledTimes(0)
     expect(res.leftoverChanges).toHaveLength(0)
@@ -207,7 +207,7 @@ describe('business hours schedule filter', () => {
       { action: 'add', data: { after: clonedSchedule } },
       expect.anything(),
       expect.anything(),
-      undefined
+      ['holidays']
     )
     expect(mockPut).toHaveBeenCalledTimes(1)
     expect(res.leftoverChanges).toHaveLength(0)

--- a/packages/zendesk-support-adapter/test/filters/routing_attribute.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/routing_attribute.test.ts
@@ -1,0 +1,142 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ObjectType, ElemID, InstanceElement,
+} from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { DEFAULT_CONFIG } from '../../src/config'
+import ZendeskClient from '../../src/client/client'
+import { paginate } from '../../src/client/pagination'
+import { ZENDESK_SUPPORT } from '../../src/constants'
+import filterCreator from '../../src/filters/routing_attribute'
+
+const mockDeployChange = jest.fn()
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn((...args) => mockDeployChange(...args)),
+    },
+  }
+})
+
+describe('routing attribute filter', () => {
+  let client: ZendeskClient
+  type FilterType = filterUtils.FilterWith<'deploy'>
+  let filter: FilterType
+  const routingAttribute = new InstanceElement(
+    'Test',
+    new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'routing_attribute') }),
+    { name: 'Test', values: [] },
+  )
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      }),
+      config: DEFAULT_CONFIG,
+    }) as FilterType
+  })
+
+  describe('deploy', () => {
+    it('should pass the correct params to deployChange on create', async () => {
+      const id = 2
+      const clonedAttribute = routingAttribute.clone()
+      mockDeployChange.mockImplementation(async () => ({ attribute: { id } }))
+      const res = await filter.deploy([{ action: 'add', data: { after: clonedAttribute } }])
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      expect(mockDeployChange).toHaveBeenCalledWith(
+        { action: 'add', data: { after: clonedAttribute } },
+        expect.anything(),
+        expect.anything(),
+        ['values'],
+      )
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(res.deployResult.appliedChanges)
+        .toEqual([{ action: 'add', data: { after: clonedAttribute } }])
+    })
+
+    it('should pass the correct params to deployChange on update', async () => {
+      const id = 2
+      const clonedAttributeBefore = routingAttribute.clone()
+      const clonedAttributeAfter = routingAttribute.clone()
+      clonedAttributeBefore.value.id = id
+      clonedAttributeAfter.value.id = id
+      clonedAttributeAfter.value.name = 'edited'
+      mockDeployChange.mockImplementation(async () => ({}))
+      const res = await filter
+        .deploy([{ action: 'modify', data: { before: clonedAttributeBefore, after: clonedAttributeAfter } }])
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      expect(mockDeployChange).toHaveBeenCalledWith(
+        { action: 'modify', data: { before: clonedAttributeBefore, after: clonedAttributeAfter } },
+        expect.anything(),
+        expect.anything(),
+        ['values']
+      )
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(res.deployResult.appliedChanges)
+        .toEqual([
+          {
+            action: 'modify',
+            data: { before: clonedAttributeBefore, after: clonedAttributeAfter },
+          },
+        ])
+    })
+
+    it('should pass the correct params to deployChange on remove', async () => {
+      const id = 2
+      const clonedAttribute = routingAttribute.clone()
+      clonedAttribute.value.id = id
+      mockDeployChange.mockImplementation(async () => ({}))
+      const res = await filter.deploy([{ action: 'remove', data: { before: clonedAttribute } }])
+      expect(mockDeployChange).toHaveBeenCalledTimes(0)
+      expect(res.leftoverChanges).toHaveLength(1)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+    })
+
+    it('should return error if deployChange failed', async () => {
+      const clonedAttribute = routingAttribute.clone()
+      mockDeployChange.mockImplementation(async () => {
+        throw new Error('err')
+      })
+      const res = await filter.deploy([{ action: 'add', data: { after: clonedAttribute } }])
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      expect(mockDeployChange).toHaveBeenCalledWith(
+        { action: 'add', data: { after: clonedAttribute } },
+        expect.anything(),
+        expect.anything(),
+        ['values'],
+      )
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
_Fix routing attribute deploy in zendesk_

---

_Additional context for reviewer_
Also removed the deploy of holidays in schedule (it's currently working but we don't want to deploy it)

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
