### PR TITLE
SALTO-2001: fix context dups

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -50,6 +50,7 @@ import fieldStructureFilter from './filters/fields/field_structure_filter'
 import fieldDeploymentFilter from './filters/fields/field_deployment_filter'
 import contextDeploymentFilter from './filters/fields/context_deployment_filter'
 import fieldTypeReferencesFilter from './filters/fields/field_type_references_filter'
+import contextReferencesFilter from './filters/fields/context_references_filter'
 import avatarsFilter from './filters/avatars'
 import userFilter from './filters/user'
 import { JIRA } from './constants'
@@ -69,6 +70,13 @@ export const DEFAULT_FILTERS = [
   missingStatusesFilter,
   // This should happen before any filter that creates references
   duplicateIdsFilter,
+  fieldStructureFilter,
+  // This should run here again because fieldStructureFilter creates the instances and references
+  duplicateIdsFilter,
+  contextReferencesFilter,
+  fieldTypeReferencesFilter,
+  fieldDeploymentFilter,
+  contextDeploymentFilter,
   avatarsFilter,
   workflowFilter,
   workflowPropertiesFilter,
@@ -79,10 +87,6 @@ export const DEFAULT_FILTERS = [
   boardFilter,
   projectFilter,
   projectComponentFilter,
-  fieldStructureFilter,
-  fieldTypeReferencesFilter,
-  fieldDeploymentFilter,
-  contextDeploymentFilter,
   screenFilter,
   issueTypeScreenSchemeFilter,
   fieldConfigurationFilter,

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1479,6 +1479,7 @@ export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
   types: DEFAULT_TYPE_CUSTOMIZATIONS,
   typesToFallbackToInternalId: [
     'Field',
+    'CustomFieldContext',
     'Status',
     'Resolution',
   ],

--- a/packages/jira-adapter/src/filters/duplicate_ids.ts
+++ b/packages/jira-adapter/src/filters/duplicate_ids.ts
@@ -17,23 +17,12 @@ import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { naclCase } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import { elements as elementUtils } from '@salto-io/adapter-components'
-import { JiraConfig } from '../config'
 import { FilterCreator } from '../filter'
-
-const { generateInstanceNameFromConfig } = elementUtils
-
 
 const log = logger(module)
 
-const getInstanceName = (instance: InstanceElement, config: JiraConfig): string => {
-  const originalName = generateInstanceNameFromConfig(
-    instance.value,
-    instance.elemID.typeName,
-    config.apiDefinitions
-  ) ?? instance.elemID.name
-  return naclCase(`${originalName}_${instance.value.id}`)
-}
+const getInstanceName = (instance: InstanceElement): string =>
+  naclCase(`${instance.elemID.name}_${instance.value.id}`)
 
 /**
  * Add id to the name of instances with duplicate names to prevent conflicts in the names
@@ -81,7 +70,7 @@ If changing the names is not possible, you can add the fetch.fallbackToInternalI
       .filter(instance => config.apiDefinitions.typesToFallbackToInternalId
         .includes(instance.elemID.typeName))
       .map(instance => new InstanceElement(
-        getInstanceName(instance, config),
+        getInstanceName(instance),
         instance.refType,
         instance.value,
         instance.path,

--- a/packages/jira-adapter/src/filters/fields/context_references_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/context_references_filter.ts
@@ -1,0 +1,41 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, InstanceElement, isInstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { getParents } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { FilterCreator } from '../../filter'
+import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from './constants'
+
+const filter: FilterCreator = () => ({
+  onFetch: async (elements: Element[]) => {
+    const parentToContext = _.groupBy(
+      elements
+        .filter(isInstanceElement)
+        .filter(instance => instance.elemID.typeName === FIELD_CONTEXT_TYPE_NAME),
+      instance => getParents(instance)[0].elemID.getFullName(),
+    )
+
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === FIELD_TYPE_NAME)
+      .forEach(instance => {
+        instance.value.contexts = parentToContext[instance.elemID.getFullName()]
+          ?.map((context: InstanceElement) => new ReferenceExpression(context.elemID, context))
+      })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
@@ -262,8 +262,7 @@ const filter: FilterCreator = ({ config, getElemIdFunc }) => ({
             getElemIdFunc,
           ))
 
-        instance.value.contexts = contexts
-          .map((context: InstanceElement) => new ReferenceExpression(context.elemID, context))
+        delete instance.value.contexts
         if (instance.path !== undefined) {
           instance.path = [...instance.path, instance.path[instance.path.length - 1]]
         }

--- a/packages/jira-adapter/test/filters/fields/context_references_filter.test.ts
+++ b/packages/jira-adapter/test/filters/fields/context_references_filter.test.ts
@@ -1,0 +1,76 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression, Values } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { mockClient } from '../../utils'
+import { DEFAULT_CONFIG } from '../../../src/config'
+import { JIRA } from '../../../src/constants'
+import contextReferencesFilter from '../../../src/filters/fields/context_references_filter'
+
+describe('context_references_filter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let fieldType: ObjectType
+  let fieldContextType: ObjectType
+  beforeEach(() => {
+    const { client, paginator } = mockClient()
+    filter = contextReferencesFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    }) as typeof filter
+
+    fieldType = new ObjectType({ elemID: new ElemID(JIRA, 'Field') })
+    fieldContextType = new ObjectType({ elemID: new ElemID(JIRA, 'CustomFieldContext') })
+  })
+
+  it('should add contexts to fields', async () => {
+    const field1 = new InstanceElement(
+      'field1',
+      fieldType,
+    )
+    const field2 = new InstanceElement(
+      'field2',
+      fieldType,
+    )
+
+    const context1 = new InstanceElement(
+      'context1',
+      fieldContextType,
+      {},
+      [],
+      {
+        [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(field1.elemID, field1)],
+      },
+    )
+
+    const context2 = new InstanceElement(
+      'context2',
+      fieldContextType,
+      {},
+      [],
+      {
+        [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(field1.elemID, field1)],
+      },
+    )
+
+    await filter.onFetch([field1, field2, context1, context2])
+    expect(field1.value.contexts.map((e: Values) => e.elemID.getFullName())).toEqual([
+      context1.elemID.getFullName(),
+      context2.elemID.getFullName(),
+    ])
+    expect(field2.value.contexts).toBeUndefined()
+  })
+})

--- a/packages/jira-adapter/test/filters/fields/field_structure.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_structure.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { BuiltinTypes, ElemID, Field, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { mockClient } from '../../utils'
 import { DEFAULT_CONFIG } from '../../../src/config'
@@ -61,7 +61,6 @@ describe('fields_structure', () => {
     ])
     expect(instance.value).toEqual({
       type: 'someType',
-      contexts: [],
     })
   })
 
@@ -80,9 +79,7 @@ describe('fields_structure', () => {
       fieldContextDefaultValueType,
       fieldContextOptionType,
     ])
-    expect(instance.value).toEqual({
-      contexts: [],
-    })
+    expect(instance.value).toEqual({})
   })
 
   it('should not remove isLocked if locked', async () => {
@@ -102,7 +99,6 @@ describe('fields_structure', () => {
     ])
     expect(instance.value).toEqual({
       isLocked: true,
-      contexts: [],
     })
   })
 
@@ -171,9 +167,6 @@ describe('fields_structure', () => {
     expect(fieldInstance.value).toEqual(
       {
         name: 'name',
-        contexts: [
-          new ReferenceExpression(contextInstance.elemID, contextInstance),
-        ],
       },
     )
     expect(contextInstance.value).toEqual(


### PR DESCRIPTION
Fixed duplicateIdsFilter to run also on duplicates field contexts since the UI in Jira permits to contexts with the same name on the same field

---
_Release Notes_: 
None

---
_User Notifications_: 
None