### PR TITLE
SALTO-2060 Add base folder in Workato

### DIFF
--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -23,6 +23,7 @@ import { logger } from '@salto-io/logging'
 import WorkatoClient from './client/client'
 import { FilterCreator, Filter, filtersRunner } from './filter'
 import { WorkatoConfig } from './config'
+import addRootFolderFilter from './filters/add_root_folder'
 import fieldReferencesFilter from './filters/field_references'
 import recipeCrossServiceReferencesFilter from './filters/cross_service/recipe_references'
 import serviceUrlFilter from './filters/service_url'
@@ -36,6 +37,8 @@ const { returnFullEntry, simpleGetArgs } = elementUtils
 const { getAllElements } = elementUtils.ducktype
 
 export const DEFAULT_FILTERS = [
+  addRootFolderFilter,
+  // fieldReferencesFilter should run after all element manipulations are done
   fieldReferencesFilter,
   recipeCrossServiceReferencesFilter,
   serviceUrlFilter,

--- a/packages/workato-adapter/src/filters/add_root_folder.ts
+++ b/packages/workato-adapter/src/filters/add_root_folder.ts
@@ -1,0 +1,63 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  Element, InstanceElement, isInstanceElement, isObjectType,
+} from '@salto-io/adapter-api'
+import { elements as elementUtils } from '@salto-io/adapter-components'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../filter'
+import { FOLDER_TYPE, WORKATO } from '../constants'
+
+const log = logger(module)
+const { RECORDS_PATH } = elementUtils
+
+// using a single-word folder name guarantees the id will be unique,
+// because all other folder ids include their parent as well as their own name
+const ROOT_FOLDER_NAME = 'ROOT'
+const ROOT_FOLDER_PATH = 'ROOT'
+
+/**
+ * Add root folder instance, since it is not returned from the service but can contain resources.
+ */
+const filterCreator: FilterCreator = () => ({
+  onFetch: async (elements: Element[]): Promise<void> => {
+    const folderType = elements.filter(isObjectType).find(e => e.elemID.typeName === FOLDER_TYPE)
+    if (folderType === undefined) {
+      log.warn('Could not find object type for folder')
+      return
+    }
+    const folders = elements
+      .filter(isInstanceElement)
+      .filter(e => e.elemID.typeName === FOLDER_TYPE)
+    const existingIDs = new Set(folders.map(f => f.value.id).filter(val => val !== undefined))
+    const parentIDs = new Set(folders.map(f => f.value.parent_id).filter(val => val !== undefined))
+    const missingParents = [...parentIDs].filter(id => !existingIDs.has(id))
+    if (missingParents.length !== 1) {
+      log.warn('Expected one missing parent folder, found %d: %s', missingParents.length, missingParents)
+      return
+    }
+    const rootFolderId = missingParents[0]
+    const rootFolderInstance = new InstanceElement(
+      ROOT_FOLDER_NAME,
+      folderType,
+      { id: rootFolderId, name: ROOT_FOLDER_PATH },
+      [WORKATO, RECORDS_PATH, FOLDER_TYPE, ROOT_FOLDER_NAME],
+    )
+    elements.push(rootFolderInstance)
+  },
+})
+
+export default filterCreator

--- a/packages/workato-adapter/src/filters/add_root_folder.ts
+++ b/packages/workato-adapter/src/filters/add_root_folder.ts
@@ -36,7 +36,7 @@ const filterCreator: FilterCreator = () => ({
   onFetch: async (elements: Element[]): Promise<void> => {
     const folderType = elements.filter(isObjectType).find(e => e.elemID.typeName === FOLDER_TYPE)
     if (folderType === undefined) {
-      log.warn('Could not find object type for folder')
+      log.warn('Could not find object type for folder - not adding a root folder instance')
       return
     }
     const folders = elements

--- a/packages/workato-adapter/src/filters/field_references.ts
+++ b/packages/workato-adapter/src/filters/field_references.ts
@@ -51,7 +51,7 @@ const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition<never>
     target: { type: 'connection' },
   },
   {
-    src: { field: 'folder_id', parentTypes: ['recipe'] },
+    src: { field: 'folder_id', parentTypes: ['recipe', 'connection'] },
     serializationStrategy: 'id',
     target: { type: 'folder' },
   },

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -71,9 +71,9 @@ describe('adapter', () => {
           ),
           elementsSource: buildElementsSourceFromElements([]),
         }).fetch({ progressReporter: { reportProgress: () => null } })
-        expect(elements).toHaveLength(84)
+        expect(elements).toHaveLength(85)
         expect(elements.filter(isObjectType)).toHaveLength(49)
-        expect(elements.filter(isInstanceElement)).toHaveLength(35)
+        expect(elements.filter(isInstanceElement)).toHaveLength(36)
         expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
           'workato.api_access_profile',
           'workato.api_access_profile.instance.ap1',
@@ -91,6 +91,7 @@ describe('adapter', () => {
           'workato.connection.instance.dev2_sfdc_account@s',
           'workato.connection.instance.sfdev1',
           'workato.folder',
+          'workato.folder.instance.ROOT',
           'workato.folder.instance.basedir1_257262',
           'workato.folder.instance.f1_nested1_300506',
           'workato.folder.instance.f1_nested2_300506@vu',

--- a/packages/workato-adapter/test/filters/add_root_folder.test.ts
+++ b/packages/workato-adapter/test/filters/add_root_folder.test.ts
@@ -1,0 +1,131 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, Element, BuiltinTypes, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import filterCreator from '../../src/filters/add_root_folder'
+import WorkatoClient from '../../src/client/client'
+import { paginate } from '../../src/client/pagination'
+import { DEFAULT_TYPES, DEFAULT_ID_FIELDS } from '../../src/config'
+import { WORKATO } from '../../src/constants'
+
+
+describe('Field references filter', () => {
+  let client: WorkatoClient
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  let filter: FilterType
+
+  beforeAll(() => {
+    client = new WorkatoClient({
+      credentials: { username: 'a', token: 'b' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      }),
+      config: {
+        fetch: {
+          includeTypes: ['connection', 'folder'],
+        },
+        apiDefinitions: {
+          typeDefaults: {
+            transformation: {
+              idFields: DEFAULT_ID_FIELDS,
+            },
+          },
+          types: DEFAULT_TYPES,
+        },
+      },
+    }) as FilterType
+  })
+
+  const connectionType = new ObjectType({
+    elemID: new ElemID(WORKATO, 'connection'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER, annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true } },
+    },
+  })
+  const folderType = new ObjectType({
+    elemID: new ElemID(WORKATO, 'folder'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER, annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true } },
+      // eslint-disable-next-line camelcase
+      parent_id: { refType: BuiltinTypes.NUMBER },
+    },
+  })
+
+  const generateElements = (
+  ): Element[] => ([
+    connectionType,
+    new InstanceElement('conn123', connectionType, { id: 123 }),
+    folderType,
+    new InstanceElement('folder11', folderType, { id: 11, parent_id: 55 }),
+    new InstanceElement('folder222', folderType, { id: 22, parent_id: 11 }),
+    new InstanceElement('folder222', folderType, { id: 33, parent_id: 55 }),
+  ])
+
+  describe('on fetch', () => {
+    it('should create a root folder when exactly one parent id does not exist', async () => {
+      const elements = generateElements()
+      const lengthBefore = elements.length
+      await filter.onFetch(elements)
+      expect(elements.length).toEqual(lengthBefore + 1)
+      const rootFolder = elements.find(e => e.elemID.getFullName() === 'workato.folder.instance.ROOT') as InstanceElement
+      expect(rootFolder).toBeInstanceOf(InstanceElement)
+      expect(rootFolder.value).toEqual({ id: 55, name: 'ROOT' })
+    })
+
+    it('should not create a root folder if all parents already exist', async () => {
+      const elements = generateElements()
+      elements.push(new InstanceElement('aaa', folderType, { id: 55, parent_id: 11 }))
+      const lengthBefore = elements.length
+      await filter.onFetch(elements)
+      expect(elements.length).toEqual(lengthBefore)
+      const rootFolder = elements.find(e => e.elemID.getFullName() === 'workato.folder.instance.ROOT')
+      expect(rootFolder).toBeUndefined()
+    })
+
+    it('should not create a root folder if all parents already exist and some parent ids are missing', async () => {
+      const elements = generateElements()
+      elements.push(new InstanceElement('aaa', folderType, { id: 55 }))
+      const lengthBefore = elements.length
+      await filter.onFetch(elements)
+      expect(elements.length).toEqual(lengthBefore)
+      const rootFolder = elements.find(e => e.elemID.getFullName() === 'workato.folder.instance.ROOT')
+      expect(rootFolder).toBeUndefined()
+    })
+
+    it('should not create a root folder if multiple parents are missing', async () => {
+      const elements = generateElements()
+      elements.push(new InstanceElement('aaa', folderType, { id: 44, parent_id: 56 }))
+      const lengthBefore = elements.length
+      await filter.onFetch(elements)
+      expect(elements.length).toEqual(lengthBefore)
+      const rootFolder = elements.find(e => e.elemID.getFullName() === 'workato.folder.instance.ROOT')
+      expect(rootFolder).toBeUndefined()
+    })
+
+    it('should do nothing if folder type is missing', async () => {
+      const elements = generateElements().filter(e => e.elemID.typeName !== 'folder')
+      const lengthBefore = elements.length
+      await filter.onFetch(elements)
+      expect(elements.length).toEqual(lengthBefore)
+      const rootFolder = elements.find(e => e.elemID.getFullName() === 'workato.folder.instance.ROOT')
+      expect(rootFolder).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
Add a placeholder root folder (since none is returned by the API but it is referenced by a lot of instances).

---

I will add a noise-reduction PR before this is merged (if needed - need to check - (update: not needed))

---
_Release Notes_: 
Workato adapter:
* Add a new `ROOT` folder instance
* Add more references to folders

---
_User Notifications_: 
Workato adapter:
* A new `ROOT` folder instance will be added
* Some references to folder instances will be added