### PR TITLE
SALTO-2059 Hide Workato internal ids and non-multienv fields

### DIFF
--- a/packages/workato-adapter/src/config.ts
+++ b/packages/workato-adapter/src/config.ts
@@ -33,6 +33,7 @@ export const FIELDS_TO_OMIT: configUtils.FieldToOmitType[] = [
   { fieldName: 'extended_input_schema' },
   { fieldName: 'extended_output_schema' },
 ]
+export const FIELDS_TO_HIDE: configUtils.FieldToHideType[] = []
 
 export const CLIENT_CONFIG = 'client'
 export const FETCH_CONFIG = 'fetch'
@@ -57,6 +58,17 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
     request: {
       url: '/connections',
     },
+    transformation: {
+      fieldsToHide: [
+        ...FIELDS_TO_HIDE,
+        { fieldName: 'id' },
+      ],
+      fieldsToOmit: [
+        ...FIELDS_TO_OMIT,
+        { fieldName: 'authorized_at', fieldType: 'string' },
+        { fieldName: 'authorization_status', fieldType: 'string' },
+      ],
+    },
   },
   [RECIPE_TYPE]: {
     request: {
@@ -65,6 +77,11 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
     },
     transformation: {
       idFields: ['name', 'id'], // not multienv-friendly - see SALTO-1241
+      fieldsToHide: [
+        ...FIELDS_TO_HIDE,
+        { fieldName: 'id' },
+        { fieldName: 'user_id' },
+      ],
       fieldsToOmit: [
         ...FIELDS_TO_OMIT,
         { fieldName: 'last_run_at' },
@@ -87,16 +104,24 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
     },
     transformation: {
       idFields: ['name', 'parent_id'], // not multienv-friendly - see SALTO-1241
+      fieldsToHide: [
+        ...FIELDS_TO_HIDE,
+        { fieldName: 'id' },
+      ],
     },
   },
-  // eslint-disable-next-line camelcase
   [API_COLLECTION_TYPE]: {
     request: {
       url: '/api_collections',
       paginationField: 'page',
     },
+    transformation: {
+      fieldsToHide: [
+        ...FIELDS_TO_HIDE,
+        { fieldName: 'id' },
+      ],
+    },
   },
-  // eslint-disable-next-line camelcase
   [API_ENDPOINT_TYPE]: {
     request: {
       url: '/api_endpoints',
@@ -104,25 +129,45 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
     },
     transformation: {
       idFields: ['name', 'base_path'],
+      fieldsToHide: [
+        ...FIELDS_TO_HIDE,
+        { fieldName: 'id' },
+      ],
     },
   },
-  // eslint-disable-next-line camelcase
   [API_CLIENT_TYPE]: {
     request: {
       url: '/api_clients',
       paginationField: 'page',
     },
+    transformation: {
+      fieldsToHide: [
+        ...FIELDS_TO_HIDE,
+        { fieldName: 'id' },
+      ],
+    },
   },
-  // eslint-disable-next-line camelcase
   [API_ACCESS_PROFILE_TYPE]: {
     request: {
       url: '/api_access_profiles',
       paginationField: 'page',
     },
+    transformation: {
+      fieldsToHide: [
+        ...FIELDS_TO_HIDE,
+        { fieldName: 'id' },
+      ],
+    },
   },
   [ROLE_TYPE]: {
     request: {
       url: '/roles',
+    },
+    transformation: {
+      fieldsToHide: [
+        ...FIELDS_TO_HIDE,
+        { fieldName: 'id' },
+      ],
     },
   },
   [PROPERTY_TYPE]: {
@@ -134,6 +179,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
     },
     transformation: {
       hasDynamicFields: true,
+      isSingleton: true,
     },
   },
 }

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -96,7 +96,7 @@ describe('adapter', () => {
           'workato.folder.instance.f1_nested2_300506@vu',
           'workato.folder.instance.f1n2_leaf1_300508@su',
           'workato.property',
-          'workato.property.instance.unnamed_0',
+          'workato.property.instance',
           'workato.recipe',
           'workato.recipe.instance.Copy_of_New_email_in_Gmail_will_add_a_new_row_in_Google_Sheets_1109414@sssssssssssssu',
           'workato.recipe.instance.Copy_of_New_or_updated_standard_record___________in_NetSuite__will_create_record_in_Salesforce_1109550@ssssss_00010sssssssssss_00010sssssu',


### PR DESCRIPTION
Hide non-multienv-friendly fields in Workato resources.
Note that some ids still exist in the element ids themselves - this will be handled as part of SALTO-1241.

---

Will add a noise-reduction PR before merging (as needed)

---
_Release Notes_: 
Workato adapter:
* Hide fields containing internal ids that are different between environments
* Change the id of the `property` instance to mark it as a singleton

---
_User Notifications_: 
Workato adapter:
* Hide fields containing internal ids that are different between environments
* Change the id of the `property` instance to mark it as a singleton
