### PR TITLE
SALTO-2024: do not treat empty values as hidden

### DIFF
--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -195,6 +195,7 @@ export const removeHiddenFromElement = <T extends Element>(
         : removeHidden(elementsSource),
       strict: false,
       elementsSource,
+      allowEmpty: true,
     })
   )
 

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -502,7 +502,11 @@ describe('handleHiddenChanges', () => {
       new ObjectType({
         elemID: new ElemID('test', 'type'),
       }),
-      { [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [{ reference: 'aaa', occurrences: undefined }] },
+      {
+        [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [{ reference: 'aaa', occurrences: undefined }],
+        emptyList: [],
+        undefinedValue: undefined,
+      },
     )
 
     const change: DetailedChange = {


### PR DESCRIPTION
_Do not treat empty values as hidden_

---

_Additional context for reviewer_
@ori-moisis FYI

---
_Release Notes_: 
_Core_
* empty values will stop being treated as hidden

---
_User Notifications_: 
_Fetches of envs that have elements with empty values will stop to be hidden_
