### PR TITLE
SALTO-1241 Add special handling for recipe and folder multienv ids

### DIFF
--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -25,6 +25,7 @@ import { FilterCreator, Filter, filtersRunner } from './filter'
 import { WorkatoConfig } from './config'
 import addRootFolderFilter from './filters/add_root_folder'
 import fieldReferencesFilter from './filters/field_references'
+import fixMultienvIDs from './filters/fix_multienv_ids'
 import recipeCrossServiceReferencesFilter from './filters/cross_service/recipe_references'
 import serviceUrlFilter from './filters/service_url'
 import { WORKATO } from './constants'
@@ -38,6 +39,8 @@ const { getAllElements } = elementUtils.ducktype
 
 export const DEFAULT_FILTERS = [
   addRootFolderFilter,
+  // fixMultienvIDs should run after addRootFolderFilter
+  fixMultienvIDs,
   // fieldReferencesFilter should run after all element manipulations are done
   fieldReferencesFilter,
   recipeCrossServiceReferencesFilter,

--- a/packages/workato-adapter/src/config.ts
+++ b/packages/workato-adapter/src/config.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { ElemID, ObjectType, CORE_ANNOTATIONS, BuiltinTypes, ListType, MapType } from '@salto-io/adapter-api'
 import { client as clientUtils, config as configUtils } from '@salto-io/adapter-components'
-import { WORKATO, PROPERTY_TYPE, ROLE_TYPE, API_COLLECTION_TYPE, FOLDER_TYPE, RECIPE_TYPE, CONNECTION_TYPE, API_ENDPOINT_TYPE, API_CLIENT_TYPE, API_ACCESS_PROFILE_TYPE } from './constants'
+import { WORKATO, PROPERTY_TYPE, ROLE_TYPE, API_COLLECTION_TYPE, FOLDER_TYPE, RECIPE_TYPE, CONNECTION_TYPE, API_ENDPOINT_TYPE, API_CLIENT_TYPE, API_ACCESS_PROFILE_TYPE, RECIPE_CODE_TYPE } from './constants'
 
 const { createClientConfigType } = clientUtils
 const {
@@ -87,10 +87,17 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
         { fieldName: 'last_run_at' },
         { fieldName: 'job_succeeded_count' },
         { fieldName: 'job_failed_count' },
+        { fieldName: 'copy_count' },
+        { fieldName: 'lifetime_task_count' },
       ],
       standaloneFields: [
         { fieldName: 'code', parseJSON: true },
       ],
+    },
+  },
+  [RECIPE_CODE_TYPE]: {
+    transformation: {
+      idFields: [], // there is one code per recipe, so no need for additional details
     },
   },
   [FOLDER_TYPE]: {

--- a/packages/workato-adapter/src/filters/add_root_folder.ts
+++ b/packages/workato-adapter/src/filters/add_root_folder.ts
@@ -26,7 +26,7 @@ const { RECORDS_PATH } = elementUtils
 
 // using a single-word folder name guarantees the id will be unique,
 // because all other folder ids include their parent as well as their own name
-const ROOT_FOLDER_NAME = 'Root'
+export const ROOT_FOLDER_NAME = 'Root'
 const ROOT_FOLDER_PATH = 'Root'
 
 /**

--- a/packages/workato-adapter/src/filters/fix_multienv_ids.ts
+++ b/packages/workato-adapter/src/filters/fix_multienv_ids.ts
@@ -1,0 +1,271 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { Element, isInstanceElement, Values, InstanceElement, ReferenceExpression, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { config as configUtils } from '@salto-io/adapter-components'
+import { getParents, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../filter'
+import { API_DEFINITIONS_CONFIG, WorkatoApiConfig } from '../config'
+import { RECIPE_TYPE, RECIPE_CODE_TYPE, FOLDER_TYPE } from '../constants'
+import { ROOT_FOLDER_NAME } from './add_root_folder'
+
+const log = logger(module)
+const { getConfigWithDefault } = configUtils
+
+const DEREFERENCE_PLACEHOLDER = '&' // should move to adapter-components in SALTO-1687
+
+/**
+ * Get an updated instance name with a single dereferenced field,
+ * using the provided lookup mapping.
+ * based on getInstanceName in adapter-components.
+ */
+const getDereferencedInstanceName = (
+  instanceValues: Values,
+  idFields: string[],
+  lookup: Record<string, string>
+): string | undefined => {
+  const nameParts = idFields.map(
+    fieldName => {
+      if (fieldName.startsWith(DEREFERENCE_PLACEHOLDER)) {
+        return lookup[_.get(instanceValues, fieldName.substring(1))]
+      }
+      return _.get(instanceValues, fieldName)
+    }
+  )
+  if (nameParts.includes(undefined)) {
+    log.warn(`could not find id for entry - expected id fields ${idFields}, available fields ${Object.keys(instanceValues)}`)
+  }
+  return nameParts.every(part => part !== undefined && part !== '') ? nameParts.map(String).join('_') : undefined
+}
+
+/**
+ * Create an instance with a new name and path
+ * Note: does not change any references
+ */
+const toRenamedInstance = (inst: InstanceElement, newName: string): InstanceElement => (
+  new InstanceElement(
+    naclCase(newName),
+    inst.refType,
+    inst.value,
+    // not allowing customizing paths in this case
+    [
+      ...(inst.path?.slice(0, -1) ?? []),
+      pathNaclCase(naclCase(newName)),
+    ],
+    inst.annotations,
+  )
+)
+
+/**
+ * Ensure the id fields are as expected, otherwise do not change anything.
+ */
+const getValidatedIdFields = (
+  typeName: string,
+  expectedReferencedFields: string[],
+  apiDefinitions: WorkatoApiConfig,
+): string[] | undefined => {
+  const { idFields } = getConfigWithDefault(
+    apiDefinitions.types[typeName]?.transformation ?? {},
+    apiDefinitions.typeDefaults.transformation
+  )
+
+  if (_.isEqual(
+    idFields.filter(f => f.startsWith(DEREFERENCE_PLACEHOLDER)),
+    expectedReferencedFields.map(name => `${DEREFERENCE_PLACEHOLDER}${name}`)
+  )) {
+    return idFields
+  }
+  log.debug('unexpected %s id fields %s', typeName, idFields)
+  return undefined
+}
+
+// sort folders by parent
+const getSortedFolders = (
+  folders: InstanceElement[],
+  rootFolderId: number,
+): InstanceElement[] => {
+  const ROOT_PARENT_PLACEHOLDER_ID = 0
+
+  const foldersById = _.keyBy(
+    folders.filter(f => f.value.id !== undefined),
+    f => f.value.id as number,
+  )
+
+  const foldersByParent = _.groupBy(
+    folders.map(f => ({
+      parentId: f.value.parent_id ?? ROOT_PARENT_PLACEHOLDER_ID,
+      id: f.value.id,
+    })),
+    f => f.parentId,
+  )
+  if (
+    foldersByParent[0] === undefined
+    || foldersByParent[0][0]?.id !== rootFolderId
+  ) {
+    log.warn('could not find root folder, not changing folder ids')
+    return []
+  }
+
+  const sortedFolders = []
+  const visited = new Set<number>()
+  const queue = [ROOT_PARENT_PLACEHOLDER_ID]
+  while (queue.length > 0) {
+    const cur = queue.shift()
+    if (cur === undefined) {
+      break // can never happen
+    }
+    if (visited.has(cur)) {
+      log.warn('folder dependency cycle detected, ignoring repeating folder id %s', cur)
+      // eslint-disable-next-line no-continue
+      continue
+    }
+    visited.add(cur)
+    if (foldersById[cur] !== undefined) {
+      sortedFolders.push(foldersById[cur])
+    }
+    queue.push(...(foldersByParent[cur] ?? []).map(f => f.id))
+  }
+
+  return sortedFolders
+}
+
+/**
+ * If folders use their parent_id as an id field, update it recursively to include the paths.
+ */
+const fixFolderIDs = (elements: Element[], apiDefinitions: WorkatoApiConfig): void => {
+  const idFields = getValidatedIdFields(FOLDER_TYPE, ['parent_id'], apiDefinitions)
+  if (idFields === undefined) {
+    log.info('unexpected id fields, not changing folder ids: %s', idFields)
+    return
+  }
+
+  const folders = elements.filter(isInstanceElement).filter(e => e.elemID.typeName === FOLDER_TYPE)
+  const rootFolderId = folders.find(f => f.elemID.name === ROOT_FOLDER_NAME)?.value.id
+  if (rootFolderId === undefined) {
+    log.warn('could not find root folder, not changing folders')
+    return
+  }
+  const sortedFolders = getSortedFolders(folders, rootFolderId)
+  if (sortedFolders.length === 0) {
+    return
+  }
+
+  const oldFolders = _.remove(elements, e =>
+    isInstanceElement(e)
+    && e.elemID.typeName === FOLDER_TYPE)
+
+  if (sortedFolders.length !== oldFolders.length) {
+    log.warn('unexpected inconsistency found, not changing folders')
+    elements.push(...oldFolders)
+    return
+  }
+
+  const folderNameMapping = { [rootFolderId]: ROOT_FOLDER_NAME }
+  const newFolders = sortedFolders.map(inst => {
+    const newName = getDereferencedInstanceName(inst.value, idFields, folderNameMapping)
+    if (inst.value.id === rootFolderId || newName === undefined) {
+      return inst
+    }
+    folderNameMapping[inst.value.id] = newName
+    return toRenamedInstance(inst, newName)
+  })
+  elements.push(...newFolders)
+}
+
+/**
+ * If recipes use their folder_id as an id field, update the recipes and corresponding recipe_codes.
+ */
+const fixRecipeIDs = (elements: Element[], apiDefinitions: WorkatoApiConfig): void => {
+  const recipeIdFields = getValidatedIdFields(RECIPE_TYPE, ['folder_id'], apiDefinitions)
+  const codeIdFields = getValidatedIdFields(RECIPE_CODE_TYPE, [], apiDefinitions)
+  if (recipeIdFields === undefined || codeIdFields === undefined) {
+    log.debug('unexpected id fields, not changing recipes')
+    return
+  }
+
+  const instances = elements.filter(isInstanceElement)
+  const folders = instances.filter(e => e.elemID.typeName === FOLDER_TYPE)
+  const folderLookup: Record<number, string> = Object.fromEntries(
+    folders.map(f => [f.value.id, f.elemID.name])
+  )
+  const recipes = instances.filter(e => e.elemID.typeName === RECIPE_TYPE)
+
+  const recipeNameMapping = Object.fromEntries(
+    recipes
+      .map(inst => [
+        inst.elemID.name,
+        getDereferencedInstanceName(inst.value, recipeIdFields, folderLookup),
+      ])
+      .filter(([_key, value]) => value !== undefined)
+  )
+  const oldRecipes = _.remove(elements, e =>
+    isInstanceElement(e)
+    && e.elemID.typeName === RECIPE_TYPE
+    && recipeNameMapping[e.elemID.name] !== undefined)
+
+  const newRecipesByOldName = Object.fromEntries(
+    oldRecipes.filter(isInstanceElement).map(inst => [
+      inst.elemID.name,
+      toRenamedInstance(inst, recipeNameMapping[inst.elemID.name]),
+    ])
+  )
+  elements.push(...Object.values(newRecipesByOldName))
+
+  const getRecipeFromCode = (codeInst: InstanceElement): string => (
+    getParents(codeInst)?.[0]?.elemID.name ?? ''
+  )
+
+  const oldCodes = _.remove(elements, e =>
+    isInstanceElement(e)
+    && e.elemID.typeName === RECIPE_CODE_TYPE
+    && recipeNameMapping[getRecipeFromCode(e)] !== undefined)
+
+  const newRecipeCodeName = (inst: InstanceElement): string => {
+    const parentNewName = recipeNameMapping[getRecipeFromCode(inst)]
+    const nestedName = getDereferencedInstanceName(inst.value, codeIdFields, {})
+    return naclCase(`${parentNewName}_${nestedName}`)
+  }
+
+  const newCodes = oldCodes.filter(isInstanceElement).map(inst => {
+    const oldRecipeName = getRecipeFromCode(inst)
+    const newCode = toRenamedInstance(inst, newRecipeCodeName(inst))
+    newCode.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(
+      newRecipesByOldName[oldRecipeName].elemID,
+      newRecipesByOldName[oldRecipeName],
+    )]
+    newRecipesByOldName[oldRecipeName].value.code = new ReferenceExpression(
+      newCode.elemID,
+      newCode,
+    )
+    return newCode
+  })
+  elements.push(...newCodes)
+}
+
+/**
+ * Temporary filter to fix the ids of folders and recipes and make them multienv-friendly.
+ * Will be replaced by SALTO-1687 and a config change.
+ *
+ */
+const filter: FilterCreator = ({ config }) => ({
+  onFetch: async (elements: Element[]) => {
+    fixFolderIDs(elements, config[API_DEFINITIONS_CONFIG])
+    fixRecipeIDs(elements, config[API_DEFINITIONS_CONFIG])
+  },
+})
+
+export default filter

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -110,16 +110,16 @@ describe('adapter', () => {
           'workato.recipe.instance.pubsub_recipe_412_1383313@ssu',
           'workato.recipe.instance.test_recipe_321_1381119@ssu',
           'workato.recipe__code',
-          'workato.recipe__code.instance.Copy_of_New_email_in_Gmail_will_add_a_new_row_in_Google_Sheets_1109414_sssssssssssssu__new_email@uuuuuuuuuuuuuumuuu',
-          'workato.recipe__code.instance.Copy_of_New_or_updated_standard_record___________in_NetSuite__will_create_record_in_Salesforce_1109550_ssssss_00010sssssssssss_00010sssssu__updated_object@uuuuuuuuuuuuuuuuuuuuuuuuumuuuuu',
-          'workato.recipe__code.instance.Copy_of_New_updated_record_in_Salesforce_will_add_a_new_row_in_a_sheet_in_Google_Sheets_1109425_ssdssssssssssssssu__updated_custom_object@uuuuuuuuuuuuuuuuuumuuuu',
-          'workato.recipe__code.instance.Copy_of_pubsub_recipe_412_1283313_ssssu__subscribe_to_topic@uuuuumuuuu',
-          'workato.recipe__code.instance.Copy_of_test_recipe_321_1321119_ssssu__receive_request@uuuuumuuu',
-          'workato.recipe__code.instance.New_email_in_Gmail_will_add_a_new_row_in_Google_Sheets_1209414_sssssssssssu__new_email@uuuuuuuuuuuumuuu',
-          'workato.recipe__code.instance.New_updated_record_in_Salesforce_will_add_a_new_row_in_a_sheet_in_Google_Sheets_1209425_dssssssssssssssu__updated_custom_object@uuuuuuuuuuuuuuuumuuuu',
-          'workato.recipe__code.instance.__________New_or_updated_standard_record___________in_NetSuite__will_create_record_in_Salesforce_1209550_ssssssssssssss_00010sssssssssss_00010sssssu__updated_object@uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuumuuuuu',
-          'workato.recipe__code.instance.pubsub_recipe_412_1383313_ssu__subscribe_to_topic@uuumuuuu',
-          'workato.recipe__code.instance.test_recipe_321_1381119_ssu__receive_request@uuumuuu',
+          'workato.recipe__code.instance.Copy_of_New_email_in_Gmail_will_add_a_new_row_in_Google_Sheets_1109414_sssssssssssssu__@uuuuuuuuuuuuuumuu',
+          'workato.recipe__code.instance.Copy_of_New_or_updated_standard_record___________in_NetSuite__will_create_record_in_Salesforce_1109550_ssssss_00010sssssssssss_00010sssssu__@uuuuuuuuuuuuuuuuuuuuuuuuumuuuu',
+          'workato.recipe__code.instance.Copy_of_New_updated_record_in_Salesforce_will_add_a_new_row_in_a_sheet_in_Google_Sheets_1109425_ssdssssssssssssssu__@uuuuuuuuuuuuuuuuuumuu',
+          'workato.recipe__code.instance.Copy_of_pubsub_recipe_412_1283313_ssssu__@uuuuumuu',
+          'workato.recipe__code.instance.Copy_of_test_recipe_321_1321119_ssssu__@uuuuumuu',
+          'workato.recipe__code.instance.New_email_in_Gmail_will_add_a_new_row_in_Google_Sheets_1209414_sssssssssssu__@uuuuuuuuuuuumuu',
+          'workato.recipe__code.instance.New_updated_record_in_Salesforce_will_add_a_new_row_in_a_sheet_in_Google_Sheets_1209425_dssssssssssssssu__@uuuuuuuuuuuuuuuumuu',
+          'workato.recipe__code.instance.__________New_or_updated_standard_record___________in_NetSuite__will_create_record_in_Salesforce_1209550_ssssssssssssss_00010sssssssssss_00010sssssu__@uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuumuuuu',
+          'workato.recipe__code.instance.pubsub_recipe_412_1383313_ssu__@uuumuu',
+          'workato.recipe__code.instance.test_recipe_321_1381119_ssu__@uuumuu',
           'workato.recipe__code__block',
           'workato.recipe__code__block__block',
           'workato.recipe__code__block__block__dynamicPickListSelection',
@@ -180,8 +180,6 @@ describe('adapter', () => {
           user_id: 191676,
           name: 'New/updated record in Salesforce will add a new row in a sheet in Google Sheets',
           // eslint-disable-next-line camelcase
-          copy_count: 1,
-          // eslint-disable-next-line camelcase
           trigger_application: 'salesforce',
           // eslint-disable-next-line camelcase
           action_applications: [
@@ -213,8 +211,8 @@ describe('adapter', () => {
         })
         const recipeCodeReference = recipe?.value.code
         expect(recipeCodeReference).toBeInstanceOf(ReferenceExpression)
-        expect((recipeCodeReference as ReferenceExpression).elemID.getFullName()).toEqual('workato.recipe__code.instance.New_updated_record_in_Salesforce_will_add_a_new_row_in_a_sheet_in_Google_Sheets_1209425_dssssssssssssssu__updated_custom_object@uuuuuuuuuuuuuuuumuuuu')
-        const recipeCode = elements.filter(isInstanceElement).find(e => e.elemID.getFullName() === 'workato.recipe__code.instance.New_updated_record_in_Salesforce_will_add_a_new_row_in_a_sheet_in_Google_Sheets_1209425_dssssssssssssssu__updated_custom_object@uuuuuuuuuuuuuuuumuuuu')
+        expect((recipeCodeReference as ReferenceExpression).elemID.getFullName()).toEqual('workato.recipe__code.instance.New_updated_record_in_Salesforce_will_add_a_new_row_in_a_sheet_in_Google_Sheets_1209425_dssssssssssssssu__@uuuuuuuuuuuuuuuumuu')
+        const recipeCode = elements.filter(isInstanceElement).find(e => e.elemID.getFullName() === 'workato.recipe__code.instance.New_updated_record_in_Salesforce_will_add_a_new_row_in_a_sheet_in_Google_Sheets_1209425_dssssssssssssssu__@uuuuuuuuuuuuuuuumuu')
         expect(recipeCode).toBeDefined()
         expect(recipeCode?.value).toEqual({
           number: 0,

--- a/packages/workato-adapter/test/filters/fix_multienv_ids.test.ts
+++ b/packages/workato-adapter/test/filters/fix_multienv_ids.test.ts
@@ -1,0 +1,226 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { ElemID, InstanceElement, ObjectType, Element, BuiltinTypes, CORE_ANNOTATIONS, ReferenceExpression, isInstanceElement } from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { getParents } from '@salto-io/adapter-utils'
+import filterCreator from '../../src/filters/fix_multienv_ids'
+import WorkatoClient from '../../src/client/client'
+import { paginate } from '../../src/client/pagination'
+import { DEFAULT_TYPES, DEFAULT_ID_FIELDS } from '../../src/config'
+import { WORKATO } from '../../src/constants'
+
+describe('Fix multienv ids filter', () => {
+  let client: WorkatoClient
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  let filter: FilterType
+
+  beforeAll(() => {
+    client = new WorkatoClient({
+      credentials: { username: 'a', token: 'b' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      }),
+      config: {
+        fetch: {
+          includeTypes: ['recipe', 'folder'],
+        },
+        apiDefinitions: {
+          typeDefaults: {
+            transformation: {
+              idFields: DEFAULT_ID_FIELDS,
+            },
+          },
+          types: _.defaultsDeep(
+            {},
+            {
+              recipe: {
+                transformation: {
+                  idFields: ['name', '&folder_id'],
+                },
+              },
+              folder: {
+                transformation: {
+                  idFields: ['name', '&parent_id'],
+                },
+              },
+            },
+            DEFAULT_TYPES,
+          ),
+        },
+      },
+    }) as FilterType
+  })
+
+  const recipeType = new ObjectType({
+    elemID: new ElemID(WORKATO, 'recipe'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER, annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true } },
+      folder_id: { refType: BuiltinTypes.NUMBER },
+      code: { refType: BuiltinTypes.UNKNOWN },
+    },
+  })
+  const recipeCodeType = new ObjectType({
+    elemID: new ElemID(WORKATO, 'recipe__code'),
+  })
+  const folderType = new ObjectType({
+    elemID: new ElemID(WORKATO, 'folder'),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER, annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true } },
+      // eslint-disable-next-line camelcase
+      parent_id: { refType: BuiltinTypes.NUMBER },
+    },
+  })
+
+  const generateElements = (
+  ): Element[] => ([
+    recipeType,
+    new InstanceElement(
+      'recipe123',
+      recipeType,
+      {
+        name: 'recipe123',
+        id: 123,
+        folder_id: 11,
+        code: new ReferenceExpression(new ElemID('workato', 'recipe__code', 'instance', 'recipe123_')),
+      },
+      ['Records', 'recipe', 'recipe123'],
+    ),
+    recipeCodeType,
+    new InstanceElement(
+      'recipe123_',
+      recipeCodeType,
+      { id: 123 },
+      ['Records', 'recipe__code', 'recipe123_'],
+      { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(new ElemID('workato', 'recipe', 'instance', 'recipe123'))] },
+    ),
+    folderType,
+    new InstanceElement('Root', folderType, { name: 'Root', id: 55 }), // root folder
+    new InstanceElement('folder11_55', folderType, { name: 'folder11', id: 11, parent_id: 55 }),
+    new InstanceElement('folder22_11', folderType, { name: 'folder22', id: 22, parent_id: 11 }),
+    new InstanceElement('folder33_55', folderType, { name: 'folder33', id: 33, parent_id: 55 }),
+  ])
+
+  describe('on fetch', () => {
+    it('should update all ids when configuration and instances are as expected', async () => {
+      const elements = generateElements()
+      const lengthBefore = elements.length
+      await filter.onFetch(elements)
+      expect(elements.length).toEqual(lengthBefore)
+      const instances = elements.filter(isInstanceElement)
+      expect(instances.map(e => e.elemID.getFullName())).toEqual([
+        'workato.folder.instance.Root',
+        'workato.folder.instance.folder11_Root',
+        'workato.folder.instance.folder33_Root',
+        'workato.folder.instance.folder22_folder11_Root',
+        'workato.recipe.instance.recipe123_folder11_Root',
+        'workato.recipe__code.instance.recipe123_folder11_Root_',
+      ])
+      expect(instances[4].value.code).toBeInstanceOf(ReferenceExpression)
+      expect(instances[4].value.code.elemID.getFullName()).toEqual('workato.recipe__code.instance.recipe123_folder11_Root_')
+      expect(getParents(instances[5])[0]).toBeInstanceOf(ReferenceExpression)
+      expect(getParents(instances[5])[0].elemID.getFullName()).toEqual('workato.recipe.instance.recipe123_folder11_Root')
+    })
+    it('should update recipes but not update folder ids if root folder is not found', async () => {
+      const elements = generateElements().filter(e => e.elemID.name !== 'Root')
+      const lengthBefore = elements.length
+      await filter.onFetch(elements)
+      expect(elements.length).toEqual(lengthBefore)
+      const instances = elements.filter(isInstanceElement)
+      expect(instances.map(e => e.elemID.getFullName())).toEqual([
+        'workato.folder.instance.folder11_55',
+        'workato.folder.instance.folder22_11',
+        'workato.folder.instance.folder33_55',
+        'workato.recipe.instance.recipe123_folder11_55',
+        'workato.recipe__code.instance.recipe123_folder11_55_',
+      ])
+      expect(instances[3].value.code).toBeInstanceOf(ReferenceExpression)
+      expect(instances[3].value.code.elemID.getFullName()).toEqual('workato.recipe__code.instance.recipe123_folder11_55_')
+      expect(getParents(instances[4])[0]).toBeInstanceOf(ReferenceExpression)
+      expect(getParents(instances[4])[0].elemID.getFullName()).toEqual('workato.recipe.instance.recipe123_folder11_55')
+    })
+    it('should update recipes but not update folder ids if root folder id is not as expected', async () => {
+      const elements = generateElements().filter(e => e.elemID.name !== 'Root')
+      elements.push(new InstanceElement('Root', folderType, { name: 'Root', id: 66 }))
+      const lengthBefore = elements.length
+      await filter.onFetch(elements)
+      expect(elements.length).toEqual(lengthBefore)
+      const instances = elements.filter(isInstanceElement)
+      expect(instances.map(e => e.elemID.getFullName())).toEqual([
+        'workato.folder.instance.folder11_55',
+        'workato.folder.instance.folder22_11',
+        'workato.folder.instance.folder33_55',
+        'workato.folder.instance.Root',
+        'workato.recipe.instance.recipe123_folder11_55',
+        'workato.recipe__code.instance.recipe123_folder11_55_',
+      ])
+      expect(instances[4].value.code).toBeInstanceOf(ReferenceExpression)
+      expect(instances[4].value.code.elemID.getFullName()).toEqual('workato.recipe__code.instance.recipe123_folder11_55_')
+      expect(getParents(instances[5])[0]).toBeInstanceOf(ReferenceExpression)
+      expect(getParents(instances[5])[0].elemID.getFullName()).toEqual('workato.recipe.instance.recipe123_folder11_55')
+    })
+
+    it('should do nothing if config is not in customized form', async () => {
+      filter = filterCreator({
+        client,
+        paginator: clientUtils.createPaginator({
+          client,
+          paginationFuncCreator: paginate,
+        }),
+        config: {
+          fetch: {
+            includeTypes: ['recipe', 'folder'],
+          },
+          apiDefinitions: {
+            typeDefaults: {
+              transformation: {
+                idFields: DEFAULT_ID_FIELDS,
+              },
+            },
+            types: _.defaultsDeep(
+              {},
+              {
+                folder: {
+                  transformation: {
+                    idFields: ['name', '&something_else'],
+                  },
+                },
+              },
+              DEFAULT_TYPES,
+            ),
+          },
+        },
+      }) as FilterType
+      const elements = generateElements()
+      const lengthBefore = elements.length
+      await filter.onFetch(elements)
+      expect(elements.length).toEqual(lengthBefore)
+      const instances = elements.filter(isInstanceElement)
+      expect(instances.map(e => e.elemID.getFullName())).toEqual([
+        'workato.recipe.instance.recipe123',
+        'workato.recipe__code.instance.recipe123_',
+        'workato.folder.instance.Root',
+        'workato.folder.instance.folder11_55',
+        'workato.folder.instance.folder22_11',
+        'workato.folder.instance.folder33_55',
+      ])
+    })
+  })
+})


### PR DESCRIPTION
* Add support for multienv-friendly ids with "expected" repetitions (repeating names but not under the same paths), specifically for recipes and folders.
This is temporary until SALTO-1241 and SALTO-1687 are fully implemented, and then the default config will use these options.
For now, adding a filter that does nothing with the default config, but supports customizing for multienv-friendly ids when needed - by using the following id field overrides:
```
  apiDefinitions = {
    types = {
      recipe = {
        transformation = {
          idFields = [
            "name",
            "&folder_id",
          ]
        }
      }
      folder = {
        transformation = {
          idFields = [
            "name",
            "&parent_id",
          ]
        }
      }
    }
  }
```

* Also removing a couple of recipe fields that are not needed, and cleaning up the ids of recipe_code instances for future workspaces (since we have elemIdGetter)

---
_Release Notes_: 
None

---
_User Notifications_: 
None (no notifications are currently set on the fields that will be removed)