### PR TITLE
SALTO-2057: Fix e2e setup for salesforce adapter

### DIFF
--- a/packages/salesforce-adapter/e2e_test/setup.ts
+++ b/packages/salesforce-adapter/e2e_test/setup.ts
@@ -22,6 +22,7 @@ import { createDeployPackage } from '../src/transformers/xml_transformer'
 import { MetadataValues, createInstanceElement } from '../src/transformers/transformer'
 import SalesforceClient from '../src/client/client'
 import { mockTypes, mockDefaultValues } from '../test/mock_elements'
+import { removeMetadataIfAlreadyExists } from './utils'
 
 
 export const gvsName = 'TestGlobalValueSet'
@@ -91,6 +92,11 @@ export const verifyElementsExist = async (client: SalesforceClient): Promise<voi
   }
 
   const addCustomObjectWithVariousFields = async (): Promise<void> => {
+    await removeMetadataIfAlreadyExists(
+      client,
+      constants.CUSTOM_FIELD,
+      summaryFieldName,
+    )
     await removeCustomObjectsWithVariousFields(client)
     const objectToAdd = {
       deploymentStatus: 'Deployed',


### PR DESCRIPTION
The current setup attempts to remove an object before creating it but the object
cannot be removed while there is still a reference to it.
Added a removal of the referring field from Case before attempting to remove the object

---

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
