### PR TITLE
SALTO-2042: added triggers to workflows

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -16,7 +16,7 @@
 import { InstanceElement, Element, ElemID, CORE_ANNOTATIONS, ReferenceExpression } from '@salto-io/adapter-api'
 import { naclCase } from '@salto-io/adapter-utils'
 import { CUSTOM_FIELDS_SUFFIX } from '../../src/filters/fields/field_name_filter'
-import { ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, JIRA } from '../../src/constants'
+import { ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, JIRA, WORKFLOW_TYPE_NAME } from '../../src/constants'
 import { createReference, findType } from '../utils'
 import { createBoardValues } from './board'
 import { createContextValues, createFieldValues } from './field'
@@ -57,7 +57,7 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[] =
 
   const workflow = new InstanceElement(
     randomString,
-    findType('Workflow', fetchedElements),
+    findType(WORKFLOW_TYPE_NAME, fetchedElements),
     createWorkflowValues(randomString, fetchedElements),
   )
 

--- a/packages/jira-adapter/e2e_test/instances/workflowScheme.ts
+++ b/packages/jira-adapter/e2e_test/instances/workflowScheme.ts
@@ -15,7 +15,7 @@
 */
 import { Values, Element, ElemID } from '@salto-io/adapter-api'
 import { createReference } from '../utils'
-import { ISSUE_TYPE_NAME, JIRA } from '../../src/constants'
+import { ISSUE_TYPE_NAME, JIRA, WORKFLOW_TYPE_NAME } from '../../src/constants'
 
 export const createWorkflowSchemeValues = (
   name: string,
@@ -23,11 +23,11 @@ export const createWorkflowSchemeValues = (
 ): Values => ({
   name,
   description: name,
-  defaultWorkflow: createReference(new ElemID(JIRA, 'Workflow', 'instance', 'jira'), allElements),
+  defaultWorkflow: createReference(new ElemID(JIRA, WORKFLOW_TYPE_NAME, 'instance', 'jira'), allElements),
   items: [
     {
       issueType: createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Bug'), allElements),
-      workflow: createReference(new ElemID(JIRA, 'Workflow', 'instance', 'jira'), allElements),
+      workflow: createReference(new ElemID(JIRA, WORKFLOW_TYPE_NAME, 'instance', 'jira'), allElements),
     },
   ],
 })

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -42,8 +42,11 @@ import hiddenValuesInListsFilter from './filters/hidden_value_in_lists'
 import projectFilter from './filters/project'
 import projectComponentFilter from './filters/project_component'
 import defaultInstancesDeployFilter from './filters/default_instances_deploy'
-import workflowFilter from './filters/workflow/workflow'
-import workflowPropertiesFilter from './filters/workflow/workflow_properties'
+import workflowStructureFilter from './filters/workflow/workflow_structure_filter'
+import workflowPropertiesFilter from './filters/workflow/workflow_properties_filter'
+import transitionIdsFilter from './filters/workflow/transition_ids_filter'
+import workflowDeployFilter from './filters/workflow/workflow_deploy_filter'
+import triggersFilter from './filters/workflow/triggers_filter'
 import workflowSchemeFilter from './filters/workflow_scheme'
 import duplicateIdsFilter from './filters/duplicate_ids'
 import fieldNameFilter from './filters/fields/field_name_filter'
@@ -81,8 +84,11 @@ export const DEFAULT_FILTERS = [
   fieldDeploymentFilter,
   contextDeploymentFilter,
   avatarsFilter,
-  workflowFilter,
+  workflowStructureFilter,
+  transitionIdsFilter,
+  triggersFilter,
   workflowPropertiesFilter,
+  workflowDeployFilter,
   workflowSchemeFilter,
   issueTypeSchemeReferences,
   issueTypeSchemeFilter,

--- a/packages/jira-adapter/src/change_validators/workflow.ts
+++ b/packages/jira-adapter/src/change_validators/workflow.ts
@@ -16,9 +16,10 @@
 import { ChangeValidator, getChangeData, isAdditionChange, isInstanceChange, SaltoErrorSeverity } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { resolveValues } from '@salto-io/adapter-utils'
-import { UNDEPLOYALBE_POST_FUNCTION_TYPES, UNDEPLOYALBE_VALIDATOR_TYPES } from '../filters/workflow/workflow'
 import { isWorkflowInstance, WorkflowInstance } from '../filters/workflow/types'
 import { getLookUpName } from '../reference_mapping'
+import { WORKFLOW_TYPE_NAME } from '../constants'
+import { UNDEPLOYALBE_POST_FUNCTION_TYPES, UNDEPLOYALBE_VALIDATOR_TYPES } from '../filters/workflow/workflow_deploy_filter'
 
 const { awu } = collections.asynciterable
 
@@ -41,7 +42,7 @@ export const workflowValidator: ChangeValidator = async changes => (
     .filter(isInstanceChange)
     .filter(isAdditionChange)
     .map(getChangeData)
-    .filter(instance => instance.elemID.typeName === 'Workflow')
+    .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
     .map(instance => resolveValues(instance, getLookUpName))
     .filter(isWorkflowInstance)
     .filter(hasUndeployableTypes)

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1003,13 +1003,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       ],
     },
   },
-  Transition: {
-    transformation: {
-      fieldsToOmit: [
-        { fieldName: 'id' },
-      ],
-    },
-  },
   Workflow: {
     transformation: {
       fieldTypeOverrides: [

--- a/packages/jira-adapter/src/filters/sort_lists.ts
+++ b/packages/jira-adapter/src/filters/sort_lists.ts
@@ -15,6 +15,7 @@
 */
 import { InstanceElement, isInstanceElement, isReferenceExpression, Value } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { WORKFLOW_TYPE_NAME } from '../constants'
 import { FilterCreator } from '../filter'
 
 type ValueToSort = {
@@ -30,7 +31,7 @@ const VALUES_TO_SORT: ValueToSort[] = [
     sortBy: ['permission', 'holder.type', 'holder.parameter'],
   },
   {
-    typeName: 'Workflow',
+    typeName: WORKFLOW_TYPE_NAME,
     fieldName: 'statuses',
     sortBy: ['id.elemID.name'],
   },

--- a/packages/jira-adapter/src/filters/workflow/transition_ids_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/transition_ids_filter.ts
@@ -1,0 +1,123 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, Element, Field, getChangeData, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, MapType } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import _ from 'lodash'
+import { collections, values } from '@salto-io/lowerdash'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { findObject } from '../../utils'
+import { FilterCreator } from '../../filter'
+import { WORKFLOW_TYPE_NAME } from '../../constants'
+import { isWorkflowInstance, isWorkflowValues, Transition, WorkflowInstance } from './types'
+import JiraClient from '../../client/client'
+
+const { awu } = collections.asynciterable
+
+
+const log = logger(module)
+
+export const getTransitionKey = (transition: Transition): string => [
+  ...(transition.from ?? []),
+  transition.name ?? '',
+].join('-')
+
+const addTransitionIds = (
+  instance: WorkflowInstance,
+  transitions: Transition[] | undefined,
+): void => {
+  if (transitions === undefined) {
+    return
+  }
+  instance.value.transitionIds = _(transitions)
+    .keyBy(getTransitionKey)
+    .mapValues(transition => transition.id)
+    .pickBy(values.isDefined)
+    .value()
+
+  instance.value.transitions?.forEach(transition => {
+    delete transition.id
+  })
+}
+
+const getTransitionsFromService = async (
+  client: JiraClient,
+  workflowName: string,
+): Promise<Transition[]> => {
+  const response = await client.getSinglePage({
+    url: '/rest/api/3/workflow/search',
+    queryParams: {
+      expand: 'transitions',
+      workflowName,
+    },
+  })
+
+  if (!Array.isArray(response.data.values)) {
+    log.warn(`Unexpected workflows response from Jira: ${safeJsonStringify(response.data.values)}`)
+    return []
+  }
+
+  if (response.data.values.length !== 1) {
+    log.warn(`Received unexpected number of workflows from Jira: ${safeJsonStringify(response.data.values)}`)
+    return []
+  }
+
+  const workflowValues = response.data.values[0]
+
+  if (!isWorkflowValues(workflowValues)) {
+    log.warn(`Received an invalid workflow from Jira: ${safeJsonStringify(workflowValues)}`)
+    return []
+  }
+
+  return workflowValues.transitions ?? []
+}
+
+const filter: FilterCreator = ({ client }) => ({
+  onFetch: async (elements: Element[]) => {
+    const workflowType = findObject(elements, WORKFLOW_TYPE_NAME)
+    if (workflowType === undefined) {
+      log.warn(`${WORKFLOW_TYPE_NAME} type not found`)
+    } else {
+      workflowType.fields.transitionIds = new Field(
+        workflowType,
+        'transitionIds',
+        new MapType(BuiltinTypes.STRING),
+        { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true }
+      )
+    }
+
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
+      .filter(isWorkflowInstance)
+      .forEach(instance => {
+        addTransitionIds(instance, instance.value.transitions)
+      })
+  },
+
+  onDeploy: async changes => {
+    await awu(changes)
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === WORKFLOW_TYPE_NAME)
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
+      .forEach(async instance => {
+        const transitions = await getTransitionsFromService(client, instance.value.name)
+        addTransitionIds(instance, transitions)
+      })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/workflow/triggers_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/triggers_filter.ts
@@ -1,0 +1,86 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Field, isInstanceElement, ListType } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { findObject } from '../../utils'
+import { FilterCreator } from '../../filter'
+import { WORKFLOW_RULES_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../constants'
+import { isWorkflowInstance } from './types'
+import { triggerType } from './triggers_types'
+import { getTransitionKey } from './transition_ids_filter'
+
+const log = logger(module)
+
+
+const filter: FilterCreator = ({ client, config }) => ({
+  onFetch: async elements => {
+    if (!config.client.usePrivateAPI) {
+      log.debug('Skipping triggers filter because private API is not enabled')
+      return
+    }
+
+    elements.push(triggerType)
+
+    const workflowRulesType = findObject(elements, WORKFLOW_RULES_TYPE_NAME)
+    if (workflowRulesType === undefined) {
+      log.warn(`${WORKFLOW_RULES_TYPE_NAME} type not found`)
+    } else {
+      workflowRulesType.fields.triggers = new Field(
+        workflowRulesType,
+        'triggers',
+        new ListType(triggerType),
+      )
+    }
+
+    await Promise.all(elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
+      .filter(isWorkflowInstance)
+      .filter(workflow => workflow.value.name !== undefined)
+      .map(async instance => {
+        const transitionIds = instance.value.transitionIds ?? {}
+
+        await Promise.all(
+          (instance.value.transitions ?? []).map(async transition => {
+            const transitionId = transitionIds[getTransitionKey(transition)]
+            if (transitionId === undefined) {
+              log.warn(`Did not find transition id of transition ${safeJsonStringify(transition)}`)
+              return
+            }
+
+            const response = await client.getSinglePage({
+              url: '/rest/triggers/1.0/workflow/config',
+              queryParams: {
+                workflowName: instance.value.name as string,
+                actionId: transitionId,
+              },
+            })
+
+            if (!Array.isArray(response.data)) {
+              log.warn(`Unexpected triggers response from Jira: ${safeJsonStringify(response.data)}`)
+              return
+            }
+
+            _.set(transition, ['rules', 'triggers'], response.data.map(trigger => _.omit(trigger, 'id')))
+          })
+        )
+      }))
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/workflow/triggers_types.ts
+++ b/packages/jira-adapter/src/filters/workflow/triggers_types.ts
@@ -13,12 +13,17 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export const JIRA = 'jira'
-export const ISSUE_TYPE_SCHEMA_NAME = 'IssueTypeScheme'
-export const ISSUE_TYPE_NAME = 'IssueType'
-export const WORKFLOW_TYPE_NAME = 'Workflow'
-export const WORKFLOW_RULES_TYPE_NAME = 'WorkflowRules'
+import { BuiltinTypes, ElemID, MapType } from '@salto-io/adapter-api'
+import { elements } from '@salto-io/adapter-components'
+import { createMatchingObjectType } from '@salto-io/adapter-utils'
+import { JIRA } from '../../constants'
+import { Trigger } from './types'
 
-export const PRIVATE_API_HEADERS = {
-  'X-Atlassian-Token': 'no-check',
-}
+export const triggerType = createMatchingObjectType<Trigger>({
+  elemID: new ElemID(JIRA, 'Trigger'),
+  fields: {
+    key: { refType: BuiltinTypes.STRING },
+    configuration: { refType: new MapType(BuiltinTypes.UNKNOWN) },
+  },
+  path: [JIRA, elements.TYPES_PATH, 'Trigger'],
+})

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -19,8 +19,6 @@ import Joi from 'joi'
 
 const log = logger(module)
 
-export const WORKFLOW_TYPE_NAME = 'Workflow'
-
 type Id = {
   name?: string
   entityId?: string
@@ -94,9 +92,20 @@ const postFunctionSchema = Joi.object({
   configuration: postFunctionConfigurationSchema.optional(),
 }).unknown(true)
 
+export type Trigger = {
+  key?: string
+  configuration?: Record<string, unknown>
+}
+
+const triggerSchema = Joi.object({
+  key: Joi.string().optional(),
+  configuration: Joi.object().optional(),
+}).unknown(true)
+
 export type Rules = {
   validators?: Validator[]
   postFunctions?: PostFunction[]
+  triggers?: PostFunction[]
   conditionsTree?: unknown
   conditions?: unknown
 }
@@ -104,18 +113,25 @@ export type Rules = {
 const rulesSchema = Joi.object({
   validators: Joi.array().items(validatorSchema).optional(),
   postFunctions: Joi.array().items(postFunctionSchema).optional(),
+  triggers: Joi.array().items(triggerSchema).optional(),
   conditionsTree: Joi.any().optional(),
   conditions: Joi.any().optional(),
 }).unknown(true)
 
-type Transitions = {
+export type Transition = {
+  id?: string
   type?: string
   rules?: Rules
+  name?: string
+  from?: unknown[]
 }
 
 const transitionsSchema = Joi.object({
+  id: Joi.string().optional(),
   type: Joi.string().optional(),
   rules: rulesSchema.optional(),
+  name: Joi.string().optional(),
+  from: Joi.array().items(Joi.any()).optional(),
 }).unknown(true)
 
 export type Status = {
@@ -127,14 +143,16 @@ const statusSchema = Joi.object({
 }).unknown(true)
 
 export type Workflow = {
+  transitionIds?: Record<string, string>
   id?: Id
   entityId?: string
   name?: string
-  transitions?: Transitions[]
+  transitions?: Transition[]
   statuses?: Status[]
 }
 
 const workflowSchema = Joi.object({
+  transitionIds: Joi.object().pattern(Joi.string(), Joi.string()).optional(),
   id: idSchema.optional(),
   entityId: Joi.string().optional(),
   name: Joi.string().optional(),
@@ -144,12 +162,14 @@ const workflowSchema = Joi.object({
 
 export type WorkflowInstance = InstanceElement & { value: InstanceElement['value'] & Workflow }
 
-export const isWorkflowInstance = (instance: InstanceElement)
-: instance is WorkflowInstance => {
-  const { error } = workflowSchema.validate(instance.value)
+export const isWorkflowValues = (values: unknown): values is Workflow => {
+  const { error } = workflowSchema.validate(values)
   if (error !== undefined) {
     log.warn(`Received an invalid workflow: ${error.message}`)
     return false
   }
   return true
 }
+
+export const isWorkflowInstance = (instance: InstanceElement)
+: instance is WorkflowInstance => isWorkflowValues(instance.value)

--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -1,0 +1,127 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { AdditionChange, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, toChange } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { resolveValues } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../../filter'
+import { isWorkflowInstance, WorkflowInstance } from './types'
+import JiraClient from '../../client/client'
+import { JiraConfig } from '../../config'
+import { getLookUpName } from '../../reference_mapping'
+import { defaultDeployChange, deployChanges } from '../../deployment'
+import { WORKFLOW_TYPE_NAME } from '../../constants'
+
+export const UNDEPLOYALBE_VALIDATOR_TYPES = [
+  'com.onresolve.jira.groovy.groovyrunner__script-workflow-validators',
+]
+
+export const UNDEPLOYALBE_POST_FUNCTION_TYPES = [
+  'com.onresolve.jira.groovy.groovyrunner__script-postfunction',
+]
+
+export const INITIAL_VALIDATOR = {
+  type: 'PermissionValidator',
+  configuration: {
+    permissionKey: 'CREATE_ISSUES',
+  },
+}
+
+/**
+ * When creating a workflow, the initial transition is always created
+ * with an extra PermissionValidator with CREATE_ISSUES permission key.
+ * Currently the API does not allow us to remove it but we can at least make sure to
+ * not create an additional one if one validator like that already appears in the nacl.
+ */
+const removeCreateIssuePermissionValidator = (instance: WorkflowInstance): void => {
+  instance.value.transitions
+    ?.filter(transition => transition.type === 'initial')
+    .forEach(transition => {
+      const createIssuePermissionValidatorIndex = _.findLastIndex(
+        transition.rules?.validators ?? [],
+        validator => _.isEqual(
+          validator,
+          INITIAL_VALIDATOR,
+        ),
+      )
+
+      _.remove(
+        transition.rules?.validators ?? [],
+        (_validator, index) => index === createIssuePermissionValidatorIndex,
+      )
+    })
+}
+
+const removeUnsupportedRules = (instance: WorkflowInstance): void => {
+  instance.value.transitions
+    ?.forEach(transition => {
+      if (transition.rules?.postFunctions !== undefined) {
+        transition.rules.postFunctions = transition.rules.postFunctions.filter(
+          postFunction => !UNDEPLOYALBE_POST_FUNCTION_TYPES.includes(postFunction.type ?? ''),
+        )
+      }
+
+      if (transition.rules?.validators !== undefined) {
+        transition.rules.validators = transition.rules.validators.filter(
+          validator => !UNDEPLOYALBE_VALIDATOR_TYPES.includes(validator.type ?? ''),
+        )
+      }
+    })
+}
+
+const deployWorkflow = async (
+  change: AdditionChange<InstanceElement>,
+  client: JiraClient,
+  config: JiraConfig,
+): Promise<void> => {
+  const instance = await resolveValues(getChangeData(change), getLookUpName)
+  if (isWorkflowInstance(instance)) {
+    removeCreateIssuePermissionValidator(instance)
+    removeUnsupportedRules(instance)
+  }
+  await defaultDeployChange({
+    change: toChange({ after: instance }),
+    client,
+    apiDefinitions: config.apiDefinitions,
+  })
+  getChangeData(change).value.entityId = instance.value.entityId
+}
+
+// This filter transforms the workflow values structure so it will fit its deployment endpoint
+const filter: FilterCreator = ({ config, client }) => ({
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => isInstanceChange(change)
+        && isAdditionChange(change)
+        && getChangeData(change).elemID.typeName === WORKFLOW_TYPE_NAME
+    )
+
+
+    const deployResult = await deployChanges(
+      relevantChanges
+        .filter(isInstanceChange)
+        .filter(isAdditionChange),
+      async change => deployWorkflow(change, client, config)
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/workflow/workflow_properties_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_properties_filter.ts
@@ -20,8 +20,8 @@ import { collections } from '@salto-io/lowerdash'
 import { elements as elementUtils } from '@salto-io/adapter-components'
 import { findObject } from '../../utils'
 import { FilterCreator } from '../../filter'
-import { isWorkflowInstance, WorkflowInstance, WORKFLOW_TYPE_NAME } from './types'
-import { JIRA } from '../../constants'
+import { isWorkflowInstance, WorkflowInstance } from './types'
+import { JIRA, WORKFLOW_TYPE_NAME } from '../../constants'
 
 const STATUS_PROPERTY_TYPE_NAME = 'StatusProperty'
 

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -16,7 +16,7 @@
 import { isReferenceExpression } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
-import { ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME } from './constants'
+import { ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, WORKFLOW_TYPE_NAME } from './constants'
 import { getFieldsLookUpName } from './filters/fields/field_type_references_filter'
 
 
@@ -219,12 +219,12 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
   {
     src: { field: 'defaultWorkflow', parentTypes: ['WorkflowScheme'] },
     serializationStrategy: 'name',
-    target: { type: 'Workflow' },
+    target: { type: WORKFLOW_TYPE_NAME },
   },
   {
     src: { field: 'workflow', parentTypes: ['WorkflowSchemeItem'] },
     serializationStrategy: 'name',
-    target: { type: 'Workflow' },
+    target: { type: WORKFLOW_TYPE_NAME },
   },
   {
     src: { field: 'issueType', parentTypes: ['WorkflowSchemeItem'] },

--- a/packages/jira-adapter/test/change_validators/workflow.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflow.test.ts
@@ -15,14 +15,14 @@
 */
 import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
 import { workflowValidator } from '../../src/change_validators/workflow'
-import { JIRA } from '../../src/constants'
+import { JIRA, WORKFLOW_TYPE_NAME } from '../../src/constants'
 
 describe('workflowValidator', () => {
   let type: ObjectType
   let instance: InstanceElement
 
   beforeEach(() => {
-    type = new ObjectType({ elemID: new ElemID(JIRA, 'Workflow') })
+    type = new ObjectType({ elemID: new ElemID(JIRA, WORKFLOW_TYPE_NAME) })
     instance = new InstanceElement('instance', type)
   })
   it('should return an error if there is a non-deployable post function', async () => {

--- a/packages/jira-adapter/test/filters/workflow/transition_ids_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/transition_ids_filter.test.ts
@@ -1,0 +1,246 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import JiraClient from '../../../src/client/client'
+import { DEFAULT_CONFIG } from '../../../src/config'
+import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import transitionIdsFilter from '../../../src/filters/workflow/transition_ids_filter'
+import { mockClient } from '../../utils'
+
+describe('transitionIdsFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch' | 'onDeploy'>
+  let workflowType: ObjectType
+  let client: JiraClient
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  beforeEach(async () => {
+    workflowType = new ObjectType({ elemID: new ElemID(JIRA, WORKFLOW_TYPE_NAME) })
+
+    const { client: cli, paginator, connection } = mockClient()
+    client = cli
+    mockConnection = connection
+
+    filter = transitionIdsFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    }) as typeof filter
+  })
+
+  describe('onFetch', () => {
+    it('should add transitionIds field to the type', async () => {
+      await filter.onFetch([workflowType])
+      expect(workflowType.fields.transitionIds).toBeDefined()
+      expect(workflowType.fields.transitionIds.annotations).toEqual({
+        [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+      })
+    })
+
+    it('should add transitionIds value', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          transitions: [
+            { id: '1', name: 'transition1', from: ['4', '5'] },
+            { id: '2', name: 'transition2' },
+            { id: '3', from: ['6', '7'] },
+          ],
+        },
+      )
+      await filter.onFetch([instance])
+      expect(instance.value).toEqual({
+        transitionIds: {
+          '4-5-transition1': '1',
+          transition2: '2',
+          '6-7-': '3',
+        },
+        transitions: [
+          { name: 'transition1', from: ['4', '5'] },
+          { name: 'transition2' },
+          { from: ['6', '7'] },
+        ],
+      })
+    })
+
+    it('if there are no transitions should do nothing', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'name',
+        },
+      )
+      await filter.onFetch([instance])
+      expect(instance.value).toEqual({
+        name: 'name',
+      })
+    })
+  })
+
+  describe('onDeploy', () => {
+    it('should add transitionIds value', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'name',
+          transitions: [
+            { name: 'transition1', from: ['4', '5'] },
+            { name: 'transition2' },
+            { from: ['6', '7'] },
+          ],
+        },
+      )
+
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          values: [
+            {
+              transitions: [
+                { id: '1', name: 'transition1', from: ['4', '5'] },
+                { id: '2', name: 'transition2' },
+                { id: '3', from: ['6', '7'] },
+              ],
+            },
+          ],
+        },
+      })
+
+      await filter.onDeploy([toChange({ after: instance })])
+
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        '/rest/api/3/workflow/search',
+        {
+          params: {
+            expand: 'transitions',
+            workflowName: 'name',
+          },
+        }
+      )
+
+      expect(instance.value.transitionIds).toEqual({
+        '4-5-transition1': '1',
+        transition2: '2',
+        '6-7-': '3',
+      })
+    })
+
+    it('should do nothing when response values is not an array', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'name',
+          transitions: [
+            { name: 'transition1', from: ['4', '5'] },
+            { name: 'transition2' },
+            { from: ['6', '7'] },
+          ],
+        },
+      )
+
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          values: {},
+        },
+      })
+
+      await filter.onDeploy([toChange({ after: instance })])
+
+      expect(instance.value.transitionIds).toEqual({})
+    })
+
+    it('should do nothing when number of workflows in response is invalid', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'name',
+          transitions: [
+            { name: 'transition1', from: ['4', '5'] },
+            { name: 'transition2' },
+            { from: ['6', '7'] },
+          ],
+        },
+      )
+
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          values: [],
+        },
+      })
+
+      await filter.onDeploy([toChange({ after: instance })])
+
+      expect(instance.value.transitionIds).toEqual({})
+    })
+
+    it('should do nothing when workflow in response is invalid', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'name',
+          transitions: [
+            { name: 'transition1', from: ['4', '5'] },
+            { name: 'transition2' },
+            { from: ['6', '7'] },
+          ],
+        },
+      )
+
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          values: [{
+            transitions: 2,
+          }],
+        },
+      })
+
+      await filter.onDeploy([toChange({ after: instance })])
+
+      expect(instance.value.transitionIds).toEqual({})
+    })
+
+    it('should do nothing when there are not transitions in response', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'name',
+        },
+      )
+
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          values: [{
+          }],
+        },
+      })
+
+      await filter.onDeploy([toChange({ after: instance })])
+
+      expect(instance.value.transitionIds).toEqual({})
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/workflow/triggers_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/triggers_filter.test.ts
@@ -1,0 +1,196 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import _ from 'lodash'
+import JiraClient from '../../../src/client/client'
+import { DEFAULT_CONFIG, JiraConfig } from '../../../src/config'
+import { JIRA, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import triggersFilter from '../../../src/filters/workflow/triggers_filter'
+import { mockClient } from '../../utils'
+
+describe('triggersFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let workflowType: ObjectType
+  let workflowRulesType: ObjectType
+  let client: JiraClient
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let config: JiraConfig
+  beforeEach(async () => {
+    workflowType = new ObjectType({ elemID: new ElemID(JIRA, WORKFLOW_TYPE_NAME) })
+    workflowRulesType = new ObjectType({ elemID: new ElemID(JIRA, WORKFLOW_RULES_TYPE_NAME) })
+
+    const { client: cli, paginator, connection } = mockClient()
+    client = cli
+    mockConnection = connection
+
+    config = _.cloneDeep(DEFAULT_CONFIG)
+
+    filter = triggersFilter({
+      client,
+      paginator,
+      config,
+    }) as typeof filter
+  })
+
+  describe('onFetch', () => {
+    it('should add triggers field to the type', async () => {
+      const elements = [workflowRulesType]
+      await filter.onFetch(elements)
+      expect(elements).toHaveLength(2)
+      expect(workflowRulesType.fields.triggers).toBeDefined()
+    })
+
+    it('should add triggers value to instances', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'name',
+          transitionIds: { '4-5-transition1': '1' },
+          transitions: [
+            { id: '1', name: 'transition1', from: ['4', '5'] },
+          ],
+        },
+      )
+
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: [
+          {
+            id: '1',
+            key: 'key',
+            configuration: {},
+          },
+        ],
+      })
+      await filter.onFetch([instance])
+
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        '/rest/triggers/1.0/workflow/config',
+        {
+          params: {
+            workflowName: 'name',
+            actionId: '1',
+          },
+        }
+      )
+      expect(instance.value.transitions[0].rules.triggers).toEqual([
+        {
+          key: 'key',
+          configuration: {},
+        },
+      ])
+    })
+
+    it('do nothing if transition id not found', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'name',
+          transitions: [
+            { id: '1', name: 'transition1', from: ['4', '5'] },
+          ],
+        },
+      )
+
+      await filter.onFetch([instance])
+
+      expect(mockConnection.get).not.toHaveBeenCalled()
+      expect(instance.value).toEqual({
+        name: 'name',
+        transitions: [
+          { id: '1', name: 'transition1', from: ['4', '5'] },
+        ],
+      })
+    })
+
+    it('do nothing when there are no transitions', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'name',
+        },
+      )
+
+      await filter.onFetch([instance])
+
+      expect(mockConnection.get).not.toHaveBeenCalled()
+      expect(instance.value).toEqual({
+        name: 'name',
+      })
+    })
+
+    it('do nothing if response is invalid', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'name',
+          transitionIds: { '4-5-transition1': '1' },
+          transitions: [
+            { id: '1', name: 'transition1', from: ['4', '5'] },
+          ],
+        },
+      )
+
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: {},
+      })
+
+      await filter.onFetch([instance])
+
+      expect(instance.value).toEqual({
+        name: 'name',
+        transitionIds: { '4-5-transition1': '1' },
+        transitions: [
+          { id: '1', name: 'transition1', from: ['4', '5'] },
+        ],
+      })
+    })
+
+    it('do nothing if usePrivateApi is false', async () => {
+      config.client.usePrivateAPI = false
+
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'name',
+          transitionIds: { '4-5-transition1': '1' },
+          transitions: [
+            { id: '1', name: 'transition1', from: ['4', '5'] },
+          ],
+        },
+      )
+
+      await filter.onFetch([instance])
+
+      expect(mockConnection.get).not.toHaveBeenCalled()
+      expect(instance.value).toEqual({
+        name: 'name',
+        transitionIds: { '4-5-transition1': '1' },
+        transitions: [
+          { id: '1', name: 'transition1', from: ['4', '5'] },
+        ],
+      })
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -1,0 +1,255 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { deployment, filterUtils } from '@salto-io/adapter-components'
+import JiraClient from '../../../src/client/client'
+import { DEFAULT_CONFIG } from '../../../src/config'
+import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import workflowFilter, { INITIAL_VALIDATOR } from '../../../src/filters/workflow/workflow_deploy_filter'
+import { mockClient } from '../../utils'
+import { WITH_PERMISSION_VALIDATORS, WITH_SCRIPT_RUNNERS } from './workflow_values'
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn(),
+    },
+  }
+})
+
+describe('workflowDeployFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let workflowType: ObjectType
+  let client: JiraClient
+  beforeEach(async () => {
+    workflowType = new ObjectType({ elemID: new ElemID(JIRA, WORKFLOW_TYPE_NAME) })
+
+    const { client: cli, paginator } = mockClient()
+    client = cli
+    filter = workflowFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+    }) as typeof filter
+  })
+
+  describe('deploy', () => {
+    const deployChangeMock = deployment.deployChange as jest.MockedFunction<
+      typeof deployment.deployChange
+    >
+
+    beforeEach(() => {
+      deployChangeMock.mockClear()
+    })
+    it('should remove the last PermissionValidator with permissionKey CREATE_ISSUES', async () => {
+      const change = toChange({
+        after: new InstanceElement(
+          'instance',
+          workflowType,
+          WITH_PERMISSION_VALIDATORS
+        ),
+      })
+
+      await filter.deploy([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        toChange({
+          after: new InstanceElement(
+            'instance',
+            workflowType,
+            {
+              transitions: [
+                {
+                  type: 'initial',
+                  rules: {
+                    validators: [
+                      INITIAL_VALIDATOR,
+                      {
+                        type: 'PreviousStatusValidator',
+                        configuration: {
+                          previousStatus: {
+                            id: '1',
+                            name: 'name',
+                          },
+                        },
+                      },
+                      {
+                        type: 'PermissionValidator',
+                        configuration: {
+                          permissionKey: 'OTHER',
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            }
+          ),
+        }),
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.Workflow.deployRequests,
+        [],
+        undefined
+      )
+    })
+
+    it('should remove the undeployable post functions and validators', async () => {
+      const change = toChange({
+        after: new InstanceElement(
+          'instance',
+          workflowType,
+          WITH_SCRIPT_RUNNERS
+        ),
+      })
+
+      await filter.deploy([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        toChange({
+          after: new InstanceElement(
+            'instance',
+            workflowType,
+            {
+              transitions: [
+                {
+                  rules: {
+                    validators: [
+                      {
+                        type: 'other',
+                      },
+                      {
+                        val: 'val',
+                      },
+                    ],
+                    postFunctions: [
+                      {
+                        type: 'other',
+                      },
+                      {
+                        val: 'val',
+                      },
+                    ],
+                  },
+                },
+              ],
+            }
+          ),
+        }),
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.Workflow.deployRequests,
+        [],
+        undefined
+      )
+    })
+
+    it('should not change the values if there are no transitions', async () => {
+      const change = toChange({
+        after: new InstanceElement(
+          'instance',
+          workflowType,
+          {}
+        ),
+      })
+
+      await filter.deploy([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        toChange({
+          after: new InstanceElement(
+            'instance',
+            workflowType,
+            {},
+          ),
+        }),
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.Workflow.deployRequests,
+        [],
+        undefined
+      )
+    })
+
+    it('should not change the values if there are no rules', async () => {
+      const change = toChange({
+        after: new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            transitions: [
+              {
+                type: 'initial',
+              },
+            ],
+          }
+        ),
+      })
+
+      await filter.deploy([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        toChange({
+          after: new InstanceElement(
+            'instance',
+            workflowType,
+            {
+              transitions: [
+                {
+                  type: 'initial',
+                },
+              ],
+            },
+          ),
+        }),
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.Workflow.deployRequests,
+        [],
+        undefined
+      )
+    })
+
+    it('should not change the values if values are not a valid workflow', async () => {
+      const change = toChange({
+        after: new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            transitions: 2,
+          }
+        ),
+      })
+
+      await filter.deploy([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        toChange({
+          after: new InstanceElement(
+            'instance',
+            workflowType,
+            {
+              transitions: 2,
+            },
+          ),
+        }),
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.Workflow.deployRequests,
+        [],
+        undefined
+      )
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/workflow/workflow_properties_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_properties_filter.test.ts
@@ -15,11 +15,11 @@
 */
 import { ElemID, InstanceElement, ListType, ObjectType, toChange } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import JiraClient from '../../src/client/client'
-import { DEFAULT_CONFIG } from '../../src/config'
-import { JIRA } from '../../src/constants'
-import workflowPropertiesFilter from '../../src/filters/workflow/workflow_properties'
-import { mockClient } from '../utils'
+import JiraClient from '../../../src/client/client'
+import { DEFAULT_CONFIG } from '../../../src/config'
+import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import workflowPropertiesFilter from '../../../src/filters/workflow/workflow_properties_filter'
+import { mockClient } from '../../utils'
 
 describe('workflowPropertiesFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
@@ -29,7 +29,7 @@ describe('workflowPropertiesFilter', () => {
   beforeEach(async () => {
     workflowStatusType = new ObjectType({ elemID: new ElemID(JIRA, 'WorkflowStatus') })
     workflowType = new ObjectType({
-      elemID: new ElemID(JIRA, 'Workflow'),
+      elemID: new ElemID(JIRA, WORKFLOW_TYPE_NAME),
       fields: {
         statuses: { refType: new ListType(workflowStatusType) },
       },

--- a/packages/jira-adapter/test/filters/workflow/workflow_values.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_values.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { INITIAL_VALIDATOR } from '../../src/filters/workflow/workflow'
+import { INITIAL_VALIDATOR } from '../../../src/filters/workflow/workflow_deploy_filter'
 
 export const WITH_POST_FUNCTIONS = {
   transitions: [


### PR DESCRIPTION
Added the triggers of transitions to workflows (not deployable yet)

---

Added filter `transitionIds` to save the ids of the transition on the workflow and use them in `triggersFilter` to get the triggers of each workflow

I split the workflow filter to `workflowStructureFilter` and `workflowDeployFilter` so that's the changes in these filters

---
_Release Notes_: 
Jira Adapter:
- Added triggers to transitions in workflows

---
_User Notifications_: 
Jira Adapter:
Added triggers to transitions in workflows so workflows NaCls are going to change in existing workspaces