### PR TITLE
SALTO-1975 add suiteapp activation key

### DIFF
--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -148,7 +148,7 @@ export const getApprovedChanges = async (
 
 // TODO: SALTO-770 CLI should mask secret credentials based on adapter definition
 const isPasswordInputType = (fieldName: string): boolean =>
-  ['token', 'password', 'tokenId', 'tokenSecret', 'consumerKey', 'consumerSecret', 'suiteAppTokenId', 'suiteAppTokenSecret', 'clientSecret'].includes(fieldName)
+  ['token', 'password', 'tokenId', 'tokenSecret', 'consumerKey', 'consumerSecret', 'suiteAppTokenId', 'suiteAppTokenSecret', 'accountIdSignature', 'clientSecret'].includes(fieldName)
 
 export const getFieldInputType = (fieldType: TypeElement, fieldName: string): string => {
   if (!isPrimitiveType(fieldType) || fieldType.primitive === PrimitiveTypes.UNKNOWN) {

--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -148,7 +148,7 @@ export const getApprovedChanges = async (
 
 // TODO: SALTO-770 CLI should mask secret credentials based on adapter definition
 const isPasswordInputType = (fieldName: string): boolean =>
-  ['token', 'password', 'tokenId', 'tokenSecret', 'consumerKey', 'consumerSecret', 'suiteAppTokenId', 'suiteAppTokenSecret', 'accountIdSignature', 'clientSecret'].includes(fieldName)
+  ['token', 'password', 'tokenId', 'tokenSecret', 'consumerKey', 'consumerSecret', 'suiteAppTokenId', 'suiteAppTokenSecret', 'suiteAppActivationKey', 'clientSecret'].includes(fieldName)
 
 export const getFieldInputType = (fieldType: TypeElement, fieldName: string): string => {
   if (!isPrimitiveType(fieldType) || fieldType.primitive === PrimitiveTypes.UNKNOWN) {

--- a/packages/netsuite-adapter/e2e_test/credentials_store/adapter.ts
+++ b/packages/netsuite-adapter/e2e_test/credentials_store/adapter.ts
@@ -14,13 +14,16 @@
 * limitations under the License.
 */
 import { Adapter } from '@salto-io/e2e-credentials-store'
-import { Credentials } from '../../src/client/credentials'
-import SdfClient from '../../src/client/sdf_client'
+import NetsuiteClient from '../../src/client/client'
+import { Credentials, toCredentialsAccountId } from '../../src/client/credentials'
 
 type Args = {
   accountId: string
   tokenId: string
   tokenSecret: string
+  suiteAppTokenId: string
+  suiteAppTokenSecret: string
+  accountIdSignature: string
 }
 
 const adapter: Adapter<Args, Credentials> = {
@@ -38,14 +41,29 @@ const adapter: Adapter<Args, Credentials> = {
       type: 'string',
       demand: true,
     },
+    suiteAppTokenId: {
+      type: 'string',
+      demand: true,
+    },
+    suiteAppTokenSecret: {
+      type: 'string',
+      demand: true,
+    },
+    accountIdSignature: {
+      type: 'string',
+      demand: true,
+    },
   },
   credentials: async args => ({
-    accountId: args.accountId,
+    accountId: toCredentialsAccountId(args.accountId),
     tokenId: args.tokenId,
     tokenSecret: args.tokenSecret,
+    suiteAppTokenId: args.suiteAppTokenId,
+    suiteAppTokenSecret: args.suiteAppTokenSecret,
+    accountIdSignature: args.accountIdSignature,
   }),
   validateCredentials: credentials =>
-   SdfClient.validateCredentials(credentials) as unknown as Promise<void>,
+    NetsuiteClient.validateCredentials(credentials) as unknown as Promise<void>,
 }
 
 export default adapter

--- a/packages/netsuite-adapter/e2e_test/credentials_store/adapter.ts
+++ b/packages/netsuite-adapter/e2e_test/credentials_store/adapter.ts
@@ -23,7 +23,7 @@ type Args = {
   tokenSecret: string
   suiteAppTokenId: string
   suiteAppTokenSecret: string
-  accountIdSignature: string
+  suiteAppActivationKey: string
 }
 
 const adapter: Adapter<Args, Credentials> = {
@@ -49,7 +49,7 @@ const adapter: Adapter<Args, Credentials> = {
       type: 'string',
       demand: true,
     },
-    accountIdSignature: {
+    suiteAppActivationKey: {
       type: 'string',
       demand: true,
     },
@@ -60,7 +60,7 @@ const adapter: Adapter<Args, Credentials> = {
     tokenSecret: args.tokenSecret,
     suiteAppTokenId: args.suiteAppTokenId,
     suiteAppTokenSecret: args.suiteAppTokenSecret,
-    accountIdSignature: args.accountIdSignature,
+    suiteAppActivationKey: args.suiteAppActivationKey,
   }),
   validateCredentials: credentials =>
     NetsuiteClient.validateCredentials(credentials) as unknown as Promise<void>,

--- a/packages/netsuite-adapter/e2e_test/jest_environment.ts
+++ b/packages/netsuite-adapter/e2e_test/jest_environment.ts
@@ -31,6 +31,7 @@ export const credsSpec = (envName?: string): CredsSpec<Required<Credentials>> =>
   const tokenSecretEnvVarName = addEnvName('NS_TOKEN_SECRET')
   const suiteAppTokenIdEnvVarName = addEnvName('NS_SUITE_APP_TOKEN_ID')
   const suiteAppTokenSecretEnvVarName = addEnvName('NS_SUITE_APP_TOKEN_SECRET')
+  const accountIdSignatureEnvVarName = addEnvName('NS_SUITE_APP_ACCOUNT_ID_SIGNATURE')
   return {
     envHasCreds: env => accountIdEnvVarName in env,
     fromEnv: env => {
@@ -41,6 +42,7 @@ export const credsSpec = (envName?: string): CredsSpec<Required<Credentials>> =>
         tokenSecret: envUtils.required(tokenSecretEnvVarName),
         suiteAppTokenId: envUtils.required(suiteAppTokenIdEnvVarName),
         suiteAppTokenSecret: envUtils.required(suiteAppTokenSecretEnvVarName),
+        accountIdSignature: envUtils.required(accountIdSignatureEnvVarName),
       }
     },
     validate: async (_credentials: Credentials): Promise<void> => {

--- a/packages/netsuite-adapter/e2e_test/jest_environment.ts
+++ b/packages/netsuite-adapter/e2e_test/jest_environment.ts
@@ -31,7 +31,7 @@ export const credsSpec = (envName?: string): CredsSpec<Required<Credentials>> =>
   const tokenSecretEnvVarName = addEnvName('NS_TOKEN_SECRET')
   const suiteAppTokenIdEnvVarName = addEnvName('NS_SUITE_APP_TOKEN_ID')
   const suiteAppTokenSecretEnvVarName = addEnvName('NS_SUITE_APP_TOKEN_SECRET')
-  const accountIdSignatureEnvVarName = addEnvName('NS_SUITE_APP_ACCOUNT_ID_SIGNATURE')
+  const suiteAppActivationKeyEnvVarName = addEnvName('NS_SUITE_APP_ACTIVATION_KEY')
   return {
     envHasCreds: env => accountIdEnvVarName in env,
     fromEnv: env => {
@@ -42,7 +42,7 @@ export const credsSpec = (envName?: string): CredsSpec<Required<Credentials>> =>
         tokenSecret: envUtils.required(tokenSecretEnvVarName),
         suiteAppTokenId: envUtils.required(suiteAppTokenIdEnvVarName),
         suiteAppTokenSecret: envUtils.required(suiteAppTokenSecretEnvVarName),
-        accountIdSignature: envUtils.required(accountIdSignatureEnvVarName),
+        suiteAppActivationKey: envUtils.required(suiteAppActivationKeyEnvVarName),
       }
     },
     validate: async (_credentials: Credentials): Promise<void> => {

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -43,6 +43,7 @@
     "axios-mock-adapter": "^1.19.0",
     "axios-retry": "^3.1.9",
     "bottleneck": "^2.19.5",
+    "compare-versions": "4.1.3",
     "crypto": "^1.0.1",
     "fast-xml-parser": "^3.15.0",
     "he": "^1.2.0",

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -77,7 +77,7 @@ export const defaultCredentialsType = new ObjectType({
         message: 'Salto SuiteApp Token Secret (optional)',
       },
     },
-    accountIdSignature: {
+    suiteAppActivationKey: {
       refType: BuiltinTypes.STRING,
       annotations: {
         message: 'Salto SuiteApp Activation Key (optional)',
@@ -186,15 +186,15 @@ const throwOnMissingSuiteAppLoginCreds = (credentials: Credentials): void => {
   if (isSdfCredentialsOnly(credentials)) {
     return
   }
-  // accountIdSignature may be undefined but empty string is forbidden
-  if (isSuiteAppCredentials(credentials) && credentials.accountIdSignature !== '') {
+  // suiteAppActivationKey may be undefined but empty string is forbidden
+  if (isSuiteAppCredentials(credentials) && credentials.suiteAppActivationKey !== '') {
     return
   }
   const undefinedBaseCreds = [
     { key: 'suiteAppTokenId', value: credentials.suiteAppTokenId },
     { key: 'suiteAppTokenSecret', value: credentials.suiteAppTokenSecret },
   ].filter(item => !item.value).map(item => item.key)
-  const undefinedCreds = undefinedBaseCreds.concat(credentials.accountIdSignature === '' ? ['accountIdSignature'] : [])
+  const undefinedCreds = undefinedBaseCreds.concat(credentials.suiteAppActivationKey === '' ? ['suiteAppActivationKey'] : [])
   throw new Error(`Missing SuiteApp login creds: ${undefinedCreds.join(', ')}. Please login again.`)
 }
 
@@ -207,7 +207,7 @@ const netsuiteCredentialsFromCredentials = (
     tokenSecret: credsInstance.value.tokenSecret,
     suiteAppTokenId: credsInstance.value.suiteAppTokenId === '' ? undefined : credsInstance.value.suiteAppTokenId,
     suiteAppTokenSecret: credsInstance.value.suiteAppTokenSecret === '' ? undefined : credsInstance.value.suiteAppTokenSecret,
-    accountIdSignature: credsInstance.value.accountIdSignature,
+    suiteAppActivationKey: credsInstance.value.suiteAppActivationKey,
   }
   throwOnMissingSuiteAppLoginCreds(credentials)
   return credentials
@@ -225,7 +225,7 @@ const getAdapterOperations = (context: AdapterOperationsContext): AdapterOperati
       ),
   })
 
-  const suiteAppClient = isSuiteAppCredentials(credentials) && credentials.accountIdSignature
+  const suiteAppClient = isSuiteAppCredentials(credentials) && credentials.suiteAppActivationKey
     ? new SuiteAppClient({
       credentials,
       config: adapterConfig[SUITEAPP_CLIENT_CONFIG],

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -200,7 +200,7 @@ const throwOnMissingSuiteAppLoginCreds = (
     { key: 'suiteAppTokenId', value: credentials.suiteAppTokenId },
     { key: 'suiteAppTokenSecret', value: credentials.suiteAppTokenSecret },
     { key: 'accountIdSignature', value: credentials.accountIdSignature },
-  ].filter(item => item.value === undefined).map(item => item.key)
+  ].filter(item => !item.value).map(item => item.key)
   throw new Error(`Missing SuiteApp login creds: ${undefinedCreds.join(', ')}. Please authenticate using 'salto service login'`)
 }
 

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -68,19 +68,19 @@ export const defaultCredentialsType = new ObjectType({
     suiteAppTokenId: {
       refType: BuiltinTypes.STRING,
       annotations: {
-        message: 'Salto SuiteApp Token ID (empty if Salto SuiteApp is not installed)',
+        message: 'Salto SuiteApp Token ID (optional)',
       },
     },
     suiteAppTokenSecret: {
       refType: BuiltinTypes.STRING,
       annotations: {
-        message: 'Salto SuiteApp Token Secret (empty if Salto SuiteApp is not installed)',
+        message: 'Salto SuiteApp Token Secret (optional)',
       },
     },
     accountIdSignature: {
       refType: BuiltinTypes.STRING,
       annotations: {
-        message: 'Salto SuiteApp Account ID Signature (empty if Salto SuiteApp is not installed)',
+        message: 'Salto SuiteApp Activation Key (optional)',
       },
     },
   },
@@ -195,7 +195,7 @@ const throwOnMissingSuiteAppLoginCreds = (credentials: Credentials): void => {
     { key: 'suiteAppTokenSecret', value: credentials.suiteAppTokenSecret },
   ].filter(item => !item.value).map(item => item.key)
   const undefinedCreds = undefinedBaseCreds.concat(credentials.accountIdSignature === '' ? ['accountIdSignature'] : [])
-  throw new Error(`Missing SuiteApp login creds: ${undefinedCreds.join(', ')}. Please authenticate using 'salto service login'`)
+  throw new Error(`Missing SuiteApp login creds: ${undefinedCreds.join(', ')}. Please login again.`)
 }
 
 const netsuiteCredentialsFromCredentials = (

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -66,16 +66,13 @@ export default class NetsuiteClient {
   static async validateCredentials(credentials: Credentials): Promise<AccountId> {
     if (isSuiteAppCredentials(credentials)) {
       try {
-        await SuiteAppClient.validateCredentials({
-          accountId: credentials.accountId,
-          suiteAppTokenId: credentials.suiteAppTokenId,
-          suiteAppTokenSecret: credentials.suiteAppTokenSecret,
-          accountIdSignature: credentials.accountIdSignature,
-        })
+        await SuiteAppClient.validateCredentials(credentials)
       } catch (e) {
         e.message = `Salto SuiteApp Authentication failed. ${e.message}`
         throw e
       }
+    } else {
+      log.debug('SuiteApp is not configured - skipping SuiteApp credentials validation')
     }
 
     try {

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -21,7 +21,7 @@ import { resolveValues } from '@salto-io/adapter-utils'
 import { WSDL } from 'soap'
 import _ from 'lodash'
 import { NetsuiteQuery } from '../query'
-import { Credentials, toUrlAccountId } from './credentials'
+import { Credentials, isSuiteAppCredentials, toUrlAccountId } from './credentials'
 import SdfClient from './sdf_client'
 import SuiteAppClient from './suiteapp_client/suiteapp_client'
 import { createSuiteAppFileCabinetOperations, SuiteAppFileCabinetOperations, DeployType } from '../suiteapp_file_cabinet'
@@ -64,12 +64,13 @@ export default class NetsuiteClient {
 
   @NetsuiteClient.logDecorator
   static async validateCredentials(credentials: Credentials): Promise<AccountId> {
-    if (credentials.suiteAppTokenId && credentials.suiteAppTokenSecret) {
+    if (isSuiteAppCredentials(credentials)) {
       try {
         await SuiteAppClient.validateCredentials({
           accountId: credentials.accountId,
           suiteAppTokenId: credentials.suiteAppTokenId,
           suiteAppTokenSecret: credentials.suiteAppTokenSecret,
+          accountIdSignature: credentials.accountIdSignature,
         })
       } catch (e) {
         e.message = `Salto SuiteApp Authentication failed. ${e.message}`

--- a/packages/netsuite-adapter/src/client/credentials.ts
+++ b/packages/netsuite-adapter/src/client/credentials.ts
@@ -17,7 +17,7 @@ export type SuiteAppCredentials = {
   accountId: string
   suiteAppTokenId: string
   suiteAppTokenSecret: string
-  accountIdSignature: string
+  accountIdSignature?: string
 }
 
 export type SuiteAppSoapCredentials = Omit<SuiteAppCredentials, 'accountIdSignature'>
@@ -35,7 +35,13 @@ export const isSuiteAppCredentials = (
 ): credentials is SdfCredentials & SuiteAppCredentials =>
   credentials.suiteAppTokenId !== undefined
   && credentials.suiteAppTokenSecret !== undefined
-  && credentials.accountIdSignature !== undefined
+
+export const isSdfCredentialsOnly = (
+  credentials: Credentials
+): boolean =>
+  credentials.suiteAppTokenId === undefined
+  && credentials.suiteAppTokenSecret === undefined
+  && credentials.accountIdSignature === undefined
 
 export const toUrlAccountId = (accountId: string): string => accountId.toLowerCase().replace('_', '-')
 

--- a/packages/netsuite-adapter/src/client/credentials.ts
+++ b/packages/netsuite-adapter/src/client/credentials.ts
@@ -17,10 +17,10 @@ export type SuiteAppCredentials = {
   accountId: string
   suiteAppTokenId: string
   suiteAppTokenSecret: string
-  accountIdSignature?: string
+  suiteAppActivationKey?: string
 }
 
-export type SuiteAppSoapCredentials = Omit<SuiteAppCredentials, 'accountIdSignature'>
+export type SuiteAppSoapCredentials = Omit<SuiteAppCredentials, 'suiteAppActivationKey'>
 
 export type SdfCredentials = {
   accountId: string

--- a/packages/netsuite-adapter/src/client/credentials.ts
+++ b/packages/netsuite-adapter/src/client/credentials.ts
@@ -41,7 +41,6 @@ export const isSdfCredentialsOnly = (
 ): boolean =>
   credentials.suiteAppTokenId === undefined
   && credentials.suiteAppTokenSecret === undefined
-  && credentials.accountIdSignature === undefined
 
 export const toUrlAccountId = (accountId: string): string => accountId.toLowerCase().replace('_', '-')
 

--- a/packages/netsuite-adapter/src/client/credentials.ts
+++ b/packages/netsuite-adapter/src/client/credentials.ts
@@ -17,7 +17,10 @@ export type SuiteAppCredentials = {
   accountId: string
   suiteAppTokenId: string
   suiteAppTokenSecret: string
+  accountIdSignature: string
 }
+
+export type SuiteAppSoapCredentials = Omit<SuiteAppCredentials, 'accountIdSignature'>
 
 export type SdfCredentials = {
   accountId: string
@@ -26,6 +29,13 @@ export type SdfCredentials = {
 }
 
 export type Credentials = SdfCredentials & Partial<SuiteAppCredentials>
+
+export const isSuiteAppCredentials = (
+  credentials: Credentials
+): credentials is SdfCredentials & SuiteAppCredentials =>
+  credentials.suiteAppTokenId !== undefined
+  && credentials.suiteAppTokenSecret !== undefined
+  && credentials.accountIdSignature !== undefined
 
 export const toUrlAccountId = (accountId: string): string => accountId.toLowerCase().replace('_', '-')
 

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -22,7 +22,7 @@ import _ from 'lodash'
 import { InstanceElement, isListType, isObjectType, ObjectType } from '@salto-io/adapter-api'
 import { collections, decorators, strings } from '@salto-io/lowerdash'
 import { v4 as uuidv4 } from 'uuid'
-import { SuiteAppCredentials, toUrlAccountId } from '../../credentials'
+import { SuiteAppSoapCredentials, toUrlAccountId } from '../../credentials'
 import { CONSUMER_KEY, CONSUMER_SECRET } from '../constants'
 import { ReadFileError } from '../errors'
 import { CallsLimiter, ExistingFileCabinetInstanceDetails, FileCabinetInstanceDetails, FileDetails, FolderDetails } from '../types'
@@ -93,12 +93,12 @@ const retryOnBadResponseWithDelay = (
 const retryOnBadResponse = retryOnBadResponseWithDelay(RETRYABLE_MESSAGES)
 
 export default class SoapClient {
-  private credentials: SuiteAppCredentials
+  private credentials: SuiteAppSoapCredentials
   private callsLimiter: CallsLimiter
   private ajv: Ajv
   private client: soap.Client | undefined
 
-  constructor(credentials: SuiteAppCredentials, callsLimiter: CallsLimiter) {
+  constructor(credentials: SuiteAppSoapCredentials, callsLimiter: CallsLimiter) {
     this.credentials = credentials
     this.callsLimiter = callsLimiter
     this.ajv = new Ajv({ allErrors: true, strict: false })

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -197,7 +197,7 @@ export default class SuiteAppClient {
 
   public static async validateCredentials(credentials: SuiteAppCredentials): Promise<void> {
     const client = new SuiteAppClient({ credentials, globalLimiter: new Bottleneck() })
-    await client.sendRestletRequest('sysInfo', {}, true)
+    await client.sendRestletRequest('sysInfo', {})
   }
 
   private async safeAxiosPost(
@@ -252,12 +252,8 @@ export default class SuiteAppClient {
 
   private async sendRestletRequest(
     operation: RestletOperation,
-    args: Record<string, unknown> = {},
-    allowSignatureUndefined = false
+    args: Record<string, unknown> = {}
   ): Promise<unknown> {
-    if (!this.credentials.accountIdSignature && !allowSignatureUndefined) {
-      throw new Error('Got forbidden undefined parameter: accountIdSignature')
-    }
     const response = await this.safeAxiosPost(
       this.restletUrl.href,
       this.useSignatureInRestletRequests && this.credentials.accountIdSignature

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -294,12 +294,6 @@ export default class SuiteAppClient {
       }
       log.debug('set SuiteApp version features successfully', { versionFeatures: this.versionFeatures })
     })
-
-    if (this.versionFeatures) {
-      return
-    }
-
-    throw new Error('failed setting SuiteApp version features')
   }
 
   private async innerSendRestletRequest(

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -90,8 +90,7 @@ export default class SuiteAppClient {
 
     const accountIdUrl = toUrlAccountId(params.credentials.accountId)
     this.suiteQLUrl = new URL(`https://${accountIdUrl}.suitetalk.api.netsuite.com/services/rest/query/v1/suiteql`)
-    // this.restletUrl = new URL(`https://${accountIdUrl}.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=customscript_salto_restlet&deploy=customdeploy_salto_restlet`)
-    this.restletUrl = new URL(`https://${accountIdUrl}.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=24&deploy=5`)
+    this.restletUrl = new URL(`https://${accountIdUrl}.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=customscript_salto_restlet&deploy=customdeploy_salto_restlet`)
 
     this.ajv = new Ajv({ allErrors: true, strict: false })
     this.soapClient = new SoapClient(this.credentials, this.callsLimiter)

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -120,18 +120,8 @@ describe('NetsuiteAdapter creator', () => {
       }
 
       await adapter.validateCredentials(cred)
-      expect(netsuiteValidateMock).toHaveBeenCalledWith(expect.objectContaining({
-        accountId: 'FOO_A',
-        tokenId: 'bar',
-        tokenSecret: 'secret',
-      }))
-
-      expect(suiteAppClientValidateMock).toHaveBeenCalledWith({
-        accountId: 'FOO_A',
-        suiteAppTokenId: 'aaa',
-        suiteAppTokenSecret: 'bbb',
-        accountIdSignature: 'signature',
-      })
+      expect(netsuiteValidateMock).toHaveBeenCalledWith({ ...cred.value, accountId: 'FOO_A' })
+      expect(suiteAppClientValidateMock).toHaveBeenCalledWith({ ...cred.value, accountId: 'FOO_A' })
     })
 
     it('SDF validation failure should throw SDF error', async () => {
@@ -228,12 +218,7 @@ describe('NetsuiteAdapter creator', () => {
         elementsSource: buildElementsSourceFromElements([]),
       })
       expect(SuiteAppClient).toHaveBeenCalledWith({
-        credentials: {
-          accountId: 'FOO_A',
-          suiteAppTokenId: 'aaa',
-          suiteAppTokenSecret: 'bbb',
-          accountIdSignature: 'signature',
-        },
+        credentials: { ...cred.value, accountId: 'FOO_A' },
         globalLimiter: expect.any(Bottleneck),
       })
     })
@@ -261,12 +246,7 @@ describe('NetsuiteAdapter creator', () => {
         elementsSource: buildElementsSourceFromElements([]),
       })
       expect(SuiteAppClient).toHaveBeenCalledWith({
-        credentials: {
-          accountId: 'FOO_A',
-          suiteAppTokenId: 'aaa',
-          suiteAppTokenSecret: 'bbb',
-          accountIdSignature: 'signature',
-        },
+        credentials: { ...cred.value, accountId: 'FOO_A' },
         config: {
           [SUITEAPP_CONCURRENCY_LIMIT]: 5,
         },

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -62,6 +62,7 @@ describe('NetsuiteAdapter creator', () => {
       tokenSecret: 'secret',
       suiteAppTokenId: '',
       suiteAppTokenSecret: '',
+      accountIdSignature: '',
     },
   )
 
@@ -115,6 +116,7 @@ describe('NetsuiteAdapter creator', () => {
         ...cred.value,
         suiteAppTokenId: 'aaa',
         suiteAppTokenSecret: 'bbb',
+        accountIdSignature: 'signature',
       }
 
       await adapter.validateCredentials(cred)
@@ -128,6 +130,7 @@ describe('NetsuiteAdapter creator', () => {
         accountId: 'FOO_A',
         suiteAppTokenId: 'aaa',
         suiteAppTokenSecret: 'bbb',
+        accountIdSignature: 'signature',
       })
     })
 
@@ -140,6 +143,7 @@ describe('NetsuiteAdapter creator', () => {
         ...cred.value,
         suiteAppTokenId: 'aaa',
         suiteAppTokenSecret: 'bbb',
+        accountIdSignature: 'signature',
       }
 
       await expect(adapter.validateCredentials(cred)).rejects.toThrow('SDF Authentication failed.')
@@ -153,6 +157,7 @@ describe('NetsuiteAdapter creator', () => {
         ...cred.value,
         suiteAppTokenId: 'aaa',
         suiteAppTokenSecret: 'bbb',
+        accountIdSignature: 'signature',
       }
 
       await expect(adapter.validateCredentials(cred)).rejects.toThrow('SuiteApp Authentication failed.')
@@ -174,6 +179,7 @@ describe('NetsuiteAdapter creator', () => {
           tokenSecret: 'secret',
           suiteAppTokenId: undefined,
           suiteAppTokenSecret: undefined,
+          accountIdSignature: undefined,
         },
         config: clientConfig,
         globalLimiter: expect.any(Bottleneck),
@@ -191,12 +197,29 @@ describe('NetsuiteAdapter creator', () => {
       expect(SuiteAppClient).not.toHaveBeenCalled()
     })
 
+    it('should throw when missing account id signature', () => {
+      const cred = credentials.clone()
+      cred.value = {
+        ...cred.value,
+        suiteAppTokenId: 'aaa',
+        suiteAppTokenSecret: 'bbb',
+        accountIdSignature: '',
+      }
+
+      expect(() => adapter.operations({
+        credentials: cred,
+        config,
+        elementsSource: buildElementsSourceFromElements([]),
+      })).toThrow('Missing SuiteApp login creds')
+    })
+
     it('should create the client if credentials were passed', () => {
       const cred = credentials.clone()
       cred.value = {
         ...cred.value,
         suiteAppTokenId: 'aaa',
         suiteAppTokenSecret: 'bbb',
+        accountIdSignature: 'signature',
       }
 
       adapter.operations({
@@ -209,6 +232,7 @@ describe('NetsuiteAdapter creator', () => {
           accountId: 'FOO_A',
           suiteAppTokenId: 'aaa',
           suiteAppTokenSecret: 'bbb',
+          accountIdSignature: 'signature',
         },
         globalLimiter: expect.any(Bottleneck),
       })
@@ -220,6 +244,7 @@ describe('NetsuiteAdapter creator', () => {
         ...cred.value,
         suiteAppTokenId: 'aaa',
         suiteAppTokenSecret: 'bbb',
+        accountIdSignature: 'signature',
       }
 
       const configuration = config.clone()
@@ -240,6 +265,7 @@ describe('NetsuiteAdapter creator', () => {
           accountId: 'FOO_A',
           suiteAppTokenId: 'aaa',
           suiteAppTokenSecret: 'bbb',
+          accountIdSignature: 'signature',
         },
         config: {
           [SUITEAPP_CONCURRENCY_LIMIT]: 5,

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -62,7 +62,6 @@ describe('NetsuiteAdapter creator', () => {
       tokenSecret: 'secret',
       suiteAppTokenId: '',
       suiteAppTokenSecret: '',
-      accountIdSignature: '',
     },
   )
 
@@ -169,7 +168,6 @@ describe('NetsuiteAdapter creator', () => {
           tokenSecret: 'secret',
           suiteAppTokenId: undefined,
           suiteAppTokenSecret: undefined,
-          accountIdSignature: undefined,
         },
         config: clientConfig,
         globalLimiter: expect.any(Bottleneck),

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -115,7 +115,7 @@ describe('NetsuiteAdapter creator', () => {
         ...cred.value,
         suiteAppTokenId: 'aaa',
         suiteAppTokenSecret: 'bbb',
-        accountIdSignature: 'signature',
+        suiteAppActivationKey: 'ccc',
       }
 
       await adapter.validateCredentials(cred)
@@ -132,7 +132,7 @@ describe('NetsuiteAdapter creator', () => {
         ...cred.value,
         suiteAppTokenId: 'aaa',
         suiteAppTokenSecret: 'bbb',
-        accountIdSignature: 'signature',
+        suiteAppActivationKey: 'ccc',
       }
 
       await expect(adapter.validateCredentials(cred)).rejects.toThrow('SDF Authentication failed.')
@@ -146,7 +146,7 @@ describe('NetsuiteAdapter creator', () => {
         ...cred.value,
         suiteAppTokenId: 'aaa',
         suiteAppTokenSecret: 'bbb',
-        accountIdSignature: 'signature',
+        suiteAppActivationKey: 'ccc',
       }
 
       await expect(adapter.validateCredentials(cred)).rejects.toThrow('SuiteApp Authentication failed.')
@@ -185,13 +185,13 @@ describe('NetsuiteAdapter creator', () => {
       expect(SuiteAppClient).not.toHaveBeenCalled()
     })
 
-    it('should throw when missing account id signature', () => {
+    it('should throw when missing activation key', () => {
       const cred = credentials.clone()
       cred.value = {
         ...cred.value,
         suiteAppTokenId: 'aaa',
         suiteAppTokenSecret: 'bbb',
-        accountIdSignature: '',
+        suiteAppActivationKey: '',
       }
 
       expect(() => adapter.operations({
@@ -207,7 +207,7 @@ describe('NetsuiteAdapter creator', () => {
         ...cred.value,
         suiteAppTokenId: 'aaa',
         suiteAppTokenSecret: 'bbb',
-        accountIdSignature: 'signature',
+        suiteAppActivationKey: 'ccc',
       }
 
       adapter.operations({
@@ -227,7 +227,7 @@ describe('NetsuiteAdapter creator', () => {
         ...cred.value,
         suiteAppTokenId: 'aaa',
         suiteAppTokenSecret: 'bbb',
-        accountIdSignature: 'signature',
+        suiteAppActivationKey: 'ccc',
       }
 
       const configuration = config.clone()

--- a/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
@@ -474,5 +474,15 @@ describe('SuiteAppClient', () => {
       expect(client.getVersionFeatures()).toEqual({ signature: true })
       expect(mockAxiosAdapter.history.post.length).toEqual(3)
     })
+    it('should not set versionFeatures when getting invalid results', async () => {
+      mockAxiosAdapter.onPost().reply(200, {
+        status: 'success',
+        results: {
+          time: 1000,
+        },
+      })
+      await client.getSystemInformation()
+      expect(client.getVersionFeatures()).toBeUndefined()
+    })
   })
 })

--- a/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
@@ -294,18 +294,6 @@ describe('SuiteAppClient', () => {
         mockAxiosAdapter.onPost().reply(200, { status: 'success', results: {} })
         expect(await client.getSystemInformation()).toBeUndefined()
       })
-      it('should throw when no signature', async () => {
-        const clientWithoutSignature = new SuiteAppClient({
-          credentials: {
-            accountId: 'ACCOUNT_ID',
-            suiteAppTokenId: 'tokenId',
-            suiteAppTokenSecret: 'tokenSecret',
-          },
-          globalLimiter: new Bottleneck(),
-        })
-        expect(await clientWithoutSignature.getSystemInformation()).toBeUndefined()
-        expect(mockAxiosAdapter.history.post.length).toEqual(0)
-      })
     })
   })
 

--- a/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
@@ -42,7 +42,7 @@ describe('SuiteAppClient', () => {
           accountId: 'ACCOUNT_ID',
           suiteAppTokenId: 'tokenId',
           suiteAppTokenSecret: 'tokenSecret',
-          accountIdSignature: 'signature',
+          suiteAppActivationKey: 'activationKey',
         },
         globalLimiter: new Bottleneck(),
       })
@@ -149,7 +149,7 @@ describe('SuiteAppClient', () => {
         expect(req.url).toEqual('https://account-id.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=customscript_salto_restlet&deploy=customdeploy_salto_restlet')
         expect(JSON.parse(req.data)).toEqual({
           operation: 'search',
-          signature: 'signature',
+          activationKey: 'activationKey',
           args: {
             type: 'type',
             columns: [],
@@ -224,7 +224,7 @@ describe('SuiteAppClient', () => {
 
         expect(JSON.parse(requests[0].data)).toEqual({
           operation: 'search',
-          signature: 'signature',
+          activationKey: 'activationKey',
           args: {
             type: 'type',
             columns: [],
@@ -236,7 +236,7 @@ describe('SuiteAppClient', () => {
 
         expect(JSON.parse(requests[1].data)).toEqual({
           operation: 'search',
-          signature: 'signature',
+          activationKey: 'activationKey',
           args: {
             type: 'type',
             columns: [],
@@ -265,7 +265,7 @@ describe('SuiteAppClient', () => {
         const req = mockAxiosAdapter.history.post[0]
         expect(JSON.parse(req.data)).toEqual({
           operation: 'sysInfo',
-          signature: 'signature',
+          activationKey: 'activationKey',
           args: {},
         })
       })
@@ -331,7 +331,7 @@ describe('SuiteAppClient', () => {
         expect(req.url).toEqual('https://account-id.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=customscript_salto_restlet&deploy=customdeploy_salto_restlet')
         expect(JSON.parse(req.data)).toEqual({
           operation: 'readFile',
-          signature: 'signature',
+          activationKey: 'activationKey',
           args: {
             ids: [1, 2, 3, 4, 5],
           },
@@ -381,12 +381,12 @@ describe('SuiteAppClient', () => {
           accountId: 'ACCOUNT_ID',
           suiteAppTokenId: 'tokenId',
           suiteAppTokenSecret: 'tokenSecret',
-          accountIdSignature: 'signature',
+          suiteAppActivationKey: 'activationKey',
         },
       )).rejects.toThrow()
     })
 
-    it('should succeed with signature', async () => {
+    it('should succeed with activationKey', async () => {
       mockAxiosAdapter.onPost().reply(200, {
         status: 'success',
         results: {
@@ -400,11 +400,11 @@ describe('SuiteAppClient', () => {
           accountId: 'ACCOUNT_ID',
           suiteAppTokenId: 'tokenId',
           suiteAppTokenSecret: 'tokenSecret',
-          accountIdSignature: 'signature',
+          suiteAppActivationKey: 'activationKey',
         },
       )).resolves.toBeUndefined()
     })
-    it('should succeed without signature', async () => {
+    it('should succeed without activationKey', async () => {
       mockAxiosAdapter.onPost().reply(200, {
         status: 'success',
         results: {
@@ -431,7 +431,7 @@ describe('SuiteAppClient', () => {
           accountId: 'ACCOUNT_ID',
           suiteAppTokenId: 'tokenId',
           suiteAppTokenSecret: 'tokenSecret',
-          accountIdSignature: 'signature',
+          suiteAppActivationKey: 'activationKey',
         },
         globalLimiter: new Bottleneck(),
       })
@@ -445,7 +445,7 @@ describe('SuiteAppClient', () => {
         },
       })
       await client.getSystemInformation()
-      expect(client.getVersionFeatures()).toEqual({ signature: false })
+      expect(client.getVersionFeatures()).toEqual({ activationKey: false })
     })
     it('should set new versionFeatures', async () => {
       mockAxiosAdapter.onPost().reply(200, {
@@ -456,7 +456,7 @@ describe('SuiteAppClient', () => {
         },
       })
       await client.getSystemInformation()
-      expect(client.getVersionFeatures()).toEqual({ signature: true })
+      expect(client.getVersionFeatures()).toEqual({ activationKey: true })
     })
     it('should set versionFeatures once on parallel request', async () => {
       mockAxiosAdapter.onPost().reply(200, {
@@ -471,7 +471,7 @@ describe('SuiteAppClient', () => {
         client.getSystemInformation(),
         client.getSystemInformation(),
       ])
-      expect(client.getVersionFeatures()).toEqual({ signature: true })
+      expect(client.getVersionFeatures()).toEqual({ activationKey: true })
       expect(mockAxiosAdapter.history.post.length).toEqual(3)
     })
     it('should not set versionFeatures when getting invalid results', async () => {

--- a/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
@@ -25,243 +25,232 @@ import { InvalidSuiteAppCredentialsError } from '../../src/client/types'
 
 describe('SuiteAppClient', () => {
   let mockAxiosAdapter: MockAdapter
-  let client: SuiteAppClient
+
   beforeEach(() => {
     mockAxiosAdapter = new MockAdapter(axios, { delayResponse: 1, onNoMatch: 'throwException' })
-
-    client = new SuiteAppClient({
-      credentials: {
-        accountId: 'ACCOUNT_ID',
-        suiteAppTokenId: 'tokenId',
-        suiteAppTokenSecret: 'tokenSecret',
-        accountIdSignature: 'signature',
-      },
-      globalLimiter: new Bottleneck(),
-    })
   })
 
   afterEach(() => {
     mockAxiosAdapter.restore()
   })
 
-  describe('runSuiteQL', () => {
-    it('successful query should return the results', async () => {
-      mockAxiosAdapter.onPost().reply(200, {
-        hasMore: false,
-        items: [{ links: [], a: 1 }, { links: [], a: 2 }],
-      })
-
-      const results = await client.runSuiteQL('query')
-
-      expect(results).toEqual([{ a: 1 }, { a: 2 }])
-      expect(mockAxiosAdapter.history.post.length).toBe(1)
-      const req = mockAxiosAdapter.history.post[0]
-      expect(req.url).toEqual('https://account-id.suitetalk.api.netsuite.com/services/rest/query/v1/suiteql?limit=1000&offset=0')
-      expect(JSON.parse(req.data)).toEqual({ q: 'query' })
-      expect(req.headers).toEqual({
-        Authorization: expect.any(String),
-        'Content-Type': 'application/json',
-        Accept: 'application/json, text/plain, */*',
-        prefer: 'transient',
-      })
-    })
-
-    it('should return all pages', async () => {
-      const range = _.range(1500)
-      const items = range.map(i => ({ i }))
-      const chunks = range.filter(i => i % PAGE_SIZE === 0)
-
-      chunks.forEach(offset => {
-        mockAxiosAdapter.onPost(new RegExp(`.*limit=${PAGE_SIZE}.*offset=${offset}`)).reply(200, {
-          hasMore: offset + PAGE_SIZE < items.length,
-          items: items.slice(offset, offset + PAGE_SIZE).map(item => ({ ...item, links: [] })),
-        })
-      })
-
-      const results = await client.runSuiteQL('query')
-
-      expect(results).toEqual(items)
-      expect(mockAxiosAdapter.history.post.length).toBe(2)
-      const requests = mockAxiosAdapter.history.post
-      expect(requests[0].url).toEqual('https://account-id.suitetalk.api.netsuite.com/services/rest/query/v1/suiteql?limit=1000&offset=0')
-      expect(requests[1].url).toEqual('https://account-id.suitetalk.api.netsuite.com/services/rest/query/v1/suiteql?limit=1000&offset=1000')
-    })
-
-    it('should throw InvalidSuiteAppCredentialsError', async () => {
-      mockAxiosAdapter.onPost().reply(401, 'Invalid SuiteApp credentials')
-      await expect(client.runSuiteQL('query')).rejects.toThrow(InvalidSuiteAppCredentialsError)
-    })
-
-    describe('query failure', () => {
-      it('exception thrown', async () => {
-        mockAxiosAdapter.onPost().reply(() => [])
-        expect(await client.runSuiteQL('')).toBeUndefined()
-      })
-      it('with retry', async () => {
-        jest.spyOn(global, 'setTimeout').mockImplementation((cb: TimerHandler) => (_.isFunction(cb) ? cb() : undefined))
-        mockAxiosAdapter
-          .onPost().replyOnce(429)
-          .onPost().replyOnce(200, {
-            hasMore: false,
-            items: [{ links: [], a: 1 }, { links: [], a: 2 }],
-          })
-
-        expect(await client.runSuiteQL('query')).toEqual([{ a: 1 }, { a: 2 }])
-        expect(mockAxiosAdapter.history.post.length).toBe(2)
-      })
-      it('invalid results', async () => {
-        mockAxiosAdapter.onPost().reply(200, {})
-        expect(await client.runSuiteQL('')).toBeUndefined()
-      })
-    })
-  })
-
-  describe('runSavedSearchQuery', () => {
-    it('successful query should return the results', async () => {
-      mockAxiosAdapter.onPost().reply(200, {
-        status: 'success',
-        results: [{ a: 1 }, { a: 2 }],
-      })
-
-      const results = await client.runSavedSearchQuery({
-        type: 'type',
-        columns: [],
-        filters: [],
-      })
-
-      expect(results).toEqual([{ a: 1 }, { a: 2 }])
-      expect(mockAxiosAdapter.history.post.length).toBe(1)
-      const req = mockAxiosAdapter.history.post[0]
-      expect(req.url).toEqual('https://account-id.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=customscript_salto_restlet&deploy=customdeploy_salto_restlet')
-      expect(JSON.parse(req.data)).toEqual({
-        operation: 'search',
-        signature: 'signature',
-        args: {
-          type: 'type',
-          columns: [],
-          filters: [],
-          offset: 0,
-          limit: 1000,
+  describe('SuiteApp client', () => {
+    let client: SuiteAppClient
+    beforeEach(async () => {
+      client = new SuiteAppClient({
+        credentials: {
+          accountId: 'ACCOUNT_ID',
+          suiteAppTokenId: 'tokenId',
+          suiteAppTokenSecret: 'tokenSecret',
+          accountIdSignature: 'signature',
         },
-      })
-    })
-
-    describe('query failure', () => {
-      it('exception thrown', async () => {
-        mockAxiosAdapter.onPost().reply(() => [])
-        expect(await client.runSavedSearchQuery({
-          type: 'type',
-          columns: [],
-          filters: [],
-        })).toBeUndefined()
+        globalLimiter: new Bottleneck(),
       })
 
-      it('invalid saved search results', async () => {
-        mockAxiosAdapter.onPost().reply(200, { status: 'success', results: {} })
-        expect(await client.runSavedSearchQuery({
-          type: 'type',
-          columns: [],
-          filters: [],
-        })).toBeUndefined()
-      })
-
-      it('invalid restlet results', async () => {
-        mockAxiosAdapter.onPost().reply(200, {})
-        expect(await client.runSavedSearchQuery({
-          type: 'type',
-          columns: [],
-          filters: [],
-        })).toBeUndefined()
-      })
-
-      it('error status', async () => {
-        mockAxiosAdapter.onPost().reply(200, { status: 'error', message: '', error: new Error('error') })
-        expect(await client.runSavedSearchQuery({
-          type: 'type',
-          columns: [],
-          filters: [],
-        })).toBeUndefined()
-      })
-    })
-
-    it('should return all pages', async () => {
-      const items = _.range(1500).map(i => ({ i }))
-
-      mockAxiosAdapter.onPost().reply(({ data }) => {
-        const { args } = JSON.parse(data)
-        return [
-          200,
-          {
-            status: 'success',
-            results: items.slice(args.offset, args.offset + args.limit),
-          },
-        ]
-      })
-
-      const results = await client.runSavedSearchQuery({
-        type: 'type',
-        columns: [],
-        filters: [],
-      })
-
-      expect(results).toEqual(items)
-      expect(mockAxiosAdapter.history.post.length).toBe(2)
-      const requests = mockAxiosAdapter.history.post
-
-      expect(JSON.parse(requests[0].data)).toEqual({
-        operation: 'search',
-        signature: 'signature',
-        args: {
-          type: 'type',
-          columns: [],
-          filters: [],
-          offset: 0,
-          limit: 1000,
-        },
-      })
-
-      expect(JSON.parse(requests[1].data)).toEqual({
-        operation: 'search',
-        signature: 'signature',
-        args: {
-          type: 'type',
-          columns: [],
-          filters: [],
-          offset: 1000,
-          limit: 1000,
-        },
-      })
-    })
-  })
-
-  describe('getSystemInformation', () => {
-    it('successful request should return the results', async () => {
-      mockAxiosAdapter.onPost().reply(200, {
+      mockAxiosAdapter.onPost().replyOnce(200, {
         status: 'success',
         results: {
           appVersion: [0, 1, 2],
           time: 1000,
         },
       })
+      await client.getSystemInformation()
+      mockAxiosAdapter.resetHistory()
+    })
 
-      const results = await client.getSystemInformation()
+    describe('runSuiteQL', () => {
+      it('successful query should return the results', async () => {
+        mockAxiosAdapter.onPost().reply(200, {
+          hasMore: false,
+          items: [{ links: [], a: 1 }, { links: [], a: 2 }],
+        })
 
-      expect(results).toEqual({ appVersion: [0, 1, 2], time: new Date(1000) })
-      expect(mockAxiosAdapter.history.post.length).toBe(1)
-      const req = mockAxiosAdapter.history.post[0]
-      expect(JSON.parse(req.data)).toEqual({
-        operation: 'sysInfo',
-        signature: 'signature',
-        args: {},
+        const results = await client.runSuiteQL('query')
+
+        expect(results).toEqual([{ a: 1 }, { a: 2 }])
+        expect(mockAxiosAdapter.history.post.length).toBe(1)
+        const req = mockAxiosAdapter.history.post[0]
+        expect(req.url).toEqual('https://account-id.suitetalk.api.netsuite.com/services/rest/query/v1/suiteql?limit=1000&offset=0')
+        expect(JSON.parse(req.data)).toEqual({ q: 'query' })
+        expect(req.headers).toEqual({
+          Authorization: expect.any(String),
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/plain, */*',
+          prefer: 'transient',
+        })
+      })
+
+      it('should return all pages', async () => {
+        const range = _.range(1500)
+        const items = range.map(i => ({ i }))
+        const chunks = range.filter(i => i % PAGE_SIZE === 0)
+
+        chunks.forEach(offset => {
+          mockAxiosAdapter.onPost(new RegExp(`.*limit=${PAGE_SIZE}.*offset=${offset}`)).reply(200, {
+            hasMore: offset + PAGE_SIZE < items.length,
+            items: items.slice(offset, offset + PAGE_SIZE).map(item => ({ ...item, links: [] })),
+          })
+        })
+
+        const results = await client.runSuiteQL('query')
+
+        expect(results).toEqual(items)
+        expect(mockAxiosAdapter.history.post.length).toBe(2)
+        const requests = mockAxiosAdapter.history.post
+        expect(requests[0].url).toEqual('https://account-id.suitetalk.api.netsuite.com/services/rest/query/v1/suiteql?limit=1000&offset=0')
+        expect(requests[1].url).toEqual('https://account-id.suitetalk.api.netsuite.com/services/rest/query/v1/suiteql?limit=1000&offset=1000')
+      })
+
+      it('should throw InvalidSuiteAppCredentialsError', async () => {
+        mockAxiosAdapter.onPost().reply(401, 'Invalid SuiteApp credentials')
+        await expect(client.runSuiteQL('query')).rejects.toThrow(InvalidSuiteAppCredentialsError)
+      })
+
+      describe('query failure', () => {
+        it('exception thrown', async () => {
+          mockAxiosAdapter.onPost().reply(() => [])
+          expect(await client.runSuiteQL('')).toBeUndefined()
+        })
+        it('with retry', async () => {
+          jest.spyOn(global, 'setTimeout').mockImplementation((cb: TimerHandler) => (_.isFunction(cb) ? cb() : undefined))
+          mockAxiosAdapter
+            .onPost().replyOnce(429)
+            .onPost().replyOnce(200, {
+              hasMore: false,
+              items: [{ links: [], a: 1 }, { links: [], a: 2 }],
+            })
+
+          expect(await client.runSuiteQL('query')).toEqual([{ a: 1 }, { a: 2 }])
+          expect(mockAxiosAdapter.history.post.length).toBe(2)
+        })
+        it('invalid results', async () => {
+          mockAxiosAdapter.onPost().reply(200, {})
+          expect(await client.runSuiteQL('')).toBeUndefined()
+        })
       })
     })
-    it('fallback after trying to use "signature" param', async () => {
-      mockAxiosAdapter
-        .onPost().replyOnce(200, {
-          status: 'error',
-          message: 'Invalid input: data should NOT have additional properties',
+
+    describe('runSavedSearchQuery', () => {
+      it('successful query should return the results', async () => {
+        mockAxiosAdapter.onPost().reply(200, {
+          status: 'success',
+          results: [{ a: 1 }, { a: 2 }],
         })
-        .onPost().replyOnce(200, {
+
+        const results = await client.runSavedSearchQuery({
+          type: 'type',
+          columns: [],
+          filters: [],
+        })
+
+        expect(results).toEqual([{ a: 1 }, { a: 2 }])
+        expect(mockAxiosAdapter.history.post.length).toBe(1)
+        const req = mockAxiosAdapter.history.post[0]
+        expect(req.url).toEqual('https://account-id.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=customscript_salto_restlet&deploy=customdeploy_salto_restlet')
+        expect(JSON.parse(req.data)).toEqual({
+          operation: 'search',
+          signature: 'signature',
+          args: {
+            type: 'type',
+            columns: [],
+            filters: [],
+            offset: 0,
+            limit: 1000,
+          },
+        })
+      })
+
+      describe('query failure', () => {
+        it('exception thrown', async () => {
+          mockAxiosAdapter.onPost().reply(() => [])
+          expect(await client.runSavedSearchQuery({
+            type: 'type',
+            columns: [],
+            filters: [],
+          })).toBeUndefined()
+        })
+
+        it('invalid saved search results', async () => {
+          mockAxiosAdapter.onPost().reply(200, { status: 'success', results: {} })
+          expect(await client.runSavedSearchQuery({
+            type: 'type',
+            columns: [],
+            filters: [],
+          })).toBeUndefined()
+        })
+
+        it('invalid restlet results', async () => {
+          mockAxiosAdapter.onPost().reply(200, {})
+          expect(await client.runSavedSearchQuery({
+            type: 'type',
+            columns: [],
+            filters: [],
+          })).toBeUndefined()
+        })
+
+        it('error status', async () => {
+          mockAxiosAdapter.onPost().reply(200, { status: 'error', message: '', error: new Error('error') })
+          expect(await client.runSavedSearchQuery({
+            type: 'type',
+            columns: [],
+            filters: [],
+          })).toBeUndefined()
+        })
+      })
+
+      it('should return all pages', async () => {
+        const items = _.range(1500).map(i => ({ i }))
+
+        mockAxiosAdapter.onPost().reply(({ data }) => {
+          const { args } = JSON.parse(data)
+          return [
+            200,
+            {
+              status: 'success',
+              results: items.slice(args.offset, args.offset + args.limit),
+            },
+          ]
+        })
+
+        const results = await client.runSavedSearchQuery({
+          type: 'type',
+          columns: [],
+          filters: [],
+        })
+
+        expect(results).toEqual(items)
+        expect(mockAxiosAdapter.history.post.length).toBe(2)
+        const requests = mockAxiosAdapter.history.post
+
+        expect(JSON.parse(requests[0].data)).toEqual({
+          operation: 'search',
+          signature: 'signature',
+          args: {
+            type: 'type',
+            columns: [],
+            filters: [],
+            offset: 0,
+            limit: 1000,
+          },
+        })
+
+        expect(JSON.parse(requests[1].data)).toEqual({
+          operation: 'search',
+          signature: 'signature',
+          args: {
+            type: 'type',
+            columns: [],
+            filters: [],
+            offset: 1000,
+            limit: 1000,
+          },
+        })
+      })
+    })
+
+    describe('getSystemInformation', () => {
+      it('successful request should return the results', async () => {
+        mockAxiosAdapter.onPost().reply(200, {
           status: 'success',
           results: {
             appVersion: [0, 1, 2],
@@ -269,30 +258,117 @@ describe('SuiteAppClient', () => {
           },
         })
 
-      const results = await client.getSystemInformation()
+        const results = await client.getSystemInformation()
 
-      expect(results).toEqual({ appVersion: [0, 1, 2], time: new Date(1000) })
-      expect(mockAxiosAdapter.history.post.length).toBe(2)
-      const req = mockAxiosAdapter.history.post
-      expect(JSON.parse(req[0].data)).toEqual({
-        operation: 'sysInfo',
-        signature: 'signature',
-        args: {},
+        expect(results).toEqual({ appVersion: [0, 1, 2], time: new Date(1000) })
+        expect(mockAxiosAdapter.history.post.length).toBe(1)
+        const req = mockAxiosAdapter.history.post[0]
+        expect(JSON.parse(req.data)).toEqual({
+          operation: 'sysInfo',
+          signature: 'signature',
+          args: {},
+        })
       })
-      expect(JSON.parse(req[1].data)).toEqual({
-        operation: 'sysInfo',
-        args: {},
+
+      describe('request failure', () => {
+        it('exception thrown', async () => {
+          mockAxiosAdapter.onPost().reply(() => [])
+          expect(await client.getSystemInformation()).toBeUndefined()
+        })
+        it('invalid results', async () => {
+          mockAxiosAdapter.onPost().reply(200, { status: 'success', results: {} })
+          expect(await client.getSystemInformation()).toBeUndefined()
+        })
+      })
+    })
+    describe('readFiles', () => {
+      it('should return the right results', async () => {
+        mockAxiosAdapter.onPost().reply(200, {
+          status: 'success',
+          results: [
+            {
+              status: 'success',
+              type: 'PLAINTEXT',
+              content: 'someText1',
+            },
+            {
+              status: 'success',
+              type: 'bin',
+              content: Buffer.from('someText2').toString('base64'),
+            },
+            {
+              status: 'error',
+              error: {
+                name: 'INVALID_FILE_ENCODING',
+              },
+            },
+            {
+              status: 'error',
+              error: {
+                name: 'INSUFFICIENT_PERMISSION',
+              },
+            },
+            {
+              status: 'error',
+              error: {
+                name: 'OTHER_ERROR',
+              },
+            },
+          ],
+        })
+
+        const results = await client.readFiles([1, 2, 3, 4, 5])
+        expect(results).toEqual([
+          Buffer.from('someText1'),
+          Buffer.from('someText2'),
+          expect.any(ReadFileEncodingError),
+          expect.any(ReadFileInsufficientPermissionError),
+          expect.any(ReadFileError),
+        ])
+
+        expect(mockAxiosAdapter.history.post.length).toBe(1)
+        const req = mockAxiosAdapter.history.post[0]
+        expect(req.url).toEqual('https://account-id.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=customscript_salto_restlet&deploy=customdeploy_salto_restlet')
+        expect(JSON.parse(req.data)).toEqual({
+          operation: 'readFile',
+          signature: 'signature',
+          args: {
+            ids: [1, 2, 3, 4, 5],
+          },
+        })
+      })
+
+      it('Invalid response should return undefined', async () => {
+        mockAxiosAdapter.onPost().reply(200, {
+          status: 'success',
+          results: { invalid: 1 },
+        })
+
+        expect(await client.readFiles([1, 2, 3, 4])).toBeUndefined()
+      })
+
+      it('When exception is thrown should return undefined', async () => {
+        mockAxiosAdapter.onPost().reply(() => [])
+
+        expect(await client.readFiles([1, 2, 3, 4])).toBeUndefined()
       })
     })
 
-    describe('request failure', () => {
-      it('exception thrown', async () => {
-        mockAxiosAdapter.onPost().reply(() => [])
-        expect(await client.getSystemInformation()).toBeUndefined()
+    describe('readLargeFile', () => {
+      const readFileMock = jest.spyOn(SoapClient.prototype, 'readFile')
+      beforeEach(() => {
+        readFileMock.mockReset()
       })
-      it('invalid results', async () => {
-        mockAxiosAdapter.onPost().reply(200, { status: 'success', results: {} })
-        expect(await client.getSystemInformation()).toBeUndefined()
+
+      it('Should return the SOAP client results', async () => {
+        readFileMock.mockResolvedValue(Buffer.from('aaa'))
+        expect(await client.readLargeFile(1)).toEqual(Buffer.from('aaa'))
+        expect(readFileMock).toHaveBeenCalledWith(1)
+      })
+
+      it('Should return the SOAP client error', async () => {
+        readFileMock.mockRejectedValue(new Error('bbb'))
+        expect(await client.readLargeFile(1)).toEqual(new Error('bbb'))
       })
     })
   })
@@ -315,7 +391,7 @@ describe('SuiteAppClient', () => {
         status: 'success',
         results: {
           appVersion: [0, 1, 2],
-          time: '2021-02-22T18:55:17.949Z',
+          time: 1000,
         },
       })
 
@@ -333,7 +409,7 @@ describe('SuiteAppClient', () => {
         status: 'success',
         results: {
           appVersion: [0, 1, 2],
-          time: '2021-02-22T18:55:17.949Z',
+          time: 1000,
         },
       })
 
@@ -347,94 +423,56 @@ describe('SuiteAppClient', () => {
     })
   })
 
-  describe('readFiles', () => {
-    it('should return the right results', async () => {
+  describe('versionFeatures', () => {
+    let client: SuiteAppClient
+    beforeEach(async () => {
+      client = new SuiteAppClient({
+        credentials: {
+          accountId: 'ACCOUNT_ID',
+          suiteAppTokenId: 'tokenId',
+          suiteAppTokenSecret: 'tokenSecret',
+          accountIdSignature: 'signature',
+        },
+        globalLimiter: new Bottleneck(),
+      })
+    })
+    it('should set old versionFeatures', async () => {
       mockAxiosAdapter.onPost().reply(200, {
         status: 'success',
-        results: [
-          {
-            status: 'success',
-            type: 'PLAINTEXT',
-            content: 'someText1',
-          },
-          {
-            status: 'success',
-            type: 'bin',
-            content: Buffer.from('someText2').toString('base64'),
-          },
-          {
-            status: 'error',
-            error: {
-              name: 'INVALID_FILE_ENCODING',
-            },
-          },
-          {
-            status: 'error',
-            error: {
-              name: 'INSUFFICIENT_PERMISSION',
-            },
-          },
-          {
-            status: 'error',
-            error: {
-              name: 'OTHER_ERROR',
-            },
-          },
-        ],
-      })
-
-      const results = await client.readFiles([1, 2, 3, 4, 5])
-      expect(results).toEqual([
-        Buffer.from('someText1'),
-        Buffer.from('someText2'),
-        expect.any(ReadFileEncodingError),
-        expect.any(ReadFileInsufficientPermissionError),
-        expect.any(ReadFileError),
-      ])
-
-      expect(mockAxiosAdapter.history.post.length).toBe(1)
-      const req = mockAxiosAdapter.history.post[0]
-      expect(req.url).toEqual('https://account-id.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=customscript_salto_restlet&deploy=customdeploy_salto_restlet')
-      expect(JSON.parse(req.data)).toEqual({
-        operation: 'readFile',
-        signature: 'signature',
-        args: {
-          ids: [1, 2, 3, 4, 5],
+        results: {
+          appVersion: [0, 1, 1],
+          time: 1000,
         },
       })
+      await client.getSystemInformation()
+      expect(client.getVersionFeatures()).toEqual({ signature: false })
     })
-
-    it('Invalid response should return undefined', async () => {
+    it('should set new versionFeatures', async () => {
       mockAxiosAdapter.onPost().reply(200, {
         status: 'success',
-        results: { invalid: 1 },
+        results: {
+          appVersion: [0, 1, 2],
+          time: 1000,
+        },
       })
-
-      expect(await client.readFiles([1, 2, 3, 4])).toBeUndefined()
+      await client.getSystemInformation()
+      expect(client.getVersionFeatures()).toEqual({ signature: true })
     })
-
-    it('When exception is thrown should return undefined', async () => {
-      mockAxiosAdapter.onPost().reply(() => [])
-
-      expect(await client.readFiles([1, 2, 3, 4])).toBeUndefined()
-    })
-  })
-
-  describe('readLargeFile', () => {
-    const readFileMock = jest.spyOn(SoapClient.prototype, 'readFile')
-    beforeEach(() => {
-      readFileMock.mockReset()
-    })
-
-    it('Should return the SOAP client results', async () => {
-      readFileMock.mockResolvedValue(Buffer.from('aaa'))
-      expect(await client.readLargeFile(1)).toEqual(Buffer.from('aaa'))
-      expect(readFileMock).toHaveBeenCalledWith(1)
-    })
-
-    it('Should return the SOAP client error', async () => {
-      readFileMock.mockRejectedValue(new Error('bbb'))
-      expect(await client.readLargeFile(1)).toEqual(new Error('bbb'))
+    it('should set versionFeatures once on parallel request', async () => {
+      mockAxiosAdapter.onPost().reply(200, {
+        status: 'success',
+        results: {
+          appVersion: [0, 1, 2],
+          time: 1000,
+        },
+      })
+      expect(client.getVersionFeatures()).toBeUndefined()
+      await Promise.all([
+        client.getSystemInformation(),
+        client.getSystemInformation(),
+      ])
+      expect(client.getVersionFeatures()).toEqual({ signature: true })
+      expect(mockAxiosAdapter.history.post.length).toEqual(3)
     })
   })
 })

--- a/packages/netsuite-adapter/test/data_elements/data_elements.test.ts
+++ b/packages/netsuite-adapter/test/data_elements/data_elements.test.ts
@@ -53,6 +53,7 @@ describe('data_elements', () => {
     tokenSecret: 'tokenSecret',
     suiteAppTokenId: 'suiteAppTokenId',
     suiteAppTokenSecret: 'suiteAppTokenSecret',
+    accountIdSignature: 'signature',
   }
   const client = new NetsuiteClient(
     new SdfClient({ credentials: creds, globalLimiter: new Bottleneck() }),

--- a/packages/netsuite-adapter/test/data_elements/data_elements.test.ts
+++ b/packages/netsuite-adapter/test/data_elements/data_elements.test.ts
@@ -53,7 +53,7 @@ describe('data_elements', () => {
     tokenSecret: 'tokenSecret',
     suiteAppTokenId: 'suiteAppTokenId',
     suiteAppTokenSecret: 'suiteAppTokenSecret',
-    accountIdSignature: 'signature',
+    suiteAppActivationKey: 'suiteAppActivationKey',
   }
   const client = new NetsuiteClient(
     new SdfClient({ credentials: creds, globalLimiter: new Bottleneck() }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3882,6 +3882,11 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
+compare-versions@4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-4.1.3.tgz#8f7b8966aef7dc4282b45dfa6be98434fc18a1a4"
+  integrity sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg==
+
 component-emitter@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"


### PR DESCRIPTION
Passing `activationKey` param in suiteapp restlet requests. It is the `accountId` signature and it is given by the user on `salto service add/login`. If the installed SuiteApp is not updated to the version that verifies `activationKey` - falling back to restlet requests without the `activationKey` param.

---
_Release Notes_: 
Netsuite Adapter:
- Added `suiteAppActivationKey` parameter to the adapter's SuiteApp credentials - please run `salto service login` and enter all required parameters to use SuiteApp
- Using SuiteApp with activation key verification

---
_User Notifications_: 
None
