### PR TITLE
SALTO-1965: change hide type default to true in ducktype adapters

### DIFF
--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -99,7 +99,7 @@ export default class WorkatoAdapter implements AdapterOperations {
       nestedFieldFinder: returnFullEntry,
       computeGetArgs: simpleGetArgs,
       typeDefaults: this.userConfig.apiDefinitions.typeDefaults,
-      hideTypes: this.userConfig.fetch.hideTypes ?? false,
+      hideTypes: this.userConfig.fetch.hideTypes,
       getElemIdFunc: this.getElemIdFunc,
     })
   }

--- a/packages/workato-adapter/src/adapter_creator.ts
+++ b/packages/workato-adapter/src/adapter_creator.ts
@@ -20,8 +20,7 @@ import WorkatoAdapter from './adapter'
 import { Credentials, usernameTokenCredentialsType } from './auth'
 import {
   configType, WorkatoConfig, CLIENT_CONFIG, validateFetchConfig,
-  FETCH_CONFIG,
-  DEFAULT_CONFIG,
+  FETCH_CONFIG, DEFAULT_CONFIG, WorkatoFetchConfig,
 } from './config'
 import WorkatoClient from './client/client'
 import { createConnection } from './client/connection'
@@ -42,9 +41,14 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
     config?.value.apiDefinitions
   ) as configUtils.AdapterDuckTypeApiConfig
 
+  const fetch = configUtils.mergeWithDefaultConfig(
+    DEFAULT_CONFIG.fetch,
+    config?.value.fetch
+  ) as WorkatoFetchConfig
+
   const adapterConfig: { [K in keyof Required<WorkatoConfig>]: WorkatoConfig[K] } = {
     client: configValue.client,
-    fetch: configValue.fetch,
+    fetch,
     apiDefinitions,
   }
 

--- a/packages/workato-adapter/src/config.ts
+++ b/packages/workato-adapter/src/config.ts
@@ -195,6 +195,7 @@ export const DEFAULT_CONFIG: WorkatoConfig = {
     includeTypes: [
       ...Object.keys(_.pickBy(DEFAULT_TYPES, def => def.request !== undefined)),
     ].sort(),
+    hideTypes: true,
   },
   [API_DEFINITIONS_CONFIG]: {
     typeDefaults: {
@@ -229,7 +230,9 @@ export const configType = new ObjectType({
     },
   },
   annotations: {
-    [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, API_DEFINITIONS_CONFIG),
+    [CORE_ANNOTATIONS.DEFAULT]: _.omit(
+      DEFAULT_CONFIG, API_DEFINITIONS_CONFIG, `${FETCH_CONFIG}.hideTypes`
+    ),
   },
 })
 

--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -156,7 +156,7 @@ export default class ZendeskAdapter implements AdapterOperations {
       computeGetArgs,
       typeDefaults: this.userConfig.apiDefinitions.typeDefaults,
       getElemIdFunc: this.getElemIdFunc,
-      hideTypes: this.userConfig.fetch.hideTypes ?? false,
+      hideTypes: this.userConfig.fetch.hideTypes,
     })
   }
 

--- a/packages/zendesk-support-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-support-adapter/src/adapter_creator.ts
@@ -20,7 +20,7 @@ import ZendeskAdapter from './adapter'
 import { Credentials, oauthAccessTokenCredentialsType, oauthRequestParametersType, usernamePasswordCredentialsType } from './auth'
 import {
   configType, ZendeskConfig, CLIENT_CONFIG, FETCH_CONFIG, validateFetchConfig,
-  API_DEFINITIONS_CONFIG, DEFAULT_CONFIG,
+  API_DEFINITIONS_CONFIG, DEFAULT_CONFIG, ZendeskFetchConfig,
 } from './config'
 import ZendeskClient from './client/client'
 import { createConnection } from './client/connection'
@@ -81,9 +81,14 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
     config?.value.apiDefinitions
   ) as configUtils.AdapterDuckTypeApiConfig
 
+  const fetch = configUtils.mergeWithDefaultConfig(
+    DEFAULT_CONFIG.fetch,
+    config?.value.fetch
+  ) as ZendeskFetchConfig
+
   const adapterConfig: { [K in keyof Required<ZendeskConfig>]: ZendeskConfig[K] } = {
     client: configValue.client,
-    fetch: configValue.fetch,
+    fetch,
     apiDefinitions,
   }
 

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -1473,6 +1473,7 @@ export const DEFAULT_INCLUDE_ENDPOINTS: string[] = [
 export const DEFAULT_CONFIG: ZendeskConfig = {
   [FETCH_CONFIG]: {
     includeTypes: DEFAULT_INCLUDE_ENDPOINTS,
+    hideTypes: true,
   },
   [API_DEFINITIONS_CONFIG]: {
     typeDefaults: {
@@ -1508,7 +1509,9 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
     },
   },
   annotations: {
-    [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, API_DEFINITIONS_CONFIG),
+    [CORE_ANNOTATIONS.DEFAULT]: _.omit(
+      DEFAULT_CONFIG, API_DEFINITIONS_CONFIG, `${FETCH_CONFIG}.hideTypes`
+    ),
   },
 })
 


### PR DESCRIPTION
_change hide type default to true in duck type adapters_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Zendesk_support adapter_:
* hiding the types by default
_Workato adapter_:
* hiding the types by default

---
_User Notifications_: 
_All the types in Zendesk and Workato will become hidden_
