### PR TITLE
SALTO-2066: make dump internally sync

### DIFF
--- a/packages/workspace/src/parser/internal/native/consumers/blocks.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/blocks.ts
@@ -97,7 +97,7 @@ export const consumeBlockBody = (context: ParseContext, idPrefix: ElemID,
           filename: context.filename,
         }, key))
       }
-      addValuePromiseWatcher(context, attrs, key)
+      addValuePromiseWatcher(context.valuePromiseWatchers, attrs, key)
       registerRange(context, attrID, { start: defTokens.range.start, end: consumedValue.range.end })
     } else if (isAnnotationBlockDef(idPrefix, defTokens.value, context)) {
       const annoBlockID = idPrefix.createNestedID('annotation')

--- a/packages/workspace/src/parser/internal/native/consumers/values.ts
+++ b/packages/workspace/src/parser/internal/native/consumers/values.ts
@@ -240,7 +240,7 @@ const consumeArrayItems = (
       }
     }
     items.push(consumedValue.value)
-    addValuePromiseWatcher(context, items, itemIndex)
+    addValuePromiseWatcher(context.valuePromiseWatchers, items, itemIndex)
     if (itemId) {
       registerRange(context, itemId, consumedValue.range)
     }
@@ -388,7 +388,7 @@ const consumeObject = (context: ParseContext, idPrefix?: ElemID): ConsumerReturn
     } else {
       context.errors.push(duplicatedAttribute({ ...tokens.range, filename: context.filename }, key))
     }
-    addValuePromiseWatcher(context, obj, key)
+    addValuePromiseWatcher(context.valuePromiseWatchers, obj, key)
     if (attrId) {
       registerRange(context, attrId, { start: tokens.range.start, end: consumedValue.range.end })
     }

--- a/packages/workspace/src/parser/internal/native/helpers.ts
+++ b/packages/workspace/src/parser/internal/native/helpers.ts
@@ -17,7 +17,7 @@ import { ReferenceExpression, ElemID, Value, ListType, PrimitiveTypes, MapType, 
 import isPromise from 'is-promise'
 import { LexerToken, WILDCARD } from './lexer'
 import { SourcePos, IllegalReference, SourceRange } from '../types'
-import { ParseContext } from './types'
+import { ParseContext, ValuePromiseWatcher } from './types'
 import { Keywords } from '../../language'
 import { invalidElemIDType } from './errors'
 
@@ -83,8 +83,8 @@ export const addValuePromiseWatcher = (
   }
 }
 
-export const replaceValuePromises = async (context: ParseContext): Promise<void> => {
-  await Promise.all(context.valuePromiseWatchers.map(async watcher => {
+export const replaceValuePromises = async (valuePromiseWatchers: ValuePromiseWatcher[]): Promise<void> => {
+  await Promise.all(valuePromiseWatchers.map(async watcher => {
     const { parent, key } = watcher
     parent[key] = await parent[key]
   }))

--- a/packages/workspace/src/parser/internal/native/helpers.ts
+++ b/packages/workspace/src/parser/internal/native/helpers.ts
@@ -74,16 +74,18 @@ export const registerRange = (
 }
 
 export const addValuePromiseWatcher = (
-  context: ParseContext,
+  valuePromiseWatchers: ValuePromiseWatcher[],
   parent: Value,
   key: string | number
 ): void => {
   if (isPromise(parent[key])) {
-    context.valuePromiseWatchers.push({ parent, key })
+    valuePromiseWatchers.push({ parent, key })
   }
 }
 
-export const replaceValuePromises = async (valuePromiseWatchers: ValuePromiseWatcher[]): Promise<void> => {
+export const replaceValuePromises = async (
+  valuePromiseWatchers: ValuePromiseWatcher[]
+): Promise<void> => {
   await Promise.all(valuePromiseWatchers.map(async watcher => {
     const { parent, key } = watcher
     parent[key] = await parent[key]

--- a/packages/workspace/src/parser/internal/native/parse.ts
+++ b/packages/workspace/src/parser/internal/native/parse.ts
@@ -75,7 +75,7 @@ export const parseBuffer = async (
 
   // Adding the list types so they will be accesible during merge.
   elements.push(...Object.values(context.listTypes), ...Object.values(context.mapTypes))
-  await replaceValuePromises(context)
+  await replaceValuePromises(context.valuePromiseWatchers)
   return {
     // Elements string are flatten to solve a memory leak
     elements: elements.map(flattenElementStr),


### PR DESCRIPTION
_Make dump internally sync by adding promise value watchers_

---

The dump method is currently async since the functions dump method is async.
Tests showed that removing this can improve the dump performance in about 50%.

This is can be done by creating value promise watchers and awaiting them all at once like we do in the parser. 

---
_Release Notes_: 
_Improved the NaCL dump methods performance_

---
_User Notifications_: 
_NA_
