### PR TITLE
SALTO-2078: make dummy adapter process safe

### DIFF
--- a/packages/core/test/workspace/local/remote_map.test.ts
+++ b/packages/core/test/workspace/local/remote_map.test.ts
@@ -90,8 +90,7 @@ describe('test operations on remote db', () => {
     elements = await createElements()
     sortedElements = _.sortBy(elements, e => e.elemID.getFullName())
       .map(e => e.elemID.getFullName())
-    const namespace = `${Math.random().toString(36).substring(2, 15)} -_${Math.random()
-      .toString(36).substring(2, 15)}`
+    const namespace = 'namespace'
     remoteMap = await createMap(namespace)
     await remoteMap.set(elements[0].elemID.getFullName(), elements[0])
     await remoteMap.flush()

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -248,7 +248,7 @@ export const generateElements = async (
       dictionaries: [adjectives, colors, names],
       style: 'capital',
       separator: '',
-      seed: randomGen(),
+      seed: randomGen() * 10000000000000,
     })
     const cleanName = name.replace(/\W/g, '')
     generatedNamesCount[cleanName] = generatedNamesCount[cleanName] ?? 0

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -242,15 +242,21 @@ export const generateElements = async (
     }
     return fieldType
   }
-
+  const generatedNamesCount: Record<string, number> = {}
   const getName = (): string => {
     const name = uniqueNamesGenerator({
       dictionaries: [adjectives, colors, names],
       style: 'capital',
       separator: '',
-      seed: randomGen()
+      seed: randomGen(),
     })
-    return name.replace(/\W/g, '')
+    const cleanName = name.replace(/\W/g, '')
+    generatedNamesCount[cleanName] = generatedNamesCount[cleanName] ?? 0
+    const uniqueName = generatedNamesCount[cleanName] === 0
+      ? cleanName
+      : `${cleanName}${generatedNamesCount[cleanName] + 1}`
+    generatedNamesCount[cleanName] += 1
+    return uniqueName
   }
 
   const getMaxRank = async (elements: Element[]): Promise<number> => (elements.length > 0

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -171,7 +171,8 @@ export const generateElements = async (
   params: GeneratorParams,
   progressReporter: ProgressReporter
 ): Promise<Element[]> => {
-  seedrandom(params.seed.toString(), { global: true })
+  const randomGen = seedrandom(params.seed.toString())
+  console.log(">>>>", randomGen(), randomGen(), randomGen())
   const elementRanks: Record<string, number> = {}
   const primitiveByRank: PrimitiveType[][] = arrayOf(defaultParams.maxRank + 1, () => [])
   const objByRank: ObjectType[][] = arrayOf(defaultParams.maxRank + 1, () => [])
@@ -188,8 +189,8 @@ export const generateElements = async (
     let u; let v
     let s: number
     do {
-      u = (Math.random() * 2) - 1
-      v = (Math.random() * 2) - 1
+      u = (randomGen() * 2) - 1
+      v = (randomGen() * 2) - 1
       s = u * u + v * v
     } while (s >= 1 || s === 0)
     s = Math.sqrt(-2.0 * (Math.log(s) / s))
@@ -197,7 +198,7 @@ export const generateElements = async (
   }
 
   const weightedRandomSelect = <T>(items: T[], weights?: number[]): T => {
-    const rValue = Math.random()
+    const rValue = randomGen()
     let sumOfWeights = 0
     // I also hate disabling lint - but in this specific case I think its legit.
     // Just makes the code simpler... (lint does not allow for/in loops)
@@ -231,9 +232,9 @@ export const generateElements = async (
     )
     if (
       allowContainers
-      && Math.random() < defaultParams.listFieldFreq + defaultParams.mapFieldFreq
+      && randomGen() < defaultParams.listFieldFreq + defaultParams.mapFieldFreq
     ) {
-      if (Math.random() < (
+      if (randomGen() < (
         defaultParams.mapFieldFreq / (defaultParams.listFieldFreq + defaultParams.listFieldFreq)
       )) {
         return new MapType(fieldType)
@@ -248,6 +249,7 @@ export const generateElements = async (
       dictionaries: [adjectives, colors, names],
       style: 'capital',
       separator: '',
+      seed: randomGen()
     })
     return name.replace(/\W/g, '')
   }
@@ -278,14 +280,14 @@ export const generateElements = async (
   const getListLength = (): number => normalRandom(params.listLengthMean, params.listLengthStd) + 1
 
   const getSingleLine = (): string => (
-    stringLinesOpts[Math.floor(Math.random() * stringLinesOpts.length)]
+    stringLinesOpts[Math.floor(randomGen() * stringLinesOpts.length)]
   )
   const getMultiLine = (numOflines: number): string => (
     arrayOf(numOflines, getSingleLine).join('\n')
   )
-  const generateBoolean = (): boolean => Math.random() < 0.5
-  const generateNumber = (): number => Math.floor(Math.random() * 1000)
-  const generateString = (): string => (Math.random() > defaultParams.multilineFreq
+  const generateBoolean = (): boolean => randomGen() < 0.5
+  const generateNumber = (): number => Math.floor(randomGen() * 1000)
+  const generateString = (): string => (randomGen() > defaultParams.multilineFreq
     ? getSingleLine()
     : getMultiLine(
       normalRandom(params.multilLinesStringLinesMean, params.multilLinesStringLinesStd)
@@ -410,10 +412,10 @@ export const generateElements = async (
       })
       await updateElementRank(element)
       if (element.primitive === PrimitiveTypes.STRING
-        && Math.random() < 1
+        && randomGen() < 1
       ) { // defaultParams.staticFileFreq) {
         staticFileIds.add(element.elemID.getFullName())
-      } else if (Math.random() < defaultParams.staticFileFreq) {
+      } else if (randomGen() < defaultParams.staticFileFreq) {
         referenceFields.add(element.elemID.getFullName())
       }
       return element
@@ -481,7 +483,7 @@ export const generateElements = async (
       ),
       [DUMMY_ADAPTER, 'Records', instanceType.elemID.name, name]
     )
-    if (Math.random() < defaultParams.parentFreq) {
+    if (randomGen() < defaultParams.parentFreq) {
       record.annotations[CORE_ANNOTATIONS.PARENT] = new ReferenceExpression(
         chooseObjIgnoreRank().elemID
       )

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -172,7 +172,6 @@ export const generateElements = async (
   progressReporter: ProgressReporter
 ): Promise<Element[]> => {
   const randomGen = seedrandom(params.seed.toString())
-  console.log(">>>>", randomGen(), randomGen(), randomGen())
   const elementRanks: Record<string, number> = {}
   const primitiveByRank: PrimitiveType[][] = arrayOf(defaultParams.maxRank + 1, () => [])
   const objByRank: ObjectType[][] = arrayOf(defaultParams.maxRank + 1, () => [])

--- a/packages/dummy-adapter/test/generator.test.ts
+++ b/packages/dummy-adapter/test/generator.test.ts
@@ -33,7 +33,7 @@ describe('elements generator', () => {
     it('should create the same set of elements when invoked with the same seed and params concurrently', async () => {
       const [run1, run2] = await Promise.all([
         generateElements(testParams, mockProgressReporter),
-        generateElements(testParams, mockProgressReporter)
+        generateElements(testParams, mockProgressReporter),
       ])
       expect(run1).toEqual(run2)
     })

--- a/packages/dummy-adapter/test/generator.test.ts
+++ b/packages/dummy-adapter/test/generator.test.ts
@@ -30,6 +30,13 @@ describe('elements generator', () => {
       const run2 = await generateElements(testParams, mockProgressReporter)
       expect(run1).toEqual(run2)
     })
+    it('should create the same set of elements when invoked with the same seed and params concurrently', async () => {
+      const [run1, run2] = await Promise.all([
+        generateElements(testParams, mockProgressReporter),
+        generateElements(testParams, mockProgressReporter)
+      ])
+      expect(run1).toEqual(run2)
+    })
     it('should create different results when invoked with different seeds', async () => {
       const run1 = await generateElements(testParams, mockProgressReporter)
       const run2 = await generateElements({


### PR DESCRIPTION
_make dummy adapter process safe_

---

The random mechanism used in the dummy adapter is currently global for the process and is reset when the dummy adapter fetch begins. As a result, if two fetches takes place concurrently, the random generator is shared between them - causing them to generate different outputs.

While this is not an issue when invoked via the cli, it can create issues when the adapter is fetched in an other execution environments  (for example, a nodejs express server)

When used globally, `seedrandom` override Math.random functionality. Since we are now using a local generator, changes to the uniqueNameGenerator were also needed. Namely:
1. Explicitly provide a seed value for the name generation
2. Explicitly ensuring names are unique (since seed random does not provide unique values)

NOTE - **This changes the values currently returned by the dummy adapter for a given seed. If any code assumes the existence of any non-fixed dummy adapter value it will break with this change.**
---
_Release Notes_: 
_Made dummy adapter process safe (Changes current return values of the dummy adapter)_

---
_User Notifications_: 
_This changes the values currently returned by the dummy adapter for a given seed. If any code assumes the existence of any non-fixed dummy adapter value it will break with this change._
