### PR TITLE
SALTO-2082: Prevent creating new environments with the '/' char or renaming to it

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -56,7 +56,7 @@ const MULTI_ENV_SOURCE_PREFIX = 'multi_env_element_source'
 const STATE_SOURCE_PREFIX = 'state_element_source'
 
 export const isValidEnvName = (envName: string): boolean =>
-  /^[a-z0-9-_.!\s/]+$/i.test(envName) && envName.length <= MAX_ENV_NAME_LEN
+  /^[a-z0-9-_.!\s]+$/i.test(envName) && envName.length <= MAX_ENV_NAME_LEN
 
 export type SourceFragment = {
   sourceRange: SourceRange

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -4006,6 +4006,7 @@ describe('isValidEnvName', () => {
     expect(isValidEnvName('why?')).toEqual(false)
     expect(isValidEnvName('no:pe')).toEqual(false)
     expect(isValidEnvName('100%')).toEqual(false)
+    expect(isValidEnvName('created at 24/02/2022')).toEqual(false)
   })
 })
 


### PR DESCRIPTION
Prevent creating new environments with the '/' char or renaming to it.

---

_Release Notes_: 
Core: Prevent creating new environments with the '/' char or renaming to it.

---

_User Notifications_: 
None