### PR TITLE
SALTO-2086 change order of filters

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -121,9 +121,10 @@ export default class NetsuiteAdapter implements AdapterOperations {
       addParentFolder,
       parseSavedSearch,
       convertLists,
-      // convertListsToMaps must run after convertLists and before replaceInstanceReferencesFilter
-      convertListsToMaps,
       consistentValues,
+      // convertListsToMaps must run after convertLists and consistentValues
+      // and must run before replaceInstanceReferencesFilter
+      convertListsToMaps,
       replaceInstanceReferencesFilter,
       SDFInternalIds,
       dataInstancesAttributes,


### PR DESCRIPTION
change the order of `consistentValues` and `convertListsToMaps` filters to prevent inconsistent key names.

---
_Release Notes_: 
Netsuite Adapter
- fix bug in inconsistent key names

---
_User Notifications_: 
None
