### PR TITLE
SALTO-2089: Updating workflow scheme id when changed

### DIFF
--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -110,12 +110,10 @@ const updateSchemeId = async (
     return
   }
 
-  const workflowSchemes = await awu(paginator(
+  const id = (await awu(paginator(
     config.apiDefinitions.types.WorkflowSchemes.request as configUtils.FetchRequestConfig,
     page => collections.array.makeArray(page.values) as clientUtils.ResponseValue[]
-  )).flat().toArray()
-
-  const id = workflowSchemes.find(scheme => scheme.name === instance.value.name)?.id
+  )).flat().find(scheme => scheme.name === instance.value.name))?.id
 
   if (id !== undefined) {
     instance.value.id = id


### PR DESCRIPTION
I saw a case where after publishing a workflow scheme draft, the id of the workflow scheme is changed, so before deploying, I added a check that we have the right id

---
_Release Notes_: 
None

---
_User Notifications_: 
None