### PR TITLE
SALTO-2042: added support for step names in workflow

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/workflow.ts
@@ -262,6 +262,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
   statuses: [
     {
       id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'Backlog'), allElements),
+      name: 'CustomBacklog',
       properties: [{
         key: 'jira.issue.editable',
         value: 'true',
@@ -269,6 +270,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
     },
     {
       id: createReference(new ElemID(JIRA, 'Status', 'instance', 'Done'), allElements),
+      name: 'Done',
       properties: [{
         key: 'jira.issue.editable',
         value: 'true',

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -45,6 +45,7 @@ import defaultInstancesDeployFilter from './filters/default_instances_deploy'
 import workflowStructureFilter from './filters/workflow/workflow_structure_filter'
 import workflowPropertiesFilter from './filters/workflow/workflow_properties_filter'
 import transitionIdsFilter from './filters/workflow/transition_ids_filter'
+import stepIdsFilter from './filters/workflow/step_ids_filter'
 import workflowDeployFilter from './filters/workflow/workflow_deploy_filter'
 import triggersFilter from './filters/workflow/triggers_filter'
 import workflowSchemeFilter from './filters/workflow_scheme'
@@ -91,6 +92,7 @@ export const DEFAULT_FILTERS = [
   iconUrlFilter,
   workflowStructureFilter,
   transitionIdsFilter,
+  stepIdsFilter,
   triggersFilter,
   workflowPropertiesFilter,
   workflowDeployFilter,

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1005,13 +1005,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       ],
     },
   },
-  WorkflowStatus: {
-    transformation: {
-      fieldsToOmit: [
-        { fieldName: 'name' },
-      ],
-    },
-  },
   TransitionScreenDetails: {
     transformation: {
       fieldsToOmit: [

--- a/packages/jira-adapter/src/filters/workflow/step_ids_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/step_ids_filter.ts
@@ -26,6 +26,8 @@ import { JiraConfig } from '../../config'
 
 const log = logger(module)
 
+const STEP_IDS_FIELD = 'stepIds'
+
 type StatusesResponse = {
   layout: {
     statuses: {
@@ -68,7 +70,7 @@ export const addStepIds = async (
   }
 
   const response = await client.getPrivate({
-    url: 'rest/workflowDesigner/1.0/workflows',
+    url: '/rest/workflowDesigner/1.0/workflows',
     queryParams: {
       name: instance.value.name,
     },
@@ -91,9 +93,9 @@ const filter: FilterCreator = ({ client, config }) => ({
     if (workflowType === undefined) {
       log.warn(`${WORKFLOW_TYPE_NAME} type not found`)
     } else {
-      workflowType.fields.stepIds = new Field(
+      workflowType.fields[STEP_IDS_FIELD] = new Field(
         workflowType,
-        'stepIds',
+        STEP_IDS_FIELD,
         new MapType(BuiltinTypes.STRING),
         { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true }
       )

--- a/packages/jira-adapter/src/filters/workflow/step_ids_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/step_ids_filter.ts
@@ -1,0 +1,110 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, Element, Field, isInstanceElement, MapType } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import Joi from 'joi'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { findObject } from '../../utils'
+import { FilterCreator } from '../../filter'
+import { WORKFLOW_TYPE_NAME } from '../../constants'
+import { isWorkflowInstance, WorkflowInstance } from './types'
+import JiraClient from '../../client/client'
+import { JiraConfig } from '../../config'
+
+const log = logger(module)
+
+type StatusesResponse = {
+  layout: {
+    statuses: {
+      stepId: number
+      statusId?: string
+    }[]
+  }
+}
+
+const isValidStatusesResponse = (response: unknown): response is StatusesResponse => {
+  const { error } = Joi.object({
+    layout: Joi.object({
+      statuses: Joi.array().items(Joi.object({
+        stepId: Joi.number().required(),
+        statusId: Joi.number(),
+      }).unknown(true)),
+    }).unknown(true).required(),
+  }).unknown(true).required().validate(response)
+
+  if (error !== undefined) {
+    log.error(`Received invalid statuses response from Jira: ${error}. ${safeJsonStringify(response)}`)
+    return false
+  }
+  return true
+}
+
+export const addStepIds = async (
+  instance: WorkflowInstance,
+  client: JiraClient,
+  config: JiraConfig,
+): Promise<void> => {
+  if (!config.client.usePrivateAPI) {
+    log.debug('Skipping stepIds filter because Jira is not configured to use private API')
+    return
+  }
+
+  if (instance.value.name === undefined) {
+    log.error(`Received a workflow ${instance.elemID.getFullName()} without a name. ${safeJsonStringify(instance.value)}`)
+    return
+  }
+
+  const response = await client.getPrivate({
+    url: 'rest/workflowDesigner/1.0/workflows',
+    queryParams: {
+      name: instance.value.name,
+    },
+  })
+
+  if (!isValidStatusesResponse(response.data)) {
+    return
+  }
+
+  instance.value.stepIds = Object.fromEntries(
+    response.data.layout.statuses
+      .filter(({ statusId }) => statusId !== undefined)
+      .map(status => [status.statusId, status.stepId.toString()])
+  )
+}
+
+const filter: FilterCreator = ({ client, config }) => ({
+  onFetch: async (elements: Element[]) => {
+    const workflowType = findObject(elements, WORKFLOW_TYPE_NAME)
+    if (workflowType === undefined) {
+      log.warn(`${WORKFLOW_TYPE_NAME} type not found`)
+    } else {
+      workflowType.fields.stepIds = new Field(
+        workflowType,
+        'stepIds',
+        new MapType(BuiltinTypes.STRING),
+        { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true }
+      )
+    }
+
+    await Promise.all(elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === WORKFLOW_TYPE_NAME)
+      .filter(isWorkflowInstance)
+      .map(instance => addStepIds(instance, client, config)))
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/workflow/steps_deployment.ts
+++ b/packages/jira-adapter/src/filters/workflow/steps_deployment.ts
@@ -1,0 +1,64 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { isReferenceExpression } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import JiraClient from '../../client/client'
+import { WorkflowInstance } from './types'
+
+const { awu } = collections.asynciterable
+
+export const deploySteps = async (
+  instance: WorkflowInstance,
+  client: JiraClient
+): Promise<void> => {
+  const statuses = instance.value.statuses ?? []
+
+  const workflowName = instance.value.name
+
+  if (workflowName === undefined) {
+    throw new Error(`Workflow name is missing from ${instance.elemID.getFullName()}`)
+  }
+
+  await awu(statuses)
+    .filter(status => !isReferenceExpression(status.id)
+      || status.name !== status.id.value.value.name)
+    .forEach(async status => {
+      if (status.name === undefined) {
+        throw new Error(`status name is missing in ${instance.elemID.getFullName()}`)
+      }
+
+      const statusId = isReferenceExpression(status.id) ? status.id.value.value.id : status.id
+      if (statusId === undefined) {
+        throw new Error(`status id is missing for ${status.name} in ${instance.elemID.getFullName()}`)
+      }
+
+      const stepId = instance.value.stepIds?.[statusId]
+      if (stepId === undefined) {
+        throw new Error(`step id is missing for ${status.name} in ${instance.elemID.getFullName()}`)
+      }
+
+      await client.jspPost({
+        url: '/secure/admin/workflows/EditWorkflowStep.jspa',
+        data: {
+          stepName: status.name,
+          workflowStep: stepId,
+          stepStatus: statusId,
+          workflowName,
+          workflowMode: 'live',
+        },
+      })
+    })
+}

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -149,15 +149,20 @@ const transitionsSchema = Joi.object({
 }).unknown(true)
 
 export type Status = {
+  id?: unknown
+  name?: string
   properties?: Values
 }
 
 const statusSchema = Joi.object({
+  id: Joi.optional(),
+  name: Joi.string().optional(),
   properties: Joi.alternatives(Joi.object(), Joi.array()).optional(),
 }).unknown(true)
 
 export type Workflow = {
   transitionIds?: Record<string, string>
+  stepIds?: Record<string, string>
   id?: Id
   entityId?: string
   name?: string
@@ -167,6 +172,7 @@ export type Workflow = {
 
 export const workflowSchema = Joi.object({
   transitionIds: Joi.object().pattern(Joi.string(), Joi.string()).optional(),
+  stepIds: Joi.object().pattern(Joi.string(), Joi.string()).optional(),
   id: idSchema.optional(),
   entityId: Joi.string().optional(),
   name: Joi.string().optional(),

--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -112,7 +112,9 @@ const deployWorkflow = async (
     change: resolvedChange,
     client,
     apiDefinitions: config.apiDefinitions,
-    fieldsToIgnore: path => path.name === 'triggers' || (path.name === 'name' && path.getFullNameParts().includes('statuses')),
+    fieldsToIgnore: path => path.name === 'triggers'
+      // Matching here the 'name' of status inside the statuses array
+      || (path.name === 'name' && path.getFullNameParts().includes('statuses')),
   })
 
   const transitions = await getTransitionsFromService(client, instance.value.name)

--- a/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, Element, Field, isInstanceElement, ListType, MapType } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, Element, Field, isInstanceElement, ListType, MapType } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { findObject } from '../../utils'
@@ -148,6 +148,7 @@ const filter: FilterCreator = () => ({
       log.warn('WorkflowStatus type was not received in fetch')
     } else {
       workflowStatusType.fields.properties = new Field(workflowStatusType, 'properties', new MapType(BuiltinTypes.STRING))
+      workflowStatusType.fields.name.annotations[CORE_ANNOTATIONS.CREATABLE] = true
     }
 
     const workflowRulesType = findObject(elements, WORKFLOW_RULES_TYPE_NAME)

--- a/packages/jira-adapter/test/filters/workflow/step_ids_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/step_ids_filter.test.ts
@@ -1,0 +1,192 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import _ from 'lodash'
+import JiraClient, { PRIVATE_API_HEADERS } from '../../../src/client/client'
+import { DEFAULT_CONFIG, JiraConfig } from '../../../src/config'
+import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import stepIdsFilter from '../../../src/filters/workflow/step_ids_filter'
+import { mockClient } from '../../utils'
+
+describe('stepIdsFilter', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let workflowType: ObjectType
+  let client: JiraClient
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let config: JiraConfig
+  beforeEach(async () => {
+    workflowType = new ObjectType({ elemID: new ElemID(JIRA, WORKFLOW_TYPE_NAME) })
+
+    const { client: cli, paginator, connection } = mockClient()
+    client = cli
+    mockConnection = connection
+
+    config = _.cloneDeep(DEFAULT_CONFIG)
+
+    filter = stepIdsFilter({
+      client,
+      paginator,
+      config,
+    }) as typeof filter
+  })
+
+  describe('onFetch', () => {
+    it('should add stepIds field to the type', async () => {
+      await filter.onFetch([workflowType])
+      expect(workflowType.fields.stepIds).toBeDefined()
+      expect(workflowType.fields.stepIds.annotations).toEqual({
+        [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+      })
+    })
+
+    it('should add stepIds value', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'workflowName',
+          statuses: [
+            { id: '1' },
+            { id: '2' },
+            { id: '3' },
+          ],
+        },
+      )
+
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          layout: {
+            statuses: [
+              {
+                statusId: '1',
+                stepId: '4',
+              },
+              {
+                statusId: '2',
+                stepId: '5',
+              },
+              {
+                statusId: '3',
+                stepId: '6',
+              },
+            ],
+          },
+        },
+      })
+
+      await filter.onFetch([instance])
+      expect(instance.value.stepIds).toEqual({
+        1: '4',
+        2: '5',
+        3: '6',
+      })
+
+      expect(mockConnection.get).toHaveBeenCalledWith(
+        'rest/workflowDesigner/1.0/workflows',
+        {
+          params: {
+            name: 'workflowName',
+          },
+          headers: PRIVATE_API_HEADERS,
+        },
+      )
+    })
+
+    it('should do nothing if usePrivateAPI is false', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'workflowName',
+          statuses: [
+            { id: '1' },
+            { id: '2' },
+            { id: '3' },
+          ],
+        },
+      )
+
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          layout: {
+            statuses: [
+              {
+                statusId: '1',
+                stepId: '4',
+              },
+              {
+                statusId: '2',
+                stepId: '5',
+              },
+              {
+                statusId: '3',
+                stepId: '6',
+              },
+            ],
+          },
+        },
+      })
+
+      config.client.usePrivateAPI = false
+
+      await filter.onFetch([instance])
+      expect(instance.value.stepIds).toBeUndefined()
+    })
+
+    it('should do nothing if workflow does not have a name', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          statuses: [
+            { id: '1' },
+            { id: '2' },
+            { id: '3' },
+          ],
+        },
+      )
+
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          layout: {
+            statuses: [
+              {
+                statusId: '1',
+                stepId: '4',
+              },
+              {
+                statusId: '2',
+                stepId: '5',
+              },
+              {
+                statusId: '3',
+                stepId: '6',
+              },
+            ],
+          },
+        },
+      })
+
+      await filter.onFetch([instance])
+      expect(instance.value.stepIds).toBeUndefined()
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/workflow/step_ids_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/step_ids_filter.test.ts
@@ -98,7 +98,7 @@ describe('stepIdsFilter', () => {
       })
 
       expect(mockConnection.get).toHaveBeenCalledWith(
-        'rest/workflowDesigner/1.0/workflows',
+        '/rest/workflowDesigner/1.0/workflows',
         {
           params: {
             name: 'workflowName',

--- a/packages/jira-adapter/test/filters/workflow/steps_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/steps_deployment.test.ts
@@ -1,0 +1,116 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import JiraClient, { JSP_API_HEADERS } from '../../../src/client/client'
+import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import { mockClient } from '../../utils'
+import { deploySteps } from '../../../src/filters/workflow/steps_deployment'
+
+describe('steps_deployment', () => {
+  let workflowType: ObjectType
+  let instance: InstanceElement
+  let client: JiraClient
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  beforeEach(async () => {
+    workflowType = new ObjectType({ elemID: new ElemID(JIRA, WORKFLOW_TYPE_NAME) })
+    instance = new InstanceElement(
+      'instance',
+      workflowType,
+      {
+        name: 'workflowName',
+        stepIds: {
+          1: '4',
+          2: '5',
+          3: '6',
+        },
+        statuses: [
+          {
+            name: 'name1',
+            id: new ReferenceExpression(new ElemID(JIRA, 'status'), { value: { name: 'name1', id: '1' } }),
+          },
+          {
+            name: 'name2',
+            id: new ReferenceExpression(new ElemID(JIRA, 'status'), { value: { name: 'other', id: '2' } }),
+          },
+          {
+            name: 'name3',
+            id: '3',
+          },
+        ],
+      }
+    )
+
+    const { client: cli, connection } = mockClient()
+    client = cli
+    mockConnection = connection
+  })
+
+  it('should call the deploy steps endpoint', async () => {
+    await deploySteps(instance, client)
+
+    expect(mockConnection.post).toHaveBeenCalledWith(
+      '/secure/admin/workflows/EditWorkflowStep.jspa',
+      new URLSearchParams({
+        stepName: 'name2',
+        workflowStep: '5',
+        stepStatus: '2',
+        workflowName: 'workflowName',
+        workflowMode: 'live',
+      }),
+      {
+        headers: JSP_API_HEADERS,
+      },
+    )
+
+    expect(mockConnection.post).toHaveBeenCalledWith(
+      '/secure/admin/workflows/EditWorkflowStep.jspa',
+      new URLSearchParams({
+        stepName: 'name3',
+        workflowStep: '6',
+        stepStatus: '3',
+        workflowName: 'workflowName',
+        workflowMode: 'live',
+      }),
+      {
+        headers: JSP_API_HEADERS,
+      },
+    )
+
+    expect(mockConnection.post).toHaveBeenCalledTimes(2)
+  })
+
+  it('should throw if workflow does not have a name', async () => {
+    delete instance.value.name
+    await expect(deploySteps(instance, client)).rejects.toThrow()
+  })
+
+  it('should throw if status does not have a name', async () => {
+    delete instance.value.statuses[0].name
+    await expect(deploySteps(instance, client)).rejects.toThrow()
+  })
+
+  it('should throw if status does not have an id', async () => {
+    delete instance.value.statuses[0].id
+    await expect(deploySteps(instance, client)).rejects.toThrow()
+  })
+
+  it('should throw if there are not step ids', async () => {
+    delete instance.value.stepIds
+    await expect(deploySteps(instance, client)).rejects.toThrow()
+  })
+})

--- a/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
@@ -70,6 +70,9 @@ describe('workflowStructureFilter', () => {
     it('should set the properties field in WorkflowStatus', async () => {
       const workflowStatusType = new ObjectType({
         elemID: new ElemID(JIRA, 'WorkflowStatus'),
+        fields: {
+          name: { refType: BuiltinTypes.STRING },
+        },
       })
       await filter.onFetch([workflowStatusType])
       expect(workflowStatusType.fields.properties).toBeDefined()


### PR DESCRIPTION
Added support for deploying step names in workflow

---

Added the ids of the steps in the workflow to the workflow using the private API and used the ids to create a post request to a JSP page to edit the name of the steps after creating the workflow

---
_Release Notes_: 
_Jira Adapter_
- Workflow status names are now fetched from the service and are deployable when creating a workflow

---
_User Notifications_: 
_Jira Adapter_
- After the next fetch, a name value will be added to each status in each workflow