### PR TITLE
SALTO-2094: Fixed to not omit all the instances when recurseInto of one instance is failing

### DIFF
--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -397,12 +397,17 @@ const getEntriesForType = async (
       })
   )
 
-  const filledEntries = await Promise.all(
+  const filledEntries = (await Promise.all(
     entries.map(async entry => {
-      const extraFields = await getExtraFieldValues(entry)
-      return { ...entry, ...Object.fromEntries(extraFields) }
+      try {
+        const extraFields = await getExtraFieldValues(entry)
+        return { ...entry, ...Object.fromEntries(extraFields) }
+      } catch (err) {
+        log.warn(`Failed getting extra field values for ${typeName} entry: ${safeJsonStringify(entry)}. Error: ${err.message}`)
+        return undefined
+      }
     })
-  )
+  )).filter(lowerdashValues.isDefined)
 
   return { entries: filledEntries, objType }
 }

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -942,6 +942,7 @@ describe('swagger_instance_elements', () => {
 
     describe('with types that require recursing', () => {
       let instances: InstanceElement[]
+      let getAllInstancesParams: Parameters<typeof getAllInstances>[0]
       beforeEach(async () => {
         mockPaginator.mockImplementation(({ url }) => {
           if (url === '/pet') {
@@ -970,7 +971,8 @@ describe('swagger_instance_elements', () => {
         })
 
         const objectTypes = generateObjectTypes()
-        instances = await getAllInstances({
+
+        getAllInstancesParams = {
           paginator: mockPaginator,
           apiConfig: {
             typeDefaults: {
@@ -1045,7 +1047,9 @@ describe('swagger_instance_elements', () => {
               fields: { numOfPets: { refType: BuiltinTypes.NUMBER } },
             }),
           },
-        })
+        }
+
+        instances = await getAllInstances(getAllInstancesParams)
       })
       it('should get inner types recursively for instances that match the condition', () => {
         expect(mockPaginator).toHaveBeenCalledWith(expect.objectContaining({ url: '/pet/dog/owner' }), expect.anything())
@@ -1094,6 +1098,62 @@ describe('swagger_instance_elements', () => {
             { name: 'o2', additionalProperties: { info: { numOfPets: 2 } } },
           ]
         )
+      })
+
+      it('should not return instances if failed to get their inner values', async () => {
+        mockPaginator.mockImplementation(({ url }) => {
+          if (url === '/pet') {
+            return toAsyncIterable([[
+              { id: 'dog', name: 'def' },
+              { id: 'cat', name: 'def' },
+              { id: 'fish', name: 'fish' },
+            ]])
+          }
+          if (url === '/pet/fish/owner') {
+            throw new Error('some error')
+          }
+          if (url === '/pet/dog/owner') {
+            return toAsyncIterable([[
+              { name: 'o1' },
+              { name: 'o2' },
+            ]])
+          }
+          if (url === '/pet/dog/owner/o1/nicknames') {
+            return toAsyncIterable([[{ names: ['n1', 'n2'] }]])
+          }
+          if (url === '/pet/dog/owner/o2/nicknames') {
+            return toAsyncIterable([[{ names: ['n3'] }]])
+          }
+          if (url.match(/\/pet\/.*\/owner\/.*\/info/) !== null) {
+            return toAsyncIterable([[{ numOfPets: 2 }]])
+          }
+          return toAsyncIterable([[]])
+        })
+
+        instances = await getAllInstances(getAllInstancesParams)
+
+        expect(instances).toHaveLength(2)
+        const [dog, cat] = instances
+        expect(dog.value).toHaveProperty(
+          'owners',
+          [
+            {
+              name: 'o1',
+              additionalProperties: {
+                nicknames: [{ names: ['n1', 'n2'] }],
+                info: { numOfPets: 2 },
+              },
+            },
+            {
+              name: 'o2',
+              additionalProperties: {
+                nicknames: [{ names: ['n3'] }],
+                info: { numOfPets: 2 },
+              },
+            },
+          ]
+        )
+        expect(cat.value).not.toHaveProperty('owners')
       })
     })
 


### PR DESCRIPTION
Currently, if we would fail to fetch the recurseInto data of one instance, we would omit from the workspace all the instances of that type. This causes the issue in Jira where a team-managed project in the trash would cause all the screen instances to be omitted from the workspace

---
_Release Notes_: 
_Jira Adapter_:
- Fixed a bug where putting a team-managed project in the trash would cause the screen instances to be omitted from the workspace

---
_User Notifications_: 
None