### PR TITLE
SALTO-1975 correct suiteapp version with activation key

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -60,7 +60,7 @@ const NON_BINARY_FILETYPES = new Set([
 
 const UNAUTHORIZED_STATUSES = [401, 403]
 
-const ACTIVATION_KEY_APP_VERSION = '0.1.2'
+const ACTIVATION_KEY_APP_VERSION = '0.1.3'
 
 type VersionFeatures = {
   activationKey: boolean


### PR DESCRIPTION
changed to 0.1.3 (https://github.com/salto-io/salto_suiteapp/pull/10)

---
_Release Notes_: 
None

---
_User Notifications_: 
None
