### PR TITLE
SALTO-2100: some users internal ids are not changed into emails

### DIFF
--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -85,9 +85,10 @@ export const DEFAULT_FILTERS = [
   restrictionFilter,
   organizationFieldFilter,
   hardcodedChannelFilter,
+  // fieldReferencesFilter should be after usersFilter
+  usersFilter,
   fieldReferencesFilter,
   appsFilter,
-  usersFilter,
   routingAttributeFilter,
   addFieldOptionsFilter,
   // removeDefinitionInstancesFilter should be after hardcodedChannelFilter

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -241,6 +241,11 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskSupportFieldReferenceDefi
     target: { type: 'brand' },
   },
   {
+    src: { field: 'restricted_brand_ids' },
+    serializationStrategy: 'id',
+    target: { type: 'brand' },
+  },
+  {
     src: { field: 'category_id' },
     serializationStrategy: 'id',
     target: { type: 'trigger_category' },


### PR DESCRIPTION
_Some user's internal ids are not changed into emails_

---

_Additional context for reviewer_
Two tiny changes here:
- There was a bug that prevented the users filter from running in some cases
- Added references for restricted_brand_ids (brands)

---
_Release Notes_: 
_Zendesk_support adapter_
* Fixed a bug that prevented users internal ids to change into emails
* Added one more reference

---
_User Notifications_: 
* Zendesk - Some users internal ids can be changed into emails
* Zendesk - added references for brands for restricted_brand_ids field
