### PR TITLE
(SALTO-2102) added file location as path fallback in fetch from

### DIFF
--- a/packages/core/test/common/workspace.ts
+++ b/packages/core/test/common/workspace.ts
@@ -75,6 +75,7 @@ export const mockWorkspace = ({
   errors = [],
   accountConfigs = {},
   accountToServiceName = {},
+  parsedNaclFiles = {},
 }: {
   elements?: Element[]
   name?: string
@@ -85,7 +86,20 @@ export const mockWorkspace = ({
   accountConfigs?: Record<string, InstanceElement>
   getValue?: Promise<Value | undefined>
   accountToServiceName?: Record<string, string>
+  parsedNaclFiles?: Record<string, Element[]>
 }): workspace.Workspace => {
+  const elementIDtoFileMap = Object.entries(parsedNaclFiles).reduce(
+    (acc, entry) => {
+      const [filename, elems] = entry
+      elems.forEach(elem => {
+        const key = elem.elemID.getFullName()
+        acc[key] = acc[key] || []
+        acc[key].push(filename)
+      })
+      return acc
+    },
+    {} as Record<string, string[]>
+  )
   const state = mockState(ACCOUNTS, stateElements || elements, index)
   return {
     elements: jest.fn().mockImplementation(
@@ -119,5 +133,9 @@ export const mockWorkspace = ({
     errors: jest.fn().mockImplementation(() => mockErrors(errors)),
     hasErrors: () => errors.length > 0,
     getValue: async (id: ElemID) => elements.find(e => e.elemID.getFullName() === id.getFullName()),
+    getElementNaclFiles: async (id: ElemID) => elementIDtoFileMap[id.getFullName()] ?? [],
+    getParsedNaclFile: async (filename: string) => ({
+      elements: async () => parsedNaclFiles[filename],
+    }),
   } as unknown as workspace.Workspace
 }

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -15,14 +15,13 @@
 */
 import { getChangeData, ElemID, Value, DetailedChange, ChangeDataType, Element, isObjectType, isPrimitiveType, isInstanceElement, isField, isAdditionChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import path from 'path'
 import { promises, values, collections } from '@salto-io/lowerdash'
 import { resolvePath, filterByID, detailedCompare, applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import {
   projectChange, projectElementOrValueToEnv, createAddChange, createRemoveChange,
 } from './projections'
 import { wrapAdditions, DetailedAddition, wrapNestedValues } from '../addition_wrapper'
-import { NaclFilesSource, RoutingMode } from '../nacl_files_source'
+import { NaclFilesSource, RoutingMode, toPathHint } from '../nacl_files_source'
 import { mergeElements } from '../../../merger'
 
 const { awu } = collections.asynciterable
@@ -77,12 +76,6 @@ const filterByFile = async (
     ) !== undefined
   ))
 )
-
-const toPathHint = (filename: string): string[] => {
-  const dirName = path.dirname(filename)
-  const dirPathSplitted = (dirName === '.') ? [] : dirName.split(path.sep)
-  return [...dirPathSplitted, path.basename(filename, path.extname(filename))]
-}
 
 const isEmptyAnnoAndAnnoTypes = (element: Element): boolean =>
   (_.isEmpty(element.annotations) && _.isEmpty(element.annotationRefTypes))

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -77,6 +77,9 @@ const validateParsedNaclFile = async (
   if (parsed) {
     const parsedElements = await awu((await parsed.elements()) ?? []).toArray()
     expect(parsedElements).toEqual(elements)
+    parsedElements.forEach(
+      elem => expect(elem.path).toEqual(naclFileSourceModule.toPathHint(filename))
+    )
     expect(await parsed.data.errors()).toEqual(errors)
     expect(parsed.filename).toEqual(filename)
   }


### PR DESCRIPTION
_added file location as path fallback in fetch from_

---

If an element was added to the nacls and then deployed, it will be in the state - but not in the path index.

In the long term - this should be handled by the fragments refactor epic. As a short term solution until  - we should use the nacl files location as a fallback.

---
_Release Notes_: 
_Added file location as a fallback for changes path in fetch from workspace_

---
_User Notifications_: 
_NA_
