### PR TITLE
SALTO-2095: Added supportedTypes to Stripe's config to avoid fetching unsupported…

### DIFF
--- a/packages/stripe-adapter/e2e_test/adapter.test.ts
+++ b/packages/stripe-adapter/e2e_test/adapter.test.ts
@@ -81,9 +81,20 @@ describe('Stripe adapter E2E with real swagger and mock replies', () => {
       'stripe.webhook_endpoint_metadata',
     ])(
       '%s',
-      async expectedType => {
+      expectedType => {
         expect(fetchedElementsNames).toContain(expectedType)
       }
     )
+
+    it.each([
+      'stripe.plan',
+      'stripe.plan_metadata',
+      'stripe.plan_tier',
+      'stripe.transform_usage',
+      'stripe.prices',
+    ])('%s',
+      unsupportedType => {
+        expect(fetchedElementsNames).not.toContain(unsupportedType)
+      })
   })
 })

--- a/packages/stripe-adapter/e2e_test/adapter.test.ts
+++ b/packages/stripe-adapter/e2e_test/adapter.test.ts
@@ -57,7 +57,6 @@ describe('Stripe adapter E2E with real swagger and mock replies', () => {
     it.each([
       'stripe.country_specs',
       'stripe.coupons',
-      'stripe.prices',
       'stripe.products',
       'stripe.reporting__report_types',
       'stripe.tax_rates',
@@ -67,7 +66,6 @@ describe('Stripe adapter E2E with real swagger and mock replies', () => {
       'stripe.reporting_report_type',
       'stripe.country_spec',
       'stripe.coupon',
-      'stripe.plan',
       'stripe.tax_rate',
       'stripe.webhook_endpoint',
       'stripe.product_metadata',
@@ -79,9 +77,6 @@ describe('Stripe adapter E2E with real swagger and mock replies', () => {
       'stripe.country_spec_verification_fields',
       'stripe.coupon_applies_to',
       'stripe.coupon_metadata',
-      'stripe.plan_metadata',
-      'stripe.plan_tier',
-      'stripe.transform_usage',
       'stripe.tax_rate_metadata',
       'stripe.webhook_endpoint_metadata',
     ])(

--- a/packages/stripe-adapter/e2e_test/adapter.test.ts
+++ b/packages/stripe-adapter/e2e_test/adapter.test.ts
@@ -25,6 +25,7 @@ import { credsLease, realAdapter } from './adapter'
  * for all the supported types in {@link DEFAULT_API_DEFINITIONS.swagger.typeNameOverrides}
  */
 describe('Stripe adapter E2E with real swagger and mock replies', () => {
+  let fetchedElementNames: string[]
   let fetchedSwaggerElements: Element[]
   let credLease: CredsLease<AccessTokenCredentials>
 
@@ -36,6 +37,7 @@ describe('Stripe adapter E2E with real swagger and mock replies', () => {
         { reportProgress: () => null },
     })
     fetchedSwaggerElements = elements
+    fetchedElementNames = fetchedSwaggerElements.map(e => e.elemID.getFullName())
   })
 
   afterAll(async () => {
@@ -49,11 +51,6 @@ describe('Stripe adapter E2E with real swagger and mock replies', () => {
   })
 
   describe('fetches swagger types', () => {
-    let fetchedElementsNames: string[]
-
-    beforeAll(() => {
-      fetchedElementsNames = fetchedSwaggerElements.map(e => e.elemID.getFullName())
-    })
     it.each([
       'stripe.country_specs',
       'stripe.coupons',
@@ -82,10 +79,12 @@ describe('Stripe adapter E2E with real swagger and mock replies', () => {
     ])(
       '%s',
       expectedType => {
-        expect(fetchedElementsNames).toContain(expectedType)
+        expect(fetchedElementNames).toContain(expectedType)
       }
     )
+  })
 
+  describe('does not fetch unsupported types', () => {
     it.each([
       'stripe.plan',
       'stripe.plan_metadata',
@@ -94,7 +93,7 @@ describe('Stripe adapter E2E with real swagger and mock replies', () => {
       'stripe.prices',
     ])('%s',
       unsupportedType => {
-        expect(fetchedElementsNames).not.toContain(unsupportedType)
+        expect(fetchedElementNames).not.toContain(unsupportedType)
       })
   })
 })

--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -55,7 +55,6 @@ const ALL_SUPPORTED_TYPES = [
   'webhook_endpoints',
 ]
 
-// noinspection UnnecessaryLocalVariableJS
 export const DEFAULT_INCLUDE_TYPES = ALL_SUPPORTED_TYPES
 
 const DEFAULT_TYPE_CUSTOMIZATIONS: StripeApiConfig['types'] = {

--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -46,6 +46,18 @@ export type StripeConfig = {
   [API_DEFINITIONS_CONFIG]: StripeApiConfig
 }
 
+const ALL_SUPPORTED_TYPES = [
+  'country_specs',
+  'coupons',
+  'products',
+  'reporting__report_types',
+  'tax_rates',
+  'webhook_endpoints',
+]
+
+// noinspection UnnecessaryLocalVariableJS
+export const DEFAULT_INCLUDE_TYPES = ALL_SUPPORTED_TYPES
+
 const DEFAULT_TYPE_CUSTOMIZATIONS: StripeApiConfig['types'] = {
   coupon: {
     transformation: {
@@ -116,19 +128,8 @@ export const DEFAULT_API_DEFINITIONS: StripeApiConfig = {
     },
   },
   types: DEFAULT_TYPE_CUSTOMIZATIONS,
+  supportedTypes: ALL_SUPPORTED_TYPES,
 }
-
-const ALL_SUPPORTED_TYPES = [
-  'country_specs',
-  'coupons',
-  'products',
-  'reporting__report_types',
-  'tax_rates',
-  'webhook_endpoints',
-]
-
-// noinspection UnnecessaryLocalVariableJS
-export const DEFAULT_INCLUDE_TYPES = ALL_SUPPORTED_TYPES
 
 export const DEFAULT_CONFIG: StripeConfig = {
   [FETCH_CONFIG]: {


### PR DESCRIPTION
Added supported types specification to Stripe adapter's config.

---

In an older refactor I've done to Stripe, I accidentally removed the supportedTypes from the config, which caused fetching unsupported types. Reverted the change.

---
_Release Notes_: 
Stripe Adapter:
- Only supported types will be fetched.

---
_User Notifications_: 
_None_
