### PR TITLE
SAAS-4317/validation rules authour information

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -33,6 +33,7 @@ import customObjectsSplitFilter from './filters/custom_object_split'
 import customObjectAuthorFilter from './filters/author_information/custom_objects'
 import dataInstancesAuthorFilter from './filters/author_information/data_instances'
 import sharingRulesAuthorFilter from './filters/author_information/sharing_rules'
+import validationRulesAuthorFilter from './filters/author_information/validation_rules'
 import profileInstanceSplitFilter from './filters/profile_instance_split'
 import customObjectsInstancesFilter from './filters/custom_objects_instances'
 import profilePermissionsFilter from './filters/profile_permissions'
@@ -122,6 +123,7 @@ export const DEFAULT_FILTERS = [
   customObjectAuthorFilter,
   dataInstancesAuthorFilter,
   sharingRulesAuthorFilter,
+  validationRulesAuthorFilter,
   hideReadOnlyValuesFilter,
   // The following filters should remain last in order to make sure they fix all elements
   convertListsFilter,

--- a/packages/salesforce-adapter/src/filters/author_information/validation_rules.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/validation_rules.ts
@@ -16,6 +16,7 @@
 import { Element, isInstanceElement } from '@salto-io/adapter-api'
 import { FileProperties } from 'jsforce-types'
 import { logger } from '@salto-io/logging'
+import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
 import { VALIDATION_RULES_METADATA_TYPE } from '../../constants'
 import { getAuthorAnnotations } from '../../transformers/transformer'
@@ -44,7 +45,7 @@ const fetchAllValidationRules = async (
   client: SalesforceClient
 ): Promise<Record<string, FileProperties>> => {
   const allRules = await getValidationRulesFileProperties(client)
-  return Object.fromEntries(allRules.map(fileProp => [fileProp.fullName, fileProp]))
+  return _.keyBy(allRules, 'fullName')
 }
 
 export const WARNING_MESSAGE = 'Encountered an error while trying to populate author information in some of the Salesforce configuration elements.'

--- a/packages/salesforce-adapter/src/filters/author_information/validation_rules.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/validation_rules.ts
@@ -1,0 +1,77 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, isInstanceElement } from '@salto-io/adapter-api'
+import { FileProperties } from 'jsforce-types'
+import { logger } from '@salto-io/logging'
+import { collections, values } from '@salto-io/lowerdash'
+import { VALIDATION_RULES_METADATA_TYPE } from '../../constants'
+import { getAuthorAnnotations } from '../../transformers/transformer'
+import { FilterCreator, FilterWith } from '../../filter'
+import SalesforceClient from '../../client/client'
+import { ensureSafeFilterFetch, isInstanceOfType } from '../utils'
+
+const { isDefined } = values
+const { awu } = collections.asynciterable
+const log = logger(module)
+const VALIDATION_RULES_API_NAME = 'ValidationRule'
+
+const isValidationRulesInstance = isInstanceOfType(VALIDATION_RULES_METADATA_TYPE)
+
+const getValidationRulesFileProperties = async (client: SalesforceClient):
+  Promise<FileProperties[]> => {
+  const { result, errors } = await client.listMetadataObjects({ type: VALIDATION_RULES_API_NAME })
+  if (errors && errors.length > 0) {
+    log.warn(`Encountered errors while listing file properties for SharingRules: ${errors}`)
+  }
+  return result
+}
+
+
+const fetchAllValidationRules = async (
+  client: SalesforceClient
+): Promise<Record<string, FileProperties>> => {
+  const allRules = await getValidationRulesFileProperties(client)
+  return Object.fromEntries(allRules.map(fileProp => [fileProp.fullName, fileProp]))
+}
+
+export const WARNING_MESSAGE = 'Encountered an error while trying to populate author information in some of the Salesforce configuration elements.'
+
+/*
+ * Add author information to validation rules instances.
+ */
+const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
+  onFetch: ensureSafeFilterFetch({
+    warningMessage: WARNING_MESSAGE,
+    config,
+    filterName: 'authorInformation',
+    fetchFilterFunc: async (elements: Element[]) => {
+      const ValidationRulesMap = await fetchAllValidationRules(client)
+      const validationRulesInstances = await (awu(elements)
+        .filter(isInstanceElement)
+        .filter(isValidationRulesInstance)
+        .toArray())
+      validationRulesInstances.forEach(validationRule => {
+        if (isDefined(ValidationRulesMap[validationRule.value.fullName])) {
+          validationRule.annotate(
+            getAuthorAnnotations(ValidationRulesMap[validationRule.value.fullName]),
+          )
+        }
+      })
+    },
+  }),
+})
+
+export default filterCreator

--- a/packages/salesforce-adapter/test/filters/author_information/validation_rules.test.ts
+++ b/packages/salesforce-adapter/test/filters/author_information/validation_rules.test.ts
@@ -1,0 +1,94 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, ElemID, ObjectType, InstanceElement } from '@salto-io/adapter-api'
+import { MockInterface } from '@salto-io/test-utils'
+import { buildFetchProfile } from '../../../src/fetch_profile/fetch_profile'
+import { mockFileProperties } from '../../connection'
+import mockClient from '../../client'
+import Connection from '../../../src/client/jsforce'
+import SalesforceClient from '../../../src/client/client'
+import { Filter, FilterResult } from '../../../src/filter'
+import validationRules, { WARNING_MESSAGE } from '../../../src/filters/author_information/validation_rules'
+import { defaultFilterContext } from '../../utils'
+import { API_NAME } from '../../../src/constants'
+
+describe('validation rules author information test', () => {
+  let filter: Filter
+  let client: SalesforceClient
+  let connection: MockInterface<Connection>
+  let validationRuleInstance: InstanceElement
+  const mockedFileProperties = mockFileProperties({ fullName: 'Account.rule1',
+    type: 'test',
+    createdByName: 'Ruler',
+    createdDate: 'created_date',
+    lastModifiedByName: 'Ruler',
+    lastModifiedDate: '2021-10-19T06:30:10.000Z' })
+  const validationRulesObjectType = new ObjectType({
+    elemID: new ElemID('salesforce', 'ValidationRule'),
+    annotations: { [API_NAME]: 'ValidationRule' },
+    fields: {},
+  })
+  const instanceToIgnore = new InstanceElement('ignore', validationRulesObjectType)
+  instanceToIgnore.value.fullName = 'ignore'
+  beforeEach(async () => {
+    ({ connection, client } = mockClient())
+    filter = validationRules({ client, config: defaultFilterContext })
+    validationRuleInstance = new InstanceElement('name', validationRulesObjectType)
+    validationRuleInstance.value.fullName = 'Account.rule1'
+  })
+  describe('success', () => {
+    beforeEach(async () => {
+      connection.metadata.list.mockResolvedValueOnce([mockedFileProperties])
+      await filter.onFetch?.([validationRuleInstance, instanceToIgnore])
+    })
+    it('should add author annotations to validation rules', async () => {
+      expect(validationRuleInstance.annotations[CORE_ANNOTATIONS.CHANGED_BY]).toEqual('Ruler')
+      expect(validationRuleInstance.annotations[CORE_ANNOTATIONS.CHANGED_AT]).toEqual('2021-10-19T06:30:10.000Z')
+    })
+    it('should leave rules with no information as they are', async () => {
+      expect(instanceToIgnore.annotations[CORE_ANNOTATIONS.CHANGED_BY]).not.toBeDefined()
+      expect(instanceToIgnore.annotations[CORE_ANNOTATIONS.CHANGED_AT]).not.toBeDefined()
+    })
+  })
+  describe('failure', () => {
+    it('should return a warning', async () => {
+      connection.metadata.list.mockImplementation(() => {
+        throw new Error()
+      })
+      const res = await filter.onFetch?.([validationRuleInstance]) as FilterResult
+      const err = res.errors ?? []
+      expect(res.errors).toHaveLength(1)
+      expect(err[0]).toEqual({
+        severity: 'Warning',
+        message: WARNING_MESSAGE,
+      })
+    })
+  })
+  describe('when feature is disabled', () => {
+    it('should not add any annotations', async () => {
+      filter = validationRules({
+        client,
+        config: {
+          ...defaultFilterContext,
+          fetchProfile: buildFetchProfile({ optionalFeatures: { authorInformation: false } }),
+        },
+      })
+      await filter.onFetch?.([validationRuleInstance])
+      expect(validationRuleInstance.annotations[CORE_ANNOTATIONS.CHANGED_BY]).not.toBeDefined()
+      expect(validationRuleInstance.annotations[CORE_ANNOTATIONS.CHANGED_AT]).not.toBeDefined()
+    })
+  })
+})


### PR DESCRIPTION
add author information to validation rule instances.

---

_Additional context for reviewer_
there is an option to merge sharing rules author information filter and this new one into a single generic filter that will handle even more types but it will be done in a different pr.

---
_Release Notes_: 

---
_User Notifications_: 

