### PR TITLE
SALTO-2110: SF fetch fails sporadically due to "unknown_error: retry your request"

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -83,6 +83,8 @@ const DEFAULT_READ_METADATA_CHUNK_SIZE: Required<ReadMetadataChunkSizeConfig> = 
 const errorMessagesToRetry = [
   'Cannot read property \'result\' of null',
   'Too many properties to enumerate',
+  'retry your request', // We saw "unknown_error: retry your request" error message,
+  //  but in case there is another error that says "retry your request", probably we should retry it
 ]
 
 type RateLimitBucketName = keyof ClientRateLimitConfig
@@ -415,7 +417,7 @@ export default class SalesforceClient {
       try {
         res = await request()
       } catch (e) {
-        if (attempts > 1 && errorMessagesToRetry.includes(e.message)) {
+        if (attempts > 1 && errorMessagesToRetry.some(message => e.message.includes(message))) {
           log.warn('Encountered invalid result from salesforce, error message: %s, will retry %d more times', e.message, attempts - 1)
           return requestWithRetry(attempts - 1)
         }

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -309,6 +309,7 @@ describe('salesforce client', () => {
     let testConnection: MockInterface<Connection>
     let nullFailingImplementation: Metadata['list']
     let rangeErrorFailingImplementation: Metadata['list']
+    let unknownErrorToRetryImplementation: Metadata['list']
 
     beforeEach(() => {
       const mockClientAndConnection = mockClient()
@@ -321,6 +322,9 @@ describe('salesforce client', () => {
       rangeErrorFailingImplementation = async () => {
         throw new RangeError('Too many properties to enumerate')
       }
+      unknownErrorToRetryImplementation = async () => {
+        throw new Error('unknown_error: retry your request')
+      }
     })
     describe('when the error is recoverable', () => {
       let result: ReturnType<typeof testClient.listMetadataObjects>
@@ -331,6 +335,7 @@ describe('salesforce client', () => {
           .mockImplementationOnce(nullFailingImplementation)
           .mockImplementationOnce(nullFailingImplementation)
           .mockImplementationOnce(rangeErrorFailingImplementation)
+          .mockImplementationOnce(unknownErrorToRetryImplementation)
           .mockResolvedValueOnce([expectedProperties])
 
         result = testClient.listMetadataObjects({ type: 'CustomObject' })


### PR DESCRIPTION
_Release Notes_: 
Salesforce Adapter: retry upon "unknown_error: retry your request" error when listing metadata types.