### PR TITLE
SALTO-1406: Fix issue where temporary env switches the active env

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -284,7 +284,10 @@ export const loadWorkspace = async (
     throw new Error('Workspace with no environments is illegal')
   }
   const envs = (): ReadonlyArray<string> => workspaceConfig.envs.map(e => e.name)
-  const currentEnv = (): string => workspaceConfig.currentEnv ?? workspaceConfig.envs[0].name
+  let overrideEnv: string
+  const currentEnv = (): string => overrideEnv
+    ?? workspaceConfig.currentEnv
+    ?? workspaceConfig.envs[0].name
   const getRemoteMapNamespace = (
     namespace: string, env?: string
   ): string => `workspace-${env || currentEnv()}-${namespace}`
@@ -1181,9 +1184,12 @@ export const loadWorkspace = async (
       if (!envs().includes(env)) {
         throw new UnknownEnvError(env)
       }
-      workspaceConfig.currentEnv = env
+
       if (persist) {
+        workspaceConfig.currentEnv = env
         await config.setWorkspaceConfig(workspaceConfig)
+      } else {
+        overrideEnv = env
       }
     },
 

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2534,33 +2534,54 @@ describe('workspace', () => {
     let workspaceConf: WorkspaceConfigSource
     let workspace: Workspace
 
-    beforeEach(async () => {
-      workspaceConf = mockWorkspaceConfigSource()
-      workspace = await createWorkspace(undefined, undefined, workspaceConf)
-      await workspace.addAccount('salto', 'new')
+    describe('when creating an account', () => {
+      beforeEach(async () => {
+        workspaceConf = mockWorkspaceConfigSource({})
+        workspace = await createWorkspace(undefined, undefined, workspaceConf)
+        await workspace.addAccount('salto', 'new')
+      })
+
+      it('should change workspace state', async () => {
+        expect(workspace.accounts().includes('new')).toBeTruthy()
+      })
+
+      it('should throw account duplication error', async () => {
+        await expect(workspace.addAccount('salto', 'new')).rejects.toThrow(AccountDuplicationError)
+      })
+
+      it('should throw invalidAccountNameError', async () => {
+        await expect(workspace.addAccount('salto', 'new;;')).rejects.toThrow(InvalidAccountNameError)
+        await expect(workspace.addAccount('salto', 'new account')).rejects.toThrow(InvalidAccountNameError)
+        await expect(workspace.addAccount('salto', 'new.')).rejects.toThrow(InvalidAccountNameError)
+      })
+
+      it('should persist', () => {
+        expect(workspaceConf.setWorkspaceConfig).toHaveBeenCalledTimes(1)
+        const envs = (
+          workspaceConf.setWorkspaceConfig as jest.Mock
+        ).mock.calls[0][0].envs as EnvConfig[]
+        expect((envs as {name: string}[]).find(e => e.name === 'default'))
+          .toBeDefined()
+      })
     })
 
-    it('should change workspace state', async () => {
-      expect(workspace.accounts().includes('new')).toBeTruthy()
-    })
+    describe('when specifing an override environment', () => {
+      beforeEach(async () => {
+        workspaceConf = mockWorkspaceConfigSource({}, true)
+        workspace = await createWorkspace(undefined, undefined, workspaceConf)
+        await workspace.setCurrentEnv('inactive', false)
+        await workspace.addAccount('salto')
+      })
 
-    it('should throw account duplication error', async () => {
-      await expect(workspace.addAccount('salto', 'new')).rejects.toThrow(AccountDuplicationError)
-    })
+      it('should add the account only in the other enviroment', () => {
+        expect(workspace.accounts('default')).not.toContain('salto')
+        expect(workspace.accounts('inactive')).toContain('salto')
+      })
 
-    it('should throw invalidAccountNameError', async () => {
-      await expect(workspace.addAccount('salto', 'new;;')).rejects.toThrow(InvalidAccountNameError)
-      await expect(workspace.addAccount('salto', 'new account')).rejects.toThrow(InvalidAccountNameError)
-      await expect(workspace.addAccount('salto', 'new.')).rejects.toThrow(InvalidAccountNameError)
-    })
-
-    it('should persist', () => {
-      expect(workspaceConf.setWorkspaceConfig).toHaveBeenCalledTimes(1)
-      const envs = (
-        workspaceConf.setWorkspaceConfig as jest.Mock
-      ).mock.calls[0][0].envs as EnvConfig[]
-      expect((envs as {name: string}[]).find(e => e.name === 'default'))
-        .toBeDefined()
+      it('should not change the persisted current environment', () => {
+        const setWorkspaceConfig = (workspaceConf.setWorkspaceConfig as jest.Mock)
+        expect(setWorkspaceConfig.mock.calls[setWorkspaceConfig.mock.calls.length - 1][0].currentEnv).toBe('default')
+      })
     })
   })
 

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2579,7 +2579,7 @@ describe('workspace', () => {
       })
 
       it('should not change the persisted current environment', () => {
-        expect(workspaceConf.setWorkspaceConfig as jest.Mock).toHaveBeenCalledWith(
+        expect(workspaceConf.setWorkspaceConfig as jest.Mock).toHaveBeenLastCalledWith(
           expect.objectContaining({ currentEnv: 'default' })
         )
       })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2579,8 +2579,9 @@ describe('workspace', () => {
       })
 
       it('should not change the persisted current environment', () => {
-        const setWorkspaceConfig = (workspaceConf.setWorkspaceConfig as jest.Mock)
-        expect(setWorkspaceConfig.mock.calls[setWorkspaceConfig.mock.calls.length - 1][0].currentEnv).toBe('default')
+        expect(workspaceConf.setWorkspaceConfig as jest.Mock).toHaveBeenCalledWith(
+          expect.objectContaining({ currentEnv: 'default' })
+        )
       })
     })
   })


### PR DESCRIPTION
Added a new optional target env to the workspace, so actions will use that as instead of the active env for most operations.

---

None

---

_Release Notes_: 
CLI - Fix issue where setting the -e flag would change the active env 

---
_User Notifications_: 
None
