### PR TITLE
SAAS-4452 force login on salesforce oauth flow

### DIFF
--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -125,7 +125,7 @@ SalesforceConfig => {
 
 export const createUrlFromUserInput = (value: Values): string => {
   const endpoint = value.sandbox ? 'test' : 'login'
-  return `https://${endpoint}.salesforce.com/services/oauth2/authorize?response_type=token&client_id=${value.consumerKey}&scope=refresh_token%20full&redirect_uri=http://localhost:${value.port}`
+  return `https://${endpoint}.salesforce.com/services/oauth2/authorize?response_type=token&client_id=${value.consumerKey}&scope=refresh_token%20full&redirect_uri=http://localhost:${value.port}&prompt=login%20consent`
 }
 
 const createOAuthRequest = (userInput: InstanceElement): OAuthRequestParameters => ({


### PR DESCRIPTION
Force login on salesforce oauth flow - using the `prompt=login%20consent` url parameter.

---
_Release Notes_: 
Salesforce Adapter:
- Force login on Salesforce OAuth flow

---
_User Notifications_: 
None
