### PR TITLE
SALTO-1934: fixed bug in transform values

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -189,7 +189,10 @@ export const transformValues = async (
         if (strict) {
           log.debug(`Value mis-match for field ${field?.name} - value is not an object`)
         }
-        return (_.isEmpty(newVal) && !allowEmpty) ? undefined : newVal
+        return (_.isEmpty(newVal)
+          && (Array.isArray(newVal)
+          || _.isString(newVal))
+          && !allowEmpty) ? undefined : newVal
       }
       const transformed = _.omitBy(
         await transformValues({

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -189,12 +189,12 @@ export const transformValues = async (
         if (strict) {
           log.debug(`Value mis-match for field ${field?.name} - value is not an object`)
         }
-        return (_.isEmpty(newVal)
-          // No need to check if for isPlainObject because in
-          // this flow we already checked that it is not
-          && (Array.isArray(newVal)
-            || _.isString(newVal))
-          && !allowEmpty) ? undefined : newVal
+        // _.isEmpty returns true for primitive values (boolean, number)
+        // but we do not want to omit those, we only want to omit empty
+        // objects, arrays and strings. we don't need to check for objects here
+        // because we cannot get here with an object
+        const valueIsEmpty = (Array.isArray(newVal) || _.isString(newVal)) && _.isEmpty(newVal)
+        return (valueIsEmpty && !allowEmpty) ? undefined : newVal
       }
       const transformed = _.omitBy(
         await transformValues({

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -190,8 +190,10 @@ export const transformValues = async (
           log.debug(`Value mis-match for field ${field?.name} - value is not an object`)
         }
         return (_.isEmpty(newVal)
+          // No need to check if for isPlainObject because in
+          // this flow we already checked that it is not
           && (Array.isArray(newVal)
-          || _.isString(newVal))
+            || _.isString(newVal))
           && !allowEmpty) ? undefined : newVal
       }
       const transformed = _.omitBy(

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -934,6 +934,7 @@ describe('Test utils.ts', () => {
           elemID: new ElemID('salesforce', 'obj'),
           fields: {
             nested: { refType: nestedType },
+            numberNested: { refType: nestedType },
             nestedArray: { refType: new ListType(nestedType) },
           },
         })
@@ -942,6 +943,7 @@ describe('Test utils.ts', () => {
           otherObjType,
           {
             nested: 'aaa',
+            numberNested: 1,
             nestedArray: ['aaa', 'bbb'],
           },
         )
@@ -950,12 +952,14 @@ describe('Test utils.ts', () => {
         result = await transformElement({ element: invalidInst, transformFunc, strict: false })
         expect(isInstanceElement(result)).toBeTruthy()
         expect(result.value.nested).toEqual('aaa')
+        expect(result.value.numberNested).toEqual(1)
         expect(result.value.nestedArray).toEqual(['aaa', 'bbb'])
       })
       it('should correctly handle type inconsistencies when strict=true', async () => {
         result = await transformElement({ element: invalidInst, transformFunc, strict: true })
         expect(isInstanceElement(result)).toBeTruthy()
         expect(result.value.nested).toEqual('aaa')
+        expect(result.value.numberNested).toEqual(1)
         expect(result.value.nestedArray).toEqual(['aaa', 'bbb'])
       })
     })

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -935,6 +935,7 @@ describe('Test utils.ts', () => {
           fields: {
             nested: { refType: nestedType },
             numberNested: { refType: nestedType },
+            booleanNested: { refType: nestedType },
             nestedArray: { refType: new ListType(nestedType) },
           },
         })
@@ -944,6 +945,7 @@ describe('Test utils.ts', () => {
           {
             nested: 'aaa',
             numberNested: 1,
+            booleanNested: true,
             nestedArray: ['aaa', 'bbb'],
           },
         )
@@ -953,6 +955,7 @@ describe('Test utils.ts', () => {
         expect(isInstanceElement(result)).toBeTruthy()
         expect(result.value.nested).toEqual('aaa')
         expect(result.value.numberNested).toEqual(1)
+        expect(result.value.booleanNested).toBeTruthy()
         expect(result.value.nestedArray).toEqual(['aaa', 'bbb'])
       })
       it('should correctly handle type inconsistencies when strict=true', async () => {
@@ -960,6 +963,7 @@ describe('Test utils.ts', () => {
         expect(isInstanceElement(result)).toBeTruthy()
         expect(result.value.nested).toEqual('aaa')
         expect(result.value.numberNested).toEqual(1)
+        expect(result.value.booleanNested).toBeTruthy()
         expect(result.value.nestedArray).toEqual(['aaa', 'bbb'])
       })
     })


### PR DESCRIPTION
Fixed a bug in transform values where we would run `_.isEmpty` on values that might be numbers or booleans which `_.isEmpty` returns true for but we would not want treat as empty

---
_Release Notes_: 
None

---
_User Notifications_: 
None