### PR TITLE
SAAS-3619-increase-max-workspace-errors

### DIFF
--- a/packages/lang-server/src/diagnostics.ts
+++ b/packages/lang-server/src/diagnostics.ts
@@ -28,7 +28,7 @@ export interface SaltoDiagnostic {
 
 export type WorkspaceSaltoDiagnostics = Record<string, SaltoDiagnostic[]>
 
-const MAX_WORKSPACE_ERRORS = 30
+const MAX_WORKSPACE_ERRORS = 50
 
 export const getDiagnostics = async (
   workspace: EditorWorkspace,


### PR DESCRIPTION
Increasing the MAX_WORKSPACE_ERRORS const 
---

_Additional context for reviewer_
For converting ws errors to git conflicts in the UI (and not from the OSS) we filter diagnostics and find the git conflicts there. Every git conflict raise 16 errors, which won't be replaced in the errors list until fixed. Raising the maximum number of ws errors will allow us to have maximum of 4 git conflicts errors

---
_Release Notes_: 
* max number of workspace error will be raised to 50 (while git conflict error == 16 errors)

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
