### PR TITLE
Skip resolving elements in plan when not needed

### DIFF
--- a/packages/workspace/src/expressions.ts
+++ b/packages/workspace/src/expressions.ts
@@ -14,10 +14,12 @@
 * limitations under the License.
 */
 import _ from 'lodash'
+import { logger } from '@salto-io/logging'
 import { ElemID, Element, Value, ReferenceExpression, TemplateExpression, isReferenceExpression, isVariableExpression, isElement, ReadOnlyElementsSource, isVariable, isInstanceElement, isObjectType, isContainerType, isField, Field, isTypeReference, createRefToElmWithValue } from '@salto-io/adapter-api'
 import { resolvePath, TransformFunc, transformValues } from '@salto-io/adapter-utils'
 import { collections, promises } from '@salto-io/lowerdash'
 
+const log = logger(module)
 const { mapValuesAsync } = promises.object
 
 type WorkingSetElement = {
@@ -302,11 +304,11 @@ const resolveElement = async <T extends Element>(
   return element as T
 }
 
-export const resolve = async (
+export const resolve = (
   elements: Element[],
   elementsSource: ReadOnlyElementsSource,
   resolveRoot = false
-): Promise<Element[]> => {
+): Promise<Element[]> => log.time(async () => {
   const elementsToResolve = elements.map(_.clone)
   const resolvedElements = await awu(elementsToResolve)
     .map(element => ({ element }))
@@ -326,4 +328,4 @@ export const resolve = async (
     resolveRoot
   ))
   return elementsToResolve
-}
+}, 'resolve %d elements', elements.length)


### PR DESCRIPTION
Before this change, the plan algorithm would resolve elements twice.
The second resolve was there in order to make sure everything is resolved after filtering.
When no changes were filtered out, there is no need to resolve again.
Skipping that second resolve seems to have a significant effect on performance

Also added more granular timing logs for different parts of the plan algorithm

---


---
_Release Notes_: 
Core:
- Improve performance of comparisons (fetch, diff)

---
_User Notifications_: 
_None_