### PR TITLE
SALTO-1387 support account features: fetch and deploy

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -45,8 +45,8 @@ const { awu } = collections.asynciterable
 describe('Netsuite adapter E2E with real account', () => {
   let adapter: NetsuiteAdapter
   let credentialsLease: CredsLease<Required<Credentials>>
-  const { customTypes, enums, fileCabinetTypes, fieldTypes } = getMetadataTypes()
-  const metadataTypes = metadataTypesToList({ customTypes, enums, fileCabinetTypes, fieldTypes })
+  const { customTypes, enums, additionalTypes, fieldTypes } = getMetadataTypes()
+  const metadataTypes = metadataTypesToList({ customTypes, enums, additionalTypes, fieldTypes })
 
   const createInstanceElement = (type: string, valuesOverride: Values): InstanceElement => {
     const instValues = {
@@ -59,7 +59,7 @@ describe('Netsuite adapter E2E with real account', () => {
 
     return new InstanceElement(
       instanceName,
-      isCustomTypeName(type) ? customTypes[type].type : fileCabinetTypes[type],
+      isCustomTypeName(type) ? customTypes[type].type : additionalTypes[type],
       instValues
     )
   }

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -36,7 +36,7 @@
     "@salto-io/file": "0.3.12",
     "@salto-io/logging": "0.3.12",
     "@salto-io/lowerdash": "0.3.12",
-    "@salto-io/suitecloud-cli": "1.3.2-salto-1",
+    "@salto-io/suitecloud-cli": "1.3.2-salto-2",
     "ajv": "^7.1.1",
     "async-lock": "^1.2.4",
     "axios": "^0.21.3",

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -28,6 +28,7 @@ import subInstancesValidator from './change_validators/subinstances'
 import customTypesInvalidValuesValidator from './change_validators/custom_types_invalid_values'
 import safeDeployValidator, { FetchByQueryFunc } from './change_validators/safe_deploy'
 import mappedListsIndexesValidator from './change_validators/mapped_lists_indexes'
+import accountFeaturesObjectValidator from './change_validators/account_features'
 import { validateDependsOnInvalidElement } from './change_validators/dependencies'
 
 
@@ -43,6 +44,7 @@ const changeValidators: ChangeValidator[] = [
   subInstancesValidator,
   customTypesInvalidValuesValidator,
   mappedListsIndexesValidator,
+  accountFeaturesObjectValidator,
 ]
 
 const nonSuiteAppValidators: ChangeValidator[] = [

--- a/packages/netsuite-adapter/src/change_validators/account_features.ts
+++ b/packages/netsuite-adapter/src/change_validators/account_features.ts
@@ -1,0 +1,140 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { values } from '@salto-io/lowerdash'
+import {
+  ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionChange,
+  isInstanceChange, isModificationChange, isRemovalChange, ModificationChange,
+} from '@salto-io/adapter-api'
+import { ACCOUNT_FEATURES, ACCOUNT_FEATURES_VALID_STATUS_VALUES } from '../constants'
+
+// These features cannot be configure using SDF
+// because they require a Terms of Service user agreement
+const UNDEPLOYABLE_FEATURES = [
+  'AUTOLOCATIONASSIGNMENT',
+  'FULFILLMENTREQUEST',
+  'WEEKLYTIMESHEETSNEWUI',
+  'SUPPLYCHAINPREDICTEDRISKS',
+  'WEBDUPLICATEEMAILMANAGEMENT',
+  'OPENIDSSO',
+  'OIDC',
+  'SAMLSSO',
+  'OAUTH2',
+  'NSASOIDCPROVIDER',
+  'SUITEAPPCONTROLCENTER',
+  'MULTICURRENCYCUSTOMER',
+  'MULTICURRENCYVENDOR',
+  'FXRATEUPDATES',
+  'MOBILEPUSHNTF',
+  'EFT',
+  'ACHVEND',
+  'MAILMERGE',
+  'ITEMOPTIONS',
+  'CUSTOMRECORDS',
+  'ADVANCEDPRINTING',
+  'CUSTOMCODE',
+  'SERVERSIDESCRIPTING',
+  'WEBAPPLICATIONS',
+  'WORKFLOW',
+  'CUSTOMGLLINES',
+  'CUSTOMSEGMENTS',
+  'CREATESUITEBUNDLES',
+  'WEBSERVICESEXTERNAL',
+  'RESTWEBSERVICES',
+  'SUITESIGNON',
+  'TBA',
+]
+
+const INVALID_MODIFICATION_ERROR: Omit<ChangeError, 'elemID'> = {
+  severity: 'Error',
+  message: 'Only feature.status field modification is supported',
+  detailedMessage: 'Only feature.status field modification is supported, with the following values: ENABLED, DISABLED',
+}
+
+const UNDEPLOYABLE_FEATURE_ERROR: Omit<ChangeError, 'elemID'> = {
+  severity: 'Warning',
+  message: 'Feature configuration is not supported',
+  detailedMessage: 'You cannot use Salto to configure this feature because it requires a Terms of Service user agreement.',
+}
+
+const getModificationErrors = (change: ModificationChange<InstanceElement>): ChangeError[] => {
+  const beforeFeatures = change.data.before.value.features
+  const afterFeatures = change.data.after.value.features
+  const featuresElemID = change.data.after.elemID.createNestedID('features')
+
+  if (!_.isPlainObject(afterFeatures) || !_.isPlainObject(beforeFeatures)
+    || Object.keys(beforeFeatures).length !== Object.keys(afterFeatures).length) {
+    return [{
+      elemID: featuresElemID,
+      ...INVALID_MODIFICATION_ERROR,
+    }]
+  }
+
+  return Object.entries(afterFeatures).map(([key, feature]) => {
+    if (_.isEqual(feature, beforeFeatures[key])) {
+      return undefined
+    }
+    if (!beforeFeatures[key]
+      || !values.isPlainRecord(feature)
+      || feature.label !== beforeFeatures[key].label
+      || feature.id !== beforeFeatures[key].id
+      || !_.isString(feature.status)
+      || !ACCOUNT_FEATURES_VALID_STATUS_VALUES.includes(feature.status)) {
+      return {
+        elemID: featuresElemID.createNestedID(key),
+        ...INVALID_MODIFICATION_ERROR,
+      }
+    }
+    return UNDEPLOYABLE_FEATURES.includes(key) ? {
+      elemID: featuresElemID.createNestedID(key),
+      ...UNDEPLOYABLE_FEATURE_ERROR,
+    } : undefined
+  }).filter(values.isDefined)
+}
+
+const changeValidator: ChangeValidator = async changes => {
+  const accountFeaturesChanges = changes
+    .filter(isInstanceChange)
+    .filter(change => getChangeData(change).elemID.typeName === ACCOUNT_FEATURES)
+
+  const removalErrors: ChangeError[] = accountFeaturesChanges
+    .filter(isRemovalChange)
+    .map(getChangeData)
+    .map(({ elemID }) => ({
+      elemID,
+      severity: 'Error',
+      message: 'Removal of the accountFeatures instance has no effect on your NetSuite account',
+      detailedMessage: 'Removal of the accountFeatures instance has no effect on your NetSuite account. This instance will be restored in the next fetch.',
+    }))
+
+  const additionErrors: ChangeError[] = accountFeaturesChanges
+    .filter(isAdditionChange)
+    .map(getChangeData)
+    .map(({ elemID }) => ({
+      elemID,
+      severity: 'Error',
+      message: 'Addition of an accountFeatures instance is not supported',
+      detailedMessage: 'Addition of an accountFeatures instance is not supported. This instance can only be modified.',
+    }))
+
+  const modificationErrors: ChangeError[] = accountFeaturesChanges
+    .filter(isModificationChange)
+    .flatMap(getModificationErrors)
+
+  return removalErrors.concat(additionErrors).concat(modificationErrors)
+}
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { collections, decorators, objects as lowerdashObjects, promises, values } from '@salto-io/lowerdash'
+import { collections, decorators, objects as lowerdashObjects, promises, values as valuesUtils } from '@salto-io/lowerdash'
 import { Values, AccountId, Value } from '@salto-io/adapter-api'
 import { mkdirp, readDir, readFile, writeFile, rm, rename } from '@salto-io/file'
 import { logger } from '@salto-io/logging'
@@ -32,6 +32,7 @@ import AsyncLock from 'async-lock'
 import wu from 'wu'
 import shellQuote from 'shell-quote'
 import {
+  ACCOUNT_FEATURES,
   APPLICATION_ID,
   FILE_CABINET_PATH_SEPARATOR,
 } from '../constants'
@@ -40,6 +41,7 @@ import {
   DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST, DEFAULT_CONCURRENCY, SdfClientConfig,
 } from '../config'
 import { NetsuiteQuery, NetsuiteQueryParameters, ObjectID } from '../query'
+import { FeaturesDeployError } from '../errors'
 import { SdfCredentials } from './credentials'
 import {
   CustomizationInfo, CustomTypeInfo, FailedImport, FailedTypes, FileCustomizationInfo,
@@ -55,7 +57,7 @@ import { fixManifest } from './manifest_utils'
 
 const { makeArray } = collections.array
 const { withLimitedConcurrency } = promises.array
-const { isDefined } = values
+const { isDefined } = valuesUtils
 const { concatObjects } = lowerdashObjects
 const log = logger(module)
 
@@ -80,6 +82,7 @@ export const COMMANDS = {
   IMPORT_FILES: 'file:import',
   DEPLOY_PROJECT: 'project:deploy',
   ADD_PROJECT_DEPENDENCIES: 'project:adddependencies',
+  IMPORT_CONFIGURATION: 'configuration:import',
 }
 
 
@@ -93,11 +96,24 @@ const FILE_SEPARATOR = '.'
 const ALL = 'ALL'
 const ADDITIONAL_FILE_PATTERN = '.template.'
 
+const ALL_FEATURES = 'FEATURES:ALL_FEATURES'
+const ACCOUNT_CONFIGURATION_DIR = 'AccountConfiguration'
+const FEATURES_XML = 'features.xml'
+const FEATURES_TAG = 'features'
+const FEATURE_ID = 'featureId'
+const configureFeatureFailRegex = RegExp(`Configure feature -- (Enabling|Disabling) of the (?<${FEATURE_ID}>\\w+)\\(.*?\\) feature has FAILED`)
+
 export const MINUTE_IN_MILLISECONDS = 1000 * 60
 const SINGLE_OBJECT_RETRIES = 3
 const READ_CONCURRENCY = 100
 
 const baseExecutionPath = os.tmpdir()
+
+const XML_PARSE_OPTIONS: xmlParser.J2xOptionsOptional = {
+  attributeNamePrefix: ATTRIBUTE_PREFIX,
+  ignoreAttributes: false,
+  tagValueProcessor: val => he.decode(val),
+}
 
 const safeQuoteArgument = (argument: Value): Value => {
   if (typeof argument === 'string') {
@@ -108,11 +124,7 @@ const safeQuoteArgument = (argument: Value): Value => {
 
 export const convertToCustomizationInfo = (xmlContent: string):
   CustomizationInfo => {
-  const parsedXmlValues = xmlParser.parse(xmlContent, {
-    attributeNamePrefix: ATTRIBUTE_PREFIX,
-    ignoreAttributes: false,
-    tagValueProcessor: val => he.decode(val),
-  })
+  const parsedXmlValues = xmlParser.parse(xmlContent, XML_PARSE_OPTIONS)
   const typeName = Object.keys(parsedXmlValues)[0]
   return { typeName, values: parsedXmlValues[typeName] }
 }
@@ -273,11 +285,40 @@ export default class SdfClient {
     }
   }
 
+  private static verifySuccessfulDeploy(data: Value): void {
+    if (!_.isArray(data)) {
+      log.warn('suitecloud deploy returned unexpected value: %o', data)
+      return
+    }
+
+    const featureDeployFailes = data
+      .filter(_.isString)
+      .filter(line => configureFeatureFailRegex.test(line))
+
+    if (featureDeployFailes.length === 0) return
+
+    log.error('suitecloud deploy failed to configure the following features: %o', featureDeployFailes)
+    const errorIds = featureDeployFailes
+      .map(line => line.match(configureFeatureFailRegex)?.groups)
+      .filter(isDefined)
+      .map(groups => groups[FEATURE_ID])
+
+    const errorMessage = data
+      .filter(_.isString)
+      .filter(line => errorIds.some(id => (new RegExp(`\\b${id}\\b`)).test(line)))
+      .join(os.EOL)
+
+    throw new FeaturesDeployError(errorMessage, errorIds)
+  }
+
   private static verifySuccessfulAction(actionResult: ActionResult, commandName: string):
     void {
     if (!actionResult.isSuccess()) {
       log.error(`SDF command ${commandName} has failed.`)
       throw Error(ActionResultUtils.getErrorMessagesString(actionResult))
+    }
+    if (commandName === COMMANDS.DEPLOY_PROJECT) {
+      SdfClient.verifySuccessfulDeploy(actionResult.data)
     }
   }
 
@@ -425,6 +466,15 @@ export default class SdfClient {
           if (suiteAppId !== undefined) {
             elements.forEach(e => { e.values[APPLICATION_ID] = suiteAppId })
           }
+          if (suiteAppId === undefined && query.isTypeMatch(ACCOUNT_FEATURES)) {
+            // use existing project to import features object
+            const { typeName, values } = await this.getFeaturesObject(executor, projectName)
+            elements.push({
+              scriptId: typeName,
+              typeName,
+              values,
+            })
+          }
           await this.projectCleanup(projectName, authId)
 
           return { elements, failedToFetchAllAtOnce, failedTypes }
@@ -444,6 +494,27 @@ export default class SdfClient {
     const failedToFetchAllAtOnce = importResult.some(res => res.failedToFetchAllAtOnce)
 
     return { elements, failedToFetchAllAtOnce, failedTypes }
+  }
+
+  private async getFeaturesObject(
+    executor: CommandActionExecutor,
+    projectName: string,
+  ): Promise<CustomizationInfo> {
+    try {
+      await this.executeProjectAction(
+        COMMANDS.IMPORT_CONFIGURATION, { configurationid: ALL_FEATURES }, executor
+      )
+      const xmlContent = await readFile(SdfClient.getFeaturesXmlPath(projectName))
+      const featuresXml = xmlParser.parse(xmlContent.toString(), XML_PARSE_OPTIONS)
+
+      const features = _(makeArray(featuresXml.features?.feature))
+        .keyBy(item => item.id)
+        .value()
+      return { typeName: ACCOUNT_FEATURES, values: { features } }
+    } catch (e) {
+      log.error('Attempt to import features object has failed with error: %o', e)
+      return { typeName: ACCOUNT_FEATURES, values: { features: {} } }
+    }
   }
 
   private async importObjects(
@@ -783,6 +854,9 @@ export default class SdfClient {
     const objectsDirPath = SdfClient.getObjectsDirPath(project.projectName)
     const fileCabinetDirPath = SdfClient.getFileCabinetDirPath(project.projectName)
     await Promise.all(customizationInfos.map(async customizationInfo => {
+      if (customizationInfo.typeName === ACCOUNT_FEATURES) {
+        return SdfClient.addFeaturesObjectToProject(customizationInfo, project.projectName)
+      }
       if (isCustomTypeInfo(customizationInfo)) {
         return SdfClient.addCustomTypeInfoToProject(customizationInfo, objectsDirPath)
       }
@@ -835,6 +909,23 @@ export default class SdfClient {
     }
   }
 
+  private static async addFeaturesObjectToProject(
+    customizationInfo: CustomizationInfo,
+    projectName: string
+  ): Promise<void> {
+    if (customizationInfo.values.features) {
+      await writeFile(
+        SdfClient.getFeaturesXmlPath(projectName),
+        convertToXmlContent({
+          typeName: FEATURES_TAG,
+          values: {
+            feature: Object.values(customizationInfo.values.features),
+          },
+        })
+      )
+    }
+  }
+
   private static async addFileInfoToProject(fileCustomizationInfo: FileCustomizationInfo,
     fileCabinetDirPath: string): Promise<void> {
     const attrsFilename = fileCustomizationInfo.path.slice(-1)[0] + ATTRIBUTES_FILE_SUFFIX
@@ -869,5 +960,14 @@ export default class SdfClient {
 
   private static getFileCabinetDirPath(projectName: string): string {
     return osPath.resolve(SdfClient.getProjectPath(projectName), SRC_DIR, FILE_CABINET_DIR)
+  }
+
+  private static getFeaturesXmlPath(projectName: string): string {
+    return osPath.resolve(
+      SdfClient.getProjectPath(projectName),
+      SRC_DIR,
+      ACCOUNT_CONFIGURATION_DIR,
+      FEATURES_XML
+    )
   }
 }

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 export const NETSUITE = 'netsuite'
+export const SETTINGS_PATH = 'Settings'
 export const RECORDS_PATH = 'Records'
 export const FILE_CABINET_PATH = 'FileCabinet'
 export const TYPES_PATH = 'Types'
@@ -45,6 +46,7 @@ export const WORKBOOK = 'workbook'
 export const WORKFLOW = 'workflow'
 export const FILE = 'file'
 export const FOLDER = 'folder'
+export const ACCOUNT_FEATURES = 'accountFeatures'
 
 // Fields
 export const SCRIPT_ID = 'scriptid'
@@ -59,6 +61,7 @@ export const IS_ATTRIBUTE = 'isAttribute'
 export const ADDITIONAL_FILE_SUFFIX = 'additionalFileSuffix'
 export const LIST_MAPPED_BY_FIELD = 'map_key_field'
 export const INDEX = 'index'
+export const ACCOUNT_FEATURES_VALID_STATUS_VALUES = ['ENABLED', 'DISABLED']
 
 // SDF FileCabinet top level folders
 export const FILE_CABINET_PATH_SEPARATOR = '/'

--- a/packages/netsuite-adapter/src/errors.ts
+++ b/packages/netsuite-adapter/src/errors.ts
@@ -1,0 +1,23 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+export class FeaturesDeployError extends Error {
+  ids: string[]
+  constructor(message: string, ids: string[]) {
+    super(message)
+    this.ids = ids
+    this.name = 'FeaturesDeployError'
+  }
+}

--- a/packages/netsuite-adapter/src/filters/account_features.ts
+++ b/packages/netsuite-adapter/src/filters/account_features.ts
@@ -1,0 +1,49 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { getChangeData, isInstanceChange, isModificationChange } from '@salto-io/adapter-api'
+import { FilterWith } from '../filter'
+import { ACCOUNT_FEATURES } from '../constants'
+import { FeaturesDeployError } from '../errors'
+
+const filterCreator = (): FilterWith<'onDeploy'> => ({
+  onDeploy: async (changes, deployInfo) => {
+    const errorIds = deployInfo.errors.flatMap(error => {
+      if (error instanceof FeaturesDeployError) {
+        return error.ids
+      }
+      return []
+    })
+
+    if (errorIds.length === 0) return
+
+    const [featuresChange] = changes
+      .filter(isInstanceChange)
+      .filter(isModificationChange)
+      .filter(change => getChangeData(change).elemID.typeName === ACCOUNT_FEATURES)
+
+    if (!featuresChange) return
+
+    const { after, before } = featuresChange.data
+    const fixedFeatures = {
+      ..._.omit(after.value.features, errorIds),
+      ..._.pick(before.value.features, errorIds),
+    }
+    featuresChange.data.after.value.features = fixedFeatures
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/group_changes.ts
+++ b/packages/netsuite-adapter/src/group_changes.ts
@@ -25,7 +25,7 @@ import { values, collections } from '@salto-io/lowerdash'
 import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import * as suiteAppFileCabinet from './suiteapp_file_cabinet'
-import { isDataObjectType, isFileCabinetInstance } from './types'
+import { isConfigurationTypeName, isDataObjectType, isFileCabinetInstance } from './types'
 import { APPLICATION_ID } from './constants'
 import { isCustomTypeName } from './autogen/types'
 import { fileCabinetTypesNames } from './types/file_cabinet_types'
@@ -59,7 +59,8 @@ const getChangeGroupIdsWithoutSuiteApp: ChangeGroupIdFunction = async changes =>
     const changeData = getChangeData(change)
     return isInstanceElement(changeData)
       && (isCustomTypeName(changeData.elemID.typeName)
-        || fileCabinetTypesNames.has(changeData.elemID.typeName))
+        || fileCabinetTypesNames.has(changeData.elemID.typeName)
+        || isConfigurationTypeName(changeData.elemID.typeName))
   }
   return new Map(
     wu(changes.entries())
@@ -139,6 +140,7 @@ const isSdfChange = (change: Change): boolean => {
   return isCustomTypeName(changeData.elemID.typeName)
     || (isFileCabinetInstance(changeData)
       && !suiteAppFileCabinet.isChangeDeployable(change))
+    || isConfigurationTypeName(changeData.elemID.typeName)
 }
 
 const isSuiteAppRecordChange = async (change: Change): Promise<boolean> => {

--- a/packages/netsuite-adapter/src/query.ts
+++ b/packages/netsuite-adapter/src/query.ts
@@ -16,7 +16,7 @@
 
 import { regex, strings } from '@salto-io/lowerdash'
 import { getCustomTypesNames } from './autogen/types'
-import { INCLUDE, EXCLUDE, LOCKED_ELEMENTS_TO_EXCLUDE, AUTHOR_INFO_CONFIG } from './constants'
+import { INCLUDE, EXCLUDE, LOCKED_ELEMENTS_TO_EXCLUDE, AUTHOR_INFO_CONFIG, ACCOUNT_FEATURES } from './constants'
 import { SUPPORTED_TYPES, TYPES_TO_INTERNAL_ID } from './data_elements/types'
 
 export interface ObjectID {
@@ -82,7 +82,7 @@ export const validateFetchParameters = ({ types, fileCabinet }:
   if (corruptedTypesIds.length !== 0) {
     throw new Error(`${errMessagePrefix} Expected type ids to be an array of strings, but found:\n${JSON.stringify(corruptedTypesIds, null, 4)}}.`)
   }
-  const existingTypes = [...getCustomTypesNames(), ...SUPPORTED_TYPES]
+  const existingTypes = [...getCustomTypesNames(), ...SUPPORTED_TYPES, ACCOUNT_FEATURES]
   const receivedTypes = types.map(obj => obj.name)
   const idsRegexes = types
     .map(obj => obj.ids)

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -27,9 +27,10 @@ import {
   SCRIPT_ID, ADDITIONAL_FILE_SUFFIX, FILE, FILE_CABINET_PATH, PATH, FILE_CABINET_PATH_SEPARATOR,
   LAST_FETCH_TIME,
   APPLICATION_ID,
+  SETTINGS_PATH,
 } from './constants'
 import { fieldTypes } from './types/field_types'
-import { isCustomType, isFileCabinetType } from './types'
+import { isConfigurationType, isCustomType, isFileCabinetType } from './types'
 import { isFileCustomizationInfo, isFolderCustomizationInfo, isTemplateCustomTypeInfo } from './client/utils'
 import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, TemplateCustomTypeInfo } from './client/types'
 import { ATTRIBUTE_PREFIX, CDATA_TAG_NAME } from './client/constants'
@@ -46,25 +47,32 @@ const removeDotPrefix = (name: string): string => name.replace(/^\.+/, '_')
 export const createInstanceElement = async (customizationInfo: CustomizationInfo, type: ObjectType,
   getElemIdFunc?: ElemIdGetter, fetchTime?: Date): Promise<InstanceElement> => {
   const getInstanceName = (transformedValues: Values): string => {
-    if (!isCustomType(type) && !isFileCabinetType(type)) {
+    if (!isCustomType(type) && !isFileCabinetType(type) && !isConfigurationType(type)) {
       throw new Error(`Failed to getInstanceName for unknown type: ${type.elemID.name}`)
     }
-    const serviceIdFieldName = isCustomType(type) ? SCRIPT_ID : PATH
+    const serviceIdFieldName = isFileCabinetType(type) ? PATH : SCRIPT_ID
+    const serviceId = isConfigurationType(type)
+      ? ElemID.CONFIG_NAME : transformedValues[serviceIdFieldName]
     const serviceIds: ServiceIds = {
-      [serviceIdFieldName]: transformedValues[serviceIdFieldName],
+      [serviceIdFieldName]: serviceId,
       [OBJECT_SERVICE_ID]: toServiceIdsString({
         [OBJECT_NAME]: type.elemID.getFullName(),
       }),
     }
-    const desiredName = naclCase(transformedValues[serviceIdFieldName]
-      .replace(new RegExp(`^${FILE_CABINET_PATH_SEPARATOR}`), ''))
+    const desiredName = naclCase(serviceId.replace(new RegExp(`^${FILE_CABINET_PATH_SEPARATOR}`), ''))
     return getElemIdFunc ? getElemIdFunc(NETSUITE, serviceIds, desiredName).name : desiredName
   }
 
-  const getInstancePath = (instanceName: string): string[] =>
-    (isFolderCustomizationInfo(customizationInfo) || isFileCustomizationInfo(customizationInfo)
-      ? [NETSUITE, FILE_CABINET_PATH, ...customizationInfo.path.map(removeDotPrefix)]
-      : [NETSUITE, RECORDS_PATH, type.elemID.name, instanceName])
+  const getInstancePath = (instanceName: string): string[] => {
+    if (isFolderCustomizationInfo(customizationInfo)
+      || isFileCustomizationInfo(customizationInfo)) {
+      return [NETSUITE, FILE_CABINET_PATH, ...customizationInfo.path.map(removeDotPrefix)]
+    }
+    if (isConfigurationType(type)) {
+      return [NETSUITE, SETTINGS_PATH, type.elemID.name]
+    }
+    return [NETSUITE, RECORDS_PATH, type.elemID.name, instanceName]
+  }
 
   const transformPrimitive: TransformFunc = async ({ value, field }) => {
     const fieldType = await field?.getType()

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -19,6 +19,8 @@ import { enums } from './autogen/types/enums'
 import { CustomType, getCustomTypes, isCustomTypeName } from './autogen/types'
 import { TypesMap } from './types/object_types'
 import { fileCabinetTypesNames, getFileCabinetTypes } from './types/file_cabinet_types'
+import { getConfigurationTypes } from './types/configuration_types'
+import { ACCOUNT_FEATURES } from './constants'
 
 export const isCustomType = (type: ObjectType | TypeReference): boolean =>
   isCustomTypeName(type.elemID.name)
@@ -35,17 +37,23 @@ export const isFileInstance = (element: Element): boolean =>
 export const isDataObjectType = (element: ObjectType): boolean =>
   element.annotations.source === 'soap'
 
+export const isConfigurationTypeName = (typeName: string): boolean =>
+  typeName === ACCOUNT_FEATURES
+
+export const isConfigurationType = (type: ObjectType | TypeReference): boolean =>
+  isConfigurationTypeName(type.elemID.name)
+
 type MetadataTypes = {
   customTypes: TypesMap<CustomType>
   enums: Readonly<Record<string, PrimitiveType>>
-  fileCabinetTypes: Readonly<Record<string, ObjectType>>
+  additionalTypes: Readonly<Record<string, ObjectType>>
   fieldTypes: Readonly<Record<string, PrimitiveType>>
 }
 
 export const getMetadataTypes = (): MetadataTypes => ({
   customTypes: getCustomTypes(),
   enums,
-  fileCabinetTypes: getFileCabinetTypes(),
+  additionalTypes: { ...getFileCabinetTypes(), ...getConfigurationTypes() },
   fieldTypes,
 })
 
@@ -56,12 +64,12 @@ export const getInnerCustomTypes = (customTypes: TypesMap<CustomType>): ObjectTy
   Object.values(customTypes).flatMap(customType => Object.values(customType.innerTypes))
 
 export const metadataTypesToList = (metadataTypes: MetadataTypes): TypeElement[] => {
-  const { customTypes, fileCabinetTypes } = metadataTypes
+  const { customTypes, additionalTypes } = metadataTypes
   return [
     ...getTopLevelCustomTypes(customTypes),
     ...getInnerCustomTypes(customTypes),
     ...Object.values(enums),
-    ...Object.values(fileCabinetTypes),
+    ...Object.values(additionalTypes),
     ...Object.values(fieldTypes),
   ]
 }

--- a/packages/netsuite-adapter/src/types/configuration_types.ts
+++ b/packages/netsuite-adapter/src/types/configuration_types.ts
@@ -1,0 +1,72 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable camelcase */
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ObjectType, createRefToElmWithValue, MapType, createRestriction } from '@salto-io/adapter-api'
+import * as constants from '../constants'
+
+export const featuresType = (): Record<string, ObjectType> => {
+  const featuresElemID = new ElemID(constants.NETSUITE, 'accountFeatures')
+  const features_featureElemID = new ElemID(constants.NETSUITE, 'accountFeatures_feature')
+  const accountFeatures_feature = new ObjectType({
+    elemID: features_featureElemID,
+    annotations: {
+    },
+    fields: {
+      label: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+          [constants.IS_ATTRIBUTE]: true,
+        },
+      },
+      id: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+        },
+      },
+      status: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
+            values: constants.ACCOUNT_FEATURES_VALID_STATUS_VALUES,
+          }),
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, featuresElemID.name],
+  })
+  const accountFeatures = new ObjectType({
+    elemID: featuresElemID,
+    annotations: {
+    },
+    fields: {
+      features: {
+        refType: createRefToElmWithValue(new MapType(accountFeatures_feature)),
+        annotations: {
+        },
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, featuresElemID.name],
+    isSettings: true,
+  })
+  return { accountFeatures, accountFeatures_feature }
+}
+
+export const getConfigurationTypes = (): Readonly<Record<string, ObjectType>> => ({
+  ...featuresType(),
+})

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -120,8 +120,8 @@ describe('Adapter', () => {
     progressReporter: { reportProgress: jest.fn() },
   }
 
-  const { customTypes, enums, fileCabinetTypes, fieldTypes } = getMetadataTypes()
-  const metadataTypes = metadataTypesToList({ customTypes, enums, fileCabinetTypes, fieldTypes })
+  const { customTypes, enums, additionalTypes, fieldTypes } = getMetadataTypes()
+  const metadataTypes = metadataTypesToList({ customTypes, enums, additionalTypes, fieldTypes })
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -534,11 +534,11 @@ describe('Adapter', () => {
       })
     let instance: InstanceElement
 
-    const fileInstance = new InstanceElement('fileInstance', fileCabinetTypes[FILE], {
+    const fileInstance = new InstanceElement('fileInstance', additionalTypes[FILE], {
       [PATH]: 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html',
     })
 
-    const folderInstance = new InstanceElement('folderInstance', fileCabinetTypes[FOLDER], {
+    const folderInstance = new InstanceElement('folderInstance', additionalTypes[FOLDER], {
       [PATH]: 'Templates/E-mail Templates/Inner EmailTemplates Folder',
     })
 

--- a/packages/netsuite-adapter/test/change_validators/account_features.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/account_features.test.ts
@@ -1,0 +1,95 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, toChange } from '@salto-io/adapter-api'
+import { featuresType } from '../../src/types/configuration_types'
+import accountFeaturesObjectValidator from '../../src/change_validators/account_features'
+
+describe('account feautures validator', () => {
+  const origInstance = new InstanceElement(
+    ElemID.CONFIG_NAME,
+    featuresType().accountFeatures,
+    {
+      features: {
+        ABC: { label: 'label1', id: 'ABC', status: 'DISABLED' },
+        DEF: { label: 'label2', id: 'DEF', status: 'DISABLED' },
+      },
+    }
+  )
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    instance = origInstance.clone()
+  })
+
+  it('should not have errors', async () => {
+    instance.value.features.ABC.status = 'ENABLED'
+    const changeErrors = await accountFeaturesObjectValidator(
+      [toChange({ before: origInstance, after: instance })]
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('should have errors on addition and removal', async () => {
+    const changeErrors = await accountFeaturesObjectValidator(
+      [toChange({ before: origInstance }), toChange({ after: origInstance })]
+    )
+    expect(changeErrors).toHaveLength(2)
+    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[1].severity).toEqual('Error')
+  })
+
+  it('should have errors on adding/removing features', async () => {
+    instance.value.features.NEW = { label: 'new', id: 'NEW', status: 'ENABLED' }
+    const changeErrors = await accountFeaturesObjectValidator(
+      [toChange({ before: origInstance, after: instance })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Error')
+  })
+
+  it('should have errors on change in wrong field', async () => {
+    instance.value.features.ABC.label = 'changed'
+    const changeErrors = await accountFeaturesObjectValidator(
+      [toChange({ before: origInstance, after: instance })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Error')
+  })
+
+  it('should have errors on change to invalid value', async () => {
+    instance.value.features.ABC.status = 'invalid'
+    const changeErrors = await accountFeaturesObjectValidator(
+      [toChange({ before: origInstance, after: instance })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Error')
+  })
+
+  it('should have warning on change in undeployable feature', async () => {
+    instance.value.features.SUITEAPPCONTROLCENTER = {
+      label: 'SuiteApp Control Center',
+      id: 'SUITEAPPCONTROLCENTER',
+      status: 'DISABLED',
+    }
+    const changed = instance.clone()
+    changed.value.features.SUITEAPPCONTROLCENTER.status = 'ENABLED'
+    const changeErrors = await accountFeaturesObjectValidator(
+      [toChange({ before: instance, after: changed })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Warning')
+  })
+})

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -18,115 +18,195 @@ import SuiteAppClient from '../../src/client/suiteapp_client/suiteapp_client'
 import SdfClient from '../../src/client/sdf_client'
 import * as suiteAppFileCabinet from '../../src/suiteapp_file_cabinet'
 import NetsuiteClient from '../../src/client/client'
-import { SUITEAPP_CREATING_RECORDS_GROUP_ID, SUITEAPP_DELETING_RECORDS_GROUP_ID, SUITEAPP_UPDATING_RECORDS_GROUP_ID } from '../../src/group_changes'
+import { SDF_CHANGE_GROUP_ID, SUITEAPP_CREATING_RECORDS_GROUP_ID, SUITEAPP_DELETING_RECORDS_GROUP_ID, SUITEAPP_UPDATING_RECORDS_GROUP_ID } from '../../src/group_changes'
 import { NETSUITE } from '../../src/constants'
+import { FeaturesDeployError } from '../../src/errors'
+import { featuresType } from '../../src/types/configuration_types'
 
 describe('NetsuiteClient', () => {
-  const sdfClient = {
-    getCredentials: () => ({ accountId: 'someId' }),
-  } as unknown as SdfClient
+  describe('with SDF client', () => {
+    describe('deploy', () => {
+      const mockSdfDeploy = jest.fn()
+      const sdfClient = {
+        getCredentials: () => ({ accountId: 'someId' }),
+        deploy: mockSdfDeploy,
+      } as unknown as SdfClient
+      const client = new NetsuiteClient(sdfClient)
 
-  const updateInstancesMock = jest.fn()
-  const addInstancesMock = jest.fn()
-  const deleteInstancesMock = jest.fn()
+      beforeEach(() => {
+        jest.resetAllMocks()
+      })
 
-  const suiteAppClient = {
-    updateInstances: updateInstancesMock,
-    addInstances: addInstancesMock,
-    deleteInstances: deleteInstancesMock,
-  } as unknown as SuiteAppClient
-
-  const getPathToIdMapMock = jest.fn()
-  jest.spyOn(suiteAppFileCabinet, 'createSuiteAppFileCabinetOperations').mockReturnValue({
-    getPathToIdMap: getPathToIdMapMock,
-  } as unknown as suiteAppFileCabinet.SuiteAppFileCabinetOperations)
-
-  const client = new NetsuiteClient(sdfClient, suiteAppClient)
-
-  beforeEach(() => {
-    jest.resetAllMocks()
-  })
-
-  describe('getPathInternalId', () => {
-    it('should return the right id', async () => {
-      getPathToIdMapMock.mockResolvedValue({ '/some/path': 1 })
-      expect(await client.getPathInternalId('/some/path')).toBe(1)
-      expect(await client.getPathInternalId('/some/path2')).toBeUndefined()
-    })
-
-    it('should return undefined when failed to get map', async () => {
-      getPathToIdMapMock.mockResolvedValue(undefined)
-      expect(await client.getPathInternalId('/some/path1')).toBeUndefined()
-    })
-  })
-
-  describe('deploy', () => {
-    const type = new ObjectType({
-      elemID: new ElemID(NETSUITE, 'subsidiary'),
-    })
-    const instance1 = new InstanceElement(
-      'instance1',
-      type,
-    )
-
-    const instance2 = new InstanceElement(
-      'instance2',
-      type,
-    )
-    const change1 = toChange({ before: instance1, after: instance1 })
-    const change2 = toChange({ before: instance2, after: instance2 })
-    it('should return error if suiteApp is not installed', async () => {
-      const clientWithoutSuiteApp = new NetsuiteClient(sdfClient)
-      const results = await clientWithoutSuiteApp.deploy(
-        [change1, change2],
-        SUITEAPP_UPDATING_RECORDS_GROUP_ID,
-        false,
-      )
-      expect(results).toEqual({
-        errors: [new Error(`Salto SuiteApp is not configured and therefore changes group "${SUITEAPP_UPDATING_RECORDS_GROUP_ID}" cannot be deployed`)],
-        elemIdToInternalId: {},
-        appliedChanges: [],
+      describe('features', () => {
+        const accountFeaturesType = featuresType().accountFeatures
+        const featuresDeployError = new FeaturesDeployError('error', ['ABC'])
+        beforeEach(() => {
+          mockSdfDeploy.mockRejectedValue(featuresDeployError)
+        })
+        it('should return error only when the only feature to deployed failed', async () => {
+          const before = new InstanceElement(
+            ElemID.CONFIG_NAME,
+            accountFeaturesType,
+            {
+              features: {
+                ABC: { label: 'label1', id: 'ABC', status: 'DISABLED' },
+                DEF: { label: 'label2', id: 'DEF', status: 'DISABLED' },
+              },
+            }
+          )
+          const after = new InstanceElement(
+            ElemID.CONFIG_NAME,
+            accountFeaturesType,
+            {
+              features: {
+                ABC: { label: 'label1', id: 'ABC', status: 'ENABLED' },
+                DEF: { label: 'label2', id: 'DEF', status: 'DISABLED' },
+              },
+            }
+          )
+          const change = toChange({ before, after })
+          expect(await client.deploy([change], SDF_CHANGE_GROUP_ID, false)).toEqual({
+            errors: [featuresDeployError],
+            appliedChanges: [],
+          })
+        })
+        it('should return change and error when some features deployed and some failed', async () => {
+          const before = new InstanceElement(
+            ElemID.CONFIG_NAME,
+            accountFeaturesType,
+            {
+              features: {
+                ABC: { label: 'label1', id: 'ABC', status: 'DISABLED' },
+                DEF: { label: 'label2', id: 'DEF', status: 'DISABLED' },
+              },
+            }
+          )
+          const after = new InstanceElement(
+            ElemID.CONFIG_NAME,
+            accountFeaturesType,
+            {
+              features: {
+                ABC: { label: 'label1', id: 'ABC', status: 'ENABLED' },
+                DEF: { label: 'label2', id: 'DEF', status: 'ENABLED' },
+              },
+            }
+          )
+          const change = toChange({ before, after })
+          expect(await client.deploy([change], SDF_CHANGE_GROUP_ID, false)).toEqual({
+            errors: [featuresDeployError],
+            appliedChanges: [change],
+          })
+        })
       })
     })
-    it('should use updateInstances for data instances modifications', async () => {
-      updateInstancesMock.mockResolvedValue([1, new Error('error')])
-      const results = await client.deploy(
-        [change1, change2],
-        SUITEAPP_UPDATING_RECORDS_GROUP_ID,
-        false,
-      )
-      expect(results.appliedChanges).toEqual([change1])
-      expect(results.errors).toEqual([new Error('error')])
-      expect(results.elemIdToInternalId).toEqual({ [instance1.elemID.getFullName()]: '1' })
+  })
+  describe('with SuiteApp client', () => {
+    const sdfClient = {
+      getCredentials: () => ({ accountId: 'someId' }),
+    } as unknown as SdfClient
+
+    const updateInstancesMock = jest.fn()
+    const addInstancesMock = jest.fn()
+    const deleteInstancesMock = jest.fn()
+
+    const suiteAppClient = {
+      updateInstances: updateInstancesMock,
+      addInstances: addInstancesMock,
+      deleteInstances: deleteInstancesMock,
+    } as unknown as SuiteAppClient
+
+    const getPathToIdMapMock = jest.fn()
+    jest.spyOn(suiteAppFileCabinet, 'createSuiteAppFileCabinetOperations').mockReturnValue({
+      getPathToIdMap: getPathToIdMapMock,
+    } as unknown as suiteAppFileCabinet.SuiteAppFileCabinetOperations)
+
+    const client = new NetsuiteClient(sdfClient, suiteAppClient)
+
+    beforeEach(() => {
+      jest.resetAllMocks()
     })
 
-    it('should use addInstances for data instances creations', async () => {
-      addInstancesMock.mockResolvedValue([1, new Error('error')])
-      const results = await client.deploy(
-        [
-          toChange({ after: instance1 }),
-          toChange({ after: instance2 }),
-        ],
-        SUITEAPP_CREATING_RECORDS_GROUP_ID,
-        false,
-      )
-      expect(results.appliedChanges).toEqual([toChange({ after: instance1 })])
-      expect(results.errors).toEqual([new Error('error')])
-      expect(results.elemIdToInternalId).toEqual({ [instance1.elemID.getFullName()]: '1' })
+    describe('getPathInternalId', () => {
+      it('should return the right id', async () => {
+        getPathToIdMapMock.mockResolvedValue({ '/some/path': 1 })
+        expect(await client.getPathInternalId('/some/path')).toBe(1)
+        expect(await client.getPathInternalId('/some/path2')).toBeUndefined()
+      })
+
+      it('should return undefined when failed to get map', async () => {
+        getPathToIdMapMock.mockResolvedValue(undefined)
+        expect(await client.getPathInternalId('/some/path1')).toBeUndefined()
+      })
     })
 
-    it('should use deleteInstances for data instances deletions', async () => {
-      deleteInstancesMock.mockResolvedValue([1, new Error('error')])
-      const results = await client.deploy(
-        [
-          toChange({ before: instance1 }),
-          toChange({ before: instance2 }),
-        ],
-        SUITEAPP_DELETING_RECORDS_GROUP_ID,
-        false,
+    describe('deploy', () => {
+      const type = new ObjectType({
+        elemID: new ElemID(NETSUITE, 'subsidiary'),
+      })
+      const instance1 = new InstanceElement(
+        'instance1',
+        type,
       )
-      expect(results.appliedChanges).toEqual([toChange({ before: instance1 })])
-      expect(results.errors).toEqual([new Error('error')])
+
+      const instance2 = new InstanceElement(
+        'instance2',
+        type,
+      )
+      const change1 = toChange({ before: instance1, after: instance1 })
+      const change2 = toChange({ before: instance2, after: instance2 })
+      it('should return error if suiteApp is not installed', async () => {
+        const clientWithoutSuiteApp = new NetsuiteClient(sdfClient)
+        const results = await clientWithoutSuiteApp.deploy(
+          [change1, change2],
+          SUITEAPP_UPDATING_RECORDS_GROUP_ID,
+          false,
+        )
+        expect(results).toEqual({
+          errors: [new Error(`Salto SuiteApp is not configured and therefore changes group "${SUITEAPP_UPDATING_RECORDS_GROUP_ID}" cannot be deployed`)],
+          elemIdToInternalId: {},
+          appliedChanges: [],
+        })
+      })
+      it('should use updateInstances for data instances modifications', async () => {
+        updateInstancesMock.mockResolvedValue([1, new Error('error')])
+        const results = await client.deploy(
+          [change1, change2],
+          SUITEAPP_UPDATING_RECORDS_GROUP_ID,
+          false,
+        )
+        expect(results.appliedChanges).toEqual([change1])
+        expect(results.errors).toEqual([new Error('error')])
+        expect(results.elemIdToInternalId).toEqual({ [instance1.elemID.getFullName()]: '1' })
+      })
+
+      it('should use addInstances for data instances creations', async () => {
+        addInstancesMock.mockResolvedValue([1, new Error('error')])
+        const results = await client.deploy(
+          [
+            toChange({ after: instance1 }),
+            toChange({ after: instance2 }),
+          ],
+          SUITEAPP_CREATING_RECORDS_GROUP_ID,
+          false,
+        )
+        expect(results.appliedChanges).toEqual([toChange({ after: instance1 })])
+        expect(results.errors).toEqual([new Error('error')])
+        expect(results.elemIdToInternalId).toEqual({ [instance1.elemID.getFullName()]: '1' })
+      })
+
+      it('should use deleteInstances for data instances deletions', async () => {
+        deleteInstancesMock.mockResolvedValue([1, new Error('error')])
+        const results = await client.deploy(
+          [
+            toChange({ before: instance1 }),
+            toChange({ before: instance2 }),
+          ],
+          SUITEAPP_DELETING_RECORDS_GROUP_ID,
+          false,
+        )
+        expect(results.appliedChanges).toEqual([toChange({ before: instance1 })])
+        expect(results.errors).toEqual([new Error('error')])
+      })
     })
   })
 })

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -29,9 +29,10 @@ import SdfClient, {
   FOLDER_ATTRIBUTES_FILE_SUFFIX,
   MINUTE_IN_MILLISECONDS,
 } from '../../src/client/sdf_client'
-import { CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, TemplateCustomTypeInfo } from '../../src/client/types'
+import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, TemplateCustomTypeInfo } from '../../src/client/types'
 import { fileCabinetTopLevelFolders } from '../../src/client/constants'
 import { DEFAULT_COMMAND_TIMEOUT_IN_MINUTES } from '../../src/config'
+import { FeaturesDeployError } from '../../src/errors'
 
 
 const MOCK_TEMPLATE_CONTENT = Buffer.from('Template Inner Content')
@@ -97,6 +98,8 @@ const MOCK_MANIFEST_VALID_DEPENDENCIES = `<manifest projecttype="ACCOUNTCUSTOMIZ
 </dependencies>
 </manifest>`
 
+const MOCK_FEATURES_XML = '<features><feature label="SuiteApp Control Center"><id>SUITEAPPCONTROLCENTER</id><status>ENABLED</status></feature></features>'
+
 jest.mock('@salto-io/file', () => ({
   readDir: jest.fn().mockImplementation(() => ['a.xml', 'b.xml', 'a.template.html']),
   readFile: jest.fn().mockImplementation(filePath => {
@@ -115,6 +118,9 @@ jest.mock('@salto-io/file', () => ({
 
     if (filePath.endsWith('manifest.xml')) {
       return MOCK_MANIFEST_INVALID_DEPENDENCIES
+    }
+    if (filePath.endsWith('/features.xml')) {
+      return MOCK_FEATURES_XML
     }
     return `<addressForm filename="${filePath.split('/').pop()}">`
   }),
@@ -178,11 +184,16 @@ describe('netsuite client', () => {
   const typeNames = instancesIds.map(instance => instance.type)
 
   const typeNamesQuery = buildNetsuiteQuery({
-    types: instancesIds.map(instance => ({ name: instance.type, ids: ['.*'] })),
+    types: [
+      ...instancesIds.map(instance => ({ name: instance.type, ids: ['.*'] })),
+      { name: 'accountFeatures', ids: ['.*'] },
+    ],
   })
 
   const importObjectsCommandMatcher = expect
     .objectContaining({ commandName: COMMANDS.IMPORT_OBJECTS })
+  const importConfigurationCommandMatcher = expect
+    .objectContaining({ commandName: COMMANDS.IMPORT_CONFIGURATION })
   const listObjectsCommandMatcher = expect
     .objectContaining({ commandName: COMMANDS.LIST_OBJECTS })
   const listFilesCommandMatcher = expect
@@ -331,14 +342,15 @@ describe('netsuite client', () => {
       })
       const client = mockClient({ fetchAllTypesAtOnce: true })
       const getCustomObjectsResult = await client.getCustomObjects(typeNames, typeNamesQuery)
-      expect(mockExecuteAction).toHaveBeenCalledTimes(7)
+      expect(mockExecuteAction).toHaveBeenCalledTimes(8)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(3, importObjectsCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(4, listObjectsCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(5, importObjectsCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(6, importObjectsCommandMatcher)
-      expect(mockExecuteAction).toHaveBeenNthCalledWith(7, deleteAuthIdCommandMatcher)
+      expect(mockExecuteAction).toHaveBeenNthCalledWith(7, importConfigurationCommandMatcher)
+      expect(mockExecuteAction).toHaveBeenNthCalledWith(8, deleteAuthIdCommandMatcher)
       expect(getCustomObjectsResult.failedToFetchAllAtOnce).toEqual(true)
       expect(getCustomObjectsResult.failedTypes).toEqual({ lockedError: {}, unexpectedError: {} })
     })
@@ -398,7 +410,7 @@ describe('netsuite client', () => {
       const client = mockClient({ fetchAllTypesAtOnce: false })
       await client.getCustomObjects(typeNames, typeNamesQuery)
       // createProject & setupAccount & listObjects & 3*importObjects & deleteAuthId
-      const numberOfExecuteActions = 7
+      const numberOfExecuteActions = 8
       expect(mockExecuteAction).toHaveBeenCalledTimes(numberOfExecuteActions)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
@@ -421,6 +433,7 @@ describe('netsuite client', () => {
         scriptid: 'b',
       }))
 
+      expect(mockExecuteAction).toHaveBeenNthCalledWith(7, importConfigurationCommandMatcher)
       expect(mockExecuteAction)
         .toHaveBeenNthCalledWith(numberOfExecuteActions, deleteAuthIdCommandMatcher)
     })
@@ -455,7 +468,7 @@ describe('netsuite client', () => {
       const client = mockClient({ fetchAllTypesAtOnce: false })
       await client.getCustomObjects(typeNames, typeNamesQuery)
       // createProject & setupAccount & listObjects & 3*importObjects & deleteAuthId
-      const numberOfExecuteActions = 7
+      const numberOfExecuteActions = 8
       expect(mockExecuteAction).toHaveBeenCalledTimes(numberOfExecuteActions)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
@@ -478,6 +491,7 @@ describe('netsuite client', () => {
         scriptid: 'a',
       }))
 
+      expect(mockExecuteAction).toHaveBeenNthCalledWith(7, importConfigurationCommandMatcher)
       expect(mockExecuteAction)
         .toHaveBeenNthCalledWith(numberOfExecuteActions, deleteAuthIdCommandMatcher)
     })
@@ -508,7 +522,7 @@ describe('netsuite client', () => {
       const client = mockClient({ fetchAllTypesAtOnce: false, maxItemsInImportObjectsRequest: 2 })
       await client.getCustomObjects(typeNames, typeNamesQuery)
       // createProject & setupAccount & listObjects & 3*importObjects & deleteAuthId
-      const numberOfExecuteActions = 7
+      const numberOfExecuteActions = 8
       expect(mockExecuteAction).toHaveBeenCalledTimes(numberOfExecuteActions)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
@@ -531,6 +545,7 @@ describe('netsuite client', () => {
         scriptid: 'd',
       }))
 
+      expect(mockExecuteAction).toHaveBeenNthCalledWith(7, importConfigurationCommandMatcher)
       expect(mockExecuteAction)
         .toHaveBeenNthCalledWith(numberOfExecuteActions, deleteAuthIdCommandMatcher)
     })
@@ -560,9 +575,9 @@ describe('netsuite client', () => {
       expect(failedToFetchAllAtOnce).toBe(false)
       expect(failedTypes).toEqual({ lockedError: {}, unexpectedError: {} })
       expect(readDirMock).toHaveBeenCalledTimes(1)
-      expect(readFileMock).toHaveBeenCalledTimes(3)
+      expect(readFileMock).toHaveBeenCalledTimes(4)
       expect(rmMock).toHaveBeenCalledTimes(1)
-      expect(customizationInfos).toHaveLength(2)
+      expect(customizationInfos).toHaveLength(3)
       expect(customizationInfos).toEqual([{
         typeName: 'addressForm',
         scriptId: 'a',
@@ -577,6 +592,19 @@ describe('netsuite client', () => {
         scriptId: 'b',
         values: {
           '@_filename': 'b.xml',
+        },
+      },
+      {
+        scriptId: 'accountFeatures',
+        typeName: 'accountFeatures',
+        values: {
+          features: {
+            SUITEAPPCONTROLCENTER: {
+              '@_label': 'SuiteApp Control Center',
+              id: 'SUITEAPPCONTROLCENTER',
+              status: 'ENABLED',
+            },
+          },
         },
       }])
 
@@ -620,7 +648,7 @@ describe('netsuite client', () => {
       expect(failedToFetchAllAtOnce).toBe(false)
       expect(failedTypes).toEqual({ lockedError: {}, unexpectedError: {} })
       expect(readDirMock).toHaveBeenCalledTimes(2)
-      expect(readFileMock).toHaveBeenCalledTimes(6)
+      expect(readFileMock).toHaveBeenCalledTimes(7)
       expect(rmMock).toHaveBeenCalledTimes(2)
       expect(customizationInfos).toEqual([{
         typeName: 'addressForm',
@@ -636,6 +664,19 @@ describe('netsuite client', () => {
         scriptId: 'b',
         values: {
           '@_filename': 'b.xml',
+        },
+      },
+      {
+        scriptId: 'accountFeatures',
+        typeName: 'accountFeatures',
+        values: {
+          features: {
+            SUITEAPPCONTROLCENTER: {
+              '@_label': 'SuiteApp Control Center',
+              id: 'SUITEAPPCONTROLCENTER',
+              status: 'ENABLED',
+            },
+          },
         },
       },
       {
@@ -664,9 +705,10 @@ describe('netsuite client', () => {
       expect(mockExecuteAction).toHaveBeenNthCalledWith(5, listObjectsCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(6, listObjectsCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(7, importObjectsCommandMatcher)
-      expect(mockExecuteAction).toHaveBeenNthCalledWith(8, deleteAuthIdCommandMatcher)
-      expect(mockExecuteAction).toHaveBeenNthCalledWith(9, importObjectsCommandMatcher)
-      expect(mockExecuteAction).toHaveBeenNthCalledWith(10, deleteAuthIdCommandMatcher)
+      expect(mockExecuteAction).toHaveBeenNthCalledWith(8, importObjectsCommandMatcher)
+      expect(mockExecuteAction).toHaveBeenNthCalledWith(9, deleteAuthIdCommandMatcher)
+      expect(mockExecuteAction).toHaveBeenNthCalledWith(10, importConfigurationCommandMatcher)
+      expect(mockExecuteAction).toHaveBeenNthCalledWith(11, deleteAuthIdCommandMatcher)
     })
 
     it('should succeed and return failedTypeToInstances that failed also after retry', async () => {
@@ -1332,6 +1374,40 @@ describe('netsuite client', () => {
         expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
         expect(mockExecuteAction).toHaveBeenNthCalledWith(3, addDependenciesCommandMatcher)
         expect(mockExecuteAction).toHaveBeenNthCalledWith(4, deployProjectCommandMatcher)
+      })
+    })
+
+    describe('deploy features object', () => {
+      const featuresCustomizationInfo: CustomizationInfo = {
+        typeName: 'accountFeatures',
+        values: {
+          features: {
+            SUITEAPPCONTROLCENTER: {
+              '@_label': 'SuiteApp Control Center',
+              id: 'SUITEAPPCONTROLCENTER',
+              status: 'ENABLED',
+            },
+          },
+        },
+      }
+      it('should succeed', async () => {
+        mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: ['Configure feature -- The SUITEAPPCONTROLCENTER(Departments) feature has been DISABLED'] })
+        await client.deploy([featuresCustomizationInfo])
+        expect(writeFileMock).toHaveBeenCalledTimes(2)
+        expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('features.xml'), MOCK_FEATURES_XML)
+        expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('manifest.xml'), MOCK_MANIFEST_VALID_DEPENDENCIES)
+        expect(rmMock).toHaveBeenCalledTimes(1)
+        expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
+        expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
+        expect(mockExecuteAction).toHaveBeenNthCalledWith(3, addDependenciesCommandMatcher)
+        expect(mockExecuteAction).toHaveBeenNthCalledWith(4, deployProjectCommandMatcher)
+      })
+
+      it('should throw FeaturesDeployError on failed features deploy', async () => {
+        const errorMessage = 'Configure feature -- Enabling of the SUITEAPPCONTROLCENTER(SuiteApp Control Center) feature has FAILED'
+        mockExecuteAction.mockResolvedValue({ isSuccess: () => true, data: [errorMessage] })
+        await expect(client.deploy([featuresCustomizationInfo]))
+          .rejects.toThrow(new FeaturesDeployError(errorMessage, ['SUITEAPPCONTROLCENTER']))
       })
     })
 

--- a/packages/netsuite-adapter/test/filters/account_features.test.ts
+++ b/packages/netsuite-adapter/test/filters/account_features.test.ts
@@ -1,0 +1,66 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, ElemID, getChangeData, InstanceElement, toChange } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/account_features'
+import { FeaturesDeployError } from '../../src/errors'
+import { featuresType } from '../../src/types/configuration_types'
+
+const getChange = (): Change<InstanceElement> => {
+  const before = new InstanceElement(
+    ElemID.CONFIG_NAME,
+    featuresType().accountFeatures,
+    {
+      features: {
+        ABC: { label: 'label1', id: 'ABC', status: 'DISABLED' },
+        DEF: { label: 'label2', id: 'DEF', status: 'DISABLED' },
+      },
+    }
+  )
+  const after = new InstanceElement(
+    ElemID.CONFIG_NAME,
+    featuresType().accountFeatures,
+    {
+      features: {
+        ABC: { label: 'label1', id: 'ABC', status: 'ENABLED' },
+        DEF: { label: 'label2', id: 'DEF', status: 'ENABLED' },
+      },
+    }
+  )
+  return toChange({ before, after })
+}
+
+describe('account features filter', () => {
+  it('should succeed', async () => {
+    const change = getChange()
+    await filterCreator().onDeploy([change], { errors: [new Error('error')], appliedChanges: [] })
+    expect(getChangeData(change).value).toEqual({
+      features: {
+        ABC: { label: 'label1', id: 'ABC', status: 'ENABLED' },
+        DEF: { label: 'label2', id: 'DEF', status: 'ENABLED' },
+      },
+    })
+  })
+  it('should restore failed to deploy features', async () => {
+    const change = getChange()
+    await filterCreator().onDeploy([change], { errors: [new FeaturesDeployError('error', ['ABC'])], appliedChanges: [] })
+    expect(getChangeData(change).value).toEqual({
+      features: {
+        ABC: { label: 'label1', id: 'ABC', status: 'DISABLED' },
+        DEF: { label: 'label2', id: 'DEF', status: 'ENABLED' },
+      },
+    })
+  })
+})

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -28,6 +28,7 @@ import { CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, Templat
 import { isFileCustomizationInfo, isFolderCustomizationInfo } from '../src/client/utils'
 import { entitycustomfieldType } from '../src/autogen/types/custom_types/entitycustomfield'
 import { getFileCabinetTypes } from '../src/types/file_cabinet_types'
+import { getConfigurationTypes } from '../src/types/configuration_types'
 import { customrecordtypeType } from '../src/autogen/types/custom_types/customrecordtype'
 import { emailtemplateType } from '../src/autogen/types/custom_types/emailtemplate'
 import { addressFormType } from '../src/autogen/types/custom_types/addressForm'
@@ -124,6 +125,7 @@ describe('Transformer', () => {
   const transactionForm = transactionFormType().type
   const workflow = workflowType().type
   const { file, folder } = getFileCabinetTypes()
+  const { accountFeatures } = getConfigurationTypes()
 
   describe('createInstanceElement', () => {
     const transformCustomFieldRecord = (xmlContent: string): Promise<InstanceElement> => {
@@ -366,6 +368,31 @@ describe('Transformer', () => {
           filepath: `${NETSUITE}/${FILE_CABINET_PATH}/Templates/E-mail Templates/Inner EmailTemplates Folder/content.html`,
           content: Buffer.from('dummy file content'),
         }))
+      })
+    })
+
+    describe('configuration types', () => {
+      const featuresCustomizationInfo: CustomTypeInfo = {
+        typeName: 'accountFeatures',
+        scriptId: 'accountFeatures',
+        values: {
+          features: {
+            TEST: { '@_label': 'test', id: 'TEST', status: 'ENABLED' },
+          },
+        },
+      }
+      it('should create features instance correctly', async () => {
+        const result = await createInstanceElement(
+          featuresCustomizationInfo,
+          accountFeatures,
+          mockGetElemIdFunc
+        )
+        expect(result.elemID.getFullName()).toEqual(`netsuite.accountFeatures.instance.${NAME_FROM_GET_ELEM_ID}_config`)
+        expect(result.value).toEqual({
+          features: {
+            TEST: { id: 'TEST', label: 'test', status: 'ENABLED' },
+          },
+        })
       })
     })
   })

--- a/packages/netsuite-adapter/test/types.test.ts
+++ b/packages/netsuite-adapter/test/types.test.ts
@@ -24,7 +24,7 @@ import { getMetadataTypes, getTopLevelCustomTypes } from '../src/types'
 const { awu } = collections.asynciterable
 
 describe('Types', () => {
-  const { customTypes, fieldTypes, fileCabinetTypes } = getMetadataTypes()
+  const { customTypes, fieldTypes, additionalTypes } = getMetadataTypes()
   describe('CustomTypes', () => {
     it('should have a required SCRIPT_ID field with regex restriction for all custom types', () => {
       getTopLevelCustomTypes(customTypes)
@@ -54,10 +54,10 @@ describe('Types', () => {
     })
   })
 
-  describe('FileCabinetTypes', () => {
+  describe('Additional Types', () => {
     describe('file type definition', () => {
       it('should have single fileContent field', () => {
-        expect(Object.values(fileCabinetTypes.file.fields)
+        expect(Object.values(additionalTypes.file.fields)
           .find(async f => {
             const fType = await f.getType()
             return isPrimitiveType(fType) && fType.isEqual(fieldTypes.fileContent)
@@ -66,15 +66,15 @@ describe('Types', () => {
       })
 
       it('should have service_id path field', async () => {
-        expect(Object.keys(fileCabinetTypes.file.fields)).toContain(PATH)
-        const pathFieldType = await fileCabinetTypes.file.fields[PATH].getType()
+        expect(Object.keys(additionalTypes.file.fields)).toContain(PATH)
+        const pathFieldType = await additionalTypes.file.fields[PATH].getType()
         expect(isPrimitiveType(pathFieldType) && isServiceId(pathFieldType))
           .toBe(true)
       })
 
       it('should have correct path regex restriction', () => {
-        expect(Object.keys(fileCabinetTypes.file.fields)).toContain(PATH)
-        const pathField = fileCabinetTypes.file.fields[PATH]
+        expect(Object.keys(additionalTypes.file.fields)).toContain(PATH)
+        const pathField = additionalTypes.file.fields[PATH]
         const { regex } = getRestriction(pathField)
         expect(values.isDefined(regex)).toBe(true)
         const regExpObj = new RegExp(regex as string)
@@ -89,15 +89,15 @@ describe('Types', () => {
 
     describe('folder type definition', () => {
       it('should have service_id path field', async () => {
-        expect(Object.keys(fileCabinetTypes.folder.fields)).toContain(PATH)
-        const pathFieldType = await fileCabinetTypes.folder.fields[PATH].getType()
+        expect(Object.keys(additionalTypes.folder.fields)).toContain(PATH)
+        const pathFieldType = await additionalTypes.folder.fields[PATH].getType()
         expect(isPrimitiveType(pathFieldType) && isServiceId(pathFieldType))
           .toBe(true)
       })
 
       it('should have correct path regex restriction', () => {
-        expect(Object.keys(fileCabinetTypes.folder.fields)).toContain(PATH)
-        const pathField = fileCabinetTypes.folder.fields[PATH]
+        expect(Object.keys(additionalTypes.folder.fields)).toContain(PATH)
+        const pathField = additionalTypes.folder.fields[PATH]
         const { regex } = getRestriction(pathField)
         expect(values.isDefined(regex)).toBe(true)
         const regExpObj = new RegExp(regex as string)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1807,10 +1807,10 @@
     napi-macros "^2.0.0"
     node-gyp-build "^4.3.0"
 
-"@salto-io/suitecloud-cli@1.3.2-salto-1":
-  version "1.3.2-salto-1"
-  resolved "https://registry.yarnpkg.com/@salto-io/suitecloud-cli/-/suitecloud-cli-1.3.2-salto-1.tgz#7420945c99d02d2e9896a5adedeffdfa51051912"
-  integrity sha512-4SJURCxzem5Vvm6huLH486Xh5InR7+xqgo9VfDbmabVIAQTRXK9PqX8hdI2B37N9A4YZCzojVprf1xGLRh6+Lg==
+"@salto-io/suitecloud-cli@1.3.2-salto-2":
+  version "1.3.2-salto-2"
+  resolved "https://registry.yarnpkg.com/@salto-io/suitecloud-cli/-/suitecloud-cli-1.3.2-salto-2.tgz#0b00fdfe1ff1d14a209fb3df91ada81903738be4"
+  integrity sha512-kgqGv9/pwqTV27AlRG8JWhHKJyfv9nFIYcASpCYu10AsV5xvrn+8s0EfCoyqglnWqjToqgGSL0tF5AvrnyBhPQ==
   dependencies:
     "@salto-io/logging" "<0.4.0"
     chalk "4.1.1"


### PR DESCRIPTION
Support new type using SDF - `accountFeatures`. This type represent the features in the NetSuite account.
Both fetch and deploy are supported, also partial success deploy (when some features fails and some succeed)


---
_Release Notes_: 
Netsuite-Adapter:
- Supporting fetch and deploy on new settings type using SDF - `accountFeatures`

---
_User Notifications_: 
Netsuite - new settings type and instance will be added to the workspace - `accountFeatures`.
Instance example: `netsuite/Settings/accountFeatures.nacl`
```
netsuite.accountFeatures {
  features = {
    DEPARTMENTS = {
      label = "Departments"
      id = "DEPARTMENTS"
      status = "ENABLED"
    }
    LOCATIONS = {
      label = "Locations"
      id = "LOCATIONS"
      status = "ENABLED"
    }
  }
}
```