### PR TITLE
SAAS-3619-identify-and-alert-for-merge-conflicts

### DIFF
--- a/packages/workspace/src/parser/internal/native/errors.ts
+++ b/packages/workspace/src/parser/internal/native/errors.ts
@@ -172,6 +172,11 @@ export const missingBlockOpen = (range: SourceRange): ParseError => createError(
   'Expected {',
 )
 
+export const contentMergeConflict = (range: SourceRange): ParseError => createError(
+  range,
+  'Content merge conflict',
+)
+
 export const invalidStringChar = (stringRange: SourceRange, errMsg: string): ParseError => {
   const errMsgPosition = Number.parseInt(_.last(errMsg.split(' ')) || '', 10)
   const range = Number.isNaN(errMsgPosition)

--- a/packages/workspace/src/parser/internal/native/parse.ts
+++ b/packages/workspace/src/parser/internal/native/parse.ts
@@ -25,7 +25,6 @@ import { ParseContext } from './types'
 import { replaceValuePromises, positionAtStart } from './helpers'
 import { consumeVariableBlock, consumeElement } from './consumers/top_level'
 
-
 const isVariableDef = (context: ParseContext): boolean => (
   context.lexer.peek()?.type === TOKEN_TYPES.WORD
   && context.lexer.peek()?.value === Keywords.VARIABLES_DEFINITION
@@ -76,6 +75,11 @@ export const parseBuffer = async (
     } else if (e instanceof ContentMergeConflictError && e.lastValidToken) {
       const pos = positionAtStart(e.lastValidToken)
       try {
+        // Having the beginning string of a merge conflict, Salto verifies if the
+        // middle and end strings exist as well. In case they aren't exist salto
+        // raises an invalid error token, without covering the rest of the file.
+        // This is a trade off for creating a regex merge conflict token, which
+        // seems to work slowly.
         context.lexer.recover([TOKEN_TYPES.MERGE_CONFLICT_MID], true)
         context.lexer.recover([TOKEN_TYPES.MERGE_CONFLICT_END], true)
         context.errors = [contentMergeConflict({ start: pos, end: pos, filename })]

--- a/packages/workspace/src/parser/internal/native/parse.ts
+++ b/packages/workspace/src/parser/internal/native/parse.ts
@@ -18,9 +18,9 @@ import { flattenElementStr } from '@salto-io/adapter-utils'
 import { ParseResult } from '../../types'
 import { Keywords } from '../../language'
 import { Functions } from '../../functions'
-import Lexer, { TOKEN_TYPES, NoSuchElementError } from './lexer'
+import Lexer, { TOKEN_TYPES, NoSuchElementError, ContentMergeConflictError } from './lexer'
 import { SourceMap } from '../../source_map'
-import { unexpectedEndOfFile } from './errors'
+import { contentMergeConflict, invalidStringChar, unexpectedEndOfFile } from './errors'
 import { ParseContext } from './types'
 import { replaceValuePromises, positionAtStart } from './helpers'
 import { consumeVariableBlock, consumeElement } from './consumers/top_level'
@@ -49,8 +49,8 @@ export const parseBuffer = async (
     valuePromiseWatchers: [],
   }
   const elements: Element[] = []
-  while (context.lexer.peek()) {
-    try {
+  try {
+    while (context.lexer.peek()) {
       if (isVariableDef(context)) {
         const consumedVariables = consumeVariableBlock(context)
         elements.push(...consumedVariables.value)
@@ -62,13 +62,28 @@ export const parseBuffer = async (
           elements.push(consumedElement.value)
         }
       }
-    } catch (e) {
-      // Catch the EOF error that is thrown by the lexer if the next function
-      // is called after all of the token were processed. This error is thrown
-      // since it should interrupt the flow of the code.
-      if (e instanceof NoSuchElementError && e.lastValidToken) {
-        const pos = positionAtStart(e.lastValidToken)
-        context.errors.push(unexpectedEndOfFile({ start: pos, end: pos, filename }))
+    }
+  } catch (e) {
+    // Catch the EOF error that is thrown by the lexer if the next function
+    // is called after all of the token were processed. This error is thrown
+    // since it should interrupt the flow of the code.
+    if (e instanceof NoSuchElementError && e.lastValidToken) {
+      const pos = positionAtStart(e.lastValidToken)
+      context.errors.push(unexpectedEndOfFile({ start: pos, end: pos, filename }))
+    // Catch the beginning string of a merge conflict and verify it by catching
+    // the middle and ending strings. In case they aren't found, raise an invalid
+    // sting error.
+    } else if (e instanceof ContentMergeConflictError && e.lastValidToken) {
+      const pos = positionAtStart(e.lastValidToken)
+      try {
+        context.lexer.recover([TOKEN_TYPES.MERGE_CONFLICT_MID], true)
+        context.lexer.recover([TOKEN_TYPES.MERGE_CONFLICT_END], true)
+        context.errors = [contentMergeConflict({ start: pos, end: pos, filename })]
+      } catch {
+        context.errors.push(invalidStringChar(
+          { start: pos, end: pos, filename },
+          TOKEN_TYPES.MERGE_CONFLICT,
+        ))
       }
     }
   }

--- a/packages/workspace/test/parser/errors.test.ts
+++ b/packages/workspace/test/parser/errors.test.ts
@@ -1220,7 +1220,7 @@ describe('parsing errors', () => {
       })
     })
 
-    describe('ignore content merge conflict (lacking \'>\')', () => {
+    describe('non closed conflict markers (lacking \'>\')', () => {
       const nacl = `
         rocky.racoon checked {
           only

--- a/packages/workspace/test/parser/errors.test.ts
+++ b/packages/workspace/test/parser/errors.test.ts
@@ -1220,7 +1220,7 @@ describe('parsing errors', () => {
       })
     })
 
-    describe('non content merge conflict (lacking \'>\')', () => {
+    describe('ignore content merge conflict (lacking \'>\')', () => {
       const nacl = `
         rocky.racoon checked {
           only
@@ -1251,6 +1251,39 @@ describe('parsing errors', () => {
       })
       it('should parse the first instance correctly', async () => {
         expect(await awu(res.elements).toArray()).toHaveLength(1)
+      })
+    })
+
+    describe('ignore content merge conflict (multistring)', () => {
+      const nacl = `
+        rocky.racoon checkedAgain {
+          always = '''
+            remember
+<<<<<<<
+'''
+          only = "to lose"
+=======
+          only = "to find"
+>>>>>>>
+        }
+        rocky.racoon checked {
+          only
+        }
+      `
+      let res: ParseResult
+      beforeAll(async () => {
+        res = await parse(Buffer.from(nacl), 'file.nacl', {})
+      })
+      it('should raise invalid block item error', () => {
+        expect(res.errors).toHaveLength(1)
+        expect(res.errors[0].subject).toEqual({
+          start: { byte: 120, col: 1, line: 8 },
+          end: { byte: 120, col: 1, line: 8 },
+          filename: 'file.nacl',
+        })
+        expect(res.errors[0].message)
+          .toBe('Invalid block item. Expected a new block or an attribute definition.')
+        expect(res.errors[0].summary).toBe('Invalid block item')
       })
     })
   })

--- a/packages/workspace/test/parser/errors.test.ts
+++ b/packages/workspace/test/parser/errors.test.ts
@@ -1254,21 +1254,35 @@ describe('parsing errors', () => {
       })
     })
 
-    describe('ignore content merge conflict (multistring)', () => {
+    describe('ignore conflicts inside multiline strings', () => {
       const nacl = `
         rocky.racoon checkedAgain {
           always = '''
             remember
 <<<<<<<
-'''
-          only = "to lose"
+            only = "to lose"
 =======
-          only = "to find"
+            only = "to find"
 >>>>>>>
-        }
-        rocky.racoon checked {
-          only
-        }
+'''
+}
+      `
+      let res: ParseResult
+      beforeAll(async () => {
+        res = await parse(Buffer.from(nacl), 'file.nacl', {})
+      })
+      it('should raise invalid block item error', () => {
+        expect(res.errors).toHaveLength(0)
+      })
+    })
+
+    describe('raise error for non-open conflict token', () => {
+      const nacl = `
+        rocky.racoon checkedAgain {
+            only = "to lose"
+=======
+            what = "to find"
+}
       `
       let res: ParseResult
       beforeAll(async () => {
@@ -1277,13 +1291,30 @@ describe('parsing errors', () => {
       it('should raise invalid block item error', () => {
         expect(res.errors).toHaveLength(1)
         expect(res.errors[0].subject).toEqual({
-          start: { byte: 120, col: 1, line: 8 },
-          end: { byte: 120, col: 1, line: 8 },
+          start: { byte: 66, col: 1, line: 4 },
+          end: { byte: 66, col: 1, line: 4 },
           filename: 'file.nacl',
         })
         expect(res.errors[0].message)
           .toBe('Invalid block item. Expected a new block or an attribute definition.')
         expect(res.errors[0].summary).toBe('Invalid block item')
+      })
+    })
+
+    describe('ignore error for non-open conflict token in multiline string', () => {
+      const nacl = `
+        rocky.racoon checkedAgain {
+            only = '''
+=======
+'''
+}
+      `
+      let res: ParseResult
+      beforeAll(async () => {
+        res = await parse(Buffer.from(nacl), 'file.nacl', {})
+      })
+      it('should have no errors', () => {
+        expect(res.errors).toHaveLength(0)
       })
     })
   })


### PR DESCRIPTION
Instead of showing a long list of parse errors, we should show clear indications that there are conflicts that should be resolved in the error panel. We have now those git markers as part of the files after an operation that caused conflicts are done but the error panel today shows multiple errors per such conflict and the error message is not clear

---

_Additional context for reviewer_
* The way to verify git conflict is verifying token with '<' (x7) and then recovering for '=' (x7) and recovering again for '>' (x7)
* All the errors of a merge conflict file are dropped
* In case salto detects only the beginning string of a conflict and can't find the rest of the conflict strings - an invalid error will be raised and the file won't be scanned again

---
_Release Notes_: 
* Users now will see an indicative error message for merge conflicts.