### PR TITLE
SALTO-2128: Fix build issue with axios import and old TS

### DIFF
--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import axios, { AxiosError, AxiosBasicCredentials, AxiosRequestConfig } from 'axios'
-import axiosRetry, { isNetworkOrIdempotentRequestError } from 'axios-retry'
+import axiosRetry from 'axios-retry'
 import { AccountId } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { ClientRetryConfig } from './config'
@@ -101,7 +101,7 @@ export const createRetryOptions = (retryOptions: Required<ClientRetryConfig>): R
       retryCount)
     return retryDelay
   },
-  retryCondition: err => isNetworkOrIdempotentRequestError(err)
+  retryCondition: err => axiosRetry.isNetworkOrIdempotentRequestError(err)
     || err.response?.status === 429,
 })
 


### PR DESCRIPTION


---

Seems like since [this change](https://github.com/salto-io/salto/commit/90e0df36f2540690fcac458d8e8f4b3356be32e7#diff-2880859bfcf8851294b1f831ff389e877c7b498966a488198fb2f80c42bd58bbR18) external projects would fail when importing salto packages.
The typescript issue that causes this: https://github.com/microsoft/TypeScript/issues/38540

Not clear how the CLI kept working, still investigating that part

---
_Release Notes_: 
_None_ (no behavior change)

---
_User Notifications_: 
_None_