### PR TITLE
SALTO-2130 temporarily list recurseInto type explicitly

### DIFF
--- a/packages/stripe-adapter/e2e_test/adapter.test.ts
+++ b/packages/stripe-adapter/e2e_test/adapter.test.ts
@@ -90,7 +90,6 @@ describe('Stripe adapter E2E with real swagger and mock replies', () => {
       'stripe.plan_metadata',
       'stripe.plan_tier',
       'stripe.transform_usage',
-      'stripe.prices',
     ])('%s',
       unsupportedType => {
         expect(fetchedElementNames).not.toContain(unsupportedType)

--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -46,7 +46,7 @@ export type StripeConfig = {
   [API_DEFINITIONS_CONFIG]: StripeApiConfig
 }
 
-const ALL_SUPPORTED_TYPES = [
+export const DEFAULT_INCLUDE_TYPES = [
   'country_specs',
   'coupons',
   'products',
@@ -55,7 +55,11 @@ const ALL_SUPPORTED_TYPES = [
   'webhook_endpoints',
 ]
 
-export const DEFAULT_INCLUDE_TYPES = ALL_SUPPORTED_TYPES
+const ALL_SUPPORTED_TYPES = [
+  ...DEFAULT_INCLUDE_TYPES,
+  'prices',
+]
+
 
 const DEFAULT_TYPE_CUSTOMIZATIONS: StripeApiConfig['types'] = {
   coupon: {


### PR DESCRIPTION
Quick fix for missing type that is listed in `recurseInto` - will replace by a generic fix soon.
The `products` type includes an additional query that adds `prices` instances. Adding `prices` explicitly for now

---
_Release Notes_: 
Stripe adapter:
* Fix issue that caused products to not be fetched

---
_User Notifications_: 
Stripe adapter:
* Add back product instances that were erroneously removed