### PR TITLE
SALTO-2130 Treat recurseInto types as subtypes when restricting types to only include supported types

### DIFF
--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -328,7 +328,8 @@ export const generateTypes = async (
   addServiceIdAnnotations(definedTypes, types, typeDefaults)
 
   if (supportedTypes !== undefined) {
-    const recurseIntoTypes = Object.values(_.pick(types, supportedTypes))
+    // including all recurseInto types, regardless of whether they are listed or not
+    const recurseIntoTypes = Object.values(types)
       .flatMap(def => def.request?.recurseInto ?? [])
       .map(def => def.type)
     const extendedSupportedTypes = [...new Set([...supportedTypes, ...recurseIntoTypes])]

--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -328,10 +328,14 @@ export const generateTypes = async (
   addServiceIdAnnotations(definedTypes, types, typeDefaults)
 
   if (supportedTypes !== undefined) {
+    const recurseIntoTypes = Object.values(_.pick(types, supportedTypes))
+      .flatMap(def => def.request?.recurseInto ?? [])
+      .map(def => def.type)
+    const extendedSupportedTypes = [...new Set([...supportedTypes, ...recurseIntoTypes])]
     const filteredTypes = await filterTypes(
       adapterName,
       Object.values(definedTypes),
-      supportedTypes
+      extendedSupportedTypes,
     )
 
     return {

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -365,8 +365,7 @@ describe('swagger_type_elements', () => {
   })
 
   describe('with supportedTypes', () => {
-    let allTypes: Record<string, TypeElement>
-    beforeAll(async () => {
+    it('should only generate supported types', async () => {
       const res = await generateTypes(
         ADAPTER_NAME,
         {
@@ -376,10 +375,37 @@ describe('swagger_type_elements', () => {
           supportedTypes: ['Pet'],
         },
       )
-      allTypes = res.allTypes
+      expect(Object.keys(res.allTypes).sort()).toEqual(['Pet', 'Category', 'Tag'].sort())
     })
-    it('should only generate supported types', () => {
-      expect(Object.keys(allTypes).sort()).toEqual(['Pet', 'Category', 'Tag'].sort())
+    it('should include recurseInto types', async () => {
+      const res = await generateTypes(
+        ADAPTER_NAME,
+        {
+          swagger: { url: `${BASE_DIR}/petstore_swagger.v2.yaml` },
+          typeDefaults: { transformation: { idFields: ['name'] } },
+          types: {
+            Pet: {
+              request: {
+                url: '/abc',
+                recurseInto: [
+                  {
+                    type: 'Food',
+                    toField: 'food',
+                    context: [],
+                  },
+                  {
+                    type: 'Order',
+                    toField: 'order',
+                    context: [],
+                  },
+                ],
+              },
+            },
+          },
+          supportedTypes: ['Pet'],
+        },
+      )
+      expect(Object.keys(res.allTypes).sort()).toEqual(['Pet', 'Category', 'Tag', 'Food', 'Order'].sort())
     })
   })
 

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -393,6 +393,13 @@ describe('swagger_type_elements', () => {
                     toField: 'food',
                     context: [],
                   },
+                ],
+              },
+            },
+            Food: {
+              request: {
+                url: '/def',
+                recurseInto: [
                   {
                     type: 'Order',
                     toField: 'order',

--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -46,7 +46,7 @@ export type StripeConfig = {
   [API_DEFINITIONS_CONFIG]: StripeApiConfig
 }
 
-export const DEFAULT_INCLUDE_TYPES = [
+const ALL_SUPPORTED_TYPES = [
   'country_specs',
   'coupons',
   'products',
@@ -55,11 +55,7 @@ export const DEFAULT_INCLUDE_TYPES = [
   'webhook_endpoints',
 ]
 
-const ALL_SUPPORTED_TYPES = [
-  ...DEFAULT_INCLUDE_TYPES,
-  'prices',
-]
-
+export const DEFAULT_INCLUDE_TYPES = ALL_SUPPORTED_TYPES
 
 const DEFAULT_TYPE_CUSTOMIZATIONS: StripeApiConfig['types'] = {
   coupon: {


### PR DESCRIPTION
Generic solution that replaces https://github.com/salto-io/salto/pull/2856:

When using simple adapters to only generate types for `supportedTypes`, we did not consider the types listed in `recurseInto` to be subtypes. 
Note that we now list all `recurseInto` types as subtypes, regardless of whether they are used by `supportedTypes` or not.


---
_Release Notes_: 
Adapter-components:
* Fixed bug where if `supportedTypes` was enabled, `recurseInto` might break because its types were not considered as subtypes

Stripe adapter:
* Fix a recent regression that caused `product` instances to be omitted

---
_User Notifications_: 
None (not deployed yet)