### PR TITLE
SALTO-1334: Make numeric restrictions non enforcing in salesforce

### DIFF
--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -156,12 +156,12 @@ const geoLocationElemID = new ElemID(SALESFORCE, LOCATION_INTERNAL_COMPOUND_FIEL
 
 const restrictedNumberTypeDefinitions = {
   TextLength: createRestriction({ min: 1, max: 255, enforce_value: false }),
-  TextAreaLength: createRestriction({ min: 1, max: 131072 }),
-  EncryptedTextLength: createRestriction({ min: 1, max: 175 }),
-  LongTextAreaVisibleLines: createRestriction({ min: 2, max: 50 }),
+  TextAreaLength: createRestriction({ min: 1, max: 131072, enforce_value: false }),
+  EncryptedTextLength: createRestriction({ min: 1, max: 175, enforce_value: false }),
+  LongTextAreaVisibleLines: createRestriction({ min: 2, max: 50, enforce_value: false }),
   MultiPicklistVisibleLines: createRestriction({ min: 3, max: 10, enforce_value: false }),
-  RichTextAreaVisibleLines: createRestriction({ min: 10, max: 50 }),
-  RelationshipOrder: createRestriction({ min: 0, max: 1 }),
+  RichTextAreaVisibleLines: createRestriction({ min: 10, max: 50, enforce_value: false }),
+  RelationshipOrder: createRestriction({ min: 0, max: 1, enforce_value: false }),
 }
 
 const restrictedNumberTypes = _.mapValues(


### PR DESCRIPTION
Seems like the restrictions from the documentation are sometimes inaccurate
Making them non-enforcing to avoid false positive warnings

---


---
_Release Notes_: 
Salesforce Adapter:
- Avoid false warnings on "visibleLines" values

---
_User Notifications_: 
Salesforce Adapter:
- On the next fetch, `enforce_value = false` will be added to several elements in the `annotationTypes.nacl` file