### PR TITLE
SALTO-2125: perform update workspace on all the envs

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -611,12 +611,8 @@ export const loadWorkspace = async (
         )
       }
     }
-    const relevantEnvs = awu(envs())
-      .filter(async name =>
-        (workspaceChanges[name]?.changes ?? []).length > 0
-        || (stateOnlyChanges[name]?.changes ?? []).length > 0)
 
-    await relevantEnvs.forEach(async envName => { await updateWorkspace(envName) })
+    await awu(envs()).forEach(async envName => { await updateWorkspace(envName) })
     return stateToBuild
   }
 


### PR DESCRIPTION
_Perform update workspace on all the envs_

---

Background on the issue:
There was a bug in the code that caused changes that were done only on the state and not on the workspace, to not update the whole cache (only update the state level cache but not the workspace level cache). The reason for that is that we skipped running the update cache mechanism on envs that didn't have nacl changes. We changed the behavior to always update the cache of all the envs. We did a test to check if it causes a performance issue, and it didn't

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
