### PR TITLE
SAAS-3481 Add detailedMessage to cpq_trigger change validator

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/cpq_trigger.ts
+++ b/packages/salesforce-adapter/src/change_validators/cpq_trigger.ts
@@ -27,11 +27,11 @@ const getCpqError = (
   elemID,
   severity: 'Info',
   message: 'CPQ data changes detected',
-  detailedMessage: '',
+  detailedMessage: 'CPQ data changes detected',
   deployActions: {
     preAction: {
       title: 'Disable CPQ Triggers',
-      description: 'CPQ triggers should be disabled before deploying:',
+      description: 'CPQ triggers must be disabled before deploying:',
       subActions: [
         'In Salesforce, navigate to Setup > Installed Packages > Salesforce CPQ > Configure > Additional Settings tab',
         'Check the "Triggers Disabled" checkbox',

--- a/packages/salesforce-adapter/src/change_validators/cpq_trigger.ts
+++ b/packages/salesforce-adapter/src/change_validators/cpq_trigger.ts
@@ -31,7 +31,7 @@ const getCpqError = (
   deployActions: {
     preAction: {
       title: 'Disable CPQ Triggers',
-      description: 'CPQ triggers must be disabled before deploying:',
+      description: 'CPQ triggers should be disabled before deploying:',
       subActions: [
         'In Salesforce, navigate to Setup > Installed Packages > Salesforce CPQ > Configure > Additional Settings tab',
         'Check the "Triggers Disabled" checkbox',


### PR DESCRIPTION


---

We've decided not to hide empty detailedMessages on the SAAS, so we need to add a message here.
@liorn asked me that the detailedMessage will be identical to the message

---
_Release Notes_: 


---
_User Notifications_: 
None
