### PR TITLE
Add logs for remote maps

### DIFF
--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -226,6 +226,7 @@ const closeConnection = async (
 ): Promise<void> => {
   await closeDangalingConnection(connection)
   delete connPool[location]
+  log.debug('closed connection to %s', location)
 }
 
 const closeTmpConnection = async (
@@ -236,6 +237,7 @@ const closeTmpConnection = async (
   await closeDangalingConnection(connection)
   await deleteLocation(tmpLocation)
   delete (tmpDBConnections[location] ?? {})[tmpLocation]
+  log.debug('closed temporary connection to %s', tmpLocation)
 }
 
 export const closeRemoteMapsOfLocation = async (location: string): Promise<void> => {
@@ -260,6 +262,7 @@ export const closeRemoteMapsOfLocation = async (location: string): Promise<void>
       await closeDangalingConnection(conn)
     })
     delete readonlyDBConnectionsPerRemoteMap[location]
+    log.debug('closed read-only connections per remote map of location %s', location)
   }
   locationCaches.del(location)
 }
@@ -315,6 +318,7 @@ const getOpenDBConnection = async (
   isReadOnly: boolean
 ): Promise<rocksdb> => {
   const newDb = getRemoteDbImpl()(loc)
+  log.debug('opening connection to %s, read-only=%s', loc, isReadOnly)
   await promisify(newDb.open.bind(newDb, { readOnly: isReadOnly }))()
   return newDb
 }
@@ -671,6 +675,7 @@ remoteMap.RemoteMapCreator => {
           false,
           DELETE_OPERATION
         )
+        log.debug('flushed %s. results %o', namespace, { writeRes, deleteRes, wasClearCalled })
         const flushRes = writeRes || deleteRes || wasClearCalled
         wasClearCalled = false
         return flushRes

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -486,7 +486,7 @@ export const loadWorkspace = async (
         // To preserve the old ws functionality - hidden values should be added to the workspace
         // cache only if their top level element is in the nacls, or they are marked as hidden
         // (SAAS-2639)
-        const [stateChangesForExistingNaclElements, dropedStateOnlyChange] = await partition(
+        const [stateChangesForExistingNaclElements, droppedStateOnlyChange] = await partition(
           partialStateChanges.changes,
           async change => {
             const changeData = getChangeData(change)
@@ -497,8 +497,15 @@ export const loadWorkspace = async (
           }
         )
 
-        log.debug('dropped hidden changes due to missing nacl element for ids:',
-          dropedStateOnlyChange.map(getChangeData).map(elem => elem.elemID.getFullName()))
+        if (droppedStateOnlyChange.length > 0) {
+          log.debug(
+            'dropped hidden changes due to missing nacl element for ids: %s',
+            droppedStateOnlyChange
+              .map(getChangeData)
+              .map(elem => elem.elemID.getFullName())
+              .join(', ')
+          )
+        }
 
         return {
           changes: stateChangesForExistingNaclElements


### PR DESCRIPTION
Also fixed empty log in workspace

---

Hopefully this will help debugging future issues with caches by at least providing some information about when connections are flushed and closed and what hash we had each time

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_