### PR TITLE
SALTO-2150: support ordering of sla policies

### DIFF
--- a/packages/zendesk-support-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/e2e_test/adapter.test.ts
@@ -311,6 +311,7 @@ describe('Zendesk support adapter E2E', () => {
         'user_field_order',
         'organization_field_order',
         'ticket_form_order',
+        'sla_policy_order',
       ]
       const orderElementsElemIDs = orderElements.map(name => ({
         type: new ElemID(ZENDESK_SUPPORT, name),

--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -41,6 +41,7 @@ import ticketFormOrderFilter from './filters/reorder/ticket_form'
 import userFieldOrderFilter from './filters/reorder/user_field'
 import organizationFieldOrderFilter from './filters/reorder/organization_field'
 import workspaceOrderFilter from './filters/reorder/workspace'
+import slaPolicyOrderFilter from './filters/reorder/sla_policy'
 import businessHoursScheduleFilter from './filters/business_hours_schedule'
 import collisionErrorsFilter from './filters/collision_errors'
 import accountSettingsFilter from './filters/account_settings'
@@ -80,6 +81,7 @@ export const DEFAULT_FILTERS = [
   userFieldOrderFilter,
   organizationFieldOrderFilter,
   workspaceOrderFilter,
+  slaPolicyOrderFilter,
   businessHoursScheduleFilter,
   collisionErrorsFilter,
   accountSettingsFilter,

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -319,6 +319,14 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       },
     },
   },
+  sla_policy_order: {
+    deployRequests: {
+      modify: {
+        url: '/slas/policies/reorder',
+        method: 'put',
+      },
+    },
+  },
   sla_policy_definition: {
     transformation: {
       sourceTypeName: 'sla_policies_definitions__definitions',

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -318,6 +318,11 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskSupportFieldReferenceDefi
     target: { type: 'workspace' },
   },
   {
+    src: { field: 'sla_policy_ids', parentTypes: ['sla_policy_order'] },
+    serializationStrategy: 'id',
+    target: { type: 'sla_policy' },
+  },
+  {
     src: { field: 'id', parentTypes: ['workspace__selected_macros'] },
     serializationStrategy: 'id',
     target: { type: 'macro' },

--- a/packages/zendesk-support-adapter/src/filters/reorder/sla_policy.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/sla_policy.ts
@@ -1,0 +1,27 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { SLA_POLICY_TYPE_NAME } from '../sla_policy'
+import { createReorderFilterCreator } from './creator'
+
+/**
+ * Add sla policy order element with all the user fields ordered
+ */
+const filterCreator = createReorderFilterCreator({
+  typeName: SLA_POLICY_TYPE_NAME,
+  orderFieldName: 'sla_policy_ids',
+})
+
+export default filterCreator

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -81,9 +81,9 @@ describe('adapter', () => {
           ),
           elementsSource: buildElementsSourceFromElements([]),
         }).fetch({ progressReporter: { reportProgress: () => null } })
-        expect(elements).toHaveLength(396)
-        expect(elements.filter(isObjectType)).toHaveLength(192)
-        expect(elements.filter(isInstanceElement)).toHaveLength(204)
+        expect(elements).toHaveLength(398)
+        expect(elements.filter(isObjectType)).toHaveLength(193)
+        expect(elements.filter(isInstanceElement)).toHaveLength(205)
         expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
           'zendesk_support.account_setting',
           'zendesk_support.account_setting.instance',
@@ -324,6 +324,8 @@ describe('adapter', () => {
           'zendesk_support.sla_policy_definition__any__values__label',
           'zendesk_support.sla_policy_definition__any__values__labels',
           'zendesk_support.sla_policy_definition__any__values__list',
+          'zendesk_support.sla_policy_order',
+          'zendesk_support.sla_policy_order.instance',
           'zendesk_support.support_address',
           'zendesk_support.support_address.instance.myBrand',
           'zendesk_support.support_addresses',
@@ -534,7 +536,7 @@ describe('adapter', () => {
           elementsSource: buildElementsSourceFromElements([]),
         }).fetch({ progressReporter: { reportProgress: () => null } })
         const instances = elements.filter(isInstanceElement)
-        expect(instances).toHaveLength(8)
+        expect(instances).toHaveLength(9)
         expect(instances.map(e => e.elemID.getFullName()).sort())
           .toEqual([
             'zendesk_support.group.instance.Support',
@@ -543,6 +545,7 @@ describe('adapter', () => {
             'zendesk_support.group.instance.Support5',
             // The order element are always created on fetch
             'zendesk_support.organization_field_order.instance',
+            'zendesk_support.sla_policy_order.instance',
             'zendesk_support.ticket_form_order.instance',
             'zendesk_support.user_field_order.instance',
             'zendesk_support.workspace_order.instance',


### PR DESCRIPTION
_support ordering of sla policies_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Zendesk_support adapter_
* Add sla policy order element

---
_User Notifications_: 
_A new sla policy order element will appear_
