### PR TITLE
SALTO-2149: support reorder of automations

### DIFF
--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -42,6 +42,7 @@ import userFieldOrderFilter from './filters/reorder/user_field'
 import organizationFieldOrderFilter from './filters/reorder/organization_field'
 import workspaceOrderFilter from './filters/reorder/workspace'
 import slaPolicyOrderFilter from './filters/reorder/sla_policy'
+import automationOrderFilter from './filters/reorder/automation'
 import businessHoursScheduleFilter from './filters/business_hours_schedule'
 import collisionErrorsFilter from './filters/collision_errors'
 import accountSettingsFilter from './filters/account_settings'
@@ -82,6 +83,7 @@ export const DEFAULT_FILTERS = [
   organizationFieldOrderFilter,
   workspaceOrderFilter,
   slaPolicyOrderFilter,
+  automationOrderFilter,
   businessHoursScheduleFilter,
   collisionErrorsFilter,
   accountSettingsFilter,

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -288,6 +288,14 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       },
     },
   },
+  automation_order: {
+    deployRequests: {
+      modify: {
+        url: '/automations/update_many',
+        method: 'put',
+      },
+    },
+  },
   sla_policy: {
     transformation: {
       sourceTypeName: 'sla_policies__sla_policies',

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -323,6 +323,11 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskSupportFieldReferenceDefi
     target: { type: 'sla_policy' },
   },
   {
+    src: { field: 'ids', parentTypes: ['automation_order'] },
+    serializationStrategy: 'id',
+    target: { type: 'automation' },
+  },
+  {
     src: { field: 'id', parentTypes: ['workspace__selected_macros'] },
     serializationStrategy: 'id',
     target: { type: 'macro' },

--- a/packages/zendesk-support-adapter/src/filters/reorder/automation.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/automation.ts
@@ -35,9 +35,8 @@ export const deployFunc: DeployFuncType = async (change, client, apiDefinitions)
  */
 const filterCreator = createReorderFilterCreator({
   typeName: 'automation',
-  orderFieldName: 'ids',
-  iterateesToSortBy: [
-    instance => instance.value.position,
+  orderFieldName: ORDER_FIELD_NAME,
+  additionalIterateesToSortBy: [
     instance => instance.value.title,
   ],
   deployFunc,

--- a/packages/zendesk-support-adapter/src/filters/reorder/automation.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/automation.ts
@@ -1,0 +1,46 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { getChangeData } from '@salto-io/adapter-api'
+import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
+import { deployChange } from '../../deployment'
+import { createReorderFilterCreator, DeployFuncType } from './creator'
+
+export const ORDER_FIELD_NAME = 'ids'
+
+export const deployFunc: DeployFuncType = async (change, client, apiDefinitions) => {
+  const clonedChange = await applyFunctionToChangeData(change, inst => inst.clone())
+  const instance = getChangeData(clonedChange)
+  const idsWithPositions = (instance.value.ids as number[])
+    .map((id, position) => ({ id, position: position + 1 }))
+  instance.value.automations = idsWithPositions
+  delete instance.value.ids
+  await deployChange(clonedChange, client, apiDefinitions)
+}
+
+/**
+ * Add automation order element with all the automations ordered
+ */
+const filterCreator = createReorderFilterCreator({
+  typeName: 'automation',
+  orderFieldName: 'ids',
+  iterateesToSortBy: [
+    instance => instance.value.position,
+    instance => instance.value.title,
+  ],
+  deployFunc,
+})
+
+export default filterCreator

--- a/packages/zendesk-support-adapter/src/filters/reorder/sla_policy.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/sla_policy.ts
@@ -17,7 +17,7 @@ import { SLA_POLICY_TYPE_NAME } from '../sla_policy'
 import { createReorderFilterCreator } from './creator'
 
 /**
- * Add sla policy order element with all the user fields ordered
+ * Add sla policy order element with all the sla policies ordered
  */
 const filterCreator = createReorderFilterCreator({
   typeName: SLA_POLICY_TYPE_NAME,

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -81,9 +81,9 @@ describe('adapter', () => {
           ),
           elementsSource: buildElementsSourceFromElements([]),
         }).fetch({ progressReporter: { reportProgress: () => null } })
-        expect(elements).toHaveLength(398)
-        expect(elements.filter(isObjectType)).toHaveLength(193)
-        expect(elements.filter(isInstanceElement)).toHaveLength(205)
+        expect(elements).toHaveLength(400)
+        expect(elements.filter(isObjectType)).toHaveLength(194)
+        expect(elements.filter(isInstanceElement)).toHaveLength(206)
         expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
           'zendesk_support.account_setting',
           'zendesk_support.account_setting.instance',
@@ -139,6 +139,8 @@ describe('adapter', () => {
           'zendesk_support.automation__conditions',
           'zendesk_support.automation__conditions__all',
           'zendesk_support.automation__conditions__any',
+          'zendesk_support.automation_order',
+          'zendesk_support.automation_order.instance',
           'zendesk_support.automations',
           'zendesk_support.brand',
           'zendesk_support.brand.instance.myBrand',
@@ -536,7 +538,7 @@ describe('adapter', () => {
           elementsSource: buildElementsSourceFromElements([]),
         }).fetch({ progressReporter: { reportProgress: () => null } })
         const instances = elements.filter(isInstanceElement)
-        expect(instances).toHaveLength(9)
+        expect(instances).toHaveLength(10)
         expect(instances.map(e => e.elemID.getFullName()).sort())
           .toEqual([
             'zendesk_support.group.instance.Support',
@@ -544,12 +546,13 @@ describe('adapter', () => {
             'zendesk_support.group.instance.Support4',
             'zendesk_support.group.instance.Support5',
             // The order element are always created on fetch
+            'zendesk_support.automation_order.instance',
             'zendesk_support.organization_field_order.instance',
             'zendesk_support.sla_policy_order.instance',
             'zendesk_support.ticket_form_order.instance',
             'zendesk_support.user_field_order.instance',
             'zendesk_support.workspace_order.instance',
-          ])
+          ].sort())
       })
     })
     it('should use elemIdGetter', async () => {

--- a/packages/zendesk-support-adapter/test/filters/reorder/automation.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/automation.test.ts
@@ -1,0 +1,187 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ObjectType, ElemID, InstanceElement, Element, isObjectType,
+  isInstanceElement, ReferenceExpression, ModificationChange, CORE_ANNOTATIONS,
+} from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { DEFAULT_CONFIG, DEFAULT_INCLUDE_ENDPOINTS, FETCH_CONFIG } from '../../../src/config'
+import ZendeskClient from '../../../src/client/client'
+import { ZENDESK_SUPPORT } from '../../../src/constants'
+import { paginate } from '../../../src/client/pagination'
+import filterCreator from '../../../src/filters/reorder/automation'
+import { createOrderTypeName } from '../../../src/filters/reorder/creator'
+
+const mockDeployChange = jest.fn()
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn((...args) => mockDeployChange(...args)),
+    },
+  }
+})
+
+describe('automation reorder filter', () => {
+  let client: ZendeskClient
+  type FilterType = filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let filter: FilterType
+  const typeName = 'automation'
+  const orderTypeName = createOrderTypeName(typeName)
+  const objType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, typeName) })
+  const inst1 = new InstanceElement('inst1', objType, { id: 11, position: 1, title: 'inst2' })
+  const inst2 = new InstanceElement('inst2', objType, { id: 22, position: 2, title: 'inst1' })
+  const inst3 = new InstanceElement('inst3', objType, { id: 22, position: 2, title: 'aaa' })
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      }),
+      config: DEFAULT_CONFIG,
+    }) as FilterType
+  })
+
+  describe('onFetch', () => {
+    it('should create correct order element', async () => {
+      const elements = [objType, inst1, inst2, inst3]
+      await filter.onFetch(elements)
+      expect(elements).toHaveLength(6)
+      expect(elements.map(e => e.elemID.getFullName()).sort())
+        .toEqual([
+          'zendesk_support.automation',
+          'zendesk_support.automation.instance.inst1',
+          'zendesk_support.automation.instance.inst2',
+          'zendesk_support.automation.instance.inst3',
+          'zendesk_support.automation_order',
+          'zendesk_support.automation_order.instance',
+        ])
+      const ticketFormOrderType = elements
+        .find(e => isObjectType(e) && e.elemID.typeName === orderTypeName)
+      expect(ticketFormOrderType).toBeDefined()
+      const ticketFormOrderInstance = elements
+        .find(e => isInstanceElement(e) && e.elemID.typeName === orderTypeName)
+      expect(ticketFormOrderInstance).toBeDefined()
+      expect(ticketFormOrderInstance?.elemID.name).toEqual(ElemID.CONFIG_NAME)
+      expect((ticketFormOrderInstance as InstanceElement)?.value)
+        .toEqual({ ids: [
+          new ReferenceExpression(inst1.elemID, inst1),
+          new ReferenceExpression(inst3.elemID, inst3),
+          new ReferenceExpression(inst2.elemID, inst2),
+        ] })
+      const orderType = elements
+        .find(elem => elem.elemID.getFullName() === 'zendesk_support.automation_order')
+      expect(orderType).toBeDefined()
+      expect(orderType?.annotations[CORE_ANNOTATIONS.HIDDEN]).toEqual(true)
+    })
+    it('should create correct order element with non hidden types', async () => {
+      const filterWithHideType = filterCreator({
+        client,
+        paginator: clientUtils.createPaginator({
+          client,
+          paginationFuncCreator: paginate,
+        }),
+        config: {
+          ...DEFAULT_CONFIG,
+          [FETCH_CONFIG]: {
+            includeTypes: DEFAULT_INCLUDE_ENDPOINTS,
+            hideTypes: false,
+          },
+        },
+      }) as FilterType
+      const elements = [objType, inst1, inst2, inst3]
+      await filterWithHideType.onFetch(elements)
+      expect(elements).toHaveLength(6)
+      expect(elements.map(e => e.elemID.getFullName()).sort())
+        .toEqual([
+          'zendesk_support.automation',
+          'zendesk_support.automation.instance.inst1',
+          'zendesk_support.automation.instance.inst2',
+          'zendesk_support.automation.instance.inst3',
+          'zendesk_support.automation_order',
+          'zendesk_support.automation_order.instance',
+        ])
+      const orderType = elements
+        .find(elem => elem.elemID.getFullName() === 'zendesk_support.automation_order')
+      expect(orderType).toBeDefined()
+      expect(orderType?.annotations[CORE_ANNOTATIONS.HIDDEN]).not.toBeDefined()
+    })
+    it('should not create new elements if there are no automations', async () => {
+      const elements: Element[] = []
+      await filter.onFetch(elements)
+      expect(elements).toHaveLength(0)
+    })
+  })
+  describe('deploy', () => {
+    const orderType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, orderTypeName) })
+    const before = new InstanceElement(
+      ElemID.CONFIG_NAME, orderType, { ids: [11, 22, 33] },
+    )
+    const after = new InstanceElement(
+      ElemID.CONFIG_NAME, orderType, { ids: [22, 33, 11] },
+    )
+    const change: ModificationChange<InstanceElement> = {
+      action: 'modify',
+      data: { before, after },
+    }
+    it('should pass the correct params to deployChange', async () => {
+      const res = await filter.deploy([change])
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toEqual([change])
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      const instanceToDeploy = after.clone()
+      instanceToDeploy.value = {
+        automations: [
+          { id: 22, position: 1 },
+          { id: 33, position: 2 },
+          { id: 11, position: 3 },
+        ],
+      }
+      expect(mockDeployChange).toHaveBeenCalledWith(
+        {
+          action: 'modify',
+          data: {
+            after: instanceToDeploy,
+            before,
+          },
+        },
+        expect.anything(),
+        expect.anything(),
+        undefined,
+      )
+    })
+    it('should return an error if there are multiple order changes', async () => {
+      const res = await filter.deploy([change, change])
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(mockDeployChange).toHaveBeenCalledTimes(0)
+    })
+    it('should return an error if the order change is not modification', async () => {
+      const res = await filter.deploy([{ action: 'add', data: { after } }])
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(mockDeployChange).toHaveBeenCalledTimes(0)
+    })
+  })
+})

--- a/packages/zendesk-support-adapter/test/filters/reorder/automation.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/automation.test.ts
@@ -22,7 +22,7 @@ import { DEFAULT_CONFIG, DEFAULT_INCLUDE_ENDPOINTS, FETCH_CONFIG } from '../../.
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../../src/constants'
 import { paginate } from '../../../src/client/pagination'
-import filterCreator from '../../../src/filters/reorder/automation'
+import filterCreator, { ORDER_FIELD_NAME } from '../../../src/filters/reorder/automation'
 import { createOrderTypeName } from '../../../src/filters/reorder/creator'
 
 const mockDeployChange = jest.fn()
@@ -77,15 +77,15 @@ describe('automation reorder filter', () => {
           'zendesk_support.automation_order',
           'zendesk_support.automation_order.instance',
         ])
-      const ticketFormOrderType = elements
+      const automationOrderType = elements
         .find(e => isObjectType(e) && e.elemID.typeName === orderTypeName)
-      expect(ticketFormOrderType).toBeDefined()
-      const ticketFormOrderInstance = elements
+      expect(automationOrderType).toBeDefined()
+      const automationOrderInstance = elements
         .find(e => isInstanceElement(e) && e.elemID.typeName === orderTypeName)
-      expect(ticketFormOrderInstance).toBeDefined()
-      expect(ticketFormOrderInstance?.elemID.name).toEqual(ElemID.CONFIG_NAME)
-      expect((ticketFormOrderInstance as InstanceElement)?.value)
-        .toEqual({ ids: [
+      expect(automationOrderInstance).toBeDefined()
+      expect(automationOrderInstance?.elemID.name).toEqual(ElemID.CONFIG_NAME)
+      expect((automationOrderInstance as InstanceElement)?.value)
+        .toEqual({ [ORDER_FIELD_NAME]: [
           new ReferenceExpression(inst1.elemID, inst1),
           new ReferenceExpression(inst3.elemID, inst3),
           new ReferenceExpression(inst2.elemID, inst2),
@@ -136,10 +136,10 @@ describe('automation reorder filter', () => {
   describe('deploy', () => {
     const orderType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, orderTypeName) })
     const before = new InstanceElement(
-      ElemID.CONFIG_NAME, orderType, { ids: [11, 22, 33] },
+      ElemID.CONFIG_NAME, orderType, { [ORDER_FIELD_NAME]: [11, 22, 33] },
     )
     const after = new InstanceElement(
-      ElemID.CONFIG_NAME, orderType, { ids: [22, 33, 11] },
+      ElemID.CONFIG_NAME, orderType, { [ORDER_FIELD_NAME]: [22, 33, 11] },
     )
     const change: ModificationChange<InstanceElement> = {
       action: 'modify',


### PR DESCRIPTION
_support ordering of automations_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Zendesk_support adapter_
* Add automation order element

---
_User Notifications_: 
_A new automation order element will appear_
