### PR TITLE
SALTO-1691: Remove code fragments from workspace errors

### DIFF
--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -24,7 +24,7 @@ import {
   isStaticFile,
 } from '@salto-io/adapter-api'
 import { Plan, PlanItem, FetchChange, FetchResult, LocalChange, getSupportedServiceAdapterNames } from '@salto-io/core'
-import { errors, SourceFragment, parser, WorkspaceComponents, StateRecency } from '@salto-io/workspace'
+import { errors, parser, WorkspaceComponents, StateRecency } from '@salto-io/workspace'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections, values } from '@salto-io/lowerdash'
 import Prompts from './prompts'
@@ -58,38 +58,17 @@ export const formatWordsSeries = (words: string[]): string => (words.length > 1
 /**
   * Format workspace errors
   */
-const TAB = '  '
 
-const formatSourceFragmentHeader = (headerMetaData: parser.SourceRange): string =>
-  `${chalk.underline(headerMetaData.filename)}(${chalk.cyan(`line: ${headerMetaData.start.line}`)})\n`
+const formatSourceLocation = (sr: Readonly<parser.SourceRange>): string =>
+  `${chalk.underline(sr.filename)}(${chalk.cyan(`line: ${sr.start.line}`)})\n`
 
-const formatSourceFragmentWithsubRange = (sf: Readonly<SourceFragment>): string => {
-  const sourceSubRange = sf.subRange ?? sf.sourceRange
-  const beforeSubRange = sf.fragment.slice(0, sourceSubRange.start.byte - sf.sourceRange.start.byte)
-  let subRange = sf.fragment.slice(sourceSubRange.start.byte - sf.sourceRange.start.byte,
-    sourceSubRange.end.byte - sf.sourceRange.start.byte)
-  subRange = subRange === '\n' ? '\\n\n' : subRange
-  const afterSubRange = sf.fragment.slice(sourceSubRange.end.byte - sf.sourceRange.start.byte)
-  return `${formatSourceFragmentHeader(sourceSubRange)}${TAB}${
-    subHeader(beforeSubRange)
-  }${chalk.white(subRange)
-  }${subHeader(afterSubRange)}\n`
-}
-
-const formatSourceFragmentWithoutsubRange = (sf: Readonly<SourceFragment>): string =>
-  `${formatSourceFragmentHeader(sf.sourceRange)}${TAB}${
-    subHeader(sf.fragment.split('\n').join(`\n${TAB}`))}\n`
-
-const formatSourceFragment = (sf: Readonly<SourceFragment>): string =>
-  (sf.subRange ? formatSourceFragmentWithsubRange(sf) : formatSourceFragmentWithoutsubRange(sf))
-
-const formatSourceFragments = (sourceFragments: ReadonlyArray<SourceFragment>): string =>
-  (sourceFragments.length > 0
-    ? `\n on ${sourceFragments.map(formatSourceFragment).join('\n and ')}`
+const formatSourceLocations = (sourceLocations: ReadonlyArray<parser.SourceRange>): string =>
+  (sourceLocations.length > 0
+    ? `\n on ${sourceLocations.map(formatSourceLocation).join('\n and ')}`
     : '')
 
 export const formatWorkspaceError = (we: Readonly<errors.WorkspaceError<SaltoError>>): string =>
-  `${formatError(we)}${formatSourceFragments(we.sourceFragments)}`
+  `${formatError(we)}${formatSourceLocations(we.sourceLocations)}`
 
 const indent = (text: string, level: number): string => {
   const indentText = _.repeat('  ', level)

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -24,7 +24,7 @@ import {
   isStaticFile,
 } from '@salto-io/adapter-api'
 import { Plan, PlanItem, FetchChange, FetchResult, LocalChange, getSupportedServiceAdapterNames } from '@salto-io/core'
-import { errors, parser, WorkspaceComponents, StateRecency } from '@salto-io/workspace'
+import { errors, SourceLocation, WorkspaceComponents, StateRecency } from '@salto-io/workspace'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections, values } from '@salto-io/lowerdash'
 import Prompts from './prompts'
@@ -59,10 +59,10 @@ export const formatWordsSeries = (words: string[]): string => (words.length > 1
   * Format workspace errors
   */
 
-const formatSourceLocation = (sr: Readonly<parser.SourceRange>): string =>
-  `${chalk.underline(sr.filename)}(${chalk.cyan(`line: ${sr.start.line}`)})\n`
+const formatSourceLocation = (sl: Readonly<SourceLocation>): string =>
+  `${chalk.underline(sl.sourceRange.filename)}(${chalk.cyan(`line: ${sl.sourceRange.start.line}`)})\n`
 
-const formatSourceLocations = (sourceLocations: ReadonlyArray<parser.SourceRange>): string =>
+const formatSourceLocations = (sourceLocations: ReadonlyArray<SourceLocation>): string =>
   (sourceLocations.length > 0
     ? `\n on ${sourceLocations.map(formatSourceLocation).join('\n and ')}`
     : '')

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -27,34 +27,25 @@ import { elements, preview, detailedChange } from './mocks'
 import Prompts from '../src/prompts'
 
 describe('formatter', () => {
-  const workspaceErrorWithSourceFragments: wsErrors.WorkspaceError<SaltoError> = {
-    sourceFragments: [{
-      sourceRange: {
+  const workspaceErrorWithSourceLocations: wsErrors.WorkspaceError<SaltoError> = {
+    sourceLocations: [
+      {
         start: { byte: 20, col: 10, line: 2 },
         end: { byte: 30, col: 10, line: 3 },
         filename: 'test.nacl',
       },
-      subRange: {
-        start: { line: 2, col: 3, byte: 30 },
-        end: { line: 2, col: 4, byte: 31 },
-        filename: 'test.nacl',
-      },
-      fragment: '{ This is my first code fragment }',
-    },
-    {
-      sourceRange: {
+      {
         start: { byte: 100, col: 10, line: 10 },
         end: { byte: 150, col: 10, line: 15 },
         filename: 'test.nacl',
       },
-      fragment: '{ This is my second code fragment }',
-    }],
+    ],
     message: 'This is my error',
     severity: 'Error',
   }
   const workspaceErrorWithoutSourceFragments: wsErrors.WorkspaceError<SaltoError> = {
     message: 'This is my error',
-    sourceFragments: [],
+    sourceLocations: [],
     severity: 'Error',
   }
   const workspaceErrorWithPreDeployAction: ChangeError = {
@@ -90,7 +81,7 @@ describe('formatter', () => {
     beforeAll(async () => {
       output = await formatExecutionPlan(plan, changeErrors.map(ce => ({
         ...ce,
-        sourceFragments: workspaceErrorWithSourceFragments.sourceFragments,
+        sourceLocations: workspaceErrorWithSourceLocations.sourceLocations,
       })))
     })
 
@@ -116,7 +107,7 @@ describe('formatter', () => {
         plan,
         [workspaceErrorWithInfoSeverity].map(ce => ({
           ...ce,
-          sourceFragments: workspaceErrorWithSourceFragments.sourceFragments,
+          sourceLocations: workspaceErrorWithSourceLocations.sourceLocations,
         }))
       )
       expect(outputWithNoDeployActions).not.toMatch(`${chalk.bold(Prompts.DEPLOY_PRE_ACTION_HEADER)}`)
@@ -134,14 +125,14 @@ describe('formatter', () => {
         severity: 'Error',
         message: 'Message key for test',
         detailedMessage: 'Validation message',
-        sourceFragments: workspaceErrorWithSourceFragments.sourceFragments,
+        sourceLocations: workspaceErrorWithSourceLocations.sourceLocations,
       }]
       const output = formatChangeErrors(changeErrors)
       expect(output)
         .toContain('Error')
       expect(output)
         .toMatch(new RegExp(`.*${changeErrors[0].detailedMessage}`, 's'))
-      expect(output).toMatch(new RegExp(`.*${workspaceErrorWithSourceFragments.sourceFragments[0].sourceRange.filename}`, 's'))
+      expect(output).toMatch(new RegExp(`.*${workspaceErrorWithSourceLocations.sourceLocations[0].filename}`, 's'))
     })
     it('should have grouped validations', () => {
       const changeErrors: ReadonlyArray<wsErrors.WorkspaceError<ChangeError>> = [{
@@ -149,7 +140,7 @@ describe('formatter', () => {
         severity: 'Error',
         message: 'Message key for test',
         detailedMessage: 'Validation message',
-        sourceFragments: workspaceErrorWithSourceFragments.sourceFragments,
+        sourceLocations: workspaceErrorWithSourceLocations.sourceLocations,
 
       },
       {
@@ -157,7 +148,7 @@ describe('formatter', () => {
         severity: 'Error',
         message: 'Message key for test',
         detailedMessage: 'Validation message 2',
-        sourceFragments: workspaceErrorWithSourceFragments.sourceFragments,
+        sourceLocations: workspaceErrorWithSourceLocations.sourceLocations,
 
       }]
       const output = formatChangeErrors(changeErrors)
@@ -172,23 +163,21 @@ describe('formatter', () => {
         severity: 'Error',
         message: 'Different message key',
         detailedMessage: 'Validation message 3',
-        sourceFragments: workspaceErrorWithSourceFragments.sourceFragments,
+        sourceLocations: workspaceErrorWithSourceLocations.sourceLocations,
       }
       const changeErrors: ReadonlyArray<wsErrors.WorkspaceError<ChangeError>> = [{
         elemID: new ElemID('salesforce', 'test'),
         severity: 'Error',
         message: 'Message key for test',
         detailedMessage: 'Validation message',
-        sourceFragments: workspaceErrorWithSourceFragments.sourceFragments,
-
+        sourceLocations: workspaceErrorWithSourceLocations.sourceLocations,
       },
       {
         elemID: new ElemID('salesforce', 'test2'),
         severity: 'Error',
         message: 'Message key for test',
         detailedMessage: 'Validation message 2',
-        sourceFragments: workspaceErrorWithSourceFragments.sourceFragments,
-
+        sourceLocations: workspaceErrorWithSourceLocations.sourceLocations,
       },
       differentValidationKey]
       const output = formatChangeErrors(changeErrors)
@@ -454,19 +443,13 @@ describe('formatter', () => {
   describe('workspace error format with source fragments', () => {
     let formattedErrors: string
     beforeEach(() => {
-      formattedErrors = formatWorkspaceError(workspaceErrorWithSourceFragments)
+      formattedErrors = formatWorkspaceError(workspaceErrorWithSourceLocations)
     })
     it('should print the start line', () => {
       expect(formattedErrors).toContain('2')
     })
     it('should print the error', () => {
       expect(formattedErrors).toContain('This is my error')
-    })
-    it('should print the first code fragment', () => {
-      expect(formattedErrors).toContain('first code') // The formatted error is chalked.
-    })
-    it('should print the second code fragment', () => {
-      expect(formattedErrors).toContain('{ This is my second code fragment }')
     })
   })
   describe('workspace error format without source fragments', () => {

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -28,18 +28,25 @@ import Prompts from '../src/prompts'
 
 describe('formatter', () => {
   const workspaceErrorWithSourceLocations: wsErrors.WorkspaceError<SaltoError> = {
-    sourceLocations: [
-      {
+    sourceLocations: [{
+      sourceRange: {
         start: { byte: 20, col: 10, line: 2 },
         end: { byte: 30, col: 10, line: 3 },
         filename: 'test.nacl',
       },
-      {
+      subRange: {
+        start: { line: 2, col: 3, byte: 30 },
+        end: { line: 2, col: 4, byte: 31 },
+        filename: 'test.nacl',
+      },
+    },
+    {
+      sourceRange: {
         start: { byte: 100, col: 10, line: 10 },
         end: { byte: 150, col: 10, line: 15 },
         filename: 'test.nacl',
       },
-    ],
+    }],
     message: 'This is my error',
     severity: 'Error',
   }
@@ -132,7 +139,7 @@ describe('formatter', () => {
         .toContain('Error')
       expect(output)
         .toMatch(new RegExp(`.*${changeErrors[0].detailedMessage}`, 's'))
-      expect(output).toMatch(new RegExp(`.*${workspaceErrorWithSourceLocations.sourceLocations[0].filename}`, 's'))
+      expect(output).toMatch(new RegExp(`.*${workspaceErrorWithSourceLocations.sourceLocations[0].sourceRange.filename}`, 's'))
     })
     it('should have grouped validations', () => {
       const changeErrors: ReadonlyArray<wsErrors.WorkspaceError<ChangeError>> = [{

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -352,16 +352,13 @@ export const mockWorkspace = ({
     hasElementsInServices: mockFunction<Workspace['hasElementsInServices']>().mockResolvedValue(true),
     hasElementsInEnv: mockFunction<Workspace['hasElementsInEnv']>().mockResolvedValue(false),
     envOfFile: mockFunction<Workspace['envOfFile']>().mockReturnValue(''),
-    getSourceFragment: mockFunction<Workspace['getSourceFragment']>().mockImplementation(
-      async sourceRange => ({ sourceRange, fragment: '' })
-    ),
     hasErrors: mockFunction<Workspace['hasErrors']>().mockResolvedValue(false),
     errors: mockFunction<Workspace['errors']>().mockResolvedValue(mockErrors([])),
     transformToWorkspaceError: mockFunction<Workspace['transformToWorkspaceError']>().mockImplementation(
-      async error => ({ ...error, sourceFragments: [] })
+      async error => ({ ...error, sourceLocations: [] })
     ) as Workspace['transformToWorkspaceError'],
     transformError: mockFunction<Workspace['transformError']>().mockImplementation(
-      async error => ({ ...error, sourceFragments: [] })
+      async error => ({ ...error, sourceLocations: [] })
     ),
     updateNaclFiles: mockFunction<Workspace['updateNaclFiles']>().mockResolvedValue({
       naclFilesChangesCount: 0,

--- a/packages/cli/test/workspace/workspace.test.ts
+++ b/packages/cli/test/workspace/workspace.test.ts
@@ -36,7 +36,7 @@ const mockWsFunctions = {
   isEmpty: mockFunction<Workspace['isEmpty']>().mockResolvedValue(false),
   flush: mockFunction<Workspace['flush']>(),
   transformError: mockFunction<Workspace['transformError']>().mockImplementation(
-    error => Promise.resolve({ ...error, sourceFragments: [] })
+    error => Promise.resolve({ ...error, sourceLocations: [] })
   ),
   getTotalSize: mockFunction<Workspace['getTotalSize']>(),
   getStateRecency: mockFunction<Workspace['getStateRecency']>().mockResolvedValue({

--- a/packages/lang-server/src/diagnostics.ts
+++ b/packages/lang-server/src/diagnostics.ts
@@ -48,9 +48,8 @@ export const getDiagnostics = async (
       .map(err => workspace.transformError(err))
       .map(async errPromise => {
         const err = await errPromise
-        return err.sourceFragments.map(f => {
-          const range = f.subRange || f.sourceRange
-          return {
+        return err.sourceLocations.map(range => (
+          {
             filename: range.filename,
             severity: err.severity,
             msg: err.message,
@@ -58,8 +57,7 @@ export const getDiagnostics = async (
               start: range.start,
               end: range.end,
             },
-          }
-        })
+          }))
       })
   )
 

--- a/packages/lang-server/src/diagnostics.ts
+++ b/packages/lang-server/src/diagnostics.ts
@@ -48,8 +48,9 @@ export const getDiagnostics = async (
       .map(err => workspace.transformError(err))
       .map(async errPromise => {
         const err = await errPromise
-        return err.sourceLocations.map(range => (
-          {
+        return err.sourceLocations.map(sl => {
+          const range = sl.subRange || sl.sourceRange
+          return {
             filename: range.filename,
             severity: err.severity,
             msg: err.message,
@@ -57,7 +58,8 @@ export const getDiagnostics = async (
               start: range.start,
               end: range.end,
             },
-          }))
+          }
+        })
       })
   )
 

--- a/packages/lang-server/src/diagnostics.ts
+++ b/packages/lang-server/src/diagnostics.ts
@@ -48,8 +48,8 @@ export const getDiagnostics = async (
       .map(err => workspace.transformError(err))
       .map(async errPromise => {
         const err = await errPromise
-        return err.sourceLocations.map(sl => {
-          const range = sl.subRange || sl.sourceRange
+        return err.sourceLocations.map(location => {
+          const range = location.subRange ?? location.sourceRange
           return {
             filename: range.filename,
             severity: err.severity,

--- a/packages/lang-server/src/workspace.ts
+++ b/packages/lang-server/src/workspace.ts
@@ -319,9 +319,9 @@ export class EditorWorkspace {
     const wsError = await this.workspace.transformError(error)
     return {
       ...wsError,
-      sourceLocations: wsError.sourceLocations.map(sl => ({
-        ...sl,
-        sourceRange: this.editorSourceRange(sl.sourceRange),
+      sourceLocations: wsError.sourceLocations.map(location => ({
+        ...location,
+        sourceRange: this.editorSourceRange(location.sourceRange),
       })),
     }
   }

--- a/packages/lang-server/src/workspace.ts
+++ b/packages/lang-server/src/workspace.ts
@@ -319,7 +319,10 @@ export class EditorWorkspace {
     const wsError = await this.workspace.transformError(error)
     return {
       ...wsError,
-      sourceLocations: wsError.sourceLocations.map(range => this.editorSourceRange(range)),
+      sourceLocations: wsError.sourceLocations.map(sl => ({
+        ...sl,
+        sourceRange: this.editorSourceRange(sl.sourceRange),
+      })),
     }
   }
 

--- a/packages/lang-server/src/workspace.ts
+++ b/packages/lang-server/src/workspace.ts
@@ -319,10 +319,7 @@ export class EditorWorkspace {
     const wsError = await this.workspace.transformError(error)
     return {
       ...wsError,
-      sourceFragments: wsError.sourceFragments.map(fragment => ({
-        ...fragment,
-        sourceRange: this.editorSourceRange(fragment.sourceRange),
-      })),
+      sourceLocations: wsError.sourceLocations.map(range => this.editorSourceRange(range)),
     }
   }
 

--- a/packages/lang-server/test/diagnostics.test.ts
+++ b/packages/lang-server/test/diagnostics.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Workspace, parser } from '@salto-io/workspace'
+import { Workspace } from '@salto-io/workspace'
 import { mockFunction } from '@salto-io/test-utils'
 import { EditorWorkspace } from '../src/workspace'
 import { getDiagnostics } from '../src/diagnostics'
@@ -45,14 +45,10 @@ describe('diagnostics', () => {
     ))
     baseWs.transformError = mockFunction<Workspace['transformError']>().mockImplementation(async err => ({
       ...err,
-      sourceFragments: [{
-        fragment: '',
-        sourceRange: {
-          start: { col: 1, line: 1, byte: 1 },
-          end: { col: 2, line: 1, byte: 2 },
-          filename: '/parse_error.nacl',
-        },
-        subRange: (err as parser.ParseError).subject,
+      sourceLocations: [{
+        start: { col: 1, line: 1, byte: 1 },
+        end: { col: 2, line: 1, byte: 2 },
+        filename: '/parse_error.nacl',
       }],
     }))
   })

--- a/packages/lang-server/test/diagnostics.test.ts
+++ b/packages/lang-server/test/diagnostics.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Workspace } from '@salto-io/workspace'
+import { Workspace, parser } from '@salto-io/workspace'
 import { mockFunction } from '@salto-io/test-utils'
 import { EditorWorkspace } from '../src/workspace'
 import { getDiagnostics } from '../src/diagnostics'
@@ -46,9 +46,12 @@ describe('diagnostics', () => {
     baseWs.transformError = mockFunction<Workspace['transformError']>().mockImplementation(async err => ({
       ...err,
       sourceLocations: [{
-        start: { col: 1, line: 1, byte: 1 },
-        end: { col: 2, line: 1, byte: 2 },
-        filename: '/parse_error.nacl',
+        sourceRange: {
+          start: { col: 1, line: 1, byte: 1 },
+          end: { col: 2, line: 1, byte: 2 },
+          filename: '/parse_error.nacl',
+        },
+        subRange: (err as parser.ParseError).subject,
       }],
     }))
   })

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -15,7 +15,7 @@
 */
 import * as errors from './src/errors'
 import * as nacl from './src/workspace/nacl_files'
-import { Workspace, StateRecency, loadWorkspace, isValidEnvName,
+import { Workspace, SourceLocation, StateRecency, loadWorkspace, isValidEnvName,
   EnvironmentsSources, EnvironmentSource, initWorkspace, WorkspaceComponents, UnresolvedElemIDs,
   FromSourceWithEnv, COMMON_ENV_PREFIX, UpdateNaclFilesResult } from './src/workspace/workspace'
 import * as hiddenValues from './src/workspace/hidden_values'
@@ -62,6 +62,7 @@ export {
   EnvConfig,
   // Workspace exports
   Workspace,
+  SourceLocation,
   StateRecency,
   loadWorkspace,
   EnvironmentSource,

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -15,7 +15,7 @@
 */
 import * as errors from './src/errors'
 import * as nacl from './src/workspace/nacl_files'
-import { Workspace, SourceFragment, StateRecency, loadWorkspace, isValidEnvName,
+import { Workspace, StateRecency, loadWorkspace, isValidEnvName,
   EnvironmentsSources, EnvironmentSource, initWorkspace, WorkspaceComponents, UnresolvedElemIDs,
   FromSourceWithEnv, COMMON_ENV_PREFIX, UpdateNaclFilesResult } from './src/workspace/workspace'
 import * as hiddenValues from './src/workspace/hidden_values'
@@ -62,7 +62,6 @@ export {
   EnvConfig,
   // Workspace exports
   Workspace,
-  SourceFragment,
   StateRecency,
   loadWorkspace,
   EnvironmentSource,

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -746,7 +746,7 @@ export const loadWorkspace = async (
       : (await getLoadedNaclFilesSource()).getSourceRanges(currentEnv(), error.elemID)
   )
 
-  const transformParseError = async (error: ParseError): Promise<WorkspaceError<SaltoError>> => ({
+  const transformParseError = (error: ParseError): WorkspaceError<SaltoError> => ({
     ...error,
     sourceLocations: [{ sourceRange: error.context, subRange: error.subject }],
   })
@@ -754,9 +754,7 @@ export const loadWorkspace = async (
   const transformToWorkspaceError = async <T extends SaltoElementError>(saltoElemErr: T):
     Promise<Readonly<WorkspaceError<T>>> => {
     const sourceRanges = await getErrorSourceRange(saltoElemErr)
-    const sourceLocations: SourceLocation[] = await awu(sourceRanges)
-      .map(sourceRange => ({ sourceRange }))
-      .toArray()
+    const sourceLocations: SourceLocation[] = sourceRanges.map(sourceRange => ({ sourceRange }))
 
     return {
       ...saltoElemErr,

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -58,14 +58,8 @@ const STATE_SOURCE_PREFIX = 'state_element_source'
 export const isValidEnvName = (envName: string): boolean =>
   /^[a-z0-9-_.!\s]+$/i.test(envName) && envName.length <= MAX_ENV_NAME_LEN
 
-export type SourceFragment = {
-  sourceRange: SourceRange
-  fragment: string
-  subRange?: SourceRange
-}
-
 export type WorkspaceError<T extends SaltoError> = Readonly<T & {
-  sourceFragments: SourceFragment[]
+  sourceLocations: SourceRange[]
 }>
 
 type RecencyStatus = 'Old' | 'Nonexistent' | 'Valid'
@@ -153,7 +147,6 @@ export type Workspace = {
   hasElementsInAccounts(accountNames: string[]): Promise<boolean>
   hasElementsInEnv(envName: string): Promise<boolean>
   envOfFile(filename: string): string
-  getSourceFragment(sourceRange: SourceRange): Promise<SourceFragment>
   hasErrors(env?: string): Promise<boolean>
   errors(): Promise<Readonly<Errors>>
   transformToWorkspaceError<T extends SaltoElementError>(saltoElemErr: T):
@@ -740,33 +733,6 @@ export const loadWorkspace = async (
     return elementChanges
   }
 
-  const getSourceFragment = async (
-    sourceRange: SourceRange,
-    subRange?: SourceRange,
-    sourceToUse?: Pick<NaclFilesSource, 'getNaclFile'>
-  ): Promise<SourceFragment> => {
-    const source = sourceToUse ?? await getLoadedNaclFilesSource()
-
-    const naclFile = await source.getNaclFile(sourceRange.filename)
-    log.debug(`error context: start=${sourceRange.start.byte}, end=${sourceRange.end.byte}`)
-    const fragment = naclFile
-      ? naclFile.buffer.substring(sourceRange.start.byte, sourceRange.end.byte)
-      : ''
-    if (!naclFile) {
-      log.warn('failed to resolve source fragment for %o', sourceRange)
-    }
-    return {
-      sourceRange,
-      fragment,
-      subRange,
-    }
-  }
-
-  const getErrorSource = async (error: SaltoError):
-    Promise<AdaptersConfigSource | MultiEnvSource> => (
-    error.source === 'config' ? adaptersConfig : getLoadedNaclFilesSource()
-  )
-
   const getErrorSourceRange = async <T extends SaltoElementError>(error: T):
   Promise<SourceRange[]> => (
     error.source === 'config'
@@ -776,25 +742,17 @@ export const loadWorkspace = async (
 
   const transformParseError = async (error: ParseError): Promise<WorkspaceError<SaltoError>> => ({
     ...error,
-    sourceFragments: [await getSourceFragment(
-      error.context,
-      error.subject,
-      await getErrorSource(error),
-    )],
+    sourceLocations: [error.context],
   })
 
   const transformToWorkspaceError = async <T extends SaltoElementError>(saltoElemErr: T):
     Promise<Readonly<WorkspaceError<T>>> => {
-    const source = await getErrorSource(saltoElemErr)
     const sourceRanges = await getErrorSourceRange(saltoElemErr)
-    const sourceFragments = await awu(sourceRanges)
-      .map(range => getSourceFragment(range, undefined, source))
-      .toArray()
 
     return {
       ...saltoElemErr,
       message: saltoElemErr.message,
-      sourceFragments,
+      sourceLocations: sourceRanges,
     }
   }
   const transformError = async (error: SaltoError): Promise<WorkspaceError<SaltoError>> => {
@@ -808,7 +766,7 @@ export const loadWorkspace = async (
     if (isElementError(error)) {
       return transformToWorkspaceError(error)
     }
-    return { ...error, sourceFragments: [] }
+    return { ...error, sourceLocations: [] }
   }
 
   const errors = async (env?: string): Promise<Errors> => {
@@ -1032,7 +990,6 @@ export const loadWorkspace = async (
     },
     transformToWorkspaceError,
     transformError,
-    getSourceFragment,
     flush: async (): Promise<void> => {
       if (!persistent) {
         throw new Error('Can not flush a non-persistent workspace.')

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -577,9 +577,9 @@ describe('workspace', () => {
       expect(wsErros.message).toMatch(mergeError)
       expect(wsErros.severity).toBe('Error')
       const firstSourceLocation = wsErros.sourceLocations[0]
-      expect(firstSourceLocation.filename).toBe('file.nacl')
-      expect(firstSourceLocation.start).toEqual({ byte: 26, col: 3, line: 3 })
-      expect(firstSourceLocation.end).toEqual({ byte: 79, col: 4, line: 5 })
+      expect(firstSourceLocation.sourceRange.filename).toBe('file.nacl')
+      expect(firstSourceLocation.sourceRange.start).toEqual({ byte: 26, col: 3, line: 3 })
+      expect(firstSourceLocation.sourceRange.end).toEqual({ byte: 79, col: 4, line: 5 })
     })
     it('should have merge error when hidden values are added to nacl', async () => {
       const obj = new ObjectType({

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -541,7 +541,7 @@ describe('workspace', () => {
         wu(errors.all()).map(error => erroredWorkspace.transformError(error))
       )
       expect(workspaceErrors.length).toBeGreaterThanOrEqual(1)
-      expect(workspaceErrors[0].sourceFragments).toHaveLength(1)
+      expect(workspaceErrors[0].sourceLocations).toHaveLength(1)
     })
     it('should contain validation errors', async () => {
       const erroredWorkspace = await createWorkspace(mockDirStore(['dup.nacl', 'error.nacl']))
@@ -556,7 +556,7 @@ describe('workspace', () => {
         wu(errors.all()).map(error => erroredWorkspace.transformError(error))
       )
       expect(workspaceErrors.length).toBeGreaterThanOrEqual(1)
-      expect(workspaceErrors[0].sourceFragments).toHaveLength(1)
+      expect(workspaceErrors[0].sourceLocations).toHaveLength(1)
     })
     it('should contain merge errors', async () => {
       const erroredWorkspace = await createWorkspace(mockDirStore(['error.nacl', 'reference_error.nacl']))
@@ -573,14 +573,13 @@ describe('workspace', () => {
       )
       expect(workspaceErrors).toHaveLength(1)
       const wsErros = workspaceErrors[0]
-      expect(wsErros.sourceFragments).toHaveLength(2)
+      expect(wsErros.sourceLocations).toHaveLength(2)
       expect(wsErros.message).toMatch(mergeError)
       expect(wsErros.severity).toBe('Error')
-      const firstSourceFragment = wsErros.sourceFragments[0]
-      expect(firstSourceFragment.sourceRange.filename).toBe('file.nacl')
-      expect(firstSourceFragment.sourceRange.start).toEqual({ byte: 26, col: 3, line: 3 })
-      expect(firstSourceFragment.sourceRange.end).toEqual({ byte: 79, col: 4, line: 5 })
-      expect(firstSourceFragment.fragment).toContain('salesforce.text base_field')
+      const firstSourceLocation = wsErros.sourceLocations[0]
+      expect(firstSourceLocation.filename).toBe('file.nacl')
+      expect(firstSourceLocation.start).toEqual({ byte: 26, col: 3, line: 3 })
+      expect(firstSourceLocation.end).toEqual({ byte: 79, col: 4, line: 5 })
     })
     it('should have merge error when hidden values are added to nacl', async () => {
       const obj = new ObjectType({
@@ -625,7 +624,7 @@ describe('workspace', () => {
       it('should return empty source fragments', async () => {
         const ws = await createWorkspace()
         const wsError = await ws.transformError({ severity: 'Warning', message: '' })
-        expect(wsError.sourceFragments).toHaveLength(0)
+        expect(wsError.sourceLocations).toHaveLength(0)
       })
     })
 


### PR DESCRIPTION
Remove the actual code fragments attached to the workspace errors, and keep only the location of the error.  
This should help with readability, and should improve the performance so that we can increase the limit of errors returned. Currently we limit only to 30 errors. 

---

None

---
_Release Notes_: 
Core - Errors will now contain only the location of the error, without the of the source file

---
_User Notifications_: 
None
