### PR TITLE
SALTO-2148: support reorder of triggers

### DIFF
--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -163,6 +163,7 @@ export const replaceReferenceValues = async <
       transformFunc: transformPrimitive,
       strict: false,
       pathID: instance.elemID,
+      allowEmpty: true,
     }
   ) ?? instance.value
 }

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -432,10 +432,13 @@ export type GetLookupNameFunc = (args: GetLookupNameFuncArgs) => Promise<Value>
 export type ResolveValuesFunc = <T extends Element>(
   element: T,
   getLookUpName: GetLookupNameFunc,
-  elementsSource?: ReadOnlyElementsSource
+  elementsSource?: ReadOnlyElementsSource,
+  allowEmpty?: boolean
 ) => Promise<T>
 
-export const resolveValues: ResolveValuesFunc = async (element, getLookUpName, elementsSource) => {
+export const resolveValues: ResolveValuesFunc = async (
+  element, getLookUpName, elementsSource, allowEmpty = false,
+) => {
   const valuesReplacer: TransformFunc = async ({ value, field, path }) => {
     if (isReferenceExpression(value)) {
       return getLookUpName({
@@ -461,16 +464,20 @@ export const resolveValues: ResolveValuesFunc = async (element, getLookUpName, e
     transformFunc: valuesReplacer,
     strict: false,
     elementsSource,
+    allowEmpty,
   })
 }
 
 export type RestoreValuesFunc = <T extends Element>(
   source: T,
   targetElement: T,
-  getLookUpName: GetLookupNameFunc
+  getLookUpName: GetLookupNameFunc,
+  allowEmpty?: boolean
 ) => Promise<T>
 
-export const restoreValues: RestoreValuesFunc = async (source, targetElement, getLookUpName) => {
+export const restoreValues: RestoreValuesFunc = async (
+  source, targetElement, getLookUpName, allowEmpty = false
+) => {
   const allReferencesPaths = new Map<string, ReferenceExpression>()
   const allStaticFilesPaths = new Map<string, StaticFile>()
   const createPathMapCallback: WalkOnFunc = ({ value, path }) => {
@@ -510,6 +517,7 @@ export const restoreValues: RestoreValuesFunc = async (source, targetElement, ge
     element: targetElement,
     transformFunc: restoreValuesFunc,
     strict: false,
+    allowEmpty,
   })
 }
 

--- a/packages/zendesk-support-adapter/e2e_test/mock_elements.ts
+++ b/packages/zendesk-support-adapter/e2e_test/mock_elements.ts
@@ -209,7 +209,6 @@ export const mockDefaultValues: Record<string, Values> = {
     type: 'tagger',
     title: 'Test',
     description: '',
-    position: 9999,
     active: true,
     required: false,
     collapsed_for_agents: false,

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -266,6 +266,11 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       },
     },
   },
+  trigger_order_entry: {
+    transformation: {
+      sourceTypeName: 'trigger_order__order',
+    },
+  },
   automation: {
     transformation: {
       sourceTypeName: 'automations__automations',

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -161,6 +161,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       idFields: ['title'],
       fileNameFields: ['title'],
       fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
+      fieldsToOmit: FIELDS_TO_OMIT.concat({ fieldName: 'position', fieldType: 'number' }),
       serviceUrl: '/admin/workspaces/agent-workspace/views/{id}',
     },
     deployRequests: {
@@ -387,6 +388,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       idFields: ['title'],
       fileNameFields: ['title'],
       fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
+      fieldsToOmit: FIELDS_TO_OMIT.concat({ fieldName: 'position', fieldType: 'number' }),
       serviceUrl: '/admin/workspaces/agent-workspace/macros/{id}',
     },
     deployRequests: {
@@ -636,6 +638,7 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       fileNameFields: ['type', 'title'],
       standaloneFields: [{ fieldName: 'custom_field_options' }],
       fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
+      fieldsToOmit: FIELDS_TO_OMIT.concat({ fieldName: 'position', fieldType: 'number' }),
       serviceUrl: '/admin/objects-rules/tickets/ticket-fields/{id}',
     },
     deployRequests: {

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -256,6 +256,15 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       },
     },
   },
+  trigger_order: {
+    deployRequests: {
+      modify: {
+        url: '/trigger_categories/jobs',
+        method: 'post',
+        deployAsField: 'job',
+      },
+    },
+  },
   automation: {
     transformation: {
       sourceTypeName: 'automations__automations',

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -328,6 +328,16 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskSupportFieldReferenceDefi
     target: { type: 'automation' },
   },
   {
+    src: { field: 'ids', parentTypes: ['trigger_order__order'] },
+    serializationStrategy: 'id',
+    target: { type: 'trigger' },
+  },
+  {
+    src: { field: 'category', parentTypes: ['trigger_order__order'] },
+    serializationStrategy: 'id',
+    target: { type: 'trigger_category' },
+  },
+  {
     src: { field: 'id', parentTypes: ['workspace__selected_macros'] },
     serializationStrategy: 'id',
     target: { type: 'macro' },

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -328,12 +328,12 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskSupportFieldReferenceDefi
     target: { type: 'automation' },
   },
   {
-    src: { field: 'ids', parentTypes: ['trigger_order__order'] },
+    src: { field: 'ids', parentTypes: ['trigger_order_entry'] },
     serializationStrategy: 'id',
     target: { type: 'trigger' },
   },
   {
-    src: { field: 'category', parentTypes: ['trigger_order__order'] },
+    src: { field: 'category', parentTypes: ['trigger_order_entry'] },
     serializationStrategy: 'id',
     target: { type: 'trigger_category' },
   },

--- a/packages/zendesk-support-adapter/src/filters/reorder/automation.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/automation.ts
@@ -36,7 +36,9 @@ export const deployFunc: DeployFuncType = async (change, client, apiDefinitions)
 const filterCreator = createReorderFilterCreator({
   typeName: 'automation',
   orderFieldName: ORDER_FIELD_NAME,
-  additionalIterateesToSortBy: [
+  iterateesToSortBy: [
+    instance => !instance.value.active,
+    instance => instance.value.position,
     instance => instance.value.title,
   ],
   deployFunc,

--- a/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
@@ -37,7 +37,7 @@ export type DeployFuncType = (
 type ReorderFilterCreatorParams = {
   typeName: string
   orderFieldName: string
-  additionalIterateesToSortBy?: Array<_.Many<_.ListIteratee<InstanceElement>>>
+  iterateesToSortBy?: Array<_.Many<_.ListIteratee<InstanceElement>>>
   deployFunc?: DeployFuncType
 }
 
@@ -47,7 +47,7 @@ export const createReorderFilterCreator = (
   {
     typeName,
     orderFieldName,
-    additionalIterateesToSortBy = [],
+    iterateesToSortBy = [instance => instance.value.position],
     deployFunc = async (change, client, apiDefinitions) => {
       await deployChange(change, client, apiDefinitions)
     },
@@ -65,8 +65,7 @@ export const createReorderFilterCreator = (
       elements
         .filter(isInstanceElement)
         .filter(e => e.elemID.typeName === typeName),
-      instance => instance.value.position,
-      ...additionalIterateesToSortBy,
+      ...iterateesToSortBy,
     )
       .map(inst => {
         delete inst.value.position

--- a/packages/zendesk-support-adapter/src/filters/reorder/organization_field.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/organization_field.ts
@@ -21,6 +21,10 @@ import { createReorderFilterCreator } from './creator'
 const filterCreator = createReorderFilterCreator({
   typeName: 'organization_field',
   orderFieldName: 'organization_field_ids',
+  iterateesToSortBy: [
+    instance => !instance.value.active,
+    instance => instance.value.position,
+  ],
 })
 
 export default filterCreator

--- a/packages/zendesk-support-adapter/system_config_doc.md
+++ b/packages/zendesk-support-adapter/system_config_doc.md
@@ -225,6 +225,26 @@ zendesk_support {
               fieldType = "number"
             },
           ]
+          fieldsToOmit = [
+            {
+              fieldName = "extended_input_schema"
+            },
+            {
+              fieldName = "extended_output_schema"
+            },
+            {
+              fieldName = "url"
+              fieldType = "string"
+            },
+            {
+              fieldName = "count"
+              fieldType = "number"
+            },
+            {
+              fieldName = "position"
+              fieldType = "number"
+            },
+          ]
           serviceUrl = "/admin/workspaces/agent-workspace/views/{id}"
         }
         deployRequests = {
@@ -354,6 +374,20 @@ zendesk_support {
           }
         }
       }
+      trigger_order = {
+        deployRequests = {
+          modify = {
+            url = "/trigger_categories/jobs"
+            method = "post"
+            deployAsField = "job"
+          }
+        }
+      }
+      trigger_order_entry = {
+        transformation = {
+          sourceTypeName = "trigger_order__order"
+        }
+      }
       automation = {
         transformation = {
           sourceTypeName = "automations__automations"
@@ -400,6 +434,14 @@ zendesk_support {
             urlParamsToFields = {
               automationId = "id"
             }
+          }
+        }
+      }
+      automation_order = {
+        deployRequests = {
+          modify = {
+            url = "/automations/update_many"
+            method = "put"
           }
         }
       }
@@ -565,6 +607,10 @@ zendesk_support {
             },
             {
               fieldName = "attachments"
+            },
+            {
+              fieldName = "position"
+              fieldType = "number"
             },
           ]
           serviceUrl = "/admin/workspaces/agent-workspace/macros/{id}"
@@ -1066,6 +1112,26 @@ zendesk_support {
             },
             {
               fieldName = "id"
+              fieldType = "number"
+            },
+          ]
+          fieldsToOmit = [
+            {
+              fieldName = "extended_input_schema"
+            },
+            {
+              fieldName = "extended_output_schema"
+            },
+            {
+              fieldName = "url"
+              fieldType = "string"
+            },
+            {
+              fieldName = "count"
+              fieldType = "number"
+            },
+            {
+              fieldName = "position"
               fieldType = "number"
             },
           ]

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -402,6 +402,9 @@ describe('adapter', () => {
           'zendesk_support.trigger_definition__conditions_any__operators',
           'zendesk_support.trigger_definition__conditions_any__values',
           'zendesk_support.trigger_definitions',
+          'zendesk_support.trigger_order',
+          'zendesk_support.trigger_order.instance',
+          'zendesk_support.trigger_order__order',
           'zendesk_support.triggers',
           'zendesk_support.user_field',
           'zendesk_support.user_field.instance.another_text_3425',
@@ -537,7 +540,6 @@ describe('adapter', () => {
           elementsSource: buildElementsSourceFromElements([]),
         }).fetch({ progressReporter: { reportProgress: () => null } })
         const instances = elements.filter(isInstanceElement)
-        expect(instances).toHaveLength(10)
         expect(instances.map(e => e.elemID.getFullName()).sort())
           .toEqual([
             'zendesk_support.group.instance.Support',
@@ -549,6 +551,7 @@ describe('adapter', () => {
             'zendesk_support.organization_field_order.instance',
             'zendesk_support.sla_policy_order.instance',
             'zendesk_support.ticket_form_order.instance',
+            'zendesk_support.trigger_order.instance',
             'zendesk_support.user_field_order.instance',
             'zendesk_support.workspace_order.instance',
           ].sort())

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -404,7 +404,7 @@ describe('adapter', () => {
           'zendesk_support.trigger_definitions',
           'zendesk_support.trigger_order',
           'zendesk_support.trigger_order.instance',
-          'zendesk_support.trigger_order__order',
+          'zendesk_support.trigger_order_entry',
           'zendesk_support.triggers',
           'zendesk_support.user_field',
           'zendesk_support.user_field.instance.another_text_3425',

--- a/packages/zendesk-support-adapter/test/filters/reorder/trigger.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/trigger.test.ts
@@ -1,0 +1,252 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ObjectType, ElemID, InstanceElement, Element, isObjectType,
+  isInstanceElement, ReferenceExpression, CORE_ANNOTATIONS, ModificationChange,
+} from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { DEFAULT_CONFIG, DEFAULT_INCLUDE_ENDPOINTS, FETCH_CONFIG } from '../../../src/config'
+import ZendeskClient from '../../../src/client/client'
+import { ZENDESK_SUPPORT } from '../../../src/constants'
+import { paginate } from '../../../src/client/pagination'
+import filterCreator from '../../../src/filters/reorder/trigger'
+import { createOrderTypeName } from '../../../src/filters/reorder/creator'
+
+const mockDeployChange = jest.fn()
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn((...args) => mockDeployChange(...args)),
+    },
+  }
+})
+
+describe('trigger reorder filter', () => {
+  let client: ZendeskClient
+  type FilterType = filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let filter: FilterType
+  const triggerTypeName = 'trigger'
+  const categoryTypeName = 'trigger_category'
+  const orderTypeName = createOrderTypeName(triggerTypeName)
+  const triggerType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, triggerTypeName) })
+  const categoryType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, categoryTypeName) })
+  const categoty1 = new InstanceElement('cate1', categoryType, { id: 1, position: 1, title: 'cate1' })
+  const categoty2 = new InstanceElement('cate2', categoryType, { id: 2, position: 2, title: 'cate3' })
+  const categoty3 = new InstanceElement('cate3', categoryType, { id: 3, position: 3, title: 'cate2' })
+  const trigger1 = new InstanceElement('trigger1', triggerType, { id: 11, position: 1, title: 'trigger2', category_id: '1', active: true })
+  const trigger2 = new InstanceElement('trigger2', triggerType, { id: 22, position: 2, title: 'trigger1', category_id: '1', active: true })
+  const trigger3 = new InstanceElement('trigger3', triggerType, { id: 33, position: 2, title: 'aaa', category_id: '2', active: true })
+  const trigger4 = new InstanceElement('trigger4', triggerType, { id: 44, position: 2, title: 'bbb', category_id: '2', active: true })
+  const trigger5 = new InstanceElement('trigger5', triggerType, { id: 55, position: 1, title: 'a', category_id: '2', active: false })
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      }),
+      config: DEFAULT_CONFIG,
+    }) as FilterType
+  })
+
+  describe('onFetch', () => {
+    it('should create correct order element', async () => {
+      const elements = [
+        triggerType, categoryType, categoty1, categoty2, categoty3,
+        trigger1, trigger2, trigger3, trigger4, trigger5,
+      ]
+      await filter.onFetch(elements)
+      expect(elements.map(e => e.elemID.getFullName()).sort())
+        .toEqual([
+          'zendesk_support.trigger',
+          'zendesk_support.trigger.instance.trigger1',
+          'zendesk_support.trigger.instance.trigger2',
+          'zendesk_support.trigger.instance.trigger3',
+          'zendesk_support.trigger.instance.trigger4',
+          'zendesk_support.trigger.instance.trigger5',
+          'zendesk_support.trigger_category',
+          'zendesk_support.trigger_category.instance.cate1',
+          'zendesk_support.trigger_category.instance.cate2',
+          'zendesk_support.trigger_category.instance.cate3',
+          'zendesk_support.trigger_order',
+          'zendesk_support.trigger_order.instance',
+          'zendesk_support.trigger_order__order',
+        ])
+      const triggerOrderType = elements
+        .find(e => isObjectType(e) && e.elemID.typeName === orderTypeName)
+      expect(triggerOrderType).toBeDefined()
+      const triggerOrderInstance = elements
+        .find(e => isInstanceElement(e) && e.elemID.typeName === orderTypeName)
+      expect(triggerOrderInstance).toBeDefined()
+      expect(triggerOrderInstance?.elemID.name).toEqual(ElemID.CONFIG_NAME)
+      expect((triggerOrderInstance as InstanceElement)?.value)
+        .toEqual({ order: [
+          {
+            category: new ReferenceExpression(categoty1.elemID, categoty1),
+            ids: [
+              new ReferenceExpression(trigger1.elemID, trigger1),
+              new ReferenceExpression(trigger2.elemID, trigger2),
+            ],
+          },
+          {
+            category: new ReferenceExpression(categoty2.elemID, categoty2),
+            ids: [
+              new ReferenceExpression(trigger3.elemID, trigger3),
+              new ReferenceExpression(trigger4.elemID, trigger4),
+              new ReferenceExpression(trigger5.elemID, trigger5),
+            ],
+          },
+          {
+            category: new ReferenceExpression(categoty3.elemID, categoty3),
+            ids: [],
+          },
+        ] })
+      const orderType = elements
+        .find(elem => elem.elemID.getFullName() === 'zendesk_support.trigger_order')
+      expect(orderType).toBeDefined()
+      expect(orderType?.annotations[CORE_ANNOTATIONS.HIDDEN]).toEqual(true)
+    })
+    it('should create correct order element with non hidden types', async () => {
+      const filterWithHideType = filterCreator({
+        client,
+        paginator: clientUtils.createPaginator({
+          client,
+          paginationFuncCreator: paginate,
+        }),
+        config: {
+          ...DEFAULT_CONFIG,
+          [FETCH_CONFIG]: {
+            includeTypes: DEFAULT_INCLUDE_ENDPOINTS,
+            hideTypes: false,
+          },
+        },
+      }) as FilterType
+      const elements = [
+        triggerType, categoryType, categoty1, categoty2, categoty3,
+        trigger1, trigger2, trigger3, trigger4,
+      ]
+      await filterWithHideType.onFetch(elements)
+      expect(elements.map(e => e.elemID.getFullName()).sort())
+        .toEqual([
+          'zendesk_support.trigger',
+          'zendesk_support.trigger.instance.trigger1',
+          'zendesk_support.trigger.instance.trigger2',
+          'zendesk_support.trigger.instance.trigger3',
+          'zendesk_support.trigger.instance.trigger4',
+          'zendesk_support.trigger_category',
+          'zendesk_support.trigger_category.instance.cate1',
+          'zendesk_support.trigger_category.instance.cate2',
+          'zendesk_support.trigger_category.instance.cate3',
+          'zendesk_support.trigger_order',
+          'zendesk_support.trigger_order.instance',
+          'zendesk_support.trigger_order__order',
+        ])
+      const orderType = elements
+        .find(elem => elem.elemID.getFullName() === 'zendesk_support.trigger_order')
+      expect(orderType).toBeDefined()
+      expect(orderType?.annotations[CORE_ANNOTATIONS.HIDDEN]).not.toBeDefined()
+    })
+    it('should not create new elements if there are no triggers', async () => {
+      const elements: Element[] = []
+      await filter.onFetch(elements)
+      expect(elements).toHaveLength(0)
+    })
+  })
+  describe('deploy', () => {
+    const orderType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, orderTypeName) })
+    const before = new InstanceElement(
+      ElemID.CONFIG_NAME,
+      orderType,
+      {
+        order: [
+          { category: '1', ids: [11, 22] },
+          { category: '2', ids: [33, 44] },
+          { category: '3', ids: [] },
+        ],
+      },
+    )
+    const after = new InstanceElement(
+      ElemID.CONFIG_NAME,
+      orderType,
+      {
+        order: [
+          { category: '2', ids: [44, 33] },
+          { category: '3', ids: [] },
+          { category: '1', ids: [11, 22] },
+        ],
+      },
+    )
+    const change: ModificationChange<InstanceElement> = {
+      action: 'modify',
+      data: { before, after },
+    }
+    it('should pass the correct params to deployChange', async () => {
+      const res = await filter.deploy([change])
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toEqual([change])
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      const instanceToDeploy = after.clone()
+      instanceToDeploy.value = {
+        action: 'patch',
+        items: {
+          trigger_categories: [
+            { id: '2', position: 1 },
+            { id: '3', position: 2 },
+            { id: '1', position: 3 },
+          ],
+          triggers: [
+            { id: '44', position: 1, category_id: '2' },
+            { id: '33', position: 2, category_id: '2' },
+            { id: '11', position: 1, category_id: '1' },
+            { id: '22', position: 2, category_id: '1' },
+          ],
+        },
+      }
+      expect(mockDeployChange).toHaveBeenCalledWith(
+        {
+          action: 'modify',
+          data: {
+            after: instanceToDeploy,
+            before,
+          },
+        },
+        expect.anything(),
+        expect.anything(),
+        undefined,
+      )
+    })
+    it('should return an error if there are multiple order changes', async () => {
+      const res = await filter.deploy([change, change])
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(mockDeployChange).toHaveBeenCalledTimes(0)
+    })
+    it('should return an error if the order change is not modification', async () => {
+      const res = await filter.deploy([{ action: 'add', data: { after } }])
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(mockDeployChange).toHaveBeenCalledTimes(0)
+    })
+  })
+})


### PR DESCRIPTION
_Support reorder of triggers_

---

_Additional context for reviewer_
* We use [this](https://developer.zendesk.com/api-reference/ticketing/business-rules/trigger_categories/#create-batch-job-for-trigger-categories) API to reorder the triggers and their categories.  According to [this](https://support.zendesk.com/hc/en-us/articles/4408834781594-Creating-categories-to-organize-triggers), the order of categories effect the order of the triggers as well (all the triggers of one category will be done before the triggers of another category with higher position)
* Removed positions field for ticket_field, macro and view
* inactive objects will be last in the order element

---
_Release Notes_: 
_Zendesk_support adapter_
* support reorder of triggers

---
_User Notifications_: 
A new trigger order element will be added
In addition, the order element of automation and organization field might be changed as well
