### PR TITLE
SAAS-3619 Change unresolved merge conflict message

### DIFF
--- a/packages/workspace/src/parser/internal/native/errors.ts
+++ b/packages/workspace/src/parser/internal/native/errors.ts
@@ -174,7 +174,7 @@ export const missingBlockOpen = (range: SourceRange): ParseError => createError(
 
 export const contentMergeConflict = (range: SourceRange): ParseError => createError(
   range,
-  'Merge conflict',
+  'Unresolved merge conflict',
 )
 
 export const invalidStringChar = (stringRange: SourceRange, errMsg: string): ParseError => {

--- a/packages/workspace/src/parser/internal/native/lexer.ts
+++ b/packages/workspace/src/parser/internal/native/lexer.ts
@@ -98,9 +98,9 @@ class InvalidLexerTokenError extends Error {
   }
 }
 
-export class ContentMergeConflictError extends Error {
+export class UnresolvedMergeConflictError extends Error {
   constructor(public lastValidToken?: LexerToken) {
-    super('Merge conflict')
+    super('Unresolved merge conflict')
   }
 }
 
@@ -114,7 +114,7 @@ const validateToken = (token?: moo.Token): token is LexerToken => {
     throw new InvalidLexerTokenError()
   } else if (token.type === TOKEN_TYPES.MERGE_CONFLICT) {
     if (isAtBeginningOfLine(token)) {
-      throw new ContentMergeConflictError(token as LexerToken)
+      throw new UnresolvedMergeConflictError(token as LexerToken)
     } else {
       throw new InvalidLexerTokenError()
     }

--- a/packages/workspace/src/parser/internal/native/parse.ts
+++ b/packages/workspace/src/parser/internal/native/parse.ts
@@ -18,7 +18,7 @@ import { flattenElementStr } from '@salto-io/adapter-utils'
 import { ParseResult } from '../../types'
 import { Keywords } from '../../language'
 import { Functions } from '../../functions'
-import Lexer, { TOKEN_TYPES, NoSuchElementError, ContentMergeConflictError } from './lexer'
+import Lexer, { TOKEN_TYPES, NoSuchElementError, UnresolvedMergeConflictError } from './lexer'
 import { SourceMap } from '../../source_map'
 import { contentMergeConflict, invalidStringChar, unexpectedEndOfFile } from './errors'
 import { ParseContext } from './types'
@@ -72,7 +72,7 @@ export const parseBuffer = async (
     // Catch the beginning string of a merge conflict and verify it by catching
     // the middle and ending strings. In case they aren't found, raise an invalid
     // sting error.
-    } else if (e instanceof ContentMergeConflictError && e.lastValidToken) {
+    } else if (e instanceof UnresolvedMergeConflictError && e.lastValidToken) {
       const pos = positionAtStart(e.lastValidToken)
       try {
         // Having the beginning string of a merge conflict, Salto verifies if the

--- a/packages/workspace/test/parser/errors.test.ts
+++ b/packages/workspace/test/parser/errors.test.ts
@@ -1184,7 +1184,7 @@ describe('parsing errors', () => {
     })
   })
   describe('merge conflict errors', () => {
-    describe('Merge conflict', () => {
+    describe('Unresolved merge conflict', () => {
       const nacl = `
         rocky.racoon checked {
           only = "us"
@@ -1210,8 +1210,8 @@ describe('parsing errors', () => {
           filename: 'file.nacl',
         })
         expect(res.errors[0].message)
-          .toBe('Merge conflict')
-        expect(res.errors[0].summary).toBe('Merge conflict')
+          .toBe('Unresolved merge conflict')
+        expect(res.errors[0].summary).toBe('Unresolved merge conflict')
       })
       it('should parse the first instance correctly', async () => {
         expect(await awu(res.elements).toArray()).toHaveLength(1)


### PR DESCRIPTION
Changed unresolved merge conflict message
---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
