### PR TITLE
SALTO-2153: support reordering of views

### DIFF
--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -44,6 +44,7 @@ import workspaceOrderFilter from './filters/reorder/workspace'
 import slaPolicyOrderFilter from './filters/reorder/sla_policy'
 import automationOrderFilter from './filters/reorder/automation'
 import triggerOrderFilter from './filters/reorder/trigger'
+import viewOrderFilter from './filters/reorder/view'
 import businessHoursScheduleFilter from './filters/business_hours_schedule'
 import collisionErrorsFilter from './filters/collision_errors'
 import accountSettingsFilter from './filters/account_settings'
@@ -87,6 +88,7 @@ export const DEFAULT_FILTERS = [
   slaPolicyOrderFilter,
   automationOrderFilter,
   triggerOrderFilter,
+  viewOrderFilter,
   businessHoursScheduleFilter,
   collisionErrorsFilter,
   accountSettingsFilter,

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -188,6 +188,14 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       },
     },
   },
+  view_order: {
+    deployRequests: {
+      modify: {
+        url: '/views/update_many',
+        method: 'put',
+      },
+    },
+  },
   view__restriction: {
     transformation: {
       fieldTypeOverrides: [

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -161,7 +161,6 @@ export const DEFAULT_TYPES: Record<string, configUtils.TypeDuckTypeConfig> = {
       idFields: ['title'],
       fileNameFields: ['title'],
       fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
-      fieldsToOmit: FIELDS_TO_OMIT.concat({ fieldName: 'position', fieldType: 'number' }),
       serviceUrl: '/admin/workspaces/agent-workspace/views/{id}',
     },
     deployRequests: {

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -328,6 +328,11 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskSupportFieldReferenceDefi
     target: { type: 'automation' },
   },
   {
+    src: { field: 'ids', parentTypes: ['view_order'] },
+    serializationStrategy: 'id',
+    target: { type: 'view' },
+  },
+  {
     src: { field: 'ids', parentTypes: ['trigger_order_entry'] },
     serializationStrategy: 'id',
     target: { type: 'trigger' },

--- a/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
@@ -19,7 +19,7 @@ import {
   BuiltinTypes, ReferenceExpression, Change, getChangeData, isModificationChange, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils, config as configUtils } from '@salto-io/adapter-components'
-import { pathNaclCase } from '@salto-io/adapter-utils'
+import { applyFunctionToChangeData, pathNaclCase } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../../filter'
 import { ZENDESK_SUPPORT } from '../../constants'
 import { deployChange } from '../../deployment'
@@ -135,3 +135,14 @@ export const createReorderFilterCreator = (
     }
   },
 })
+
+export const deployFuncCreator = (fieldName: string): DeployFuncType =>
+  async (change, client, apiDefinitions) => {
+    const clonedChange = await applyFunctionToChangeData(change, inst => inst.clone())
+    const instance = getChangeData(clonedChange)
+    const idsWithPositions = (instance.value.ids as number[])
+      .map((id, position) => ({ id, position: position + 1 }))
+    instance.value[fieldName] = idsWithPositions
+    delete instance.value.ids
+    await deployChange(clonedChange, client, apiDefinitions)
+  }

--- a/packages/zendesk-support-adapter/src/filters/reorder/view.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/view.ts
@@ -14,21 +14,22 @@
 * limitations under the License.
 */
 import { createReorderFilterCreator, deployFuncCreator } from './creator'
+import { VIEW_TYPE_NAME } from '../view'
 
 export const ORDER_FIELD_NAME = 'ids'
 
 /**
- * Add automation order element with all the automations ordered
+ * Add view order element with all the views ordered
  */
 const filterCreator = createReorderFilterCreator({
-  typeName: 'automation',
+  typeName: VIEW_TYPE_NAME,
   orderFieldName: ORDER_FIELD_NAME,
   iterateesToSortBy: [
     instance => !instance.value.active,
     instance => instance.value.position,
     instance => instance.value.title,
   ],
-  deployFunc: deployFuncCreator('automations'),
+  deployFunc: deployFuncCreator('views'),
 })
 
 export default filterCreator

--- a/packages/zendesk-support-adapter/src/filters/view.ts
+++ b/packages/zendesk-support-adapter/src/filters/view.ts
@@ -22,7 +22,7 @@ import { FilterCreator } from '../filter'
 import { deployChange, deployChanges } from '../deployment'
 import { applyforInstanceChangesOfType } from './utils'
 
-const VIEW_TYPE_NAME = 'view'
+export const VIEW_TYPE_NAME = 'view'
 
 /**
  * Deploys views

--- a/packages/zendesk-support-adapter/system_config_doc.md
+++ b/packages/zendesk-support-adapter/system_config_doc.md
@@ -271,6 +271,14 @@ zendesk_support {
           }
         }
       }
+      view_order = {
+        deployRequests = {
+          modify = {
+            url = "/views/update_many"
+            method = "put"
+          }
+        }
+      }
       view__restriction = {
         transformation = {
           fieldTypeOverrides = [
@@ -606,7 +614,8 @@ zendesk_support {
               fieldType = "number"
             },
             {
-              fieldName = "attachments"
+              fieldName = "position"
+              fieldType = "number"
             },
             {
               fieldName = "position"
@@ -637,6 +646,27 @@ zendesk_support {
               macroId = "id"
             }
           }
+        }
+      }
+      macro_attachment = {
+        transformation = {
+          idFields = [
+            "filename",
+          ]
+          fieldsToHide = [
+            {
+              fieldName = "created_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "updated_at"
+              fieldType = "string"
+            },
+            {
+              fieldName = "id"
+              fieldType = "number"
+            },
+          ]
         }
       }
       macro_action = {

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -470,6 +470,8 @@ describe('adapter', () => {
           'zendesk_support.view__execution__group',
           'zendesk_support.view__execution__sort',
           'zendesk_support.view__restriction',
+          'zendesk_support.view_order',
+          'zendesk_support.view_order.instance',
           'zendesk_support.views',
           'zendesk_support.webhook',
           'zendesk_support.webhook.instance.test',
@@ -553,6 +555,7 @@ describe('adapter', () => {
             'zendesk_support.ticket_form_order.instance',
             'zendesk_support.trigger_order.instance',
             'zendesk_support.user_field_order.instance',
+            'zendesk_support.view_order.instance',
             'zendesk_support.workspace_order.instance',
           ].sort())
       })

--- a/packages/zendesk-support-adapter/test/filters/reorder/automation.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/automation.test.ts
@@ -183,5 +183,21 @@ describe('automation reorder filter', () => {
       expect(res.deployResult.appliedChanges).toHaveLength(0)
       expect(mockDeployChange).toHaveBeenCalledTimes(0)
     })
+    it('should return an error if the ids are not numbers', async () => {
+      const res = await filter.deploy([
+        {
+          action: 'modify',
+          data: {
+            before,
+            after: new InstanceElement(
+              ElemID.CONFIG_NAME, orderType, { [ORDER_FIELD_NAME]: ['22', '33'] },
+            ),
+          },
+        },
+      ])
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(mockDeployChange).toHaveBeenCalledTimes(0)
+    })
   })
 })

--- a/packages/zendesk-support-adapter/test/filters/reorder/view.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/view.test.ts
@@ -1,0 +1,188 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ObjectType, ElemID, InstanceElement, Element, isObjectType,
+  isInstanceElement, ReferenceExpression, ModificationChange, CORE_ANNOTATIONS,
+} from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { DEFAULT_CONFIG, DEFAULT_INCLUDE_ENDPOINTS, FETCH_CONFIG } from '../../../src/config'
+import ZendeskClient from '../../../src/client/client'
+import { ZENDESK_SUPPORT } from '../../../src/constants'
+import { paginate } from '../../../src/client/pagination'
+import filterCreator, { ORDER_FIELD_NAME } from '../../../src/filters/reorder/view'
+import { VIEW_TYPE_NAME } from '../../../src/filters/view'
+import { createOrderTypeName } from '../../../src/filters/reorder/creator'
+
+const mockDeployChange = jest.fn()
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn((...args) => mockDeployChange(...args)),
+    },
+  }
+})
+
+describe('view reorder filter', () => {
+  let client: ZendeskClient
+  type FilterType = filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let filter: FilterType
+  const typeName = VIEW_TYPE_NAME
+  const orderTypeName = createOrderTypeName(typeName)
+  const objType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, typeName) })
+  const inst1 = new InstanceElement('inst1', objType, { id: 11, position: 1, title: 'inst2' })
+  const inst2 = new InstanceElement('inst2', objType, { id: 22, position: 2, title: 'inst1' })
+  const inst3 = new InstanceElement('inst3', objType, { id: 22, position: 2, title: 'aaa' })
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      }),
+      config: DEFAULT_CONFIG,
+    }) as FilterType
+  })
+
+  describe('onFetch', () => {
+    it('should create correct order element', async () => {
+      const elements = [objType, inst1, inst2, inst3]
+      await filter.onFetch(elements)
+      expect(elements).toHaveLength(6)
+      expect(elements.map(e => e.elemID.getFullName()).sort())
+        .toEqual([
+          'zendesk_support.view',
+          'zendesk_support.view.instance.inst1',
+          'zendesk_support.view.instance.inst2',
+          'zendesk_support.view.instance.inst3',
+          'zendesk_support.view_order',
+          'zendesk_support.view_order.instance',
+        ])
+      const viewOrderType = elements
+        .find(e => isObjectType(e) && e.elemID.typeName === orderTypeName)
+      expect(viewOrderType).toBeDefined()
+      const viewOrderInstance = elements
+        .find(e => isInstanceElement(e) && e.elemID.typeName === orderTypeName)
+      expect(viewOrderInstance).toBeDefined()
+      expect(viewOrderInstance?.elemID.name).toEqual(ElemID.CONFIG_NAME)
+      expect((viewOrderInstance as InstanceElement)?.value)
+        .toEqual({ [ORDER_FIELD_NAME]: [
+          new ReferenceExpression(inst1.elemID, inst1),
+          new ReferenceExpression(inst3.elemID, inst3),
+          new ReferenceExpression(inst2.elemID, inst2),
+        ] })
+      const orderType = elements
+        .find(elem => elem.elemID.getFullName() === 'zendesk_support.view_order')
+      expect(orderType).toBeDefined()
+      expect(orderType?.annotations[CORE_ANNOTATIONS.HIDDEN]).toEqual(true)
+    })
+    it('should create correct order element with non hidden types', async () => {
+      const filterWithHideType = filterCreator({
+        client,
+        paginator: clientUtils.createPaginator({
+          client,
+          paginationFuncCreator: paginate,
+        }),
+        config: {
+          ...DEFAULT_CONFIG,
+          [FETCH_CONFIG]: {
+            includeTypes: DEFAULT_INCLUDE_ENDPOINTS,
+            hideTypes: false,
+          },
+        },
+      }) as FilterType
+      const elements = [objType, inst1, inst2, inst3]
+      await filterWithHideType.onFetch(elements)
+      expect(elements).toHaveLength(6)
+      expect(elements.map(e => e.elemID.getFullName()).sort())
+        .toEqual([
+          'zendesk_support.view',
+          'zendesk_support.view.instance.inst1',
+          'zendesk_support.view.instance.inst2',
+          'zendesk_support.view.instance.inst3',
+          'zendesk_support.view_order',
+          'zendesk_support.view_order.instance',
+        ])
+      const orderType = elements
+        .find(elem => elem.elemID.getFullName() === 'zendesk_support.view_order')
+      expect(orderType).toBeDefined()
+      expect(orderType?.annotations[CORE_ANNOTATIONS.HIDDEN]).not.toBeDefined()
+    })
+    it('should not create new elements if there are no views', async () => {
+      const elements: Element[] = []
+      await filter.onFetch(elements)
+      expect(elements).toHaveLength(0)
+    })
+  })
+  describe('deploy', () => {
+    const orderType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, orderTypeName) })
+    const before = new InstanceElement(
+      ElemID.CONFIG_NAME, orderType, { [ORDER_FIELD_NAME]: [11, 22, 33] },
+    )
+    const after = new InstanceElement(
+      ElemID.CONFIG_NAME, orderType, { [ORDER_FIELD_NAME]: [22, 33, 11] },
+    )
+    const change: ModificationChange<InstanceElement> = {
+      action: 'modify',
+      data: { before, after },
+    }
+    it('should pass the correct params to deployChange', async () => {
+      const res = await filter.deploy([change])
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toEqual([change])
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      const instanceToDeploy = after.clone()
+      instanceToDeploy.value = {
+        views: [
+          { id: 22, position: 1 },
+          { id: 33, position: 2 },
+          { id: 11, position: 3 },
+        ],
+      }
+      expect(mockDeployChange).toHaveBeenCalledWith(
+        {
+          action: 'modify',
+          data: {
+            after: instanceToDeploy,
+            before,
+          },
+        },
+        expect.anything(),
+        expect.anything(),
+        undefined,
+      )
+    })
+    it('should return an error if there are multiple order changes', async () => {
+      const res = await filter.deploy([change, change])
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(mockDeployChange).toHaveBeenCalledTimes(0)
+    })
+    it('should return an error if the order change is not modification', async () => {
+      const res = await filter.deploy([{ action: 'add', data: { after } }])
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(mockDeployChange).toHaveBeenCalledTimes(0)
+    })
+  })
+})

--- a/packages/zendesk-support-adapter/test/filters/reorder/view.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/view.test.ts
@@ -184,5 +184,21 @@ describe('view reorder filter', () => {
       expect(res.deployResult.appliedChanges).toHaveLength(0)
       expect(mockDeployChange).toHaveBeenCalledTimes(0)
     })
+    it('should return an error if the ids are not numbers', async () => {
+      const res = await filter.deploy([
+        {
+          action: 'modify',
+          data: {
+            before,
+            after: new InstanceElement(
+              ElemID.CONFIG_NAME, orderType, { [ORDER_FIELD_NAME]: ['22', '33'] },
+            ),
+          },
+        },
+      ])
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(mockDeployChange).toHaveBeenCalledTimes(0)
+    })
   })
 })


### PR DESCRIPTION
_support reordering of views_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Zendesk_support adapter_:
* support reordering of views

---
_User Notifications_: 
_A new view order element will appear_
