### PR TITLE
SALTO-1687 add filter that removes internal IDs from instances names

### DIFF
--- a/packages/adapter-components/package.json
+++ b/packages/adapter-components/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.3",
     "@salto-io/adapter-api": "0.3.14",
+    "@salto-io/dag": "0.3.14",
     "@salto-io/adapter-utils": "0.3.14",
     "@salto-io/logging": "0.3.14",
     "@salto-io/lowerdash": "0.3.14",

--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -18,4 +18,4 @@ export { createRequestConfigs, validateRequestConfig, FetchRequestConfig, Deploy
 export { createAdapterApiConfigType, getConfigWithDefault, AdapterApiConfig, UserFetchConfig, TypeConfig, createUserFetchConfigType } from './shared'
 export { mergeWithDefaultConfig } from './merge'
 export { createSwaggerAdapterApiConfigType, AdapterSwaggerApiConfig, RequestableAdapterSwaggerApiConfig, TypeSwaggerConfig, RequestableTypeSwaggerConfig, TypeSwaggerDefaultConfig, TypeNameOverrideConfig, validateApiDefinitionConfig as validateSwaggerApiDefinitionConfig, validateFetchConfig as validateSwaggerFetchConfig } from './swagger'
-export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType, getTransformationConfigByType } from './transformation'
+export { createTransformationConfigTypes, validateTransoformationConfig, TransformationDefaultConfig, TransformationConfig, StandaloneFieldConfigType, FieldToOmitType, FieldToHideType, getTransformationConfigByType, dereferenceFieldName, isReferencedIdField } from './transformation'

--- a/packages/adapter-components/src/config/transformation.ts
+++ b/packages/adapter-components/src/config/transformation.ts
@@ -185,14 +185,13 @@ export const validateTransoformationConfig = (
     }
   }
 
-  const getInvalidIdFields = (
-    idFields: string[],
-  ): string[] => idFields.filter(fieldName => {
-    const symbolCount = (fieldName.match(/&/g) || []).length
-    return ((symbolCount > 1)
+  const getInvalidIdFields = (idFields: string[]): string[] => (
+    idFields.filter(fieldName => {
+      const symbolCount = (fieldName.match(/&/g) || []).length
+      return (symbolCount > 1)
             || (symbolCount === 1 && !fieldName.startsWith(FIELD_REFERENCE_PREFIX))
-    )
-  })
+    })
+  )
 
   const validateIdFieldsConfig = (
     defaultIdFields: string[] | undefined,

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -22,7 +22,7 @@ import { pathNaclCase, naclCase, transformValues, TransformFunc } from '@salto-i
 import { logger } from '@salto-io/logging'
 import { RECORDS_PATH } from './constants'
 import { TransformationConfig, TransformationDefaultConfig, getConfigWithDefault,
-  RecurseIntoCondition, isRecurseIntoConditionByField, AdapterApiConfig } from '../config'
+  RecurseIntoCondition, isRecurseIntoConditionByField, AdapterApiConfig, dereferenceFieldName } from '../config'
 
 const log = logger(module)
 
@@ -40,15 +40,55 @@ export type InstanceCreationParams = {
   getElemIdFunc?: ElemIdGetter
 }
 
+export const joinInstanceNameParts = (
+  nameParts: string[],
+): string | undefined => (nameParts.every(part => part !== undefined && part !== '') ? nameParts.map(String).join('_') : undefined)
+
 export const getInstanceName = (
   instanceValues: Values,
   idFields: string[],
 ): string | undefined => {
-  const nameParts = idFields.map(field => _.get(instanceValues, field))
+  const nameParts = idFields
+    .map(fieldName => _.get(instanceValues, dereferenceFieldName(fieldName)))
   if (nameParts.includes(undefined)) {
     log.warn(`could not find id for entry - expected id fields ${idFields}, available fields ${Object.keys(instanceValues)}`)
   }
-  return nameParts.every(part => part !== undefined && part !== '') ? nameParts.map(String).join('_') : undefined
+  return joinInstanceNameParts(nameParts)
+}
+
+export const getInstanceFilePath = ({
+  fileNameFields,
+  entry,
+  naclName,
+  typeName,
+  isSettingType,
+  adapterName,
+}: {
+  fileNameFields: string[] | undefined
+  entry: Values
+  naclName: string
+  typeName: string
+  isSettingType: boolean
+  adapterName: string
+}): string[] => {
+  const fileNameParts = (fileNameFields !== undefined
+    ? fileNameFields.map(field => _.get(entry, field))
+    : undefined)
+  const fileName = ((fileNameParts?.every(p => _.isString(p) || _.isNumber(p))
+    ? fileNameParts.join('_')
+    : undefined))
+  return isSettingType
+    ? [
+      adapterName,
+      RECORDS_PATH,
+      pathNaclCase(typeName),
+    ]
+    : [
+      adapterName,
+      RECORDS_PATH,
+      pathNaclCase(typeName),
+      fileName ? pathNaclCase(naclCase(fileName)) : pathNaclCase(naclName),
+    ]
 }
 
 export const generateInstanceNameFromConfig = (
@@ -82,6 +122,35 @@ export const createServiceIds = (
     [OBJECT_NAME]: typeId.getFullName(),
   }),
 })
+
+export const getInstanceNaclName = ({
+  entry,
+  name,
+  parentName,
+  adapterName,
+  getElemIdFunc,
+  serviceIdField,
+  typeElemId,
+}:{
+  entry: Values
+  name: string
+  parentName?: string
+  adapterName: string
+  getElemIdFunc?: ElemIdGetter
+  serviceIdField?: string
+  typeElemId: ElemID
+}): string => {
+  const desiredName = naclCase(
+    parentName ? `${parentName}${ID_SEPARATOR}${name}` : String(name)
+  )
+  return getElemIdFunc && serviceIdField
+    ? getElemIdFunc(
+      adapterName,
+      createServiceIds(entry, serviceIdField, typeElemId),
+      desiredName
+    ).name
+    : desiredName
+}
 
 /**
  * Generate an instance for a single entry returned for a given type.
@@ -130,37 +199,27 @@ export const toBasicInstance = async ({
   )
 
   const name = getInstanceName(entry, idFields) ?? defaultName
-
-  const fileNameParts = (fileNameFields !== undefined
-    ? fileNameFields.map(field => _.get(entry, field))
-    : undefined)
-  const fileName = ((fileNameParts?.every(p => _.isString(p) || _.isNumber(p))
-    ? fileNameParts.join('_')
-    : undefined))
-
-  const desiredName = naclCase(
-    parent && nestName ? `${parent.elemID.name}${ID_SEPARATOR}${name}` : String(name)
-  )
+  const parentName = parent && nestName ? parent.elemID.name : undefined
   const adapterName = type.elemID.adapter
-  const naclName = getElemIdFunc && serviceIdField
-    ? getElemIdFunc(
-      adapterName,
-      createServiceIds(entry, serviceIdField, type.elemID),
-      desiredName
-    ).name
-    : desiredName
-  const filePath = type.isSettings
-    ? [
-      adapterName,
-      RECORDS_PATH,
-      pathNaclCase(type.elemID.name),
-    ]
-    : [
-      adapterName,
-      RECORDS_PATH,
-      pathNaclCase(type.elemID.name),
-      fileName ? pathNaclCase(naclCase(fileName)) : pathNaclCase(naclName),
-    ]
+  const naclName = getInstanceNaclName({
+    entry,
+    name,
+    parentName,
+    adapterName,
+    getElemIdFunc,
+    serviceIdField,
+    typeElemId: type.elemID,
+  })
+
+  const filePath = getInstanceFilePath({
+    fileNameFields,
+    entry,
+    naclName,
+    typeName: type.elemID.name,
+    isSettingType: type.isSettings,
+    adapterName,
+  })
+
   return new InstanceElement(
     type.isSettings ? ElemID.CONFIG_NAME : naclName,
     type,

--- a/packages/adapter-components/src/filters/index.ts
+++ b/packages/adapter-components/src/filters/index.ts
@@ -14,3 +14,4 @@
 * limitations under the License.
 */
 export { serviceUrlFilterCreator } from './service_url'
+export { referencedInstanceNamesFilterCreator } from './referenced_instance_names'

--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -1,0 +1,192 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { Element, isInstanceElement, isReferenceExpression, InstanceElement, ElemID, ElemIdGetter } from '@salto-io/adapter-api'
+import { filter, setPath, references, getParents, transformElement } from '@salto-io/adapter-utils'
+import { DAG } from '@salto-io/dag'
+import { logger } from '@salto-io/logging'
+import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
+import { FilterCreator } from '../filter_utils'
+import { AdapterApiConfig, getTransformationConfigByType,
+  TransformationConfig, TransformationDefaultConfig, getConfigWithDefault,
+  dereferenceFieldName, isReferencedIdField } from '../config'
+import { joinInstanceNameParts, getInstanceFilePath, getInstanceNaclName } from '../elements/instance_elements'
+
+const { awu } = collections.asynciterable
+
+const log = logger(module)
+const { isDefined } = lowerDashValues
+const { getReferences, getUpdatedReference, createReferencesTransformFunc } = references
+
+type InstanceIdFields = {
+  instance: InstanceElement
+  idFields: string[]
+}
+
+/*
+ * Utility function that finds instance elements whose id relies on the ids of other instances,
+ * and replaces them with updated instances with the correct id and file path.
+ */
+export const addReferencesToInstanceNames = async (
+  elements: Element[],
+  transformationConfigByType: Record<string, TransformationConfig>,
+  transformationDefaultConfig: TransformationDefaultConfig,
+  getElemIdFunc?: ElemIdGetter
+): Promise<Element[]> => {
+  const hasReferencedIdFields = (
+    idFields: string[],
+  ): boolean => idFields.some(field => isReferencedIdField(field))
+
+  const instances = elements.filter(isInstanceElement)
+  const instancesToIdFields: InstanceIdFields[] = instances.map(instance => ({
+    instance,
+    idFields: getConfigWithDefault(
+      transformationConfigByType[instance.elemID.typeName],
+      transformationDefaultConfig
+    ).idFields,
+  }))
+
+  const graph = new DAG<InstanceElement>()
+  instancesToIdFields.forEach(({ instance, idFields }) => {
+    const getReferencedInstances = (): string[] => {
+      const referencedInstances = idFields
+        .filter(isReferencedIdField)
+        .map(fieldName => {
+          const fieldValue = _.get(instance.value, dereferenceFieldName(fieldName))
+          if (isReferenceExpression(fieldValue) && isInstanceElement(fieldValue.value)) {
+            return fieldValue.elemID.getFullName()
+          }
+          return undefined
+        })
+        .filter(isDefined)
+      return referencedInstances
+    }
+    graph.addNode(instance.elemID.getFullName(), getReferencedInstances(), instance)
+  })
+
+  await awu(graph.evaluationOrder()).forEach(
+    async graphNode => {
+      const instanceIdFields = instancesToIdFields
+        .find(instanceF => instanceF.instance.elemID.getFullName() === graphNode.toString())
+      if (instanceIdFields !== undefined) {
+        const { instance, idFields } = instanceIdFields
+        if (idFields !== undefined && hasReferencedIdFields(idFields)) {
+          const originalName = instance.elemID.name
+          const originalFullName = instance.elemID.getFullName()
+          const newNameParts = idFields.map(
+            fieldName => {
+              if (isReferencedIdField(fieldName)) {
+                const fieldValue = _.get(instance.value, dereferenceFieldName(fieldName))
+                if (isReferenceExpression(fieldValue)) {
+                  if (isInstanceElement(fieldValue.value)) {
+                    return fieldValue.elemID.name
+                  }
+                  log.warn(`reference expression of field ${fieldName} doesn't point to an instance element`)
+                }
+                log.warn(`could not find reference for referenced idField: ${fieldName}, falling back to original value`)
+                return fieldValue
+              }
+              return _.get(instance.value, fieldName)
+            }
+          )
+          const newName = joinInstanceNameParts(newNameParts) ?? originalName
+          const parentIds = getParents(instance)
+            .filter(parent => isReferenceExpression(parent) && isInstanceElement(parent.value))
+            .map(parent => parent.value.elemID.name)
+          const parentName = joinInstanceNameParts(parentIds) ?? undefined
+
+          const { typeName, adapter } = instance.elemID
+          const { fileNameFields, serviceIdField } = getConfigWithDefault(
+            transformationConfigByType[typeName],
+            transformationDefaultConfig,
+          )
+
+          const newNaclName = getInstanceNaclName({
+            entry: instance.value,
+            name: newName,
+            parentName,
+            adapterName: adapter,
+            getElemIdFunc,
+            serviceIdField,
+            typeElemId: instance.refType.elemID,
+          })
+
+          const filePath = transformationConfigByType[typeName].isSingleton
+            ? instance.path
+            : getInstanceFilePath({
+              fileNameFields,
+              entry: instance.value,
+              naclName: newNaclName,
+              typeName,
+              isSettingType: false,
+              adapterName: adapter,
+            })
+
+          const newElemId = new ElemID(adapter, typeName, 'instance', newNaclName)
+          const updatedInstance = await transformElement({
+            element: instance,
+            transformFunc: createReferencesTransformFunc(instance.elemID, newElemId),
+            strict: false,
+          })
+
+          const newInstance = new InstanceElement(
+            newElemId.name,
+            updatedInstance.refType,
+            updatedInstance.value,
+            filePath,
+            updatedInstance.annotations,
+          )
+
+          elements
+            .filter(isInstanceElement)
+          // filtering out the renamed element,
+          // its references are taken care of in getRenameElementChanges
+            .filter(element => originalFullName !== element.elemID.getFullName())
+            .forEach(element => {
+              const refs = getReferences(element, instance.elemID)
+              if (refs.length > 0) {
+                refs.forEach(ref => {
+                  const updatedReference = getUpdatedReference(ref.value, newElemId)
+                  setPath(element, ref.path, updatedReference)
+                })
+              }
+            })
+          const instanceIdx = elements.findIndex(e => (e.elemID.getFullName()) === originalFullName)
+          elements.splice(instanceIdx, 1, newInstance)
+        }
+      }
+    }
+  )
+  return elements
+}
+
+export const referencedInstanceNamesFilterCreator: <
+  TClient,
+  TContext extends { apiDefinitions: AdapterApiConfig },
+  TResult extends void | filter.FilterResult = void
+>() => FilterCreator<TClient, TContext, TResult> = () => ({ config, getElemIdFunc }) => ({
+  onFetch: async (elements: Element[]) => {
+    const transformationDefault = config.apiDefinitions.typeDefaults.transformation
+    const configByType = config.apiDefinitions.types
+    const transformationByType = getTransformationConfigByType(configByType)
+    await addReferencesToInstanceNames(
+      elements,
+      transformationByType,
+      transformationDefault,
+      getElemIdFunc
+    )
+  },
+})

--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Element, isInstanceElement, isReferenceExpression, InstanceElement, ElemID, ElemIdGetter, isObjectType } from '@salto-io/adapter-api'
+import { Element, isInstanceElement, isReferenceExpression, InstanceElement, ElemID, ElemIdGetter } from '@salto-io/adapter-api'
 import { filter, setPath, references, getParents, transformElement } from '@salto-io/adapter-utils'
 import { DAG } from '@salto-io/dag'
 import { logger } from '@salto-io/logging'
@@ -136,17 +136,18 @@ export const addReferencesToInstanceNames = async (
     _.remove(instances, instance => duplicateElemIds.has(instance.elemID.getFullName()))
   }
 
+  const instanceTypeNames = new Set(instances.map(instance => instance.elemID.typeName))
   const configByType = Object.fromEntries(
-    elements
-      .filter(isObjectType)
-      .map(type => [
-        type.elemID.name,
+    [...instanceTypeNames]
+      .map(typeName => [
+        typeName,
         getConfigWithDefault(
-          transformationConfigByType[type.elemID.name],
+          transformationConfigByType[typeName],
           transformationDefaultConfig
         ),
       ])
   )
+
   const instancesToIdFields = instances.map(instance => ({
     instance,
     idFields: configByType[instance.elemID.typeName].idFields,

--- a/packages/adapter-components/test/config/transformation.test.ts
+++ b/packages/adapter-components/test/config/transformation.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { BuiltinTypes, ListType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
-import { createTransformationConfigTypes, validateTransoformationConfig } from '../../src/config'
+import { createTransformationConfigTypes, validateTransoformationConfig, dereferenceFieldName } from '../../src/config'
 
 describe('config_transformation', () => {
   describe('createTransformationConfigTypes', () => {
@@ -213,5 +213,41 @@ describe('config_transformation', () => {
         },
       )).toThrow(new Error('Singleton types should not have dataField or fileNameFields set, misconfiguration found for the following types: t1,t2'))
     })
+    it('should fail if idFields name are invalid', () => {
+      expect(() => validateTransoformationConfig(
+        'PATH',
+        {
+          idFields: ['a', 'b', 'c'],
+          fieldsToOmit: [
+            { fieldName: 'abc', fieldType: 'something' },
+          ],
+        },
+        {
+          t1: {
+            idFields: ['&a&'],
+          },
+        },
+      )).toThrow(new Error('&a& field name of type t1 in idFields config is invalid'))
+      expect(() => validateTransoformationConfig(
+        'PATH',
+        {
+          idFields: ['a', 'b&', 'c'],
+          fieldsToOmit: [
+            { fieldName: 'abc', fieldType: 'something' },
+          ],
+        },
+        {
+          t1: {
+            idFields: ['a'],
+          },
+        },
+      )).toThrow(new Error('b& field name in idFields config is invalid'))
+    })
+  })
+
+  describe('idFields util functions', () => {
+    const idFields = ['id', '&folder_id']
+    const dereferencedIdFields = idFields.map(fieldName => dereferenceFieldName(fieldName))
+    expect(dereferencedIdFields).toEqual(['id', 'folder_id'])
   })
 })

--- a/packages/adapter-components/test/config/transformation.test.ts
+++ b/packages/adapter-components/test/config/transformation.test.ts
@@ -226,8 +226,13 @@ describe('config_transformation', () => {
           t1: {
             idFields: ['&a&'],
           },
+          t2: {
+            idFields: ['a&', 'b&'],
+          },
         },
-      )).toThrow(new Error('&a& field name of type t1 in idFields config is invalid'))
+      )).toThrow(new Error(
+        'Invalid idFields found in the following types:\nin type: t1, invalid idFields: [&a&]\nin type: t2, invalid idFields: [a&,b&]'
+      ))
       expect(() => validateTransoformationConfig(
         'PATH',
         {
@@ -241,7 +246,7 @@ describe('config_transformation', () => {
             idFields: ['a'],
           },
         },
-      )).toThrow(new Error('b& field name in idFields config is invalid'))
+      )).toThrow(new Error('Invalid idFields found in default config: b&'))
     })
   })
 

--- a/packages/adapter-components/test/filters/referenced_instance_name.test.ts
+++ b/packages/adapter-components/test/filters/referenced_instance_name.test.ts
@@ -1,0 +1,152 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, BuiltinTypes } from '@salto-io/adapter-api'
+import { references } from '@salto-io/adapter-utils'
+import { addReferencesToInstanceNames } from '../../src/filters/referenced_instance_names'
+
+const { getReferences } = references
+const ADAPTER_NAME = 'myAdapter'
+
+describe('referenced instances', () => {
+  describe('addReferencesToInstanceNames', () => {
+    const generateElements = (): Element[] => {
+      const recipeType = new ObjectType({
+        elemID: new ElemID(ADAPTER_NAME, 'recipe'),
+        fields: {
+          name: { refType: BuiltinTypes.STRING },
+          book_id: { refType: BuiltinTypes.NUMBER },
+        },
+      })
+      const bookType = new ObjectType({
+        elemID: new ElemID(ADAPTER_NAME, 'book'),
+        fields: {
+          id: { refType: BuiltinTypes.NUMBER },
+          parent_book_id: { refType: BuiltinTypes.NUMBER },
+        },
+      })
+      const rootBook = new InstanceElement(
+        'rootBook',
+        bookType,
+        {
+          id: 123,
+          parent_book_id: 'ROOT',
+        },
+      )
+      const anotherBook = new InstanceElement(
+        'book',
+        bookType,
+        {
+          id: 456,
+          parent_book_id: new ReferenceExpression(rootBook.elemID, rootBook),
+        },
+      )
+      const recipes = [
+        new InstanceElement(
+          'recipe123',
+          recipeType,
+          {
+            name: 'recipe123',
+            book_id: new ReferenceExpression(rootBook.elemID, rootBook),
+          },
+        ),
+        new InstanceElement(
+          'recipe456',
+          recipeType,
+          {
+            name: 'recipe456',
+            book_id: new ReferenceExpression(anotherBook.elemID, anotherBook),
+          },
+        ),
+      ]
+      const cycleBookA = new InstanceElement(
+        'one',
+        bookType,
+        {
+          id: 12,
+          parent_book_id: null,
+        },
+      )
+      const cycleBookB = new InstanceElement(
+        'two',
+        bookType,
+        {
+          id: 23,
+          parent_book_id: new ReferenceExpression(cycleBookA.elemID, cycleBookA),
+        },
+      )
+      const cycleBookC = new InstanceElement(
+        'three',
+        bookType,
+        {
+          id: 31,
+          parent_book_id: new ReferenceExpression(cycleBookB.elemID, cycleBookB),
+        },
+      )
+      const coolType = new ObjectType({
+        elemID: new ElemID(ADAPTER_NAME, 'cool'),
+        fields: {
+          id: { refType: BuiltinTypes.NUMBER },
+          cool_recipe: { refType: BuiltinTypes.NUMBER },
+        },
+      })
+      const aVeryCoolInstance = new InstanceElement(
+        'wow',
+        coolType,
+        {
+          id: 121212,
+          cool_recipe: new ReferenceExpression(recipes[0].elemID, recipes[0]),
+        },
+      )
+      const cyleRef = new ReferenceExpression(cycleBookC.elemID, cycleBookC)
+      cycleBookA.value.parent_book_id = cyleRef
+      return [recipeType, bookType, ...recipes, anotherBook, rootBook,
+        cycleBookA, cycleBookB, cycleBookC, coolType, aVeryCoolInstance]
+    }
+
+    const transformationDefaultConfig = {
+      idFields: ['id'],
+    }
+    const transformationConfigByType = {
+      recipe: {
+        idFields: ['name', '&book_id'],
+      },
+      book: {
+        idFields: ['id', '&parent_book_id'],
+      },
+    }
+    let elements: Element[]
+
+    beforeAll(() => {
+      elements = generateElements()
+    })
+
+    it('should change name and references correctly', async () => {
+      const result = await addReferencesToInstanceNames(
+        elements.slice(0, -5).concat(elements.slice(-2)),
+        transformationConfigByType,
+        transformationDefaultConfig
+      )
+      expect(result.length).toEqual(8)
+      expect(result[2].elemID.name).toEqual('recipe123_123_ROOT')
+      expect(result[3].elemID.name).toEqual('recipe456_456_123_ROOT')
+      expect(result[4].elemID.name).toEqual('456_123_ROOT')
+      expect(result[5].elemID.name).toEqual('123_ROOT')
+      const ref = getReferences(result[7], result[2].elemID)
+      expect(ref[0].value.elemID).toEqual(result[2].elemID)
+    })
+  })
+})

--- a/packages/adapter-components/tsconfig.json
+++ b/packages/adapter-components/tsconfig.json
@@ -12,6 +12,7 @@
     "index.ts"
   ],
   "references": [
+      { "path": "../dag" },
       { "path": "../lowerdash" },
       { "path": "../logging" },
       { "path": "../adapter-api" },


### PR DESCRIPTION

Add a filter that replaces internal ID's from instances names with the referenced instances names
This PR continues https://github.com/salto-io/salto/pull/2812 (which is split to a few PRs)

---
The PR includes the following changes:
1. Add a new configuration symbol '&' in idFields, which marks an idField as 'referenced idField' - idField that should be replaced with instance name. This includes a validation function that checks that the symbol is being used correctly.
2. A filter that makes the changes in all the relevant instance elements (that contains referenced idFields) names after its references are resolved. This also includes sorting the instances according to the name dependencies.
3. As some of the code relies on the instance name creation on `toBasicInstance`, I made some changes in `toBasicInstance` as well

Please ignore the following files that belong to [this PR](https://github.com/salto-io/salto/pull/2868):
[packages/adapter-utils/index.ts](https://github.com/salto-io/salto/compare/main...SALTO-1687_ReferencedElementName#diff-1db22a4b15c58e0d4ac16fc19c48588f5adc203b2633a4d458ae0ffd1650f94e)
[packages/adapter-utils/src/references.ts](https://github.com/salto-io/salto/compare/main...SALTO-1687_ReferencedElementName#diff-23df6112848930c1fdab84b0f0202fa014fb0b12de78f2e8ab63089d0747462c)
[packages/adapter-utils/test/references.test.ts](https://github.com/salto-io/salto/compare/main...SALTO-1687_ReferencedElementName#diff-d535bc9b8d757eae7509bcb94622b52386aba52bd60f21c319aba1a903530509)
[packages/core/src/core/rename.ts](https://github.com/salto-io/salto/compare/main...SALTO-1687_ReferencedElementName#diff-d6686bca6332452a034c3ebdff74815bb3ddfa540b78e70a4acc8eb0173e460a)

---
Release Notes:
Replace internal ids from instances name with the referenced instances names