### PR TITLE
SALTO-1387 import features

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -26,12 +26,12 @@ import _ from 'lodash'
 import each from 'jest-each'
 import NetsuiteAdapter from '../src/adapter'
 import { credsLease, realAdapter } from './adapter'
-import { getMetadataTypes, metadataTypesToList } from '../src/types'
+import { getMetadataTypes, isSDFConfigTypeName, metadataTypesToList } from '../src/types'
 import { adapter as adapterCreator } from '../src/adapter_creator'
 import {
   CUSTOM_RECORD_TYPE, EMAIL_TEMPLATE, ENTITY_CUSTOM_FIELD, FETCH_ALL_TYPES_AT_ONCE,
   FILE, FILE_CABINET_PATH_SEPARATOR, FOLDER, NETSUITE, PATH, ROLE, SCRIPT_ID,
-  SKIP_LIST,
+  SKIP_LIST, CONFIG_FEATURES,
   TRANSACTION_COLUMN_CUSTOM_FIELD,
   WARN_STALE_DATA, WORKFLOW,
 } from '../src/constants'
@@ -54,8 +54,10 @@ describe('Netsuite adapter E2E with real account', () => {
       ...valuesOverride,
     }
 
-    const instanceName = naclCase(instValues[isCustomTypeName(type) ? SCRIPT_ID : PATH]
-      .replace(new RegExp(`^${FILE_CABINET_PATH_SEPARATOR}`), ''))
+    const instanceName = isSDFConfigTypeName(type)
+      ? ElemID.CONFIG_NAME
+      : naclCase(instValues[isCustomTypeName(type) ? SCRIPT_ID : PATH]
+        .replace(new RegExp(`^${FILE_CABINET_PATH_SEPARATOR}`), ''))
 
     return new InstanceElement(
       instanceName,
@@ -226,6 +228,9 @@ describe('Netsuite adapter E2E with real account', () => {
         },
       }
     )
+
+    const featuresInstance = createInstanceElement(CONFIG_FEATURES, {})
+
     afterAll(async () => {
       const revertChanges: Map<ChangeId, Change<InstanceElement>> = new Map([
         ...withSuiteApp ? [subsidiaryInstance] : [],
@@ -274,6 +279,16 @@ describe('Netsuite adapter E2E with real account', () => {
       changes.set(
         changes.size.toString(),
         toChange({ before: folderToModifyBefore, after: folderToModify })
+      )
+
+      // Toggle the feature status using 'withSuiteApp'
+      const beforeFeaturesInstance = featuresInstance.clone()
+      const afterFeaturesInstance = featuresInstance.clone()
+      beforeFeaturesInstance.value.DEPARTMENTS = !withSuiteApp
+      afterFeaturesInstance.value.DEPARTMENTS = withSuiteApp
+      changes.set(
+        changes.size.toString(),
+        toChange({ before: beforeFeaturesInstance, after: afterFeaturesInstance })
       )
 
       let deployResult: DeployResult
@@ -578,6 +593,15 @@ describe('Netsuite adapter E2E with real account', () => {
           expect(fetchSubsidiary.value.name).toEqual(randomString)
           expect(fetchSubsidiary.value.internalId).toBeDefined()
         }
+      })
+
+      it(`should fetch the modified feature (status=${withSuiteApp})`, async () => {
+        const fetchFeatures = findElement(
+          fetchedInstances,
+          featuresInstance.elemID
+        ) as InstanceElement
+        // using 'withSuiteApp' to validate both boolean values
+        expect(fetchFeatures.value.DEPARTMENTS).toBe(withSuiteApp)
       })
     })
   })

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -45,8 +45,8 @@ const { awu } = collections.asynciterable
 describe('Netsuite adapter E2E with real account', () => {
   let adapter: NetsuiteAdapter
   let credentialsLease: CredsLease<Required<Credentials>>
-  const { customTypes, enums, fileCabinetTypes, fieldTypes } = getMetadataTypes()
-  const metadataTypes = metadataTypesToList({ customTypes, enums, fileCabinetTypes, fieldTypes })
+  const { customTypes, enums, additionalTypes, fieldTypes } = getMetadataTypes()
+  const metadataTypes = metadataTypesToList({ customTypes, enums, additionalTypes, fieldTypes })
 
   const createInstanceElement = (type: string, valuesOverride: Values): InstanceElement => {
     const instValues = {
@@ -59,7 +59,7 @@ describe('Netsuite adapter E2E with real account', () => {
 
     return new InstanceElement(
       instanceName,
-      isCustomTypeName(type) ? customTypes[type].type : fileCabinetTypes[type],
+      isCustomTypeName(type) ? customTypes[type].type : additionalTypes[type],
       instValues
     )
   }

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -36,7 +36,7 @@
     "@salto-io/file": "0.3.12",
     "@salto-io/logging": "0.3.12",
     "@salto-io/lowerdash": "0.3.12",
-    "@salto-io/suitecloud-cli": "1.3.2-salto-1",
+    "@salto-io/suitecloud-cli": "1.3.2-salto-2",
     "ajv": "^7.1.1",
     "async-lock": "^1.2.4",
     "axios": "^0.21.3",

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -55,6 +55,7 @@ import translationConverter from './filters/translation_converter'
 import systemNoteAuthorInformation from './filters/author_information/system_note'
 import savedSearchesAuthorInformation from './filters/author_information/saved_searches'
 import suiteAppConfigElementsFilter from './filters/suiteapp_config_elements'
+import configFeaturesFilter from './filters/config_features'
 import { Filter, FilterCreator } from './filter'
 import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_WARN_STALE_DATA, DEFAULT_USE_CHANGES_DETECTION } from './config'
 import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery, QueryParams, convertToQueryParams } from './query'
@@ -147,6 +148,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       translationConverter,
       accountSpecificValues,
       suiteAppConfigElementsFilter,
+      configFeaturesFilter,
       // serviceUrls must run after suiteAppInternalIds filter
       serviceUrls,
     ],
@@ -197,7 +199,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     useChangesDetection: boolean,
     isPartial: boolean
   ): Promise<FetchByQueryReturnType> => {
-    const { customTypes, enums, fileCabinetTypes, fieldTypes } = getMetadataTypes()
+    const { customTypes, enums, additionalTypes, fieldTypes } = getMetadataTypes()
     const {
       changedObjectsQuery,
       serverTime,
@@ -235,7 +237,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     const topLevelCustomTypes = getTopLevelCustomTypes(customTypes)
     progressReporter.reportProgress({ message: 'Running filters for additional information' })
     _(topLevelCustomTypes)
-      .concat(Object.values(fileCabinetTypes))
+      .concat(Object.values(additionalTypes))
       .forEach(type => {
         type.fields[LAST_FETCH_TIME] = new Field(
           type,
@@ -245,7 +247,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
         )
       });
 
-    [...topLevelCustomTypes, ...Object.values(fileCabinetTypes)].forEach(type => {
+    [...topLevelCustomTypes, ...Object.values(additionalTypes)].forEach(type => {
       type.fields[APPLICATION_ID] = new Field(type, APPLICATION_ID, BuiltinTypes.STRING)
     })
 
@@ -253,7 +255,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     const instances = await awu(customizationInfos).map(customizationInfo => {
       const type = isCustomTypeName(customizationInfo.typeName)
         ? customTypes[customizationInfo.typeName].type
-        : fileCabinetTypes[customizationInfo.typeName]
+        : additionalTypes[customizationInfo.typeName]
       return type
         ? createInstanceElement(customizationInfo, type, this.getElemIdFunc, serverTime)
         : undefined
@@ -265,7 +267,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       : []
 
     const elements = [
-      ...metadataTypesToList({ customTypes, enums, fileCabinetTypes, fieldTypes }),
+      ...metadataTypesToList({ customTypes, enums, additionalTypes, fieldTypes }),
       ...dataElements,
       ...suiteAppConfigElements,
       ...instances,

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -30,6 +30,7 @@ import safeDeployValidator, { FetchByQueryFunc } from './change_validators/safe_
 import mappedListsIndexesValidator from './change_validators/mapped_lists_indexes'
 import configChangesValidator from './change_validators/config_changes'
 import suiteAppConfigElementsValidator from './change_validators/suiteapp_config_elements'
+import undeployableConfigFeaturesValidator from './change_validators/undeployable_config_features'
 import { validateDependsOnInvalidElement } from './change_validators/dependencies'
 import notYetSupportedValuesValidator from './change_validators/not_yet_supported_values'
 
@@ -49,6 +50,7 @@ const changeValidators: ChangeValidator[] = [
   notYetSupportedValuesValidator,
   configChangesValidator,
   suiteAppConfigElementsValidator,
+  undeployableConfigFeaturesValidator,
 ]
 
 const nonSuiteAppValidators: ChangeValidator[] = [

--- a/packages/netsuite-adapter/src/change_validators/undeployable_config_features.ts
+++ b/packages/netsuite-adapter/src/change_validators/undeployable_config_features.ts
@@ -1,0 +1,81 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ChangeValidator, getChangeData, InstanceElement, isInstanceChange, isModificationChange,
+  ModificationChange,
+} from '@salto-io/adapter-api'
+import { CONFIG_FEATURES } from '../constants'
+
+// These features cannot be configure using SDF
+// because they require a Terms of Service user agreement
+const UNDEPLOYABLE_FEATURES = [
+  'AUTOLOCATIONASSIGNMENT',
+  'FULFILLMENTREQUEST',
+  'WEEKLYTIMESHEETSNEWUI',
+  'SUPPLYCHAINPREDICTEDRISKS',
+  'WEBDUPLICATEEMAILMANAGEMENT',
+  'OPENIDSSO',
+  'OIDC',
+  'SAMLSSO',
+  'OAUTH2',
+  'NSASOIDCPROVIDER',
+  'SUITEAPPCONTROLCENTER',
+  'MULTICURRENCYCUSTOMER',
+  'MULTICURRENCYVENDOR',
+  'FXRATEUPDATES',
+  'MOBILEPUSHNTF',
+  'EFT',
+  'ACHVEND',
+  'MAILMERGE',
+  'ITEMOPTIONS',
+  'CUSTOMRECORDS',
+  'ADVANCEDPRINTING',
+  'CUSTOMCODE',
+  'SERVERSIDESCRIPTING',
+  'WEBAPPLICATIONS',
+  'WORKFLOW',
+  'CUSTOMGLLINES',
+  'CUSTOMSEGMENTS',
+  'CREATESUITEBUNDLES',
+  'WEBSERVICESEXTERNAL',
+  'RESTWEBSERVICES',
+  'SUITESIGNON',
+  'TBA',
+]
+
+const getDiffFeatureNames = (change: ModificationChange<InstanceElement>): string[] =>
+  Object.keys(change.data.after.value)
+    .filter(fieldName => change.data.after.value[fieldName] !== change.data.before.value[fieldName])
+
+const changeValidator: ChangeValidator = async changes => {
+  const [featuresChange] = changes
+    .filter(isInstanceChange)
+    .filter(isModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === CONFIG_FEATURES)
+
+  if (!featuresChange) return []
+
+  return getDiffFeatureNames(featuresChange)
+    .filter(featureName => UNDEPLOYABLE_FEATURES.includes(featureName))
+    .map(featureName => ({
+      elemID: featuresChange.data.after.elemID.createNestedID(featureName),
+      severity: 'Warning',
+      message: 'Feature configuration is not supported',
+      detailedMessage: 'You cannot use Salto to configure this feature because it requires a Terms of Service user agreement.',
+    }))
+}
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/undeployable_config_features.ts
+++ b/packages/netsuite-adapter/src/change_validators/undeployable_config_features.ts
@@ -74,7 +74,8 @@ const changeValidator: ChangeValidator = async changes => {
       elemID: featuresChange.data.after.elemID.createNestedID(featureName),
       severity: 'Warning',
       message: 'Feature configuration is not supported',
-      detailedMessage: 'You cannot use Salto to configure this feature because it requires a Terms of Service user agreement.',
+      detailedMessage: 'This feature cannot be configured using Salto because it requires a manual'
+        + ' Terms of Service agreement in NetSuite UI. Configuring this feature will be ignored by NetSuite.',
     }))
 }
 

--- a/packages/netsuite-adapter/src/change_validators/undeployable_config_features.ts
+++ b/packages/netsuite-adapter/src/change_validators/undeployable_config_features.ts
@@ -61,10 +61,10 @@ const getDiffFeatureNames = (change: ModificationChange<InstanceElement>): strin
     .filter(fieldName => change.data.after.value[fieldName] !== change.data.before.value[fieldName])
 
 const changeValidator: ChangeValidator = async changes => {
-  const [featuresChange] = changes
+  const featuresChange = changes
     .filter(isInstanceChange)
     .filter(isModificationChange)
-    .filter(change => getChangeData(change).elemID.typeName === CONFIG_FEATURES)
+    .find(change => getChangeData(change).elemID.typeName === CONFIG_FEATURES)
 
   if (!featuresChange) return []
 

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -122,7 +122,7 @@ export default class NetsuiteClient {
     return this.sdfClient.importFileCabinetContent(query)
   }
 
-  private static getFeaturesDeployResult(
+  private static toFeaturesDeployPartialSuccessResult(
     error: FeaturesDeployError,
     changes: ReadonlyArray<Change<InstanceElement>>
   ): DeployResult {
@@ -168,7 +168,7 @@ export default class NetsuiteClient {
       return { errors: [], appliedChanges: changes }
     } catch (e) {
       if (e instanceof FeaturesDeployError) {
-        return NetsuiteClient.getFeaturesDeployResult(e, changes)
+        return NetsuiteClient.toFeaturesDeployPartialSuccessResult(e, changes)
       }
       return { errors: [e], appliedChanges: [] }
     }

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -297,7 +297,7 @@ export default class SdfClient {
 
     if (featureDeployFailes.length === 0) return
 
-    log.error('suitecloud deploy failed to configure the following features: %o', featureDeployFailes)
+    log.warn('suitecloud deploy failed to configure the following features: %o', featureDeployFailes)
     const errorIds = featureDeployFailes
       .map(line => line.match(configureFeatureFailRegex)?.groups)
       .filter(isDefined)

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { collections, decorators, objects as lowerdashObjects, promises, values } from '@salto-io/lowerdash'
+import { collections, decorators, objects as lowerdashObjects, promises, values as valuesUtils } from '@salto-io/lowerdash'
 import { Values, AccountId, Value } from '@salto-io/adapter-api'
 import { mkdirp, readDir, readFile, writeFile, rm, rename } from '@salto-io/file'
 import { logger } from '@salto-io/logging'
@@ -32,6 +32,7 @@ import AsyncLock from 'async-lock'
 import wu from 'wu'
 import shellQuote from 'shell-quote'
 import {
+  CONFIG_FEATURES,
   APPLICATION_ID,
   FILE_CABINET_PATH_SEPARATOR,
 } from '../constants'
@@ -40,6 +41,7 @@ import {
   DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST, DEFAULT_CONCURRENCY, SdfClientConfig,
 } from '../config'
 import { NetsuiteQuery, NetsuiteQueryParameters, ObjectID } from '../query'
+import { FeaturesDeployError } from '../errors'
 import { SdfCredentials } from './credentials'
 import {
   CustomizationInfo, CustomTypeInfo, FailedImport, FailedTypes, FileCustomizationInfo,
@@ -55,7 +57,7 @@ import { fixManifest } from './manifest_utils'
 
 const { makeArray } = collections.array
 const { withLimitedConcurrency } = promises.array
-const { isDefined } = values
+const { isDefined } = valuesUtils
 const { concatObjects } = lowerdashObjects
 const log = logger(module)
 
@@ -80,6 +82,7 @@ export const COMMANDS = {
   IMPORT_FILES: 'file:import',
   DEPLOY_PROJECT: 'project:deploy',
   ADD_PROJECT_DEPENDENCIES: 'project:adddependencies',
+  IMPORT_CONFIGURATION: 'configuration:import',
 }
 
 
@@ -93,11 +96,24 @@ const FILE_SEPARATOR = '.'
 const ALL = 'ALL'
 const ADDITIONAL_FILE_PATTERN = '.template.'
 
+const ALL_FEATURES = 'FEATURES:ALL_FEATURES'
+const ACCOUNT_CONFIGURATION_DIR = 'AccountConfiguration'
+const FEATURES_XML = 'features.xml'
+const FEATURES_TAG = 'features'
+const FEATURE_ID = 'featureId'
+const configureFeatureFailRegex = RegExp(`Configure feature -- (Enabling|Disabling) of the (?<${FEATURE_ID}>\\w+)\\(.*?\\) feature has FAILED`)
+
 export const MINUTE_IN_MILLISECONDS = 1000 * 60
 const SINGLE_OBJECT_RETRIES = 3
 const READ_CONCURRENCY = 100
 
 const baseExecutionPath = os.tmpdir()
+
+const XML_PARSE_OPTIONS: xmlParser.J2xOptionsOptional = {
+  attributeNamePrefix: ATTRIBUTE_PREFIX,
+  ignoreAttributes: false,
+  tagValueProcessor: val => he.decode(val),
+}
 
 const safeQuoteArgument = (argument: Value): Value => {
   if (typeof argument === 'string') {
@@ -108,11 +124,7 @@ const safeQuoteArgument = (argument: Value): Value => {
 
 export const convertToCustomizationInfo = (xmlContent: string):
   CustomizationInfo => {
-  const parsedXmlValues = xmlParser.parse(xmlContent, {
-    attributeNamePrefix: ATTRIBUTE_PREFIX,
-    ignoreAttributes: false,
-    tagValueProcessor: val => he.decode(val),
-  })
+  const parsedXmlValues = xmlParser.parse(xmlContent, XML_PARSE_OPTIONS)
   const typeName = Object.keys(parsedXmlValues)[0]
   return { typeName, values: parsedXmlValues[typeName] }
 }
@@ -273,11 +285,40 @@ export default class SdfClient {
     }
   }
 
+  private static verifySuccessfulDeploy(data: Value): void {
+    if (!_.isArray(data)) {
+      log.warn('suitecloud deploy returned unexpected value: %o', data)
+      return
+    }
+
+    const featureDeployFailes = data
+      .filter(_.isString)
+      .filter(line => configureFeatureFailRegex.test(line))
+
+    if (featureDeployFailes.length === 0) return
+
+    log.error('suitecloud deploy failed to configure the following features: %o', featureDeployFailes)
+    const errorIds = featureDeployFailes
+      .map(line => line.match(configureFeatureFailRegex)?.groups)
+      .filter(isDefined)
+      .map(groups => groups[FEATURE_ID])
+
+    const errorMessage = data
+      .filter(_.isString)
+      .filter(line => errorIds.some(id => (new RegExp(`\\b${id}\\b`)).test(line)))
+      .join(os.EOL)
+
+    throw new FeaturesDeployError(errorMessage, errorIds)
+  }
+
   private static verifySuccessfulAction(actionResult: ActionResult, commandName: string):
     void {
     if (!actionResult.isSuccess()) {
       log.error(`SDF command ${commandName} has failed.`)
       throw Error(ActionResultUtils.getErrorMessagesString(actionResult))
+    }
+    if (commandName === COMMANDS.DEPLOY_PROJECT) {
+      SdfClient.verifySuccessfulDeploy(actionResult.data)
     }
   }
 
@@ -390,7 +431,7 @@ export default class SdfClient {
   @SdfClient.logDecorator
   async getCustomObjects(typeNames: string[], query: NetsuiteQuery):
     Promise<GetCustomObjectsResult> {
-    if (typeNames.every(type => !query.isTypeMatch(type))) {
+    if (typeNames.concat(CONFIG_FEATURES).every(type => !query.isTypeMatch(type))) {
       return {
         elements: [],
         failedToFetchAllAtOnce: false,
@@ -425,6 +466,15 @@ export default class SdfClient {
           if (suiteAppId !== undefined) {
             elements.forEach(e => { e.values[APPLICATION_ID] = suiteAppId })
           }
+          if (suiteAppId === undefined && query.isTypeMatch(CONFIG_FEATURES)) {
+            // use existing project to import features object
+            const { typeName, values } = await this.getFeaturesObject(executor, projectName)
+            elements.push({
+              scriptId: typeName,
+              typeName,
+              values,
+            })
+          }
           await this.projectCleanup(projectName, authId)
 
           return { elements, failedToFetchAllAtOnce, failedTypes }
@@ -444,6 +494,25 @@ export default class SdfClient {
     const failedToFetchAllAtOnce = importResult.some(res => res.failedToFetchAllAtOnce)
 
     return { elements, failedToFetchAllAtOnce, failedTypes }
+  }
+
+  private async getFeaturesObject(
+    executor: CommandActionExecutor,
+    projectName: string,
+  ): Promise<CustomizationInfo> {
+    try {
+      await this.executeProjectAction(
+        COMMANDS.IMPORT_CONFIGURATION, { configurationid: ALL_FEATURES }, executor
+      )
+      const xmlContent = await readFile(SdfClient.getFeaturesXmlPath(projectName))
+      const featuresXml = xmlParser.parse(xmlContent.toString(), XML_PARSE_OPTIONS)
+
+      const feature = makeArray(featuresXml.features?.feature)
+      return { typeName: CONFIG_FEATURES, values: { feature } }
+    } catch (e) {
+      log.error('Attempt to import features object has failed with error: %o', e)
+      return { typeName: CONFIG_FEATURES, values: { feature: [] } }
+    }
   }
 
   private async importObjects(
@@ -783,6 +852,9 @@ export default class SdfClient {
     const objectsDirPath = SdfClient.getObjectsDirPath(project.projectName)
     const fileCabinetDirPath = SdfClient.getFileCabinetDirPath(project.projectName)
     await Promise.all(customizationInfos.map(async customizationInfo => {
+      if (customizationInfo.typeName === CONFIG_FEATURES) {
+        return SdfClient.addFeaturesObjectToProject(customizationInfo, project.projectName)
+      }
       if (isCustomTypeInfo(customizationInfo)) {
         return SdfClient.addCustomTypeInfoToProject(customizationInfo, objectsDirPath)
       }
@@ -835,6 +907,20 @@ export default class SdfClient {
     }
   }
 
+  private static async addFeaturesObjectToProject(
+    customizationInfo: CustomizationInfo,
+    projectName: string
+  ): Promise<void> {
+    const { feature } = customizationInfo.values
+    await writeFile(
+      SdfClient.getFeaturesXmlPath(projectName),
+      convertToXmlContent({
+        typeName: FEATURES_TAG,
+        values: { feature },
+      })
+    )
+  }
+
   private static async addFileInfoToProject(fileCustomizationInfo: FileCustomizationInfo,
     fileCabinetDirPath: string): Promise<void> {
     const attrsFilename = fileCustomizationInfo.path.slice(-1)[0] + ATTRIBUTES_FILE_SUFFIX
@@ -869,5 +955,14 @@ export default class SdfClient {
 
   private static getFileCabinetDirPath(projectName: string): string {
     return osPath.resolve(SdfClient.getProjectPath(projectName), SRC_DIR, FILE_CABINET_DIR)
+  }
+
+  private static getFeaturesXmlPath(projectName: string): string {
+    return osPath.resolve(
+      SdfClient.getProjectPath(projectName),
+      SRC_DIR,
+      ACCOUNT_CONFIGURATION_DIR,
+      FEATURES_XML
+    )
   }
 }

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -48,7 +48,6 @@ export const FILE = 'file'
 export const FOLDER = 'folder'
 export const SELECT_OPTION = 'selectOption'
 export const CONFIG_FEATURES = 'companyFeatures'
-export const CONFIG_FEATURES_INNER_FEATURE = 'companyFeatures_feature'
 
 // Fields
 export const SCRIPT_ID = 'scriptid'

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -46,8 +46,9 @@ export const WORKBOOK = 'workbook'
 export const WORKFLOW = 'workflow'
 export const FILE = 'file'
 export const FOLDER = 'folder'
-export const SELECT_OPTION = 'selectoption'
-export const CONFIG_FEATURES = 'companyfeatures'
+export const SELECT_OPTION = 'selectOption'
+export const CONFIG_FEATURES = 'companyFeatures'
+export const CONFIG_FEATURES_INNER_FEATURE = 'companyFeatures_feature'
 
 // Fields
 export const SCRIPT_ID = 'scriptid'

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -47,6 +47,7 @@ export const WORKFLOW = 'workflow'
 export const FILE = 'file'
 export const FOLDER = 'folder'
 export const SELECT_OPTION = 'selectoption'
+export const CONFIG_FEATURES = 'companyfeatures'
 
 // Fields
 export const SCRIPT_ID = 'scriptid'

--- a/packages/netsuite-adapter/src/errors.ts
+++ b/packages/netsuite-adapter/src/errors.ts
@@ -1,0 +1,23 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+export class FeaturesDeployError extends Error {
+  ids: string[]
+  constructor(message: string, ids: string[]) {
+    super(message)
+    this.ids = ids
+    this.name = 'FeaturesDeployError'
+  }
+}

--- a/packages/netsuite-adapter/src/filters/config_features.ts
+++ b/packages/netsuite-adapter/src/filters/config_features.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import { BuiltinTypes, Field, getChangeData, InstanceElement, isInstanceChange, isInstanceElement, isModificationChange, ListType } from '@salto-io/adapter-api'
+import { BuiltinTypes, Field, getChangeData, InstanceElement, isInstanceChange, isInstanceElement, isModificationChange } from '@salto-io/adapter-api'
 import { FilterWith } from '../filter'
 import { CONFIG_FEATURES } from '../constants'
 import { FeaturesDeployError } from '../errors'
@@ -74,10 +74,8 @@ const filterCreator = (): FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'> => ({
     })
 
     const type = await getChangeData<InstanceElement>(featuresChange).getType()
-    const { companyFeatures_feature: innerFeatureType } = featuresType()
-    type.fields = {
-      feature: new Field(type, 'feature', new ListType(innerFeatureType)),
-    }
+    // restore the fields to the hardcoded definitions, used in fetch & deploy
+    type.fields = featuresType().fields
   },
   onDeploy: async (changes, deployInfo) => {
     const errorIds = deployInfo.errors.flatMap(error => {

--- a/packages/netsuite-adapter/src/filters/config_features.ts
+++ b/packages/netsuite-adapter/src/filters/config_features.ts
@@ -1,0 +1,103 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { BuiltinTypes, Field, getChangeData, InstanceElement, isInstanceChange, isInstanceElement, isModificationChange, ListType, Value } from '@salto-io/adapter-api'
+import { FilterWith } from '../filter'
+import { CONFIG_FEATURES } from '../constants'
+import { FeaturesDeployError } from '../errors'
+import { featuresType } from '../types/configuration_types'
+
+const ENABLED = 'ENABLED'
+const DISABLED = 'DISABLED'
+
+const filterCreator = (): FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'> => ({
+  onFetch: async elements => {
+    const [featuresInstance] = elements.filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === CONFIG_FEATURES)
+
+    if (!featuresInstance) return
+
+    const type = await featuresInstance.getType()
+    const features = _.keyBy(featuresInstance.value.feature, feature => feature.id)
+
+    type.fields = _.mapValues(features, feature => new Field(
+      type,
+      feature.id,
+      BuiltinTypes.BOOLEAN,
+      { label: feature.label }
+    ))
+
+    featuresInstance.value = _.mapValues(
+      features,
+      feature => (
+        [ENABLED, DISABLED].includes(feature.status)
+          ? feature.status === ENABLED
+          : feature.status
+      )
+    )
+  },
+  preDeploy: async changes => {
+    const [featuresChange] = changes.filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === CONFIG_FEATURES)
+
+    if (!featuresChange) return
+
+    const getStatus = (value: Value): Value => {
+      if (_.isBoolean(value)) {
+        return value ? ENABLED : DISABLED
+      }
+      return value
+    }
+
+    Object.values(featuresChange.data).forEach(instance => {
+      instance.value = {
+        feature: Object.entries(instance.value)
+          .map(([id, value]) => ({ id, status: getStatus(value) })),
+      }
+    })
+
+    const type = await getChangeData<InstanceElement>(featuresChange).getType()
+    const { companyfeatures_feature: innerFeatureType } = featuresType()
+    type.fields = {
+      feature: new Field(type, 'feature', new ListType(innerFeatureType)),
+    }
+  },
+  onDeploy: async (changes, deployInfo) => {
+    const errorIds = deployInfo.errors.flatMap(error => {
+      if (error instanceof FeaturesDeployError) {
+        return error.ids
+      }
+      return []
+    })
+
+    if (errorIds.length === 0) return
+
+    const [featuresChange] = changes
+      .filter(isInstanceChange)
+      .filter(isModificationChange)
+      .filter(change => getChangeData(change).elemID.typeName === CONFIG_FEATURES)
+
+    if (!featuresChange) return
+
+    const { after, before } = featuresChange.data
+    after.value = {
+      ..._.omit(after.value, errorIds),
+      ..._.pick(before.value, errorIds),
+    }
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/config_features.ts
+++ b/packages/netsuite-adapter/src/filters/config_features.ts
@@ -25,8 +25,8 @@ const DISABLED = 'DISABLED'
 
 const filterCreator = (): FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'> => ({
   onFetch: async elements => {
-    const [featuresInstance] = elements.filter(isInstanceElement)
-      .filter(instance => instance.elemID.typeName === CONFIG_FEATURES)
+    const featuresInstance = elements.filter(isInstanceElement)
+      .find(instance => instance.elemID.typeName === CONFIG_FEATURES)
 
     if (!featuresInstance) return
 
@@ -50,8 +50,8 @@ const filterCreator = (): FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'> => ({
     )
   },
   preDeploy: async changes => {
-    const [featuresChange] = changes.filter(isInstanceChange)
-      .filter(change => getChangeData(change).elemID.typeName === CONFIG_FEATURES)
+    const featuresChange = changes.filter(isInstanceChange)
+      .find(change => getChangeData(change).elemID.typeName === CONFIG_FEATURES)
 
     if (!featuresChange) return
 
@@ -70,7 +70,7 @@ const filterCreator = (): FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'> => ({
     })
 
     const type = await getChangeData<InstanceElement>(featuresChange).getType()
-    const { companyfeatures_feature: innerFeatureType } = featuresType()
+    const { companyFeatures_feature: innerFeatureType } = featuresType()
     type.fields = {
       feature: new Field(type, 'feature', new ListType(innerFeatureType)),
     }
@@ -85,10 +85,10 @@ const filterCreator = (): FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'> => ({
 
     if (errorIds.length === 0) return
 
-    const [featuresChange] = changes
+    const featuresChange = changes
       .filter(isInstanceChange)
       .filter(isModificationChange)
-      .filter(change => getChangeData(change).elemID.typeName === CONFIG_FEATURES)
+      .find(change => getChangeData(change).elemID.typeName === CONFIG_FEATURES)
 
     if (!featuresChange) return
 

--- a/packages/netsuite-adapter/src/group_changes.ts
+++ b/packages/netsuite-adapter/src/group_changes.ts
@@ -25,7 +25,7 @@ import { values, collections } from '@salto-io/lowerdash'
 import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import * as suiteAppFileCabinet from './suiteapp_file_cabinet'
-import { isSuiteAppConfigInstance, isDataObjectType, isFileCabinetInstance } from './types'
+import { isSuiteAppConfigInstance, isSDFConfigTypeName, isDataObjectType, isFileCabinetInstance } from './types'
 import { APPLICATION_ID } from './constants'
 import { isCustomTypeName } from './autogen/types'
 import { fileCabinetTypesNames } from './types/file_cabinet_types'
@@ -60,7 +60,8 @@ const getChangeGroupIdsWithoutSuiteApp: ChangeGroupIdFunction = async changes =>
     const changeData = getChangeData(change)
     return isInstanceElement(changeData)
       && (isCustomTypeName(changeData.elemID.typeName)
-        || fileCabinetTypesNames.has(changeData.elemID.typeName))
+        || fileCabinetTypesNames.has(changeData.elemID.typeName)
+        || isSDFConfigTypeName(changeData.elemID.typeName))
   }
   return new Map(
     wu(changes.entries())
@@ -140,6 +141,7 @@ const isSdfChange = (change: Change): boolean => {
   return isCustomTypeName(changeData.elemID.typeName)
     || (isFileCabinetInstance(changeData)
       && !suiteAppFileCabinet.isChangeDeployable(change))
+    || isSDFConfigTypeName(changeData.elemID.typeName)
 }
 
 const isSuiteAppRecordChange = async (change: Change): Promise<boolean> => {

--- a/packages/netsuite-adapter/src/query.ts
+++ b/packages/netsuite-adapter/src/query.ts
@@ -16,7 +16,7 @@
 
 import { regex, strings } from '@salto-io/lowerdash'
 import { getCustomTypesNames } from './autogen/types'
-import { INCLUDE, EXCLUDE, LOCKED_ELEMENTS_TO_EXCLUDE, AUTHOR_INFO_CONFIG } from './constants'
+import { INCLUDE, EXCLUDE, LOCKED_ELEMENTS_TO_EXCLUDE, AUTHOR_INFO_CONFIG, CONFIG_FEATURES } from './constants'
 import { SUPPORTED_TYPES, TYPES_TO_INTERNAL_ID } from './data_elements/types'
 import { SUITEAPP_CONFIG_TYPE_NAMES } from './types'
 
@@ -87,6 +87,7 @@ export const validateFetchParameters = ({ types, fileCabinet }:
     ...getCustomTypesNames(),
     ...SUPPORTED_TYPES,
     ...SUITEAPP_CONFIG_TYPE_NAMES,
+    CONFIG_FEATURES,
   ]
   const receivedTypes = types.map(obj => obj.name)
   const idsRegexes = types

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -47,19 +47,21 @@ const removeDotPrefix = (name: string): string => name.replace(/^\.+/, '_')
 export const createInstanceElement = async (customizationInfo: CustomizationInfo, type: ObjectType,
   getElemIdFunc?: ElemIdGetter, fetchTime?: Date): Promise<InstanceElement> => {
   const getInstanceName = (transformedValues: Values): string => {
-    if (!isCustomType(type) && !isFileCabinetType(type) && !isSDFConfigType(type)) {
+    if (isSDFConfigType(type)) {
+      return ElemID.CONFIG_NAME
+    }
+    if (!isCustomType(type) && !isFileCabinetType(type)) {
       throw new Error(`Failed to getInstanceName for unknown type: ${type.elemID.name}`)
     }
-    const serviceIdFieldName = isFileCabinetType(type) ? PATH : SCRIPT_ID
-    const serviceId = isSDFConfigType(type)
-      ? ElemID.CONFIG_NAME : transformedValues[serviceIdFieldName]
+    const serviceIdFieldName = isCustomType(type) ? SCRIPT_ID : PATH
     const serviceIds: ServiceIds = {
-      [serviceIdFieldName]: serviceId,
+      [serviceIdFieldName]: transformedValues[serviceIdFieldName],
       [OBJECT_SERVICE_ID]: toServiceIdsString({
         [OBJECT_NAME]: type.elemID.getFullName(),
       }),
     }
-    const desiredName = naclCase(serviceId.replace(new RegExp(`^${FILE_CABINET_PATH_SEPARATOR}`), ''))
+    const desiredName = naclCase(transformedValues[serviceIdFieldName]
+      .replace(new RegExp(`^${FILE_CABINET_PATH_SEPARATOR}`), ''))
     return getElemIdFunc ? getElemIdFunc(NETSUITE, serviceIds, desiredName).name : desiredName
   }
 

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -27,9 +27,10 @@ import {
   SCRIPT_ID, ADDITIONAL_FILE_SUFFIX, FILE, FILE_CABINET_PATH, PATH, FILE_CABINET_PATH_SEPARATOR,
   LAST_FETCH_TIME,
   APPLICATION_ID,
+  SETTINGS_PATH,
 } from './constants'
 import { fieldTypes } from './types/field_types'
-import { isCustomType, isFileCabinetType } from './types'
+import { isSDFConfigType, isCustomType, isFileCabinetType } from './types'
 import { isFileCustomizationInfo, isFolderCustomizationInfo, isTemplateCustomTypeInfo } from './client/utils'
 import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, TemplateCustomTypeInfo } from './client/types'
 import { ATTRIBUTE_PREFIX, CDATA_TAG_NAME } from './client/constants'
@@ -46,25 +47,32 @@ const removeDotPrefix = (name: string): string => name.replace(/^\.+/, '_')
 export const createInstanceElement = async (customizationInfo: CustomizationInfo, type: ObjectType,
   getElemIdFunc?: ElemIdGetter, fetchTime?: Date): Promise<InstanceElement> => {
   const getInstanceName = (transformedValues: Values): string => {
-    if (!isCustomType(type) && !isFileCabinetType(type)) {
+    if (!isCustomType(type) && !isFileCabinetType(type) && !isSDFConfigType(type)) {
       throw new Error(`Failed to getInstanceName for unknown type: ${type.elemID.name}`)
     }
-    const serviceIdFieldName = isCustomType(type) ? SCRIPT_ID : PATH
+    const serviceIdFieldName = isFileCabinetType(type) ? PATH : SCRIPT_ID
+    const serviceId = isSDFConfigType(type)
+      ? ElemID.CONFIG_NAME : transformedValues[serviceIdFieldName]
     const serviceIds: ServiceIds = {
-      [serviceIdFieldName]: transformedValues[serviceIdFieldName],
+      [serviceIdFieldName]: serviceId,
       [OBJECT_SERVICE_ID]: toServiceIdsString({
         [OBJECT_NAME]: type.elemID.getFullName(),
       }),
     }
-    const desiredName = naclCase(transformedValues[serviceIdFieldName]
-      .replace(new RegExp(`^${FILE_CABINET_PATH_SEPARATOR}`), ''))
+    const desiredName = naclCase(serviceId.replace(new RegExp(`^${FILE_CABINET_PATH_SEPARATOR}`), ''))
     return getElemIdFunc ? getElemIdFunc(NETSUITE, serviceIds, desiredName).name : desiredName
   }
 
-  const getInstancePath = (instanceName: string): string[] =>
-    (isFolderCustomizationInfo(customizationInfo) || isFileCustomizationInfo(customizationInfo)
-      ? [NETSUITE, FILE_CABINET_PATH, ...customizationInfo.path.map(removeDotPrefix)]
-      : [NETSUITE, RECORDS_PATH, type.elemID.name, instanceName])
+  const getInstancePath = (instanceName: string): string[] => {
+    if (isFolderCustomizationInfo(customizationInfo)
+      || isFileCustomizationInfo(customizationInfo)) {
+      return [NETSUITE, FILE_CABINET_PATH, ...customizationInfo.path.map(removeDotPrefix)]
+    }
+    if (isSDFConfigType(type)) {
+      return [NETSUITE, SETTINGS_PATH, type.elemID.name]
+    }
+    return [NETSUITE, RECORDS_PATH, type.elemID.name, instanceName]
+  }
 
   const transformPrimitive: TransformFunc = async ({ value, field }) => {
     const fieldType = await field?.getType()

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -19,6 +19,8 @@ import { enums } from './autogen/types/enums'
 import { CustomType, getCustomTypes, isCustomTypeName } from './autogen/types'
 import { TypesMap } from './types/object_types'
 import { fileCabinetTypesNames, getFileCabinetTypes } from './types/file_cabinet_types'
+import { getConfigurationTypes } from './types/configuration_types'
+import { CONFIG_FEATURES } from './constants'
 
 export const isCustomType = (type: ObjectType | TypeReference): boolean =>
   isCustomTypeName(type.elemID.name)
@@ -38,14 +40,14 @@ export const isDataObjectType = (element: ObjectType): boolean =>
 type MetadataTypes = {
   customTypes: TypesMap<CustomType>
   enums: Readonly<Record<string, PrimitiveType>>
-  fileCabinetTypes: Readonly<Record<string, ObjectType>>
+  additionalTypes: Readonly<Record<string, ObjectType>>
   fieldTypes: Readonly<Record<string, PrimitiveType>>
 }
 
 export const getMetadataTypes = (): MetadataTypes => ({
   customTypes: getCustomTypes(),
   enums,
-  fileCabinetTypes: getFileCabinetTypes(),
+  additionalTypes: { ...getFileCabinetTypes(), ...getConfigurationTypes() },
   fieldTypes,
 })
 
@@ -56,12 +58,12 @@ export const getInnerCustomTypes = (customTypes: TypesMap<CustomType>): ObjectTy
   Object.values(customTypes).flatMap(customType => Object.values(customType.innerTypes))
 
 export const metadataTypesToList = (metadataTypes: MetadataTypes): TypeElement[] => {
-  const { customTypes, fileCabinetTypes } = metadataTypes
+  const { customTypes, additionalTypes } = metadataTypes
   return [
     ...getTopLevelCustomTypes(customTypes),
     ...getInnerCustomTypes(customTypes),
     ...Object.values(enums),
-    ...Object.values(fileCabinetTypes),
+    ...Object.values(additionalTypes),
     ...Object.values(fieldTypes),
   ]
 }
@@ -129,3 +131,9 @@ export const SUITEAPP_CONFIG_TYPE_NAMES = Object.values(SUITEAPP_CONFIG_TYPES_TO
 
 export const isSuiteAppConfigInstance = (instance: InstanceElement): boolean =>
   SUITEAPP_CONFIG_TYPE_NAMES.includes(instance.elemID.typeName)
+
+export const isSDFConfigTypeName = (typeName: string): boolean =>
+  typeName === CONFIG_FEATURES
+
+export const isSDFConfigType = (type: ObjectType | TypeReference): boolean =>
+  isSDFConfigTypeName(type.elemID.name)

--- a/packages/netsuite-adapter/src/types/configuration_types.ts
+++ b/packages/netsuite-adapter/src/types/configuration_types.ts
@@ -17,34 +17,28 @@
 import { BuiltinTypes, ElemID, ObjectType, ListType } from '@salto-io/adapter-api'
 import * as constants from '../constants'
 
-type FeatureTypeName = typeof constants.CONFIG_FEATURES
-  | typeof constants.CONFIG_FEATURES_INNER_FEATURE
+type ConfigurationTypeName = typeof constants.CONFIG_FEATURES
 
-export const featuresType = (): Record<FeatureTypeName, ObjectType> => {
-  const featuresElemID = new ElemID(constants.NETSUITE, constants.CONFIG_FEATURES)
-  const features_featureElemID = new ElemID(constants.NETSUITE, `${constants.CONFIG_FEATURES}_feature`)
-  const companyFeatures_feature = new ObjectType({
-    elemID: features_featureElemID,
-    fields: {
-      label: { refType: BuiltinTypes.STRING },
-      id: { refType: BuiltinTypes.STRING },
-      status: { refType: BuiltinTypes.STRING },
+export const featuresType = (): ObjectType => new ObjectType({
+  elemID: new ElemID(constants.NETSUITE, constants.CONFIG_FEATURES),
+  fields: {
+    feature: {
+      refType: new ListType(
+        new ObjectType({
+          elemID: new ElemID(constants.NETSUITE, `${constants.CONFIG_FEATURES}_feature`),
+          fields: {
+            label: { refType: BuiltinTypes.STRING },
+            id: { refType: BuiltinTypes.STRING },
+            status: { refType: BuiltinTypes.STRING },
+          },
+        })
+      ),
     },
-    path: [constants.NETSUITE, constants.TYPES_PATH, featuresElemID.name],
-  })
-  const companyFeatures = new ObjectType({
-    elemID: featuresElemID,
-    fields: {
-      feature: {
-        refType: new ListType(companyFeatures_feature),
-      },
-    },
-    path: [constants.NETSUITE, constants.TYPES_PATH, featuresElemID.name],
-    isSettings: true,
-  })
-  return { companyFeatures, companyFeatures_feature }
-}
+  },
+  path: [constants.NETSUITE, constants.TYPES_PATH, constants.CONFIG_FEATURES],
+  isSettings: true,
+})
 
-export const getConfigurationTypes = (): Readonly<Record<string, ObjectType>> => ({
-  ...featuresType(),
+export const getConfigurationTypes = (): Readonly<Record<ConfigurationTypeName, ObjectType>> => ({
+  companyFeatures: featuresType(),
 })

--- a/packages/netsuite-adapter/src/types/configuration_types.ts
+++ b/packages/netsuite-adapter/src/types/configuration_types.ts
@@ -17,12 +17,13 @@
 import { BuiltinTypes, ElemID, ObjectType, ListType } from '@salto-io/adapter-api'
 import * as constants from '../constants'
 
-type FeatureTypeName = 'companyfeatures' | 'companyfeatures_feature'
+type FeatureTypeName = typeof constants.CONFIG_FEATURES
+  | typeof constants.CONFIG_FEATURES_INNER_FEATURE
 
 export const featuresType = (): Record<FeatureTypeName, ObjectType> => {
   const featuresElemID = new ElemID(constants.NETSUITE, constants.CONFIG_FEATURES)
   const features_featureElemID = new ElemID(constants.NETSUITE, `${constants.CONFIG_FEATURES}_feature`)
-  const companyfeatures_feature = new ObjectType({
+  const companyFeatures_feature = new ObjectType({
     elemID: features_featureElemID,
     fields: {
       label: { refType: BuiltinTypes.STRING },
@@ -31,17 +32,17 @@ export const featuresType = (): Record<FeatureTypeName, ObjectType> => {
     },
     path: [constants.NETSUITE, constants.TYPES_PATH, featuresElemID.name],
   })
-  const companyfeatures = new ObjectType({
+  const companyFeatures = new ObjectType({
     elemID: featuresElemID,
     fields: {
       feature: {
-        refType: new ListType(companyfeatures_feature),
+        refType: new ListType(companyFeatures_feature),
       },
     },
     path: [constants.NETSUITE, constants.TYPES_PATH, featuresElemID.name],
     isSettings: true,
   })
-  return { companyfeatures, companyfeatures_feature }
+  return { companyFeatures, companyFeatures_feature }
 }
 
 export const getConfigurationTypes = (): Readonly<Record<string, ObjectType>> => ({

--- a/packages/netsuite-adapter/src/types/configuration_types.ts
+++ b/packages/netsuite-adapter/src/types/configuration_types.ts
@@ -1,0 +1,49 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* eslint-disable camelcase */
+import { BuiltinTypes, ElemID, ObjectType, ListType } from '@salto-io/adapter-api'
+import * as constants from '../constants'
+
+type FeatureTypeName = 'companyfeatures' | 'companyfeatures_feature'
+
+export const featuresType = (): Record<FeatureTypeName, ObjectType> => {
+  const featuresElemID = new ElemID(constants.NETSUITE, constants.CONFIG_FEATURES)
+  const features_featureElemID = new ElemID(constants.NETSUITE, `${constants.CONFIG_FEATURES}_feature`)
+  const companyfeatures_feature = new ObjectType({
+    elemID: features_featureElemID,
+    fields: {
+      label: { refType: BuiltinTypes.STRING },
+      id: { refType: BuiltinTypes.STRING },
+      status: { refType: BuiltinTypes.STRING },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, featuresElemID.name],
+  })
+  const companyfeatures = new ObjectType({
+    elemID: featuresElemID,
+    fields: {
+      feature: {
+        refType: new ListType(companyfeatures_feature),
+      },
+    },
+    path: [constants.NETSUITE, constants.TYPES_PATH, featuresElemID.name],
+    isSettings: true,
+  })
+  return { companyfeatures, companyfeatures_feature }
+}
+
+export const getConfigurationTypes = (): Readonly<Record<string, ObjectType>> => ({
+  ...featuresType(),
+})

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -120,8 +120,8 @@ describe('Adapter', () => {
     progressReporter: { reportProgress: jest.fn() },
   }
 
-  const { customTypes, enums, fileCabinetTypes, fieldTypes } = getMetadataTypes()
-  const metadataTypes = metadataTypesToList({ customTypes, enums, fileCabinetTypes, fieldTypes })
+  const { customTypes, enums, additionalTypes, fieldTypes } = getMetadataTypes()
+  const metadataTypes = metadataTypesToList({ customTypes, enums, additionalTypes, fieldTypes })
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -534,11 +534,11 @@ describe('Adapter', () => {
       })
     let instance: InstanceElement
 
-    const fileInstance = new InstanceElement('fileInstance', fileCabinetTypes[FILE], {
+    const fileInstance = new InstanceElement('fileInstance', additionalTypes[FILE], {
       [PATH]: 'Templates/E-mail Templates/Inner EmailTemplates Folder/content.html',
     })
 
-    const folderInstance = new InstanceElement('folderInstance', fileCabinetTypes[FOLDER], {
+    const folderInstance = new InstanceElement('folderInstance', additionalTypes[FOLDER], {
       [PATH]: 'Templates/E-mail Templates/Inner EmailTemplates Folder',
     })
 

--- a/packages/netsuite-adapter/test/change_validators/undeployable_config_features.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/undeployable_config_features.test.ts
@@ -1,0 +1,51 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, toChange } from '@salto-io/adapter-api'
+import { featuresType } from '../../src/types/configuration_types'
+import undeployableConfigFeaturesValidator from '../../src/change_validators/undeployable_config_features'
+
+describe('account feautures validator', () => {
+  const origInstance = new InstanceElement(
+    ElemID.CONFIG_NAME,
+    featuresType().companyfeatures,
+    {
+      ABC: true,
+      SUITEAPPCONTROLCENTER: false,
+    }
+  )
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    instance = origInstance.clone()
+  })
+
+  it('should not have errors', async () => {
+    instance.value.ABC = false
+    const changeErrors = await undeployableConfigFeaturesValidator(
+      [toChange({ before: origInstance, after: instance })]
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('should have warning on change in undeployable feature', async () => {
+    instance.value.SUITEAPPCONTROLCENTER = true
+    const changeErrors = await undeployableConfigFeaturesValidator(
+      [toChange({ before: origInstance, after: instance })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Warning')
+  })
+})

--- a/packages/netsuite-adapter/test/change_validators/undeployable_config_features.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/undeployable_config_features.test.ts
@@ -20,7 +20,7 @@ import undeployableConfigFeaturesValidator from '../../src/change_validators/und
 describe('account feautures validator', () => {
   const origInstance = new InstanceElement(
     ElemID.CONFIG_NAME,
-    featuresType().companyfeatures,
+    featuresType().companyFeatures,
     {
       ABC: true,
       SUITEAPPCONTROLCENTER: false,

--- a/packages/netsuite-adapter/test/change_validators/undeployable_config_features.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/undeployable_config_features.test.ts
@@ -17,10 +17,10 @@ import { ElemID, InstanceElement, toChange } from '@salto-io/adapter-api'
 import { featuresType } from '../../src/types/configuration_types'
 import undeployableConfigFeaturesValidator from '../../src/change_validators/undeployable_config_features'
 
-describe('account feautures validator', () => {
+describe('undeployable config feautures validator', () => {
   const origInstance = new InstanceElement(
     ElemID.CONFIG_NAME,
-    featuresType().companyFeatures,
+    featuresType(),
     {
       ABC: true,
       SUITEAPPCONTROLCENTER: false,

--- a/packages/netsuite-adapter/test/filters/config_features.test.ts
+++ b/packages/netsuite-adapter/test/filters/config_features.test.ts
@@ -41,10 +41,12 @@ const getChange = (): Change<InstanceElement> => {
 }
 
 describe('config features filter', () => {
+  // eslint-disable-next-line camelcase
+  const { companyFeatures, companyFeatures_feature } = featuresType()
   describe('onFetch', () => {
     const origInstance = new InstanceElement(
       '_config',
-      featuresType().companyfeatures,
+      companyFeatures,
       {
         feature: [
           { id: 'ABC', label: 'A Blue Cat', status: 'ENABLED' },
@@ -80,7 +82,7 @@ describe('config features filter', () => {
       const fieldType = await feature.getType()
       expect(isListType(fieldType)).toBeTruthy()
       expect(isListType(fieldType) && fieldType.refInnerType.elemID.typeName)
-        .toEqual(featuresType().companyfeatures_feature.elemID.typeName)
+        .toEqual(companyFeatures_feature.elemID.typeName)
       expect(instance.value).toEqual({
         feature: [
           { id: 'ABC', status: 'ENABLED' },

--- a/packages/netsuite-adapter/test/filters/config_features.test.ts
+++ b/packages/netsuite-adapter/test/filters/config_features.test.ts
@@ -42,7 +42,7 @@ const getChange = (): Change<InstanceElement> => {
 
 describe('config features filter', () => {
   // eslint-disable-next-line camelcase
-  const { companyFeatures, companyFeatures_feature } = featuresType()
+  const companyFeatures = featuresType()
   describe('onFetch', () => {
     const origInstance = new InstanceElement(
       '_config',
@@ -82,7 +82,7 @@ describe('config features filter', () => {
       const fieldType = await feature.getType()
       expect(isListType(fieldType)).toBeTruthy()
       expect(isListType(fieldType) && fieldType.refInnerType.elemID.typeName)
-        .toEqual(companyFeatures_feature.elemID.typeName)
+        .toEqual(`${CONFIG_FEATURES}_feature`)
       expect(instance.value).toEqual({
         feature: [
           { id: 'ABC', status: 'ENABLED' },

--- a/packages/netsuite-adapter/test/filters/config_features.test.ts
+++ b/packages/netsuite-adapter/test/filters/config_features.test.ts
@@ -1,0 +1,104 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, Change, ElemID, getChangeData, InstanceElement, isListType, ObjectType, toChange } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/config_features'
+import { FeaturesDeployError } from '../../src/errors'
+import { CONFIG_FEATURES, NETSUITE } from '../../src/constants'
+import { featuresType } from '../../src/types/configuration_types'
+
+const getChange = (): Change<InstanceElement> => {
+  const type = new ObjectType({
+    elemID: new ElemID(NETSUITE, CONFIG_FEATURES),
+    fields: {
+      ABC: { refType: BuiltinTypes.BOOLEAN },
+      DEF: { refType: BuiltinTypes.BOOLEAN },
+    },
+  })
+  const before = new InstanceElement(
+    ElemID.CONFIG_NAME,
+    type,
+    { ABC: false, DEF: false }
+  )
+  const after = new InstanceElement(
+    ElemID.CONFIG_NAME,
+    type,
+    { ABC: true, DEF: true }
+  )
+  return toChange({ before, after })
+}
+
+describe('config features filter', () => {
+  describe('onFetch', () => {
+    const origInstance = new InstanceElement(
+      '_config',
+      featuresType().companyfeatures,
+      {
+        feature: [
+          { id: 'ABC', label: 'A Blue Cat', status: 'ENABLED' },
+          { id: 'DEF', label: 'Delightful Elephents Family', status: 'DISABLED' },
+          { id: 'NO', label: 'Not O', status: 'UNKNOWN' },
+        ],
+      }
+    )
+
+    let instance: InstanceElement
+    beforeEach(() => {
+      instance = origInstance.clone()
+    })
+
+    it('should transform values', async () => {
+      await filterCreator().onFetch([instance])
+      const type = await instance.getType()
+      expect(Object.keys(type.fields)).toEqual(['ABC', 'DEF', 'NO'])
+      expect(type.fields.ABC.annotations).toEqual({ label: 'A Blue Cat' })
+      expect(type.fields.DEF.annotations).toEqual({ label: 'Delightful Elephents Family' })
+      expect(type.fields.NO.annotations).toEqual({ label: 'Not O' })
+      expect(instance.value).toEqual({ ABC: true, DEF: false, NO: 'UNKNOWN' })
+    })
+  })
+  describe('preDeploy', () => {
+    it('should transform values', async () => {
+      const change = getChange()
+      await filterCreator().preDeploy([change])
+      const instance = getChangeData(change)
+      const type = await instance.getType()
+
+      const { feature } = type.fields
+      const fieldType = await feature.getType()
+      expect(isListType(fieldType)).toBeTruthy()
+      expect(isListType(fieldType) && fieldType.refInnerType.elemID.typeName)
+        .toEqual(featuresType().companyfeatures_feature.elemID.typeName)
+      expect(instance.value).toEqual({
+        feature: [
+          { id: 'ABC', status: 'ENABLED' },
+          { id: 'DEF', status: 'ENABLED' },
+        ],
+      })
+    })
+  })
+  describe('onDeploy', () => {
+    it('should succeed', async () => {
+      const change = getChange()
+      await filterCreator().onDeploy([change], { errors: [new Error('error')], appliedChanges: [] })
+      expect(getChangeData(change).value).toEqual({ ABC: true, DEF: true })
+    })
+    it('should restore failed to deploy features', async () => {
+      const change = getChange()
+      await filterCreator().onDeploy([change], { errors: [new FeaturesDeployError('error', ['ABC'])], appliedChanges: [] })
+      expect(getChangeData(change).value).toEqual({ ABC: false, DEF: true })
+    })
+  })
+})

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -125,7 +125,7 @@ describe('Transformer', () => {
   const transactionForm = transactionFormType().type
   const workflow = workflowType().type
   const { file, folder } = getFileCabinetTypes()
-  const { companyFeatures } = featuresType()
+  const companyFeatures = featuresType()
 
   describe('createInstanceElement', () => {
     const transformCustomFieldRecord = (xmlContent: string): Promise<InstanceElement> => {

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -21,13 +21,14 @@ import _ from 'lodash'
 import { createInstanceElement, getLookUpName, toCustomizationInfo } from '../src/transformer'
 import {
   ENTITY_CUSTOM_FIELD, SCRIPT_ID,
-  EMAIL_TEMPLATE, NETSUITE, RECORDS_PATH, FILE, FILE_CABINET_PATH, FOLDER, PATH,
+  EMAIL_TEMPLATE, NETSUITE, RECORDS_PATH, FILE, FILE_CABINET_PATH, FOLDER, PATH, CONFIG_FEATURES,
 } from '../src/constants'
 import { convertToCustomTypeInfo, convertToXmlContent } from '../src/client/sdf_client'
 import { CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, TemplateCustomTypeInfo } from '../src/client/types'
 import { isFileCustomizationInfo, isFolderCustomizationInfo } from '../src/client/utils'
 import { entitycustomfieldType } from '../src/autogen/types/custom_types/entitycustomfield'
 import { getFileCabinetTypes } from '../src/types/file_cabinet_types'
+import { featuresType } from '../src/types/configuration_types'
 import { customrecordtypeType } from '../src/autogen/types/custom_types/customrecordtype'
 import { emailtemplateType } from '../src/autogen/types/custom_types/emailtemplate'
 import { addressFormType } from '../src/autogen/types/custom_types/addressForm'
@@ -124,6 +125,7 @@ describe('Transformer', () => {
   const transactionForm = transactionFormType().type
   const workflow = workflowType().type
   const { file, folder } = getFileCabinetTypes()
+  const { companyfeatures } = featuresType()
 
   describe('createInstanceElement', () => {
     const transformCustomFieldRecord = (xmlContent: string): Promise<InstanceElement> => {
@@ -366,6 +368,31 @@ describe('Transformer', () => {
           filepath: `${NETSUITE}/${FILE_CABINET_PATH}/Templates/E-mail Templates/Inner EmailTemplates Folder/content.html`,
           content: Buffer.from('dummy file content'),
         }))
+      })
+    })
+
+    describe('configuration types', () => {
+      const featuresCustomizationInfo: CustomTypeInfo = {
+        typeName: CONFIG_FEATURES,
+        scriptId: CONFIG_FEATURES,
+        values: {
+          feature: [
+            { '@_label': 'test', id: 'TEST', status: 'ENABLED' },
+          ],
+        },
+      }
+      it('should create features instance correctly', async () => {
+        const result = await createInstanceElement(
+          featuresCustomizationInfo,
+          companyfeatures,
+          mockGetElemIdFunc
+        )
+        expect(result.elemID.getFullName()).toEqual(`netsuite.${CONFIG_FEATURES}.instance.${NAME_FROM_GET_ELEM_ID}_config`)
+        expect(result.value).toEqual({
+          feature: [
+            { id: 'TEST', label: 'test', status: 'ENABLED' },
+          ],
+        })
       })
     })
   })

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -125,7 +125,7 @@ describe('Transformer', () => {
   const transactionForm = transactionFormType().type
   const workflow = workflowType().type
   const { file, folder } = getFileCabinetTypes()
-  const { companyfeatures } = featuresType()
+  const { companyFeatures } = featuresType()
 
   describe('createInstanceElement', () => {
     const transformCustomFieldRecord = (xmlContent: string): Promise<InstanceElement> => {
@@ -384,10 +384,10 @@ describe('Transformer', () => {
       it('should create features instance correctly', async () => {
         const result = await createInstanceElement(
           featuresCustomizationInfo,
-          companyfeatures,
+          companyFeatures,
           mockGetElemIdFunc
         )
-        expect(result.elemID.getFullName()).toEqual(`netsuite.${CONFIG_FEATURES}.instance.${NAME_FROM_GET_ELEM_ID}_config`)
+        expect(result.elemID.getFullName()).toEqual(`netsuite.${CONFIG_FEATURES}.instance`)
         expect(result.value).toEqual({
           feature: [
             { id: 'TEST', label: 'test', status: 'ENABLED' },

--- a/packages/netsuite-adapter/test/types.test.ts
+++ b/packages/netsuite-adapter/test/types.test.ts
@@ -24,7 +24,7 @@ import { getMetadataTypes, getTopLevelCustomTypes } from '../src/types'
 const { awu } = collections.asynciterable
 
 describe('Types', () => {
-  const { customTypes, fieldTypes, fileCabinetTypes } = getMetadataTypes()
+  const { customTypes, fieldTypes, additionalTypes } = getMetadataTypes()
   describe('CustomTypes', () => {
     it('should have a required SCRIPT_ID field with regex restriction for all custom types', () => {
       getTopLevelCustomTypes(customTypes)
@@ -54,10 +54,10 @@ describe('Types', () => {
     })
   })
 
-  describe('FileCabinetTypes', () => {
+  describe('Additional Types', () => {
     describe('file type definition', () => {
       it('should have single fileContent field', () => {
-        expect(Object.values(fileCabinetTypes.file.fields)
+        expect(Object.values(additionalTypes.file.fields)
           .find(async f => {
             const fType = await f.getType()
             return isPrimitiveType(fType) && fType.isEqual(fieldTypes.fileContent)
@@ -66,15 +66,15 @@ describe('Types', () => {
       })
 
       it('should have service_id path field', async () => {
-        expect(Object.keys(fileCabinetTypes.file.fields)).toContain(PATH)
-        const pathFieldType = await fileCabinetTypes.file.fields[PATH].getType()
+        expect(Object.keys(additionalTypes.file.fields)).toContain(PATH)
+        const pathFieldType = await additionalTypes.file.fields[PATH].getType()
         expect(isPrimitiveType(pathFieldType) && isServiceId(pathFieldType))
           .toBe(true)
       })
 
       it('should have correct path regex restriction', () => {
-        expect(Object.keys(fileCabinetTypes.file.fields)).toContain(PATH)
-        const pathField = fileCabinetTypes.file.fields[PATH]
+        expect(Object.keys(additionalTypes.file.fields)).toContain(PATH)
+        const pathField = additionalTypes.file.fields[PATH]
         const { regex } = getRestriction(pathField)
         expect(values.isDefined(regex)).toBe(true)
         const regExpObj = new RegExp(regex as string)
@@ -89,15 +89,15 @@ describe('Types', () => {
 
     describe('folder type definition', () => {
       it('should have service_id path field', async () => {
-        expect(Object.keys(fileCabinetTypes.folder.fields)).toContain(PATH)
-        const pathFieldType = await fileCabinetTypes.folder.fields[PATH].getType()
+        expect(Object.keys(additionalTypes.folder.fields)).toContain(PATH)
+        const pathFieldType = await additionalTypes.folder.fields[PATH].getType()
         expect(isPrimitiveType(pathFieldType) && isServiceId(pathFieldType))
           .toBe(true)
       })
 
       it('should have correct path regex restriction', () => {
-        expect(Object.keys(fileCabinetTypes.folder.fields)).toContain(PATH)
-        const pathField = fileCabinetTypes.folder.fields[PATH]
+        expect(Object.keys(additionalTypes.folder.fields)).toContain(PATH)
+        const pathField = additionalTypes.folder.fields[PATH]
         const { regex } = getRestriction(pathField)
         expect(values.isDefined(regex)).toBe(true)
         const regExpObj = new RegExp(regex as string)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1807,10 +1807,10 @@
     napi-macros "^2.0.0"
     node-gyp-build "^4.3.0"
 
-"@salto-io/suitecloud-cli@1.3.2-salto-1":
-  version "1.3.2-salto-1"
-  resolved "https://registry.yarnpkg.com/@salto-io/suitecloud-cli/-/suitecloud-cli-1.3.2-salto-1.tgz#7420945c99d02d2e9896a5adedeffdfa51051912"
-  integrity sha512-4SJURCxzem5Vvm6huLH486Xh5InR7+xqgo9VfDbmabVIAQTRXK9PqX8hdI2B37N9A4YZCzojVprf1xGLRh6+Lg==
+"@salto-io/suitecloud-cli@1.3.2-salto-2":
+  version "1.3.2-salto-2"
+  resolved "https://registry.yarnpkg.com/@salto-io/suitecloud-cli/-/suitecloud-cli-1.3.2-salto-2.tgz#0b00fdfe1ff1d14a209fb3df91ada81903738be4"
+  integrity sha512-kgqGv9/pwqTV27AlRG8JWhHKJyfv9nFIYcASpCYu10AsV5xvrn+8s0EfCoyqglnWqjToqgGSL0tF5AvrnyBhPQ==
   dependencies:
     "@salto-io/logging" "<0.4.0"
     chalk "4.1.1"


### PR DESCRIPTION
Import features config type using SDF

---

_Additional context for reviewer_
This PR is rebased on https://github.com/salto-io/salto/pull/2882
Please review this one starting this commit - [SALTO-1387 import features](https://github.com/salto-io/salto/pull/2887/commits/47d6f7eeffff0008e6ef6e176ed8073b6d952c1a)

---
_Release Notes_: 
NetSuite Adapter:
- Support `companyFeatures` config type using SDF

---
_User Notifications_: 
Netsuite - new features config type will be added to the workspace

Type example: `netsuite/Types/companyFeatures.nacl`
```
settings netsuite.companyFeatures {
  boolean DEPARTMENTS {
    label = "Departments"
  }
  boolean LOCATIONS {
    label = "Locations"
  }
  boolean CLASSES {
    label = "Classes"
  }
  boolean JOBS {
    label = "Projects"
  }
}
```

Instance example: `netsuite/Settings/companyFeatures.nacl`
```
netsuite.companyFeatures {
  DEPARTMENTS = true
  LOCATIONS = true
  CLASSES = true
  JOBS = true
}
```
