### PR TITLE
SALTO-2159 - Remove the different config restriction from FetchFromWorkspace

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -815,7 +815,7 @@ export const fetchChangesFromWorkspace = async (
 
   const differentConfig = await getDifferentConfigs()
   if (!_.isEmpty(differentConfig)) {
-    return createEmptyFetchChangeDueToError(`Can not fetch from a workspace. Found different configs for ${
+    log.warn(`Found different configs for ${
       differentConfig.map(config => config.elemID.adapter).join(', ')
     }`)
   }

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -23,9 +23,7 @@ import {
   isSaltoElementError, ProgressReporter, ReadOnlyElementsSource, TypeMap, isServiceId,
   CORE_ANNOTATIONS, AdapterOperationsContext, FetchResult, isAdditionChange,
 } from '@salto-io/adapter-api'
-import {
-  applyInstancesDefaults, resolvePath, flattenElementStr, buildElementsSourceFromElements,
-} from '@salto-io/adapter-utils'
+import { applyInstancesDefaults, resolvePath, flattenElementStr, buildElementsSourceFromElements, safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { merger, elementSource, expressions, Workspace, pathIndex, updateElementsWithAlternativeAccount, createAdapterReplacedID, remoteMap } from '@salto-io/workspace'
 import { collections, promises, types, values } from '@salto-io/lowerdash'
@@ -815,9 +813,14 @@ export const fetchChangesFromWorkspace = async (
 
   const differentConfig = await getDifferentConfigs()
   if (!_.isEmpty(differentConfig)) {
-    log.warn(`Found different configs for ${
-      differentConfig.map(config => config.elemID.adapter).join(', ')
-    }`)
+    const configsByAdapter = _.groupBy(
+      [...differentConfig, ...currentConfigs],
+      config => config.elemID.adapter,
+    )
+    Object.entries(configsByAdapter).forEach(([adapter, configs]) => {
+      log.warn(`Found different configs for ${adapter} - 
+      ${configs.map(config => safeJsonStringify(config.value, undefined, 2)).join('\n')}`)
+    })
   }
   if (!fromState
     && (await otherWorkspace.errors()).hasErrors('Error')) {

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -20,7 +20,6 @@ import {
   PrimitiveType, PrimitiveTypes, OBJECT_SERVICE_ID, InstanceElement, CORE_ANNOTATIONS,
   ListType, FieldDefinition, FIELD_NAME, INSTANCE_NAME, OBJECT_NAME, ReferenceExpression,
   ReadOnlyElementsSource,
-  TypeReference,
   createRefToElmWithValue,
 } from '@salto-io/adapter-api'
 import * as utils from '@salto-io/adapter-utils'
@@ -1443,51 +1442,6 @@ describe('fetch from workspace', () => {
       expect(fetchRes.unmergedElements).toHaveLength(0)
       expect(fetchRes.errors).toHaveLength(1)
       expect(fetchRes.errors[0].message).toBe('Can not fetch from a workspace with errors.')
-      expect(fetchRes.errors[0].severity).toBe('Error')
-    })
-
-    it('should fail if there is a mismatch in the adapter configs', async () => {
-      const currentServiceConfigs = [
-        new InstanceElement(
-          'salto_config',
-          new TypeReference(ElemID.fromFullName('salto_config')),
-          {
-            key: 'value',
-          }
-        ),
-        new InstanceElement(
-          'salto_config2',
-          new TypeReference(ElemID.fromFullName('salto_config2')),
-          {
-            key: 'value2',
-          }
-        ),
-      ]
-
-      const sourceServiceConfigs = {
-        salto_config: currentServiceConfigs[0].clone(),
-        salto_config2: currentServiceConfigs[1].clone(),
-      }
-      sourceServiceConfigs.salto_config2.value.key = 'otherValue'
-      const sourceWS = mockWorkspace({
-        accountConfigs: sourceServiceConfigs,
-      })
-
-      const fetchRes = await fetchChangesFromWorkspace(
-        sourceWS,
-        ['salto'],
-        createInMemoryElementSource([]),
-        createInMemoryElementSource([]),
-        currentServiceConfigs,
-        'default',
-        false,
-      )
-
-      expect([...fetchRes.changes]).toHaveLength(0)
-      expect(fetchRes.elements).toHaveLength(0)
-      expect(fetchRes.unmergedElements).toHaveLength(0)
-      expect(fetchRes.errors).toHaveLength(1)
-      expect(fetchRes.errors[0].message).toBe('Can not fetch from a workspace. Found different configs for salto_config2')
       expect(fetchRes.errors[0].severity).toBe('Error')
     })
   })


### PR DESCRIPTION

---
_Release Notes_: 
*Core*:
* Removed a restriction from FetchFromWorkspace that failed if the adapter configs were different

---
_User Notifications_: 
None 
