### PR TITLE
SALTO-2162: remove organizations from the default type list

### DIFF
--- a/packages/zendesk-support-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/e2e_test/adapter.test.ts
@@ -22,7 +22,7 @@ import { naclCase } from '@salto-io/adapter-utils'
 import { config as configUtils } from '@salto-io/adapter-components'
 import { values, collections } from '@salto-io/lowerdash'
 import { CredsLease } from '@salto-io/e2e-credentials-store'
-import { DEFAULT_CONFIG, API_DEFINITIONS_CONFIG } from '../src/config'
+import { DEFAULT_CONFIG, API_DEFINITIONS_CONFIG, FETCH_CONFIG } from '../src/config'
 import { ZENDESK_SUPPORT } from '../src/constants'
 import { Credentials } from '../src/auth'
 import { getChangeGroupIds } from '../src/group_change'
@@ -75,6 +75,7 @@ describe('Zendesk support adapter E2E', () => {
     const testOptionValue = uuidv4().slice(0, 8)
     let elements: Element[] = []
     const createName = (type: string): string => `Test${type}${testSuffix}`
+    const additionalTypesToFetch = ['organizations']
 
     const automationInstance = createInstanceElement(
       'automation',
@@ -216,7 +217,19 @@ describe('Zendesk support adapter E2E', () => {
 
     beforeAll(async () => {
       credLease = await credsLease()
-      adapterAttr = realAdapter({ credentials: credLease.value })
+      adapterAttr = realAdapter(
+        { credentials: credLease.value },
+        {
+          ...DEFAULT_CONFIG,
+          [FETCH_CONFIG]: {
+            ...DEFAULT_CONFIG[FETCH_CONFIG],
+            includeTypes: [
+              ...DEFAULT_CONFIG[FETCH_CONFIG].includeTypes,
+              ...additionalTypesToFetch,
+            ],
+          },
+        }
+      )
       const instancesToAdd = [
         ticketFieldInstance,
         ticketFieldOption1,
@@ -281,8 +294,8 @@ describe('Zendesk support adapter E2E', () => {
         'macro',
         'oauth_client',
         'oauth_global_client',
-        'organization_field',
         'organization',
+        'organization_field',
         'resource_collection',
         'routing_attribute',
         'sharing_agreement',

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -1511,7 +1511,6 @@ export const DEFAULT_INCLUDE_ENDPOINTS: string[] = [
   'oauth_clients',
   'oauth_global_clients',
   'organization_fields',
-  'organizations',
   'resource_collections',
   'routing_attribute_definitions',
   'routing_attributes',

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -63,6 +63,7 @@ describe('adapter', () => {
 
   describe('fetch', () => {
     describe('full fetch', () => {
+      const additionalTypesToFetch = ['organizations']
       it('should generate the right elements on fetch', async () => {
         const { elements } = await adapter.operations({
           credentials: new InstanceElement(
@@ -75,7 +76,7 @@ describe('adapter', () => {
             configType,
             {
               [FETCH_CONFIG]: {
-                includeTypes: DEFAULT_INCLUDE_ENDPOINTS.sort(),
+                includeTypes: [...DEFAULT_INCLUDE_ENDPOINTS, ...additionalTypesToFetch].sort(),
               },
             }
           ),


### PR DESCRIPTION
_Remove organizations from the default type list_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Zendesk_support adapter_
* Remove organizations from the default include type list

---
_User Notifications_: 
_None_
