### PR TITLE
SALTO-2161: change setNaclFiles to receive array

### DIFF
--- a/packages/lang-server/src/workspace.ts
+++ b/packages/lang-server/src/workspace.ts
@@ -326,12 +326,12 @@ export class EditorWorkspace {
     }
   }
 
-  setNaclFiles(...naclFiles: nacl.NaclFile[]): Promise<void> {
+  setNaclFiles(naclFiles: nacl.NaclFile[]): Promise<void> {
     this.addPendingNaclFiles(naclFiles.map(file => this.workspaceNaclFile(file)))
     return this.triggerAggregatedSetOperation()
   }
 
-  removeNaclFiles(...names: string[]): Promise<void> {
+  removeNaclFiles(names: string[]): Promise<void> {
     this.addPendingDeletes(names.map(name => this.workspaceFilename(name)))
     return this.triggerAggregatedSetOperation()
   }

--- a/packages/lang-server/test/workspace.test.ts
+++ b/packages/lang-server/test/workspace.test.ts
@@ -51,7 +51,7 @@ describe('workspace', () => {
     const workspace = new EditorWorkspace(workspaceBaseDir, baseWs)
     const filename = 'new'
     const buffer = 'test'
-    await workspace.setNaclFiles({ filename, buffer })
+    await workspace.setNaclFiles([{ filename, buffer }])
     await workspace.awaitAllUpdates()
     expect((await workspace.getNaclFile(filename))?.buffer).toEqual(buffer)
   })
@@ -60,7 +60,7 @@ describe('workspace', () => {
     const baseWs = await mockWorkspace([naclFileName])
     const workspace = new EditorWorkspace(workspaceBaseDir, baseWs)
     baseWs.hasErrors = jest.fn().mockResolvedValue(true)
-    await workspace.setNaclFiles({ filename: 'error', buffer: 'error content' })
+    await workspace.setNaclFiles([{ filename: 'error', buffer: 'error content' }])
     await workspace.awaitAllUpdates()
     expect(await workspace.elements).toBeDefined()
     expect(await workspace.hasErrors()).toBeTruthy()
@@ -70,7 +70,7 @@ describe('workspace', () => {
   it('should support file removal', async () => {
     const baseWs = await mockWorkspace([naclFileName])
     const workspace = new EditorWorkspace(workspaceBaseDir, baseWs)
-    await workspace.removeNaclFiles(naclFileName)
+    await workspace.removeNaclFiles([naclFileName])
     await workspace.awaitAllUpdates()
     expect(await workspace.getNaclFile(naclFileName)).toEqual(undefined)
   })
@@ -89,7 +89,7 @@ describe('workspace', () => {
           _parent = vs.type.instance.referenced
       }
       `
-      await workspace.setNaclFiles({ filename: validation1FileName, buffer })
+      await workspace.setNaclFiles([{ filename: validation1FileName, buffer }])
       await workspace.awaitAllUpdates()
       expect((await workspace.errors()).validation).toHaveLength(0)
     })
@@ -107,7 +107,7 @@ describe('workspace', () => {
       vs.type oldReferenced {
       }
       `
-      await workspace.setNaclFiles({ filename: validation2FileName, buffer })
+      await workspace.setNaclFiles([{ filename: validation2FileName, buffer }])
       await workspace.awaitAllUpdates()
       const newValidationErrors = (await workspace.errors()).validation
       expect(newValidationErrors).toHaveLength(3)
@@ -134,7 +134,7 @@ describe('workspace', () => {
       }
     
       `
-      await workspace.setNaclFiles({ filename: validation2FileName, buffer })
+      await workspace.setNaclFiles([{ filename: validation2FileName, buffer }])
       await workspace.awaitAllUpdates()
       const newValidationErrors = (await workspace.errors()).validation
       expect(newValidationErrors).toHaveLength(2)
@@ -153,7 +153,7 @@ describe('workspace', () => {
       vs.type oldReferenced {
       }
       `
-      await workspace.setNaclFiles({ filename: validation2FileName, buffer })
+      await workspace.setNaclFiles([{ filename: validation2FileName, buffer }])
       await workspace.awaitAllUpdates()
       const newValidationErrors = (await workspace.errors()).validation
       expect(newValidationErrors).toHaveLength(3)
@@ -175,7 +175,7 @@ describe('workspace', () => {
       vs.type referenced {
       }
       `
-      await workspace.setNaclFiles({ filename: validation2FileName, buffer })
+      await workspace.setNaclFiles([{ filename: validation2FileName, buffer }])
       await workspace.awaitAllUpdates()
       const firstUpdateValidationErrors = (await workspace.errors()).validation
       expect(firstUpdateValidationErrors).toHaveLength(2)
@@ -187,7 +187,7 @@ describe('workspace', () => {
         field = "4"
       }
       `
-      await workspace.setNaclFiles({ filename: validation2FileName, buffer: newBuffer })
+      await workspace.setNaclFiles([{ filename: validation2FileName, buffer: newBuffer }])
       await workspace.awaitAllUpdates()
       const newValidationErrors = (await workspace.errors()).validation
       expect(newValidationErrors).toHaveLength(3)
@@ -208,7 +208,7 @@ describe('workspace', () => {
         string field {}
       }
       `
-      await workspace.setNaclFiles({ filename: validation3FileName, buffer })
+      await workspace.setNaclFiles([{ filename: validation3FileName, buffer }])
       await workspace.awaitAllUpdates()
     })
     it('should validate specific files correctly', async () => {
@@ -228,7 +228,7 @@ describe('workspace', () => {
           boolean field {}
         }
       `
-      await newWorkspace.setNaclFiles({ filename: validation1FileName, buffer })
+      await newWorkspace.setNaclFiles([{ filename: validation1FileName, buffer }])
       await newWorkspace.awaitAllUpdates()
       const newErrors = await newWorkspace.validateFiles([validation2FileName])
       expect(newErrors.validation).toHaveLength(2)
@@ -249,7 +249,7 @@ describe('workspace', () => {
       const errors = await newWorkspace.errors()
       expect(errors.validation).toHaveLength(0)
       const buffer = ''
-      await newWorkspace.setNaclFiles({ filename: splitted2FileName, buffer })
+      await newWorkspace.setNaclFiles([{ filename: splitted2FileName, buffer }])
       await newWorkspace.awaitAllUpdates()
       const newErrors = await newWorkspace.errors()
       expect(newErrors.validation).toHaveLength(1)

--- a/packages/vscode/src/events.ts
+++ b/packages/vscode/src/events.ts
@@ -51,7 +51,7 @@ export const onTextChangeEvent = (
     const naclFile = { filename: event.document.fileName, buffer: event.document.getText() }
     // We really do *not* want to await on this.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    workspace.setNaclFiles(naclFile)
+    workspace.setNaclFiles([naclFile])
   }
 }
 

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -98,7 +98,7 @@ export type MultiEnvSource = {
   getNaclFile: (filename: string) => Promise<NaclFile | undefined>
   getElementNaclFiles: (env: string, id: ElemID) => Promise<string[]>
   getElementReferencedFiles: (env: string, id: ElemID) => Promise<string[]>
-  setNaclFiles: (...naclFiles: NaclFile[]) => Promise<EnvsChanges>
+  setNaclFiles: (naclFiles: NaclFile[]) => Promise<EnvsChanges>
   removeNaclFiles: (...names: string[]) => Promise<EnvsChanges>
   getSourceMap: (filename: string) => Promise<SourceMap>
   getSourceRanges: (env: string, elemID: ElemID) => Promise<SourceRange[]>
@@ -608,7 +608,7 @@ const buildMultiEnvSource = (
     getTotalSize: async (): Promise<number> => (
       _.sum(await Promise.all(Object.values(sources).map(s => s.getTotalSize())))
     ),
-    setNaclFiles: async (...naclFiles: NaclFile[]): Promise<EnvsChanges> => {
+    setNaclFiles: async (naclFiles: NaclFile[]): Promise<EnvsChanges> => {
       const envNameToNaclFiles = _.groupBy(
         naclFiles, naclFile => getSourceNameForNaclFile(naclFile.filename)
       )
@@ -620,7 +620,7 @@ const buildMultiEnvSource = (
               filename: getRelativePath(naclFile.filename, envName),
             }))
           return getSourceFromEnvName(envName)
-            .setNaclFiles(...naclFilesWithRelativePath)
+            .setNaclFiles(naclFilesWithRelativePath)
         })
       const buildRes = await buildMultiEnvState({ envChanges: envNameToChanges })
       state = buildRes.state

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -99,7 +99,7 @@ export type MultiEnvSource = {
   getElementNaclFiles: (env: string, id: ElemID) => Promise<string[]>
   getElementReferencedFiles: (env: string, id: ElemID) => Promise<string[]>
   setNaclFiles: (naclFiles: NaclFile[]) => Promise<EnvsChanges>
-  removeNaclFiles: (...names: string[]) => Promise<EnvsChanges>
+  removeNaclFiles: (names: string[]) => Promise<EnvsChanges>
   getSourceMap: (filename: string) => Promise<SourceMap>
   getSourceRanges: (env: string, elemID: ElemID) => Promise<SourceRange[]>
   getErrors: (env: string) => Promise<Errors>
@@ -626,11 +626,11 @@ const buildMultiEnvSource = (
       state = buildRes.state
       return buildRes.changes
     },
-    removeNaclFiles: async (...names: string[]): Promise<EnvsChanges> => {
+    removeNaclFiles: async (names: string[]): Promise<EnvsChanges> => {
       const envNameToFilesToRemove = _.groupBy(names, getSourceNameForNaclFile)
       const envNameToChanges = await mapValuesAsync(envNameToFilesToRemove, (files, envName) =>
         getSourceFromEnvName(envName)
-          .removeNaclFiles(...files.map(fileName => getRelativePath(fileName, envName))))
+          .removeNaclFiles(files.map(fileName => getRelativePath(fileName, envName))))
       const buildRes = await buildMultiEnvState({ envChanges: envNameToChanges })
       state = buildRes.state
       return buildRes.changes

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -563,8 +563,6 @@ const buildNaclFilesSource = (
         currentState.parsedNaclFiles,
         functions
       )
-      // eslint-disable-next-line no-console
-      console.log('IN THIS THING: %d', parsedModifiedFiles.length)
       const result = await buildNaclFilesState({
         newNaclFiles: parsedModifiedFiles,
         currentState,
@@ -784,8 +782,6 @@ const buildNaclFilesSource = (
     )).filter(values.isDefined)
 
     if (updatedNaclFiles.length > 0) {
-      // eslint-disable-next-line no-console
-      console.log('going to update %d NaCl files', updatedNaclFiles.length)
       log.debug('going to update %d NaCl files', updatedNaclFiles.length)
       // The map is to avoid saving unnecessary fields in the nacl files
       await setNaclFiles(

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -74,7 +74,7 @@ export type NaclFilesSource<Changes=ChangeSet<Change>> = Omit<ElementsSource, 'c
   getElementNaclFiles: (id: ElemID) => Promise<string[]>
   getElementReferencedFiles: (id: ElemID) => Promise<string[]>
   // TODO: this should be for single?
-  setNaclFiles: (...naclFiles: NaclFile[]) => Promise<Changes>
+  setNaclFiles: (naclFiles: NaclFile[]) => Promise<Changes>
   removeNaclFiles: (...names: string[]) => Promise<Changes>
   getSourceMap: (filename: string) => Promise<SourceMap>
   getSourceRanges: (elemID: ElemID) => Promise<SourceRange[]>
@@ -687,7 +687,7 @@ const buildNaclFilesSource = (
   }
 
   const setNaclFiles = async (
-    ...naclFiles: NaclFile[]
+    naclFiles: NaclFile[]
   ): Promise<void> => {
     const [emptyNaclFiles, nonEmptyNaclFiles] = _.partition(
       naclFiles,
@@ -786,7 +786,7 @@ const buildNaclFilesSource = (
       log.debug('going to update %d NaCl files', updatedNaclFiles.length)
       // The map is to avoid saving unnecessary fields in the nacl files
       await setNaclFiles(
-        ...updatedNaclFiles.map(file => _.pick(file, ['buffer', 'filename']))
+        updatedNaclFiles.map(file => _.pick(file, ['buffer', 'filename']))
       )
       const res = await buildNaclFilesStateInner(updatedNaclFiles)
       state = Promise.resolve(res.state)
@@ -947,8 +947,8 @@ const buildNaclFilesSource = (
       state,
     ),
     updateNaclFiles,
-    setNaclFiles: async (...naclFiles) => {
-      await setNaclFiles(...naclFiles)
+    setNaclFiles: async naclFiles => {
+      await setNaclFiles(naclFiles)
       const res = await buildNaclFilesStateInner(
         await parseNaclFiles(naclFiles, (await getState()).parsedNaclFiles, functions)
       )

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -75,7 +75,7 @@ export type NaclFilesSource<Changes=ChangeSet<Change>> = Omit<ElementsSource, 'c
   getElementReferencedFiles: (id: ElemID) => Promise<string[]>
   // TODO: this should be for single?
   setNaclFiles: (naclFiles: NaclFile[]) => Promise<Changes>
-  removeNaclFiles: (...names: string[]) => Promise<Changes>
+  removeNaclFiles: (names: string[]) => Promise<Changes>
   getSourceMap: (filename: string) => Promise<SourceMap>
   getSourceRanges: (elemID: ElemID) => Promise<SourceRange[]>
   getErrors: () => Promise<Errors>
@@ -394,7 +394,6 @@ const buildNaclFilesState = async ({
         oldNaclFileElements.map(e => e.elemID.getFullName()),
         currentNaclFileElements.map(e => e.elemID.getFullName()),
       )
-
       relevantElementIDs.push(
         ...currentNaclFileElements.map(e => e.elemID),
         ...oldNaclFileElements.map(e => e.elemID),
@@ -564,6 +563,8 @@ const buildNaclFilesSource = (
         currentState.parsedNaclFiles,
         functions
       )
+      // eslint-disable-next-line no-console
+      console.log('IN THIS THING: %d', parsedModifiedFiles.length)
       const result = await buildNaclFilesState({
         newNaclFiles: parsedModifiedFiles,
         currentState,
@@ -783,6 +784,8 @@ const buildNaclFilesSource = (
     )).filter(values.isDefined)
 
     if (updatedNaclFiles.length > 0) {
+      // eslint-disable-next-line no-console
+      console.log('going to update %d NaCl files', updatedNaclFiles.length)
       log.debug('going to update %d NaCl files', updatedNaclFiles.length)
       // The map is to avoid saving unnecessary fields in the nacl files
       await setNaclFiles(
@@ -864,7 +867,7 @@ const buildNaclFilesSource = (
       return _.flatten(sourceRanges)
     },
 
-    removeNaclFiles: async (...names: string[]) => {
+    removeNaclFiles: async (names: string[]) => {
       const preChangeHash = await (await getState()).parsedNaclFiles.getHash()
       await awu(names).forEach(name => naclFilesStore.delete(name))
       const res = await buildNaclFilesStateInner(

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -40,7 +40,7 @@ import { RemoteMap, RemoteMapCreator } from '../remote_map'
 import { ParsedNaclFile } from './parsed_nacl_file'
 import { ParsedNaclFileCache, createParseResultCache } from './parsed_nacl_files_cache'
 
-const { awu, concatAsync } = collections.asynciterable
+const { awu } = collections.asynciterable
 type ThenableIterable<T> = collections.asynciterable.ThenableIterable<T>
 const { withLimitedConcurrency } = promises.array
 
@@ -459,7 +459,7 @@ const buildNaclFilesState = async ({
           ))
     }).filter(values.isDefined) as AsyncIterable<Element>
   const changes = await buildNewMergedElementsAndErrors({
-    afterElements: awu(concatAsync(...newElementsToMerge, awu(unmodifiedFragments))),
+    afterElements: awu(newElementsToMerge).flat().concat(unmodifiedFragments),
     relevantElementIDs: awu(relevantElementIDs),
     currentElements: currentState.mergedElements,
     currentErrors: currentState.mergeErrors,

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -734,7 +734,7 @@ export const loadWorkspace = async (
   }
 
   const removeNaclFiles = async (names: string[], validate = true): Promise<EnvsChanges> => {
-    const elementChanges = await (await getLoadedNaclFilesSource()).removeNaclFiles(...names)
+    const elementChanges = await (await getLoadedNaclFilesSource()).removeNaclFiles(names)
     workspaceState = buildWorkspaceState({ workspaceChanges: elementChanges, validate })
     return elementChanges
   }

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -721,11 +721,11 @@ export const loadWorkspace = async (
     )
 
     if (configFiles.length !== 0) {
-      await adaptersConfig.setNaclFiles(...configFiles)
+      await adaptersConfig.setNaclFiles(configFiles)
     }
 
     if (otherFiles.length !== 0) {
-      const elementChanges = await (await getLoadedNaclFilesSource()).setNaclFiles(...otherFiles)
+      const elementChanges = await (await getLoadedNaclFilesSource()).setNaclFiles(otherFiles)
       workspaceState = buildWorkspaceState({ workspaceChanges: elementChanges, validate })
       return elementChanges
     }

--- a/packages/workspace/test/workspace/adapters_config.test.ts
+++ b/packages/workspace/test/workspace/adapters_config.test.ts
@@ -252,7 +252,7 @@ describe('adapters config', () => {
     it('setNaclFile should recalculate errors', async () => {
       jest.spyOn(validator, 'validateElements').mockResolvedValue([new validator.InvalidValueValidationError({ elemID: new ElemID('someID'), value: 'val', fieldName: 'field', expectedValue: 'expVal' })])
 
-      await configSource.setNaclFiles(...[])
+      await configSource.setNaclFiles([])
       expect(validationErrorsMap.setAll).toHaveBeenCalled()
     })
 

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -731,12 +731,12 @@ describe('multi env source', () => {
   })
   describe('removeNaclFiles', () => {
     it('should forward the removeNaclFiles command to the active source', async () => {
-      await source.removeNaclFiles(path.join(ENVS_PREFIX, activePrefix, 'env.nacl'))
+      await source.removeNaclFiles([path.join(ENVS_PREFIX, activePrefix, 'env.nacl')])
       expect(envSource.removeNaclFiles).toHaveBeenCalled()
     })
 
     it('should forward the removeNaclFiles command to the common source', async () => {
-      await source.removeNaclFiles(path.join(commonPrefix, 'common.nacl'))
+      await source.removeNaclFiles([path.join(commonPrefix, 'common.nacl')])
       expect(envSource.removeNaclFiles).toHaveBeenCalled()
     })
 
@@ -764,7 +764,7 @@ describe('multi env source', () => {
       ).toArray()
       expect(currentElements).toHaveLength(2)
       const elementChanges = (await multiEnvSourceWithMockSources
-        .removeNaclFiles('test.nacl'))
+        .removeNaclFiles(['test.nacl']))
       expect(elementChanges[primarySourceName].changes).toEqual([change])
       expect(await awu(
         await multiEnvSourceWithMockSources.getAll(primarySourceName)
@@ -797,7 +797,7 @@ describe('multi env source', () => {
       ).toArray()
       expect(currentElements).toHaveLength(2)
       const elementChanges = (await multiEnvSourceWithMockSources.removeNaclFiles(
-        'test.nacl', path.join(ENVS_PREFIX, primarySourceName, 'env.nacl')
+        ['test.nacl', path.join(ENVS_PREFIX, primarySourceName, 'env.nacl')]
       ))
       expect(elementChanges[primarySourceName].changes).toEqual([removalPrimary, removalCommon])
       expect(await awu(

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -528,7 +528,7 @@ describe('multi env source', () => {
         filename: path.join(ENVS_PREFIX, activePrefix, 'env.nacl'),
         buffer: '',
       }
-      await source.setNaclFiles(naclFile)
+      await source.setNaclFiles([naclFile])
       expect(envSource.setNaclFiles).toHaveBeenCalled()
     })
 
@@ -537,7 +537,7 @@ describe('multi env source', () => {
         filename: path.join(commonPrefix, 'common.nacl'),
         buffer: '',
       }
-      await source.setNaclFiles(naclFile)
+      await source.setNaclFiles([naclFile])
       expect(commonSource.setNaclFiles).toHaveBeenCalled()
     })
 
@@ -572,7 +572,7 @@ describe('multi env source', () => {
       ).toArray()
       expect(currentElements).toHaveLength(2)
       const elementChanges = (await multiEnvSourceWithMockSources.setNaclFiles(
-        { filename: path.join(ENVS_PREFIX, inactiveSourceName, 'env.nacl'), buffer: 'test' }
+        [{ filename: path.join(ENVS_PREFIX, inactiveSourceName, 'env.nacl'), buffer: 'test' }]
       ))
       expect(elementChanges).not.toHaveProperty(primarySourceName)
       const elements = await awu(
@@ -604,7 +604,7 @@ describe('multi env source', () => {
       ).toArray()
       expect(currentElements).toHaveLength(2)
       const elementChanges = (await multiEnvSourceWithMockSources.setNaclFiles(
-        { filename: 'test', buffer: 'test' }
+        [{ filename: 'test', buffer: 'test' }]
       ))[primarySourceName].changes
       expect(elementChanges).toEqual([change])
       const mergedSaltoObject = new ObjectType({
@@ -638,7 +638,7 @@ describe('multi env source', () => {
       ).toArray()
       expect(currentElements).toHaveLength(2)
       const elementChanges = (await multiEnvSourceWithMockSources.setNaclFiles(
-        { filename: path.join(ENVS_PREFIX, primarySourceName, 'env.nacl'), buffer: 'test' }
+        [{ filename: path.join(ENVS_PREFIX, primarySourceName, 'env.nacl'), buffer: 'test' }]
       ))
       expect(elementChanges[primarySourceName].changes).toEqual([change])
       const mergedSaltoObject = new ObjectType({
@@ -683,7 +683,7 @@ describe('multi env source', () => {
       ).toArray()
       expect(currentElements).toHaveLength(2)
       const elementChanges = (await multiEnvSourceWithMockSources.setNaclFiles(
-        { filename: path.join(ENVS_PREFIX, primarySourceName, 'env.nacl'), buffer: 'test' }
+        [{ filename: path.join(ENVS_PREFIX, primarySourceName, 'env.nacl'), buffer: 'test' }]
       ))
       expect(elementChanges[primarySourceName].changes).toEqual([change])
       const mergedSaltoObject = new ObjectType({
@@ -719,10 +719,10 @@ describe('multi env source', () => {
         await multiEnvSourceWithMockSources.getAll(primarySourceName)
       ).toArray()
       expect(currentElements).toHaveLength(2)
-      const elementChanges = (await multiEnvSourceWithMockSources.setNaclFiles(
+      const elementChanges = (await multiEnvSourceWithMockSources.setNaclFiles([
         { filename: path.join(ENVS_PREFIX, primarySourceName, 'env.nacl'), buffer: 'test' },
         { filename: 'test', buffer: 'test' },
-      ))
+      ]))
       expect(elementChanges[primarySourceName].changes).toEqual([])
       expect(sortElemArray(await awu(
         await multiEnvSourceWithMockSources.getAll(primarySourceName)

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
@@ -413,13 +413,13 @@ describe('Nacl Files Source', () => {
     })
     describe('removeNaclFiles', () => {
       it('should not change anything if the file does not exist', async () => {
-        expect((await naclFileSourceTest.removeNaclFiles('blabla')).changes).toHaveLength(0)
+        expect((await naclFileSourceTest.removeNaclFiles(['blabla'])).changes).toHaveLength(0)
         expect(await awu(await naclFileSourceTest.getAll()).toArray()).toMatchObject([
           objectTypeObjectMatcher, instanceElementObjectMatcher,
         ])
       })
       it('should remove one file correctly', async () => {
-        const { changes } = (await naclFileSourceTest.removeNaclFiles('file2.nacl'))
+        const { changes } = (await naclFileSourceTest.removeNaclFiles(['file2.nacl']))
         expect(changes).toHaveLength(2)
         expect((changes[0] as unknown as ModificationChange<ObjectType>).data.after.fields.b)
           .toBeUndefined()
@@ -448,7 +448,7 @@ describe('Nacl Files Source', () => {
       })
       it('should remove multiple files correctly', async () => {
         const { changes } = await naclFileSourceTest
-          .removeNaclFiles('file1.nacl', 'file2.nacl')
+          .removeNaclFiles(['file1.nacl', 'file2.nacl'])
         expect(changes).toMatchObject([
           {
             action: 'remove',

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
@@ -131,7 +131,7 @@ describe('Nacl Files Source', () => {
             }
           `,
         }
-        const res = (await naclFileSourceTest.setNaclFiles(newFile)).changes
+        const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
         expect(res).toHaveLength(1)
         const change = res[0] as unknown as ModificationChange<InstanceElement>
         expect(change).toMatchObject({
@@ -158,7 +158,7 @@ describe('Nacl Files Source', () => {
             }
           `,
         }
-        const res = (await naclFileSourceTest.setNaclFiles(newFile)).changes
+        const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
         expect(res).toHaveLength(1)
         expect(res[0] as unknown as RemovalChange<InstanceElement>).toMatchObject({
           action: 'remove',
@@ -181,7 +181,7 @@ describe('Nacl Files Source', () => {
             }
           `,
         }
-        const res = (await naclFileSourceTest.setNaclFiles(newFile)).changes
+        const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
         expect(res).toHaveLength(1)
         expect(res[0] as unknown as AdditionChange<InstanceElement>).toMatchObject({
           action: 'add',
@@ -206,7 +206,7 @@ describe('Nacl Files Source', () => {
             }
           `,
         }
-        const res = (await naclFileSourceTest.setNaclFiles(newFile)).changes
+        const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
         expect(res).toHaveLength(0)
         const allElements = await awu(await naclFileSourceTest.getAll()).toArray()
         expect(allElements).toHaveLength(2)
@@ -233,7 +233,7 @@ describe('Nacl Files Source', () => {
           filename: 'file2.nacl',
           buffer: ' ',
         }
-        const res = (await naclFileSourceTest.setNaclFiles(newFile1, newFile2)).changes
+        const res = (await naclFileSourceTest.setNaclFiles([newFile1, newFile2])).changes
         expect(res).toHaveLength(3)
         const newObjectTypeObjectMatcher = {
           elemID: objectTypeElemID,
@@ -267,7 +267,7 @@ describe('Nacl Files Source', () => {
             }
           `,
         }
-        const res = (await naclFileSourceTest.setNaclFiles(newFile)).changes
+        const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
         expect(res).toHaveLength(1)
         const elements = await awu(await naclFileSourceTest.getAll()).toArray()
         expect(elements).toHaveLength(2)
@@ -288,7 +288,7 @@ describe('Nacl Files Source', () => {
         }
         expect(await awu(await naclFileSourceTest.list()).map(e => e.getFullName()).toArray())
           .toEqual(['dummy.test', 'dummy.test.instance.inst'])
-        await naclFileSourceTest.setNaclFiles(newFile)
+        await naclFileSourceTest.setNaclFiles([newFile])
         expect(await awu(await naclFileSourceTest.list()).map(e => e.getFullName()).toArray())
           .toEqual(['dummy.test'])
       })
@@ -300,7 +300,7 @@ describe('Nacl Files Source', () => {
         const removedElemId = new ElemID('dummy', 'test')
         expect(await naclFileSourceTest.getElementReferencedFiles(removedElemId))
           .toEqual(['file2.nacl'])
-        await naclFileSourceTest.setNaclFiles(newFile)
+        await naclFileSourceTest.setNaclFiles([newFile])
         expect(await naclFileSourceTest.getElementReferencedFiles(removedElemId))
           .toEqual([])
       })
@@ -355,7 +355,7 @@ describe('Nacl Files Source', () => {
               `,
             }
             const currentElements = await awu(await naclFileSourceWithFragments.getAll()).toArray()
-            const res = (await naclFileSourceWithFragments.setNaclFiles(newFile)).changes
+            const res = (await naclFileSourceWithFragments.setNaclFiles([newFile])).changes
             expect(res).toHaveLength(2)
             const objType1ElemID = new ElemID('dummy', 'test1')
             const objType2ElemID = new ElemID('dummy', 'test2')

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -813,7 +813,7 @@ describe('workspace', () => {
 
     it('should call the adaptersConfigSource when the path is in the config dir', async () => {
       expect(naclFileStore.set as jest.Mock).not.toHaveBeenCalledWith(changedConfFile)
-      expect(mockAdaptersConfig.setNaclFiles as jest.Mock).toHaveBeenCalledWith(changedConfFile)
+      expect(mockAdaptersConfig.setNaclFiles as jest.Mock).toHaveBeenCalledWith([changedConfFile])
     })
 
     it('should return the correct changes', async () => {


### PR DESCRIPTION
_change setNaclFiles to receive array_

---

_Additional context for reviewer_
Fetch on one of our customers failed due to the fact that we passed 150k elements to setNaclFiles that use the spread notation. Changing the parameters to list instead of the spread notation fixes the problem. More details in the ticket

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
