### PR TITLE
SALTO-2090: Change Validator for "NOT_YET_SUPPORTED" values in NetSuite

### DIFF
--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -29,6 +29,7 @@ import customTypesInvalidValuesValidator from './change_validators/custom_types_
 import safeDeployValidator, { FetchByQueryFunc } from './change_validators/safe_deploy'
 import mappedListsIndexesValidator from './change_validators/mapped_lists_indexes'
 import { validateDependsOnInvalidElement } from './change_validators/dependencies'
+import notYetSupportedValuesValidator from './change_validators/not_yet_supported_values'
 
 
 const changeValidators: ChangeValidator[] = [
@@ -43,6 +44,7 @@ const changeValidators: ChangeValidator[] = [
   subInstancesValidator,
   customTypesInvalidValuesValidator,
   mappedListsIndexesValidator,
+  notYetSupportedValuesValidator,
 ]
 
 const nonSuiteAppValidators: ChangeValidator[] = [

--- a/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
@@ -13,7 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
 import { values, collections } from '@salto-io/lowerdash'
 import {
   ChangeError,

--- a/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
@@ -24,7 +24,7 @@ import {
 } from '@salto-io/adapter-api'
 import { isCustomType } from '../types'
 import { ACCOUNT_SPECIFIC_VALUE } from '../constants'
-import { isInstanceContainStringValue } from './utils'
+import { isInstanceContainsStringValue } from './utils'
 
 const { awu } = collections.asynciterable
 const { isDefined } = values
@@ -38,7 +38,7 @@ const changeValidator: ChangeValidator = async changes => (
       if (!isCustomType(instance.refType)) {
         return undefined
       }
-      if (!isInstanceContainStringValue(instance, ACCOUNT_SPECIFIC_VALUE)) {
+      if (!isInstanceContainsStringValue(instance, ACCOUNT_SPECIFIC_VALUE)) {
         return undefined
       }
       return {

--- a/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
@@ -19,34 +19,15 @@ import {
   ChangeError,
   ChangeValidator,
   getChangeData,
-  InstanceElement,
   isAdditionOrModificationChange,
   isInstanceChange,
 } from '@salto-io/adapter-api'
-import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { isCustomType } from '../types'
 import { ACCOUNT_SPECIFIC_VALUE } from '../constants'
+import { isInstanceContainStringValue } from './utils'
 
 const { awu } = collections.asynciterable
 const { isDefined } = values
-
-const hasAccountSpecificValue = (instance: InstanceElement): boolean => {
-  let foundAccountSpecificValue = false
-  walkOnElement({
-    element: instance,
-    func: ({ value, path }) => {
-      if (path.isAttrID()) {
-        return WALK_NEXT_STEP.SKIP
-      }
-      if (_.isString(value) && value.includes(ACCOUNT_SPECIFIC_VALUE)) {
-        foundAccountSpecificValue = true
-        return WALK_NEXT_STEP.EXIT
-      }
-      return WALK_NEXT_STEP.RECURSE
-    },
-  })
-  return foundAccountSpecificValue
-}
 
 const changeValidator: ChangeValidator = async changes => (
   awu(changes)
@@ -57,7 +38,7 @@ const changeValidator: ChangeValidator = async changes => (
       if (!isCustomType(instance.refType)) {
         return undefined
       }
-      if (!hasAccountSpecificValue(instance)) {
+      if (!isInstanceContainStringValue(instance, ACCOUNT_SPECIFIC_VALUE)) {
         return undefined
       }
       return {

--- a/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
@@ -1,0 +1,69 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
+import {
+  ChangeError,
+  ChangeValidator,
+  getChangeData,
+  InstanceElement,
+  isAdditionOrModificationChange,
+  isInstanceChange,
+} from '@salto-io/adapter-api'
+import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { isCustomType } from '../types'
+import { NOT_YET_SUPPORTED_VALUE } from '../constants'
+
+const { awu } = collections.asynciterable
+
+const isInstanceContainStringValue = (
+  instance: InstanceElement, expectedValue: string
+): boolean => {
+  let foundValue = false
+  walkOnElement({
+    element: instance,
+    func: ({ value, path }) => {
+      if (path.isAttrID()) {
+        return WALK_NEXT_STEP.SKIP
+      }
+      if (_.isString(value) && value.includes(expectedValue)) {
+        foundValue = true
+        return WALK_NEXT_STEP.EXIT
+      }
+      return WALK_NEXT_STEP.RECURSE
+    },
+  })
+  return foundValue
+}
+
+
+const changeValidator: ChangeValidator = async changes => (
+  awu(changes)
+    .filter(isAdditionOrModificationChange)
+    .filter(isInstanceChange)
+    .map(getChangeData)
+    .filter(instance => isCustomType(instance.refType))
+    .filter(instance => isInstanceContainStringValue(instance, NOT_YET_SUPPORTED_VALUE))
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error',
+      message: 'Instance has an NOT_YET_SUPPORTED value that Salto cannot deploy',
+      detailedMessage: `Instance ${instance.elemID.getFullName()} has a NOT_YET_SUPPORTED value that Salto cannot deploy. In order to deploy the instance, please fill the NOT_YET_SUPPORTED value`,
+    } as ChangeError))
+    .toArray()
+)
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
@@ -37,8 +37,8 @@ const changeValidator: ChangeValidator = async changes => (
     .map(instance => ({
       elemID: instance.elemID,
       severity: 'Error',
-      message: 'Instance has a NOT_YET_SUPPORTED value that Salto cannot deploy',
-      detailedMessage: `Instance ${instance.elemID.getFullName()} has a NOT_YET_SUPPORTED value that Salto cannot deploy. In order to deploy the instance, please fill the NOT_YET_SUPPORTED value`,
+      message: 'Instances with values set to \'NOT_YET_SUPPORTED\' cannot be deployed',
+      detailedMessage: 'Instances with values set to \'NOT_YET_SUPPORTED\' cannot be deployed. In order to deploy, please manually replace \'NOT_YET_SUPPORTED\' with a valid value.',
     } as ChangeError))
     .toArray()
 )

--- a/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
@@ -13,7 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import {
   ChangeError,

--- a/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
@@ -24,7 +24,7 @@ import {
 } from '@salto-io/adapter-api'
 import { isCustomType } from '../types'
 import { NOT_YET_SUPPORTED_VALUE } from '../constants'
-import { isInstanceContainStringValue } from './utils'
+import { isInstanceContainsStringValue } from './utils'
 
 const { awu } = collections.asynciterable
 
@@ -34,7 +34,7 @@ const changeValidator: ChangeValidator = async changes => (
     .filter(isInstanceChange)
     .map(getChangeData)
     .filter(instance => isCustomType(instance.refType))
-    .filter(instance => isInstanceContainStringValue(instance, NOT_YET_SUPPORTED_VALUE))
+    .filter(instance => isInstanceContainsStringValue(instance, NOT_YET_SUPPORTED_VALUE))
     .map(instance => ({
       elemID: instance.elemID,
       severity: 'Error',

--- a/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
@@ -37,7 +37,7 @@ const changeValidator: ChangeValidator = async changes => (
     .map(instance => ({
       elemID: instance.elemID,
       severity: 'Error',
-      message: 'Instance has an NOT_YET_SUPPORTED value that Salto cannot deploy',
+      message: 'Instance has a NOT_YET_SUPPORTED value that Salto cannot deploy',
       detailedMessage: `Instance ${instance.elemID.getFullName()} has a NOT_YET_SUPPORTED value that Salto cannot deploy. In order to deploy the instance, please fill the NOT_YET_SUPPORTED value`,
     } as ChangeError))
     .toArray()

--- a/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/not_yet_supported_values.ts
@@ -19,36 +19,14 @@ import {
   ChangeError,
   ChangeValidator,
   getChangeData,
-  InstanceElement,
   isAdditionOrModificationChange,
   isInstanceChange,
 } from '@salto-io/adapter-api'
-import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { isCustomType } from '../types'
 import { NOT_YET_SUPPORTED_VALUE } from '../constants'
+import { isInstanceContainStringValue } from './utils'
 
 const { awu } = collections.asynciterable
-
-const isInstanceContainStringValue = (
-  instance: InstanceElement, expectedValue: string
-): boolean => {
-  let foundValue = false
-  walkOnElement({
-    element: instance,
-    func: ({ value, path }) => {
-      if (path.isAttrID()) {
-        return WALK_NEXT_STEP.SKIP
-      }
-      if (_.isString(value) && value.includes(expectedValue)) {
-        foundValue = true
-        return WALK_NEXT_STEP.EXIT
-      }
-      return WALK_NEXT_STEP.RECURSE
-    },
-  })
-  return foundValue
-}
-
 
 const changeValidator: ChangeValidator = async changes => (
   awu(changes)

--- a/packages/netsuite-adapter/src/change_validators/utils.ts
+++ b/packages/netsuite-adapter/src/change_validators/utils.ts
@@ -1,0 +1,39 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import _ from 'lodash'
+import { InstanceElement } from '@salto-io/adapter-api'
+import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+
+export const isInstanceContainStringValue = (
+  instance: InstanceElement, expectedValue: string
+): boolean => {
+  let foundValue = false
+  walkOnElement({
+    element: instance,
+    func: ({ value, path }) => {
+      if (path.isAttrID()) {
+        return WALK_NEXT_STEP.SKIP
+      }
+      if (_.isString(value) && value.includes(expectedValue)) {
+        foundValue = true
+        return WALK_NEXT_STEP.EXIT
+      }
+      return WALK_NEXT_STEP.RECURSE
+    },
+  })
+  return foundValue
+}

--- a/packages/netsuite-adapter/src/change_validators/utils.ts
+++ b/packages/netsuite-adapter/src/change_validators/utils.ts
@@ -18,7 +18,7 @@ import _ from 'lodash'
 import { InstanceElement } from '@salto-io/adapter-api'
 import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 
-export const isInstanceContainStringValue = (
+export const isInstanceContainsStringValue = (
   instance: InstanceElement, expectedValue: string
 ): boolean => {
   let foundValue = false

--- a/packages/netsuite-adapter/src/change_validators/utils.ts
+++ b/packages/netsuite-adapter/src/change_validators/utils.ts
@@ -19,7 +19,8 @@ import { InstanceElement } from '@salto-io/adapter-api'
 import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 
 export const isInstanceContainsStringValue = (
-  instance: InstanceElement, expectedValue: string
+  instance: InstanceElement,
+  expectedValue: string
 ): boolean => {
   let foundValue = false
   walkOnElement({

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -93,3 +93,4 @@ export const DEPLOY = 'deploy'
 export const INSTALLED_SUITEAPPS = 'installedSuiteApps'
 
 export const ACCOUNT_SPECIFIC_VALUE = '[ACCOUNT_SPECIFIC_VALUE]'
+export const NOT_YET_SUPPORTED_VALUE = '[NOT_YET_SUPPORTED]'

--- a/packages/netsuite-adapter/test/change_validators/not_yet_supported.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/not_yet_supported.test.ts
@@ -20,7 +20,7 @@ import notYetSupportedChangeValidator from '../../src/change_validators/not_yet_
 import { ACCOUNT_SPECIFIC_VALUE, PATH, SCRIPT_ID, NOT_YET_SUPPORTED_VALUE } from '../../src/constants'
 
 
-describe('account specific value validator', () => {
+describe('not yet supported validator', () => {
   const origInstance = new InstanceElement(
     'instance',
     workflowType().type,

--- a/packages/netsuite-adapter/test/change_validators/not_yet_supported.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/not_yet_supported.test.ts
@@ -17,7 +17,7 @@ import { InstanceElement, toChange } from '@salto-io/adapter-api'
 import { fileType } from '../../src/types/file_cabinet_types'
 import { workflowType } from '../../src/autogen/types/custom_types/workflow'
 import notYetSupportedChangeValidator from '../../src/change_validators/not_yet_supported_values'
-import { ACCOUNT_SPECIFIC_VALUE, PATH, SCRIPT_ID, NOT_YET_SUPPORTED_VALUE } from '../../src/constants'
+import { PATH, SCRIPT_ID, NOT_YET_SUPPORTED_VALUE } from '../../src/constants'
 
 
 describe('not yet supported validator', () => {
@@ -42,7 +42,7 @@ describe('not yet supported validator', () => {
       fileType(),
       {
         [PATH]: '/Path/to/file',
-        content: ACCOUNT_SPECIFIC_VALUE,
+        content: NOT_YET_SUPPORTED_VALUE,
       }
     )
     const changeErrors = await notYetSupportedChangeValidator(
@@ -51,7 +51,7 @@ describe('not yet supported validator', () => {
     expect(changeErrors).toHaveLength(0)
   })
 
-  it('should not have ChangeError when deploying an instance without ACCOUNT_SPECIFIC_VALUE', async () => {
+  it('should not have ChangeError when deploying an instance without NOT_YET_SUPPORTED', async () => {
     const after = instance.clone()
     after.value.name = 'NewName'
     const changeErrors = await notYetSupportedChangeValidator(
@@ -60,7 +60,7 @@ describe('not yet supported validator', () => {
     expect(changeErrors).toHaveLength(0)
   })
 
-  it('should have Error ChangeError when modifying an instance with ACCOUNT_SPECIFIC_VALUE', async () => {
+  it('should have Error ChangeError when modifying an instance with NOT_YET_SUPPORTED', async () => {
     const after = instance.clone()
     after.value.name = NOT_YET_SUPPORTED_VALUE
     const changeErrors = await notYetSupportedChangeValidator(

--- a/packages/netsuite-adapter/test/change_validators/not_yet_supported.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/not_yet_supported.test.ts
@@ -1,0 +1,93 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, toChange } from '@salto-io/adapter-api'
+import { fileType } from '../../src/types/file_cabinet_types'
+import { workflowType } from '../../src/autogen/types/custom_types/workflow'
+import notYetSupportedChangeValidator from '../../src/change_validators/not_yet_supported_values'
+import { ACCOUNT_SPECIFIC_VALUE, PATH, SCRIPT_ID, NOT_YET_SUPPORTED_VALUE } from '../../src/constants'
+
+
+describe('account specific value validator', () => {
+  const origInstance = new InstanceElement(
+    'instance',
+    workflowType().type,
+    {
+      isinactive: false,
+      [SCRIPT_ID]: 'customworkflow1',
+      name: 'WokrflowName',
+    }
+  )
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    instance = origInstance.clone()
+  })
+
+  it('should not have ChangeError when deploying a file cabinet instance', async () => {
+    const newFileInstance = new InstanceElement(
+      'instance',
+      fileType(),
+      {
+        [PATH]: '/Path/to/file',
+        content: ACCOUNT_SPECIFIC_VALUE,
+      }
+    )
+    const changeErrors = await notYetSupportedChangeValidator(
+      [toChange({ after: newFileInstance })]
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('should not have ChangeError when deploying an instance without ACCOUNT_SPECIFIC_VALUE', async () => {
+    const after = instance.clone()
+    after.value.name = 'NewName'
+    const changeErrors = await notYetSupportedChangeValidator(
+      [toChange({ before: instance, after })]
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('should have Error ChangeError when modifying an instance with ACCOUNT_SPECIFIC_VALUE', async () => {
+    const after = instance.clone()
+    after.value.name = NOT_YET_SUPPORTED_VALUE
+    const changeErrors = await notYetSupportedChangeValidator(
+      [toChange({ before: instance, after })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].elemID).toEqual(instance.elemID)
+  })
+
+  it('should have Error ChangeError when modifying an instance with value that includes NOT_YET_SUPPORTED', async () => {
+    const after = instance.clone()
+    after.value.name = `prefix${NOT_YET_SUPPORTED_VALUE}suffix`
+    const changeErrors = await notYetSupportedChangeValidator(
+      [toChange({ before: instance, after })]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].elemID).toEqual(instance.elemID)
+  })
+
+  it('should not have Error if NOT_YET_SUPPORTED was changed to a concrete value', async () => {
+    const before = instance.clone()
+    before.value.name = `${NOT_YET_SUPPORTED_VALUE}`
+    const changeErrors = await notYetSupportedChangeValidator(
+      [toChange({ before, after: instance })]
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+})

--- a/packages/netsuite-adapter/test/change_validators/not_yet_supported.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/not_yet_supported.test.ts
@@ -84,7 +84,7 @@ describe('not yet supported validator', () => {
 
   it('should not have Error if NOT_YET_SUPPORTED was changed to a concrete value', async () => {
     const before = instance.clone()
-    before.value.name = `${NOT_YET_SUPPORTED_VALUE}`
+    before.value.name = NOT_YET_SUPPORTED_VALUE
     const changeErrors = await notYetSupportedChangeValidator(
       [toChange({ before, after: instance })]
     )


### PR DESCRIPTION
Add a change validator to create an error when trying to deploy instances with a "NOT YET SUPPORTED" value, as they would fail to deploy them anyway. 
---

None

---
_Release Notes_: 

NetSuite Adapter: Prevent deploying instances which contain a "NOT_YET_SUPPORTED" value 

---
_User Notifications_: 

None