### PR TITLE
SALTO-2166: Allow overriding the credential source in loadLocalWorkspace

### DIFF
--- a/packages/cli/e2e_test/helpers/workspace.ts
+++ b/packages/cli/e2e_test/helpers/workspace.ts
@@ -170,7 +170,7 @@ export const runDeleteEnv = async (workspacePath: string, envName: string): Prom
 }
 
 export const getCurrentEnv = async (workspacePath: string): Promise<string> => {
-  const workspace = await loadLocalWorkspace(workspacePath)
+  const workspace = await loadLocalWorkspace({ path: workspacePath })
   return workspace.currentEnv()
 }
 
@@ -238,7 +238,7 @@ export const runClean = async ({
 }
 
 export const loadValidWorkspace = async (fetchOutputDir: string): Promise<Workspace> => {
-  const workspace = await loadLocalWorkspace(fetchOutputDir)
+  const workspace = await loadLocalWorkspace({ path: fetchOutputDir })
   const { errors } = await validateWorkspace(workspace)
   expect(errors).toHaveLength(0)
   return workspace
@@ -248,7 +248,7 @@ export const runPreviewGetPlan = async (
   fetchOutputDir: string,
   accounts?: string[]
 ): Promise<Plan> => {
-  const workspace = await loadLocalWorkspace(fetchOutputDir)
+  const workspace = await loadLocalWorkspace({ path: fetchOutputDir })
   return preview(workspace, accounts)
 }
 

--- a/packages/cli/src/command_builder.ts
+++ b/packages/cli/src/command_builder.ts
@@ -219,10 +219,10 @@ export const createWorkspaceCommand = <T>(
   const { properties, action, extraTelemetryTags } = def
 
   const workspaceAction: CommandDefAction<T & ConfigOverrideArg> = async args => {
-    const workspace = await loadLocalWorkspace(
-      args.workspacePath,
-      getConfigOverrideChanges(args.input),
-    )
+    const workspace = await loadLocalWorkspace({
+      path: args.workspacePath,
+      configOverrides: getConfigOverrideChanges(args.input),
+    })
 
     args.cliTelemetry.setTags({
       ...getWorkspaceTelemetryTags(workspace),

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -331,7 +331,10 @@ Promise<CliExitCode> => {
   // We do it since we need the workspace config in order to create the environment source
   const { force, yesAll, envName } = args.input
   const configOverrides = getConfigOverrideChanges(args.input)
-  const workspace = await loadLocalWorkspace(args.workspacePath, configOverrides)
+  const workspace = await loadLocalWorkspace({
+    path: args.workspacePath,
+    configOverrides,
+  })
   args.cliTelemetry.setTags(getWorkspaceTelemetryTags(workspace))
   args.cliTelemetry.start()
 

--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -69,7 +69,10 @@ const createFetchFromWorkspaceCommand = (
 ): FetchFunc => async (workspace, progressEmitter, accounts) => {
   let otherWorkspace: Workspace
   try {
-    otherWorkspace = await loadLocalWorkspace(otherWorkspacePath, [], false)
+    otherWorkspace = await loadLocalWorkspace({
+      path: otherWorkspacePath,
+      persistent: false,
+    })
   } catch (err) {
     throw new Error(`Failed to load source workspace: ${err.message ?? err}`)
   }

--- a/packages/cli/test/command_builder.test.ts
+++ b/packages/cli/test/command_builder.test.ts
@@ -230,7 +230,9 @@ describe('Command builder', () => {
         })
         it('should pass workspace path and config overrides to the workspace', () => {
           const expectedChanges = getConfigOverrideChanges(configOverrides)
-          expect(loadLocalWorkspace).toHaveBeenCalledWith('test_path', expectedChanges)
+          expect(loadLocalWorkspace).toHaveBeenCalledWith(
+            { path: 'test_path', configOverrides: expectedChanges }
+          )
         })
       })
       describe('when action is successful', () => {

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -906,7 +906,9 @@ describe('fetch command', () => {
             },
             workspace,
           })
-          expect(mockLoadLocalWorkspace).toHaveBeenCalledWith(sourcePath, [], false)
+          expect(mockLoadLocalWorkspace).toHaveBeenCalledWith(
+            { path: sourcePath, persistent: false }
+          )
           expect(mockFetchFromWorkspace).toHaveBeenCalled()
           const usedArgs = mockFetchFromWorkspace.mock.calls[0][0]
           expect(usedArgs.workspace).toEqual(workspace)
@@ -938,7 +940,9 @@ describe('fetch command', () => {
             },
             workspace,
           })
-          expect(mockLoadLocalWorkspace).toHaveBeenCalledWith(sourcePath, [], false)
+          expect(mockLoadLocalWorkspace).toHaveBeenCalledWith(
+            { path: sourcePath, persistent: false }
+          )
           expect(mockFetchFromWorkspace).toHaveBeenCalled()
           const usedArgs = mockFetchFromWorkspace.mock.calls[0][0]
           expect(usedArgs.workspace).toEqual(workspace)

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -210,7 +210,10 @@ const getAdapterConfigsPerAccount = async (envs: EnvConfig[]): Promise<ObjectTyp
 }
 
 export const loadLocalWorkspace = async (
-  lookupDir: string, configOverrides?: DetailedChange[], persistent = true
+  lookupDir: string,
+  configOverrides?: DetailedChange[],
+  persistent = true,
+  credentialSource?: cs.ConfigSource
 ): Promise<Workspace> => {
   const baseDir = await locateWorkspaceRoot(path.resolve(lookupDir))
   if (_.isUndefined(baseDir)) {
@@ -229,7 +232,7 @@ export const loadLocalWorkspace = async (
     configOverrides,
   )
   const envNames = envs.map(e => e.name)
-  const credentials = credentialsSource(workspaceConfig.localStorage)
+  const credentials = credentialSource ?? credentialsSource(workspaceConfig.localStorage)
 
   const elemSources = await loadLocalElementsSources(
     baseDir,

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -36,11 +36,10 @@ const onActivate = async (context: vscode.ExtensionContext): Promise<void> => {
   const { name, rootPath } = vscode.workspace
   if (name && rootPath) {
     const diagCollection = vscode.languages.createDiagnosticCollection('@salto-io/core')
-    const workspace = new ws.EditorWorkspace(rootPath, await loadLocalWorkspace(
+    const workspace = new ws.EditorWorkspace(
       rootPath,
-      undefined,
-      false
-    ))
+      await loadLocalWorkspace({ path: rootPath, persistent: false }),
+    )
 
     const completionProvider = vscode.languages.registerCompletionItemProvider(
       { scheme: 'file', pattern: { base: rootPath, pattern: '**/*.nacl' } },


### PR DESCRIPTION
Add optional parameter allowing the caller to use an alternative credentials source.
This can be useful for runtimes that would like to use a different credential storage option.

---

Given the amount of arguments that `loadLocalWorkspace` now gets and since a lot of them are optional, changing the interface to an argument object seems justified.
However, since this is a central API, I tried to avoid breaking it right now.
We should probably remove the old function format in a few weeks

---
_Release Notes_: 
- Add ability to pass a custom credentials source to `loadLocalWorkspace`

---
_User Notifications_: 
_None_
