### PR TITLE
SALTO-1804 - Validate no addition instances are dependent on other instances of the same type that were not deployed yet

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/ref_to_instance_of_same_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/ref_to_instance_of_same_type.ts
@@ -24,12 +24,12 @@ const { awu, groupByAsync } = collections.asynciterable
 
 const getDepOnAdditionOfSameTypeInstanceIDs = async (
   instance: InstanceElement,
-  typeToAdditionInstancesElemIDs: Record<string, ElemID[]>,
+  typeToAdditionInstancesElemIDs: Record<string, Set<ElemID>>,
 ): Promise<ElemID[]> => {
   const dependentOnAdditionInstanceIDs: ElemID[] = []
-  const typeAdditionInstancesElemIDs = typeToAdditionInstancesElemIDs[
+  const typeAdditionInstancesElemIDs = Array.from(typeToAdditionInstancesElemIDs[
     (await apiName(await (instance as InstanceElement).getType(), true))
-  ]
+  ])
   const func: WalkOnFunc = ({ value }) => {
     if (isReferenceExpression(value)
       && typeAdditionInstancesElemIDs.find(elemID => elemID.isEqual(value.elemID))) {
@@ -56,7 +56,7 @@ const changeValidator: ChangeValidator = async changes => {
       )),
     te => te.type,
   ),
-  teArr => teArr.map(te => te.elemID))
+  teArr => new Set(teArr.map(te => te.elemID)))
   return awu(changes)
     .filter(isInstanceOfCustomObjectChange)
     .filter(isAdditionChange)

--- a/packages/salesforce-adapter/src/change_validators/ref_to_instance_of_same_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/ref_to_instance_of_same_type.ts
@@ -53,6 +53,14 @@ const changeValidator: ChangeValidator = async changes => {
           severity: 'Error' as SeverityLevel,
           message: 'This new instance cannot be deployed, as it contains a reference to another new instance. To successfully deploy both instances, please run this deploy, then another deploy to create the referencing instance.',
           detailedMessage: `New instance ${instance.elemID.getFullName()} cannot be deployed, as it contains a reference to another new instance ${dependentOnAdditionInstanceIDs.map(e => e.getFullName()).join(', ')}. To successfully deploy both instances, please run this deploy to create ${dependentOnAdditionInstanceIDs.map(e => e.getFullName()).join(', ')}, then another deploy to create ${instance.elemID.getFullName()}.`,
+          deployActions: {
+            postAction: {
+              title: 'Deploy skipped referencing instance',
+              subActions: [
+                'Initiate another deployment and deploy skipped referencing instance',
+              ],
+            },
+          },
         })
       }).filter(values.isDefined)
     })

--- a/packages/salesforce-adapter/src/change_validators/ref_to_instance_of_same_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/ref_to_instance_of_same_type.ts
@@ -1,0 +1,83 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { ChangeValidator, getChangeData, InstanceElement, isAdditionChange, ElemID, SeverityLevel, isReferenceExpression } from '@salto-io/adapter-api'
+import { values, collections } from '@salto-io/lowerdash'
+import { isInstanceOfCustomObjectChange } from '../custom_object_instances_deploy'
+import { apiName } from '../transformers/transformer'
+
+const { awu, groupByAsync } = collections.asynciterable
+
+const getDepOnAdditionOfSameTypeInstanceIDs = async (
+  instance: InstanceElement,
+  typeToAdditionInstancesElemIDs: Record<string, ElemID[]>,
+): Promise<ElemID[]> => {
+  const dependentOnAdditionInstanceIDs: ElemID[] = []
+  const typeAdditionInstancesElemIDs = typeToAdditionInstancesElemIDs[
+    (await apiName(await (instance as InstanceElement).getType(), true))
+  ]
+  const func: WalkOnFunc = ({ value }) => {
+    if (isReferenceExpression(value)
+      && typeAdditionInstancesElemIDs.find(elemID => elemID.isEqual(value.elemID))) {
+      dependentOnAdditionInstanceIDs.push(value.elemID)
+      return WALK_NEXT_STEP.SKIP
+    }
+    return WALK_NEXT_STEP.RECURSE
+  }
+  walkOnElement({ element: instance, func })
+  return dependentOnAdditionInstanceIDs
+}
+
+const changeValidator: ChangeValidator = async changes => {
+  const typeToAdditionInstancesElemIDs = _.mapValues(await groupByAsync(
+    awu(changes)
+      .filter(isInstanceOfCustomObjectChange)
+      .filter(isAdditionChange)
+      .map(getChangeData)
+      .map(async instance => (
+        {
+          type: (await apiName(await (instance as InstanceElement).getType(), true)),
+          elemID: instance.elemID,
+        }
+      )),
+    te => te.type,
+  ),
+  teArr => teArr.map(te => te.elemID))
+  return awu(changes)
+    .filter(isInstanceOfCustomObjectChange)
+    .filter(isAdditionChange)
+    .map(getChangeData)
+    .map(async instance => {
+      const dependentOnAdditionOfSameTypeInstancesIds = await getDepOnAdditionOfSameTypeInstanceIDs(
+        instance as InstanceElement,
+        typeToAdditionInstancesElemIDs,
+      )
+      if (dependentOnAdditionOfSameTypeInstancesIds.length === 0) {
+        return undefined
+      }
+      return ({
+        elemID: instance.elemID,
+        severity: 'Error' as SeverityLevel,
+        message: 'Instance depends on a new instance that has no ID yet. Run this deploy and then deploy again to avoid this error.',
+        detailedMessage: `Instance ${instance.elemID.getFullName()} depends on new instance that has no ID yet: ${dependentOnAdditionOfSameTypeInstancesIds.map(e => e.getFullName()).join(', ')}`,
+      })
+    })
+    .filter(values.isDefined)
+    .toArray()
+}
+
+export default changeValidator

--- a/packages/salesforce-adapter/test/change_validators/ref_to_instance_of_same_type.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/ref_to_instance_of_same_type.test.ts
@@ -1,0 +1,85 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, ObjectType, toChange, InstanceElement, BuiltinTypes, ReferenceExpression, ChangeError } from '@salto-io/adapter-api'
+import refToInstanceSameType from '../../src/change_validators/ref_to_instance_of_same_type'
+import { API_NAME, CUSTOM_OBJECT, METADATA_TYPE } from '../../src/constants'
+
+describe('ref to custom object instance of same type', () => {
+  let changeErrors: Readonly<ChangeError[]>
+  const customObject = new ObjectType({
+    elemID: new ElemID('salesforce', 'co'),
+    fields: {
+      refField: {
+        refType: BuiltinTypes.STRING,
+      },
+    },
+    annotations: {
+      [METADATA_TYPE]: CUSTOM_OBJECT,
+      [API_NAME]: 'co',
+    },
+  })
+
+  const otherObject = new ObjectType({
+    elemID: new ElemID('salesforce', 'notCo'),
+    annotations: {
+      [METADATA_TYPE]: 'NotCustomObject',
+      [API_NAME]: 'notCo',
+    },
+  })
+
+  const coInstA = new InstanceElement('coInstA', customObject, {
+    refField: 'a',
+  })
+
+  const coInstB = new InstanceElement('coInstB', customObject, {
+    refField: new ReferenceExpression(coInstA.elemID, coInstA),
+  })
+
+  const otherInst = new InstanceElement('notCoInst', otherObject, {})
+
+  it('Should have an error if an instance that is added has a ref to another added instance of same type', async () => {
+    changeErrors = await refToInstanceSameType(
+      [
+        toChange({ after: coInstB }),
+        toChange({ after: coInstA }),
+      ]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].elemID).toEqual(coInstB.elemID)
+  })
+
+  it('Should not send an error if the referenced inst has a modification change and not addition', async () => {
+    changeErrors = await refToInstanceSameType(
+      [
+        toChange({ before: coInstB, after: coInstB }),
+        toChange({ after: coInstA }),
+      ]
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('Should not send an error if the referenced inst is not custom object', async () => {
+    coInstA.value.refField = new ReferenceExpression(otherInst.elemID, otherInst)
+    changeErrors = await refToInstanceSameType(
+      [
+        toChange({ after: otherInst }),
+        toChange({ after: coInstA }),
+      ]
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
This is a short term solution for an issue we currently have with deploys of Custom Object Instances.
When deploying additions of two instances, that one has a reference to the other, because they are grouped together in the same group we have an issue with deploying the one that has the instance.
Thus we add an Error to it and direct the user to deploy twice, and the second deploy should work for it.
The longer term solution for this is to change the grouping or handle refs inside groups somehow different.

---
_Release Notes_: 
*Salesforce*: 
* Added a change validator to detect Instances with dependencies on other instances of the same type that were not yet deployed. Since our grouping does not split them at the moment and causes issues on deploy.

