### PR TITLE
SALTO-2163 return warnings on fetch

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -317,10 +317,12 @@ export default class NetsuiteAdapter implements AdapterOperations {
       failedToFetchAllAtOnce, failedFilePaths, failedTypes, this.userConfig
     )
 
+    const errors = this.client.getErrors()
+
     if (_.isUndefined(updatedConfig)) {
-      return { elements, isPartial }
+      return { elements, errors, isPartial }
     }
-    return { elements, updatedConfig, isPartial }
+    return { elements, errors, updatedConfig, isPartial }
   }
 
   private async runSuiteAppOperations(

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { AccountId, Change, getChangeData, InstanceElement, isInstanceChange, isModificationChange } from '@salto-io/adapter-api'
+import { AccountId, Change, getChangeData, InstanceElement, isInstanceChange, isModificationChange, SaltoError } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { decorators, collections, values } from '@salto-io/lowerdash'
 import { resolveValues } from '@salto-io/adapter-utils'
@@ -289,5 +289,10 @@ export default class NetsuiteClient {
       throw new Error('Cannot call getAllRecords when SuiteApp is not installed')
     }
     return this.suiteAppClient.getAllRecords(types)
+  }
+
+  public getErrors(): SaltoError[] {
+    return this.sdfClient.getErrors()
+      .concat(this.suiteAppClient?.getErrors() ?? [])
   }
 }

--- a/packages/netsuite-adapter/src/service_url/instances_urls.ts
+++ b/packages/netsuite-adapter/src/service_url/instances_urls.ts
@@ -27,7 +27,8 @@ const getScriptIdToInternalId = async (
 ): Promise<Record<string, number>> => {
   const results = await client.runSuiteQL(query)
   if (!areQueryResultsValid(results)) {
-    throw new Error('Got invalid results from SuiteQL query')
+    log.debug('getScriptIdToInternalId returning empty record object')
+    return {}
   }
 
   return Object.fromEntries(

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -140,7 +140,7 @@ describe('Adapter', () => {
         failedPaths: { lockedError: [], otherError: [] },
       })
 
-    suiteAppImportFileCabinetMock.mockResolvedValue({ elements: [], failedPaths: [] })
+    suiteAppImportFileCabinetMock.mockResolvedValue({ elements: [], failedPaths: [], errors: [] })
   })
 
   describe('fetch', () => {
@@ -938,6 +938,11 @@ describe('Adapter', () => {
       expect(getChangedObjectsMock).not.toHaveBeenCalled()
     })
     it('should return fetch errors', async () => {
+      suiteAppImportFileCabinetMock.mockResolvedValue({
+        elements: [],
+        failedPaths: [],
+        errors: [{ severity: 'Warning', message: 'file cabinet error' }],
+      })
       const suiteAppClient = {
         getSystemInformation: getSystemInformationMock,
         getNetsuiteWsdl: () => undefined,
@@ -954,7 +959,10 @@ describe('Adapter', () => {
       })
 
       const { errors } = await nsAdapter.fetch(mockFetchOpts)
-      expect(errors).toEqual([{ severity: 'Warning', message: 'fetch error' }])
+      expect(errors).toEqual([
+        { severity: 'Warning', message: 'file cabinet error' },
+        { severity: 'Warning', message: 'fetch error' },
+      ])
     })
 
     describe('getChangedObjects', () => {

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -871,6 +871,7 @@ describe('Adapter', () => {
         getSystemInformation: getSystemInformationMock,
         getNetsuiteWsdl: () => undefined,
         getConfigRecords: () => [],
+        getErrors: () => [],
       } as unknown as SuiteAppClient
 
       adapter = new NetsuiteAdapter({
@@ -901,6 +902,7 @@ describe('Adapter', () => {
         getSystemInformation: getSystemInformationMock,
         getNetsuiteWsdl: () => undefined,
         getConfigRecords: () => [],
+        getErrors: () => [],
       } as unknown as SuiteAppClient
 
       adapter = new NetsuiteAdapter({
@@ -935,6 +937,25 @@ describe('Adapter', () => {
         .toEqual(new Date(1000).toJSON())
       expect(getChangedObjectsMock).not.toHaveBeenCalled()
     })
+    it('should return fetch errors', async () => {
+      const suiteAppClient = {
+        getSystemInformation: getSystemInformationMock,
+        getNetsuiteWsdl: () => undefined,
+        getConfigRecords: () => [],
+        getErrors: () => [{ severity: 'Warning', message: 'fetch error' }],
+      } as unknown as SuiteAppClient
+
+      const nsAdapter = new NetsuiteAdapter({
+        client: new NetsuiteClient(client, suiteAppClient),
+        elementsSource,
+        filtersCreators: [firstDummyFilter, secondDummyFilter],
+        config,
+        getElemIdFunc: mockGetElemIdFunc,
+      })
+
+      const { errors } = await nsAdapter.fetch(mockFetchOpts)
+      expect(errors).toEqual([{ severity: 'Warning', message: 'fetch error' }])
+    })
 
     describe('getChangedObjects', () => {
       let suiteAppClient: SuiteAppClient
@@ -952,6 +973,7 @@ describe('Adapter', () => {
           getSystemInformation: getSystemInformationMock,
           getNetsuiteWsdl: () => undefined,
           getConfigRecords: () => [],
+          getErrors: () => [],
         } as unknown as SuiteAppClient
 
         adapter = new NetsuiteAdapter({

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -795,9 +795,10 @@ describe('netsuite client', () => {
           { name: 'advancedpdftemplate' },
         ],
       })
+      const client = mockClient()
       const {
         failedTypes,
-      } = await mockClient().getCustomObjects(typeNames, query)
+      } = await client.getCustomObjects(typeNames, query)
       expect(failedTypes).toEqual({
         lockedError: {
           savedcsvimport: ['d'],
@@ -807,6 +808,20 @@ describe('netsuite client', () => {
           advancedpdftemplate: ['a'],
         },
       })
+      expect(client.getErrors()).toEqual([
+        {
+          message: 'Some instances are locked and couldn\'t be fetched',
+          severity: 'Warning',
+        },
+        {
+          message: 'Failed to fetch some instances of type \'savedcsvimport\' due to SDF unexpected error',
+          severity: 'Warning',
+        },
+        {
+          message: 'Failed to fetch some instances of type \'advancedpdftemplate\' due to SDF unexpected error',
+          severity: 'Warning',
+        },
+      ])
     })
 
     it('should succeed and return merged failedTypeToInstances when split to smaller chunks', async () => {
@@ -852,15 +867,22 @@ describe('netsuite client', () => {
         return Promise.resolve({ isSuccess: () => true })
       })
 
+      const client = mockClient()
       const {
         failedTypes,
-      } = await mockClient().getCustomObjects(typeNames, typeNamesQuery)
+      } = await client.getCustomObjects(typeNames, typeNamesQuery)
       expect(failedTypes).toEqual({
         lockedError: {},
         unexpectedError: {
           addressForm: ['a', 'b'],
         },
       })
+      expect(client.getErrors()).toEqual([
+        {
+          message: 'Failed to fetch some instances of type \'addressForm\' due to SDF unexpected error',
+          severity: 'Warning',
+        },
+      ])
     })
 
     it('should list and import only objects that match the query', async () => {

--- a/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
@@ -109,8 +109,14 @@ describe('SuiteAppClient', () => {
 
       describe('query failure', () => {
         it('exception thrown', async () => {
-          mockAxiosAdapter.onPost().reply(() => [])
+          mockAxiosAdapter.onPost().reply(500)
           expect(await client.runSuiteQL('')).toBeUndefined()
+          expect(client.getErrors()).toEqual([
+            {
+              message: 'Some elements may not been fetched due to a SuiteQL Query Error: Request failed with status code 500',
+              severity: 'Warning',
+            },
+          ])
         })
         it('with retry', async () => {
           jest.spyOn(global, 'setTimeout').mockImplementation((cb: TimerHandler) => (_.isFunction(cb) ? cb() : undefined))
@@ -163,12 +169,18 @@ describe('SuiteAppClient', () => {
 
       describe('query failure', () => {
         it('exception thrown', async () => {
-          mockAxiosAdapter.onPost().reply(() => [])
+          mockAxiosAdapter.onPost().reply(500)
           expect(await client.runSavedSearchQuery({
             type: 'type',
             columns: [],
             filters: [],
           })).toBeUndefined()
+          expect(client.getErrors()).toEqual([
+            {
+              message: 'Some elements may not been fetched due to a Saved Search Query Error: Request failed with status code 500',
+              severity: 'Warning',
+            },
+          ])
         })
 
         it('invalid saved search results', async () => {

--- a/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client.test.ts
@@ -479,7 +479,7 @@ describe('SuiteAppClient', () => {
           status: 'error', message: 'error', error: new Error('error'),
         })
         expect(await client.setConfigRecordsValues([])).toEqual({
-          errorMessage: 'Restlet request failed. Message: error, error: {}',
+          errorMessage: 'Salto SuiteApp Error - error',
         })
       })
       it('should return error on invalid result', async () => {

--- a/packages/netsuite-adapter/test/service_url/custom_field.test.ts
+++ b/packages/netsuite-adapter/test/service_url/custom_field.test.ts
@@ -85,8 +85,9 @@ describe('setCustomFieldsUrls', () => {
     expect(notFoundElement.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 
-  it('invalid results should throw an error', async () => {
+  it('should not set url if received invalid results', async () => {
     runSuiteQlMock.mockResolvedValue([{ scriptid: 'someScriptID' }])
-    await expect(setServiceUrl(elements, client)).rejects.toThrow()
+    await setServiceUrl(elements, client)
+    expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 })

--- a/packages/netsuite-adapter/test/service_url/custom_record_type.test.ts
+++ b/packages/netsuite-adapter/test/service_url/custom_record_type.test.ts
@@ -55,8 +55,9 @@ describe('setCustomRecordTypesUrls', () => {
     expect(notFoundElement.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 
-  it('invalid results should throw an error', async () => {
+  it('should not set url if received invalid results', async () => {
     runSuiteQlMock.mockResolvedValue([{ scriptid: 'someScriptID' }])
-    await expect(setServiceUrl(elements, client)).rejects.toThrow()
+    await setServiceUrl(elements, client)
+    expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 })

--- a/packages/netsuite-adapter/test/service_url/custom_transaction_type.test.ts
+++ b/packages/netsuite-adapter/test/service_url/custom_transaction_type.test.ts
@@ -50,8 +50,9 @@ describe('setCustomTransactionTypesUrls', () => {
     expect(notFoundElement.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 
-  it('invalid results should throw an error', async () => {
+  it('should not set url if received invalid results', async () => {
     runSuiteQlMock.mockResolvedValue([{ scriptid: 'someScriptID' }])
-    await expect(setServiceUrl(elements, client)).rejects.toThrow()
+    await setServiceUrl(elements, client)
+    expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 })

--- a/packages/netsuite-adapter/test/service_url/emailtemplate.test.ts
+++ b/packages/netsuite-adapter/test/service_url/emailtemplate.test.ts
@@ -50,8 +50,9 @@ describe('setEmailTemplatesUrls', () => {
     expect(notFoundElement.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 
-  it('invalid results should throw an error', async () => {
+  it('should not set url if received invalid results', async () => {
     runSuiteQlMock.mockResolvedValue([{ scriptid: 'someScriptID' }])
-    await expect(setServiceUrl(elements, client)).rejects.toThrow()
+    await setServiceUrl(elements, client)
+    expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 })

--- a/packages/netsuite-adapter/test/service_url/role.test.ts
+++ b/packages/netsuite-adapter/test/service_url/role.test.ts
@@ -50,8 +50,9 @@ describe('setRolesUrls', () => {
     expect(notFoundElement.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 
-  it('invalid results should throw an error', async () => {
+  it('should not set url if received invalid results', async () => {
     runSuiteQlMock.mockResolvedValue([{ scriptid: 'someScriptID' }])
-    await expect(setServiceUrl(elements, client)).rejects.toThrow()
+    await setServiceUrl(elements, client)
+    expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 })

--- a/packages/netsuite-adapter/test/service_url/script.test.ts
+++ b/packages/netsuite-adapter/test/service_url/script.test.ts
@@ -61,13 +61,19 @@ describe('setScriptsUrls', () => {
     expect(notFoundElement.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 
-  it('invalid results should throw an error', async () => {
+  it('should not set url if received invalid results', async () => {
     runSuiteQlMock.mockResolvedValue([{ scriptid: 'someScriptID' }])
-    await expect(setServiceUrl(elements, client)).rejects.toThrow()
+    await setServiceUrl(elements, client)
+    expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+    expect(elements[1].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+    expect(elements[2].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 
-  it('query failure should throw an error', async () => {
+  it('should not set url if query fails', async () => {
     runSuiteQlMock.mockResolvedValue(undefined)
-    await expect(setServiceUrl(elements, client)).rejects.toThrow()
+    await setServiceUrl(elements, client)
+    expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+    expect(elements[1].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+    expect(elements[2].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 })

--- a/packages/netsuite-adapter/test/service_url/sublist.test.ts
+++ b/packages/netsuite-adapter/test/service_url/sublist.test.ts
@@ -50,8 +50,9 @@ describe('setSublistsUrls', () => {
     expect(notFoundElement.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 
-  it('invalid results should throw an error', async () => {
+  it('should not set url if received invalid results', async () => {
     runSuiteQlMock.mockResolvedValue([{ scriptid: 'someScriptID' }])
-    await expect(setServiceUrl(elements, client)).rejects.toThrow()
+    await setServiceUrl(elements, client)
+    expect(elements[0].annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
   })
 })


### PR DESCRIPTION
Return warnings on fetch in case of sdf/suiteapp errors.
These errors aren't thrown during fetch and it was transparent to the user, so now they will be display at the fetch summary. 

---
_Release Notes_: 
NetSuite Adapter:
- Return warnings on fetch

---
_User Notifications_: 
None
