### PR TITLE
SALTO-2157: Added generated_dependencies to dynamic content items

### DIFF
--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -51,6 +51,7 @@ import accountSettingsFilter from './filters/account_settings'
 import ticketFieldFilter from './filters/custom_field_options/ticket_field'
 import userFieldFilter from './filters/custom_field_options/user_field'
 import dynamicContentFilter from './filters/dynamic_content'
+import dynamicContentReferencesFilter from './filters/dynamic_content_references'
 import restrictionFilter from './filters/restriction'
 import organizationFieldFilter from './filters/organization_field'
 import removeDefinitionInstancesFilter from './filters/remove_definition_instances'
@@ -108,6 +109,7 @@ export const DEFAULT_FILTERS = [
   removeDefinitionInstancesFilter,
   // unorderedListsFilter should run after fieldReferencesFilter
   unorderedListsFilter,
+  dynamicContentReferencesFilter,
   serviceUrlFilter,
   // defaultDeployFilter should be last!
   defaultDeployFilter,

--- a/packages/zendesk-support-adapter/src/filters/dynamic_content_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/dynamic_content_references.ts
@@ -1,0 +1,74 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  CORE_ANNOTATIONS,
+  Element, InstanceElement, isInstanceElement, ReferenceExpression,
+} from '@salto-io/adapter-api'
+import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { strings, values } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { FilterCreator } from '../filter'
+import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from './dynamic_content'
+
+const PLACEHOLDER_REGEX = /{{.+?}}/g
+
+const extractPlaceholders = (value: string): string[] =>
+  _.uniq(Array.from(strings.matchAll(value, PLACEHOLDER_REGEX)).map(match => match[0]))
+
+const getDynamicContentReferences = (
+  instance: InstanceElement,
+  placeholderToItem: Record<string, InstanceElement>
+): ReferenceExpression[] => {
+  const references: ReferenceExpression[] = []
+  walkOnElement({
+    element: instance,
+    func: ({ value, path }) => {
+      if (path.name.startsWith('raw_') && typeof value === 'string') {
+        references.push(
+          ...extractPlaceholders(value)
+            .map(placeholder => placeholderToItem[placeholder])
+            .filter(values.isDefined)
+            .map(itemInstance => new ReferenceExpression(itemInstance.elemID, itemInstance))
+        )
+      }
+
+      return WALK_NEXT_STEP.RECURSE
+    },
+  })
+
+  return references
+}
+
+const filterCreator: FilterCreator = () => ({
+  onFetch: async (elements: Element[]): Promise<void> => {
+    const instances = elements.filter(isInstanceElement)
+
+    const placeholderToItem = _(instances)
+      .filter(instance => instance.elemID.typeName === DYNAMIC_CONTENT_ITEM_TYPE_NAME)
+      .keyBy(instance => instance.value.placeholder)
+      .value()
+
+    instances.forEach(instance => {
+      const references = getDynamicContentReferences(instance, placeholderToItem)
+      if (references.length > 0) {
+        instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] = references
+          .map(reference => ({ reference }))
+      }
+    })
+  },
+})
+
+export default filterCreator

--- a/packages/zendesk-support-adapter/test/filters/dynamic_content_references.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/dynamic_content_references.test.ts
@@ -76,6 +76,12 @@ describe('dynamic content references filter', () => {
           dynamicContentInstance.elemID,
           dynamicContentInstance
         ),
+        occurrences: [{
+          location: new ReferenceExpression(
+            instance.elemID.createNestedID('raw_value'),
+            '{{somePlaceholder}} {{notExistsPlaceholder}} {{somePlaceholder}}'
+          ),
+        }],
       }])
 
       expect(dynamicContentInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES])

--- a/packages/zendesk-support-adapter/test/filters/dynamic_content_references.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/dynamic_content_references.test.ts
@@ -1,0 +1,85 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  ObjectType, ElemID, InstanceElement, ReferenceExpression, CORE_ANNOTATIONS,
+} from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { DEFAULT_CONFIG } from '../../src/config'
+import ZendeskClient from '../../src/client/client'
+import { ZENDESK_SUPPORT } from '../../src/constants'
+import { paginate } from '../../src/client/pagination'
+import filterCreator from '../../src/filters/dynamic_content_references'
+import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from '../../src/filters/dynamic_content'
+
+describe('dynamic content references filter', () => {
+  let client: ZendeskClient
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  let filter: FilterType
+  let dynamicContentType: ObjectType
+  let type: ObjectType
+
+  beforeEach(async () => {
+    dynamicContentType = new ObjectType({
+      elemID: new ElemID(ZENDESK_SUPPORT, DYNAMIC_CONTENT_ITEM_TYPE_NAME),
+    })
+    type = new ObjectType({
+      elemID: new ElemID(ZENDESK_SUPPORT, 'someType'),
+    })
+
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+    })
+    filter = filterCreator({
+      client,
+      paginator: clientUtils.createPaginator({
+        client,
+        paginationFuncCreator: paginate,
+      }),
+      config: DEFAULT_CONFIG,
+    }) as FilterType
+  })
+
+  describe('onFetch', () => {
+    it('should add generated dependencies for dynamic content placeholders', async () => {
+      const dynamicContentInstance = new InstanceElement(
+        'dynamicContentInstance',
+        dynamicContentType,
+        {
+          placeholder: '{{somePlaceholder}}',
+        },
+      )
+
+      const instance = new InstanceElement(
+        'instance',
+        type,
+        {
+          raw_value: '{{somePlaceholder}} {{notExistsPlaceholder}} {{somePlaceholder}}',
+        }
+      )
+
+      await filter.onFetch([dynamicContentInstance, instance])
+      expect(instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual([{
+        reference: new ReferenceExpression(
+          dynamicContentInstance.elemID,
+          dynamicContentInstance
+        ),
+      }])
+
+      expect(dynamicContentInstance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES])
+        .toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
Added generated_dependencies to dynamic content items

---
_Release Notes_: 
_Zendesk Support Adapter_:
- Added references to dynamic content items if their placeholder is used

---
_User Notifications_: 
_Zendesk Support Adapter_:
- After the next fetch, `_generated dependecies` value will be added to instances that use placeholders of dynamic content items
