### PR TITLE
SALTO-2171: Fixed gadgets field type

### DIFF
--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -163,7 +163,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     ],
     transformation: {
       fieldTypeOverrides: [
-        { fieldName: 'gadgets', fieldType: 'DashboardGadget' },
+        { fieldName: 'gadgets', fieldType: 'List<DashboardGadget>' },
         { fieldName: 'layout', fieldType: 'string' },
       ],
       fieldsToHide: [

--- a/packages/jira-adapter/system_config_doc.md
+++ b/packages/jira-adapter/system_config_doc.md
@@ -284,7 +284,7 @@ jira {
           fieldTypeOverrides = [
             {
               fieldName = "gadgets"
-              fieldType = "DashboardGadget"
+              fieldType = "List<DashboardGadget>"
             },
             {
               fieldName = "layout"


### PR DESCRIPTION
Fixed the field type in gadgets.

---

It looks like the incorrect type caused `Unexpected hidden part found in array:` for some reason

---
_Release Notes_: 
_Jira Adapter_:
- Fixed incorrect gadgets field type

---
_User Notifications_: 
None