### PR TITLE
SALTO-2176: Detach TypeReference from ReferenceExpression

### DIFF
--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -36,18 +36,13 @@ export const createRefToElmWithValue = (element: TypeElement): TypeReference => 
     ?? new TypeReference(element.elemID, element)
 )
 
-// This is used to allow contructors Elements with Placeholder types
+// This is used to allow constructors Elements with Placeholder types
 // to receive TypeElement and save the appropriate Reference
-const getRefType = (typeOrRef: TypeOrRef): TypeReference =>
-  (isTypeReference(typeOrRef)
+const getRefType = (typeOrRef: TypeOrRef): TypeReference => (
+  isTypeReference(typeOrRef)
     ? typeOrRef
-    : new TypeReference(typeOrRef.elemID, typeOrRef))
-
-const getRefTypeValue = async (
-  refType: TypeReference,
-  elementsSource?: ReadOnlyElementsSource,
-): Promise<Value> =>
-  (refType.getResolvedValue(elementsSource))
+    : createRefToElmWithValue(typeOrRef)
+)
 
 /**
  * An abstract class that represent the base element.
@@ -188,7 +183,7 @@ export class ListType<T extends TypeElement = TypeElement> extends Element {
   }
 
   async getInnerType(elementsSource?: ReadOnlyElementsSource): Promise<TypeElement> {
-    const refInnerTypeVal = await getRefTypeValue(this.refInnerType, elementsSource)
+    const refInnerTypeVal = await this.refInnerType.getResolvedValue(elementsSource)
     // eslint-disable-next-line no-use-before-define
     if (!isType(refInnerTypeVal)) {
       throw new Error(`Element with ElemID ${this.elemID.getFullName()}'s innerType is resolved non-TypeElement`)
@@ -250,7 +245,7 @@ export class MapType<T extends TypeElement = TypeElement> extends Element {
   }
 
   async getInnerType(elementsSource?: ReadOnlyElementsSource): Promise<TypeElement> {
-    const refInnerTypeVal = await getRefTypeValue(this.refInnerType, elementsSource)
+    const refInnerTypeVal = await this.refInnerType.getResolvedValue(elementsSource)
     // eslint-disable-next-line no-use-before-define
     if (!isType(refInnerTypeVal)) {
       throw new Error(`Element with ElemID ${this.elemID.getFullName()}'s innerType is resolved non-TypeElement`)
@@ -299,7 +294,7 @@ export class Field extends Element {
   }
 
   async getType(elementsSource?: ReadOnlyElementsSource): Promise<TypeElement> {
-    const type = await getRefTypeValue(this.refType, elementsSource)
+    const type = await this.refType.getResolvedValue(elementsSource)
     // eslint-disable-next-line no-use-before-define
     if (!isType(type)) {
       throw new Error(`Element with ElemID ${this.elemID.getFullName()}'s type is resolved non-TypeElement`)
@@ -464,7 +459,7 @@ export class InstanceElement extends Element {
   }
 
   async getType(elementsSource?: ReadOnlyElementsSource): Promise<ObjectType> {
-    const type = await getRefTypeValue(this.refType, elementsSource)
+    const type = await this.refType.getResolvedValue(elementsSource)
     // This can happen when the user has an instance like
     // string name {}
     // an instance like that can be created in some cases of syntax errors in the user's nacl

--- a/packages/adapter-api/test/change.test.ts
+++ b/packages/adapter-api/test/change.test.ts
@@ -17,7 +17,6 @@ import { ObjectType, InstanceElement, PrimitiveType, PrimitiveTypes, Field } fro
 import { ElemID } from '../src/element_id'
 import { BuiltinTypes } from '../src/builtins'
 import { getChangeData, Change, isInstanceChange, isObjectTypeChange, isFieldChange, toChange, isAdditionChange, isRemovalChange, isModificationChange, getAllChangeData } from '../src/change'
-import { TypeReference } from '../src/values'
 
 describe('change.ts', () => {
   const objElemID = new ElemID('adapter', 'type')
@@ -29,7 +28,7 @@ describe('change.ts', () => {
       },
     },
   })
-  const inst = new InstanceElement('inst', new TypeReference(obj.elemID, obj), { field: 'val' })
+  const inst = new InstanceElement('inst', obj, { field: 'val' })
 
   it('should getChangeData for removal change', () => {
     const elem = getChangeData({

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -21,7 +21,6 @@ import {
   isVariable, isMapType, MapType, isContainerType, createRefToElmWithValue, PlaceholderObjectType,
 } from '../src/elements'
 import { ElemID, INSTANCE_ANNOTATIONS } from '../src/element_id'
-import { TypeReference } from '../src/values'
 
 describe('Test elements.ts', () => {
   /**   ElemIDs   * */
@@ -48,9 +47,9 @@ describe('Test elements.ts', () => {
     elemID: otID,
     fields: {
       // eslint-disable-next-line camelcase
-      num_field: { refType: new TypeReference(primNum.elemID, primNum) },
+      num_field: { refType: primNum },
       // eslint-disable-next-line camelcase
-      str_field: { refType: new TypeReference(primStr.elemID, primStr) },
+      str_field: { refType: primStr },
     },
     annotationRefsOrTypes: {},
     annotations: {},
@@ -812,7 +811,7 @@ describe('Test elements.ts', () => {
       const obj = new ObjectType({ elemID: new ElemID('a', 'elemID') })
       const objRef = createRefToElmWithValue(obj)
       expect(objRef.elemID).toEqual(obj.elemID)
-      expect(objRef.value).toEqual(obj)
+      expect(objRef.type).toEqual(obj)
     })
   })
 

--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -16,7 +16,7 @@
 */
 import _ from 'lodash'
 import { FieldDefinition, Field, CORE_ANNOTATIONS, TypeElement, isObjectType, isContainerType,
-  getDeepInnerType, ObjectType, BuiltinTypes, createRestriction, createRefToElmWithValue, PrimitiveType, LIST_ID_PREFIX, GENERIC_ID_PREFIX, GENERIC_ID_SUFFIX, MAP_ID_PREFIX, ListType, MapType, isEqualElements, isPrimitiveType, PrimitiveTypes, isReferenceExpression } from '@salto-io/adapter-api'
+  getDeepInnerType, ObjectType, BuiltinTypes, createRestriction, createRefToElmWithValue, PrimitiveType, LIST_ID_PREFIX, GENERIC_ID_PREFIX, GENERIC_ID_SUFFIX, MAP_ID_PREFIX, ListType, MapType, isEqualElements, isPrimitiveType, PrimitiveTypes, isTypeReference } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { values, collections } from '@salto-io/lowerdash'
 import { FieldToHideType, FieldTypeOverrideType, getTypeTransformationConfig } from '../config/transformation'
@@ -68,8 +68,8 @@ export const markServiceIdField = (
     return
   }
   log.debug('Mark field %s.%s as service_id', typeName, fieldName)
-  const fieldType = isReferenceExpression(field.refType)
-    ? field.refType.value
+  const fieldType = isTypeReference(field.refType)
+    ? field.refType.type
     : field.refType
 
   if (!isPrimitiveType(fieldType)) {
@@ -78,10 +78,10 @@ export const markServiceIdField = (
   }
   switch (fieldType.primitive) {
     case (PrimitiveTypes.NUMBER):
-      field.refType = createRefToElmWithValue(BuiltinTypes.SERVICE_ID_NUMBER)
+      field.refType = BuiltinTypes.SERVICE_ID_NUMBER
       return
     case (PrimitiveTypes.STRING):
-      field.refType = createRefToElmWithValue(BuiltinTypes.SERVICE_ID)
+      field.refType = BuiltinTypes.SERVICE_ID
       return
     default:
       log.warn(

--- a/packages/adapter-components/src/elements/type_elements.ts
+++ b/packages/adapter-components/src/elements/type_elements.ts
@@ -58,7 +58,7 @@ export const hideFields = (
  */
 export const markServiceIdField = (
   fieldName: string,
-  typeFields: Record<string, FieldDefinition>,
+  typeFields: Record<string, FieldDefinition | Field>,
   typeName: string,
 ): void => {
   const field = Object.prototype.hasOwnProperty.call(typeFields, fieldName)
@@ -78,10 +78,10 @@ export const markServiceIdField = (
   }
   switch (fieldType.primitive) {
     case (PrimitiveTypes.NUMBER):
-      field.refType = BuiltinTypes.SERVICE_ID_NUMBER
+      field.refType = createRefToElmWithValue(BuiltinTypes.SERVICE_ID_NUMBER)
       return
     case (PrimitiveTypes.STRING):
-      field.refType = BuiltinTypes.SERVICE_ID
+      field.refType = createRefToElmWithValue(BuiltinTypes.SERVICE_ID)
       return
     default:
       log.warn(

--- a/packages/adapter-components/test/elements/ducktype/deployment_placeholder_types.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/deployment_placeholder_types.test.ts
@@ -98,7 +98,7 @@ describe('ducktype deployment functions', () => {
         },
       })
       expect(instanceForDeploy).toBeDefined()
-      expect(instanceForDeploy.refType.value).toEqual(expectedType)
+      expect(instanceForDeploy.refType.type).toEqual(expectedType)
     })
     it('should replace and restore correctly', () => {
       const originalType = instance.clone().refType
@@ -111,7 +111,7 @@ describe('ducktype deployment functions', () => {
         },
       })
       expect(instanceForDeploy).toBeDefined()
-      expect(instanceForDeploy.refType.value).toEqual(expectedType)
+      expect(instanceForDeploy.refType.type).toEqual(expectedType)
       const changes = restoreInstanceTypeFromDeploy({
         appliedChanges: [toChange({ after: instanceForDeploy.clone() })],
         originalInstanceChanges: originalChanges,
@@ -138,7 +138,7 @@ describe('ducktype deployment functions', () => {
       expect(changes).toHaveLength(1)
       const [change] = changes as Change<InstanceElement>[]
       expect(change.action).toEqual('add')
-      expect(getChangeData(change).refType.value).toEqual(objType)
+      expect(getChangeData(change).refType.type).toEqual(objType)
     })
   })
 })

--- a/packages/adapter-components/test/elements/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/type_elements.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { FieldDefinition, BuiltinTypes, ObjectType, ElemID } from '@salto-io/adapter-api'
+import { FieldDefinition, BuiltinTypes, ObjectType, ElemID, createRefToElmWithValue } from '@salto-io/adapter-api'
 import { SUBTYPES_PATH, TYPES_PATH } from '../../src/elements/constants'
 import { filterTypes, hideFields, markServiceIdField } from '../../src/elements/type_elements'
 
@@ -117,7 +117,9 @@ describe('type_elements', () => {
           anotherField: { refType: BuiltinTypes.STRING },
         }
         markServiceIdField('id', typeFields, 'test')
-        expect(typeFields.id.refType).toEqual(BuiltinTypes.SERVICE_ID)
+        expect(typeFields.id.refType).toEqual(
+          createRefToElmWithValue(BuiltinTypes.SERVICE_ID)
+        )
       })
       it('should mark number', () => {
         const typeFields = {
@@ -125,7 +127,9 @@ describe('type_elements', () => {
           anotherField: { refType: BuiltinTypes.STRING },
         }
         markServiceIdField('id', typeFields, 'test')
-        expect(typeFields.id.refType).toEqual(BuiltinTypes.SERVICE_ID_NUMBER)
+        expect(typeFields.id.refType).toEqual(
+          createRefToElmWithValue(BuiltinTypes.SERVICE_ID_NUMBER)
+        )
       })
       it('should not mark boolean', () => {
         const typeFields = {

--- a/packages/adapter-components/test/elements/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/type_elements.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { FieldDefinition, BuiltinTypes, ObjectType, ElemID, createRefToElmWithValue } from '@salto-io/adapter-api'
+import { FieldDefinition, BuiltinTypes, ObjectType, ElemID } from '@salto-io/adapter-api'
 import { SUBTYPES_PATH, TYPES_PATH } from '../../src/elements/constants'
 import { filterTypes, hideFields, markServiceIdField } from '../../src/elements/type_elements'
 
@@ -117,9 +117,7 @@ describe('type_elements', () => {
           anotherField: { refType: BuiltinTypes.STRING },
         }
         markServiceIdField('id', typeFields, 'test')
-        expect(typeFields.id.refType).toEqual(
-          createRefToElmWithValue(BuiltinTypes.SERVICE_ID)
-        )
+        expect(typeFields.id.refType).toEqual(BuiltinTypes.SERVICE_ID)
       })
       it('should mark number', () => {
         const typeFields = {
@@ -127,9 +125,7 @@ describe('type_elements', () => {
           anotherField: { refType: BuiltinTypes.STRING },
         }
         markServiceIdField('id', typeFields, 'test')
-        expect(typeFields.id.refType).toEqual(
-          createRefToElmWithValue(BuiltinTypes.SERVICE_ID_NUMBER)
-        )
+        expect(typeFields.id.refType).toEqual(BuiltinTypes.SERVICE_ID_NUMBER)
       })
       it('should not mark boolean', () => {
         const typeFields = {

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -23,7 +23,7 @@ import {
   Element, isInstanceElement, InstanceElement, isPrimitiveType, TypeMap, isField, ChangeDataType,
   ReferenceExpression, Field, InstanceAnnotationTypes, isType, isObjectType, isAdditionChange,
   CORE_ANNOTATIONS, TypeElement, Change, isRemovalChange, isModificationChange, isListType,
-  ChangeData, ListType, CoreAnnotationTypes, isMapType, MapType, isContainerType,
+  ChangeData, ListType, CoreAnnotationTypes, isMapType, MapType, isContainerType, isTypeReference,
   ReadOnlyElementsSource, ReferenceMap, TypeReference, createRefToElmWithValue, isElement,
 } from '@salto-io/adapter-api'
 import { walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from './walk_element'
@@ -891,11 +891,15 @@ export const createDefaultInstanceFromType = async (name: string, objectType: Ob
 
 type Replacer = (key: string, value: Value) => Value
 
-export const referenceExpressionStringifyReplacer: Replacer = (_key, value) => (
-  isReferenceExpression(value)
-    ? `ReferenceExpression(${value.elemID.getFullName()}, ${value.value ? '<omitted>' : '<no value>'})`
-    : value
-)
+export const referenceExpressionStringifyReplacer: Replacer = (_key, value) => {
+  if (isReferenceExpression(value)) {
+    return `ReferenceExpression(${value.elemID.getFullName()}, ${value.value ? '<omitted>' : '<no value>'})`
+  }
+  if (isTypeReference(value)) {
+    return `TypeReference(${value.elemID.getFullName()}, ${value.type ? '<omitted>' : '<no value>'})`
+  }
+  return value
+}
 
 export const safeJsonStringify = (value: Value,
   replacer?: Replacer,

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -2107,7 +2107,7 @@ describe('Test utils.ts', () => {
     "refWithVal": "ReferenceExpression(a.b, <omitted>)",
     "refWithoutVal": "ReferenceExpression(c.d, <no value>)"
   },
-  "refType": "ReferenceExpression(salto.obj, <omitted>)"
+  "refType": "TypeReference(salto.obj, <omitted>)"
 }`)
       })
     })

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -21,6 +21,7 @@ import {
   ListType, FieldDefinition, FIELD_NAME, INSTANCE_NAME, OBJECT_NAME, ReferenceExpression,
   ReadOnlyElementsSource,
   createRefToElmWithValue,
+  TypeReference,
 } from '@salto-io/adapter-api'
 import * as utils from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -1103,9 +1104,7 @@ describe('fetch', () => {
         const expectedHiddenInstanceAlternateId = instanceWithHiddenAlternateId.clone()
         expectedHiddenInstanceAlternateId.refType = _.clone(expectedHiddenInstanceAlternateId
           .refType)
-        expectedHiddenInstanceAlternateId.refType.value = expect.anything()
-        // refType's type property is not supposed to be transformed, so we don't assert on it.
-        _.set(expectedHiddenInstanceAlternateId.refType, 'type', expect.anything())
+        expectedHiddenInstanceAlternateId.refType.type = expect.anything()
         expect(getChangeData(changes[1].change)).toEqual(expectedHiddenInstanceAlternateId)
       })
     })
@@ -1133,9 +1132,7 @@ describe('fetch', () => {
         const expectedHiddenInstanceAlternateId = instanceWithHiddenAlternateId.clone()
         expectedHiddenInstanceAlternateId.refType = _.clone(expectedHiddenInstanceAlternateId
           .refType)
-        expectedHiddenInstanceAlternateId.refType.value = expect.anything()
-        // refType's type property is not supposed to be transformed, so we don't assert on it.
-        _.set(expectedHiddenInstanceAlternateId.refType, 'type', expect.anything())
+        expectedHiddenInstanceAlternateId.refType.type = expect.anything()
         expect(passed).toEqual([expectedHiddenInstanceAlternateId])
       })
     })
@@ -1242,10 +1239,8 @@ describe('fetch', () => {
       expectedDummy3Type1AfterRename.fields.listListStr = new Field(expectedDummy3Type1AfterRename,
         'listListStr', new ListType(new ListType(dummy3PrimStr)))
       // These next lines remove expectation from resolved values
-      expectedDummy3Type1AfterRename.fields.listListStr.refType.value = expect.anything()
-      _.set(expectedDummy3Type1AfterRename.fields.listListStr.refType, 'type', expect.anything())
-      expectedDummy3Type1AfterRename.fields.listStr.refType.value = expect.anything()
-      _.set(expectedDummy3Type1AfterRename.fields.listStr.refType, 'type', expect.anything())
+      expectedDummy3Type1AfterRename.fields.listListStr.refType.type = expect.anything()
+      expectedDummy3Type1AfterRename.fields.listStr.refType.type = expect.anything()
 
 
       const adapters = {
@@ -1584,7 +1579,7 @@ describe('fetch from workspace', () => {
       editNaclElem,
     ]
     const configs = [
-      new InstanceElement('_config', new ReferenceExpression(new ElemID('salto'))),
+      new InstanceElement('_config', new TypeReference(new ElemID('salto'))),
     ]
     const pi = new remoteMap.InMemoryRemoteMap<pathIndex.Path[]>()
     let fetchRes: FetchChangesResult

--- a/packages/salesforce-adapter/test/filters/author_information/custom_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/author_information/custom_objects.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { CORE_ANNOTATIONS, ElemID, Element, ObjectType, PrimitiveType, PrimitiveTypes, ReferenceExpression } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, ElemID, Element, ObjectType, PrimitiveType, PrimitiveTypes } from '@salto-io/adapter-api'
 import { MockInterface } from '@salto-io/test-utils'
 import { FileProperties } from 'jsforce-types'
 import { mockFileProperties } from '../../connection'
@@ -68,7 +68,7 @@ describe('custom objects author information test', () => {
     elemID: new ElemID('salesforce', 'otherName'),
     annotations: { metadataType: CUSTOM_OBJECT, [API_NAME]: 'otherName' },
     fields: {
-      StringField__c: { refType: new ReferenceExpression(primNum.elemID, primNum) },
+      StringField__c: { refType: primNum },
     },
   })
   beforeEach(() => {
@@ -78,7 +78,7 @@ describe('custom objects author information test', () => {
       elemID: new ElemID('salesforce', 'Custom__c'),
       annotations: { metadataType: CUSTOM_OBJECT, [API_NAME]: 'Custom__c' },
       fields: {
-        StringField__c: { refType: new ReferenceExpression(primNum.elemID, primNum) },
+        StringField__c: { refType: primNum },
       },
     })
   })

--- a/packages/salesforce-adapter/test/filters/author_information/data_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/author_information/data_instances.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, ElemID, Element, ObjectType, ReferenceExpression, InstanceElement } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, ElemID, Element, ObjectType, InstanceElement } from '@salto-io/adapter-api'
 import { MockInterface } from '@salto-io/test-utils'
 import { FileProperties } from 'jsforce-types'
 import { mockFileProperties, mockQueryResult } from '../../connection'
@@ -62,7 +62,7 @@ describe('data instances author information test', () => {
     ({ connection, client } = mockClient())
     testInst = new InstanceElement(
       'Custom__c',
-      new ReferenceExpression(testType.elemID, testType),
+      testType,
       { CreatedDate: 'created_date',
         CreatedById: 'creator_id',
         LastModifiedDate: 'changed_date',

--- a/packages/workspace/src/element_adapter_rename.ts
+++ b/packages/workspace/src/element_adapter_rename.ts
@@ -64,21 +64,21 @@ const recursivelyUpdateContainerType = (type: ContainerType, accountName: string
 }
 
 const updateRefTypeWithId = (refType: TypeReference, accountName: string): void => {
-  if (refType.value === undefined) {
+  if (refType.type === undefined) {
     _.set(refType, 'elemID', createAdapterReplacedID(refType.elemID, accountName))
     return
   }
-  if (isContainerType(refType.value)) {
-    refType.value = refType.value.clone()
-    recursivelyUpdateContainerType(refType.value, accountName)
+  if (isContainerType(refType.type)) {
+    refType.type = refType.type.clone()
+    recursivelyUpdateContainerType(refType.type, accountName)
   } else {
-    const newElemID = createAdapterReplacedID(refType.value.elemID, accountName)
-    if (!newElemID.isEqual(refType.value.elemID)) {
-      refType.value = refType.value.clone()
-      _.set(refType.value, 'elemID', createAdapterReplacedID(refType.value.elemID, accountName))
+    const newElemID = createAdapterReplacedID(refType.type.elemID, accountName)
+    if (!newElemID.isEqual(refType.type.elemID)) {
+      refType.type = refType.type.clone()
+      _.set(refType.type, 'elemID', createAdapterReplacedID(refType.type.elemID, accountName))
     }
   }
-  _.set(refType, 'elemID', refType.value.elemID)
+  _.set(refType, 'elemID', refType.type.elemID)
 }
 
 const transformElemIDAdapter = (accountName: string): TransformFunc => async (

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -20,7 +20,7 @@ import { transformElement, TransformFunc, transformValues, applyFunctionToChange
 import { CORE_ANNOTATIONS, Element, isInstanceElement, isType, TypeElement, getField,
   DetailedChange, isRemovalChange, ElemID, isObjectType, ObjectType, Values,
   isRemovalOrModificationChange, isAdditionOrModificationChange, isElement, isField,
-  ReadOnlyElementsSource, ReferenceMap, isPrimitiveType, PrimitiveType, InstanceElement, Field, isModificationChange, ModificationChange, ReferenceExpression, isReferenceExpression, MapType, getFieldType, isMapType } from '@salto-io/adapter-api'
+  ReadOnlyElementsSource, ReferenceMap, isPrimitiveType, PrimitiveType, InstanceElement, Field, isModificationChange, ModificationChange, ReferenceExpression, MapType, getFieldType, isMapType, isTypeReference } from '@salto-io/adapter-api'
 import { mergeElements, MergeResult } from '../merger'
 import { State } from './state'
 import { createAddChange, createRemoveChange } from './nacl_files/multi_env/projections'
@@ -312,8 +312,8 @@ const isAnnotationTypeChange = (
 ): change is DetailedChange & ModificationChange<ReferenceExpression> => (
   isModificationChange(change)
   && change.id.isAnnotationTypeID()
-  && (isReferenceExpression(change.data.before))
-  && (isReferenceExpression(change.data.after))
+  && (isTypeReference(change.data.before))
+  && (isTypeReference(change.data.after))
 )
 
 type EffectOnHidden = 'hide' | 'unHide' | 'none'

--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import path from 'path'
-import { getChangeData, isElement, ObjectType, ElemID, Element, isType, isAdditionChange, DetailedChange, Value, StaticFile, isStaticFile, isReferenceExpression, TypeReference } from '@salto-io/adapter-api'
+import { getChangeData, isElement, ObjectType, ElemID, Element, isType, isAdditionChange, DetailedChange, Value, StaticFile, isStaticFile, TypeReference, isTypeReference } from '@salto-io/adapter-api'
 import { AdditionDiff, ActionName } from '@salto-io/dag'
 import { walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -205,7 +205,7 @@ export const updateNaclFileData = async (
       const changeKey = change.id.name
       const isListElement = changeKey.match(/^\d+$/) !== null
       if (change.id.isAnnotationTypeID()) {
-        if (isType(elem) || isReferenceExpression(elem)) {
+        if (isType(elem) || isTypeReference(elem)) {
           newData = dumpSingleAnnotationType(
             changeKey,
             new TypeReference(elem.elemID),

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 /* eslint-disable camelcase */
-import { ObjectType, ElemID, BuiltinTypes, InstanceElement, CORE_ANNOTATIONS, ReferenceExpression, PrimitiveType, PrimitiveTypes, MapType, ListType, getRestriction, createRestriction, VariableExpression, Variable, StaticFile, createRefToElmWithValue } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, BuiltinTypes, InstanceElement, CORE_ANNOTATIONS, ReferenceExpression, PrimitiveType, PrimitiveTypes, MapType, ListType, getRestriction, createRestriction, VariableExpression, Variable, StaticFile, createRefToElmWithValue, TypeReference } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import {
   validateElements, InvalidValueValidationError, CircularReferenceValidationError,
@@ -2074,7 +2074,7 @@ describe('Elements validation', () => {
     it('should throw an error when an instance type is not found', async () => {
       const instance = new InstanceElement(
         'name',
-        new ReferenceExpression(new ElemID('instance', 'notExists')),
+        new TypeReference(new ElemID('instance', 'notExists')),
       )
       const errors = await validateElements(
         [instance],

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -3967,7 +3967,7 @@ describe('listUnresolvedReferences', () => {
       const defaultElements = createEnvElements() as InstanceElement[]
       defaultElements[3].value = {
         ...(defaultElements[3] as InstanceElement).value,
-        f3: new TypeReference(new ElemID('salesforce', 'unresolved')),
+        f3: new ReferenceExpression(new ElemID('salesforce', 'unresolved')),
       }
       const otherElements = createEnvElements().slice(1)
       workspace = await createWorkspace(


### PR DESCRIPTION
Currently TypeReference stores its value both in .type and in .value that is inherited from ReferenceExpression
This leads to confusion in the code where some places use .value and others use .type

Aligning all places to use .type (since that is the more strongly typed option)

---


---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_