### PR TITLE
SAAS-4713: Revert "SALTO-2156: Fix unneeded cache invalidation in multi-env source"

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -216,14 +216,18 @@ export const createMergeManager = async (flushables: Flushable[],
     const src2Changes = possibleSrc2Changes ?? createEmptyChangeSet(
       await hashes.get(getSourceHashKey(cacheUpdate.src2Prefix))
     )
-    const preChangeHash = (src1Changes.preChangeHash || '') + (src2Changes.preChangeHash || '')
-    const mergedHashKey = getMergedHashKey(cacheUpdate.src1Prefix, cacheUpdate.src2Prefix)
-    const cachePreChangeHash = await hashes.get(mergedHashKey) ?? ''
-    const cacheValid = (
-      preChangeHash === cachePreChangeHash
-      && src1Changes.cacheValid
-      && src2Changes.cacheValid
-    )
+    const preChangeHash = (((src1Changes.preChangeHash || '')
+      + (src2Changes.preChangeHash || '')))
+    const postChangeHash = ((src1Changes.postChangeHash || '')
+      + (src2Changes.postChangeHash || ''))
+    const cachePreChangeHash = await hashes.get(getMergedHashKey(cacheUpdate.src1Prefix,
+      cacheUpdate.src2Prefix)) ?? ''
+    log.debug('Setting merged hash of namespace %s to %s', fullNamespace, postChangeHash)
+    await hashes.set(getMergedHashKey(cacheUpdate.src1Prefix, cacheUpdate.src2Prefix),
+      postChangeHash)
+    const cacheValid = ((!preChangeHash && !cachePreChangeHash)
+      || preChangeHash === cachePreChangeHash)
+      && src1Changes.cacheValid && src2Changes.cacheValid
     if (!src1Changes.cacheValid) {
       log.debug(`Invalid cache: ${cacheUpdate.src1Prefix}`)
     }
@@ -234,10 +238,6 @@ export const createMergeManager = async (flushables: Flushable[],
       log.debug(`Invalid cache merge between ${cacheUpdate.src1Prefix} and ${cacheUpdate.src2Prefix}`)
       log.debug(`Prechange hash: ${cachePreChangeHash} and update merged hash: ${preChangeHash}`)
     }
-    const postChangeHash = (src1Changes.postChangeHash || '') + (src2Changes.postChangeHash || '')
-    log.debug('Setting hash %s::%s to %s', fullNamespace, mergedHashKey, postChangeHash)
-    await hashes.set(mergedHashKey, postChangeHash)
-
     const getElementsToMerge = async (): Promise<{
       src1ElementsToMerge: ThenableIterable<Element>
       src2ElementsToMerge: ThenableIterable<Element>

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -63,6 +63,7 @@ export type NaclFile = {
 }
 export type SourceLoadParams = {
   ignoreFileChanges?: boolean
+  env?: string
 }
 
 export type NaclFilesSource<Changes=ChangeSet<Change>> = Omit<ElementsSource, 'clear'> & {
@@ -416,7 +417,11 @@ const buildNaclFilesState = async ({
       if (oldNaclFile === undefined) {
         return
       }
-      const oldNaclFileReferenced = await oldNaclFile.data.referenced()
+      const oldNaclFileReferenced = (await oldNaclFile.data.referenced())
+      // If one of the properties of ParsedNaclFile is undefined it is considered as not exist
+      if (oldNaclFileReferenced === undefined) {
+        return
+      }
       oldNaclFileReferenced.forEach((elementFullName: string) => {
         referencedIndexDeletions[elementFullName] = referencedIndexDeletions[elementFullName]
           ?? new Set<string>()

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_file.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_file.ts
@@ -18,7 +18,7 @@ import { SourceMap, ParseError } from '../../parser'
 
 export type ParsedNaclFileData = {
   errors: () => Promise<ParseError[] | undefined>
-  referenced: () => Promise<string[]>
+  referenced: () => Promise<string[] | undefined>
 }
 
 export type ParsedNaclFile = {

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
@@ -75,7 +75,7 @@ const parseNaclFileFromCacheSources = async (
   elements: () => cacheSources.elements.get(filename),
   data: {
     errors: async () => (await cacheSources.errors.get(filename) ?? []),
-    referenced: async () => (await cacheSources.referenced.get(filename) ?? []),
+    referenced: () => cacheSources.referenced.get(filename),
   },
   sourceMap: () => cacheSources.sourceMap.get(filename),
 })
@@ -183,7 +183,7 @@ export const createParseResultCache = (
           await errors.delete(value.filename)
         }
       }
-      await referenced.set(value.filename, await value.data.referenced())
+      await referenced.set(value.filename, (await value.data.referenced()) ?? [])
       const sourceMapValue = await value.sourceMap?.()
       if (sourceMapValue !== undefined) {
         await sourceMap.set(value.filename, sourceMapValue)
@@ -214,7 +214,7 @@ export const createParseResultCache = (
       await errors.setAll(errorEntriesToAdd)
       await errors.deleteAll(errorEntriesToDelete)
       await referenced.setAll(awu(Object.keys(files))
-        .map(async file => ({ key: file, value: await files[file].data.referenced() })))
+        .map(async file => ({ key: file, value: await files[file].data.referenced() ?? [] })))
       await sourceMap.setAll(awu(Object.keys(files))
         .map(async file => {
           const fileSourceMap = await files[file].sourceMap?.()


### PR DESCRIPTION
This reverts commit cfa72e575c17bca9274e2b3dd9893157e2098ea5.

_Release Notes_: 
Fix failures in fetch from workspace flows