### PR TITLE
SALTO-2157 change prompt message for invoking clean workspace

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -68,7 +68,7 @@ export const shouldDeploy = async (
   if (_.isEmpty(actions)) {
     return false
   }
-  return getUserBooleanInput(Prompts.SHOULD_EXECUTE_PLAN)
+  return getUserBooleanInput(Prompts.SHOULD_EXECUTE_DEPLOY_PLAN)
 }
 
 type DeployArgs = {

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -18,7 +18,8 @@ import moment from 'moment'
 import os from 'os'
 
 export default class Prompts {
-  public static readonly SHOULD_EXECUTE_PLAN = 'Do you want to deploy?'
+  public static readonly SHOULD_EXECUTE_PLAN = 'Do you want to perform these actions?'
+  public static readonly SHOULD_EXECUTE_DEPLOY_PLAN = 'Do you want to deploy?'
 
   public static readonly CANCEL_DEPLOY_ACTION = 'Cancelled: Due to an erroneous dependency -'
   public static readonly START_DEPLOY_EXEC = 'Starting the deployment plan'

--- a/packages/cli/test/commands/workspace.test.ts
+++ b/packages/cli/test/commands/workspace.test.ts
@@ -18,6 +18,7 @@ import * as callbacks from '../../src/callbacks'
 import * as mocks from '../mocks'
 import { cleanAction, cacheUpdateAction } from '../../src/commands/workspace'
 import { CliExitCode } from '../../src/types'
+import Prompts from '../../src/prompts'
 
 jest.mock('@salto-io/core', () => ({
   ...jest.requireActual<{}>('@salto-io/core'),
@@ -84,7 +85,7 @@ describe('workspace command group', () => {
           },
           workspace: mocks.mockWorkspace({}),
         })).toBe(CliExitCode.Success)
-        expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith('Do you want to deploy?')
+        expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith(Prompts.SHOULD_EXECUTE_PLAN)
         expect(output.stdout.content.search('Canceling...')).toBeGreaterThan(0)
       })
       it('should prompt user and exit if no (regenerate-cache)', async () => {
@@ -103,7 +104,7 @@ describe('workspace command group', () => {
           },
           workspace: mocks.mockWorkspace({}),
         })).toBe(CliExitCode.Success)
-        expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith('Do you want to deploy?')
+        expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith(Prompts.SHOULD_EXECUTE_PLAN)
         expect(output.stdout.content.search('Canceling...')).toBeGreaterThan(0)
       })
       it('should fail if trying to clean static resources without all dependent components', async () => {
@@ -140,7 +141,7 @@ describe('workspace command group', () => {
           },
           workspace,
         })).toBe(CliExitCode.Success)
-        expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith('Do you want to deploy?')
+        expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith(Prompts.SHOULD_EXECUTE_PLAN)
         expect(core.cleanWorkspace).toHaveBeenCalledWith(workspace, {
           nacl: true,
           state: true,

--- a/packages/cli/test/commands/workspace.test.ts
+++ b/packages/cli/test/commands/workspace.test.ts
@@ -18,7 +18,6 @@ import * as callbacks from '../../src/callbacks'
 import * as mocks from '../mocks'
 import { cleanAction, cacheUpdateAction } from '../../src/commands/workspace'
 import { CliExitCode } from '../../src/types'
-import Prompts from '../../src/prompts'
 
 jest.mock('@salto-io/core', () => ({
   ...jest.requireActual<{}>('@salto-io/core'),
@@ -85,7 +84,7 @@ describe('workspace command group', () => {
           },
           workspace: mocks.mockWorkspace({}),
         })).toBe(CliExitCode.Success)
-        expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith(Prompts.SHOULD_EXECUTE_PLAN)
+        expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith('Do you want to perform these actions?')
         expect(output.stdout.content.search('Canceling...')).toBeGreaterThan(0)
       })
       it('should prompt user and exit if no (regenerate-cache)', async () => {
@@ -104,7 +103,7 @@ describe('workspace command group', () => {
           },
           workspace: mocks.mockWorkspace({}),
         })).toBe(CliExitCode.Success)
-        expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith(Prompts.SHOULD_EXECUTE_PLAN)
+        expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith('Do you want to perform these actions?')
         expect(output.stdout.content.search('Canceling...')).toBeGreaterThan(0)
       })
       it('should fail if trying to clean static resources without all dependent components', async () => {
@@ -141,7 +140,7 @@ describe('workspace command group', () => {
           },
           workspace,
         })).toBe(CliExitCode.Success)
-        expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith(Prompts.SHOULD_EXECUTE_PLAN)
+        expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith('Do you want to perform these actions?')
         expect(core.cleanWorkspace).toHaveBeenCalledWith(workspace, {
           nacl: true,
           state: true,


### PR DESCRIPTION
change prompt msg

---
In SAAS-3481 I've changed SHOULD_EXECUTE_PLAN prompt message to fit the desire text (by product decision) to execute deploy plan.

When invoking a clean ws we want the old prompt msg, so I've split it into two different prompts

---
_Release Notes_: 
None

---
_User Notifications_: 
None