### PR TITLE
Restored jira swagger url to main

### DIFF
--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1508,7 +1508,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
 
 export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
   platformSwagger: {
-    url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/platform-swagger.v3.json',
+    url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/main/platform-swagger.v3.json',
     typeNameOverrides: [
       {
         originalName: 'FilterDetails',
@@ -1642,7 +1642,7 @@ export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
     ],
   },
   jiraSwagger: {
-    url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/software-swagger.v3.json',
+    url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/main/software-swagger.v3.json',
     typeNameOverrides: [
       {
         originalName: 'rest__agile__1_0__board@uuuuvuu',

--- a/packages/jira-adapter/system_config_doc.md
+++ b/packages/jira-adapter/system_config_doc.md
@@ -4,7 +4,7 @@
 jira {
   apiDefinitions = {
     platformSwagger = {
-      url = "https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/platform-swagger.v3.json"
+      url = "https://raw.githubusercontent.com/salto-io/jira-swaggers/main/platform-swagger.v3.json"
       typeNameOverrides = [
         {
           originalName = "FilterDetails"
@@ -139,7 +139,7 @@ jira {
       ]
     }
     jiraSwagger = {
-      url = "https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/software-swagger.v3.json"
+      url = "https://raw.githubusercontent.com/salto-io/jira-swaggers/main/software-swagger.v3.json"
       typeNameOverrides = [
         {
           originalName = "rest__agile__1_0__board@uuuuvuu"

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -225,13 +225,13 @@ describe('adapter', () => {
     })
     it('should generate types for the platform and the jira apis', () => {
       expect(loadSwagger).toHaveBeenCalledTimes(2)
-      expect(loadSwagger).toHaveBeenCalledWith('https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/platform-swagger.v3.json')
-      expect(loadSwagger).toHaveBeenCalledWith('https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/software-swagger.v3.json')
+      expect(loadSwagger).toHaveBeenCalledWith('https://raw.githubusercontent.com/salto-io/jira-swaggers/main/platform-swagger.v3.json')
+      expect(loadSwagger).toHaveBeenCalledWith('https://raw.githubusercontent.com/salto-io/jira-swaggers/main/software-swagger.v3.json')
       expect(generateTypes).toHaveBeenCalledWith(
         JIRA,
         expect.objectContaining({
           swagger: expect.objectContaining({
-            url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/platform-swagger.v3.json',
+            url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/main/platform-swagger.v3.json',
           }),
         }),
         undefined,
@@ -241,7 +241,7 @@ describe('adapter', () => {
         JIRA,
         expect.objectContaining({
           swagger: expect.objectContaining({
-            url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/next-main/software-swagger.v3.json',
+            url: 'https://raw.githubusercontent.com/salto-io/jira-swaggers/main/software-swagger.v3.json',
           }),
         }),
         undefined,


### PR DESCRIPTION
We changed the url of the Jira swagger to work with a temporary branch `next-main` to handle a breaking change in the swagger. Now that it is in production, we can return it to `main`

---
_Release Notes_: 
None

---
_User Notifications_: 
None