### PR TITLE
SALTO-1804 - Add the refToInstanceSameType validator to the salesforce config

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -27,6 +27,7 @@ import multipleDefaultsValidator from './change_validators/multiple_defaults'
 import picklistPromoteValidator from './change_validators/picklist_promote'
 import createValidateOnlyFlagValidator from './change_validators/validate_only_flag'
 import cpqValidator from './change_validators/cpq_trigger'
+import refToInstanceSameType from './change_validators/ref_to_instance_of_same_type'
 import { ChangeValidatorName, SalesforceConfig } from './types'
 
 type ChangeValidatorCreator = (config: SalesforceConfig) => ChangeValidator
@@ -42,6 +43,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   picklistPromote: () => picklistPromoteValidator,
   validateOnlyFlag: createValidateOnlyFlagValidator,
   cpqValidator: () => cpqValidator,
+  refToInstanceSameType: () => refToInstanceSameType,
 }
 
 

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -76,6 +76,7 @@ export type ChangeValidatorName = (
   | 'picklistPromote'
   | 'validateOnlyFlag'
   | 'cpqValidator'
+  | 'refToInstanceSameType'
 )
 export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -472,6 +473,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     picklistPromote: { refType: BuiltinTypes.BOOLEAN },
     validateOnlyFlag: { refType: BuiltinTypes.BOOLEAN },
     cpqValidator: { refType: BuiltinTypes.BOOLEAN },
+    refToInstanceSameType: { refType: BuiltinTypes.BOOLEAN },
   },
 })
 


### PR DESCRIPTION
Add the validator that was merged in https://github.com/salto-io/salto/pull/2896 to the ChangeValidators config so it will actually run 🤦‍♂️
