### PR TITLE
Salto-1578 - sbaa ApprovalRule with Custom ConditionsMet validate no incoming ref on addition

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -28,6 +28,7 @@ import picklistPromoteValidator from './change_validators/picklist_promote'
 import createValidateOnlyFlagValidator from './change_validators/validate_only_flag'
 import cpqValidator from './change_validators/cpq_trigger'
 import refToInstanceSameType from './change_validators/ref_to_instance_of_same_type'
+import sbaaApprovalRulesCustomCondition from './change_validators/sbaa_approval_rules_custom_condition'
 import { ChangeValidatorName, SalesforceConfig } from './types'
 
 type ChangeValidatorCreator = (config: SalesforceConfig) => ChangeValidator
@@ -44,6 +45,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   validateOnlyFlag: createValidateOnlyFlagValidator,
   cpqValidator: () => cpqValidator,
   refToInstanceSameType: () => refToInstanceSameType,
+  sbaaApprovalRulesCustomCondition: () => sbaaApprovalRulesCustomCondition,
 }
 
 

--- a/packages/salesforce-adapter/src/change_validators/sbaa_approval_rules_custom_condition.ts
+++ b/packages/salesforce-adapter/src/change_validators/sbaa_approval_rules_custom_condition.ts
@@ -1,0 +1,74 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ChangeValidator, getChangeData, isAdditionChange, isInstanceChange, InstanceElement, SeverityLevel } from '@salto-io/adapter-api'
+import { getAllReferencedIds } from '@salto-io/adapter-utils'
+import { values, collections } from '@salto-io/lowerdash'
+import { isInstanceOfCustomObjectChange } from '../custom_object_instances_deploy'
+import { getNamespace } from '../filters/utils'
+import { hasNamespace } from './package'
+import { SBAA_NAMESPACE, SBAA_APPROVAL_CONDITION, SBAA_APPROVAL_RULE } from '../constants'
+import { apiName } from '../transformers/transformer'
+
+const { awu } = collections.asynciterable
+
+/*
+  Add a Warning on Addition sbaa ApprovalRules with Custom ConditionMet
+  if there's also an Addition of an ApprovalCondition that references it
+  because there is a trigger validation that does not allow these to be deployed together
+*/
+const changeValidator: ChangeValidator = async changes => {
+  const sbaaAdditionInstances = await awu(changes)
+    .filter(isInstanceOfCustomObjectChange)
+    .filter(isInstanceChange)
+    .filter(isAdditionChange)
+    .map(getChangeData)
+    .filter(async (instance: InstanceElement) => {
+      const type = await instance.getType()
+      return await hasNamespace(type) && (await getNamespace(type)) === SBAA_NAMESPACE
+    })
+    .toArray()
+  const approvalRuleWithCustomCondAdditionInstances = await awu(sbaaAdditionInstances)
+    .filter(async instance =>
+      (await apiName(await instance.getType())) === SBAA_APPROVAL_RULE
+      && instance.value.sbaa__ConditionsMet__c === 'Custom')
+    .toArray()
+  const idToRuleWithCustomAdditionInst = Object.fromEntries(
+    approvalRuleWithCustomCondAdditionInstances
+      .map(instance => [instance.elemID.getFullName(), instance]),
+  )
+  const approvalRuleAdditionInstWithCustomElemIDs = Object.keys(idToRuleWithCustomAdditionInst)
+  const approvalConditionAdditionInstances = await awu(sbaaAdditionInstances)
+    .filter(async instance =>
+      (await apiName(await instance.getType())) === SBAA_APPROVAL_CONDITION)
+    .toArray()
+  const referencedFromAdditionConditions = new Set(approvalConditionAdditionInstances
+    .flatMap(instance => Array.from(getAllReferencedIds(instance))))
+  if (referencedFromAdditionConditions.size === 0) {
+    return []
+  }
+  const rulesReferencedFromAdditionConditions = approvalRuleAdditionInstWithCustomElemIDs
+    .filter(instanceElemID => referencedFromAdditionConditions.has(instanceElemID))
+  return rulesReferencedFromAdditionConditions.map(referencedInstanceElemID =>
+    ({
+      elemID: idToRuleWithCustomAdditionInst[referencedInstanceElemID].elemID,
+      severity: 'Warning' as SeverityLevel,
+      message: 'Cannot deploy an ApprovalRule with ConditionMet Custom that has a referencing ApprovalCondition if Triggers are on. Must change to All, deploy, change back and deploy again.',
+      detailedMessage: `Cannot deploy ApprovalRule ${referencedInstanceElemID} if Triggers are on cause it has ConditionMet Custom and is referenced by an ApprovalCondition. Must change to All, deploy, change back and deploy again.`,
+    })).filter(values.isDefined)
+}
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -401,3 +401,10 @@ export const TEST_OBJECT_TO_API_MAPPING = {
 export const SCHEDULE_CONTRAINT_FIELD_TO_API_MAPPING = {
   [CPQ_ACCOUNT_NO_PRE]: CPQ_ACCOUNT,
 } as Record<string, string>
+
+// sbaa
+export const SBAA_NAMESPACE = 'sbaa'
+
+// sbaa Objects
+export const SBAA_APPROVAL_CONDITION = 'sbaa__ApprovalCondition__c'
+export const SBAA_APPROVAL_RULE = 'sbaa__ApprovalRule__c'

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -77,6 +77,7 @@ export type ChangeValidatorName = (
   | 'validateOnlyFlag'
   | 'cpqValidator'
   | 'refToInstanceSameType'
+  | 'sbaaApprovalRulesCustomCondition'
 )
 export type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -474,6 +475,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     validateOnlyFlag: { refType: BuiltinTypes.BOOLEAN },
     cpqValidator: { refType: BuiltinTypes.BOOLEAN },
     refToInstanceSameType: { refType: BuiltinTypes.BOOLEAN },
+    sbaaApprovalRulesCustomCondition: { refType: BuiltinTypes.BOOLEAN },
   },
 })
 

--- a/packages/salesforce-adapter/test/change_validators/sbaa_approval_rules_custom_condition.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/sbaa_approval_rules_custom_condition.test.ts
@@ -1,0 +1,124 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { ObjectType, ElemID, BuiltinTypes, InstanceElement, ReferenceExpression, ChangeError, toChange } from '@salto-io/adapter-api'
+import sbaaApprovalRulesCustomCondition from '../../src/change_validators/sbaa_approval_rules_custom_condition'
+import { CUSTOM_OBJECT, METADATA_TYPE, API_NAME, SBAA_APPROVAL_CONDITION, SBAA_APPROVAL_RULE } from '../../src/constants'
+
+describe('sbaa addition approval rules with custom condition met with incoming addition references validator', () => {
+  let changeErrors: Readonly<ChangeError[]>
+  const approvalRuleObj = new ObjectType({
+    elemID: new ElemID('salesforce', SBAA_APPROVAL_RULE),
+    fields: {
+      sbaa__ConditionsMet__c: {
+        refType: BuiltinTypes.STRING,
+      },
+    },
+    annotations: {
+      [METADATA_TYPE]: CUSTOM_OBJECT,
+      [API_NAME]: SBAA_APPROVAL_RULE,
+    },
+  })
+  const approvalConditionObj = new ObjectType({
+    elemID: new ElemID('salesforce', SBAA_APPROVAL_CONDITION),
+    fields: {
+      refField: {
+        refType: BuiltinTypes.STRING,
+      },
+    },
+    annotations: {
+      [METADATA_TYPE]: CUSTOM_OBJECT,
+      [API_NAME]: SBAA_APPROVAL_CONDITION,
+    },
+  })
+  const approvalRuleInstCustomCond = new InstanceElement(
+    'ruleInstCustom',
+    approvalRuleObj,
+    {
+      sbaa__ConditionsMet__c: 'Custom',
+    },
+  )
+  const approvalRuleInstAllCond = new InstanceElement(
+    'ruleInstAll',
+    approvalRuleObj,
+    {
+      sbaa__ConditionsMet__c: 'All',
+    },
+  )
+  const approvalConditionWithRefToCustom = new InstanceElement(
+    'condWithRefToCustom',
+    approvalConditionObj,
+    {
+      refField: new ReferenceExpression(
+        approvalRuleInstCustomCond.elemID,
+        approvalRuleInstCustomCond,
+      ),
+    },
+  )
+  const approvalConditionWithRefToAll = new InstanceElement(
+    'condWithRefToAll',
+    approvalConditionObj,
+    {
+      refField: new ReferenceExpression(
+        approvalRuleInstAllCond.elemID,
+        approvalRuleInstAllCond,
+      ),
+    },
+  )
+  const approvalCondWithNoRef = new InstanceElement(
+    'condWithNoRef',
+    approvalConditionObj,
+    {
+      refField: 'noRef',
+    },
+  )
+
+  it('Should return an error if the instance with custom condition met has a ref to from addition instance', async () => {
+    changeErrors = await sbaaApprovalRulesCustomCondition(
+      [
+        toChange({ after: approvalConditionWithRefToCustom }),
+        toChange({ after: approvalRuleInstCustomCond }),
+      ]
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Warning')
+    expect(changeErrors[0].elemID).toEqual(approvalRuleInstCustomCond.elemID)
+  })
+
+  it('Should have no error if the ref is to an inst with All condition', async () => {
+    changeErrors = await sbaaApprovalRulesCustomCondition(
+      [
+        toChange({ after: approvalConditionWithRefToAll }),
+        toChange({ after: approvalRuleInstAllCond }),
+      ]
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+
+  it('Should have no error if the rule is with Custom cond but no add approvalCond with ref to it', async () => {
+    changeErrors = await sbaaApprovalRulesCustomCondition(
+      [
+        toChange({ after: approvalConditionWithRefToAll }),
+        toChange({ after: approvalCondWithNoRef }),
+        toChange({
+          before: approvalConditionWithRefToCustom,
+          after: approvalConditionWithRefToCustom,
+        }),
+        toChange({ after: approvalRuleInstCustomCond }),
+      ]
+    )
+  })
+})


### PR DESCRIPTION
We currently know it's impossible to add an ApprovalRule with ConditionMet valued Custom that has an incoming reference from an ApprovalCondition that is also being added, due to a package Trigger validation that is impossible to disable at the moment.
Our current workaround is to modify the value to "All", deploy, and then change back to "Custom" and deploy again. This is currently only in our memories, this validator is here is Warn the users and remind them of this painful solution so we and they won't forget.
There are longer term possible solutions for this but this has been the case for a while so a validator seems reasonable.

This is a Warning and not an Error cause someone might have another way to work around this and an Error can be painful if that's the case.

---
_Release Notes_: 
*Salesforce*:
* Added a new validator that checks for a know deploy issue in sbaa and warns the users


