### PR TITLE
SALTO-837 sdf partial successful deploy

### DIFF
--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -34,7 +34,7 @@ import { DeployResult } from '../types'
 import { CONFIG_FEATURES, APPLICATION_ID, SCRIPT_ID } from '../constants'
 import { convertInstanceMapsToLists } from '../mapped_lists/utils'
 import { toConfigDeployResult, toSetConfigTypes } from '../suiteapp_config_elements'
-import { FeaturesDeployError, ObjectsDeployError } from '../errors'
+import { FeaturesDeployError, ObjectsDeployError, SettingsDeployError } from '../errors'
 
 const { awu } = collections.asynciterable
 const log = logger(module)
@@ -203,6 +203,13 @@ export default class NetsuiteClient {
           _.remove(
             changesToDeploy,
             change => failedElemIDs.has(getChangeData(change).elemID.getFullName())
+          )
+        } else if (error instanceof SettingsDeployError) {
+          const { failedConfigTypes } = error
+          log.debug('sdf failed to deploy: %o', Array.from(failedConfigTypes))
+          _.remove(
+            changesToDeploy,
+            change => failedConfigTypes.has(getChangeData(change).elemID.typeName)
           )
         } else {
           // unknown error

--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -107,7 +107,7 @@ const configureFeatureFailRegex = RegExp(`Configure feature -- (Enabling|Disabli
 const OBJECT_ID = 'objectId'
 const deployStartMessageRegex = RegExp('^Begin deployment$', 'm')
 const objectValidationErrorRegex = RegExp(`^An error occurred during custom object validation. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'gm')
-const deployedObjectRegex = RegExp(`^Update object -- (?<${OBJECT_ID}>[a-z0-9_]+)`, 'gm')
+const deployedObjectRegex = RegExp(`^(Create|Update) object -- (?<${OBJECT_ID}>[a-z0-9_]+)`, 'gm')
 const errorObjectRegex = RegExp(`^An unexpected error has occurred. \\((?<${OBJECT_ID}>[a-z0-9_]+)\\)`, 'm')
 
 export const MINUTE_IN_MILLISECONDS = 1000 * 60
@@ -896,6 +896,8 @@ export default class SdfClient {
     const errorMessage = error.message
 
     if (!deployStartMessageRegex.test(errorMessage)) {
+      // we'll get here when the deploy failed in the validation phase.
+      // in this case we're looking for validation error message lines.
       const validationErrorObjects = getGroupItemFromRegex(
         errorMessage, objectValidationErrorRegex, OBJECT_ID
       )

--- a/packages/netsuite-adapter/src/errors.ts
+++ b/packages/netsuite-adapter/src/errors.ts
@@ -21,3 +21,12 @@ export class FeaturesDeployError extends Error {
     this.name = 'FeaturesDeployError'
   }
 }
+
+export class ObjectsDeployError extends Error {
+  failObjects: Set<string>
+  constructor(message: string, failObjects: Set<string>) {
+    super(message)
+    this.failObjects = failObjects
+    this.name = 'ObjectsDeployError'
+  }
+}

--- a/packages/netsuite-adapter/src/errors.ts
+++ b/packages/netsuite-adapter/src/errors.ts
@@ -30,3 +30,12 @@ export class ObjectsDeployError extends Error {
     this.name = 'ObjectsDeployError'
   }
 }
+
+export class SettingsDeployError extends Error {
+  failedConfigTypes: Set<string>
+  constructor(message: string, failedConfigTypes: Set<string>) {
+    super(message)
+    this.failedConfigTypes = failedConfigTypes
+    this.name = 'SettingsDeployError'
+  }
+}

--- a/packages/netsuite-adapter/src/errors.ts
+++ b/packages/netsuite-adapter/src/errors.ts
@@ -23,10 +23,10 @@ export class FeaturesDeployError extends Error {
 }
 
 export class ObjectsDeployError extends Error {
-  failObjects: Set<string>
-  constructor(message: string, failObjects: Set<string>) {
+  failedObjects: Set<string>
+  constructor(message: string, failedObjects: Set<string>) {
     super(message)
-    this.failObjects = failObjects
+    this.failedObjects = failedObjects
     this.name = 'ObjectsDeployError'
   }
 }

--- a/packages/netsuite-adapter/src/group_changes.ts
+++ b/packages/netsuite-adapter/src/group_changes.ts
@@ -49,6 +49,9 @@ export const SUITEAPP_FILE_CABINET_GROUPS = [
 
 const getSdfWithSuiteAppGroupName = (change: Change): string => {
   const element = getChangeData(change)
+  if (isSDFConfigTypeName(element.elemID.typeName)) {
+    return `${SDF_CHANGE_GROUP_ID} - Settings`
+  }
   if (!isInstanceElement(element) || element.value[APPLICATION_ID] === undefined) {
     return SDF_CHANGE_GROUP_ID
   }

--- a/packages/netsuite-adapter/src/group_changes.ts
+++ b/packages/netsuite-adapter/src/group_changes.ts
@@ -49,9 +49,6 @@ export const SUITEAPP_FILE_CABINET_GROUPS = [
 
 const getSdfWithSuiteAppGroupName = (change: Change): string => {
   const element = getChangeData(change)
-  if (isSDFConfigTypeName(element.elemID.typeName)) {
-    return `${SDF_CHANGE_GROUP_ID} - Settings`
-  }
   if (!isInstanceElement(element) || element.value[APPLICATION_ID] === undefined) {
     return SDF_CHANGE_GROUP_ID
   }

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -13,7 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
 import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import SuiteAppClient from '../../src/client/suiteapp_client/suiteapp_client'
 import SdfClient from '../../src/client/sdf_client'
@@ -38,19 +37,6 @@ describe('NetsuiteClient', () => {
 
       beforeEach(() => {
         jest.resetAllMocks()
-      })
-
-      it('should deploy in chunks', async () => {
-        const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
-        const changes = _.range(60).map(index => toChange({
-          after: new InstanceElement(`instance${index}`, type, { scriptid: `id${index}` }),
-        }))
-        expect(await client.deploy(changes, SDF_CHANGE_GROUP_ID, false))
-          .toEqual({
-            errors: [],
-            appliedChanges: changes,
-          })
-        expect(mockSdfDeploy).toHaveBeenCalledTimes(2)
       })
 
       it('should try again to deploy after ObjectsDeployError', async () => {

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -33,7 +33,7 @@ import SdfClient, {
 import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, TemplateCustomTypeInfo } from '../../src/client/types'
 import { fileCabinetTopLevelFolders } from '../../src/client/constants'
 import { DEFAULT_COMMAND_TIMEOUT_IN_MINUTES } from '../../src/config'
-import { FeaturesDeployError } from '../../src/errors'
+import { FeaturesDeployError, ObjectsDeployError } from '../../src/errors'
 
 
 const MOCK_TEMPLATE_CONTENT = Buffer.from('Template Inner Content')
@@ -164,7 +164,7 @@ jest.mock('@salto-io/suitecloud-cli', () => ({
   },
 }))
 
-describe('netsuite client', () => {
+describe('sdf client', () => {
   const createProjectCommandMatcher = expect
     .objectContaining({ commandName: COMMANDS.CREATE_PROJECT })
   const saveTokenCommandMatcher = expect.objectContaining({
@@ -1311,6 +1311,279 @@ describe('netsuite client', () => {
         })
         await expect(client.deploy([{} as CustomTypeInfo])).rejects
           .toThrow(new Error(errorMessage))
+      })
+      it('should throw ObjectsDeployError when deploy failed on object validation', async () => {
+        const errorMessage = `
+The deployment process has encountered an error.
+Deploying to TSTDRV2259448 - Salto Extended Dev - Administrator.
+2022-03-31 05:36:02 (PST) Installation started
+Info -- Account [(PRODUCTION) Salto Extended Dev]
+Info -- Account Customization Project [TempSdfProject-5492f41d-307d-4fc9-bc78-ef0834e9a197]
+Info -- Framework Version [1.0]
+Validate manifest -- Success
+Validate deploy file -- Success
+Validate configuration -- Success
+Validate objects -- Failed
+Validate files -- Success
+Validate folders -- Success
+Validate translation imports -- Success
+Validation of referenceability from custom objects to translations collection strings in progress. -- Success
+Validate preferences -- Success
+Validate flags -- Success
+Validate for circular dependencies -- Success
+*** ERROR ***
+
+Validation failed.
+
+An error occurred during custom object validation. (custform_114_t1441298_782)
+File: ~/Objects/custform_114_t1441298_782.xml
+`
+        mockExecuteAction.mockImplementation(({ commandName }) => {
+          if (commandName === COMMANDS.DEPLOY_PROJECT) {
+            throw errorMessage
+          }
+          return { isSuccess: () => true }
+        })
+        let isRejected: boolean
+        try {
+          await client.deploy([{
+            typeName: 'typeName',
+            values: {
+              key: 'val',
+            },
+            scriptId: 'scriptId',
+          } as CustomTypeInfo])
+          isRejected = false
+        } catch (e) {
+          isRejected = true
+          expect(e instanceof ObjectsDeployError).toBeTruthy()
+          expect(e instanceof ObjectsDeployError && e.failObjects).toEqual(new Set(['custform_114_t1441298_782']))
+        }
+        expect(isRejected).toBe(true)
+      })
+      it('should throw ObjectsDeployError when deploy failed with error object message', async () => {
+        const errorMessage = `
+The deployment process has encountered an error.
+Deploying to TSTDRV2259448 - Salto Extended Dev - Administrator.
+2022-03-30 23:55:26 (PST) Installation started
+Info -- Account [(PRODUCTION) Salto Extended Dev]
+Info -- Account Customization Project [TempSdfProject-e5a4eed4-e331-490f-9cfa-69cf84bd231b]
+Info -- Framework Version [1.0]
+Validate manifest -- Success
+Validate deploy file -- Success
+Validate configuration -- Success
+Validate objects -- Success
+Validate files -- Success
+Validate folders -- Success
+Validate translation imports -- Success
+Validation of referenceability from custom objects to translations collection strings in progress. -- Success
+Validate preferences -- Success
+Validate flags -- Success
+Validate for circular dependencies -- Success
+Validate account settings -- Success
+Validate Custom Objects against the Account -- Success
+Validate file cabinet items against the account -- Success
+Validate translation imports against the account -- Success
+Validation of references to translation collection strings against account in progress. -- Success
+Begin deployment
+Update object -- custform_12_t1441298_782 (entryform)
+*** ERROR ***
+
+Validation failed.
+
+An unexpected error has occurred. (custform_15_t1049933_143)
+File: ~/Objects/custform_15_t1049933_143.xml
+`
+        mockExecuteAction.mockImplementation(({ commandName }) => {
+          if (commandName === COMMANDS.DEPLOY_PROJECT) {
+            throw errorMessage
+          }
+          return { isSuccess: () => true }
+        })
+        let isRejected: boolean
+        try {
+          await client.deploy([{
+            typeName: 'typeName',
+            values: {
+              key: 'val',
+            },
+            scriptId: 'scriptId',
+          } as CustomTypeInfo])
+          isRejected = false
+        } catch (e) {
+          isRejected = true
+          expect(e instanceof ObjectsDeployError).toBeTruthy()
+          expect(e instanceof ObjectsDeployError && e.failObjects).toEqual(new Set(['custform_15_t1049933_143']))
+        }
+        expect(isRejected).toBe(true)
+      })
+      it('should throw ObjectsDeployError when deploy failed without any deployed objects', async () => {
+        const errorMessage = `
+The deployment process has encountered an error.
+Deploying to TSTDRV2259448 - Salto Extended Dev - Administrator.
+2022-03-30 23:55:26 (PST) Installation started
+Info -- Account [(PRODUCTION) Salto Extended Dev]
+Info -- Account Customization Project [TempSdfProject-e5a4eed4-e331-490f-9cfa-69cf84bd231b]
+Info -- Framework Version [1.0]
+Validate manifest -- Success
+Validate deploy file -- Success
+Validate configuration -- Success
+Validate objects -- Success
+Validate files -- Success
+Validate folders -- Success
+Validate translation imports -- Success
+Validation of referenceability from custom objects to translations collection strings in progress. -- Success
+Validate preferences -- Success
+Validate flags -- Success
+Validate for circular dependencies -- Success
+Validate account settings -- Success
+Validate Custom Objects against the Account -- Success
+Validate file cabinet items against the account -- Success
+Validate translation imports against the account -- Success
+Validation of references to translation collection strings against account in progress. -- Success
+Begin deployment
+*** ERROR ***
+
+Validation failed.
+
+An unexpected error has occurred. (custform_15_t1049933_143)
+File: ~/Objects/custform_15_t1049933_143.xml
+`
+        mockExecuteAction.mockImplementation(({ commandName }) => {
+          if (commandName === COMMANDS.DEPLOY_PROJECT) {
+            throw errorMessage
+          }
+          return { isSuccess: () => true }
+        })
+        let isRejected: boolean
+        try {
+          await client.deploy([{
+            typeName: 'typeName',
+            values: {
+              key: 'val',
+            },
+            scriptId: 'scriptId',
+          } as CustomTypeInfo])
+          isRejected = false
+        } catch (e) {
+          isRejected = true
+          expect(e instanceof ObjectsDeployError).toBeTruthy()
+          expect(e instanceof ObjectsDeployError && e.failObjects).toEqual(new Set(['custform_15_t1049933_143']))
+        }
+        expect(isRejected).toBe(true)
+      })
+      it('should throw general error when deploy failed without failed objects', async () => {
+        const errorMessage = `
+The deployment process has encountered an error.
+Deploying to TSTDRV2259448 - Salto Extended Dev - Administrator.
+2022-03-30 23:55:26 (PST) Installation started
+Info -- Account [(PRODUCTION) Salto Extended Dev]
+Info -- Account Customization Project [TempSdfProject-e5a4eed4-e331-490f-9cfa-69cf84bd231b]
+Info -- Framework Version [1.0]
+Validate manifest -- Success
+Validate deploy file -- Success
+Validate configuration -- Success
+Validate objects -- Success
+Validate files -- Success
+Validate folders -- Success
+Validate translation imports -- Success
+Validation of referenceability from custom objects to translations collection strings in progress. -- Success
+Validate preferences -- Success
+Validate flags -- Success
+Validate for circular dependencies -- Success
+Validate account settings -- Success
+Validate Custom Objects against the Account -- Success
+Validate file cabinet items against the account -- Success
+Validate translation imports against the account -- Success
+Validation of references to translation collection strings against account in progress. -- Success
+Begin deployment
+*** ERROR ***
+
+Validation failed.
+
+An error occurred during custom object update.
+File: ~/Objects/customrecord_flo_customization.xml
+Object: customrecord_flo_customization.custrecord_flo_custz_link (customrecordcustomfield)
+`
+        mockExecuteAction.mockImplementation(({ commandName }) => {
+          if (commandName === COMMANDS.DEPLOY_PROJECT) {
+            throw errorMessage
+          }
+          return { isSuccess: () => true }
+        })
+        let isRejected: boolean
+        try {
+          await client.deploy([{
+            typeName: 'typeName',
+            values: {
+              key: 'val',
+            },
+            scriptId: 'scriptId',
+          } as CustomTypeInfo])
+          isRejected = false
+        } catch (e) {
+          isRejected = true
+          expect(e instanceof ObjectsDeployError).toBeFalsy()
+        }
+        expect(isRejected).toBe(true)
+      })
+      it('should throw ObjectsDeployError when deploy failed without error object message', async () => {
+        const errorMessage = `
+The deployment process has encountered an error.
+Deploying to TSTDRV2259448 - Salto Extended Dev - Administrator.
+2022-03-31 05:27:04 (PST) Installation started
+Info -- Account [(PRODUCTION) Salto Extended Dev]
+Info -- Account Customization Project [TempSdfProject-5907cadf-1eea-40d2-9717-600ef164a3e7]
+Info -- Framework Version [1.0]
+Validate manifest -- Success
+Validate deploy file -- Success
+Validate configuration -- Success
+Validate objects -- Success
+Validate files -- Success
+Validate folders -- Success
+Validate translation imports -- Success
+Validation of referenceability from custom objects to translations collection strings in progress. -- Success
+Validate preferences -- Success
+Validate flags -- Success
+Validate for circular dependencies -- Success
+Begin deployment
+Update object -- cseg2 (customsegment)
+Update object -- cseg3 (customsegment)
+Update object -- customrecord_flo_customization.custrecord_flo_cust_type (customrecordcustomfield)
+Update object -- customrecord_flo_customization.custrecord_flo_int_id (customrecordcustomfield)
+Update object -- customrecord_flo_customization.custrecord_flo_cust_id (customrecordcustomfield)
+Update object -- customrecord_flo_customization.custrecord_flo_description (customrecordcustomfield)
+Update object -- customrecord_flo_customization.custrecord_sp_personal_data (customrecordcustomfield)
+Update object -- customrecord_flo_customization.custrecord_flo_help (customrecordcustomfield)
+Update object -- customrecord_flo_customization.custrecord_flo_custz_link (customrecordcustomfield)
+*** ERROR ***
+
+An error occurred during custom object update.
+File: ~/Objects/customrecord_flo_customization.xml
+Object: customrecord_flo_customization.custrecord_flo_custz_link (customrecordcustomfield)
+`
+        mockExecuteAction.mockImplementation(({ commandName }) => {
+          if (commandName === COMMANDS.DEPLOY_PROJECT) {
+            throw errorMessage
+          }
+          return { isSuccess: () => true }
+        })
+        let isRejected: boolean
+        try {
+          await client.deploy([{
+            typeName: 'typeName',
+            values: {
+              key: 'val',
+            },
+            scriptId: 'scriptId',
+          } as CustomTypeInfo])
+          isRejected = false
+        } catch (e) {
+          isRejected = true
+          expect(e instanceof ObjectsDeployError).toBeTruthy()
+          expect(e instanceof ObjectsDeployError && e.failObjects).toEqual(new Set(['customrecord_flo_customization']))
+        }
+        expect(isRejected).toBe(true)
       })
     })
 

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -33,7 +33,7 @@ import SdfClient, {
 import { CustomizationInfo, CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, TemplateCustomTypeInfo } from '../../src/client/types'
 import { fileCabinetTopLevelFolders } from '../../src/client/constants'
 import { DEFAULT_COMMAND_TIMEOUT_IN_MINUTES } from '../../src/config'
-import { FeaturesDeployError, ObjectsDeployError } from '../../src/errors'
+import { FeaturesDeployError, ObjectsDeployError, SettingsDeployError } from '../../src/errors'
 
 
 const MOCK_TEMPLATE_CONTENT = Buffer.from('Template Inner Content')
@@ -1582,6 +1582,65 @@ Object: customrecord_flo_customization.custrecord_flo_custz_link (customrecordcu
           isRejected = true
           expect(e instanceof ObjectsDeployError).toBeTruthy()
           expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Set(['customrecord_flo_customization']))
+        }
+        expect(isRejected).toBe(true)
+      })
+      it('should throw SettingsDeployError when deploy failed on settings validation', async () => {
+        const errorMessage = `
+The deployment process has encountered an error.
+Deploying to TSTDRV2259448 - Salto Extended Dev - Administrator.
+2022-04-06 03:06:46 (PST) Installation started
+Info -- Account [(PRODUCTION) Salto Extended Dev]
+Info -- Account Customization Project [TempSdfProject-e1b95f15-077e-4b41-8a72-572492527886]
+Info -- Framework Version [1.0]
+Validate manifest -- Success
+Validate deploy file -- Success
+Validate configuration -- Success
+Validate objects -- Success
+Validate files -- Success
+Validate folders -- Success
+Validate translation imports -- Success
+Validation of referenceability from custom objects to translations collection strings in progress. -- Success
+Validate preferences -- Success
+Validate flags -- Success
+Validate for circular dependencies -- Success
+
+WARNING -- One or more potential issues were found during custom object validation. (customrecord_flo_customization)
+Details: Circular dependencies detected. The following custom objects reference each other in a way that creates direct dependencies: customrecord_flo_customization -> tab_281_t1049933_607 -> customrecord_flo_customization 
+If deployment fails, ensure that each custom object does not reference any custom object that references it.
+File: ~/Objects/customrecord_flo_customization.xml
+Validate account settings -- Success
+Validate Custom Objects against the Account -- Failed
+Validate file cabinet items against the account -- Failed
+Validate translation imports against the account -- Failed
+Validation of references to translation collection strings against account in progress. -- Failed
+*** ERROR ***
+
+Validation of account settings failed.
+
+An error occurred during configuration validation.
+Details: Disable the SUPPLYCHAINPREDICTEDRISKS(Supply Chain Predicted Risks) feature before disabling the SUPPLYCHAINCONTROLTOWER(Supply Chain Control Tower) feature.
+File: ~/AccountConfiguration/features.xml`
+        mockExecuteAction.mockImplementation(({ commandName }) => {
+          if (commandName === COMMANDS.DEPLOY_PROJECT) {
+            throw errorMessage
+          }
+          return { isSuccess: () => true }
+        })
+        let isRejected: boolean
+        try {
+          await client.deploy([{
+            typeName: 'typeName',
+            values: {
+              key: 'val',
+            },
+            scriptId: 'scriptId',
+          } as CustomTypeInfo])
+          isRejected = false
+        } catch (e) {
+          isRejected = true
+          expect(e instanceof SettingsDeployError).toBeTruthy()
+          expect(e instanceof SettingsDeployError && e.failedConfigTypes).toEqual(new Set(['companyFeatures']))
         }
         expect(isRejected).toBe(true)
       })

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1357,7 +1357,7 @@ File: ~/Objects/custform_114_t1441298_782.xml
         } catch (e) {
           isRejected = true
           expect(e instanceof ObjectsDeployError).toBeTruthy()
-          expect(e instanceof ObjectsDeployError && e.failObjects).toEqual(new Set(['custform_114_t1441298_782']))
+          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Set(['custform_114_t1441298_782']))
         }
         expect(isRejected).toBe(true)
       })
@@ -1413,7 +1413,7 @@ File: ~/Objects/custform_15_t1049933_143.xml
         } catch (e) {
           isRejected = true
           expect(e instanceof ObjectsDeployError).toBeTruthy()
-          expect(e instanceof ObjectsDeployError && e.failObjects).toEqual(new Set(['custform_15_t1049933_143']))
+          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Set(['custform_15_t1049933_143']))
         }
         expect(isRejected).toBe(true)
       })
@@ -1468,7 +1468,7 @@ File: ~/Objects/custform_15_t1049933_143.xml
         } catch (e) {
           isRejected = true
           expect(e instanceof ObjectsDeployError).toBeTruthy()
-          expect(e instanceof ObjectsDeployError && e.failObjects).toEqual(new Set(['custform_15_t1049933_143']))
+          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Set(['custform_15_t1049933_143']))
         }
         expect(isRejected).toBe(true)
       })
@@ -1581,7 +1581,7 @@ Object: customrecord_flo_customization.custrecord_flo_custz_link (customrecordcu
         } catch (e) {
           isRejected = true
           expect(e instanceof ObjectsDeployError).toBeTruthy()
-          expect(e instanceof ObjectsDeployError && e.failObjects).toEqual(new Set(['customrecord_flo_customization']))
+          expect(e instanceof ObjectsDeployError && e.failedObjects).toEqual(new Set(['customrecord_flo_customization']))
         }
         expect(isRejected).toBe(true)
       })


### PR DESCRIPTION
Support SDF partial successful deploy:
- Retry deploying when specific change(s) fails (without the failed changes)

---
_Release Notes_: 
Netsuite Adapter:
- Support SDF partial successful deploy - retry deploying when specific change(s) fails

---
_User Notifications_: 
None
