### PR TITLE
Salto 2156 fix unneeded cache invalidation

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -213,7 +213,12 @@ const buildMultiEnvSource = (
   }
 
   let state = initState
-  const buildMultiEnvState = async ({ envChanges = {} }: { envChanges?: EnvsChanges }):
+  const buildMultiEnvState = async ({
+    envChanges = {}, ignoreFileChanges = false,
+  }: {
+    envChanges?: EnvsChanges
+    ignoreFileChanges?: boolean
+  }):
   Promise<{ state: MultiEnvState; changes: EnvsChanges }> => {
     const states = await mapValuesAsync(
       envSources(),
@@ -266,10 +271,12 @@ const buildMultiEnvSource = (
       })
       return changeResult
     }
-    const changes = await mapValuesAsync(
-      envSources(),
-      (_source, envName) => getEnvMergedChanges(envName)
-    )
+    const changes = ignoreFileChanges
+      ? {}
+      : await mapValuesAsync(
+        envSources(),
+        (_source, envName) => getEnvMergedChanges(envName)
+      )
     return {
       state: current,
       changes,
@@ -519,7 +526,7 @@ const buildMultiEnvSource = (
 
   const load = async ({ ignoreFileChanges = false }: SourceLoadParams): Promise<EnvsChanges> => {
     const changes = await mapValuesAsync(sources, src => src.load({ ignoreFileChanges }))
-    const buildResults = await buildMultiEnvState({ envChanges: changes })
+    const buildResults = await buildMultiEnvState({ envChanges: changes, ignoreFileChanges })
     state = buildResults.state
     return buildResults.changes
   }

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -215,12 +215,9 @@ const buildMultiEnvSource = (
   let state = initState
   const buildMultiEnvState = async ({ envChanges = {} }: { envChanges?: EnvsChanges }):
   Promise<{ state: MultiEnvState; changes: EnvsChanges }> => {
-    const states: Record<string, SingleState> = Object.fromEntries(
-      (await awu(Object.keys(sources))
-        .filter(name => name !== commonSourceName)
-        .map(async name => [name, state?.states[name]
-          ?? (await buildStateForSingleEnv(name))])
-        .toArray())
+    const states = await mapValuesAsync(
+      envSources(),
+      async (_source, envName) => state?.states[envName] ?? buildStateForSingleEnv(envName)
     )
     let mergeManager = state?.mergeManager
     if (!mergeManager) {
@@ -237,15 +234,6 @@ const buildMultiEnvSource = (
       states,
       mergeManager,
     }
-    if (Object.values(envChanges).every(changeSet => changeSet.changes.length === 0)) {
-      return { state: current, changes: {} }
-    }
-    const changesInCommon = (envChanges[commonSourceName]
-      ?.changes ?? []).length > 0
-    const relevantEnvs = Object.keys(sources)
-      .filter(name =>
-        (name !== commonSourceName)
-        && (changesInCommon || (envChanges[name]?.changes ?? []).length > 0))
     const getEnvMergedChanges = async (
       envName: string
     ): Promise<ChangeSet<Change<ChangeDataType>>> => {
@@ -278,10 +266,9 @@ const buildMultiEnvSource = (
       })
       return changeResult
     }
-    const changes = Object.fromEntries(
-      await awu(relevantEnvs)
-        .map(async envName => [envName, await getEnvMergedChanges(envName)])
-        .toArray()
+    const changes = await mapValuesAsync(
+      envSources(),
+      (_source, envName) => getEnvMergedChanges(envName)
     )
     return {
       state: current,

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -63,7 +63,6 @@ export type NaclFile = {
 }
 export type SourceLoadParams = {
   ignoreFileChanges?: boolean
-  env?: string
 }
 
 export type NaclFilesSource<Changes=ChangeSet<Change>> = Omit<ElementsSource, 'clear'> & {
@@ -417,11 +416,7 @@ const buildNaclFilesState = async ({
       if (oldNaclFile === undefined) {
         return
       }
-      const oldNaclFileReferenced = (await oldNaclFile.data.referenced())
-      // If one of the properties of ParsedNaclFile is undefined it is considered as not exist
-      if (oldNaclFileReferenced === undefined) {
-        return
-      }
+      const oldNaclFileReferenced = await oldNaclFile.data.referenced()
       oldNaclFileReferenced.forEach((elementFullName: string) => {
         referencedIndexDeletions[elementFullName] = referencedIndexDeletions[elementFullName]
           ?? new Set<string>()

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_file.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_file.ts
@@ -18,7 +18,7 @@ import { SourceMap, ParseError } from '../../parser'
 
 export type ParsedNaclFileData = {
   errors: () => Promise<ParseError[] | undefined>
-  referenced: () => Promise<string[] | undefined>
+  referenced: () => Promise<string[]>
 }
 
 export type ParsedNaclFile = {

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_files_cache.ts
@@ -75,7 +75,7 @@ const parseNaclFileFromCacheSources = async (
   elements: () => cacheSources.elements.get(filename),
   data: {
     errors: async () => (await cacheSources.errors.get(filename) ?? []),
-    referenced: () => cacheSources.referenced.get(filename),
+    referenced: async () => (await cacheSources.referenced.get(filename) ?? []),
   },
   sourceMap: () => cacheSources.sourceMap.get(filename),
 })
@@ -183,7 +183,7 @@ export const createParseResultCache = (
           await errors.delete(value.filename)
         }
       }
-      await referenced.set(value.filename, (await value.data.referenced()) ?? [])
+      await referenced.set(value.filename, await value.data.referenced())
       const sourceMapValue = await value.sourceMap?.()
       if (sourceMapValue !== undefined) {
         await sourceMap.set(value.filename, sourceMapValue)
@@ -214,7 +214,7 @@ export const createParseResultCache = (
       await errors.setAll(errorEntriesToAdd)
       await errors.deleteAll(errorEntriesToDelete)
       await referenced.setAll(awu(Object.keys(files))
-        .map(async file => ({ key: file, value: await files[file].data.referenced() ?? [] })))
+        .map(async file => ({ key: file, value: await files[file].data.referenced() })))
       await sourceMap.setAll(awu(Object.keys(files))
         .map(async file => {
           const fileSourceMap = await files[file].sourceMap?.()

--- a/packages/workspace/test/common/nacl_file_source.ts
+++ b/packages/workspace/test/common/nacl_file_source.ts
@@ -16,7 +16,7 @@
 import { ElemID, Element, Change, isObjectType, isStaticFile } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { resolvePath } from '@salto-io/adapter-utils'
-import { collections } from '@salto-io/lowerdash'
+import { collections, hash } from '@salto-io/lowerdash'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import { NaclFilesSource, ChangeSet } from '../../src/workspace/nacl_files'
 import { Errors } from '../../src/workspace/errors'
@@ -24,7 +24,7 @@ import { SourceRange } from '../../src/parser/internal/types'
 import { createInMemoryElementSource } from '../../src/workspace/elements_source'
 import { createAddChange } from '../../src/workspace/nacl_files/multi_env/projections'
 import { mockStaticFilesSource } from '../utils'
-import { SourceMap } from '../../src/parser'
+import { SourceMap, dumpElements } from '../../src/parser'
 
 const { awu } = collections.asynciterable
 type ThenableIterable<T> = collections.asynciterable.ThenableIterable<T>
@@ -38,6 +38,16 @@ export const createMockNaclFileSource = (
   staticFileSource = mockStaticFilesSource()
 ): MockInterface<NaclFilesSource> => {
   let currentElements = elements
+  let lastReturnedHash = ''
+  const returnChanges = (changeSet: ChangeSet<Change>) => async (): Promise<ChangeSet<Change>> => {
+    const preChangeHash = lastReturnedHash
+    lastReturnedHash = hash.toMD5(await dumpElements(currentElements))
+    return {
+      preChangeHash,
+      postChangeHash: lastReturnedHash,
+      ...changeSet,
+    }
+  }
   const getElementNaclFiles = (elemID: ElemID): string[] =>
     Object.entries(naclFiles).filter(([_filename, fileElements]) => fileElements.find(
       element => resolvePath(element, elemID) !== undefined
@@ -67,14 +77,14 @@ export const createMockNaclFileSource = (
     }),
     rename: mockFunction<NaclFilesSource['rename']>().mockResolvedValue(),
     flush: mockFunction<NaclFilesSource['flush']>().mockResolvedValue(),
-    updateNaclFiles: mockFunction<NaclFilesSource['updateNaclFiles']>().mockResolvedValue(changes),
+    updateNaclFiles: mockFunction<NaclFilesSource['updateNaclFiles']>().mockImplementation(returnChanges(changes)),
     listNaclFiles: mockFunction<NaclFilesSource['listNaclFiles']>().mockResolvedValue(_.keys(naclFiles)),
     getTotalSize: mockFunction<NaclFilesSource['getTotalSize']>().mockResolvedValue(5),
     getNaclFile: mockFunction<NaclFilesSource['getNaclFile']>().mockImplementation(
       async filename => (naclFiles[filename] ? { filename, buffer: '' } : undefined)
     ),
-    setNaclFiles: mockFunction<NaclFilesSource['setNaclFiles']>().mockResolvedValue(changes),
-    removeNaclFiles: mockFunction<NaclFilesSource['removeNaclFiles']>().mockResolvedValue(changes),
+    setNaclFiles: mockFunction<NaclFilesSource['setNaclFiles']>().mockImplementation(returnChanges(changes)),
+    removeNaclFiles: mockFunction<NaclFilesSource['removeNaclFiles']>().mockImplementation(returnChanges(changes)),
     getSourceMap: mockFunction<NaclFilesSource['getSourceMap']>().mockResolvedValue(new SourceMap()),
     getSourceRanges: mockFunction<NaclFilesSource['getSourceRanges']>().mockImplementation(
       async elemID => (
@@ -100,10 +110,12 @@ export const createMockNaclFileSource = (
     getElementNaclFiles: mockFunction<NaclFilesSource['getElementNaclFiles']>().mockImplementation(async elemID => getElementNaclFiles(elemID)),
     clone: jest.fn().mockRejectedValue(new Error('not implemented in mock')),
     getElementReferencedFiles: mockFunction<NaclFilesSource['getElementReferencedFiles']>().mockResolvedValue([]),
-    load: mockFunction<NaclFilesSource['load']>().mockResolvedValue({
-      changes: currentElements.map(e => createAddChange(e, e.elemID)),
-      cacheValid: true,
-    }),
+    load: mockFunction<NaclFilesSource['load']>().mockImplementation(
+      returnChanges({
+        cacheValid: true,
+        changes: currentElements.map(e => createAddChange(e, e.elemID)),
+      })
+    ),
     getSearchableNames: mockFunction<NaclFilesSource['getSearchableNames']>().mockResolvedValue(_.uniq(currentElements.flatMap(e => {
       const fieldNames = isObjectType(e)
         ? Object.values(e.fields).map(field => field.elemID.getFullName())

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -289,6 +289,21 @@ describe('multi env source', () => {
           expect(loadResult[inactivePrefix].postChangeHash).toBeDefined()
         })
       })
+      describe('when ignore file changes is set', () => {
+        let multiSource: MultiEnvSource
+        let loadResult: Record<string, ChangeSet<Change>>
+        beforeEach(async () => {
+          // We can re-use the sources here because the mock nacl sources don't behave correctly
+          // and will "replay" the "load" result regardless of how many times they are loaded
+          multiSource = multiEnvSource(sources, commonPrefix, remoteMaps.creator, true)
+          loadResult = await multiSource.load({ignoreFileChanges: true})
+        })
+
+        it('should return empty change sets', () => {
+          expect(loadResult[activePrefix]).not.toBeDefined()
+          expect(loadResult[inactivePrefix]).not.toBeDefined()
+        })
+      })
     })
 
     describe('second load', () => {

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -17,18 +17,20 @@ import path from 'path'
 import { Element, ElemID, BuiltinTypes, ObjectType, DetailedChange, Change, getChangeData, StaticFile } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import * as utils from '@salto-io/adapter-utils'
+import { MockInterface } from '@salto-io/test-utils'
 import { collections } from '@salto-io/lowerdash'
 import { createElementSelectors } from '../../../src/workspace/element_selector'
 import { createMockNaclFileSource } from '../../common/nacl_file_source'
-import { multiEnvSource, ENVS_PREFIX } from '../../../src/workspace/nacl_files/multi_env/multi_env_source'
+import { multiEnvSource, ENVS_PREFIX, MultiEnvSource } from '../../../src/workspace/nacl_files/multi_env/multi_env_source'
 import * as routers from '../../../src/workspace/nacl_files/multi_env/routers'
 import { Errors } from '../../../src/workspace/errors'
 import { ValidationError } from '../../../src/validator'
 import { MergeError } from '../../../src/merger'
 import { expectToContainAllItems } from '../../common/helpers'
-import { InMemoryRemoteMap, RemoteMap } from '../../../src/workspace/remote_map'
+import { InMemoryRemoteMap, RemoteMap, RemoteMapCreator, CreateRemoteMapParams } from '../../../src/workspace/remote_map'
 import { createMockRemoteMap, mockStaticFilesSource } from '../../utils'
 import { MissingStaticFile } from '../../../src/workspace/static_files'
+import { NaclFilesSource, ChangeSet } from '../../../src/workspace/nacl_files'
 
 const { awu } = collections.asynciterable
 jest.mock('@salto-io/adapter-utils', () => ({
@@ -197,12 +199,164 @@ const source = multiEnvSource(
   true
 )
 
+type MockRemoteMapCreator = {
+  maps: Record<string, InMemoryRemoteMap<unknown>>
+  creator: RemoteMapCreator
+}
+const mockRemoteMaps = (): MockRemoteMapCreator => {
+  const maps: Record<string, InMemoryRemoteMap<unknown>> = {}
+  return {
+    maps,
+    creator: async <T, K extends string>({ namespace }: CreateRemoteMapParams<T>) => {
+      maps[namespace] = maps[namespace] ?? new InMemoryRemoteMap()
+      return maps[namespace] as unknown as RemoteMap<T, K>
+    },
+  }
+}
 
 describe('multi env source', () => {
   let referencedByIndex: RemoteMap<ElemID[]>
   beforeAll(async () => {
     await source.load({})
     referencedByIndex = createMockRemoteMap<ElemID[]>()
+  })
+  describe('load', () => {
+    let remoteMaps: MockRemoteMapCreator
+    beforeEach(() => {
+      remoteMaps = mockRemoteMaps()
+    })
+    describe('first load', () => {
+      describe('with empty sources', () => {
+        let multiSource: MultiEnvSource
+        let loadCommonSource: MockInterface<NaclFilesSource>
+        let loadEnvSource: MockInterface<NaclFilesSource>
+        let loadResult: Record<string, ChangeSet<Change>>
+        beforeEach(async () => {
+          loadCommonSource = createMockNaclFileSource([])
+          loadEnvSource = createMockNaclFileSource([])
+          multiSource = multiEnvSource(
+            {
+              [commonPrefix]: loadCommonSource,
+              [activePrefix]: loadEnvSource,
+            },
+            commonPrefix,
+            remoteMaps.creator,
+            true,
+          )
+          loadResult = await multiSource.load({})
+        })
+        it('should return valid result for all environments', () => {
+          expect(loadResult[activePrefix]).toMatchObject({
+            cacheValid: true,
+            changes: [],
+            preChangeHash: '',
+          })
+        })
+      })
+      describe('with sources that have data', () => {
+        let multiSource: MultiEnvSource
+        let loadResult: Record<string, ChangeSet<Change>>
+        beforeEach(async () => {
+          // We can re-use the sources here because the mock nacl sources don't behave correctly
+          // and will "replay" the "load" result regardless of how many times they are loaded
+          multiSource = multiEnvSource(sources, commonPrefix, remoteMaps.creator, true)
+          loadResult = await multiSource.load({})
+        })
+        it('should return merged addition changes for environment elements', () => {
+          expect(loadResult[activePrefix].changes).toHaveLength(3)
+          expect(loadResult[inactivePrefix].changes).toHaveLength(3)
+          const activeEnvObjChange = loadResult[activePrefix].changes.find(
+            change => getChangeData(change).elemID.isEqual(objectElemID)
+          ) as Change<ObjectType>
+          expect(activeEnvObjChange).toBeDefined()
+          expect(activeEnvObjChange?.action).toEqual('add')
+          expect(getChangeData(activeEnvObjChange)).toBeInstanceOf(ObjectType)
+          expect(getChangeData(activeEnvObjChange).fields).toHaveProperty('envField')
+          expect(getChangeData(activeEnvObjChange).fields).toHaveProperty('commonField')
+
+          const inactiveEnvObjChange = loadResult[inactivePrefix].changes.find(
+            change => getChangeData(change).elemID.isEqual(objectElemID)
+          ) as Change<ObjectType>
+          expect(inactiveEnvObjChange).toBeDefined()
+          expect(inactiveEnvObjChange?.action).toEqual('add')
+          expect(getChangeData(inactiveEnvObjChange)).toBeInstanceOf(ObjectType)
+          expect(getChangeData(inactiveEnvObjChange).fields).toHaveProperty('inactiveField')
+          expect(getChangeData(inactiveEnvObjChange).fields).toHaveProperty('commonField')
+        })
+
+        it('should return a unique post change hash', () => {
+          expect(loadResult[activePrefix].postChangeHash).toBeDefined()
+          expect(loadResult[inactivePrefix].postChangeHash).toBeDefined()
+        })
+      })
+    })
+
+    describe('second load', () => {
+      describe('when there are no new semantic changes but the nacl hash is changed', () => {
+        let secondLoadSource: MultiEnvSource
+        let secondLoadCommonSource: MockInterface<NaclFilesSource>
+        let secondLoadEnvSource: MockInterface<NaclFilesSource>
+        let firstLoadResult: Record<string, ChangeSet<Change>>
+        let secondLoadResult: Record<string, ChangeSet<Change>>
+        beforeEach(async () => {
+          const firstLoadCommonSource = createMockNaclFileSource([commonObject])
+          const firstLoadEnvSource = createMockNaclFileSource([envObject])
+          const firstLoadSource = multiEnvSource(
+            {
+              [activePrefix]: firstLoadEnvSource,
+              [commonPrefix]: firstLoadCommonSource,
+            },
+            commonPrefix,
+            remoteMaps.creator,
+            true,
+          )
+          firstLoadResult = await firstLoadSource.load({})
+
+          // We can call "load" again here because the mock nacl sources don't behave correctly
+          // and will "replay" the "load" result regardless of how many times they are loaded
+          const commonFirstLoadHash = (await firstLoadCommonSource.load({})).postChangeHash
+          secondLoadCommonSource = createMockNaclFileSource([])
+          secondLoadCommonSource.load.mockResolvedValue({
+            cacheValid: true,
+            changes: [],
+            preChangeHash: commonFirstLoadHash,
+            postChangeHash: commonFirstLoadHash,
+          })
+          const envFirstLoadHash = (await firstLoadEnvSource.load({})).postChangeHash
+          secondLoadEnvSource = createMockNaclFileSource([])
+          secondLoadEnvSource.load.mockResolvedValue({
+            cacheValid: true,
+            changes: [],
+            preChangeHash: envFirstLoadHash,
+            postChangeHash: 'new_hash_value',
+          })
+          // In order to simulate a second load, we load a new source with the same remote maps
+          secondLoadSource = multiEnvSource(
+            {
+              [activePrefix]: secondLoadEnvSource,
+              [commonPrefix]: secondLoadCommonSource,
+            },
+            commonPrefix,
+            remoteMaps.creator,
+            true,
+          )
+          secondLoadResult = await secondLoadSource.load({})
+        })
+        it('should have no changes on the second load', () => {
+          expect(secondLoadResult[activePrefix].changes).toHaveLength(0)
+        })
+        it('should have the same pre change hash as the first load post change hash', () => {
+          expect(secondLoadResult[activePrefix].preChangeHash).toEqual(
+            firstLoadResult[activePrefix].postChangeHash
+          )
+        })
+        it('should update the post change hash because the underlying hash changed', () => {
+          expect(secondLoadResult[activePrefix].postChangeHash).not.toEqual(
+            secondLoadResult[activePrefix].preChangeHash
+          )
+        })
+      })
+    })
   })
   describe('getNaclFile', () => {
     it('should return a Nacl file from an env', async () => {
@@ -541,45 +695,6 @@ describe('multi env source', () => {
       expect(commonSource.setNaclFiles).toHaveBeenCalled()
     })
 
-    it('should not change inner state upon set with no changes', async () => {
-      const change = { action: 'add', data: { after: inactiveFragment } } as Change<ObjectType>
-      const commonSourceName = ''
-      const mockCommonNaclFileSource = createMockNaclFileSource(
-        [commonFragment], {}, undefined, undefined, { changes: [change], cacheValid: true }
-      )
-      const primarySourceName = 'env1'
-      const mockPrimaryNaclFileSource = createMockNaclFileSource(
-        [envFragment, envObject], {}, undefined, undefined, { changes: [change], cacheValid: true }
-      )
-      const inactiveSourceName = 'env2'
-      const mockInacvtiveNaclFileSource = createMockNaclFileSource(
-        [inactiveObject], {}, undefined, undefined, { changes: [change], cacheValid: true }
-      )
-      const multiEnvSourceWithMockSources = multiEnvSource(
-        {
-          [commonSourceName]: mockCommonNaclFileSource,
-          [primarySourceName]: mockPrimaryNaclFileSource,
-          [inactiveSourceName]: mockInacvtiveNaclFileSource,
-        },
-        commonSourceName,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        true
-      )
-      await multiEnvSourceWithMockSources.load({})
-      // NOTE: the getAll call initialize the init state
-      const currentElements = await awu(
-        await multiEnvSourceWithMockSources.getAll(primarySourceName)
-      ).toArray()
-      expect(currentElements).toHaveLength(2)
-      const elementChanges = (await multiEnvSourceWithMockSources.setNaclFiles(
-        [{ filename: path.join(ENVS_PREFIX, inactiveSourceName, 'env.nacl'), buffer: 'test' }]
-      ))
-      expect(elementChanges).not.toHaveProperty(primarySourceName)
-      const elements = await awu(
-        await multiEnvSourceWithMockSources.getAll(primarySourceName)
-      ).toArray()
-      expect(elements).toHaveLength(2)
-    })
     it('should change inner state upon set with addition', async () => {
       const change = { action: 'add', data: { after: commonObject } } as Change<ObjectType>
       const commonSourceName = ''

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -296,7 +296,7 @@ describe('multi env source', () => {
           // We can re-use the sources here because the mock nacl sources don't behave correctly
           // and will "replay" the "load" result regardless of how many times they are loaded
           multiSource = multiEnvSource(sources, commonPrefix, remoteMaps.creator, true)
-          loadResult = await multiSource.load({ignoreFileChanges: true})
+          loadResult = await multiSource.load({ ignoreFileChanges: true })
         })
 
         it('should return empty change sets', () => {


### PR DESCRIPTION
Before this change, if there was no semantic change in a nacl file source, the other caches
(multi env and workspace) would not be updated, which meant the hash would become out of sync
leading to incorrect cache invalidation the next time a semantic change is detected.

The fix here keeps the hash as a non-semantic meaning (unfortunately) which means there are still
many different hashes that can all represent to same elements.
this is not ideal, but hopefully now the nacl source and multi env source would both be updated
so they do not lose sync of which hash is the current hash.

---

Note that this re-calculation of the cache, when it happened in "updateNaclFiles", would cause us to report
an incorrect number of changes. so, if this cache invalidation would happen on fetch for example, we would
report a number of changes as if the entire workspace was changed.

---
_Release Notes_: 
- Fixed issue where sometimes fetch would take longer than needed and report the wrong number of changes

---
_User Notifications_: 
_None_