### PR TITLE
SALTO-2196: Fixed to remove instance with unresolved parents

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -56,6 +56,7 @@ import workflowModificationFilter from './filters/workflow/workflow_modification
 import triggersFilter from './filters/workflow/triggers_filter'
 import workflowSchemeFilter from './filters/workflow_scheme'
 import duplicateIdsFilter from './filters/duplicate_ids'
+import unresolvedParentsFilter from './filters/unresolved_parents'
 import fieldNameFilter from './filters/fields/field_name_filter'
 import fieldStructureFilter from './filters/fields/field_structure_filter'
 import fieldDeploymentFilter from './filters/fields/field_deployment_filter'
@@ -96,6 +97,8 @@ export const DEFAULT_FILTERS = [
   fieldStructureFilter,
   // This should run here again because fieldStructureFilter creates the instances and references
   duplicateIdsFilter,
+  // This must run after duplicateIdsFilter
+  unresolvedParentsFilter,
   contextReferencesFilter,
   fieldTypeReferencesFilter,
   fieldDeploymentFilter,

--- a/packages/jira-adapter/src/filters/unresolved_parents.ts
+++ b/packages/jira-adapter/src/filters/unresolved_parents.ts
@@ -1,0 +1,45 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { isInstanceElement } from '@salto-io/adapter-api'
+import { getParents } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import _ from 'lodash'
+import { FilterCreator } from '../filter'
+
+const log = logger(module)
+
+/**
+ * Filter to remove instances with unresolved parents
+ * (can happen if we remove an instance in the duplicate_ids filter)
+ */
+const filter: FilterCreator = () => ({
+  onFetch: async elements => {
+    const ids = new Set(
+      elements.map(instance => instance.elemID.getFullName())
+    )
+    const removedChildren = _.remove(
+      elements,
+      element => isInstanceElement(element)
+        && getParents(element).some(parent => !ids.has(parent.elemID.getFullName()))
+    )
+
+    if (removedChildren.length > 0) {
+      log.warn(`Removed instances with unresolved parents: ${removedChildren.map(instance => instance.elemID.getFullName()).join(', ')}`)
+    }
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/test/filters/unresolved_parents.test.ts
+++ b/packages/jira-adapter/test/filters/unresolved_parents.test.ts
@@ -1,0 +1,80 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { mockClient } from '../utils'
+import unresolvedParentsFilter from '../../src/filters/unresolved_parents'
+import { Filter } from '../../src/filter'
+import { DEFAULT_CONFIG } from '../../src/config'
+import { JIRA } from '../../src/constants'
+
+describe('unresolvedParentsFilter', () => {
+  let filter: Filter
+  let type: ObjectType
+  beforeEach(async () => {
+    const { client, paginator } = mockClient()
+
+    filter = unresolvedParentsFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+      elementsSource: buildElementsSourceFromElements([]),
+    })
+
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, 'someType'),
+    })
+  })
+
+  describe('onFetch', () => {
+    it('should remove instances with unresolved parents', async () => {
+      const inst1 = new InstanceElement(
+        'inst1',
+        type,
+        {},
+        [],
+        {
+          [CORE_ANNOTATIONS.PARENT]: [
+            new ReferenceExpression(new ElemID(JIRA, 'someType', 'instance', 'existingParent')),
+          ],
+        },
+      )
+
+      const parent = new InstanceElement(
+        'existingParent',
+        type,
+        {},
+        [],
+      )
+
+      const inst2 = new InstanceElement(
+        'inst2',
+        type,
+        {},
+        [],
+        {
+          [CORE_ANNOTATIONS.PARENT]: [
+            new ReferenceExpression(new ElemID(JIRA, 'someType', 'instance', 'nonExistingParent')),
+          ],
+        },
+      )
+
+      const elements = [inst1, inst2, parent]
+      await filter.onFetch?.(elements)
+      expect(elements.map(e => e.elemID.name)).toEqual(['inst1', 'existingParent'])
+    })
+  })
+})


### PR DESCRIPTION
Fixed to remove instances with unresolved parents

---

In the Jira adapter we remove instances has a non-unique name. We didn't remove so far also their children instances which caused unresolved references

---
_Release Notes_: 
_Jira Adapter_:
- Fixed a bug where duplicated names of dashboards in the service would cause unresolved references in the workspace

---
_User Notifications_: 
None