### PR TITLE
SALTO-2209: improved env diff logic when using selectors

### DIFF
--- a/packages/core/src/core/plan/plan_item.ts
+++ b/packages/core/src/core/plan/plan_item.ts
@@ -18,10 +18,6 @@ import wu from 'wu'
 import { NodeId, Group, ActionName } from '@salto-io/dag'
 import { Change, getChangeData, DetailedChange } from '@salto-io/adapter-api'
 import { detailedCompare } from '@salto-io/adapter-utils'
-import { values, collections } from '@salto-io/lowerdash'
-
-const { awu } = collections.asynciterable
-type SetId = collections.set.SetId
 
 export type PlanItemId = NodeId
 export type PlanItem = Group<Change> & {
@@ -60,14 +56,3 @@ export const addPlanItemAccessors = (group: Group<Change>): PlanItem => Object.a
       .flatten()
   },
 })
-
-export const filterPlanItem = async (
-  planItem: PlanItem,
-  func: (change: Change) => Promise<Change | undefined>
-) : Promise<PlanItem> => {
-  const filteredItems = new Map(await awu(planItem.items.entries())
-    .map(async ([setID, change]) => [setID, await func(change)])
-    .filter(([_setID, change]) => values.isDefined(change))
-    .toArray() as Iterable<[SetId, Change]>)
-  return addPlanItemAccessors({ items: filteredItems, groupKey: planItem.groupKey })
-}

--- a/packages/core/test/core/plan/plan_item.test.ts
+++ b/packages/core/test/core/plan/plan_item.test.ts
@@ -16,13 +16,12 @@
 import wu from 'wu'
 import _ from 'lodash'
 import { Group } from '@salto-io/dag'
-import { isListType, Change, ChangeDataType, toChange, ObjectType, ElemID, getChangeData } from '@salto-io/adapter-api'
-import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
+import { isListType, Change, ChangeDataType, toChange } from '@salto-io/adapter-api'
 import * as mock from '../../common/elements'
 import { getFirstPlanItem } from '../../common/plan'
 import { planGenerators } from '../../common/plan_generator'
 import { PlanItem } from '../../../src/core/plan'
-import { addPlanItemAccessors, filterPlanItem } from '../../../src/core/plan/plan_item'
+import { addPlanItemAccessors } from '../../../src/core/plan/plan_item'
 
 describe('PlanItem', () => {
   const allElements = mock.getAllElements()
@@ -166,80 +165,6 @@ describe('PlanItem', () => {
       expect(fromListChange.action).toEqual('modify')
       expect(fromListChange.id).toEqual(changedElem.fields.rooms.elemID)
       expect(isListType(await _.get(fromListChange.data, 'after').getType())).toBeFalsy()
-    })
-  })
-
-  describe('filter plan item', () => {
-    const objToModify = new ObjectType({
-      elemID: ElemID.fromFullName('salto.modify'),
-      annotations: {
-        str: 'modify me',
-      },
-    })
-    const objToFilter = new ObjectType({
-      elemID: ElemID.fromFullName('salto.filter'),
-      annotations: {
-        str: 'after',
-      },
-    })
-    const objToKeep = new ObjectType({
-      elemID: ElemID.fromFullName('salto.keep'),
-      annotations: {
-        str: 'keep',
-      },
-    })
-    const items = new Map([
-      [objToModify.elemID.getFullName(), toChange({ before: objToModify })],
-      [objToFilter.elemID.getFullName(), toChange({ before: objToFilter })],
-      [objToKeep.elemID.getFullName(), toChange({ before: objToKeep })],
-    ])
-    const planItem = addPlanItemAccessors({
-      groupKey: 'key',
-      items,
-    })
-
-    const copyItem = _.cloneDeep(planItem)
-
-    let modifiedPlanItem: PlanItem
-
-    beforeAll(async () => {
-      modifiedPlanItem = await filterPlanItem(
-        planItem,
-        async change => {
-          const fullName = getChangeData(change).elemID.getFullName()
-          if (fullName === 'salto.modify') {
-            return applyFunctionToChangeData(change, elem => {
-              const clone = elem.clone()
-              clone.annotations.str = 'modified!'
-              return clone
-            })
-          }
-          if (fullName === 'salto.filter') {
-            return undefined
-          }
-          return change
-        }
-      )
-    })
-    it('should replace the changes with modified changes', () => {
-      const modified = wu(modifiedPlanItem.changes())
-        .find(change => getChangeData(change).elemID.getFullName() === 'salto.modify')
-      expect(modified).toBeDefined()
-      expect(getChangeData(modified as Change).annotations.str).toEqual('modified!')
-    })
-    it('should filter out changes where before and after were set as undefined', () => {
-      const dropped = wu(modifiedPlanItem.changes())
-        .find(change => getChangeData(change).elemID.getFullName() === 'salto.filter')
-      expect(dropped).not.toBeDefined()
-    })
-    it('should keep changes that were not modified by the callback', () => {
-      const kept = wu(modifiedPlanItem.changes())
-        .find(change => getChangeData(change).elemID.getFullName() === 'salto.keep')
-      expect(kept).toBeDefined()
-      expect(getChangeData(kept as Change).annotations.str).toEqual('keep')
-    })
-    it('should not modify the original plan item', () => {
-      expect(planItem).toEqual(copyItem)
     })
   })
 })

--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -277,6 +277,9 @@ export const selectElementIdsByTraversal = async ({
   }
 
   const topLevelIDs = await getTopLevelIDs()
+  if (subElementSelectors.length === 0) {
+    return awu(topLevelIDs)
+  }
   const currentIds = new Set(topLevelIDs.map(id => id.getFullName()))
 
   const possibleParentSelectors = subElementSelectors.map(createTopLevelSelector)


### PR DESCRIPTION
Removed an unnecessary element transformation that filters the element by selectors. 

---
_Release Notes_: 
Core:
- improved env diff logic when using selectors

Workspace:
- avoid iterating `subElementSelectors` when there are only `topLevelSelectors`

---
_User Notifications_: 
None
