### PR TITLE
update authentication instructions in stripe's README

### DIFF
--- a/packages/stripe-adapter/README.md
+++ b/packages/stripe-adapter/README.md
@@ -9,5 +9,5 @@ We do this using the [Stripe REST API](https://stripe.com/docs/api).
 **Note:** Some entities are not supported due to technical limitations, such as SKUs and shipping rates.
 
 ## Connecting to your Stripe account
-Salto authenticates with Stripe using a Secret Key. To find yours, go to "Your API keys" in Stripe's dashboard.
+Salto authenticates with Stripe using a Secret Key. To find yours, search for “Developers > API keys” in the search bar in Stripe’s dashboard, reveal the Secret Key and click to copy it.
 When logging in with Salto, you will be asked to provide this Secret Key.


### PR DESCRIPTION
Update authentication instructions in stripe's README due to Stripe's UI changes.


---
_Release Notes_: 
Stripe adapter: update authentication instructions in stripe's README
---
_User Notifications_: 
None
