### PR TITLE
SALTO-2054: extract tags to references

### DIFF
--- a/packages/adapter-components/src/deployment/change_validators/check_deployment_based_on_config.ts
+++ b/packages/adapter-components/src/deployment/change_validators/check_deployment_based_on_config.ts
@@ -48,7 +48,9 @@ const createChangeErrors = (
 }
 
 export const createCheckDeploymentBasedOnConfigValidator = (
-  apiConfig: AdapterApiConfig, typesDeployedViaParent: string[] = []
+  apiConfig: AdapterApiConfig,
+  typesDeployedViaParent: string[] = [],
+  typesWithNoDeploy: string[] = [],
 ): ChangeValidator => async changes => (
   awu(changes)
     .map(async (change: Change<Element>): Promise<(ChangeError | undefined)[]> => {
@@ -59,6 +61,9 @@ export const createCheckDeploymentBasedOnConfigValidator = (
       const getChangeErrorsByTypeName = (typeName: string): ChangeError[] => {
         const typeConfig = apiConfig?.types?.[typeName]?.deployRequests ?? {}
         return createChangeErrors(typeConfig, element.elemID, change.action)
+      }
+      if (typesWithNoDeploy.includes(element.elemID.typeName)) {
+        return []
       }
       if (typesDeployedViaParent.includes(element.elemID.typeName)) {
         const parents = getParents(element)

--- a/packages/adapter-components/src/deployment/change_validators/check_deployment_based_on_config.ts
+++ b/packages/adapter-components/src/deployment/change_validators/check_deployment_based_on_config.ts
@@ -47,11 +47,13 @@ const createChangeErrors = (
   return []
 }
 
-export const createCheckDeploymentBasedOnConfigValidator = (
-  apiConfig: AdapterApiConfig,
-  typesDeployedViaParent: string[] = [],
-  typesWithNoDeploy: string[] = [],
-): ChangeValidator => async changes => (
+export const createCheckDeploymentBasedOnConfigValidator = ({
+  apiConfig, typesDeployedViaParent = [], typesWithNoDeploy = [],
+}: {
+  apiConfig: AdapterApiConfig
+  typesDeployedViaParent?: string[]
+  typesWithNoDeploy?: string[]
+}): ChangeValidator => async changes => (
   awu(changes)
     .map(async (change: Change<Element>): Promise<(ChangeError | undefined)[]> => {
       const element = getChangeData(change)

--- a/packages/adapter-components/test/deployment/change_validators/check_deployment.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/check_deployment.test.ts
@@ -41,7 +41,7 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
   })
 
   it('should not return an error when the changed element is not an instance', async () => {
-    const errors = await createCheckDeploymentBasedOnConfigValidator(apiConfig)([
+    const errors = await createCheckDeploymentBasedOnConfigValidator({ apiConfig })([
       toChange({ after: type }),
     ])
     expect(errors).toEqual([])
@@ -52,7 +52,7 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
       'test2',
       new ObjectType({ elemID: new ElemID('dum', 'test2') }),
     )
-    const errors = await createCheckDeploymentBasedOnConfigValidator(apiConfig)(
+    const errors = await createCheckDeploymentBasedOnConfigValidator({ apiConfig })(
       [toChange({ after: instance })],
     )
     expect(errors).toEqual([{
@@ -65,7 +65,7 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
 
   it('should return an error when type does not support specific method', async () => {
     const instance = new InstanceElement('test', type)
-    const errors = await createCheckDeploymentBasedOnConfigValidator(apiConfig)(
+    const errors = await createCheckDeploymentBasedOnConfigValidator({ apiConfig })(
       [toChange({ before: instance })],
     )
     expect(errors).toEqual([{
@@ -78,7 +78,7 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
 
   it('should not return an error when operation is supported', async () => {
     const instance = new InstanceElement('test', type)
-    const errors = await createCheckDeploymentBasedOnConfigValidator(apiConfig)(
+    const errors = await createCheckDeploymentBasedOnConfigValidator({ apiConfig })(
       [toChange({ after: instance })],
     )
     expect(errors).toEqual([])
@@ -93,7 +93,9 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
       undefined,
       { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parentInst.elemID, parentInst)] },
     )
-    const errors = await createCheckDeploymentBasedOnConfigValidator(apiConfig, [childTypeName])(
+    const errors = await createCheckDeploymentBasedOnConfigValidator({
+      apiConfig, typesDeployedViaParent: [childTypeName],
+    })(
       [toChange({ after: instance })],
     )
     expect(errors).toEqual([])
@@ -108,7 +110,9 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
       undefined,
       { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parentInst.elemID, parentInst)] },
     )
-    const errors = await createCheckDeploymentBasedOnConfigValidator(apiConfig, [childTypeName])(
+    const errors = await createCheckDeploymentBasedOnConfigValidator({
+      apiConfig, typesDeployedViaParent: [childTypeName],
+    })(
       [toChange({ before: instance })],
     )
     expect(errors).toEqual([{
@@ -124,7 +128,9 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
       'test',
       new ObjectType({ elemID: new ElemID('dum', typeName) }),
     )
-    const errors = await createCheckDeploymentBasedOnConfigValidator(apiConfig, [], [typeName])(
+    const errors = await createCheckDeploymentBasedOnConfigValidator({
+      apiConfig, typesDeployedViaParent: [], typesWithNoDeploy: [typeName]
+    })(
       [toChange({ after: instance })],
     )
     expect(errors).toEqual([])

--- a/packages/adapter-components/test/deployment/change_validators/check_deployment.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/check_deployment.test.ts
@@ -118,4 +118,15 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
       detailedMessage: `Salto does not support "remove" of ${instance.elemID.getFullName()}`,
     }])
   })
+  it('should not return an error when operation deployed type in in the skipped list', async () => {
+    const typeName = 'testChild'
+    const instance = new InstanceElement(
+      'test',
+      new ObjectType({ elemID: new ElemID('dum', typeName) }),
+    )
+    const errors = await createCheckDeploymentBasedOnConfigValidator(apiConfig, [], [typeName])(
+      [toChange({ after: instance })],
+    )
+    expect(errors).toEqual([])
+  })
 })

--- a/packages/adapter-components/test/deployment/change_validators/check_deployment.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/check_deployment.test.ts
@@ -129,7 +129,7 @@ describe('checkDeploymentBasedOnConfigValidator', () => {
       new ObjectType({ elemID: new ElemID('dum', typeName) }),
     )
     const errors = await createCheckDeploymentBasedOnConfigValidator({
-      apiConfig, typesDeployedViaParent: [], typesWithNoDeploy: [typeName]
+      apiConfig, typesDeployedViaParent: [], typesWithNoDeploy: [typeName],
     })(
       [toChange({ after: instance })],
     )

--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -64,6 +64,7 @@ import serviceUrlFilter from './filters/service_url'
 import slaPolicyFilter from './filters/sla_policy'
 import macroAttachmentsFilter from './filters/macro_attachments'
 import omitInactiveFilter from './filters/omit_inactive'
+import tagsFilter from './filters/tag'
 import defaultDeployFilter from './filters/default_deploy'
 import { getConfigFromConfigChanges } from './config_change'
 
@@ -109,6 +110,7 @@ export const DEFAULT_FILTERS = [
   slaPolicyFilter,
   routingAttributeFilter,
   addFieldOptionsFilter,
+  tagsFilter,
   // removeDefinitionInstancesFilter should be after hardcodedChannelFilter
   removeDefinitionInstancesFilter,
   // unorderedListsFilter should run after fieldReferencesFilter
@@ -272,6 +274,7 @@ export default class ZendeskAdapter implements AdapterOperations {
       changeValidator: createChangeValidator(
         this.userConfig[API_DEFINITIONS_CONFIG],
         ['organization_field__custom_field_options', 'macro_attachment'],
+        ['tag'],
       ),
       dependencyChanger: deploymentUtils.dependency.removeStandaloneFieldDependency,
       getChangeGroupIds,

--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -271,11 +271,11 @@ export default class ZendeskAdapter implements AdapterOperations {
   // eslint-disable-next-line class-methods-use-this
   public get deployModifiers(): DeployModifiers {
     return {
-      changeValidator: createChangeValidator(
-        this.userConfig[API_DEFINITIONS_CONFIG],
-        ['organization_field__custom_field_options', 'macro_attachment'],
-        ['tag'],
-      ),
+      changeValidator: createChangeValidator({
+        apiConfig: this.userConfig[API_DEFINITIONS_CONFIG],
+        typesDeployedViaParent: ['organization_field__custom_field_options', 'macro_attachment'],
+        typesWithNoDeploy: ['tag'],
+      }),
       dependencyChanger: deploymentUtils.dependency.removeStandaloneFieldDependency,
       getChangeGroupIds,
     }

--- a/packages/zendesk-support-adapter/src/change_validator.ts
+++ b/packages/zendesk-support-adapter/src/change_validator.ts
@@ -35,15 +35,19 @@ const {
   createSkipParentsOfSkippedInstancesValidator,
 } = deployment.changeValidators
 
-export default (
-  apiConfig: configUtils.AdapterDuckTypeApiConfig,
-  typesDeployedViaParent: string[],
-  typesWithNoDeploy: string[],
-): ChangeValidator => {
+export default ({
+  apiConfig,
+  typesDeployedViaParent,
+  typesWithNoDeploy,
+}: {
+  apiConfig: configUtils.AdapterDuckTypeApiConfig
+  typesDeployedViaParent: string[]
+  typesWithNoDeploy: string[]
+}): ChangeValidator => {
   const validators: ChangeValidator[] = [
     deployTypesNotSupportedValidator,
     createCheckDeploymentBasedOnConfigValidator(
-      apiConfig, typesDeployedViaParent, typesWithNoDeploy
+      { apiConfig, typesDeployedViaParent, typesWithNoDeploy }
     ),
     accountSettingsValidator,
     emptyCustomFieldOptionsValidator,

--- a/packages/zendesk-support-adapter/src/change_validator.ts
+++ b/packages/zendesk-support-adapter/src/change_validator.ts
@@ -36,11 +36,15 @@ const {
 } = deployment.changeValidators
 
 export default (
-  apiConfig: configUtils.AdapterDuckTypeApiConfig, typesDeployedViaParent: string[]
+  apiConfig: configUtils.AdapterDuckTypeApiConfig,
+  typesDeployedViaParent: string[],
+  typesWithNoDeploy: string[],
 ): ChangeValidator => {
   const validators: ChangeValidator[] = [
     deployTypesNotSupportedValidator,
-    createCheckDeploymentBasedOnConfigValidator(apiConfig, typesDeployedViaParent),
+    createCheckDeploymentBasedOnConfigValidator(
+      apiConfig, typesDeployedViaParent, typesWithNoDeploy
+    ),
     accountSettingsValidator,
     emptyCustomFieldOptionsValidator,
     emptyVariantsValidator,

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -41,6 +41,9 @@ const SPECIAL_CONTEXT_NAMES: Record<string, string> = {
   notification_webhook: 'webhook',
   via_id: 'channel',
   current_via_id: 'channel',
+  current_tags: 'tag',
+  set_tags: 'tag',
+  remove_tags: 'tag',
 }
 
 /**

--- a/packages/zendesk-support-adapter/src/filters/tag.ts
+++ b/packages/zendesk-support-adapter/src/filters/tag.ts
@@ -18,7 +18,7 @@ import {
   isInstanceElement, ObjectType, ReferenceExpression,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
-import { applyFunctionToChangeData, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
+import { applyFunctionToChangeData, naclCase } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
@@ -38,6 +38,7 @@ const TYPE_NAME_TO_RELEVANT_FIELD_NAMES: Record<string, string[]> = {
   workspace: ['conditions.all', 'conditions.any'],
 }
 export const TAG_TYPE_NAME = 'tag'
+const TAGS_FILE_NAME = 'tags'
 
 const { RECORDS_PATH, TYPES_PATH } = elementsUtils
 const { awu } = collections.asynciterable
@@ -117,7 +118,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
           naclCase(tag),
           tagObjectType,
           { id: tag },
-          [ZENDESK_SUPPORT, RECORDS_PATH, TAG_TYPE_NAME, pathNaclCase(tag)]
+          [ZENDESK_SUPPORT, RECORDS_PATH, TAG_TYPE_NAME, TAGS_FILE_NAME]
         ))
       .value();
     // We do this trick to avoid calling push with the spread notation

--- a/packages/zendesk-support-adapter/src/filters/tag.ts
+++ b/packages/zendesk-support-adapter/src/filters/tag.ts
@@ -1,0 +1,164 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import {
+  BuiltinTypes, Change, CORE_ANNOTATIONS, Element, ElemID, getChangeData, InstanceElement,
+  isInstanceElement, ObjectType, ReferenceExpression,
+} from '@salto-io/adapter-api'
+import { elements as elementsUtils } from '@salto-io/adapter-components'
+import { applyFunctionToChangeData, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { ZENDESK_SUPPORT } from '../constants'
+import { FilterCreator } from '../filter'
+import { areConditions } from './utils'
+
+const RELEVANT_TYPE_NAMES = [
+  'automation',
+  'trigger',
+  'view',
+  'macro',
+  'sla_policy',
+  'workspace',
+]
+const RELEVANT_FIELD_NAMES = ['current_tags', 'remove_tags', 'set_tags']
+const RELEVANT_CONDITION_FIELD_NAMES = ['actions', 'conditions.all', 'conditions.any', 'filter.all', 'filter.any']
+export const TAG_TYPE_NAME = 'tag'
+
+const { RECORDS_PATH, TYPES_PATH } = elementsUtils
+const { awu } = collections.asynciterable
+
+const TAG_SEPERATOR = ' '
+const extractTags = (value: string): string[] =>
+  value.split(TAG_SEPERATOR).filter(tag => !_.isEmpty(tag))
+
+const replaceTagsWithReferences = (instance: InstanceElement): string[] => {
+  const tags: string[] = []
+  RELEVANT_CONDITION_FIELD_NAMES
+    .forEach(fieldName => {
+      const conditions = _.get(instance.value, fieldName)
+      const fullName = instance.elemID
+        .createNestedID(...fieldName.split(ElemID.NAMESPACE_SEPARATOR)).getFullName()
+      if (!areConditions(conditions, fullName)) {
+        return
+      }
+      conditions.forEach(condition => {
+        if (RELEVANT_FIELD_NAMES.includes(condition.field) && _.isString(condition.value)) {
+          const conditionTags = extractTags(condition.value)
+          tags.push(...conditionTags)
+          condition.value = conditionTags
+            .map(tag => new ReferenceExpression(
+              new ElemID(ZENDESK_SUPPORT, TAG_TYPE_NAME, 'instance', naclCase(tag))
+            ))
+        }
+      })
+    })
+  return tags
+}
+
+const serializeReferencesToTags = (instance: InstanceElement): void => {
+  RELEVANT_CONDITION_FIELD_NAMES
+    .forEach(fieldName => {
+      const conditions = _.get(instance.value, fieldName)
+      const fullName = instance.elemID
+        .createNestedID(...fieldName.split(ElemID.NAMESPACE_SEPARATOR)).getFullName()
+      if (!areConditions(conditions, fullName)) {
+        return
+      }
+      conditions.forEach(condition => {
+        if (
+          RELEVANT_FIELD_NAMES.includes(condition.field)
+          && _.isArray(condition.value)
+          && condition.value.every(_.isString)
+        ) {
+          condition.value = condition.value.join(TAG_SEPERATOR)
+        }
+      })
+    })
+}
+
+/**
+ * Add dependencies from elements to dynamic content items in
+ * the _generated_ dependencies annotation
+ */
+const filterCreator: FilterCreator = ({ config }) => ({
+  onFetch: async (elements: Element[]): Promise<void> => {
+    const instances = elements
+      .filter(isInstanceElement)
+      .filter(instance => RELEVANT_TYPE_NAMES.includes(instance.elemID.typeName))
+
+    const tags = instances.map(instance => replaceTagsWithReferences(instance)).flat()
+    const tagObjectType = new ObjectType({
+      elemID: new ElemID(ZENDESK_SUPPORT, TAG_TYPE_NAME),
+      fields: { id: { refType: BuiltinTypes.STRING } },
+      annotations: config.fetch.hideTypes ? { [CORE_ANNOTATIONS.HIDDEN]: true } : undefined,
+      path: [ZENDESK_SUPPORT, TYPES_PATH, TAG_TYPE_NAME],
+    })
+    const tagInstances = _(tags)
+      .uniq()
+      .sort()
+      .map(tag =>
+        new InstanceElement(
+          naclCase(tag),
+          tagObjectType,
+          { id: tag },
+          [ZENDESK_SUPPORT, RECORDS_PATH, TAG_TYPE_NAME, pathNaclCase(tag)]
+        ))
+      .value();
+    // We do this trick to avoid calling push with the spread notation
+    [tagObjectType, tagInstances].flat().forEach(element => { elements.push(element) })
+  },
+  deploy: async (changes: Change<InstanceElement>[]) => {
+    const [tagsChanges, leftoverChanges] = _.partition(
+      changes,
+      change => getChangeData(change).elemID.typeName === TAG_TYPE_NAME
+    )
+    return { deployResult: { appliedChanges: tagsChanges, errors: [] }, leftoverChanges }
+  },
+  preDeploy: async (changes: Change<InstanceElement>[]) => {
+    const relevantChanges = changes
+      .filter(change => RELEVANT_TYPE_NAMES.includes(getChangeData(change).elemID.typeName))
+    if (_.isEmpty(relevantChanges)) {
+      return
+    }
+    await awu(changes).forEach(async change => {
+      await applyFunctionToChangeData<Change<InstanceElement>>(
+        change,
+        instance => {
+          serializeReferencesToTags(instance)
+          return instance
+        }
+      )
+    })
+  },
+  onDeploy: async (changes: Change<InstanceElement>[]) => {
+    const relevantChanges = changes
+      .filter(change => RELEVANT_TYPE_NAMES.includes(getChangeData(change).elemID.typeName))
+    if (_.isEmpty(relevantChanges)) {
+      return
+    }
+    await awu(changes).forEach(async change => {
+      await applyFunctionToChangeData<Change<InstanceElement>>(
+        change,
+        instance => {
+          replaceTagsWithReferences(instance)
+          return instance
+        }
+      )
+    })
+  },
+})
+
+export default filterCreator

--- a/packages/zendesk-support-adapter/src/filters/user.ts
+++ b/packages/zendesk-support-adapter/src/filters/user.ts
@@ -17,10 +17,11 @@ import _ from 'lodash'
 import Joi from 'joi'
 import { logger } from '@salto-io/logging'
 import { client as clientUtils } from '@salto-io/adapter-components'
-import { applyFunctionToChangeData, safeJsonStringify } from '@salto-io/adapter-utils'
+import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { Change, getChangeData, InstanceElement, isInstanceElement, Values } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
+import { areConditions } from './utils'
 
 const log = logger(module)
 const { toArrayAsync, awu } = collections.asynciterable
@@ -31,31 +32,16 @@ type User = {
   id: number
   email: string
 }
-type Condition = {
-  field: string
-}
 
 const EXPECTED_USER_SCHEMA = Joi.array().items(Joi.object({
   id: Joi.number().required(),
   email: Joi.string().required(),
 }).unknown(true)).required()
 
-const EXPECTED_CONDITION_SCHEMA = Joi.array().items(Joi.object({
-  field: Joi.string().required(),
-}).unknown(true)).required()
-
 const areUsers = (values: unknown): values is User[] => {
   const { error } = EXPECTED_USER_SCHEMA.validate(values)
   if (error !== undefined) {
     log.warn(`Received an invalid response for the users values: ${error.message}`)
-    return false
-  }
-  return true
-}
-const areConditions = (values: unknown, fullName: string): values is Condition[] => {
-  const { error } = EXPECTED_CONDITION_SCHEMA.validate(values)
-  if (error !== undefined) {
-    log.warn(`Received an invalid values for conditions on ${fullName}: ${safeJsonStringify(values)}`)
     return false
   }
   return true

--- a/packages/zendesk-support-adapter/src/filters/utils.ts
+++ b/packages/zendesk-support-adapter/src/filters/utils.ts
@@ -77,10 +77,12 @@ const EXPECTED_CONDITION_SCHEMA = Joi.array().items(Joi.object({
   value: Joi.optional(),
 }).unknown(true)).required()
 
+// Checks that values is from the form of conditions - must have field
+//  attribute and might have value attribute
 export const areConditions = (values: unknown, fullName: string): values is Condition[] => {
   const { error } = EXPECTED_CONDITION_SCHEMA.validate(values)
   if (error !== undefined) {
-    log.warn(`Received an invalid values for conditions on ${fullName}: ${safeJsonStringify(values)}`)
+    log.warn(`Received invalid values for conditions on ${fullName}: ${safeJsonStringify(values)}`)
     return false
   }
   return true

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -331,6 +331,8 @@ describe('adapter', () => {
           'zendesk_support.support_address',
           'zendesk_support.support_address.instance.myBrand',
           'zendesk_support.support_addresses',
+          'zendesk_support.tag',
+          'zendesk_support.tag.instance.Social',
           'zendesk_support.target',
           'zendesk_support.target.instance.Slack_integration_Endpoint_url_target_v2@ssuuu',
           'zendesk_support.targets',

--- a/packages/zendesk-support-adapter/test/change_validator.test.ts
+++ b/packages/zendesk-support-adapter/test/change_validator.test.ts
@@ -21,12 +21,12 @@ import { ZENDESK_SUPPORT } from '../src/constants'
 describe('change validator creator', () => {
   describe('deployNotSupportedValidator', () => {
     it('should not fail if there are no deploy changes', async () => {
-      expect(await createChangeValidator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG], [])([]))
+      expect(await createChangeValidator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG], [], [])([]))
         .toEqual([])
     })
 
     it('should fail each change individually', async () => {
-      expect(await createChangeValidator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG], [])([
+      expect(await createChangeValidator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG], [], [])([
         toChange({ after: new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'obj') }) }),
         toChange({ before: new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'obj2') }) }),
       ])).toEqual([
@@ -48,7 +48,7 @@ describe('change validator creator', () => {
   describe('checkDeploymentBasedOnConfigValidator', () => {
     it('should fail each change individually', async () => {
       const type = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'obj') })
-      expect(await createChangeValidator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG], [])([
+      expect(await createChangeValidator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG], [], [])([
         toChange({ after: new InstanceElement('inst1', type) }),
         toChange({ before: new InstanceElement('inst2', type) }),
       ])).toEqual([

--- a/packages/zendesk-support-adapter/test/change_validator.test.ts
+++ b/packages/zendesk-support-adapter/test/change_validator.test.ts
@@ -21,12 +21,20 @@ import { ZENDESK_SUPPORT } from '../src/constants'
 describe('change validator creator', () => {
   describe('deployNotSupportedValidator', () => {
     it('should not fail if there are no deploy changes', async () => {
-      expect(await createChangeValidator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG], [], [])([]))
+      expect(await createChangeValidator({
+        apiConfig: DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
+        typesDeployedViaParent: [],
+        typesWithNoDeploy: [],
+      })([]))
         .toEqual([])
     })
 
     it('should fail each change individually', async () => {
-      expect(await createChangeValidator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG], [], [])([
+      expect(await createChangeValidator({
+        apiConfig: DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
+        typesDeployedViaParent: [],
+        typesWithNoDeploy: [],
+      })([
         toChange({ after: new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'obj') }) }),
         toChange({ before: new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'obj2') }) }),
       ])).toEqual([
@@ -48,7 +56,11 @@ describe('change validator creator', () => {
   describe('checkDeploymentBasedOnConfigValidator', () => {
     it('should fail each change individually', async () => {
       const type = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'obj') })
-      expect(await createChangeValidator(DEFAULT_CONFIG[API_DEFINITIONS_CONFIG], [], [])([
+      expect(await createChangeValidator({
+        apiConfig: DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
+        typesDeployedViaParent: [],
+        typesWithNoDeploy: [],
+      })([
         toChange({ after: new InstanceElement('inst1', type) }),
         toChange({ before: new InstanceElement('inst2', type) }),
       ])).toEqual([

--- a/packages/zendesk-support-adapter/test/filters/tag.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/tag.test.ts
@@ -1,0 +1,377 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, InstanceElement, isInstanceElement, toChange, getChangeData, ReferenceExpression } from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { mockFunction } from '@salto-io/test-utils'
+import { DEFAULT_CONFIG } from '../../src/config'
+import ZendeskClient from '../../src/client/client'
+import { ZENDESK_SUPPORT } from '../../src/constants'
+import filterCreator, { TAG_TYPE_NAME } from '../../src/filters/tag'
+
+const mockDeployChange = jest.fn()
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn((...args) => mockDeployChange(...args)),
+    },
+  }
+})
+
+describe('tags filter', () => {
+  let client: ZendeskClient
+  type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy' | 'deploy'>
+  let filter: FilterType
+  const slaPolicyType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'sla_policy') })
+  const triggerType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'trigger') })
+
+  const triggerInstance = new InstanceElement(
+    'test',
+    triggerType,
+    {
+      title: 'test',
+      actions: [
+        {
+          field: 'status',
+          value: 'closed',
+        },
+        {
+          field: 'remove_tags',
+          value: 't1 t2',
+        },
+        {
+          field: 'set_tags',
+          value: 't3 t4 t5',
+        },
+        {
+          field: 'current_tags',
+          value: 't0',
+        },
+      ],
+      conditions: {
+        all: [
+          {
+            field: 'current_tags',
+            operator: 'includes',
+            value: '',
+          },
+        ],
+        any: [
+          {
+            field: 'current_tags',
+            operator: 'includes',
+            value: 't5 t6',
+          },
+        ],
+      },
+    },
+  )
+  const slaPolicyInstance = new InstanceElement(
+    'test',
+    slaPolicyType,
+    {
+      title: 'test',
+      filter: {
+        all: [
+          {
+            field: 'current_tags',
+            operator: 'includes',
+            value: 't3',
+          },
+        ],
+        any: [
+          {
+            field: 'current_tags',
+            operator: 'includes',
+            value: 't5 t6 t2',
+          },
+        ],
+      },
+      policy_metrics: [
+        {
+          priority: 'low',
+          metric: 'first_reply_time',
+          target: 480,
+          business_hours: false,
+        },
+      ],
+    },
+  )
+  let mockPaginator: clientUtils.Paginator
+  const tagRef = (val: string): ReferenceExpression =>
+    new ReferenceExpression(new ElemID(ZENDESK_SUPPORT, TAG_TYPE_NAME, 'instance', val))
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+    })
+    mockPaginator = mockFunction<clientUtils.Paginator>()
+      .mockImplementationOnce(async function *get() {
+        yield [
+          { users: [
+            { id: 1, email: 'a@a.com' },
+            { id: 2, email: 'b@b.com' },
+          ] },
+          { users: [
+            { id: 3, email: 'c@c.com' },
+          ] },
+        ]
+      })
+    filter = filterCreator({
+      client,
+      paginator: mockPaginator,
+      config: DEFAULT_CONFIG,
+    }) as FilterType
+  })
+
+  describe('onFetch', () => {
+    it('should change the tags to be references', async () => {
+      const elements = [
+        slaPolicyType, triggerType, slaPolicyInstance, triggerInstance,
+      ].map(e => e.clone())
+      await filter.onFetch(elements)
+      expect(elements.map(e => e.elemID.getFullName()).sort())
+        .toEqual([
+          'zendesk_support.sla_policy',
+          'zendesk_support.sla_policy.instance.test',
+          'zendesk_support.tag',
+          'zendesk_support.tag.instance.t0',
+          'zendesk_support.tag.instance.t1',
+          'zendesk_support.tag.instance.t2',
+          'zendesk_support.tag.instance.t3',
+          'zendesk_support.tag.instance.t4',
+          'zendesk_support.tag.instance.t5',
+          'zendesk_support.tag.instance.t6',
+          'zendesk_support.trigger',
+          'zendesk_support.trigger.instance.test',
+        ])
+      const instances = elements.filter(isInstanceElement)
+      const trigger = instances.find(e => e.elemID.typeName === 'trigger')
+      expect(trigger?.value).toEqual({
+        title: 'test',
+        actions: [
+          { field: 'status', value: 'closed' },
+          { field: 'remove_tags', value: [tagRef('t1'), tagRef('t2')] },
+          { field: 'set_tags', value: [tagRef('t3'), tagRef('t4'), tagRef('t5')] },
+          { field: 'current_tags', value: [tagRef('t0')] },
+        ],
+        conditions: {
+          all: [
+            { field: 'current_tags', operator: 'includes', value: [] },
+          ],
+          any: [
+            { field: 'current_tags', operator: 'includes', value: [tagRef('t5'), tagRef('t6')] },
+          ],
+        },
+      })
+      const sla = instances.find(e => e.elemID.typeName === 'sla_policy')
+      expect(sla?.value).toEqual({
+        title: 'test',
+        filter: {
+          all: [
+            { field: 'current_tags', operator: 'includes', value: [tagRef('t3')] },
+          ],
+          any: [
+            { field: 'current_tags', operator: 'includes', value: [tagRef('t5'), tagRef('t6'), tagRef('t2')] },
+          ],
+        },
+        policy_metrics: [
+          {
+            priority: 'low',
+            metric: 'first_reply_time',
+            target: 480,
+            business_hours: false,
+          },
+        ],
+      })
+    })
+  })
+  describe('preDeploy', () => {
+    it('should change the tags value to be in the correct deploy format', async () => {
+      const resolvedSlaPolicyInstance = slaPolicyInstance.clone()
+      resolvedSlaPolicyInstance.value = {
+        title: 'test',
+        filter: {
+          all: [{ field: 'current_tags', operator: 'includes', value: ['t3'] }],
+          any: [{ field: 'current_tags', operator: 'includes', value: ['t5', 't6', 't2'] }],
+        },
+        policy_metrics: [
+          {
+            priority: 'low',
+            metric: 'first_reply_time',
+            target: 480,
+            business_hours: false,
+          },
+        ],
+      }
+      const resolvedTriggerInstance = triggerInstance.clone()
+      resolvedTriggerInstance.value = {
+        title: 'test',
+        actions: [
+          { field: 'status', value: 'closed' },
+          { field: 'remove_tags', value: ['t1', 't2'] },
+          { field: 'set_tags', value: ['t3', 't4', 't5'] },
+          { field: 'current_tags', value: ['t0'] },
+        ],
+        conditions: {
+          all: [{ field: 'current_tags', operator: 'includes', value: [] }],
+          any: [{ field: 'current_tags', operator: 'includes', value: ['t5', 't6'] }],
+        },
+      }
+      const instances = [resolvedSlaPolicyInstance, resolvedTriggerInstance]
+      const changes = instances.map(instance => toChange({ after: instance }))
+      await filter.preDeploy(changes)
+      const changedInstances = changes.map(getChangeData)
+      const trigger = changedInstances.find(inst => inst.elemID.typeName === 'trigger')
+      expect(trigger?.value).toEqual({
+        title: 'test',
+        actions: [
+          { field: 'status', value: 'closed' },
+          { field: 'remove_tags', value: 't1 t2' },
+          { field: 'set_tags', value: 't3 t4 t5' },
+          { field: 'current_tags', value: 't0' },
+        ],
+        conditions: {
+          all: [{ field: 'current_tags', operator: 'includes', value: '' }],
+          any: [{ field: 'current_tags', operator: 'includes', value: 't5 t6' }],
+        },
+      })
+      const sla = changedInstances.find(e => e.elemID.typeName === 'sla_policy')
+      expect(sla?.value).toEqual({
+        title: 'test',
+        filter: {
+          all: [{ field: 'current_tags', operator: 'includes', value: 't3' }],
+          any: [{ field: 'current_tags', operator: 'includes', value: 't5 t6 t2' }],
+        },
+        policy_metrics: [
+          {
+            priority: 'low',
+            metric: 'first_reply_time',
+            target: 480,
+            business_hours: false,
+          },
+        ],
+      })
+    })
+  })
+  describe('onDeploy', () => {
+    it('should change the tags value to be reference expressions', async () => {
+      const resolvedSlaPolicyInstance = slaPolicyInstance.clone()
+      resolvedSlaPolicyInstance.value = {
+        title: 'test',
+        filter: {
+          all: [{ field: 'current_tags', operator: 'includes', value: 't3' }],
+          any: [{ field: 'current_tags', operator: 'includes', value: 't5 t6 t2' }],
+        },
+        policy_metrics: [
+          {
+            priority: 'low',
+            metric: 'first_reply_time',
+            target: 480,
+            business_hours: false,
+          },
+        ],
+      }
+      const resolvedTriggerInstance = triggerInstance.clone()
+      resolvedTriggerInstance.value = {
+        title: 'test',
+        actions: [
+          { field: 'status', value: 'closed' },
+          { field: 'remove_tags', value: 't1 t2' },
+          { field: 'set_tags', value: 't3 t4 t5' },
+          { field: 'current_tags', value: 't0' },
+        ],
+        conditions: {
+          all: [{ field: 'current_tags', operator: 'includes', value: '' }],
+          any: [{ field: 'current_tags', operator: 'includes', value: 't5 t6' }],
+        },
+      }
+      const instances = [resolvedSlaPolicyInstance, resolvedTriggerInstance]
+      const changes = instances.map(instance => toChange({ after: instance }))
+      await filter.onDeploy(changes)
+      const changedInstances = changes.map(getChangeData)
+      const sla = changedInstances.find(inst => inst.elemID.typeName === 'sla_policy')
+      expect(sla?.value).toEqual({
+        title: 'test',
+        filter: {
+          all: [
+            { field: 'current_tags', operator: 'includes', value: [tagRef('t3')] },
+          ],
+          any: [
+            { field: 'current_tags', operator: 'includes', value: [tagRef('t5'), tagRef('t6'), tagRef('t2')] },
+          ],
+        },
+        policy_metrics: [
+          {
+            priority: 'low',
+            metric: 'first_reply_time',
+            target: 480,
+            business_hours: false,
+          },
+        ],
+      })
+      const trigger = changedInstances.find(inst => inst.elemID.typeName === 'trigger')
+      expect(trigger?.value).toEqual({
+        title: 'test',
+        actions: [
+          { field: 'status', value: 'closed' },
+          { field: 'remove_tags', value: [tagRef('t1'), tagRef('t2')] },
+          { field: 'set_tags', value: [tagRef('t3'), tagRef('t4'), tagRef('t5')] },
+          { field: 'current_tags', value: [tagRef('t0')] },
+        ],
+        conditions: {
+          all: [
+            { field: 'current_tags', operator: 'includes', value: [] },
+          ],
+          any: [
+            { field: 'current_tags', operator: 'includes', value: [tagRef('t5'), tagRef('t6')] },
+          ],
+        },
+      })
+    })
+  })
+  describe('deploy', () => {
+    it('should not call deployChange function', async () => {
+      const tag = new InstanceElement(
+        'test',
+        new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, TAG_TYPE_NAME) }),
+        { id: 'test' },
+      )
+      const change = toChange({ after: tag })
+      const res = await filter.deploy([change])
+      expect(mockDeployChange).not.toHaveBeenCalled()
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toEqual([change])
+    })
+    it('should only apply relevant changes', async () => {
+      const inst = new InstanceElement(
+        'test',
+        new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'dummy') }),
+        { id: 'test' },
+      )
+      const change = toChange({ after: inst })
+      const res = await filter.deploy([change])
+      expect(mockDeployChange).not.toHaveBeenCalled()
+      expect(res.leftoverChanges).toHaveLength(1)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
_extract tags to references_

---

_Additional context for reviewer_
* Tags are not objects in zendesk (they don't have internal id and such)
* There is an API to list the 500 most popular tags (which doesn't help us)
* We decided to extract it based on all the places that refer to tags
* In those places, tags are defined with space as a separator
* There is no deploy for tags - so I created an empty deploy function

---
_Release Notes_: 
_Zendesk_support adapter:_
* Add references to tags

---
_User Notifications_: 
_New tags instances will be added and the places that refer to them will be changed_
