### PR TITLE
SALTO-2199: move the hide types part to be in a filter

### DIFF
--- a/packages/adapter-components/src/elements/ducktype/add_remaining_types.ts
+++ b/packages/adapter-components/src/elements/ducktype/add_remaining_types.ts
@@ -29,14 +29,13 @@ import { getTransformationConfigByType, TypeDuckTypeConfig, TypeDuckTypeDefaults
  * Note: modifies the elements array in-place.
  */
 export const addRemainingTypes = ({
-  elements, typesConfig, adapterName, includeTypes, typeDefaultConfig, hideTypes,
+  elements, typesConfig, adapterName, includeTypes, typeDefaultConfig,
 }: {
   elements: Element[]
   typesConfig: Record<string, TypeDuckTypeConfig>
   adapterName: string
   includeTypes: string[]
   typeDefaultConfig: TypeDuckTypeDefaultsConfig
-  hideTypes?: boolean
 }): void => {
   const sourceTypeNameToTypeName = _(typesConfig)
     .pickBy(typeConfig => typeConfig.transformation?.sourceTypeName !== undefined)
@@ -67,7 +66,6 @@ export const addRemainingTypes = ({
       entries: [{}],
       name: typeName,
       hasDynamicFields: false,
-      hideTypes,
       transformationConfigByType: getTransformationConfigByType(typesConfig),
       transformationDefaultConfig: typeDefaultConfig.transformation,
       isSubType: !includeTypes.includes(sourceTypeNameToTypeName[typeName]),

--- a/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
+++ b/packages/adapter-components/src/elements/ducktype/standalone_field_extractor.ts
@@ -63,7 +63,6 @@ const addFieldTypeAndInstances = async ({
   transformationConfigByType,
   transformationDefaultConfig,
   getElemIdFunc,
-  hideTypes,
 }: {
   adapterName: string
   typeName: string
@@ -73,7 +72,6 @@ const addFieldTypeAndInstances = async ({
   transformationConfigByType: Record<string, TransformationConfig>
   transformationDefaultConfig: TransformationDefaultConfig
   getElemIdFunc?: ElemIdGetter
-  hideTypes?: boolean
 }): Promise<Element[]> => {
   if (type.fields[fieldName] === undefined) {
     log.info('type %s field %s does not exist (maybe it is not populated by any of the instances), not extracting field', type.elemID.name, fieldName)
@@ -102,7 +100,6 @@ const addFieldTypeAndInstances = async ({
       isSubType: true,
       transformationConfigByType,
       transformationDefaultConfig,
-      hideTypes,
     })
     type.fields[fieldName].refType = isListType(currentType)
       ? createRefToElmWithValue(new ListType(fieldType.type))
@@ -161,14 +158,12 @@ export const extractStandaloneFields = async ({
   transformationDefaultConfig,
   adapterName,
   getElemIdFunc,
-  hideTypes,
 }: {
   elements: Element[]
   transformationConfigByType: Record<string, TransformationConfig>
   transformationDefaultConfig: TransformationDefaultConfig
   adapterName: string
   getElemIdFunc?: ElemIdGetter
-  hideTypes?: boolean
 }): Promise<void> => {
   const allTypes = _.keyBy(elements.filter(isObjectType), e => e.elemID.name)
   const allInstancesbyType = _.groupBy(
@@ -207,7 +202,6 @@ export const extractStandaloneFields = async ({
           transformationConfigByType,
           transformationDefaultConfig,
           getElemIdFunc,
-          hideTypes,
         }))
       })
     })

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -47,7 +47,6 @@ type GetEntriesParams = {
   contextElements?: Record<string, Element[]>
   requestContext?: Record<string, unknown>
   getElemIdFunc?: ElemIdGetter
-  hideTypes?: boolean
 }
 
 type Entries = {
@@ -70,7 +69,7 @@ const getEntriesForType = async (
 ): Promise<Entries> => {
   const {
     typeName, paginator, typesConfig, typeDefaultConfig, contextElements,
-    requestContext, nestedFieldFinder, computeGetArgs, adapterName, getElemIdFunc, hideTypes,
+    requestContext, nestedFieldFinder, computeGetArgs, adapterName, getElemIdFunc,
   } = params
   const typeConfig = typesConfig[typeName]
   if (typeConfig === undefined) {
@@ -113,7 +112,6 @@ const getEntriesForType = async (
     hasDynamicFields: hasDynamicFields === true,
     transformationConfigByType,
     transformationDefaultConfig,
-    hideTypes,
   })
   // find the field and type containing the actual instances
   const nestedFieldDetails = await nestedFieldFinder(type, fieldsToOmit, dataField)
@@ -199,7 +197,6 @@ const getEntriesForType = async (
     hasDynamicFields: hasDynamicFields === true,
     transformationConfigByType,
     transformationDefaultConfig,
-    hideTypes,
   })
   return {
     instances: instances.map(inst => new InstanceElement(
@@ -222,7 +219,6 @@ export const getTypeAndInstances = async ({
   computeGetArgs,
   typesConfig,
   typeDefaultConfig,
-  hideTypes,
   contextElements,
   getElemIdFunc,
 }: {
@@ -233,7 +229,6 @@ export const getTypeAndInstances = async ({
   computeGetArgs: ComputeGetArgsFunc
   typesConfig: Record<string, TypeDuckTypeConfig>
   typeDefaultConfig: TypeDuckTypeDefaultsConfig
-  hideTypes?: boolean
   contextElements?: Record<string, Element[]>
   getElemIdFunc?: ElemIdGetter
 }): Promise<Element[]> => {
@@ -245,7 +240,6 @@ export const getTypeAndInstances = async ({
     nestedFieldFinder,
     typeDefaultConfig,
     typesConfig,
-    hideTypes,
     contextElements,
     getElemIdFunc,
   })
@@ -259,7 +253,6 @@ export const getTypeAndInstances = async ({
     transformationConfigByType,
     transformationDefaultConfig: typeDefaultConfig.transformation,
     getElemIdFunc,
-    hideTypes,
   })
   return elements
 }
@@ -281,7 +274,6 @@ export const getAllElements = async ({
   computeGetArgs,
   typeDefaults,
   getElemIdFunc,
-  hideTypes,
   isErrorTurnToConfigSuggestion,
 }: {
   adapterName: string
@@ -292,7 +284,6 @@ export const getAllElements = async ({
   computeGetArgs: ComputeGetArgsFunc
   typeDefaults: TypeDuckTypeDefaultsConfig
   getElemIdFunc?: ElemIdGetter
-  hideTypes?: boolean
   isErrorTurnToConfigSuggestion?: (error: Error) => boolean
 }): Promise<FetchElements<Element[]>> => {
   const allTypesWithRequestEndpoints = includeTypes.filter(
@@ -307,7 +298,6 @@ export const getAllElements = async ({
     typesConfig: types,
     typeDefaultConfig: typeDefaults,
     getElemIdFunc,
-    hideTypes,
   }
 
   const configSuggestions: ConfigChangeSuggestion[] = []
@@ -354,7 +344,6 @@ export const getAllElements = async ({
     typesConfig: types,
     includeTypes,
     typeDefaultConfig: typeDefaults,
-    hideTypes,
   })
   return {
     elements: instancesAndTypes,

--- a/packages/adapter-components/src/elements/ducktype/type_elements.ts
+++ b/packages/adapter-components/src/elements/ducktype/type_elements.ts
@@ -17,7 +17,6 @@ import _ from 'lodash'
 import {
   ObjectType, ElemID, BuiltinTypes, Values, MapType, PrimitiveType, ListType, isObjectType,
   FieldDefinition,
-  CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { pathNaclCase, naclCase } from '@salto-io/adapter-utils'
 import { DuckTypeTransformationConfig, DuckTypeTransformationDefaultConfig, getConfigWithDefault } from '../../config'
@@ -49,7 +48,6 @@ const generateNestedType = ({
   transformationDefaultConfig,
   hasDynamicFields,
   typeNameOverrideConfig,
-  hideTypes,
   isUnknownEntry,
 }: {
   adapterName: string
@@ -60,7 +58,6 @@ const generateNestedType = ({
   transformationDefaultConfig: DuckTypeTransformationDefaultConfig
   typeNameOverrideConfig: Record<string, string>
   hasDynamicFields: boolean
-  hideTypes?: boolean
   isUnknownEntry?: (value: unknown) => boolean
 }): NestedTypeWithNestedTypes => {
   const validEntries = entries.filter(entry => entry !== undefined && entry !== null)
@@ -83,7 +80,6 @@ const generateNestedType = ({
         transformationConfigByType,
         transformationDefaultConfig,
         typeNameOverrideConfig,
-        hideTypes,
         isUnknownEntry,
       })
       return {
@@ -105,7 +101,6 @@ const generateNestedType = ({
         transformationDefaultConfig,
         isSubType: true,
         typeNameOverrideConfig,
-        hideTypes,
         isUnknownEntry,
       })
     }
@@ -171,7 +166,6 @@ export const generateType = ({
   transformationConfigByType,
   transformationDefaultConfig,
   typeNameOverrideConfig,
-  hideTypes,
   isSubType = false,
   isUnknownEntry,
 }: {
@@ -182,7 +176,6 @@ export const generateType = ({
   transformationConfigByType: Record<string, DuckTypeTransformationConfig>
   transformationDefaultConfig: DuckTypeTransformationDefaultConfig
   typeNameOverrideConfig?: Record<string, string>
-  hideTypes?: boolean
   isSubType?: boolean
   isUnknownEntry?: (value: unknown) => boolean
 }): ObjectTypeWithNestedTypes => {
@@ -220,7 +213,6 @@ export const generateType = ({
           transformationDefaultConfig,
           hasDynamicFields: false,
           typeNameOverrideConfig: typeRenameConfig,
-          hideTypes,
           isUnknownEntry,
         }))),
       },
@@ -239,7 +231,6 @@ export const generateType = ({
               transformationDefaultConfig,
               hasDynamicFields: false,
               typeNameOverrideConfig: typeRenameConfig,
-              hideTypes,
               isUnknownEntry,
             })),
           },
@@ -265,7 +256,6 @@ export const generateType = ({
     fields,
     path,
     isSettings: transformationConfigByType[naclName]?.isSingleton ?? false,
-    annotations: hideTypes ? ({ [CORE_ANNOTATIONS.HIDDEN]: true }) : undefined,
   })
 
   return { type, nestedTypes }

--- a/packages/adapter-components/src/filters/ducktype/hide_types.ts
+++ b/packages/adapter-components/src/filters/ducktype/hide_types.ts
@@ -1,0 +1,38 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, isObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { filter } from '@salto-io/adapter-utils'
+import { DuckTypeUserFetchConfig } from '../../config/ducktype'
+import { FilterCreator } from '../../filter_utils'
+
+/**
+ * Hide types if needed
+ */
+export const hideTypesFilterCreator: <
+ TClient,
+ TContext extends { fetch: DuckTypeUserFetchConfig },
+ TResult extends void | filter.FilterResult = void,
+ > () => FilterCreator<TClient, TContext, TResult> = () => ({ config }) => ({
+   onFetch: async (elements: Element[]) => {
+     if (config.fetch.hideTypes) {
+       elements
+         .filter(isObjectType)
+         .forEach(objType => {
+           objType.annotations[CORE_ANNOTATIONS.HIDDEN] = true
+         })
+     }
+   },
+ })

--- a/packages/adapter-components/src/filters/ducktype/index.ts
+++ b/packages/adapter-components/src/filters/ducktype/index.ts
@@ -13,6 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { serviceUrlFilterCreator } from './service_url'
-export { referencedInstanceNamesFilterCreator } from './referenced_instance_names'
-export * as ducktype from './ducktype'
+import { hideTypesFilterCreator } from './hide_types'
+
+export { hideTypesFilterCreator } from './hide_types'
+
+export const DUCKTYPE_MANDATORY_FILTER_CREATORS = [
+  hideTypesFilterCreator,
+]

--- a/packages/adapter-components/test/elements/ducktype/add_remaining_types.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/add_remaining_types.test.ts
@@ -76,7 +76,6 @@ describe('add remaining types', () => {
       adapterName: ADAPTER_NAME,
       includeTypes,
       typeDefaultConfig,
-      hideTypes: false,
     })
     expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
       'myAdapter.file',
@@ -101,7 +100,6 @@ describe('add remaining types', () => {
       adapterName: ADAPTER_NAME,
       includeTypes,
       typeDefaultConfig,
-      hideTypes: false,
     })
     expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
       'myAdapter.file',

--- a/packages/adapter-components/test/filters/ducktype/hide_types.test.ts
+++ b/packages/adapter-components/test/filters/ducktype/hide_types.test.ts
@@ -14,38 +14,27 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, isObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
-import ZendeskClient from '../../src/client/client'
-import { ZENDESK_SUPPORT } from '../../src/constants'
-import { paginate } from '../../src/client/pagination'
-import filterCreator from '../../src/filters/hide_types'
+import { FilterWith } from '../../../src/filter_utils'
+import { Paginator } from '../../../src/client'
+import { hideTypesFilterCreator } from '../../../src/filters/ducktype/hide_types'
 
 describe('hide types filter', () => {
-  let client: ZendeskClient
-  type FilterType = filterUtils.FilterWith<'onFetch'>
-  const objType1 = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 't1') })
-  const objType2 = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 't2') })
+  type FilterType = FilterWith<'onFetch'>
+  const objType1 = new ObjectType({ elemID: new ElemID('adapter', 't1') })
+  const objType2 = new ObjectType({ elemID: new ElemID('adapter', 't2') })
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    client = new ZendeskClient({
-      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
-    })
   })
 
   const createFilter = (hideTypes: boolean): FilterType =>
-  filterCreator({
-    client,
-    paginator: clientUtils.createPaginator({
-      client,
-      paginationFuncCreator: paginate,
-    }),
+  hideTypesFilterCreator()({
+    client: {} as unknown,
+    paginator: undefined as unknown as Paginator,
     config: {
-      ...DEFAULT_CONFIG,
       fetch: {
-        ...DEFAULT_CONFIG[FETCH_CONFIG],
         hideTypes,
+        includeTypes: ['t1', 't2'],
       },
     },
   }) as FilterType
@@ -60,8 +49,8 @@ describe('hide types filter', () => {
       await filter.onFetch(elements)
       expect(elements.map(e => e.elemID.getFullName()).sort())
         .toEqual([
-          'zendesk_support.t1',
-          'zendesk_support.t2',
+          'adapter.t1',
+          'adapter.t2',
         ])
       const t1 = elements
         .filter(isObjectType)
@@ -81,8 +70,8 @@ describe('hide types filter', () => {
       await filter.onFetch(elements)
       expect(elements.map(e => e.elemID.getFullName()).sort())
         .toEqual([
-          'zendesk_support.t1',
-          'zendesk_support.t2',
+          'adapter.t1',
+          'adapter.t2',
         ])
       const t1 = elements
         .filter(isObjectType)

--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -28,6 +28,7 @@ import fieldReferencesFilter from './filters/field_references'
 import fixMultienvIDs from './filters/fix_multienv_ids'
 import recipeCrossServiceReferencesFilter from './filters/cross_service/recipe_references'
 import serviceUrlFilter from './filters/service_url'
+import ducktypeCommonFilters from './filters/ducktype_common'
 import { WORKATO } from './constants'
 import changeValidator from './change_validator'
 import { paginate } from './client/pagination'
@@ -45,6 +46,7 @@ export const DEFAULT_FILTERS = [
   fieldReferencesFilter,
   recipeCrossServiceReferencesFilter,
   serviceUrlFilter,
+  ...ducktypeCommonFilters,
 ]
 
 export interface WorkatoAdapterParams {
@@ -99,7 +101,6 @@ export default class WorkatoAdapter implements AdapterOperations {
       nestedFieldFinder: returnFullEntry,
       computeGetArgs: simpleGetArgs,
       typeDefaults: this.userConfig.apiDefinitions.typeDefaults,
-      hideTypes: this.userConfig.fetch.hideTypes,
       getElemIdFunc: this.getElemIdFunc,
     })
   }

--- a/packages/workato-adapter/src/filters/ducktype_common.ts
+++ b/packages/workato-adapter/src/filters/ducktype_common.ts
@@ -13,22 +13,17 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Element, isObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { filters } from '@salto-io/adapter-components'
+import { FilterContext } from '../config'
 import { FilterCreator } from '../filter'
+import ZendeskClient from '../client/client'
 
 /**
- * Hide types if needed
+ * Filter creators of all the common ducktype filters
  */
-const filterCreator: FilterCreator = ({ config }) => ({
-  onFetch: async (elements: Element[]) => {
-    if (config.fetch.hideTypes) {
-      elements
-        .filter(isObjectType)
-        .forEach(objType => {
-          objType.annotations[CORE_ANNOTATIONS.HIDDEN] = true
-        })
-    }
-  },
-})
+const filterCreators: FilterCreator[] = filters.ducktype
+  .DUCKTYPE_MANDATORY_FILTER_CREATORS
+  .map(filterCreator => params =>
+    filterCreator<ZendeskClient, FilterContext>()(params))
 
-export default filterCreator
+export default filterCreators

--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -66,6 +66,7 @@ import macroAttachmentsFilter from './filters/macro_attachments'
 import omitInactiveFilter from './filters/omit_inactive'
 import tagsFilter from './filters/tag'
 import defaultDeployFilter from './filters/default_deploy'
+import hideTypesFilter from './filters/hide_types'
 import { getConfigFromConfigChanges } from './config_change'
 
 const log = logger(module)
@@ -117,6 +118,8 @@ export const DEFAULT_FILTERS = [
   unorderedListsFilter,
   dynamicContentReferencesFilter,
   serviceUrlFilter,
+  // hideTypesFilter should be the last onFetch filter
+  hideTypesFilter,
   // defaultDeployFilter should be last!
   defaultDeployFilter,
 ]

--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -66,7 +66,7 @@ import macroAttachmentsFilter from './filters/macro_attachments'
 import omitInactiveFilter from './filters/omit_inactive'
 import tagsFilter from './filters/tag'
 import defaultDeployFilter from './filters/default_deploy'
-import hideTypesFilter from './filters/hide_types'
+import ducktypeCommonFilters from './filters/ducktype_common'
 import { getConfigFromConfigChanges } from './config_change'
 
 const log = logger(module)
@@ -118,8 +118,7 @@ export const DEFAULT_FILTERS = [
   unorderedListsFilter,
   dynamicContentReferencesFilter,
   serviceUrlFilter,
-  // hideTypesFilter should be the last onFetch filter
-  hideTypesFilter,
+  ...ducktypeCommonFilters,
   // defaultDeployFilter should be last!
   defaultDeployFilter,
 ]
@@ -189,7 +188,6 @@ export default class ZendeskAdapter implements AdapterOperations {
       computeGetArgs,
       typeDefaults: this.userConfig.apiDefinitions.typeDefaults,
       getElemIdFunc: this.getElemIdFunc,
-      hideTypes: this.userConfig.fetch.hideTypes,
       isErrorTurnToConfigSuggestion: error =>
         error instanceof clientUtils.HTTPError && (error.response.status === 403),
     })

--- a/packages/zendesk-support-adapter/src/filters/ducktype_common.ts
+++ b/packages/zendesk-support-adapter/src/filters/ducktype_common.ts
@@ -13,6 +13,17 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { serviceUrlFilterCreator } from './service_url'
-export { referencedInstanceNamesFilterCreator } from './referenced_instance_names'
-export * as ducktype from './ducktype'
+import { filters } from '@salto-io/adapter-components'
+import { FilterContext } from '../config'
+import { FilterCreator, FilterResult } from '../filter'
+import ZendeskClient from '../client/client'
+
+/**
+ * Filter creators of all the common ducktype filters
+ */
+const filterCreators: FilterCreator[] = filters.ducktype
+  .DUCKTYPE_MANDATORY_FILTER_CREATORS
+  .map(filterCreator => params =>
+    filterCreator<ZendeskClient, FilterContext, FilterResult>()(params))
+
+export default filterCreators

--- a/packages/zendesk-support-adapter/src/filters/hardcoded_channel.ts
+++ b/packages/zendesk-support-adapter/src/filters/hardcoded_channel.ts
@@ -54,7 +54,7 @@ const isChannels = (values: unknown): values is Channel[] => {
 /**
  * Adds the hardcoded channel instances in order to add references to them
  */
-const filterCreator: FilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = () => ({
   onFetch: async elements => {
     // We are ok with picking the first instance because triggerDefinition is a singleton
     const triggerDefinitionInstance = elements
@@ -77,7 +77,6 @@ const filterCreator: FilterCreator = ({ config }) => ({
         },
         name: { refType: BuiltinTypes.STRING },
       },
-      annotations: config.fetch.hideTypes ? { [CORE_ANNOTATIONS.HIDDEN]: true } : undefined,
       path: [ZENDESK_SUPPORT, TYPES_PATH, SUBTYPES_PATH, CHANNEL_TYPE_NAME],
     })
     if (channels.length !== (new Set(channels.map(c => c.value))).size) {

--- a/packages/zendesk-support-adapter/src/filters/hide_types.ts
+++ b/packages/zendesk-support-adapter/src/filters/hide_types.ts
@@ -1,0 +1,34 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, isObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+
+/**
+ * Hide types if needed
+ */
+const filterCreator: FilterCreator = ({ config }) => ({
+  onFetch: async (elements: Element[]) => {
+    if (config.fetch.hideTypes) {
+      elements
+        .filter(isObjectType)
+        .forEach(objType => {
+          objType.annotations[CORE_ANNOTATIONS.HIDDEN] = true
+        })
+    }
+  },
+})
+
+export default filterCreator

--- a/packages/zendesk-support-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-support-adapter/src/filters/macro_attachments.ts
@@ -137,7 +137,7 @@ const createAttachmentInstance = ({
   )
 }
 
-const createAttachmentType = (hidden?: boolean): ObjectType =>
+const createAttachmentType = (): ObjectType =>
   new ObjectType({
     elemID: new ElemID(ZENDESK_SUPPORT, MACRO_ATTACHMENT_TYPE_NAME),
     fields: {
@@ -149,7 +149,6 @@ const createAttachmentType = (hidden?: boolean): ObjectType =>
       contentType: { refType: BuiltinTypes.STRING },
       content: { refType: BuiltinTypes.STRING },
     },
-    annotations: hidden ? { [CORE_ANNOTATIONS.HIDDEN]: true } : undefined,
     path: [ZENDESK_SUPPORT, TYPES_PATH, SUBTYPES_PATH, MACRO_ATTACHMENT_TYPE_NAME],
   })
 
@@ -208,7 +207,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
       .filter(isInstanceElement)
       .filter(e => e.elemID.typeName === MACRO_TYPE_NAME)
       .filter(e => !_.isEmpty(e.value[ATTACHMENTS_FIELD_NAME]))
-    const attachmentType = createAttachmentType(config.fetch.hideTypes)
+    const attachmentType = createAttachmentType()
     const macroAttachments = (await Promise.all(macrosWithAttachments
       .map(async macro => getMacroAttachments({ client, attachmentType, macro })))).flat()
     _.remove(elements, element => element.elemID.isEqual(attachmentType.elemID))

--- a/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
@@ -16,8 +16,7 @@
 import _ from 'lodash'
 import {
   Element, isInstanceElement, InstanceElement, ObjectType, ElemID, ListType, isObjectType,
-  BuiltinTypes, ReferenceExpression, Change, getChangeData, isModificationChange,
-  CORE_ANNOTATIONS, isInstanceChange,
+  BuiltinTypes, ReferenceExpression, Change, getChangeData, isModificationChange, isInstanceChange,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils, config as configUtils } from '@salto-io/adapter-components'
 import { applyFunctionToChangeData, pathNaclCase, safeJsonStringify } from '@salto-io/adapter-utils'
@@ -88,7 +87,6 @@ export const createReorderFilterCreator = (
           refType: new ListType(BuiltinTypes.NUMBER),
         },
       },
-      annotations: config.fetch.hideTypes ? { [CORE_ANNOTATIONS.HIDDEN]: true } : undefined,
       isSettings: true,
       path: [ZENDESK_SUPPORT, TYPES_PATH, SUBTYPES_PATH, typeNameNaclCase],
     })

--- a/packages/zendesk-support-adapter/src/filters/reorder/trigger.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/trigger.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import Joi from 'joi'
 import {
   getChangeData, InstanceElement, isInstanceElement, isObjectType, Element, ReferenceExpression,
-  ObjectType, ElemID, ListType, BuiltinTypes, CORE_ANNOTATIONS,
+  ObjectType, ElemID, ListType, BuiltinTypes,
 } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData, pathNaclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -129,13 +129,11 @@ const filterCreator: FilterCreator = ({ config, client, paginator }) => ({
         active: { refType: new ListType(BuiltinTypes.NUMBER) },
         inactive: { refType: new ListType(BuiltinTypes.NUMBER) },
       },
-      annotations: config.fetch.hideTypes ? { [CORE_ANNOTATIONS.HIDDEN]: true } : undefined,
       path: [ZENDESK_SUPPORT, TYPES_PATH, SUBTYPES_PATH, entryTypeNameNaclCase],
     })
     const type = new ObjectType({
       elemID: new ElemID(ZENDESK_SUPPORT, orderTypeName),
       fields: { order: { refType: new ListType(entryOrderType) } },
-      annotations: config.fetch.hideTypes ? { [CORE_ANNOTATIONS.HIDDEN]: true } : undefined,
       isSettings: true,
       path: [ZENDESK_SUPPORT, TYPES_PATH, SUBTYPES_PATH, typeNameNaclCase],
     })

--- a/packages/zendesk-support-adapter/src/filters/tag.ts
+++ b/packages/zendesk-support-adapter/src/filters/tag.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import {
-  BuiltinTypes, Change, CORE_ANNOTATIONS, Element, ElemID, getChangeData, InstanceElement,
+  BuiltinTypes, Change, Element, ElemID, getChangeData, InstanceElement,
   isInstanceElement, ObjectType, ReferenceExpression,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
@@ -96,7 +96,7 @@ const serializeReferencesToTags = (instance: InstanceElement): void => {
 /**
  * Extract tags references from business rules that refers to them
  */
-const filterCreator: FilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = () => ({
   onFetch: async (elements: Element[]): Promise<void> => {
     const instances = elements
       .filter(isInstanceElement)
@@ -107,7 +107,6 @@ const filterCreator: FilterCreator = ({ config }) => ({
     const tagObjectType = new ObjectType({
       elemID: new ElemID(ZENDESK_SUPPORT, TAG_TYPE_NAME),
       fields: { id: { refType: BuiltinTypes.STRING } },
-      annotations: config.fetch.hideTypes ? { [CORE_ANNOTATIONS.HIDDEN]: true } : undefined,
       path: [ZENDESK_SUPPORT, TYPES_PATH, TAG_TYPE_NAME],
     })
     const tagInstances = _(tags)

--- a/packages/zendesk-support-adapter/test/filters/hide_types.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/hide_types.test.ts
@@ -1,0 +1,97 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, isObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
+import ZendeskClient from '../../src/client/client'
+import { ZENDESK_SUPPORT } from '../../src/constants'
+import { paginate } from '../../src/client/pagination'
+import filterCreator from '../../src/filters/hide_types'
+
+describe('hide types filter', () => {
+  let client: ZendeskClient
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  const objType1 = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 't1') })
+  const objType2 = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 't2') })
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+    })
+  })
+
+  const createFilter = (hideTypes: boolean): FilterType =>
+  filterCreator({
+    client,
+    paginator: clientUtils.createPaginator({
+      client,
+      paginationFuncCreator: paginate,
+    }),
+    config: {
+      ...DEFAULT_CONFIG,
+      fetch: {
+        ...DEFAULT_CONFIG[FETCH_CONFIG],
+        hideTypes,
+      },
+    },
+  }) as FilterType
+
+  describe('onFetch', () => {
+    it('should hide the types if hide types is enabled in the config', async () => {
+      const filter = createFilter(true)
+      const elements = [
+        objType1.clone(),
+        objType2.clone(),
+      ]
+      await filter.onFetch(elements)
+      expect(elements.map(e => e.elemID.getFullName()).sort())
+        .toEqual([
+          'zendesk_support.t1',
+          'zendesk_support.t2',
+        ])
+      const t1 = elements
+        .filter(isObjectType)
+        .find(e => e.elemID.typeName === 't1')
+      expect(t1?.annotations[CORE_ANNOTATIONS.HIDDEN]).toEqual(true)
+      const t2 = elements
+        .filter(isObjectType)
+        .find(e => e.elemID.typeName === 't2')
+      expect(t2?.annotations[CORE_ANNOTATIONS.HIDDEN]).toEqual(true)
+    })
+    it('should not hide the types if hide types is disabled in the config', async () => {
+      const filter = createFilter(false)
+      const elements = [
+        objType1.clone(),
+        objType2.clone(),
+      ]
+      await filter.onFetch(elements)
+      expect(elements.map(e => e.elemID.getFullName()).sort())
+        .toEqual([
+          'zendesk_support.t1',
+          'zendesk_support.t2',
+        ])
+      const t1 = elements
+        .filter(isObjectType)
+        .find(e => e.elemID.typeName === 't1')
+      expect(t1?.annotations[CORE_ANNOTATIONS.HIDDEN]).not.toBeDefined()
+      const t2 = elements
+        .filter(isObjectType)
+        .find(e => e.elemID.typeName === 't2')
+      expect(t2?.annotations[CORE_ANNOTATIONS.HIDDEN]).not.toBeDefined()
+    })
+  })
+})

--- a/packages/zendesk-support-adapter/test/filters/reorder/automation.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/automation.test.ts
@@ -15,11 +15,11 @@
 */
 import {
   ObjectType, ElemID, InstanceElement, Element, isObjectType,
-  isInstanceElement, ReferenceExpression, ModificationChange, CORE_ANNOTATIONS,
+  isInstanceElement, ReferenceExpression, ModificationChange,
   toChange, getChangeData,
 } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG, DEFAULT_INCLUDE_ENDPOINTS, FETCH_CONFIG } from '../../../src/config'
+import { DEFAULT_CONFIG } from '../../../src/config'
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../../src/constants'
 import { paginate } from '../../../src/client/pagination'
@@ -98,39 +98,6 @@ describe('automation reorder filter', () => {
       const orderType = elements
         .find(elem => elem.elemID.getFullName() === 'zendesk_support.automation_order')
       expect(orderType).toBeDefined()
-      expect(orderType?.annotations[CORE_ANNOTATIONS.HIDDEN]).toEqual(true)
-    })
-    it('should create correct order element with non hidden types', async () => {
-      const filterWithHideType = filterCreator({
-        client,
-        paginator: clientUtils.createPaginator({
-          client,
-          paginationFuncCreator: paginate,
-        }),
-        config: {
-          ...DEFAULT_CONFIG,
-          [FETCH_CONFIG]: {
-            includeTypes: DEFAULT_INCLUDE_ENDPOINTS,
-            hideTypes: false,
-          },
-        },
-      }) as FilterType
-      const elements = [objType, inst1, inst2, inst3]
-      await filterWithHideType.onFetch(elements)
-      expect(elements).toHaveLength(6)
-      expect(elements.map(e => e.elemID.getFullName()).sort())
-        .toEqual([
-          'zendesk_support.automation',
-          'zendesk_support.automation.instance.inst1',
-          'zendesk_support.automation.instance.inst2',
-          'zendesk_support.automation.instance.inst3',
-          'zendesk_support.automation_order',
-          'zendesk_support.automation_order.instance',
-        ])
-      const orderType = elements
-        .find(elem => elem.elemID.getFullName() === 'zendesk_support.automation_order')
-      expect(orderType).toBeDefined()
-      expect(orderType?.annotations[CORE_ANNOTATIONS.HIDDEN]).not.toBeDefined()
     })
     it('should not create new elements if there are no automations', async () => {
       const elements: Element[] = []

--- a/packages/zendesk-support-adapter/test/filters/reorder/ticket_form.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/ticket_form.test.ts
@@ -15,11 +15,11 @@
 */
 import {
   ObjectType, ElemID, InstanceElement, Element, isObjectType,
-  isInstanceElement, ReferenceExpression, ModificationChange, CORE_ANNOTATIONS,
+  isInstanceElement, ReferenceExpression, ModificationChange,
   toChange, getChangeData,
 } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG, DEFAULT_INCLUDE_ENDPOINTS, FETCH_CONFIG } from '../../../src/config'
+import { DEFAULT_CONFIG } from '../../../src/config'
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../../src/constants'
 import { paginate } from '../../../src/client/pagination'
@@ -94,37 +94,6 @@ describe('ticket form reorder filter', () => {
             new ReferenceExpression(inst3.elemID, inst3),
           ],
         })
-    })
-    it('should create correct order element with hidden types', async () => {
-      const filterWithHideType = filterCreator({
-        client,
-        paginator: clientUtils.createPaginator({
-          client,
-          paginationFuncCreator: paginate,
-        }),
-        config: {
-          ...DEFAULT_CONFIG,
-          [FETCH_CONFIG]: {
-            includeTypes: DEFAULT_INCLUDE_ENDPOINTS,
-            hideTypes: true,
-          },
-        },
-      }) as FilterType
-      const elements = [objType, inst1, inst2]
-      await filterWithHideType.onFetch(elements)
-      expect(elements).toHaveLength(5)
-      expect(elements.map(e => e.elemID.getFullName()).sort())
-        .toEqual([
-          'zendesk_support.ticket_form',
-          'zendesk_support.ticket_form.instance.inst1',
-          'zendesk_support.ticket_form.instance.inst2',
-          'zendesk_support.ticket_form_order',
-          'zendesk_support.ticket_form_order.instance',
-        ])
-      const orderType = elements
-        .find(elem => elem.elemID.getFullName() === 'zendesk_support.ticket_form_order')
-      expect(orderType).toBeDefined()
-      expect(orderType?.annotations[CORE_ANNOTATIONS.HIDDEN]).toEqual(true)
     })
     it('should not create new elements if there are no ticket form', async () => {
       const elements: Element[] = []

--- a/packages/zendesk-support-adapter/test/filters/reorder/trigger.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/trigger.test.ts
@@ -15,10 +15,10 @@
 */
 import {
   ObjectType, ElemID, InstanceElement, isObjectType, isInstanceElement,
-  ReferenceExpression, CORE_ANNOTATIONS, ModificationChange,
+  ReferenceExpression, ModificationChange,
 } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG, DEFAULT_INCLUDE_ENDPOINTS, FETCH_CONFIG } from '../../../src/config'
+import { DEFAULT_CONFIG } from '../../../src/config'
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../../src/constants'
 import { paginate } from '../../../src/client/pagination'
@@ -129,47 +129,6 @@ describe('trigger reorder filter', () => {
       const orderType = elements
         .find(elem => elem.elemID.getFullName() === 'zendesk_support.trigger_order')
       expect(orderType).toBeDefined()
-      expect(orderType?.annotations[CORE_ANNOTATIONS.HIDDEN]).toEqual(true)
-    })
-    it('should create correct order element with non hidden types', async () => {
-      const filterWithHideType = filterCreator({
-        client,
-        paginator: clientUtils.createPaginator({
-          client,
-          paginationFuncCreator: paginate,
-        }),
-        config: {
-          ...DEFAULT_CONFIG,
-          [FETCH_CONFIG]: {
-            includeTypes: DEFAULT_INCLUDE_ENDPOINTS,
-            hideTypes: false,
-          },
-        },
-      }) as FilterType
-      const elements = [
-        triggerType, categoryType, category1, category2, category3,
-        trigger1, trigger2, trigger3, trigger4,
-      ]
-      await filterWithHideType.onFetch(elements)
-      expect(elements.map(e => e.elemID.getFullName()).sort())
-        .toEqual([
-          'zendesk_support.trigger',
-          'zendesk_support.trigger.instance.trigger1',
-          'zendesk_support.trigger.instance.trigger2',
-          'zendesk_support.trigger.instance.trigger3',
-          'zendesk_support.trigger.instance.trigger4',
-          'zendesk_support.trigger_category',
-          'zendesk_support.trigger_category.instance.cate1',
-          'zendesk_support.trigger_category.instance.cate2',
-          'zendesk_support.trigger_category.instance.cate3',
-          'zendesk_support.trigger_order',
-          'zendesk_support.trigger_order.instance',
-          'zendesk_support.trigger_order_entry',
-        ])
-      const orderType = elements
-        .find(elem => elem.elemID.getFullName() === 'zendesk_support.trigger_order')
-      expect(orderType).toBeDefined()
-      expect(orderType?.annotations[CORE_ANNOTATIONS.HIDDEN]).not.toBeDefined()
     })
     it('should not create new elements if trigger type does not exist', async () => {
       const elements = [categoryType]

--- a/packages/zendesk-support-adapter/test/filters/reorder/view.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/view.test.ts
@@ -15,11 +15,11 @@
 */
 import {
   ObjectType, ElemID, InstanceElement, Element, isObjectType,
-  isInstanceElement, ReferenceExpression, ModificationChange, CORE_ANNOTATIONS,
+  isInstanceElement, ReferenceExpression, ModificationChange,
   toChange, getChangeData,
 } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG, DEFAULT_INCLUDE_ENDPOINTS, FETCH_CONFIG } from '../../../src/config'
+import { DEFAULT_CONFIG } from '../../../src/config'
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../../src/constants'
 import { paginate } from '../../../src/client/pagination'
@@ -99,39 +99,6 @@ describe('view reorder filter', () => {
       const orderType = elements
         .find(elem => elem.elemID.getFullName() === 'zendesk_support.view_order')
       expect(orderType).toBeDefined()
-      expect(orderType?.annotations[CORE_ANNOTATIONS.HIDDEN]).toEqual(true)
-    })
-    it('should create correct order element with non hidden types', async () => {
-      const filterWithHideType = filterCreator({
-        client,
-        paginator: clientUtils.createPaginator({
-          client,
-          paginationFuncCreator: paginate,
-        }),
-        config: {
-          ...DEFAULT_CONFIG,
-          [FETCH_CONFIG]: {
-            includeTypes: DEFAULT_INCLUDE_ENDPOINTS,
-            hideTypes: false,
-          },
-        },
-      }) as FilterType
-      const elements = [objType, inst1, inst2, inst3]
-      await filterWithHideType.onFetch(elements)
-      expect(elements).toHaveLength(6)
-      expect(elements.map(e => e.elemID.getFullName()).sort())
-        .toEqual([
-          'zendesk_support.view',
-          'zendesk_support.view.instance.inst1',
-          'zendesk_support.view.instance.inst2',
-          'zendesk_support.view.instance.inst3',
-          'zendesk_support.view_order',
-          'zendesk_support.view_order.instance',
-        ])
-      const orderType = elements
-        .find(elem => elem.elemID.getFullName() === 'zendesk_support.view_order')
-      expect(orderType).toBeDefined()
-      expect(orderType?.annotations[CORE_ANNOTATIONS.HIDDEN]).not.toBeDefined()
     })
     it('should not create new elements if there are no views', async () => {
       const elements: Element[] = []


### PR DESCRIPTION
_Move the hide types part to be in a filter_

---

_Additional context for reviewer_
Currently, there is a logic that set a type as hidden in each filter that creates a type. So I moved it to a filter that should runs last.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
