### PR TITLE
Load the pathIndex to an inMemory remoteMap in fetchFrom to significantly reduce # of calls for certain workspaces

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -840,8 +840,11 @@ export const fetchChangesFromWorkspace = async (
     .toArray()
 
   const otherPathIndex = await otherWorkspace.state(env).getPathIndex()
+  const inMemoryOtherPathIndex = new remoteMap.InMemoryRemoteMap<pathIndex.Path[]>(
+    await awu(otherPathIndex.entries()).toArray(),
+  )
   const splitByPathIndex = (await withLimitedConcurrency(wu(fullElements).map(
-    elem => () => pathIndex.splitElementByPath(elem, otherPathIndex)
+    elem => () => pathIndex.splitElementByPath(elem, inMemoryOtherPathIndex)
   ), MAX_SPLIT_CONCURRENCY)).flat()
   const [unmergedWithPath, unmergedWithoutPath] = _.partition(
     splitByPathIndex,


### PR DESCRIPTION
--
_Release Notes_: 
*Core*:
* Change Fetch From workspace logic to optimize for certain workspaces when used remotely
