### PR TITLE
Fixed Jira e2e

### DIFF
--- a/packages/jira-adapter/src/filters/fields/contexts.ts
+++ b/packages/jira-adapter/src/filters/fields/contexts.ts
@@ -61,8 +61,7 @@ export const deployContextChange = async (
   } catch (err) {
     if (isRemovalChange(change)
       && err instanceof clientUtils.HTTPError
-      && Array.isArray(err.response.data.errorMessages)
-      && err.response.data.errorMessages.includes('The custom field was not found.')
+      && err.response.status === 404
     ) {
       return
     }

--- a/packages/jira-adapter/test/filters/fields/contexts.test.ts
+++ b/packages/jira-adapter/test/filters/fields/contexts.test.ts
@@ -139,9 +139,7 @@ describe('deployContextChange', () => {
     deployChangeMock.mockImplementation(async () => {
       throw new clientUtils.HTTPError('message', {
         status: 404,
-        data: {
-          errorMessages: ['The custom field was not found.'],
-        },
+        data: {},
       })
     })
 
@@ -167,10 +165,8 @@ describe('deployContextChange', () => {
 
     deployChangeMock.mockImplementation(async () => {
       throw new clientUtils.HTTPError('message', {
-        status: 404,
-        data: {
-          errorMessages: ['other'],
-        },
+        status: 500,
+        data: {},
       })
     })
 


### PR DESCRIPTION
Jira e2e fails sporadically with https://app.circleci.com/pipelines/github/salto-io/salto/12551/workflows/5a2f21e9-5ea3-4879-b9de-b8548414e775/jobs/92507  because we receive different message than expected. I think this is because we delete the field and the field context in parallel (which only happens in the e2e because in the full flow we have dependency between the field and the context)
Even though it's only relevant for the e2e I fixed it in `src` because it's generally better to look for the HTTP status and not the message

---
_Release Notes_: 
None

---
_User Notifications_: 
None