### PR TITLE
SALTO-2208: Fix workflow modification

### DIFF
--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -125,6 +125,8 @@ export const deployWorkflow = async (
     getChangeData(change).value.entityId = instance.value.entityId
     getChangeData(change).value.transitionIds = instance.value.transitionIds
     getChangeData(change).value.stepIds = instance.value.stepIds
+    // If we created the workflow we can edit it
+    getChangeData(change).value.operations = { canEdit: true }
 
     if (config.client.usePrivateAPI) {
       await deployTriggers(resolvedChange, client)

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -117,6 +117,20 @@ describe('workflowDeployFilter', () => {
       )
     })
 
+    it('should add operations value', async () => {
+      const change = toChange({
+        after: new InstanceElement(
+          'instance',
+          workflowType,
+          WITH_PERMISSION_VALIDATORS
+        ),
+      })
+
+      await filter.deploy([change])
+
+      expect(getChangeData(change).value.operations).toEqual({ canEdit: true })
+    })
+
     it('should not change the values if there are no transitions', async () => {
       const change = toChange({
         after: new InstanceElement(


### PR DESCRIPTION
Workflow modification right after creation (without a fetch in the middle) would fail because the instance would miss a required value `operations`

---
_Release Notes_: 
_Jira Adapter_:
- Fixed an issue with editing a workflow right after creating it (without a fetch in the middle)

---
_User Notifications_: 
None