### PR TITLE
SALTO-2085: Deleting an active workflow fails

### DIFF
--- a/packages/adapter-utils/src/references.ts
+++ b/packages/adapter-utils/src/references.ts
@@ -21,10 +21,10 @@ import { walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from './walk_element'
 
 const isReferenceOfElement = <T>(
   value: T,
-  elemId: ElemID
+  elemId?: ElemID
 ): boolean =>
     isReferenceExpression(value)
-    && (elemId.isEqual(value.elemID) || elemId.isParentOf(value.elemID))
+    && (elemId === undefined || elemId.isEqual(value.elemID) || elemId.isParentOf(value.elemID))
 
 export const getUpdatedReference = (
   referenceExpression: ReferenceExpression,
@@ -46,7 +46,7 @@ export const createReferencesTransformFunc = (
 
 export const getReferences = (
   element: Element,
-  sourceElemId: ElemID
+  sourceElemId?: ElemID
 ): { path: ElemID; value: ReferenceExpression }[] => {
   const references: { path: ElemID; value: ReferenceExpression }[] = []
   const func: WalkOnFunc = ({ path, value }) => {

--- a/packages/jira-adapter/src/dependency_changers/index.ts
+++ b/packages/jira-adapter/src/dependency_changers/index.ts
@@ -18,6 +18,7 @@ import { deployment } from '@salto-io/adapter-components'
 import { collections } from '@salto-io/lowerdash'
 import { dashboardGadgetsDependencyChanger } from './dashboard_gadgets'
 import { projectDependencyChanger } from './project'
+import { removalsDependencyChanger } from './removals'
 import { workflowDependencyChanger } from './workflow'
 
 const { awu } = collections.asynciterable
@@ -27,6 +28,7 @@ const DEPENDENCY_CHANGERS: DependencyChanger[] = [
   projectDependencyChanger,
   workflowDependencyChanger,
   dashboardGadgetsDependencyChanger,
+  removalsDependencyChanger,
 ]
 
 export const dependencyChanger: DependencyChanger = async (

--- a/packages/jira-adapter/src/dependency_changers/removals.ts
+++ b/packages/jira-adapter/src/dependency_changers/removals.ts
@@ -41,6 +41,7 @@ export const removalsDependencyChanger: DependencyChanger = async changes => {
         .filter(id => id in removalsChanges)
         .map(id => removalsChanges[id])
         .map(({ key }) => key)
+        .filter(key => key !== deskKey)
 
       return referencedKeys.map(
         sourceKey => dependencyChange(

--- a/packages/jira-adapter/src/dependency_changers/removals.ts
+++ b/packages/jira-adapter/src/dependency_changers/removals.ts
@@ -1,0 +1,53 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { dependencyChange, DependencyChanger, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isRemovalChange, RemovalChange } from '@salto-io/adapter-api'
+import { references } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
+
+
+export const removalsDependencyChanger: DependencyChanger = async changes => {
+  const removalsChanges = _(Array.from(changes.entries()))
+    .map(([key, change]) => ({ key, change }))
+    .filter(
+      (change): change is { key: collections.set.SetId; change: RemovalChange<InstanceElement> } =>
+        isInstanceChange(change.change)
+        && isRemovalChange(change.change)
+    )
+    .keyBy(({ change }) => getChangeData(change).elemID.getFullName())
+    .value()
+
+  return Array.from(changes.entries())
+    .flatMap(([deskKey, change]) => {
+      if (isAdditionChange(change)) {
+        return []
+      }
+
+      const referencedKeys = references.getReferences(change.data.before)
+        .map(({ value }) => value.elemID.createTopLevelParentID().parent.getFullName())
+        .filter(id => id in removalsChanges)
+        .map(id => removalsChanges[id])
+        .map(({ key }) => key)
+
+      return referencedKeys.map(
+        sourceKey => dependencyChange(
+          'add',
+          sourceKey,
+          deskKey,
+        )
+      )
+    })
+}

--- a/packages/jira-adapter/src/dependency_changers/removals.ts
+++ b/packages/jira-adapter/src/dependency_changers/removals.ts
@@ -31,7 +31,7 @@ export const removalsDependencyChanger: DependencyChanger = async changes => {
     .value()
 
   return Array.from(changes.entries())
-    .flatMap(([deskKey, change]) => {
+    .flatMap(([destKey, change]) => {
       if (isAdditionChange(change)) {
         return []
       }
@@ -41,13 +41,13 @@ export const removalsDependencyChanger: DependencyChanger = async changes => {
         .filter(id => id in removalsChanges)
         .map(id => removalsChanges[id])
         .map(({ key }) => key)
-        .filter(key => key !== deskKey)
+        .filter(key => key !== destKey)
 
       return referencedKeys.map(
         sourceKey => dependencyChange(
           'add',
           sourceKey,
-          deskKey,
+          destKey,
         )
       )
     })

--- a/packages/jira-adapter/test/dependency_changers/removals.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/removals.test.ts
@@ -1,0 +1,63 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, InstanceElement, ElemID, toChange, ReferenceExpression } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { removalsDependencyChanger } from '../../src/dependency_changers/removals'
+import { JIRA } from '../../src/constants'
+
+describe('removalsDependencyChanger', () => {
+  let type: ObjectType
+  beforeEach(() => {
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, 'someType'),
+    })
+  })
+
+  it('should add dependency from the added to removed project with the same key', async () => {
+    const removedInstance = new InstanceElement(
+      'inst',
+      type,
+      {},
+    )
+
+    const modifiedInstance = new InstanceElement(
+      'inst2',
+      type,
+      {
+        ref: new ReferenceExpression(removedInstance.elemID, removedInstance),
+      },
+    )
+
+    const addedInstance = new InstanceElement(
+      'inst3',
+      type,
+      {}
+    )
+
+    const inputChanges = new Map([
+      [0, toChange({ before: removedInstance })],
+      [1, toChange({ before: modifiedInstance, after: modifiedInstance })],
+      [2, toChange({ after: addedInstance })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+
+    const dependencyChanges = [...await removalsDependencyChanger(inputChanges, inputDeps)]
+    expect(dependencyChanges).toHaveLength(1)
+    expect(dependencyChanges[0].action).toEqual('add')
+    expect(dependencyChanges[0].dependency.source).toEqual(0)
+    expect(dependencyChanges[0].dependency.target).toEqual(1)
+  })
+})


### PR DESCRIPTION
Deleting a workflow fails if it is used in a workflow scheme. So far if the user will try to delete a workflow and remove it from its workflow scheme in the same deployment, it will fail because it will try to do it in parallel and not first remove the workflow from the workflow scheme. Added dependency changer so references will be removed before the referenced element is removed

---
_Release Notes_: 
_Jira Adapter_:
- Fixed a bug where deleting a workflow its workflow scheme at the same deployment would fail

---
_User Notifications_: 
None