### PR TITLE
SALTO-1690: Salesforce - Silence error for Custom Object instance deletion if it's already deleted

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -29,7 +29,7 @@ import { flatValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { Options, RequestCallback } from 'request'
 import { AccountId, Value } from '@salto-io/adapter-api'
-import { CUSTOM_OBJECT_ID_FIELD, DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRTY_OPTIONS, DEFAULT_MAX_CONCURRENT_API_REQUESTS, SALESFORCE } from '../constants'
+import { CUSTOM_OBJECT_ID_FIELD, DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS, DEFAULT_MAX_CONCURRENT_API_REQUESTS, SALESFORCE } from '../constants'
 import { CompleteSaveResult, SfError, SalesforceRecord } from './types'
 import { UsernamePasswordCredentials, OauthAccessTokenCredentials, Credentials,
   SalesforceClientConfig, ClientRateLimitConfig, ClientRetryConfig, ClientPollingConfig,
@@ -395,7 +395,7 @@ export default class SalesforceClient {
       _.defaults({}, config?.maxConcurrentApiRequests, DEFAULT_MAX_CONCURRENT_API_REQUESTS),
       SALESFORCE
     )
-    this.dataRetry = config?.dataRetry ?? DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRTY_OPTIONS
+    this.dataRetry = config?.dataRetry ?? DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS
     this.clientName = 'SFDC'
     this.readMetadataChunkSize = _.merge(
       {},

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -294,7 +294,7 @@ export const DEFAULT_MAX_CONCURRENT_API_REQUESTS = {
 export const DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST = 2500
 export const DEFAULT_USE_OLD_PROFILES = false
 export const MAX_QUERY_LENGTH = 2000
-export const DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRTY_OPTIONS = {
+export const DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS = {
   maxAttempts: 3,
   retryDelay: 1000,
   retryableFailures: [

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -269,11 +269,10 @@ const updateInstances: CrudFn = async (
 
 const ALREADY_DELETED_ERROR = 'ENTITY_IS_DELETED:entity is deleted:--'
 
-const isSilencedError = (error: string): boolean => error === ALREADY_DELETED_ERROR
-
-export const removeSilencedDeleteErrors = (result: BatchResultInfo): BatchResultInfo => {
+const removeSilencedDeleteErrors = (result: BatchResultInfo): BatchResultInfo => {
   if (!_.isEmpty(result.errors)) {
-    const [silencedErrors, realErrors] = _.partition(result.errors, isSilencedError)
+    const [silencedErrors, realErrors] = _.partition(result.errors,
+      error => error === ALREADY_DELETED_ERROR)
     log.debug('Ignoring delete errors: %s%s', EOL, silencedErrors.join(EOL))
     return { ...result, success: result.success || _.isEmpty(realErrors), errors: realErrors }
   }
@@ -281,7 +280,7 @@ export const removeSilencedDeleteErrors = (result: BatchResultInfo): BatchResult
   return result
 }
 
-const deleteInstances: CrudFn = async (
+export const deleteInstances: CrudFn = async (
   { typeName,
     instances,
     client }

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -24,6 +24,7 @@ import {
 } from '@salto-io/adapter-api'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { BatchResultInfo } from 'jsforce-types'
+import { EOL } from 'os'
 import {
   isInstanceOfCustomObject, instancesToCreateRecords, apiName,
   instancesToDeleteRecords, instancesToUpdateRecords, Types,
@@ -266,16 +267,30 @@ const updateInstances: CrudFn = async (
   return groupInstancesAndResultsByIndex(results, instances)
 }
 
+const ALREADY_DELETED_ERROR = 'ENTITY_IS_DELETED:entity is deleted:--'
+
+const isSilencedError = (error: string): boolean => error === ALREADY_DELETED_ERROR
+
+export const removeSilencedDeleteErrors = (result: BatchResultInfo): BatchResultInfo => {
+  if (!_.isEmpty(result.errors)) {
+    const [silencedErrors, realErrors] = _.partition(result.errors, isSilencedError)
+    log.debug('Ignoring delete errors: %s%s', EOL, silencedErrors.join(EOL))
+    return { ...result, success: result.success || _.isEmpty(realErrors), errors: realErrors }
+  }
+
+  return result
+}
+
 const deleteInstances: CrudFn = async (
   { typeName,
     instances,
     client }
 ): Promise<InstanceAndResult[]> => {
-  const results = await client.bulkLoadOperation(
+  const results = (await client.bulkLoadOperation(
     typeName,
     'delete',
-    instancesToDeleteRecords(instances),
-  )
+    instancesToDeleteRecords(instances)
+  )).map(removeSilencedDeleteErrors)
   return groupInstancesAndResultsByIndex(results, instances)
 }
 

--- a/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
@@ -198,40 +198,45 @@ describe('Custom Object Deploy', () => {
     beforeEach(() => {
       clientBulkOpSpy.mockReset()
     })
-    it('should remove "already deleted" errors, but not other errors', () => {
+    it('should remove "already deleted" errors, but not other errors', async () => {
       clientBulkOpSpy.mockResolvedValue([
         { id: '', errors: ['error1', 'ENTITY_IS_DELETED:entity is deleted:--', 'error2'] },
       ])
-      expect(deleteInstances({ typeName, instances, client }))
-        .toMatchObject({ errors: ['error1', 'error2'] })
+      const result = await deleteInstances({ typeName, instances, client })
+      expect(result).toHaveLength(1)
+      expect(result[0].result).toMatchObject({ errors: ['error1', 'error2'] })
     })
-    it('should mark success if no other errors left', () => {
+    it('should mark success if no other errors left', async () => {
       clientBulkOpSpy.mockResolvedValue([
         { id: '', success: false, errors: ['ENTITY_IS_DELETED:entity is deleted:--'] },
       ])
-      expect(deleteInstances({ typeName, instances, client }))
-        .toMatchObject({ success: true, errors: [] })
+      const result = await deleteInstances({ typeName, instances, client })
+      expect(result).toHaveLength(1)
+      expect(result[0].result).toMatchObject({ success: true, errors: [] })
     })
-    it('should not mark success if other errors exist', () => {
+    it('should not mark success if other errors exist', async () => {
       clientBulkOpSpy.mockResolvedValue([
         { id: '', errors: ['error1'] },
       ])
-      expect(deleteInstances({ typeName, instances, client }))
-        .toMatchObject({ success: false, errors: ['error1'] })
+      const result = await deleteInstances({ typeName, instances, client })
+      expect(result).toHaveLength(1)
+      expect(result[0].result).toMatchObject({ success: false, errors: ['error1'] })
     })
-    it('should not mark success if no errors were removed', () => {
+    it('should not mark success if no errors were removed', async () => {
       clientBulkOpSpy.mockResolvedValue([
         { id: '', success: false, errors: [] },
       ])
-      expect(deleteInstances({ typeName, instances, client }))
-        .toMatchObject({ success: false, errors: [] })
+      const result = await deleteInstances({ typeName, instances, client })
+      expect(result).toHaveLength(1)
+      expect(result[0].result).toMatchObject({ success: false, errors: [] })
     })
-    it('should keep the result success if it was success beforehand', () => {
+    it('should keep the result success if it was success beforehand', async () => {
       clientBulkOpSpy.mockResolvedValue([
         { id: '', success: true, errors: ['error'] },
       ])
-      expect(deleteInstances({ typeName, instances, client }))
-        .toMatchObject({ success: true, errors: ['error'] })
+      const result = await deleteInstances({ typeName, instances, client })
+      expect(result).toHaveLength(1)
+      expect(result[0].result).toMatchObject({ success: true, errors: ['error'] })
     })
   })
 })

--- a/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
@@ -16,7 +16,7 @@
 import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { BulkLoadOperation } from 'jsforce-types'
 import { SalesforceRecord } from '../src/client/types'
-import { CrudFn, retryFlow, removeSilencedDeleteErrors } from '../src/custom_object_instances_deploy'
+import { CrudFn, retryFlow, deleteInstances } from '../src/custom_object_instances_deploy'
 import { instancesToCreateRecords } from '../src/transformers/transformer'
 import mockClient from './client'
 
@@ -183,7 +183,6 @@ describe('Custom Object Deploy', () => {
             errors: ['err1'],
           }]
         }
-
       )
       const res = await retryFlow(clientOp, { typeName: 'typtyp', instances: instanceElements, client }, retries)
       expect(res).toEqual({ successInstances: [inst1], errorMessages: ['inst2:\n    \terr1'] })
@@ -191,27 +190,48 @@ describe('Custom Object Deploy', () => {
     })
   })
   describe('silence delete spurious errors', () => {
-    it('should remove "already deleted" errors', () => {
-      const result = { id: '', errors: ['error1', 'ENTITY_IS_DELETED:entity is deleted:--', 'error2'] }
-      expect(removeSilencedDeleteErrors(result)).toMatchObject({
-        errors: ['error1', 'error2'],
-      })
+    const { client } = mockClient()
+    const clientBulkOpSpy = jest.spyOn(client, 'bulkLoadOperation')
+    const typeName = 'fakeType'
+    const instances = [new InstanceElement('inst1', new ObjectType({ elemID: new ElemID('', typeName) }))]
+
+    beforeEach(() => {
+      clientBulkOpSpy.mockReset()
+    })
+    it('should remove "already deleted" errors, but not other errors', () => {
+      clientBulkOpSpy.mockResolvedValue([
+        { id: '', errors: ['error1', 'ENTITY_IS_DELETED:entity is deleted:--', 'error2'] },
+      ])
+      expect(deleteInstances({ typeName, instances, client }))
+        .toMatchObject({ errors: ['error1', 'error2'] })
     })
     it('should mark success if no other errors left', () => {
-      const result = { id: '', success: false, errors: ['ENTITY_IS_DELETED:entity is deleted:--'] }
-      expect(removeSilencedDeleteErrors(result)).toMatchObject({ success: true, errors: [] })
+      clientBulkOpSpy.mockResolvedValue([
+        { id: '', success: false, errors: ['ENTITY_IS_DELETED:entity is deleted:--'] },
+      ])
+      expect(deleteInstances({ typeName, instances, client }))
+        .toMatchObject({ success: true, errors: [] })
     })
     it('should not mark success if other errors exist', () => {
-      const result = { id: '', errors: ['error1'] }
-      expect(removeSilencedDeleteErrors(result)).toMatchObject({ success: false, errors: ['error1'] })
+      clientBulkOpSpy.mockResolvedValue([
+        { id: '', errors: ['error1'] },
+      ])
+      expect(deleteInstances({ typeName, instances, client }))
+        .toMatchObject({ success: false, errors: ['error1'] })
     })
     it('should not mark success if no errors were removed', () => {
-      const result = { id: '', success: false, errors: [] }
-      expect(removeSilencedDeleteErrors(result)).toMatchObject({ success: false, errors: [] })
+      clientBulkOpSpy.mockResolvedValue([
+        { id: '', success: false, errors: [] },
+      ])
+      expect(deleteInstances({ typeName, instances, client }))
+        .toMatchObject({ success: false, errors: [] })
     })
     it('should keep the result success if it was success beforehand', () => {
-      const result = { id: '', success: true, errors: ['error'] }
-      expect(removeSilencedDeleteErrors(result)).toMatchObject({ success: true, errors: ['error'] })
+      clientBulkOpSpy.mockResolvedValue([
+        { id: '', success: true, errors: ['error'] },
+      ])
+      expect(deleteInstances({ typeName, instances, client }))
+        .toMatchObject({ success: true, errors: ['error'] })
     })
   })
 })


### PR DESCRIPTION
Deleting a custom object instance is not considered an error, just like for metadata object instances. 

---

None

---
_Release Notes_: 
Salesforce - Trying to delete an already deleted Custom Object instance now isn't considered as an error

---
_User Notifications_: 
None