### PR TITLE
SALTO-2207: Salesforce - Don't warn on adding system fields when cloning custom objects

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
@@ -20,13 +20,16 @@ import {
 import { collections } from '@salto-io/lowerdash'
 import { CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES } from '../constants'
 import { isFieldOfCustomObject, fieldTypeName } from '../transformers/transformer'
+import { allSystemFields } from '../adapter'
 
 const { awu } = collections.asynciterable
 
 const isInvalidTypeChange = async (change: Change<Field>): Promise<boolean> => {
-  const afterFieldType = fieldTypeName(getChangeData(change).refType.elemID.name)
+  const changeData = getChangeData(change)
+  const afterFieldType = fieldTypeName(changeData.refType.elemID.name)
   const isAfterTypeAllowed = CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES.includes(afterFieldType)
-  if (isAfterTypeAllowed) {
+  const isSystemField = allSystemFields.includes(changeData.name)
+  if (isSystemField || isAfterTypeAllowed) {
     return false
   } if (isAdditionChange(change)) {
     return true

--- a/packages/salesforce-adapter/test/change_validators/custom_field_type.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/custom_field_type.test.ts
@@ -13,22 +13,17 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import {
-  ChangeError, ElemID, Field, ObjectType, toChange,
-} from '@salto-io/adapter-api'
+import { ChangeError, Field, ObjectType, toChange, BuiltinTypes } from '@salto-io/adapter-api'
 import { Types } from '../../src/transformers/transformer'
 import customFieldTypeValidator from '../../src/change_validators/custom_field_type'
-import { CUSTOM_OBJECT } from '../../src/constants'
-import { createField } from '../utils'
+import { CUSTOM_OBJECT_ID_FIELD } from '../../src/constants'
+import { createField, createCustomObjectType } from '../utils'
 
 describe('custom field type change validator', () => {
   describe('onUpdate', () => {
     let customObj: ObjectType
     beforeEach(() => {
-      customObj = new ObjectType({
-        elemID: new ElemID('salesforce', 'obj'),
-        annotations: { metadataType: CUSTOM_OBJECT, apiName: 'obj__c' },
-      })
+      customObj = createCustomObjectType('obj__c', {})
     })
 
     const runChangeValidator = (before: Field | undefined, after: Field):
@@ -86,6 +81,11 @@ describe('custom field type change validator', () => {
       const changeErrors = await customFieldTypeValidator([
         toChange({ before: customObj, after: customObj.clone() }),
       ])
+      expect(changeErrors).toHaveLength(0)
+    })
+    it('should have no error when trying to create custom object with system fields', async () => {
+      const field = new Field(customObj, CUSTOM_OBJECT_ID_FIELD, BuiltinTypes.SERVICE_ID)
+      const changeErrors = await runChangeValidator(undefined, field)
       expect(changeErrors).toHaveLength(0)
     })
   })


### PR DESCRIPTION
There is no need to return this warning as we won't try to deploy these fields anyway

---

None

---
_Release Notes_: 

Salesforce - Remove warning about Id field when deploying new custom objects
---
_User Notifications_: 

None