### PR TITLE
SALTO-1932: Create generated_dependencies out of JQL fields

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -968,11 +968,13 @@ export const resolveTypeShallow = async (
   }
 }
 
-export const createSchemeGuard = <T>(scheme: Joi.AnySchema, errorMessage: string)
+export const createSchemeGuard = <T>(scheme: Joi.AnySchema, errorMessage?: string)
 : (value: unknown) => value is T => (value): value is T => {
     const { error } = scheme.validate(value)
     if (error !== undefined) {
-      log.error(`${errorMessage}: ${error.message}, ${safeJsonStringify(value)}`)
+      if (errorMessage !== undefined) {
+        log.error(`${errorMessage}: ${error.message}, ${safeJsonStringify(value)}`)
+      }
       return false
     }
     return true

--- a/packages/jira-adapter/e2e_test/instances/webhook.ts
+++ b/packages/jira-adapter/e2e_test/instances/webhook.ts
@@ -20,7 +20,7 @@ export const createWebhookValues = (name: string): Values => ({
   url: `https://example.com/rest/webhooks/${name}`,
   excludeBody: true,
   filters: {
-    'issue-related-events-section': 'status = Done',
+    issue_related_events_section: 'status = Done',
   },
   events: [
     'option_watching_changed',

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -77,6 +77,7 @@ import notificationSchemeDeploymentFilter from './filters/notification_scheme/no
 import notificationSchemeStructureFilter from './filters/notification_scheme/notification_scheme_structure'
 import avatarsFilter from './filters/avatars'
 import iconUrlFilter from './filters/icon_url'
+import jqlReferencesFilter from './filters/jql/jql_references'
 import userFilter from './filters/user'
 import { JIRA } from './constants'
 import { removeScopedObjects } from './client/pagination'
@@ -145,6 +146,7 @@ export const DEFAULT_FILTERS = [
   fieldConfigurationFilter,
   fieldConfigurationSchemeFilter,
   userFilter,
+  jqlReferencesFilter,
   referenceBySelfLinkFilter,
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,

--- a/packages/jira-adapter/src/filters/jql/jql_references.ts
+++ b/packages/jira-adapter/src/filters/jql/jql_references.ts
@@ -1,0 +1,121 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, isInstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { extendGeneratedDependencies, transformElement } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import JiraClient from '../../client/client'
+import { FilterCreator } from '../../filter'
+import { extractReferences, generateJqlContext } from './references_extractor'
+import { isJqlParseResponse, ParsedJql } from './types'
+
+const { awu } = collections.asynciterable
+
+const log = logger(module)
+
+const JQL_CHUNK_SIZE = 1000
+
+const JQL_FIELDS = [
+  { type: 'Filter', name: 'jql' },
+  { type: 'Board', name: 'subQuery' },
+  { type: 'WebhookFilters', name: 'issue_related_events_section' },
+]
+
+type JqlDetails = {
+  jql: string
+  path: ElemID
+}
+
+
+const getJqls = async (instance: InstanceElement): Promise<JqlDetails[]> => {
+  const jqls: JqlDetails[] = []
+  await transformElement({
+    element: instance,
+    transformFunc: ({ value, field, path }) => {
+      const isJql = JQL_FIELDS.some(({ name, type }) =>
+        field?.name === name && field.parent.elemID.name === type)
+
+      if (isJql && path !== undefined) {
+        jqls.push({
+          jql: value,
+          path,
+        })
+      }
+      return value
+    },
+  })
+
+  return jqls
+}
+
+const requestJqlsStructure = async (jqls: string[], client: JiraClient): Promise<ParsedJql[]> => {
+  log.debug(`About to request JQL structure for ${jqls.length} unique JQLs`)
+
+  const responses = await Promise.all(_.chunk(jqls, JQL_CHUNK_SIZE).map(async queries => {
+    const response = await client.post({
+      url: '/rest/api/3/jql/parse',
+      data: {
+        queries,
+      },
+      queryParams: {
+        validation: 'none',
+      },
+    })
+
+    if (!isJqlParseResponse(response.data)) {
+      throw new Error('Received an invalid response from jqls request')
+    }
+
+    return response.data.queries
+  }))
+
+  return responses.flat()
+}
+
+const filter: FilterCreator = ({ client }) => ({
+  onFetch: async elements => {
+    const instances = elements.filter(isInstanceElement)
+
+    const jqls = await awu(instances)
+      .flatMap(getJqls)
+      .toArray()
+
+    const JqlsStructure = await requestJqlsStructure(
+      _(jqls).map(({ jql }) => jql).uniq().value(),
+      client
+    )
+
+    const jqlContext = generateJqlContext(instances)
+
+    const jqlToReferences: Record<string, ReferenceExpression[]> = Object.fromEntries(JqlsStructure
+      .map(parsedJql => [parsedJql.query, extractReferences(parsedJql.structure, jqlContext)]))
+
+    const idToInstance = _.keyBy(instances, instance => instance.elemID.getFullName())
+
+    jqls.forEach(({ jql, path }) => {
+      const instance = idToInstance[path.createTopLevelParentID().parent.getFullName()]
+      const references = jqlToReferences[jql]
+
+      extendGeneratedDependencies(instance, references.map(reference => ({
+        reference,
+        location: new ReferenceExpression(path, jql),
+      })))
+    })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/jql/references_extractor.ts
+++ b/packages/jira-adapter/src/filters/jql/references_extractor.ts
@@ -25,31 +25,25 @@ const JQL_NAME_TO_FIELD_NAME: Record<string, string | undefined> = {
   type: 'issue type',
 }
 
-type JqlContext = {
-  type: string
-  field: string
+const CONTEXT_TYPE_TO_FIELD: Record<string, string> = {
+  [FIELD_TYPE_NAME]: 'name',
+  [PROJECT_TYPE]: 'key',
+  [STATUS_TYPE_NAME]: 'name',
+  [RESOLUTION_TYPE_NAME]: 'name',
+  [PRIORITY_TYPE_NAME]: 'name',
+  [ISSUE_TYPE_NAME]: 'name',
 }
-
-const CONTEXT_TYPES: JqlContext[] = [
-  { type: FIELD_TYPE_NAME, field: 'name' },
-  { type: PROJECT_TYPE, field: 'key' },
-  { type: STATUS_TYPE_NAME, field: 'name' },
-  { type: RESOLUTION_TYPE_NAME, field: 'name' },
-  { type: PRIORITY_TYPE_NAME, field: 'name' },
-  { type: ISSUE_TYPE_NAME, field: 'name' },
-]
 
 export const generateJqlContext = (
   instances: InstanceElement[],
 ): Record<string, Record<string, InstanceElement>> =>
   _(instances)
-    .filter(instance => CONTEXT_TYPES.map(({ type }) => type).includes(instance.elemID.typeName))
+    .filter(instance => instance.elemID.typeName in CONTEXT_TYPE_TO_FIELD)
     .groupBy(instance => instance.elemID.typeName)
     .mapValues(instanceGroup => _.keyBy(
-      instanceGroup.filter(instance => typeof instance.value.name === 'string'),
+      instanceGroup.filter(instance => _.isString(instance.value.name)),
       instance => {
-        const fieldName = (CONTEXT_TYPES
-          .find(({ type }) => type === instance.elemID.typeName) as JqlContext).field
+        const fieldName = CONTEXT_TYPE_TO_FIELD[instance.elemID.typeName]
         return instance.value[fieldName].toLowerCase() as string
       },
     ))

--- a/packages/jira-adapter/src/filters/jql/references_extractor.ts
+++ b/packages/jira-adapter/src/filters/jql/references_extractor.ts
@@ -22,6 +22,7 @@ import { isJqlFieldDetails, JqlFieldDetails } from './types'
 
 const JQL_NAME_TO_FIELD_NAME: Record<string, string | undefined> = {
   issuetype: 'issue type',
+  type: 'issue type',
 }
 
 type JqlContext = {

--- a/packages/jira-adapter/src/filters/jql/references_extractor.ts
+++ b/packages/jira-adapter/src/filters/jql/references_extractor.ts
@@ -1,0 +1,101 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { values } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { ISSUE_TYPE_NAME, PRIORITY_TYPE_NAME, PROJECT_TYPE, RESOLUTION_TYPE_NAME, STATUS_TYPE_NAME } from '../../constants'
+import { FIELD_TYPE_NAME } from '../fields/constants'
+import { isJqlFieldDetails, JqlFieldDetails } from './types'
+
+const JQL_NAME_TO_FIELD_NAME: Record<string, string | undefined> = {
+  issuetype: 'issue type',
+}
+
+type JqlContext = {
+  type: string
+  field: string
+}
+
+const CONTEXT_TYPES: JqlContext[] = [
+  { type: FIELD_TYPE_NAME, field: 'name' },
+  { type: PROJECT_TYPE, field: 'key' },
+  { type: STATUS_TYPE_NAME, field: 'name' },
+  { type: RESOLUTION_TYPE_NAME, field: 'name' },
+  { type: PRIORITY_TYPE_NAME, field: 'name' },
+  { type: ISSUE_TYPE_NAME, field: 'name' },
+]
+
+export const generateJqlContext = (
+  instances: InstanceElement[],
+): Record<string, Record<string, InstanceElement>> =>
+  _(instances)
+    .filter(instance => CONTEXT_TYPES.map(({ type }) => type).includes(instance.elemID.typeName))
+    .groupBy(instance => instance.elemID.typeName)
+    .mapValues(instanceGroup => _.keyBy(
+      instanceGroup.filter(instance => typeof instance.value.name === 'string'),
+      instance => {
+        const fieldName = (CONTEXT_TYPES
+          .find(({ type }) => type === instance.elemID.typeName) as JqlContext).field
+        return instance.value[fieldName].toLowerCase() as string
+      },
+    ))
+    .value()
+
+const getJqlValues = (
+  jqlComponent: JqlFieldDetails
+): string[] => [
+  jqlComponent.operand?.value,
+  ...(jqlComponent.operand?.values?.map(({ value }) => value) ?? []),
+].filter(values.isDefined)
+
+export const extractReferences = (
+  jqlComponent: unknown,
+  jqlContext: Record<string, Record<string, InstanceElement>>
+): ReferenceExpression[] => {
+  if (typeof jqlComponent !== 'object' || jqlComponent === null) {
+    return []
+  }
+
+  if (!isJqlFieldDetails(jqlComponent)) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    return Object.values(jqlComponent).flatMap(val => extractReferences(val, jqlContext))
+  }
+
+  const jqlFieldName = jqlComponent.field.name.toLowerCase()
+
+  const fieldName = JQL_NAME_TO_FIELD_NAME[jqlFieldName] ?? jqlFieldName
+  const fieldInstance = jqlContext[FIELD_TYPE_NAME]?.[fieldName]
+
+  if (fieldInstance === undefined) {
+    return []
+  }
+
+  const references = [new ReferenceExpression(fieldInstance.elemID, fieldInstance)]
+
+  const nameToInstance = jqlContext[fieldInstance.value.name.replace(/\s+/g, '')]
+  if (nameToInstance !== undefined) {
+    const valueNames = getJqlValues(jqlComponent)
+
+    references.push(
+      ...valueNames
+        .map(name => nameToInstance[name.toLowerCase()])
+        .filter(values.isDefined)
+        .map(instance => new ReferenceExpression(instance.elemID, instance))
+    )
+  }
+
+  return references
+}

--- a/packages/jira-adapter/src/filters/jql/types.ts
+++ b/packages/jira-adapter/src/filters/jql/types.ts
@@ -1,0 +1,68 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+import Joi from 'joi'
+
+export type ParsedJql = {
+  query: string
+  structure: Record<string, unknown>
+}
+
+export type JqlParseResponse = {
+  queries: ParsedJql[]
+}
+
+const JQL_PARSE_RESPONSE_SCHEME = Joi.object({
+  queries: Joi.array().items(
+    Joi.object({
+      query: Joi.string().required(),
+      structure: Joi.object().required(),
+    }).unknown(true).required(),
+  ).required(),
+})
+
+export const isJqlParseResponse = createSchemeGuard<JqlParseResponse>(JQL_PARSE_RESPONSE_SCHEME, 'Received an invalid jql parse response')
+
+export type JqlFieldDetails = {
+  field: {
+    name: string
+  }
+  operand?: {
+    values?: {
+      value?: string
+    }[]
+
+    value?: string
+  }
+}
+
+const JQL_FIELD_DETAILS_SCHEME = Joi.object({
+  field: Joi.object({
+    name: Joi.string().required(),
+  }).unknown(true).required(),
+
+  operand: Joi.object({
+    values: Joi.array().items(
+      Joi.object({
+        value: Joi.string().optional(),
+      }).unknown(true),
+    ).optional(),
+
+    value: Joi.string().optional(),
+  }).unknown(true).optional(),
+}).unknown(true).required()
+
+export const isJqlFieldDetails = createSchemeGuard<JqlFieldDetails>(JQL_FIELD_DETAILS_SCHEME)

--- a/packages/jira-adapter/src/filters/webhook/types.ts
+++ b/packages/jira-adapter/src/filters/webhook/types.ts
@@ -25,7 +25,7 @@ export const createWebhookTypes = (): {
   const filtersType = new ObjectType({
     elemID: new ElemID(JIRA, 'WebhookFilters'),
     fields: {
-      'issue-related-events-section': {
+      issue_related_events_section: {
         refType: BuiltinTypes.STRING,
         annotations: {
           [CORE_ANNOTATIONS.CREATABLE]: true,
@@ -68,7 +68,7 @@ export const createWebhookTypes = (): {
           [CORE_ANNOTATIONS.UPDATABLE]: true,
         },
       },
-      filtersType: {
+      filters: {
         refType: filtersType,
         annotations: {
           [CORE_ANNOTATIONS.CREATABLE]: true,

--- a/packages/jira-adapter/test/filters/jql/jql_references.test.ts
+++ b/packages/jira-adapter/test/filters/jql/jql_references.test.ts
@@ -1,0 +1,261 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import { mockClient } from '../../utils'
+import jqlReferencesFilter from '../../../src/filters/jql/jql_references'
+import { Filter } from '../../../src/filter'
+import { DEFAULT_CONFIG } from '../../../src/config'
+import { JIRA, STATUS_TYPE_NAME } from '../../../src/constants'
+import { FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
+
+describe('jqlReferencesFilter', () => {
+  let filter: Filter
+  let type: ObjectType
+  let instance: InstanceElement
+  let connection: MockInterface<clientUtils.APIConnection>
+  let fieldInstance: InstanceElement
+  let doneInstance: InstanceElement
+  let todoInstance: InstanceElement
+
+
+  beforeEach(async () => {
+    const { client, paginator, connection: conn } = mockClient()
+    connection = conn
+
+    filter = jqlReferencesFilter({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+      elementsSource: buildElementsSourceFromElements([]),
+    })
+
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, 'Filter'),
+      fields: {
+        jql: {
+          refType: BuiltinTypes.STRING,
+        },
+      },
+    })
+
+    instance = new InstanceElement(
+      'instance',
+      type,
+      {
+        jql: 'status = Done',
+      }
+    )
+
+    fieldInstance = new InstanceElement(
+      'field',
+      new ObjectType({ elemID: new ElemID(JIRA, FIELD_TYPE_NAME) }),
+      {
+        name: 'Status',
+      }
+    )
+
+    doneInstance = new InstanceElement(
+      'done',
+      new ObjectType({ elemID: new ElemID(JIRA, STATUS_TYPE_NAME) }),
+      {
+        name: 'Done',
+      }
+    )
+    todoInstance = new InstanceElement(
+      'todo',
+      new ObjectType({ elemID: new ElemID(JIRA, STATUS_TYPE_NAME) }),
+      {
+        name: 'To Do',
+      }
+    )
+
+    connection.post.mockResolvedValue({
+      status: 200,
+      data: {
+        queries: [
+          {
+            query: 'status = Done',
+            structure: {
+              where: {
+                field: {
+                  name: 'status',
+                },
+                operator: '=',
+                operand: {
+                  value: 'Done',
+                },
+              },
+            },
+            errors: [],
+          },
+        ],
+      },
+    })
+  })
+
+  describe('onFetch', () => {
+    it('should add the jql dependencies', async () => {
+      await filter.onFetch?.([instance, fieldInstance, doneInstance, todoInstance])
+      expect(instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual([
+        {
+          reference: new ReferenceExpression(fieldInstance.elemID, fieldInstance),
+          occurrences: [
+            {
+              location: new ReferenceExpression(instance.elemID.createNestedID('jql'), 'status = Done'),
+            },
+          ],
+        },
+        {
+          reference: new ReferenceExpression(doneInstance.elemID, doneInstance),
+          occurrences: [
+            {
+              location: new ReferenceExpression(instance.elemID.createNestedID('jql'), 'status = Done'),
+            },
+          ],
+        },
+      ])
+
+      expect(connection.post).toHaveBeenCalledWith(
+        '/rest/api/3/jql/parse',
+        {
+          queries: ['status = Done'],
+        },
+        {
+          params: {
+            validation: 'none',
+          },
+        },
+      )
+    })
+
+    it('should parse correctly jql with multiple values', async () => {
+      const jql = 'status IN (Done, "To Do") AND otherfield = 2 AND issuetype = 3'
+      connection.post.mockResolvedValue({
+        status: 200,
+        data: {
+          queries: [
+            {
+              query: jql,
+              structure: {
+                otherField: 2,
+                where: {
+                  clauses: [
+                    {
+                      field: {
+                        name: 'status',
+                      },
+                      operator: 'in',
+                      operand: {
+                        values: [
+                          {
+                            value: 'Done',
+                          },
+                          {
+                            value: 'To Do',
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      field: {
+                        name: 'status',
+                      },
+                      operator: 'in',
+                    },
+                    {
+                      field: {
+                        name: 'otherfield',
+                      },
+                      operator: '=',
+                    },
+                    {
+                      field: {
+                        name: 'issuetype',
+                      },
+                      operator: '=',
+                      operand: {
+                        value: '3',
+                      },
+                    },
+                  ],
+                  operator: 'and',
+                },
+              },
+              errors: [],
+            },
+          ],
+        },
+      })
+
+      instance.value.jql = jql
+
+      const issueTypeField = new InstanceElement(
+        'issuetype',
+        new ObjectType({ elemID: new ElemID(JIRA, FIELD_TYPE_NAME) }),
+        {
+          name: 'Issue Type',
+        }
+      )
+
+      await filter.onFetch?.([instance, fieldInstance, doneInstance, todoInstance, issueTypeField])
+      expect(instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]).toEqual([
+        {
+          reference: new ReferenceExpression(fieldInstance.elemID, fieldInstance),
+          occurrences: [
+            {
+              location: new ReferenceExpression(instance.elemID.createNestedID('jql'), jql),
+            },
+          ],
+        },
+        {
+          reference: new ReferenceExpression(issueTypeField.elemID, issueTypeField),
+          occurrences: [
+            {
+              location: new ReferenceExpression(instance.elemID.createNestedID('jql'), jql),
+            },
+          ],
+        },
+        {
+          reference: new ReferenceExpression(doneInstance.elemID, doneInstance),
+          occurrences: [
+            {
+              location: new ReferenceExpression(instance.elemID.createNestedID('jql'), jql),
+            },
+          ],
+        },
+        {
+          reference: new ReferenceExpression(todoInstance.elemID, todoInstance),
+          occurrences: [
+            {
+              location: new ReferenceExpression(instance.elemID.createNestedID('jql'), jql),
+            },
+          ],
+        },
+      ])
+    })
+
+    it('should throw if jql pares response in invalid', async () => {
+      connection.post.mockResolvedValue({
+        status: 200,
+        data: {},
+      })
+      await expect(filter.onFetch?.([instance, fieldInstance, doneInstance])).rejects.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
Parsed JQLs to references and added the references in _generated_dependencies in the relevant types

Also fixed the name of the field `issue_related_events_section` so I can create a reference to it

---
_Release Notes_: 
_Jira Adapter_:
- Added references from JQLs in instances in a _generated_dependencies field

---
_User Notifications_: 
_Jira Adapter_:
- _generated_dependecies will be added to instances with JQLs