### PR TITLE
SALTO-2213: Jira e2e fails sporadically with incorrect deploy result

### DIFF
--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -31,6 +31,7 @@ type JiraClientConfig = clientUtils.ClientBaseConfig<clientUtils.ClientRateLimit
   & {
     fieldConfigurationItemsDeploymentLimit: number
     usePrivateAPI: boolean
+    boardColumnRetry: number
   }
 
 export type JspUrls = {
@@ -1829,6 +1830,7 @@ export const DEFAULT_CONFIG: JiraConfig = {
   // Jira does not allow more items in a single request than this
     fieldConfigurationItemsDeploymentLimit: 100,
     usePrivateAPI: true,
+    boardColumnRetry: 5,
   },
   fetch: {
     includeTypes: DEFAULT_INCLUDE_ENDPOINTS,
@@ -1846,6 +1848,10 @@ const createClientConfigType = (): ObjectType => {
   )
   configType.fields.usePrivateAPI = new Field(
     configType, 'usePrivateAPI', BuiltinTypes.BOOLEAN
+  )
+
+  configType.fields.boardColumnRetry = new Field(
+    configType, 'boardColumnRetry', BuiltinTypes.NUMBER
   )
   return configType
 }

--- a/packages/jira-adapter/src/filters/board/board_columns.ts
+++ b/packages/jira-adapter/src/filters/board/board_columns.ts
@@ -15,18 +15,34 @@
 */
 import { AdditionChange, CORE_ANNOTATIONS, Element, getChangeData, InstanceElement, isInstanceElement, isModificationChange, ModificationChange, Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { resolveChangeElement } from '@salto-io/adapter-utils'
+import { createSchemeGuard, resolveChangeElement } from '@salto-io/adapter-utils'
 import _ from 'lodash'
+import Joi from 'joi'
 import { FilterCreator } from '../../filter'
 import { BOARD_COLUMN_CONFIG_TYPE, BOARD_TYPE_NAME } from '../../constants'
 import { addAnnotationRecursively, findObject, setFieldDeploymentAnnotations } from '../../utils'
 import JiraClient from '../../client/client'
 import { getLookUpName } from '../../reference_mapping'
 
+const MAX_RETRIES = 5
 const KANBAN_TYPE = 'kanban'
 export const COLUMNS_CONFIG_FIELD = 'columnConfig'
 
 const log = logger(module)
+
+type UpdateColumnsResponse = {
+  mappedColumns: {
+    name: string
+  }[]
+}
+
+const UPDATE_COLUMNS_RESPONSE_SCHEME = Joi.object({
+  mappedColumns: Joi.array().items(Joi.object({
+    name: Joi.string().required(),
+  }).unknown(true)).required(),
+}).unknown(true).required()
+
+const isUpdateColumnsResponse = createSchemeGuard<UpdateColumnsResponse>(UPDATE_COLUMNS_RESPONSE_SCHEME, 'Received an invalid columns update response')
 
 const convertColumn = (column: Values): Values => ({
   name: column.name,
@@ -38,6 +54,7 @@ const convertColumn = (column: Values): Values => ({
 export const deployColumns = async (
   change: AdditionChange<InstanceElement> | ModificationChange<InstanceElement>,
   client: JiraClient,
+  retriesLeft = MAX_RETRIES,
 ): Promise<void> => {
   const resolvedChange = await resolveChangeElement(change, getLookUpName)
 
@@ -51,8 +68,7 @@ export const deployColumns = async (
 
   const instance = getChangeData(resolvedChange)
 
-
-  await client.putPrivate({
+  const response = await client.putPrivate({
     url: '/rest/greenhopper/1.0/rapidviewconfig/columns',
     data: {
       currentStatisticsField: {
@@ -64,6 +80,27 @@ export const deployColumns = async (
       mappedColumns: instance.value[COLUMNS_CONFIG_FIELD].columns.map(convertColumn),
     },
   })
+
+  if (!isUpdateColumnsResponse(response.data)) {
+    throw new Error(`Received an invalid response from Jira when updating the columns of ${instance.elemID.getFullName()}`)
+  }
+
+  const columnsToUpdate = instance.value[COLUMNS_CONFIG_FIELD].columns
+    .map(({ name }: Values) => name)
+
+  const updatedColumns = response.data.mappedColumns.map(({ name }) => name)
+  if (instance.value.type === KANBAN_TYPE) {
+    // In Kanban boards, the first column is always backlog, which is non-editable.
+    updatedColumns.shift()
+  }
+
+  if (!_.isEqual(columnsToUpdate, updatedColumns)) {
+    if (retriesLeft > 0) {
+      await deployColumns(change, client, retriesLeft - 1)
+    } else {
+      throw new Error(`Failed to update columns of ${instance.elemID.getFullName()}`)
+    }
+  }
 }
 
 const filter: FilterCreator = ({ config }) => ({

--- a/packages/jira-adapter/src/filters/board/board_columns.ts
+++ b/packages/jira-adapter/src/filters/board/board_columns.ts
@@ -24,7 +24,6 @@ import { addAnnotationRecursively, findObject, setFieldDeploymentAnnotations } f
 import JiraClient from '../../client/client'
 import { getLookUpName } from '../../reference_mapping'
 
-const MAX_RETRIES = 5
 const KANBAN_TYPE = 'kanban'
 export const COLUMNS_CONFIG_FIELD = 'columnConfig'
 
@@ -54,7 +53,7 @@ const convertColumn = (column: Values): Values => ({
 export const deployColumns = async (
   change: AdditionChange<InstanceElement> | ModificationChange<InstanceElement>,
   client: JiraClient,
-  retriesLeft = MAX_RETRIES,
+  retriesLeft: number,
 ): Promise<void> => {
   const resolvedChange = await resolveChangeElement(change, getLookUpName)
 
@@ -95,6 +94,7 @@ export const deployColumns = async (
   }
 
   if (!_.isEqual(columnsToUpdate, updatedColumns)) {
+    log.warn(`Failed to update columns of ${instance.elemID.getFullName()} - ${updatedColumns.join(', ')}`)
     if (retriesLeft > 0) {
       await deployColumns(change, client, retriesLeft - 1)
     } else {

--- a/packages/jira-adapter/src/filters/board/board_deployment.ts
+++ b/packages/jira-adapter/src/filters/board/board_deployment.ts
@@ -137,7 +137,7 @@ const filter: FilterCreator = ({ config, client }) => ({
           await deployFilter(change, client)
         }
 
-        await deployColumns(change, client)
+        await deployColumns(change, client, config.client.boardColumnRetry)
         await deploySubQuery(change, client)
         await deployEstimation(change, client)
       }


### PR DESCRIPTION
It looks like in the CI sometimes the columns of a board are not updated correctly.
Added a retry to try to deploy it again in case this happens

---
_Release Notes_: 
_Jira Adapter_:
- Fix a sporadic bug when in some cases the board columns would not be updated correctly

---
_User Notifications_: 
None