### PR TITLE
SALTO-2226/omit specific permissions from permission schemes

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -75,6 +75,7 @@ import statusDeploymentFilter from './filters/statuses/status_deployment'
 import securitySchemeFilter from './filters/security_scheme/security_scheme'
 import notificationSchemeDeploymentFilter from './filters/notification_scheme/notification_scheme_deployment'
 import notificationSchemeStructureFilter from './filters/notification_scheme/notification_scheme_structure'
+import forbiddenPermissionSchemeFilter from './filters/forbidden_permission_schemes'
 import avatarsFilter from './filters/avatars'
 import iconUrlFilter from './filters/icon_url'
 import jqlReferencesFilter from './filters/jql/jql_references'
@@ -146,6 +147,7 @@ export const DEFAULT_FILTERS = [
   fieldConfigurationFilter,
   fieldConfigurationSchemeFilter,
   userFilter,
+  forbiddenPermissionSchemeFilter,
   jqlReferencesFilter,
   referenceBySelfLinkFilter,
   // Must run after referenceBySelfLinkFilter

--- a/packages/jira-adapter/src/filters/forbidden_permission_schemes.ts
+++ b/packages/jira-adapter/src/filters/forbidden_permission_schemes.ts
@@ -1,0 +1,39 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Element, isInstanceElement } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { FilterCreator } from '../filter'
+
+const isPermissionScheme = (element: Element): boolean =>
+  element.elemID.typeName === 'PermissionScheme'
+
+const UnsupportedPermissionSchemes = [
+  'VIEW_PROJECTS',
+  'VIEW_ISSUES',
+]
+/**
+ * Remove unsupported permissions from permission schemes
+ */
+const filter: FilterCreator = () => ({
+  onFetch: async (elements: Element[]) => {
+    elements.filter(isPermissionScheme).filter(isInstanceElement).forEach(element => {
+      _.remove(element.value.permissions,
+        (p:{ permission: string }) => UnsupportedPermissionSchemes.includes(p.permission))
+    })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/forbidden_permission_schemes.ts
+++ b/packages/jira-adapter/src/filters/forbidden_permission_schemes.ts
@@ -31,7 +31,7 @@ const filter: FilterCreator = () => ({
   onFetch: async (elements: Element[]) => {
     elements.filter(isPermissionScheme).filter(isInstanceElement).forEach(element => {
       _.remove(element.value.permissions,
-        (p:{ permission: string }) => UnsupportedPermissionSchemes.includes(p.permission))
+        (p: { permission: string }) => UnsupportedPermissionSchemes.includes(p.permission))
     })
   },
 })

--- a/packages/jira-adapter/test/filters/forbidden_permission_schemes.test.ts
+++ b/packages/jira-adapter/test/filters/forbidden_permission_schemes.test.ts
@@ -1,0 +1,65 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { DEFAULT_CONFIG } from '../../src/config'
+import { JIRA } from '../../src/constants'
+import forbiddenPermissionScheme from '../../src/filters/forbidden_permission_schemes'
+import { mockClient } from '../utils'
+
+describe('forbidden permission scheme', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  const type = new ObjectType({
+    elemID: new ElemID(JIRA, 'PermissionScheme'),
+  })
+  const instance = new InstanceElement(
+    'instance',
+    type,
+    {
+      permissions: [
+        {
+          permission: 'ADMINISTER_PROJECTS',
+        },
+        {
+          permission: 'VIEW_PROJECTS',
+        },
+        {
+          permission: 'VIEW_ISSUES',
+        },
+      ],
+    }
+  )
+  beforeEach(async () => {
+    const { client, paginator } = mockClient()
+    filter = forbiddenPermissionScheme({
+      client,
+      paginator,
+      config: DEFAULT_CONFIG,
+      elementsSource: buildElementsSourceFromElements([]),
+    }) as typeof filter
+  })
+  it('should remove permissions from instances', async () => {
+    await filter.onFetch([instance])
+    expect(instance.value).toEqual({
+      permissions: [
+        {
+          permission: 'ADMINISTER_PROJECTS',
+        },
+      ],
+    })
+  })
+})


### PR DESCRIPTION
omit "VIEW_PROJECTS" and "VIEW_ISSUES" permissions from permission schemes since they are invisible in the ui and cant be deployed.

---

_Additional context for reviewer_
going to suppress notifications in saas aswell

---
_Release Notes_: 
Removed redundant values from permission scheme instances to fix the deployment of permission schemes

---
_User Notifications_: 
removed "VIEW_PROJECTS" and "VIEW_ISSUES" permissions from permission scheme NaCL files.