### PR TITLE
SALTO-2224/forbid read only changes

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -17,6 +17,7 @@ import { ChangeValidator } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
 import { createChangeValidator } from '@salto-io/adapter-utils'
 import { unsupportedFieldConfigurationsValidator } from './field_configuration_unsupported_fields'
+import { readOnlyProjectRoleChangeValidator } from './read_only_project_role'
 import { defaultFieldConfigurationValidator } from './default_field_configuration'
 import { issueTypeSchemeValidator } from './issue_type_scheme'
 import { screenValidator } from './screen'
@@ -41,6 +42,7 @@ export default (
   const validators: ChangeValidator[] = [
     deployTypesNotSupportedValidator,
     unsupportedFieldConfigurationsValidator,
+    readOnlyProjectRoleChangeValidator,
     defaultFieldConfigurationValidator,
     screenValidator,
     issueTypeSchemeValidator,

--- a/packages/jira-adapter/src/change_validators/read_only_project_role.ts
+++ b/packages/jira-adapter/src/change_validators/read_only_project_role.ts
@@ -1,0 +1,30 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isInstanceChange, isRemovalOrModificationChange, SeverityLevel } from '@salto-io/adapter-api'
+
+export const readOnlyProjectRoleChangeValidator: ChangeValidator = async changes => (
+  changes
+    .filter(isInstanceChange)
+    .filter(isRemovalOrModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === 'ProjectRole')
+    .filter(change => getChangeData(change).value.name === 'atlassian-addons-project-access')
+    .map(change => ({
+      elemID: getChangeData(change).elemID,
+      severity: 'Error' as SeverityLevel,
+      message: 'Deploying a change to "atlassian-addons-project-access" Project rule is not supported',
+      detailedMessage: 'Deploying a change to "atlassian-addons-project-access" Project rule is not supported',
+    }))
+)

--- a/packages/jira-adapter/src/change_validators/read_only_project_role.ts
+++ b/packages/jira-adapter/src/change_validators/read_only_project_role.ts
@@ -15,12 +15,14 @@
 */
 import { ChangeValidator, getChangeData, isInstanceChange, isRemovalOrModificationChange, SeverityLevel } from '@salto-io/adapter-api'
 
+export const RoleName = 'atlassian-addons-project-access'
+
 export const readOnlyProjectRoleChangeValidator: ChangeValidator = async changes => (
   changes
     .filter(isInstanceChange)
     .filter(isRemovalOrModificationChange)
     .filter(change => getChangeData(change).elemID.typeName === 'ProjectRole')
-    .filter(change => getChangeData(change).value.name === 'atlassian-addons-project-access')
+    .filter(change => getChangeData(change).value.name === RoleName)
     .map(change => ({
       elemID: getChangeData(change).elemID,
       severity: 'Error' as SeverityLevel,

--- a/packages/jira-adapter/test/change_validators/read_only_project_role.test.ts
+++ b/packages/jira-adapter/test/change_validators/read_only_project_role.test.ts
@@ -1,0 +1,68 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { readOnlyProjectRoleChangeValidator, RoleName } from '../../src/change_validators/read_only_project_role'
+import { JIRA } from '../../src/constants'
+
+describe('read only project role change validator test', () => {
+  let type: ObjectType
+  let readOnlyInstance: InstanceElement
+  let normalInstance: InstanceElement
+
+  beforeEach(() => {
+    type = new ObjectType({ elemID: new ElemID(JIRA, 'ProjectRole') })
+    readOnlyInstance = new InstanceElement('instance', type, { name: RoleName })
+    normalInstance = new InstanceElement('instance', type, { name: 'normal' })
+  })
+
+  it('should return an error if the instance that changed was read only', async () => {
+    expect(await readOnlyProjectRoleChangeValidator([
+      toChange({
+        before: readOnlyInstance,
+        after: readOnlyInstance,
+      }),
+    ])).toEqual([
+      {
+        elemID: readOnlyInstance.elemID,
+        severity: 'Error',
+        message: 'Deploying a change to "atlassian-addons-project-access" Project rule is not supported',
+        detailedMessage: 'Deploying a change to "atlassian-addons-project-access" Project rule is not supported',
+      },
+    ])
+  })
+  it('should return an error if the instance that was removed was read only', async () => {
+    expect(await readOnlyProjectRoleChangeValidator([
+      toChange({
+        after: readOnlyInstance,
+      }),
+    ])).toEqual([
+      {
+        elemID: readOnlyInstance.elemID,
+        severity: 'Error',
+        message: 'Deploying a change to "atlassian-addons-project-access" Project rule is not supported',
+        detailedMessage: 'Deploying a change to "atlassian-addons-project-access" Project rule is not supported',
+      },
+    ])
+  })
+  it('should not return an error if the instance that changed was not read only', async () => {
+    expect(await readOnlyProjectRoleChangeValidator([
+      toChange({
+        before: normalInstance,
+        after: normalInstance,
+      }),
+    ])).toBe([])
+  })
+})

--- a/packages/jira-adapter/test/change_validators/read_only_project_role.test.ts
+++ b/packages/jira-adapter/test/change_validators/read_only_project_role.test.ts
@@ -46,7 +46,7 @@ describe('read only project role change validator test', () => {
   it('should return an error if the instance that was removed was read only', async () => {
     expect(await readOnlyProjectRoleChangeValidator([
       toChange({
-        after: readOnlyInstance,
+        before: readOnlyInstance,
       }),
     ])).toEqual([
       {
@@ -63,6 +63,6 @@ describe('read only project role change validator test', () => {
         before: normalInstance,
         after: normalInstance,
       }),
-    ])).toBe([])
+    ])).toBeEmpty()
   })
 })


### PR DESCRIPTION
add a change validator for a default Project role that is read only and cant be changed.

---

_Additional context for reviewer_

---
_Release Notes_: 


---
_User Notifications_: 

