### PR TITLE
SALTO-1387 suiteapp config types bugfix

### DIFF
--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -129,6 +129,9 @@ export const SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES: Record<SuiteAppConfigRecordTyp
 
 export const SUITEAPP_CONFIG_TYPE_NAMES = Object.values(SUITEAPP_CONFIG_TYPES_TO_TYPE_NAMES)
 
+export const isSuiteAppConfigType = (type: ObjectType): boolean =>
+  SUITEAPP_CONFIG_TYPE_NAMES.includes(type.elemID.name)
+
 export const isSuiteAppConfigInstance = (instance: InstanceElement): boolean =>
   SUITEAPP_CONFIG_TYPE_NAMES.includes(instance.elemID.typeName)
 

--- a/packages/netsuite-adapter/test/filters/suiteapp_config_elements.test.ts
+++ b/packages/netsuite-adapter/test/filters/suiteapp_config_elements.test.ts
@@ -86,7 +86,7 @@ describe('configElements filter', () => {
 
   describe('onFetch', () => {
     it('should transform type', async () => {
-      await filterCreator().onFetch([selectOptionType, instance, type])
+      await filterCreator().onFetch([selectOptionType, type])
       expect(isField(type.fields.configType)).toBeTruthy()
 
       expect(isField(type.fields.checkboxField)).toBeTruthy()


### PR DESCRIPTION
transform type's fields also when it is not included in the adapter's config

---
_Release Notes_: 
Netsuite Adapter:
- suiteapp config types bugfix: transform type's fields also when it is not included in the adapter's config

---
_User Notifications_: 
None
