### PR TITLE
SALTO-2223: Deploying workflows with previousStatus condition fail 

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/workflow.ts
@@ -238,7 +238,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
           {
             type: 'FieldHasSingleValueValidator',
             configuration: {
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Creator'), allElements),
+              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Remaining_Estimate@s'), allElements),
               excludeSubtasks: true,
             },
           },
@@ -254,7 +254,114 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
           },
         ],
         conditions: {
-          type: 'AlwaysFalseCondition',
+          operator: 'AND',
+          conditions: [
+            {
+              type: 'AlwaysFalseCondition',
+            },
+            {
+              type: 'AlwaysFalseCondition',
+            },
+            {
+              type: 'BlockInProgressApprovalCondition',
+            },
+            {
+              type: 'RemoteOnlyCondition',
+            },
+            {
+              type: 'AllowOnlyAssignee',
+            },
+            {
+              type: 'OnlyBambooNotificationsCondition',
+            },
+            {
+              type: 'AllowOnlyReporter',
+            },
+            {
+              type: 'PermissionCondition',
+              configuration: {
+                permissionKey: 'DELETE_ISSUES',
+              },
+            },
+            {
+              type: 'PreviousStatusCondition',
+              configuration: {
+                ignoreLoopTransitions: true,
+                includeCurrentStatus: true,
+                mostRecentStatusOnly: true,
+                reverseCondition: true,
+                previousStatus: {
+                  id: createReference(new ElemID(JIRA, 'Status', 'instance', 'Done'), allElements),
+                },
+              },
+            },
+            {
+              type: 'SeparationOfDutiesCondition',
+              configuration: {
+                toStatus: {
+                  id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'Backlog'), allElements),
+                },
+                fromStatus: {
+                  id: createReference(new ElemID(JIRA, 'Status', 'instance', 'Done'), allElements),
+                },
+              },
+            },
+            {
+              type: 'SubTaskBlockingCondition',
+              configuration: {
+                statuses: [
+                  {
+                    id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'Backlog'), allElements),
+                  },
+                  {
+                    id: createReference(new ElemID(JIRA, 'Status', 'instance', 'Done'), allElements),
+                  },
+                ],
+              },
+            },
+            {
+              type: 'UserInAnyGroupCondition',
+              configuration: {
+                groups: [
+                  'system-administrators',
+                ],
+              },
+            },
+            {
+              type: 'InAnyProjectRoleCondition',
+              configuration: {
+                projectRoles: [
+                  {
+                    id: createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements),
+                  },
+                ],
+              },
+            },
+            {
+              type: 'UserIsInCustomFieldCondition',
+              configuration: {
+                allowUserInField: false,
+                fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee'), allElements),
+              },
+            },
+            {
+              type: 'InProjectRoleCondition',
+              configuration: {
+                projectRole: {
+                  id: createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements),
+                },
+              },
+            },
+            {
+              type: 'ValueFieldCondition',
+              configuration: {
+                fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Remaining_Estimate@s'), allElements),
+                fieldValue: 'val',
+                comparisonType: 'STRING',
+                comparator: '>',
+              },
+            },
+          ],
         },
       },
     },

--- a/packages/jira-adapter/src/filters/workflow/conditions_types.ts
+++ b/packages/jira-adapter/src/filters/workflow/conditions_types.ts
@@ -1,0 +1,123 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, ListType, ObjectType } from '@salto-io/adapter-api'
+import { elements } from '@salto-io/adapter-components'
+import { JIRA } from '../../constants'
+
+export const createConditionConfigurationTypes = (): {
+  type: ObjectType
+  subTypes: ObjectType[]
+} => {
+  const conditionProjectRoleType = new ObjectType({
+    elemID: new ElemID(JIRA, 'ConditionProjectRole'),
+    fields: {
+      id: { refType: BuiltinTypes.STRING, annotations: { [CORE_ANNOTATIONS.CREATABLE]: true } },
+    },
+    path: [JIRA, elements.TYPES_PATH, 'ConditionProjectRole'],
+  })
+
+  const conditionStatusType = new ObjectType({
+    elemID: new ElemID(JIRA, 'ConditionStatus'),
+    fields: {
+      id: { refType: BuiltinTypes.STRING, annotations: { [CORE_ANNOTATIONS.CREATABLE]: true } },
+    },
+    path: [JIRA, elements.TYPES_PATH, 'ConditionStatus'],
+  })
+
+  const conditionConfigurationType = new ObjectType({
+    elemID: new ElemID(JIRA, 'ConditionConfiguration'),
+    fields: {
+      fieldId: {
+        refType: BuiltinTypes.STRING,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      comparator: {
+        refType: BuiltinTypes.STRING,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      fieldValue: {
+        refType: BuiltinTypes.STRING,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      permissionKey: {
+        refType: BuiltinTypes.STRING,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      ignoreLoopTransitions: {
+        refType: BuiltinTypes.BOOLEAN,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      includeCurrentStatus: {
+        refType: BuiltinTypes.BOOLEAN,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      mostRecentStatusOnly: {
+        refType: BuiltinTypes.BOOLEAN,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      reverseCondition: {
+        refType: BuiltinTypes.BOOLEAN,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      previousStatus: {
+        refType: conditionStatusType,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      value: {
+        refType: BuiltinTypes.STRING,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      toStatus: {
+        refType: conditionStatusType,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      fromStatus: {
+        refType: conditionStatusType,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      statuses: {
+        refType: new ListType(conditionStatusType),
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      groups: {
+        refType: new ListType(BuiltinTypes.STRING),
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      projectRoles: {
+        refType: new ListType(conditionProjectRoleType),
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      allowUserInField: {
+        refType: BuiltinTypes.BOOLEAN,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      projectRole: {
+        refType: conditionProjectRoleType,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+      comparisonType: {
+        refType: BuiltinTypes.STRING,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
+    },
+    path: [JIRA, elements.TYPES_PATH, 'ConditionConfiguration'],
+  })
+
+  return {
+    type: conditionConfigurationType,
+    subTypes: [conditionProjectRoleType, conditionStatusType],
+  }
+}

--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -96,6 +96,20 @@ const getTransitionsFromService = async (
   return workflowValues.transitions ?? []
 }
 
+const changeIdsToString = (
+  values: Record<string | number, unknown>,
+): void => {
+  if (typeof values.id === 'number') {
+    values.id = values.id.toString()
+  }
+  Object.values(values).forEach(value => {
+    if (typeof value === 'object' && value !== null) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      changeIdsToString(value as Record<string | number, unknown>)
+    }
+  })
+}
+
 export const deployWorkflow = async (
   change: AdditionChange<InstanceElement> | RemovalChange<InstanceElement>,
   client: JiraClient,
@@ -108,6 +122,10 @@ export const deployWorkflow = async (
     throw new Error(`instance ${instance.elemID.getFullName()} is not valid for deployment`)
   }
   removeCreateIssuePermissionValidator(instance)
+  instance.value.transitions?.forEach(transition => {
+    changeIdsToString(transition.rules?.conditions ?? {})
+  })
+
   await defaultDeployChange({
     change: resolvedChange,
     client,

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -291,6 +291,21 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
     serializationStrategy: 'id',
     target: { type: 'IssueEvent' },
   },
+  {
+    src: { field: 'fieldId', parentTypes: ['ConditionConfiguration'] },
+    serializationStrategy: 'id',
+    target: { type: 'Field' },
+  },
+  {
+    src: { field: 'id', parentTypes: ['ConditionStatus'] },
+    serializationStrategy: 'id',
+    target: { type: 'Status' },
+  },
+  {
+    src: { field: 'id', parentTypes: ['ConditionProjectRole'] },
+    serializationStrategy: 'id',
+    target: { type: 'ProjectRole' },
+  },
 ]
 
 const lookupNameFuncs: GetLookupNameFunc[] = [

--- a/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_deploy_filter.test.ts
@@ -117,6 +117,77 @@ describe('workflowDeployFilter', () => {
       )
     })
 
+    it('should change ids from number to string on condition configuration', async () => {
+      const change = toChange({
+        after: new InstanceElement(
+          'instance',
+          workflowType,
+          {
+            name: 'name',
+            transitions: [
+              {
+                type: 'initial',
+                rules: {
+                  conditions: {
+                    configuration: {
+                      id: 1,
+                      other: 3,
+                    },
+                    conditions: [
+                      {
+                        configuration: [{
+                          id: 2,
+                        }],
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        ),
+      })
+
+      await filter.deploy([change])
+
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        toChange({
+          after: new InstanceElement(
+            'instance',
+            workflowType,
+            {
+              name: 'name',
+              transitions: [
+                {
+                  type: 'initial',
+                  rules: {
+                    conditions: {
+                      configuration: {
+                        id: '1',
+                        other: 3,
+                      },
+                      conditions: [
+                        {
+                          configuration: [{
+                            id: '2',
+                          }],
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          ),
+        }),
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.Workflow.deployRequests,
+        expect.toBeFunction(),
+        undefined,
+        undefined,
+      )
+    })
+
     it('should add operations value', async () => {
       const change = toChange({
         after: new InstanceElement(

--- a/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
@@ -121,6 +121,21 @@ describe('workflowStructureFilter', () => {
       expect((await workflowRulesType.fields.validators.getType()).elemID.getFullName()).toBe('List<jira.Validator>')
     })
 
+    it('should replace conditions configuration types and and return the new types', async () => {
+      const workflowConditionType = new ObjectType({
+        elemID: new ElemID(JIRA, 'WorkflowCondition'),
+        fields: {
+          configuration: {
+            refType: BuiltinTypes.STRING,
+          },
+        },
+      })
+      const elements = [workflowConditionType]
+      await filter.onFetch(elements)
+      expect(elements.length).toBeGreaterThan(1)
+      expect((await workflowConditionType.fields.configuration.getType()).elemID.getFullName()).toBe('jira.ConditionConfiguration')
+    })
+
     it('should split the id value to entityId and name in Workflow instances', async () => {
       const instance = new InstanceElement(
         'instance',
@@ -242,6 +257,58 @@ describe('workflowStructureFilter', () => {
                 conditions: [{
                   type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesCondition',
                   configuration: {
+                  },
+                }],
+              },
+            },
+          },
+        ],
+      })
+    })
+
+    it('should remove name values from condition configuration', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          transitions: [
+            {
+              rules: {
+                conditionsTree: {
+                  type: 'type',
+                  configuration: {
+                    name: 'name',
+                    other: 'other',
+                  },
+                  conditions: [{
+                    type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesCondition',
+                    configuration: {
+                      vals: [{
+                        name: 'name',
+                      }],
+                    },
+                  }],
+                },
+              },
+            },
+          ],
+        }
+      )
+      await filter.onFetch([instance])
+      expect(instance.value).toEqual({
+        transitions: [
+          {
+            rules: {
+              conditions: {
+                type: 'type',
+                configuration: {
+                  other: 'other',
+                },
+                conditions: [{
+                  type: 'com.innovalog.jmwe.jira-misc-workflow-extensions__LinkIssuesCondition',
+                  configuration: {
+                    vals: [{
+                    }],
                   },
                 }],
               },


### PR DESCRIPTION
Fixed deploying workflows with some kinds of conditions by removing redundant values from the workflows (name) and casting the ids from number to string

---
_Release Notes_: 
_Jira Adapter_:
- Fixed deploying workflow with `previousStatus` condition

---
_User Notifications_: 
None