### PR TITLE
SALTO-2215: create missing references

### DIFF
--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -51,6 +51,7 @@ type FetchEntry = {
 export type UserFetchConfig = {
   include: FetchEntry[]
   exclude: FetchEntry[]
+  enableMissingReferences?: boolean
 }
 
 export const createAdapterApiConfigType = ({

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -51,7 +51,6 @@ type FetchEntry = {
 export type UserFetchConfig = {
   include: FetchEntry[]
   exclude: FetchEntry[]
-  enableMissingReferences?: boolean
 }
 
 export const createAdapterApiConfigType = ({

--- a/packages/adapter-components/src/references/context.ts
+++ b/packages/adapter-components/src/references/context.ts
@@ -93,8 +93,7 @@ export const neighborContextGetter = ({
     }
     const contextPath = parent.createNestedID(contextFieldName)
     const context = resolvePath(instance, contextPath)
-    const shouldResolve = isReferenceExpression(context)
-    const contextStr = shouldResolve
+    const contextStr = isReferenceExpression(context)
       ? await resolveReference(context, contextPath)
       : context
 

--- a/packages/adapter-components/src/references/context.ts
+++ b/packages/adapter-components/src/references/context.ts
@@ -101,10 +101,7 @@ export const neighborContextGetter = ({
     if (!_.isString(contextStr)) {
       return undefined
     }
-    if (contextValueMapper) {
-      return contextValueMapper(contextStr)
-    }
-    return shouldResolve ? contextStr : undefined
+    return contextValueMapper ? contextValueMapper(contextStr) : contextStr
   } catch (e) {
     log.error('could not resolve context for reference. error: %s, params: %s, stack: %s', e, { fieldPath, contextFieldName, levelsUp }, e.stack)
     return undefined

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -191,6 +191,7 @@ export const addReferences = async <
   contextStrategyLookup,
   isEqualValue,
   fieldReferenceResolverCreator,
+  enableMissingReferences = false,
 }: {
   elements: Element[]
   defs: GenericFieldReferenceDefinition[]
@@ -199,9 +200,14 @@ export const addReferences = async <
   isEqualValue?: ValueIsEqualFunc
   fieldReferenceResolverCreator?:
     (def: GenericFieldReferenceDefinition) => FieldReferenceResolver<T>
+  enableMissingReferences?: boolean
 }): Promise<void> => {
+  const fixedDefs = defs
+    .map(def => (
+      enableMissingReferences ? def : _.omit(def, 'missingRefStrategy')
+    )) as GenericFieldReferenceDefinition[]
   const resolverFinder = generateReferenceResolverFinder<T, GenericFieldReferenceDefinition>(
-    defs, fieldReferenceResolverCreator
+    fixedDefs, fieldReferenceResolverCreator
   )
   const instances = elements.filter(isInstanceElement)
 

--- a/packages/adapter-components/src/references/index.ts
+++ b/packages/adapter-components/src/references/index.ts
@@ -14,11 +14,13 @@
 * limitations under the License.
 */
 export { neighborContextGetter, ContextFunc, ContextValueMapperFunc } from './context'
-export { addReferences, replaceReferenceValues, generateLookupFunc } from './field_references'
+export { addReferences, replaceReferenceValues, generateLookupFunc, MISSING_ANNOTATION } from './field_references'
 export {
   ReferenceSerializationStrategy,
   ReferenceSerializationStrategyName,
   ReferenceSerializationStrategyLookup,
+  MissingReferenceStrategy,
+  MissingReferenceStrategyName,
   FieldReferenceDefinition,
   FieldReferenceResolver,
   ReferenceResolverFinder,

--- a/packages/adapter-components/src/references/reference_mapping.ts
+++ b/packages/adapter-components/src/references/reference_mapping.ts
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { Field, Value, Element, isInstanceElement, InstanceElement, ObjectType, ElemID } from '@salto-io/adapter-api'
+import { Field, Value, Element, isInstanceElement } from '@salto-io/adapter-api'
 import { types } from '@salto-io/lowerdash'
-import { GetLookupNameFunc, naclCase } from '@salto-io/adapter-utils'
+import { GetLookupNameFunc } from '@salto-io/adapter-utils'
 
 export type ApiNameFunc = (elem: Element) => string
 export type LookupFunc = (val: Value, context?: string) => string
@@ -24,9 +24,6 @@ export type CreateMissingRefFunc = (
   params: { value: string; adapter: string; typeName?: string }
 ) => Element | undefined
 export type CheckMissingRefFunc = (element: Element) => boolean
-
-const MISSING_REF_PREFIX = 'missing_'
-const MISSING_ANNOTATION = 'missing'
 
 export type ReferenceSerializationStrategy = {
   serialize: GetLookupNameFunc
@@ -56,29 +53,8 @@ export const ReferenceSerializationStrategyLookup: Record<
 
 export type MissingReferenceStrategy = {
   create: CreateMissingRefFunc
-  check: CheckMissingRefFunc
 }
-
 export type MissingReferenceStrategyName = 'typeAndValue'
-export const MissingReferenceStrategyLookup: Record<
-MissingReferenceStrategyName, MissingReferenceStrategy
-> = {
-  typeAndValue: {
-    create: ({ value, adapter, typeName }) => {
-      if (!_.isString(typeName) || !value) {
-        return undefined
-      }
-      return new InstanceElement(
-        naclCase(`${MISSING_REF_PREFIX}${value}`),
-        new ObjectType({ elemID: new ElemID(adapter, typeName) }),
-        {},
-        undefined,
-        { [MISSING_ANNOTATION]: true },
-      )
-    },
-    check: element => element.annotations[MISSING_ANNOTATION] === true,
-  },
-}
 
 type MetadataTypeArgs<T extends string> = {
   type: string
@@ -148,9 +124,6 @@ export class FieldReferenceResolver<T extends string> {
     ]
     this.target = def.target
       ? { ...def.target, lookup: this.serializationStrategy.lookup }
-      : undefined
-    this.missingRefStrategy = def.missingRefStrategy
-      ? MissingReferenceStrategyLookup[def.missingRefStrategy]
       : undefined
   }
 

--- a/packages/adapter-components/test/references/field_references.test.ts
+++ b/packages/adapter-components/test/references/field_references.test.ts
@@ -378,47 +378,6 @@ describe('Field references', () => {
       expect(triggerWithMissingReference.value.ticket_field_id)
         .not.toBeInstanceOf(ReferenceExpression)
     })
-    describe('enable missing references is true', () => {
-      let clonedElements: Element[] = []
-      beforeEach(async () => {
-        clonedElements = generateElements()
-        await addReferences({
-          elements: clonedElements,
-          defs: fieldNameToTypeMappingDefs,
-          fieldsToGroupBy: ['id', 'name'],
-          contextStrategyLookup: {
-            parentSubject: neighborContextFunc({ contextFieldName: 'subject', levelsUp: 1, contextValueMapper: val => val.replace('_id', '') }),
-            parentValue: neighborContextFunc({ contextFieldName: 'value', levelsUp: 2, contextValueMapper: val => val.replace('_id', '') }),
-            neighborRef: neighborContextFunc({ contextFieldName: 'ref' }),
-            fail: neighborContextFunc({ contextFieldName: 'product', contextValueMapper: () => { throw new Error('fail') } }),
-          },
-          enableMissingReferences: true,
-        })
-      })
-      it('should create missing reference', async () => {
-        const triggerWithResolvedReference = clonedElements.filter(
-          e => isInstanceElement(e) && e.elemID.name === 'trigger1'
-        )[0] as InstanceElement
-        expect(triggerWithResolvedReference.value.ticket_field_id)
-          .toBeInstanceOf(ReferenceExpression)
-        expect(triggerWithResolvedReference.value.ticket_field_id.value)
-          .toBeInstanceOf(InstanceElement)
-        const triggerWithMissingReference = clonedElements.filter(
-          e => isInstanceElement(e) && e.elemID.name === 'trigger2'
-        )[0] as InstanceElement
-        expect(triggerWithMissingReference.value.ticket_field_id)
-          .toBeInstanceOf(ReferenceExpression)
-        // Should not be a resolved reference
-        expect(triggerWithMissingReference.value.ticket_field_id.value)
-          .toEqual(undefined)
-      })
-      it('should not create missing reference if the value is empty', () => {
-        const inst = clonedElements.filter(
-          e => isInstanceElement(e) && e.elemID.name === 'trigger3'
-        )[0] as InstanceElement
-        expect(inst.value.ticket_field_id).toEqual('')
-      })
-    })
   })
 
   describe('generateLookupNameFunc', () => {

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -1562,6 +1562,7 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
       { type: 'organization' },
     ],
     hideTypes: true,
+    enableMissingReferences: true,
   },
   [API_DEFINITIONS_CONFIG]: {
     typeDefaults: {
@@ -1590,7 +1591,10 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
     [FETCH_CONFIG]: {
       refType: createUserFetchConfigType(
         ZENDESK_SUPPORT,
-        { hideTypes: { refType: BuiltinTypes.BOOLEAN } },
+        {
+          hideTypes: { refType: BuiltinTypes.BOOLEAN },
+          enableMissingReferences: { refType: BuiltinTypes.BOOLEAN },
+        },
       ),
     },
     [API_DEFINITIONS_CONFIG]: {
@@ -1599,7 +1603,9 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
   },
   annotations: {
     [CORE_ANNOTATIONS.DEFAULT]: _.omit(
-      DEFAULT_CONFIG, API_DEFINITIONS_CONFIG, `${FETCH_CONFIG}.hideTypes`
+      DEFAULT_CONFIG, API_DEFINITIONS_CONFIG,
+      `${FETCH_CONFIG}.hideTypes`,
+      `${FETCH_CONFIG}.enableMissingReferences`,
     ),
   },
 })

--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -48,6 +48,7 @@ export const API_DEFINITIONS_CONFIG = 'apiDefinitions'
 export type ZendeskClientConfig = clientUtils.ClientBaseConfig<clientUtils.ClientRateLimitConfig>
 
 export type ZendeskFetchConfig = configUtils.DuckTypeUserFetchConfig
+  & { enableMissingReferences?: boolean }
 export type ZendeskApiConfig = configUtils.AdapterApiConfig<
   configUtils.DuckTypeTransformationConfig & { omitInactive?: boolean }
 >
@@ -1603,7 +1604,8 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
   },
   annotations: {
     [CORE_ANNOTATIONS.DEFAULT]: _.omit(
-      DEFAULT_CONFIG, API_DEFINITIONS_CONFIG,
+      DEFAULT_CONFIG,
+      API_DEFINITIONS_CONFIG,
       `${FETCH_CONFIG}.hideTypes`,
       `${FETCH_CONFIG}.enableMissingReferences`,
     ),

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -51,7 +51,7 @@ const SPECIAL_CONTEXT_NAMES: Record<string, string> = {
  * For strings with an id-related suffix (_id or _ids), remove the suffix.
  * e.g. `abc_id` => `abc`.
  */
-const getValueLookupType = (val: string): string | undefined => {
+const getValueLookupType: referenceUtils.ContextValueMapperFunc = val => {
   const specialTypeName = SPECIAL_CONTEXT_NAMES[val]
   if (specialTypeName !== undefined) {
     return specialTypeName
@@ -64,7 +64,7 @@ const getValueLookupType = (val: string): string | undefined => {
   return valParts.join('_')
 }
 
-const getLowerCaseSingularLookupType = (val: string): string | undefined => {
+const getLowerCaseSingularLookupType: referenceUtils.ContextValueMapperFunc = val => {
   const lowercaseVal = val.toLowerCase()
   // for now this simple conversion to singular form seems good enough, but
   // we may need to improve it later on
@@ -100,6 +100,9 @@ const neighborReferenceTicketFieldLookupFunc: GetLookupNameFunc = async ({ ref }
   return undefined
 }
 
+const neighborReferenceTicketFieldLookupType: referenceUtils.ContextValueMapperFunc = val =>
+  (val === TICKET_FIELD_OPTION_TYPE_NAME ? val : undefined)
+
 const neighborReferenceUserAndOrgFieldLookupFunc: GetLookupNameFunc = async ({ ref }) => {
   if (isInstanceElement(ref.value) && ref.value.value.type === 'dropdown') {
     if (ref.elemID.typeName === USER_FIELD_TYPE_NAME) {
@@ -111,6 +114,9 @@ const neighborReferenceUserAndOrgFieldLookupFunc: GetLookupNameFunc = async ({ r
   }
   return undefined
 }
+
+const neighborReferenceUserAndOrgFieldLookupType: referenceUtils.ContextValueMapperFunc = val =>
+  ([USER_FIELD_OPTION_TYPE_NAME, ORG_FIELD_OPTION_TYPE_NAME].includes(val) ? val : undefined)
 
 const getSerializationStrategyOfCustomFieldByContainingType = (
   prefix: string,
@@ -198,11 +204,11 @@ export const contextStrategyLookup: Record<
   ReferenceContextStrategyName, referenceUtils.ContextFunc
 > = {
   neighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: getValueLookupType }),
-  neighborReferenceTicketField: neighborContextFunc({ contextFieldName: 'field', getLookUpName: neighborReferenceTicketFieldLookupFunc }),
-  neighborReferenceTicketFormCondition: neighborContextFunc({ contextFieldName: 'parent_field_id', getLookUpName: neighborReferenceTicketFieldLookupFunc }),
-  neighborReferenceUserAndOrgField: neighborContextFunc({ contextFieldName: 'field', getLookUpName: neighborReferenceUserAndOrgFieldLookupFunc }),
-  neighborSubjectReferenceTicketField: neighborContextFunc({ contextFieldName: 'subject', getLookUpName: neighborReferenceTicketFieldLookupFunc }),
-  neighborSubjectReferenceUserAndOrgField: neighborContextFunc({ contextFieldName: 'subject', getLookUpName: neighborReferenceUserAndOrgFieldLookupFunc }),
+  neighborReferenceTicketField: neighborContextFunc({ contextFieldName: 'field', getLookUpName: neighborReferenceTicketFieldLookupFunc, contextValueMapper: neighborReferenceTicketFieldLookupType }),
+  neighborReferenceTicketFormCondition: neighborContextFunc({ contextFieldName: 'parent_field_id', getLookUpName: neighborReferenceTicketFieldLookupFunc, contextValueMapper: neighborReferenceTicketFieldLookupType }),
+  neighborReferenceUserAndOrgField: neighborContextFunc({ contextFieldName: 'field', getLookUpName: neighborReferenceUserAndOrgFieldLookupFunc, contextValueMapper: neighborReferenceUserAndOrgFieldLookupType }),
+  neighborSubjectReferenceTicketField: neighborContextFunc({ contextFieldName: 'subject', getLookUpName: neighborReferenceTicketFieldLookupFunc, contextValueMapper: neighborReferenceTicketFieldLookupType }),
+  neighborSubjectReferenceUserAndOrgField: neighborContextFunc({ contextFieldName: 'subject', getLookUpName: neighborReferenceUserAndOrgFieldLookupFunc, contextValueMapper: neighborReferenceUserAndOrgFieldLookupType }),
   neighborType: neighborContextFunc({ contextFieldName: 'type', contextValueMapper: getLowerCaseSingularLookupType }),
   parentSubject: neighborContextFunc({ contextFieldName: 'subject', levelsUp: 1, contextValueMapper: getValueLookupType }),
   neighborSubject: neighborContextFunc({ contextFieldName: 'subject', contextValueMapper: getValueLookupType }),

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -19,6 +19,7 @@ import { references as referenceUtils } from '@salto-io/adapter-components'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
 import { BRAND_NAME } from '../constants'
+import { FETCH_CONFIG } from '../config'
 
 const { neighborContextGetter } = referenceUtils
 
@@ -757,7 +758,7 @@ export const lookupFunc = referenceUtils.generateLookupFunc(
 /**
  * Convert field values into references, based on predefined rules.
  */
-const filter: FilterCreator = () => ({
+const filter: FilterCreator = ({ config }) => ({
   onFetch: async (elements: Element[]) => {
     const addReferences = async (refDefs: ZendeskSupportFieldReferenceDefinition[]):
     Promise<void> => {
@@ -769,6 +770,7 @@ const filter: FilterCreator = () => ({
         // since ids and references to ids vary inconsistently between string/number, allow both
         isEqualValue: (lhs, rhs) => _.toString(lhs) === _.toString(rhs),
         fieldReferenceResolverCreator: defs => new ZendeskSupportFieldReferenceResolver(defs),
+        enableMissingReferences: config[FETCH_CONFIG].enableMissingReferences,
       })
     }
     await addReferences(

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -220,7 +220,7 @@ export class ZendeskSupportFieldReferenceResolver extends referenceUtils.FieldRe
   ReferenceContextStrategyName
 > {
   constructor(def: ZendeskSupportFieldReferenceDefinition) {
-    super({ src: def.src })
+    super({ src: def.src, missingRefStrategy: def.missingRefStrategy })
     this.serializationStrategy = ZendeskSupportReferenceSerializationStrategyLookup[
       def.zendeskSupportSerializationStrategy ?? def.serializationStrategy ?? 'fullValue'
     ]
@@ -662,6 +662,7 @@ const secondIterationFieldNameToTypeMappingDefs: ZendeskSupportFieldReferenceDef
     },
     zendeskSupportSerializationStrategy: 'ticketFieldOption',
     target: { typeContext: 'neighborReferenceTicketField' },
+    missingRefStrategy: 'typeAndValue',
   },
   {
     src: {
@@ -677,6 +678,7 @@ const secondIterationFieldNameToTypeMappingDefs: ZendeskSupportFieldReferenceDef
     },
     zendeskSupportSerializationStrategy: 'userFieldOption',
     target: { typeContext: 'neighborReferenceUserAndOrgField' },
+    missingRefStrategy: 'typeAndValue',
   },
   {
     src: {


### PR DESCRIPTION
_Create missing references_

---

_Additional context for reviewer_
For @netama to review. She got the full context

- [ ] Still needs to add more usages of this mechanism (which means that I need to add the `missingRefStrategy` attribute to more field reference definitions

---
_Release Notes_: 
_Zendesk_support adapter:_
* Add missing references with the structure of `zendesk_support.<typeName>.instance.missing_<internalId>` will be added. When this unresolved reference will be added, it means that there is a broken reference. Go to the service and fix it!

---
_User Notifications_: 
_Zendesk_support adapter:_
* Add missing references with the structure of `zendesk_support.<typeName>.instance.missing_<internalId>` will be added. 
