### PR TITLE
SALTO-2202: Change definition instances to be hidden in order to debug weird trigger definition instance

### DIFF
--- a/packages/zendesk-support-adapter/src/filters/remove_definition_instances.ts
+++ b/packages/zendesk-support-adapter/src/filters/remove_definition_instances.ts
@@ -27,9 +27,6 @@ const DEFINITION_TYPE_NAMES = [
   'routing_attribute_definition',
 ]
 
-/**
- * Removes the definition instances
- */
 const filterCreator: FilterCreator = () => ({
   onFetch: async elements => {
     // NOTE: changed to be hidden (instead of removing the elements) in order to debug SALTO-2202

--- a/packages/zendesk-support-adapter/src/filters/remove_definition_instances.ts
+++ b/packages/zendesk-support-adapter/src/filters/remove_definition_instances.ts
@@ -13,8 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import _ from 'lodash'
-import { isInstanceElement } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, isObjectType } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
 
 // We don't fetch those type names (except for trigger_definition) by default
@@ -33,9 +32,14 @@ const DEFINITION_TYPE_NAMES = [
  */
 const filterCreator: FilterCreator = () => ({
   onFetch: async elements => {
-    _.remove(elements,
-      element =>
-        isInstanceElement(element) && DEFINITION_TYPE_NAMES.includes(element.elemID.typeName))
+    // NOTE: changed to be hidden (instead of removing the elements) in order to debug SALTO-2202
+    // We will change the implementation back to removing the elements once we will figure it out
+    elements
+      .filter(element => DEFINITION_TYPE_NAMES.includes(element.elemID.typeName))
+      .filter(isObjectType)
+      .forEach(element => {
+        element.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
+      })
   },
 })
 

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -371,6 +371,8 @@ describe('adapter', () => {
           'zendesk_support.trigger_category.instance.Custom_Events___edited@ssbs',
           'zendesk_support.trigger_category.instance.Notifications',
           'zendesk_support.trigger_definition',
+          // We should remove this instance from the expected list once we done with SALTO-2202
+          'zendesk_support.trigger_definition.instance',
           'zendesk_support.trigger_definition__actions',
           'zendesk_support.trigger_definition__actions__metadata',
           'zendesk_support.trigger_definition__actions__metadata__phone_numbers',

--- a/packages/zendesk-support-adapter/test/filters/remove_definition_instances.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/remove_definition_instances.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
@@ -49,7 +49,9 @@ describe('remove definition instances', () => {
   })
 
   describe('onFetch', () => {
-    it('should change the hidden value annotation of the relevant types', async () => {
+    // NOTE: We disabled this test in order to debug SALTO-2202
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('should remove the instances of the relevant types', async () => {
       const elements = [
         randomObjType, instanceRandomObj, triggerDefinitionObjType,
         triggerDefinition, macrosActionsObjType, macrosActions,
@@ -61,6 +63,21 @@ describe('remove definition instances', () => {
         'zendesk_support.trigger_definition',
         'zendesk_support.macros_actions',
       ])
+    })
+    // NOTE: Should be removed once we finish to debug SALTO-2202
+    it('should change the hidden value annotation of the relevant types', async () => {
+      const elements = [
+        randomObjType, instanceRandomObj, triggerDefinitionObjType, macrosActionsObjType,
+      ]
+      await filter.onFetch(elements)
+      expect(elements.map(e => e.elemID.getFullName())).toEqual([
+        'zendesk_support.obj',
+        'zendesk_support.obj.instance.test',
+        'zendesk_support.trigger_definition',
+        'zendesk_support.macros_actions',
+      ])
+      expect(triggerDefinitionObjType.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toEqual(true)
+      expect(macrosActionsObjType.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toEqual(true)
     })
   })
 })


### PR DESCRIPTION
_Change definition instances to be hidden in order to debug weird trigger definition instance_

---

_Additional context for reviewer_
This PR is for debugging purposes
This PR should be reverted once we figured what caused SALTO-2202

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
