### PR TITLE
SALTO-1243: Bump nodejs version in CLI builds to 14.15.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: circleci/node:12.16
+      - image: circleci/node:14.15
 
     resource_class: xlarge
     working_directory: /mnt/ramdisk/project
@@ -113,7 +113,7 @@ jobs:
 
   unit_test:
     docker:
-      - image: circleci/node:12.16
+      - image: circleci/node:14.15
 
     resource_class: xlarge
     working_directory: /mnt/ramdisk/project
@@ -135,7 +135,7 @@ jobs:
 
   publish_on_version_change:
     docker:
-      - image: circleci/node:12.16
+      - image: circleci/node:14.15
 
     steps:
       - attach_workspace:
@@ -186,7 +186,7 @@ jobs:
 
   package_cli:
     docker:
-      - image: circleci/node:12.16
+      - image: circleci/node:14.15
 
     steps:
       - attach_workspace:
@@ -220,7 +220,7 @@ jobs:
 
   test_cli_linux:
     docker:
-      - image: circleci/node:12.16
+      - image: circleci/node:14.15
 
     steps:
       - set_s3_pkg_urls
@@ -260,7 +260,7 @@ jobs:
 
   package_vscode_extension:
     docker:
-      - image: circleci/node:12.16
+      - image: circleci/node:14.15
 
     steps:
       - attach_workspace:
@@ -297,7 +297,7 @@ jobs:
 
   publish_canary:
     docker:
-      - image: circleci/node:12.16
+      - image: circleci/node:14.15
 
     steps:
       - attach_workspace:

--- a/.github/workflows/notices.yml
+++ b/.github/workflows/notices.yml
@@ -15,7 +15,7 @@ jobs:
     - name: setup nodejs and required npm packages
       uses: actions/setup-node@v1
       with:
-        node-version: 12.12
+        node-version: 14.15
 
     - run: |
         npm i -g synp yarn@1.22.0

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See [the vscode package documentation](packages/vscode/README.md#installation)
 
 ### Building from source
 
-  1. Install Node.js 12. You can download it directly from [here](https://nodejs.org/en/download/releases/), or use [Node Version Manager (NVM)](https://github.com/nvm-sh/nvm) to install it.
+  1. Install Node.js 14. You can download it directly from [here](https://nodejs.org/en/download/releases/), or use [Node Version Manager (NVM)](https://github.com/nvm-sh/nvm) to install it.
   2. Install [yarn](https://yarnpkg.com/en/docs/install).
   3. Fetch dependencies and build:
 

--- a/packages/cli/package_native.js
+++ b/packages/cli/package_native.js
@@ -25,7 +25,7 @@ const fontFiles = require('./dist/src/fonts').fontFiles
 const TARGET_FILE_BASENAME = 'salto'
 const TARGET_DIR = 'pkg'
 const TARGET_ARCH = 'x64'
-const TARGET_NODE_VERSION = '12.9.1'
+const TARGET_NODE_VERSION = '14.15.3'
 const TARGET_PLATFORMS = {
   win: { ext: '.exe' },
   linux: {},


### PR DESCRIPTION

---

This is the newest version that has prebuilt binaries for all the relevant platforms in the [nexe releases page](https://github.com/nexe/nexe/releases)

---
_Release Notes_: 
CLI:
- Updated node js version to v14.15.3 in released binaries

---
_User Notifications_: 
_None_
