### PR TITLE
SALTO-2037: Remove XML Attribute prefix only for fields we will convert back when deploying

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -119,7 +119,6 @@ export const DEFAULT_FILTERS = [
   valueSetFilter,
   globalValueSetFilter,
   staticResourceFileExtFilter,
-  xmlAttributesFilter,
   profilePathsFilter,
   territoryFilter,
   elementsUrlFilter,
@@ -132,6 +131,8 @@ export const DEFAULT_FILTERS = [
   // The following filters should remain last in order to make sure they fix all elements
   convertListsFilter,
   convertTypeFilter,
+  // should run after convertListsFilter
+  xmlAttributesFilter,
   replaceFieldValuesFilter,
   valueToStaticFileFilter,
   fieldReferencesFilter,

--- a/packages/salesforce-adapter/src/filters/hardcoded_lists.json
+++ b/packages/salesforce-adapter/src/filters/hardcoded_lists.json
@@ -105,6 +105,7 @@
   "salesforce.LeadConvertSettings.field.objectMapping",
   "salesforce.LightningPage.field.flexiPageRegions",
   "salesforce.LightningPageRegion.field.componentInstances",
+  "salesforce.LightningComponentBundle.field.lwcResources.lwcResource",
   "salesforce.ListView.field.columns",
   "salesforce.ListView.field.filters",
   "salesforce.LookupFilter.field.filterItems",


### PR DESCRIPTION
For Lightning Web Components, we convert known attributes to look like regular fields, and convert them
back to attributes when generating the XML for deployment. We can't do this for arbitrary attributes which
are not marked as "IS_ATTRIBUTE" on the type, since we won't be able to covert them back.

---

None

---
_Release Notes_: 

Salesforce - User defined LWC XML Attributes will now have the prefix attr_ in the NaCl file

---
_User Notifications_: 

Salesforce - User defined LWC XML Attributes will now have the prefix 'attr_' in the NaCl file 