### PR TITLE
SALTO-2225: return empty result on 404 responses in zendesk

### DIFF
--- a/packages/zendesk-support-adapter/src/client/client.ts
+++ b/packages/zendesk-support-adapter/src/client/client.ts
@@ -61,10 +61,7 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
     try {
       return await super.getSinglePage(args)
     } catch (e) {
-      // The http_client code catches the original error and transforms it such that it removes
-      // the parsed information (like the status code), so we have to parse the string here in order
-      // to realize what type of error was thrown
-      if (e.message.endsWith('Request failed with status code 404')) {
+      if (e.response.status === 404) {
         log.warn('Suppressing 404 error %o', e)
         return {
           data: [],

--- a/packages/zendesk-support-adapter/src/client/client.ts
+++ b/packages/zendesk-support-adapter/src/client/client.ts
@@ -14,11 +14,13 @@
 * limitations under the License.
 */
 import { client as clientUtils } from '@salto-io/adapter-components'
+import { logger } from '@salto-io/logging'
 import { createConnection, instanceUrl } from './connection'
 import { ZENDESK_SUPPORT } from '../constants'
 import { Credentials } from '../auth'
 
 const { DEFAULT_RETRY_OPTS, RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS } = clientUtils
+const log = logger(module)
 
 const DEFAULT_MAX_CONCURRENT_API_REQUESTS: Required<clientUtils.ClientRateLimitConfig> = {
   total: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
@@ -51,5 +53,25 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
 
   public getUrl(): URL {
     return new URL(instanceUrl(this.credentials.subdomain))
+  }
+
+  public async getSinglePage(
+    args: clientUtils.ClientBaseParams,
+  ): Promise<clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>> {
+    try {
+      return await super.getSinglePage(args)
+    } catch (e) {
+      // The http_client code catches the original error and transforms it such that it removes
+      // the parsed information (like the status code), so we have to parse the string here in order
+      // to realize what type of error was thrown
+      if (e.message.endsWith('Request failed with status code 404')) {
+        log.warn('Suppressing 404 error %o', e)
+        return {
+          data: [],
+          status: 404,
+        }
+      }
+      throw e
+    }
   }
 }

--- a/packages/zendesk-support-adapter/test/client/client.test.ts
+++ b/packages/zendesk-support-adapter/test/client/client.test.ts
@@ -1,0 +1,41 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import ZendeskClient from '../../src/client/client'
+
+describe('client', () => {
+  describe('getSinglePage', () => {
+    let mockAxios: MockAdapter
+    let client: ZendeskClient
+    beforeEach(() => {
+      mockAxios = new MockAdapter(axios)
+      client = new ZendeskClient({ credentials: { username: 'a', password: 'b', subdomain: 'ignore' } })
+    })
+
+    afterEach(() => {
+      mockAxios.restore()
+    })
+
+    it('should return an empty result when there is a 404 response', async () => {
+      // The first replyOnce with 200 is for the client authentication
+      mockAxios.onGet().replyOnce(200).onGet().replyOnce(404)
+      const res = await client.getSinglePage({ url: 'http://myBrand.zendesk.com/api/v2/routing/attributes' })
+      expect(res.data).toEqual([])
+      expect(res.status).toEqual(404)
+    })
+  })
+})


### PR DESCRIPTION
_Return empty result on 404 responses in zendesk_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
