### PR TITLE
SALTO-2245: Fixed deployment of JSM projects

### DIFF
--- a/packages/jira-adapter/test/filters/project.test.ts
+++ b/packages/jira-adapter/test/filters/project.test.ts
@@ -160,7 +160,7 @@ describe('projectFilter', () => {
     })
   })
 
-  describe('When deploying a change', () => {
+  describe('When deploying a modification change', () => {
     let change: Change
 
     beforeEach(async () => {
@@ -190,6 +190,60 @@ describe('projectFilter', () => {
           workflowSchemeId: 1,
           projectId: 2,
         },
+        undefined,
+      )
+    })
+  })
+
+  describe('When deploying an addition change', () => {
+    let change: Change
+
+    beforeEach(async () => {
+      instance.value.id = 3
+      change = toChange({ after: instance })
+
+      connection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          components: [
+            {
+              id: '1',
+            },
+            {
+              id: '2',
+            },
+          ],
+        },
+      })
+
+      await filter.deploy([change])
+    })
+    it('should call deployChange and ignore only components', () => {
+      expect(deployChangeMock).toHaveBeenCalledWith(
+        change,
+        client,
+        DEFAULT_CONFIG.apiDefinitions.types.Project.deployRequests,
+        ['components'],
+        undefined,
+        undefined,
+      )
+    })
+
+    it('should call the endpoint to get the components', () => {
+      expect(connection.get).toHaveBeenCalledWith(
+        '/rest/api/3/project/3',
+        undefined,
+      )
+    })
+
+    it('should call the endpoint to remove the components', () => {
+      expect(connection.delete).toHaveBeenCalledWith(
+        '/rest/api/3/component/1',
+        undefined,
+      )
+
+      expect(connection.delete).toHaveBeenCalledWith(
+        '/rest/api/3/component/2',
         undefined,
       )
     })


### PR DESCRIPTION
Some JSM project, when created, creates some components as a side effect. We would want to remove them so we can deploy the components in the NaCls


---
_Release Notes_: 
_Jira Adapter_:
- Fixed a bug where some project component would be created a side effect of creating the project

---
_User Notifications_: 
None