### PR TITLE
SALTO-2220: Omit sensitive Jira Automation fields from UI

### DIFF
--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -66,4 +66,4 @@ jira {
 ## Masking configuration options
 | Name                                        | Default when undefined            | Description
 |---------------------------------------------|-----------------------------------|------------
-| headers                                     | []                                | List of regexes of header keys to mask their values (currently only relevant for Automations)
+| automationHeaders                                     | []                                | List of regexes of header keys in Automations to mask their values

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -31,6 +31,7 @@ jira {
 | ---------------------------------------------------------| ------------------------------| -----------
 | [client](#client-configuration-options)                  | `{}` (no overrides)             | Configuration relating to the client used to interact with JIRA
 | [fetch](#fetch-configuration-options)                    | `{}` (no overrides)             | Configuration relating to the endpoints that will be queried during fetch
+| [masking](#masking-configuration-options)                | `{}` (mask nothing)           | Configuration to mask sensitive data from the NaCls
 
 ### Client configuration options
 
@@ -61,3 +62,8 @@ jira {
 |---------------------------------------------|-----------------------------------|------------
 | includeTypes                                | []                                | List of types to fetch
 | fallbackToInternalId                        | false                             | Whether to add the internal ids to the instance name when the name is not unique among the instances of that type
+
+## Masking configuration options
+| Name                                        | Default when undefined            | Description
+|---------------------------------------------|-----------------------------------|------------
+| headers                                     | []                                | List of regexes of header keys to mask their values (currently only relevant for Automations)

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -76,6 +76,7 @@ import securitySchemeFilter from './filters/security_scheme/security_scheme'
 import notificationSchemeDeploymentFilter from './filters/notification_scheme/notification_scheme_deployment'
 import notificationSchemeStructureFilter from './filters/notification_scheme/notification_scheme_structure'
 import forbiddenPermissionSchemeFilter from './filters/forbidden_permission_schemes'
+import maskingFilter from './filters/masking'
 import avatarsFilter from './filters/avatars'
 import iconUrlFilter from './filters/icon_url'
 import jqlReferencesFilter from './filters/jql/jql_references'
@@ -149,6 +150,7 @@ export const DEFAULT_FILTERS = [
   userFilter,
   forbiddenPermissionSchemeFilter,
   jqlReferencesFilter,
+  maskingFilter,
   referenceBySelfLinkFilter,
   // Must run after referenceBySelfLinkFilter
   removeSelfFilter,

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -83,6 +83,7 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
     client: null,
     fetch: null,
     deploy: null,
+    masking: null,
   }
   Object.keys(fullConfig)
     .filter(k => !Object.keys(adapterConfig).includes(k))

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -54,7 +54,7 @@ export default (
     dashboardGadgetsValidator,
     dashboardLayoutValidator,
     automationsValidator,
-    maskingValidator,
+    maskingValidator(client),
   ]
 
   return createChangeValidator(validators)

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -29,6 +29,7 @@ import { privateApiValidator } from './private_api'
 import { workflowValidator } from './workflow'
 import { dashboardGadgetsValidator } from './dashboard_gadgets'
 import { dashboardLayoutValidator } from './dashboard_layout'
+import { maskingValidator } from './masking'
 import { automationsValidator } from './automations'
 
 const {
@@ -53,6 +54,7 @@ export default (
     dashboardGadgetsValidator,
     dashboardLayoutValidator,
     automationsValidator,
+    maskingValidator,
   ]
 
   return createChangeValidator(validators)

--- a/packages/jira-adapter/src/change_validators/masking.ts
+++ b/packages/jira-adapter/src/change_validators/masking.ts
@@ -1,0 +1,71 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeError, ChangeValidator, ElemID, getChangeData,
+  InstanceElement,
+  isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
+import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { AUTOMATION_TYPE } from '../constants'
+import { MASK_VALUE } from '../filters/masking'
+
+export const createChangeError = (instanceElemId: ElemID): ChangeError => ({
+  elemID: instanceElemId,
+  severity: 'Info',
+  message: 'Masked data will be deployed to the service',
+  detailedMessage: '',
+  deployActions: {
+    preAction: {
+      title: 'Masked data will be overridden in the service',
+      description: `${instanceElemId.getFullName()} contains masked values which will override the real values in the service when deploying`,
+      subActions: [],
+    },
+    postAction: {
+      title: 'Update masked data in the service',
+      description: `Please updated the masked values that were deployed to the service in ${instanceElemId.getFullName()} in the service`,
+      subActions: [
+        `In the Jira UI, open System > Global automation, and open the automation of ${instanceElemId.getFullName()}`,
+        'Go over the headers with masked values (headers with <SECRET_TOKEN> values) and set the real values',
+        'Click "Save"',
+        'Click "Publish changes"',
+      ],
+    },
+  },
+})
+
+const doesHaveMaskedValues = (instance: InstanceElement): boolean => {
+  let maskedValueFound = false
+  walkOnElement({
+    element: instance,
+    func: ({ value }) => {
+      if (value === MASK_VALUE) {
+        maskedValueFound = true
+        return WALK_NEXT_STEP.EXIT
+      }
+      return WALK_NEXT_STEP.RECURSE
+    },
+  })
+
+  return maskedValueFound
+}
+
+export const maskingValidator: ChangeValidator = async changes => (
+  changes
+    .filter(isAdditionOrModificationChange)
+    .filter(isInstanceChange)
+    .filter(change => getChangeData(change).elemID.typeName === AUTOMATION_TYPE)
+    .map(getChangeData)
+    .filter(doesHaveMaskedValues)
+    .flatMap(instance => ([createChangeError(instance.elemID)]))
+)

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1814,11 +1814,16 @@ type JiraFetchConfig = configUtils.UserFetchConfig & {
   fallbackToInternalId?: boolean
 }
 
+type MaskingConfig = {
+  headers: string[]
+}
+
 export type JiraConfig = {
   client: JiraClientConfig
   fetch: JiraFetchConfig
   deploy: JiraDeployConfig
   apiDefinitions: JiraApiConfig
+  masking: MaskingConfig
 }
 
 const jspUrlsType = createMatchingObjectType<Partial<JspUrls>>({
@@ -1882,6 +1887,9 @@ export const DEFAULT_CONFIG: JiraConfig = {
     forceDelete: false,
   },
   apiDefinitions: DEFAULT_API_DEFINITIONS,
+  masking: {
+    headers: [],
+  },
 }
 
 const createClientConfigType = (): ObjectType => {
@@ -1909,6 +1917,15 @@ const jiraDeployConfigType = new ObjectType({
 const fetchConfigType = createUserFetchConfigType(JIRA)
 fetchConfigType.fields.fallbackToInternalId = new Field(fetchConfigType, 'fallbackToInternalId', BuiltinTypes.BOOLEAN)
 
+const maskingConfigType = createMatchingObjectType<Partial<MaskingConfig>>({
+  elemID: new ElemID(JIRA),
+  fields: {
+    headers: {
+      refType: new ListType(BuiltinTypes.STRING),
+    },
+  },
+})
+
 export const configType = createMatchingObjectType<Partial<JiraConfig>>({
   elemID: new ElemID(JIRA),
   fields: {
@@ -1916,6 +1933,7 @@ export const configType = createMatchingObjectType<Partial<JiraConfig>>({
     deploy: { refType: jiraDeployConfigType },
     fetch: { refType: fetchConfigType },
     apiDefinitions: { refType: apiDefinitionsType },
+    masking: { refType: maskingConfigType },
   },
   annotations: {
     [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, ['apiDefinitions', 'client']),

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1815,7 +1815,7 @@ type JiraFetchConfig = configUtils.UserFetchConfig & {
 }
 
 type MaskingConfig = {
-  headers: string[]
+  automationHeaders: string[]
 }
 
 export type JiraConfig = {
@@ -1888,7 +1888,7 @@ export const DEFAULT_CONFIG: JiraConfig = {
   },
   apiDefinitions: DEFAULT_API_DEFINITIONS,
   masking: {
-    headers: [],
+    automationHeaders: [],
   },
 }
 
@@ -1920,7 +1920,7 @@ fetchConfigType.fields.fallbackToInternalId = new Field(fetchConfigType, 'fallba
 const maskingConfigType = createMatchingObjectType<Partial<MaskingConfig>>({
   elemID: new ElemID(JIRA),
   fields: {
-    headers: {
+    automationHeaders: {
       refType: new ListType(BuiltinTypes.STRING),
     },
   },
@@ -1936,7 +1936,7 @@ export const configType = createMatchingObjectType<Partial<JiraConfig>>({
     masking: { refType: maskingConfigType },
   },
   annotations: {
-    [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, ['apiDefinitions', 'client']),
+    [CORE_ANNOTATIONS.DEFAULT]: _.omit(DEFAULT_CONFIG, ['apiDefinitions', 'client', 'masking']),
   },
 })
 

--- a/packages/jira-adapter/src/filters/masking.ts
+++ b/packages/jira-adapter/src/filters/masking.ts
@@ -1,0 +1,73 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, isInstanceElement } from '@salto-io/adapter-api'
+import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { AUTOMATION_TYPE } from '../constants'
+import { FilterCreator } from '../filter'
+
+const log = logger(module)
+
+export const MASK_VALUE = '<SECRET_TOKEN>'
+
+type Header = {
+  name: string
+  value: string
+}
+
+const maskHeaders = (
+  headers: Header[],
+  headersToMask: string[],
+  id: ElemID
+): void => {
+  const headerRegexes = headersToMask.map(header => new RegExp(`^${header}$`))
+  headers
+    .filter(({ name }) => headerRegexes.some(regex => regex.test(name)))
+    .forEach(header => {
+      log.debug(`Masked header ${header.name} in ${id.getFullName()}`)
+      header.value = MASK_VALUE
+    })
+}
+
+/**
+ * Replace sensitive data in the NaCls with some placeholder
+ * currently only relevant for Automations' headers
+ */
+const filter: FilterCreator = ({ config }) => ({
+  onFetch: async elements => {
+    if (config.masking.headers.length === 0) {
+      return
+    }
+
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE)
+      .forEach(instance => {
+        walkOnElement({
+          element: instance,
+          func: ({ path, value }) => {
+            if (path.name === 'headers') {
+              maskHeaders(value, config.masking.headers, instance.elemID)
+            }
+
+            return WALK_NEXT_STEP.RECURSE
+          },
+        })
+      })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/masking.ts
+++ b/packages/jira-adapter/src/filters/masking.ts
@@ -31,8 +31,8 @@ type Header = {
 
 const HEADERS_SCHEME = Joi.array().items(
   Joi.object({
-    name: string(),
-    value: string(),
+    name: string().allow('').required(),
+    value: string().allow('').required(),
   }).unknown(true)
 )
 
@@ -58,7 +58,7 @@ const maskHeaders = (
  */
 const filter: FilterCreator = ({ config }) => ({
   onFetch: async elements => {
-    if (config.masking.headers.length === 0) {
+    if (config.masking.automationHeaders.length === 0) {
       return
     }
 
@@ -70,7 +70,7 @@ const filter: FilterCreator = ({ config }) => ({
           element: instance,
           func: ({ path, value }) => {
             if (path.name === 'headers' && isHeaders(value)) {
-              maskHeaders(value, config.masking.headers, instance.elemID)
+              maskHeaders(value, config.masking.automationHeaders, instance.elemID)
             }
 
             return WALK_NEXT_STEP.RECURSE

--- a/packages/jira-adapter/test/change_validators/masking.test.ts
+++ b/packages/jira-adapter/test/change_validators/masking.test.ts
@@ -1,0 +1,88 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { MASK_VALUE } from '../../src/filters/masking'
+import { maskingValidator } from '../../src/change_validators/masking'
+import { AUTOMATION_TYPE, JIRA } from '../../src/constants'
+
+describe('maskingValidator', () => {
+  let type: ObjectType
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    type = new ObjectType({ elemID: new ElemID(JIRA, AUTOMATION_TYPE) })
+    instance = new InstanceElement(
+      'instance',
+      type,
+      {
+        headers: [
+          {
+            name: 'masked',
+            value: MASK_VALUE,
+          },
+          {
+            name: 'notMasked',
+            value: 'value',
+          },
+        ],
+      }
+    )
+  })
+
+  it('should return an info have a masked value', async () => {
+    expect(await maskingValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Info',
+        message: 'Masked data will be deployed to the service',
+        detailedMessage: '',
+        deployActions: {
+          preAction: {
+            title: 'Masked data will be overridden in the service',
+            description: `${instance.elemID.getFullName()} contains masked values which will override the real values in the service when deploying`,
+            subActions: [],
+          },
+          postAction: {
+            title: 'Update masked data in the service',
+            description: `Please updated the masked values that were deployed to the service in ${instance.elemID.getFullName()} in the service`,
+            subActions: [
+              `In the Jira UI, open System > Global automation, and open the automation of ${instance.elemID.getFullName()}`,
+              'Go over the headers with masked values (headers with <SECRET_TOKEN> values) and set the real values',
+              'Click "Save"',
+              'Click "Publish changes"',
+            ],
+          },
+        },
+      },
+    ])
+  })
+
+  it('should not return an info have a masked value', async () => {
+    instance.value.headers = {
+      name: 'notMasked',
+      value: 'value',
+    }
+    expect(await maskingValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([])
+  })
+})

--- a/packages/jira-adapter/test/change_validators/masking.test.ts
+++ b/packages/jira-adapter/test/change_validators/masking.test.ts
@@ -58,17 +58,40 @@ describe('maskingValidator', () => {
         message: 'Masked data will be deployed to the service',
         detailedMessage: '',
         deployActions: {
-          preAction: {
-            title: 'Masked data will be overridden in the service',
-            description: `${instance.elemID.getFullName()} contains masked values which will override the real values in the service when deploying`,
-            subActions: [],
-          },
           postAction: {
-            title: 'Update masked data in the service',
-            description: `Please updated the masked values that were deployed to the service in ${instance.elemID.getFullName()} in the service`,
+            title: 'Update deployed masked data',
+            description: 'Please update the masked values that were deployed to Jira in the jira.Automation.instance.instance automation',
             subActions: [
-              `Go to https://ori-salto-test.atlassian.net/jira/settings/automation#/rule-list, and open the automation of ${instance.elemID.getFullName()}`,
-              'Go over the headers with masked values (headers with <SECRET_TOKEN> values) and set the real values',
+              'Go to https://ori-salto-test.atlassian.net/jira/settings/automation#/rule-list, and open the jira.Automation.instance.instance automation',
+              'Go over the headers with masked values (headers with <SECRET_TOKEN> value) and set the real values',
+              'Click "Save"',
+              'Click "Publish changes"',
+            ],
+          },
+        },
+      },
+    ])
+  })
+
+  it('should return a warning on modification if have a masked value', async () => {
+    expect(await maskingValidator(client)([
+      toChange({
+        before: instance,
+        after: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Warning',
+        message: 'Masked data will be deployed to the service',
+        detailedMessage: 'jira.Automation.instance.instance contains masked values which will override the real values in the service when deploying and may prevent this automation from operating correctly',
+        deployActions: {
+          postAction: {
+            title: 'Update deployed masked data',
+            description: 'Please update the masked values that were deployed to Jira in the jira.Automation.instance.instance automation',
+            subActions: [
+              'Go to https://ori-salto-test.atlassian.net/jira/settings/automation#/rule-list, and open the jira.Automation.instance.instance automation',
+              'Go over the headers with masked values (headers with <SECRET_TOKEN> value) and set the real values',
               'Click "Save"',
               'Click "Publish changes"',
             ],

--- a/packages/jira-adapter/test/change_validators/masking.test.ts
+++ b/packages/jira-adapter/test/change_validators/masking.test.ts
@@ -17,12 +17,16 @@ import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter
 import { MASK_VALUE } from '../../src/filters/masking'
 import { maskingValidator } from '../../src/change_validators/masking'
 import { AUTOMATION_TYPE, JIRA } from '../../src/constants'
+import { mockClient } from '../utils'
+import JiraClient from '../../src/client/client'
 
 describe('maskingValidator', () => {
   let type: ObjectType
   let instance: InstanceElement
+  let client: JiraClient
 
   beforeEach(() => {
+    client = mockClient().client
     type = new ObjectType({ elemID: new ElemID(JIRA, AUTOMATION_TYPE) })
     instance = new InstanceElement(
       'instance',
@@ -43,7 +47,7 @@ describe('maskingValidator', () => {
   })
 
   it('should return an info have a masked value', async () => {
-    expect(await maskingValidator([
+    expect(await maskingValidator(client)([
       toChange({
         after: instance,
       }),
@@ -63,7 +67,7 @@ describe('maskingValidator', () => {
             title: 'Update masked data in the service',
             description: `Please updated the masked values that were deployed to the service in ${instance.elemID.getFullName()} in the service`,
             subActions: [
-              `In the Jira UI, open System > Global automation, and open the automation of ${instance.elemID.getFullName()}`,
+              `Go to https://ori-salto-test.atlassian.net/jira/settings/automation#/rule-list, and open the automation of ${instance.elemID.getFullName()}`,
               'Go over the headers with masked values (headers with <SECRET_TOKEN> values) and set the real values',
               'Click "Save"',
               'Click "Publish changes"',
@@ -79,7 +83,7 @@ describe('maskingValidator', () => {
       name: 'notMasked',
       value: 'value',
     }
-    expect(await maskingValidator([
+    expect(await maskingValidator(client)([
       toChange({
         after: instance,
       }),

--- a/packages/jira-adapter/test/filters/masking.test.ts
+++ b/packages/jira-adapter/test/filters/masking.test.ts
@@ -1,0 +1,95 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { mockClient } from '../utils'
+import maskingFilter, { MASK_VALUE } from '../../src/filters/masking'
+import { Filter } from '../../src/filter'
+import { DEFAULT_CONFIG, JiraConfig } from '../../src/config'
+import { AUTOMATION_TYPE, JIRA } from '../../src/constants'
+
+describe('maskingFilter', () => {
+  let filter: Filter
+  let type: ObjectType
+  let instance: InstanceElement
+  let config: JiraConfig
+
+  beforeEach(async () => {
+    const { client, paginator } = mockClient()
+
+    config = _.cloneDeep(DEFAULT_CONFIG)
+
+    filter = maskingFilter({
+      client,
+      paginator,
+      config,
+      elementsSource: buildElementsSourceFromElements([]),
+    })
+
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, AUTOMATION_TYPE),
+    })
+
+    instance = new InstanceElement(
+      'instance',
+      type,
+      {
+        headers: [
+          {
+            name: 'name1',
+            value: 'value1',
+          },
+          {
+            name: 'name2',
+            value: 'value2',
+          },
+          {
+            name: 'aname3',
+            value: 'avalue3',
+          },
+        ],
+      }
+    )
+  })
+
+  describe('onFetch', () => {
+    it('should mask the sensitive headers', async () => {
+      config.masking.headers = [
+        'name.*',
+      ]
+
+      await filter.onFetch?.([instance])
+
+      expect(instance.value).toEqual({
+        headers: [
+          {
+            name: 'name1',
+            value: MASK_VALUE,
+          },
+          {
+            name: 'name2',
+            value: MASK_VALUE,
+          },
+          {
+            name: 'aname3',
+            value: 'avalue3',
+          },
+        ],
+      })
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/masking.test.ts
+++ b/packages/jira-adapter/test/filters/masking.test.ts
@@ -68,7 +68,7 @@ describe('maskingFilter', () => {
 
   describe('onFetch', () => {
     it('should mask the sensitive headers', async () => {
-      config.masking.headers = [
+      config.masking.automationHeaders = [
         'name.*',
       ]
 


### PR DESCRIPTION
Added configuration option to replace sensitive header values in Automation with a masked value and a change validator to tell the user to update the values in the service

---
_Release Notes_: 
_Jira Adapter_:
- Added `masking.headers` configuration option to mask sensitive data from Automation NaCls

---
_User Notifications_: 
None