### PR TITLE
SALTO-2247 update revenue recognition type name

### DIFF
--- a/packages/zuora-billing-adapter/src/config.ts
+++ b/packages/zuora-billing-adapter/src/config.ts
@@ -616,6 +616,9 @@ const DEFAULT_SWAGGER_CONFIG: ZuoraApiConfig['swagger'] = {
 const SETTINGS_SWAGGER_CONFIG: ZuoraApiConfig['settingsSwagger'] = {
   typeNameOverrides: [
     { originalName: 'settings__tax_engines@uub', newName: `${SETTINGS_TYPE_PREFIX}TaxEngines` },
+    // map to old name for backward-compatibility reasons -
+    // can be updated once all workspaces are migrated to SALTO-1792
+    { originalName: `${SETTINGS_TYPE_PREFIX}RevenueRecognitionRuleObject`, newName: `${SETTINGS_TYPE_PREFIX}revenueRecognitionRuleDtos` },
   ],
 }
 

--- a/packages/zuora-billing-adapter/system_config_doc.md
+++ b/packages/zuora-billing-adapter/system_config_doc.md
@@ -108,6 +108,10 @@ zuora_billing {
           originalName = "settings__tax_engines@uub"
           newName = "Settings_TaxEngines"
         },
+        {
+          originalName = "Settings_RevenueRecognitionRuleObject"
+          newName = "Settings_revenueRecognitionRuleDtos"
+        },
       ]
     }
     typeDefaults = {


### PR DESCRIPTION
There was a change in the schema name (from earlier today) in the `/settings/list` response which is causing the fetch of the revenue recognition rules to fail. mapping it back to the old name, so that no upgrades are needed in existing workspaces.



---
_Release Notes_: 
Zuora Billing Adapter:
* Fix fetch failure in the `Settings_revenueRecognitionRuleDtos` type

---
_User Notifications_: 
None