### PR TITLE
SALTO-1945: Removed locked fields from field configuration

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -44,7 +44,7 @@ import mapListsFilter from './filters/map_lists'
 import missingStatusesFilter from './filters/statuses/missing_statuses'
 import issueTypeScreenSchemeFilter from './filters/issue_type_screen_scheme'
 import fieldConfigurationFilter from './filters/field_configuration'
-import fieldConfigurationTrashedFieldsFilter from './filters/field_configuration_trashed_fields'
+import fieldConfigurationIrrelevantFields from './filters/field_configuration_irrelevant_fields'
 import fieldConfigurationSchemeFilter from './filters/field_configurations_scheme'
 import dashboardFilter from './filters/dashboard/dashboard_deployment'
 import dashboardLayoutFilter from './filters/dashboard/dashboard_layout'
@@ -156,7 +156,7 @@ export const DEFAULT_FILTERS = [
   removeSelfFilter,
   fieldReferencesFilter,
   // Must run after fieldReferencesFilter
-  fieldConfigurationTrashedFieldsFilter,
+  fieldConfigurationIrrelevantFields,
   // Must run after fieldReferencesFilter
   sortListsFilter,
   // Must run after fieldReferencesFilter

--- a/packages/jira-adapter/src/filters/field_configuration_irrelevant_fields.ts
+++ b/packages/jira-adapter/src/filters/field_configuration_irrelevant_fields.ts
@@ -23,7 +23,7 @@ const log = logger(module)
 const filter: FilterCreator = ({ config }) => ({
   onFetch: async elements => {
     if (!config.fetch.includeTypes.includes('Fields')) {
-      log.warn('Fields is not included in the fetch list so we cannot know what fields is in trash. Skipping the field_configuration_trashed_fields')
+      log.warn('Fields is not included in the fetch list so we cannot know whether they are relevant. Skipping the field_configuration_trashed_fields')
       return
     }
 
@@ -34,11 +34,12 @@ const filter: FilterCreator = ({ config }) => ({
       .forEach(instance => {
         const [fields, trashedFields] = _.partition(
           instance.value.fields,
-          field => isReferenceExpression(field.id),
+          field => isReferenceExpression(field.id)
+            && !field.id.value.value.isLocked
         )
         instance.value.fields = fields
         if (trashedFields.length !== 0) {
-          log.debug(`Removed from ${instance.elemID.getFullName()} fields with ids: ${trashedFields.map(field => field.id).join(', ')}, because they are not references and thus assumed to be in trash`)
+          log.debug(`Removed from ${instance.elemID.getFullName()} fields with ids: ${trashedFields.map(field => field.id).join(', ')}`)
         }
       })
   },


### PR DESCRIPTION
Removed locked fields from field configuration since they are not editable in the UI and create references to instances that cannot be deployed

---
_Release Notes_: 
_Jira Adapter_:
- Removed locked fields from field configuration

---
_User Notifications_: 
_Jira Adapter_:
- Removed locked fields from field configuration