### PR TITLE
Skip building a source map when parsing NaCl unless it is really needed

### DIFF
--- a/packages/workspace/src/parser/parse.ts
+++ b/packages/workspace/src/parser/parse.ts
@@ -34,6 +34,10 @@ const log = logger(module)
 // Re-export these types because we do not want code outside the parser to import hcl
 export type SourceRange = InternalSourceRange
 
+export type ParseOptions = {
+  createSourceMap?: boolean
+}
+
 /**
  * Parse a Nacl file
  *
@@ -47,9 +51,10 @@ export const parse = async (
   naclFile: Buffer,
   filename: string,
   functions: Functions = {},
+  options?: ParseOptions,
 ): Promise<Required<ParseResult>> => {
   const srcString = naclFile.toString()
-  return parseBuffer(srcString, filename, functions)
+  return parseBuffer(srcString, filename, functions, options?.createSourceMap)
 }
 
 export type Token = {

--- a/packages/workspace/test/parser/parse.test.ts
+++ b/packages/workspace/test/parser/parse.test.ts
@@ -25,7 +25,7 @@ import { registerTestFunction } from '../utils'
 import {
   Functions,
 } from '../../src/parser/functions'
-import { SourceRange, parse, SourceMap, tokenizeContent } from '../../src/parser'
+import { SourceRange, parse, SourceMap, tokenizeContent, ParseResult } from '../../src/parser'
 
 const { awu } = collections.asynciterable
 const funcName = 'funcush'
@@ -817,6 +817,22 @@ describe('Salto parser', () => {
     expect(result.elements).toHaveLength(1)
     expect((result.elements as InstanceElement[])[0].elemID)
       .toEqual(new ElemID('salesforce', 'anotherType'))
+  })
+
+  describe('parse options', () => {
+    describe('with createSourceMap=false', () => {
+      let result: ParseResult
+      beforeEach(async () => {
+        const body = `
+        type salesforce.Bla {
+          asd = "foo"
+        }`
+        result = await parse(Buffer.from(body), 'none', functions, { createSourceMap: false })
+      })
+      it('should not create a source map', () => {
+        expect(result.sourceMap).toBeUndefined()
+      })
+    })
   })
 
   describe('tokenizeContent', () => {


### PR DESCRIPTION
Building a source map during NaCl parse makes parsing significantly slower.
It also greatly increases memory consumption.
It is also not actually needed in most flows and it is actually usually discarded.

Exposing the internal option to skip generating a source map and using it to improve overall perforamnce
when loading a workspace without a cache

---

Almost all flows that use parse actually don't need the source map.
However, since generating it was the default and this is an exported function that can be used in other projects, I kept the default behavior as-is for now and only skipped the source map where it was especially costly.
In a future PR we will change this default (just need to make sure all external users of this api that need a source map pass that option explicitly)

---
_Release Notes_: 
Core:
- Improve workspace loading times and memory consumption when working with out-dated cache

---
_User Notifications_: 
_None_