### PR TITLE
SALTO-2231, SALTO-2241: Add more errors to add exclude suggestions

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -97,8 +97,12 @@ const isAlreadyDeletedError = (error: SfError): boolean => (
 export type ErrorFilter = (error: Error) => boolean
 
 const NON_TRANSIENT_ERROR_TYPES = [
-  'sf:UNKNOWN_EXCEPTION',
+  'sf:DUPLICATE_VALUE',
+  'sf:INVALID_CROSS_REFERENCE_KEY',
+  'sf:INVALID_ID_FIELD',
+  'sf:INVALID_FIELD',
   'sf:INVALID_TYPE',
+  'sf:UNKNOWN_EXCEPTION',
 ]
 const isSFDCUnhandledException = (error: Error): boolean => (
   !NON_TRANSIENT_ERROR_TYPES.includes(error.name)


### PR DESCRIPTION
Add some new errors we have seen in fetch to the list of errors which will cause the element to be excluded with a suggestion, and let the fetch continue.

---

None

---
_Release Notes_: 

Salesforce - More error types will now cause an exclude config suggestion instead of just failing a fetch

---
_User Notifications_: 

None