### PR TITLE
SALTO-2250 fail deploy on SettingsDeployError if on changes matched the failedConfigType list

### DIFF
--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -200,14 +200,19 @@ export default class NetsuiteClient {
           const failedElemIDs = NetsuiteClient.getFailedSdfDeployChangesElemIDs(
             error, changesToDeploy
           )
-          log.debug('sdf failed to deploy: %o', Array.from(failedElemIDs))
+          log.debug('objects deploy error: sdf failed to deploy: %o', Array.from(failedElemIDs))
           _.remove(
             changesToDeploy,
             change => failedElemIDs.has(getChangeData(change).elemID.getFullName())
           )
         } else if (error instanceof SettingsDeployError) {
           const { failedConfigTypes } = error
-          log.debug('sdf failed to deploy: %o', Array.from(failedConfigTypes))
+          if (!changesToDeploy.some(change =>
+            failedConfigTypes.has(getChangeData(change).elemID.typeName))) {
+            log.debug('settings deploy error: no changes matched the failedConfigType list: %o', Array.from(failedConfigTypes))
+            return { errors, appliedChanges: [] }
+          }
+          log.debug('settings deploy error: sdf failed to deploy: %o', Array.from(failedConfigTypes))
           _.remove(
             changesToDeploy,
             change => failedConfigTypes.has(getChangeData(change).elemID.typeName)

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -105,6 +105,24 @@ describe('NetsuiteClient', () => {
         })
         expect(mockSdfDeploy).toHaveBeenCalledTimes(2)
       })
+      it('should not try again to deploy if SettingsDeployError doesn\'t contain an actual failing change', async () => {
+        const type = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
+        const settingsDeployError = new SettingsDeployError('error', new Set(['settingsType']))
+        mockSdfDeploy.mockRejectedValue(settingsDeployError)
+        const change = toChange({
+          after: new InstanceElement('instance', type, { scriptid: 'someObject' }),
+        })
+        expect(await client.deploy(
+          [change],
+          SDF_CHANGE_GROUP_ID,
+          false,
+          mockElementsSourceIndex
+        )).toEqual({
+          errors: [settingsDeployError],
+          appliedChanges: [],
+        })
+        expect(mockSdfDeploy).toHaveBeenCalledTimes(1)
+      })
 
       describe('features', () => {
         const type = featuresType()


### PR DESCRIPTION
fail deploy on SettingsDeployError if on changes matched the failedConfigType list

---
_Release Notes_: 
Netsuite Adapter:
- bugfix: SDF deploy caused an endless loop

---
_User Notifications_: 
None
