### PR TITLE
SALTO-2202: better find channels in trigger definition

### DIFF
--- a/packages/zendesk-support-adapter/src/filters/hardcoded_channel.ts
+++ b/packages/zendesk-support-adapter/src/filters/hardcoded_channel.ts
@@ -65,7 +65,8 @@ const filterCreator: FilterCreator = () => ({
       return
     }
     const channels = (triggerDefinitionInstance.value.conditions_all ?? [])
-      .find((condition: Values) => condition?.title === 'Channel')?.values
+      // Both via_id and current_via_id should includes the same channels and both should appear
+      .find((condition: Values) => ['via_id', 'current_via_id'].includes(condition?.subject))?.values
     if (!isChannels(channels)) {
       return
     }

--- a/packages/zendesk-support-adapter/src/filters/remove_definition_instances.ts
+++ b/packages/zendesk-support-adapter/src/filters/remove_definition_instances.ts
@@ -13,7 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, isObjectType } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { isInstanceElement } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
 
 // We don't fetch those type names (except for trigger_definition) by default
@@ -27,16 +28,14 @@ const DEFINITION_TYPE_NAMES = [
   'routing_attribute_definition',
 ]
 
+/**
+ * Removes the definition instances
+ */
 const filterCreator: FilterCreator = () => ({
   onFetch: async elements => {
-    // NOTE: changed to be hidden (instead of removing the elements) in order to debug SALTO-2202
-    // We will change the implementation back to removing the elements once we will figure it out
-    elements
-      .filter(element => DEFINITION_TYPE_NAMES.includes(element.elemID.typeName))
-      .filter(isObjectType)
-      .forEach(element => {
-        element.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
-      })
+    _.remove(elements,
+      element =>
+        isInstanceElement(element) && DEFINITION_TYPE_NAMES.includes(element.elemID.typeName))
   },
 })
 

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -373,8 +373,6 @@ describe('adapter', () => {
           'zendesk_support.trigger_category.instance.Custom_Events___edited@ssbs',
           'zendesk_support.trigger_category.instance.Notifications',
           'zendesk_support.trigger_definition',
-          // We should remove this instance from the expected list once we done with SALTO-2202
-          'zendesk_support.trigger_definition.instance',
           'zendesk_support.trigger_definition__actions',
           'zendesk_support.trigger_definition__actions__metadata',
           'zendesk_support.trigger_definition__actions__metadata__phone_numbers',

--- a/packages/zendesk-support-adapter/test/filters/hardcoded_channel.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/hardcoded_channel.test.ts
@@ -36,6 +36,7 @@ describe('hardcoded channel filter', () => {
       conditions_all: [
         {
           title: 'Channel',
+          subject: 'via_id',
           operators: [
             { value: 'is', title: 'Is', terminal: false },
             { value: 'is_not', title: 'Is not', terminal: false },
@@ -130,6 +131,7 @@ describe('hardcoded channel filter', () => {
           conditions_all: [
             {
               title: 'Channel',
+              subject: 'via_id',
               values: [
                 { value: '0', enabled: true },
                 { value: '4', title: 'Email', enabled: true },
@@ -159,6 +161,7 @@ describe('hardcoded channel filter', () => {
           conditions_all: [
             {
               title: 'Channel',
+              subject: 'via_id',
               values: [
                 { value: '4', title: 'Email', enabled: true },
                 { value: '4', title: 'Test', enabled: true },
@@ -187,7 +190,8 @@ describe('hardcoded channel filter', () => {
         {
           conditions_all: [
             {
-              title: 'Status',
+              title: 'Test',
+              subject: 'another_test',
               values: [
                 { value: '4', title: 'Email', enabled: true },
                 { value: '4', title: 'Test', enabled: true },

--- a/packages/zendesk-support-adapter/test/filters/remove_definition_instances.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/remove_definition_instances.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
@@ -49,9 +49,7 @@ describe('remove definition instances', () => {
   })
 
   describe('onFetch', () => {
-    // NOTE: We disabled this test in order to debug SALTO-2202
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('should remove the instances of the relevant types', async () => {
+    it('should change the hidden value annotation of the relevant types', async () => {
       const elements = [
         randomObjType, instanceRandomObj, triggerDefinitionObjType,
         triggerDefinition, macrosActionsObjType, macrosActions,
@@ -63,21 +61,6 @@ describe('remove definition instances', () => {
         'zendesk_support.trigger_definition',
         'zendesk_support.macros_actions',
       ])
-    })
-    // NOTE: Should be removed once we finish to debug SALTO-2202
-    it('should change the hidden value annotation of the relevant types', async () => {
-      const elements = [
-        randomObjType, instanceRandomObj, triggerDefinitionObjType, macrosActionsObjType,
-      ]
-      await filter.onFetch(elements)
-      expect(elements.map(e => e.elemID.getFullName())).toEqual([
-        'zendesk_support.obj',
-        'zendesk_support.obj.instance.test',
-        'zendesk_support.trigger_definition',
-        'zendesk_support.macros_actions',
-      ])
-      expect(triggerDefinitionObjType.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toEqual(true)
-      expect(macrosActionsObjType.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toEqual(true)
     })
   })
 })


### PR DESCRIPTION
_better find channels in trigger definition_

---

_Additional context for reviewer_
In some Zendesk instances that their locale is not english, the title of the relevant condition was not Channel but something in the default language. We are now check for the subject which is consistent

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
