### PR TITLE
SALTO-1792: added name filter to Jira

### DIFF
--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -46,7 +46,7 @@ export type AdapterApiConfig<
 
 type FetchEntry<T extends Record<string, unknown> | undefined> = {
   type: string
-  filters?: T
+  criteria?: T
 }
 
 export type UserFetchConfig<T extends Record<string, unknown> | undefined = undefined> = {
@@ -120,7 +120,7 @@ export const createAdapterApiConfigType = ({
 export const createUserFetchConfigType = (
   adapter: string,
   additionalFields?: Record<string, FieldDefinition>,
-  fetchFiltersType?: ObjectType,
+  fetchCriteriaType?: ObjectType,
 ): ObjectType => {
   const fetchEntryType = new ObjectType({
     elemID: new ElemID(adapter, 'FetchEntry'),
@@ -129,8 +129,8 @@ export const createUserFetchConfigType = (
     },
   })
 
-  if (fetchFiltersType !== undefined) {
-    fetchEntryType.fields.filters = new Field(fetchEntryType, 'filters', fetchFiltersType)
+  if (fetchCriteriaType !== undefined) {
+    fetchEntryType.fields.criteria = new Field(fetchEntryType, 'criteria', fetchCriteriaType)
   }
 
   return new ObjectType({

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import {
-  ElemID, ObjectType, BuiltinTypes, FieldDefinition, ListType, MapType,
+  ElemID, ObjectType, BuiltinTypes, FieldDefinition, ListType, MapType, Field,
 } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import type { TransformationConfig, TransformationDefaultConfig } from './transformation'
@@ -44,13 +44,14 @@ export type AdapterApiConfig<
   supportedTypes: Record<string, string[]>
 }
 
-type FetchEntry = {
+type FetchEntry<T extends Record<string, unknown> | undefined> = {
   type: string
+  filters?: T
 }
 
-export type UserFetchConfig = {
-  include: FetchEntry[]
-  exclude: FetchEntry[]
+export type UserFetchConfig<T extends Record<string, unknown> | undefined = undefined> = {
+  include: FetchEntry<T>[]
+  exclude: FetchEntry<T>[]
 }
 
 export const createAdapterApiConfigType = ({
@@ -119,6 +120,7 @@ export const createAdapterApiConfigType = ({
 export const createUserFetchConfigType = (
   adapter: string,
   additionalFields?: Record<string, FieldDefinition>,
+  fetchFiltersType?: ObjectType,
 ): ObjectType => {
   const fetchEntryType = new ObjectType({
     elemID: new ElemID(adapter, 'FetchEntry'),
@@ -126,6 +128,10 @@ export const createUserFetchConfigType = (
       type: { refType: BuiltinTypes.STRING },
     },
   })
+
+  if (fetchFiltersType !== undefined) {
+    fetchEntryType.fields.filters = new Field(fetchEntryType, 'filters', fetchFiltersType)
+  }
 
   return new ObjectType({
     elemID: new ElemID(adapter, 'userFetchConfig'),

--- a/packages/adapter-components/src/elements/element_getter.ts
+++ b/packages/adapter-components/src/elements/element_getter.ts
@@ -46,7 +46,7 @@ export const getElementsWithContext = async <E extends Element>({
   types,
   typeElementGetter,
 }: {
-  fetchQuery: ElementQuery
+  fetchQuery: Pick<ElementQuery, 'isTypeMatch'>
   supportedTypes: Record<string, string[]>
   types: Record<string, TypeConfig>
   typeElementGetter: (args: {

--- a/packages/adapter-components/src/elements/query.ts
+++ b/packages/adapter-components/src/elements/query.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { InstanceElement, Value } from '@salto-io/adapter-api'
 import { MockInterface } from '@salto-io/test-utils'
 import { UserFetchConfig } from '../config'
 
@@ -27,26 +28,59 @@ export const INCLUDE_ALL_CONFIG = {
 
 export type ElementQuery = {
   isTypeMatch: (typeName: string) => boolean
+  isInstanceMatch: (instance: InstanceElement) => boolean
 }
+
+export type QueryPredicate = (
+  args: {
+    instance: InstanceElement
+    filterValue: Value
+  }
+) => boolean
 
 const isTypeMatch = (typeName: string, typeRegex: string): boolean =>
   new RegExp(`^${typeRegex}$`).test(typeName)
 
-export const createElementQuery = (
-  fetchConfig: UserFetchConfig
+const isPredicatesMatch = (
+  instance: InstanceElement,
+  predicates: Record<string, QueryPredicate>,
+  filters: Record<string, unknown>,
+): boolean => Object.entries(filters)
+  .filter(([key]) => key in predicates)
+  .every(([key, value]) => predicates[key]({ instance, filterValue: value }))
+
+export const createElementQuery = <T extends Record<string, unknown>>(
+  fetchConfig: UserFetchConfig<T | undefined>,
+  predicates: Record<string, QueryPredicate> = {},
 ): ElementQuery => ({
-  isTypeMatch: (typeName: string) => {
-    const { include, exclude } = fetchConfig
-    const isIncluded = include.some(({ type: typeRegex }) =>
-      isTypeMatch(typeName, typeRegex))
+    isTypeMatch: (typeName: string) => {
+      const { include, exclude } = fetchConfig
+      const isIncluded = include.some(({ type: typeRegex }) =>
+        isTypeMatch(typeName, typeRegex))
 
-    const isExcluded = exclude.some(({ type: excludedType }) =>
-      isTypeMatch(typeName, excludedType))
+      const isExcluded = exclude
+        .filter(({ filters }) => filters === undefined)
+        .some(({ type: excludedType }) =>
+          isTypeMatch(typeName, excludedType))
 
-    return isIncluded && !isExcluded
-  },
-})
+      return isIncluded && !isExcluded
+    },
+
+    isInstanceMatch: (instance: InstanceElement) => {
+      const { include, exclude } = fetchConfig
+      const isIncluded = include.some(({ type, filters }) =>
+        isTypeMatch(instance.elemID.typeName, type)
+      && (filters === undefined || isPredicatesMatch(instance, predicates, filters)))
+
+      const isExcluded = exclude.some(({ type, filters }) =>
+        isTypeMatch(instance.elemID.typeName, type)
+      && (filters === undefined || isPredicatesMatch(instance, predicates, filters)))
+
+      return isIncluded && !isExcluded
+    },
+  })
 
 export const createMockQuery = (): MockInterface<ElementQuery> => ({
   isTypeMatch: jest.fn().mockReturnValue(true),
+  isInstanceMatch: jest.fn().mockReturnValue(true),
 })

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -461,7 +461,7 @@ export const getAllInstances = async ({
 }: {
   paginator: Paginator
   apiConfig: Pick<AdapterSwaggerApiConfig, 'types' | 'typeDefaults'>
-  fetchQuery: ElementQuery
+  fetchQuery: Pick<ElementQuery, 'isTypeMatch'>
   supportedTypes: Record<string, string[]>
   objectTypes: Record<string, ObjectType>
   nestedFieldFinder?: FindNestedFieldFunc

--- a/packages/adapter-components/src/filter_utils.ts
+++ b/packages/adapter-components/src/filter_utils.ts
@@ -16,6 +16,7 @@
 import { ElemIdGetter } from '@salto-io/adapter-api'
 import { filter } from '@salto-io/adapter-utils'
 import { Paginator } from './client'
+import { ElementQuery } from './elements/query'
 
 export type Filter<TResult extends void | filter.FilterResult = void> = filter.Filter<TResult>
 
@@ -28,6 +29,7 @@ export type FilterOpts<TClient, TContext, TAdditional={}> = {
   paginator: Paginator
   config: TContext
   getElemIdFunc?: ElemIdGetter
+  fetchQuery: ElementQuery
 } & TAdditional
 
 export type FilterCreator<

--- a/packages/adapter-components/src/filters/query.ts
+++ b/packages/adapter-components/src/filters/query.ts
@@ -38,7 +38,7 @@ export const queryFilterCreator: <
     )
 
     if (removedInstances.length > 0) {
-      log.debug(`Omitted ${removedInstances.length} instances that did not match the fetch filters. The first 100 ids that were removed are: ${removedInstances.slice(0, 100).map(e => e.elemID.getFullName()).join(', ')}`)
+      log.debug(`Omitted ${removedInstances.length} instances that did not match the fetch criteria. The first 100 ids that were removed are: ${removedInstances.slice(0, 100).map(e => e.elemID.getFullName()).join(', ')}`)
     }
   },
 })

--- a/packages/adapter-components/src/filters/query.ts
+++ b/packages/adapter-components/src/filters/query.ts
@@ -1,0 +1,34 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { isInstanceElement } from '@salto-io/adapter-api'
+import { filter } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { FilterCreator } from '../filter_utils'
+import { ElementQuery } from '../elements/query'
+
+export const queryFilterCreator: <
+  TClient,
+  TContext,
+  TResult extends void | filter.FilterResult,
+  TAdditional extends { fetchQuery: ElementQuery }
+>() => FilterCreator<TClient, TContext, TResult, TAdditional> = () => ({ fetchQuery }) => ({
+  onFetch: async elements => {
+    _.remove(
+      elements,
+      element => isInstanceElement(element) && !fetchQuery.isInstanceMatch(element)
+    )
+  },
+})

--- a/packages/adapter-components/test/elements/query.test.ts
+++ b/packages/adapter-components/test/elements/query.test.ts
@@ -62,7 +62,7 @@ describe('query', () => {
           include: [
             {
               type: 'type1.*',
-              filters: {
+              criteria: {
                 name: 'name1',
               },
             },
@@ -74,7 +74,7 @@ describe('query', () => {
           ],
         },
         {
-          name: ({ instance, filterValue }) => instance.value.name === filterValue,
+          name: ({ instance, value }) => instance.value.name === value,
         }
       )
       expect(query.isTypeMatch('type11')).toBeTruthy()
@@ -91,14 +91,14 @@ describe('query', () => {
           exclude: [
             {
               type: 'type12.*',
-              filters: {
+              criteria: {
                 name: 'name1',
               },
             },
           ],
         },
         {
-          name: ({ instance, filterValue }) => instance.value.name === filterValue,
+          name: ({ instance, value }) => instance.value.name === value,
         }
       )
       expect(query.isTypeMatch('type12')).toBeTruthy()
@@ -114,7 +114,7 @@ describe('query', () => {
           include: [
             {
               type: 'type1.*',
-              filters: {
+              criteria: {
                 name: 'name1',
               },
             },
@@ -122,7 +122,7 @@ describe('query', () => {
           exclude: [],
         },
         {
-          name: ({ instance, filterValue }) => instance.value.name === filterValue,
+          name: ({ instance, value }) => instance.value.name === value,
         }
       )
       expect(query.isInstanceMatch(inst)).toBeFalsy()
@@ -141,14 +141,14 @@ describe('query', () => {
           exclude: [
             {
               type: 'type1.*',
-              filters: {
+              criteria: {
                 name: 'name1',
               },
             },
           ],
         },
         {
-          name: ({ instance, filterValue }) => instance.value.name === filterValue,
+          name: ({ instance, value }) => instance.value.name === value,
         }
       )
       expect(query.isInstanceMatch(inst)).toBeTruthy()

--- a/packages/adapter-components/test/elements/query.test.ts
+++ b/packages/adapter-components/test/elements/query.test.ts
@@ -13,24 +13,35 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { createElementQuery, ElementQuery } from '../../src/elements/query'
 
 describe('query', () => {
-  describe('createElementsQuery', () => {
+  describe('createElementQuery', () => {
     let query: ElementQuery
+    let inst: InstanceElement
+
     beforeEach(() => {
-      query = createElementQuery({
-        include: [
-          {
-            type: 'type1.*',
-          },
-        ],
-        exclude: [
-          {
-            type: 'type12.*',
-          },
-        ],
-      })
+      query = createElementQuery(
+        {
+          include: [
+            {
+              type: 'type1.*',
+            },
+          ],
+          exclude: [
+            {
+              type: 'type12.*',
+            },
+          ],
+        },
+      )
+
+      inst = new InstanceElement(
+        'instance',
+        new ObjectType({ elemID: new ElemID('adapter', 'type11') }),
+        {},
+      )
     })
 
     it('isTypeMatch should return true if the type matches the include but not the exclude', () => {
@@ -43,6 +54,106 @@ describe('query', () => {
 
     it('isTypeMatch should return false if the type does not match the include', () => {
       expect(query.isTypeMatch('atype11')).toBeFalsy()
+    })
+
+    it('isTypeMatch should match if include contain filter', () => {
+      query = createElementQuery(
+        {
+          include: [
+            {
+              type: 'type1.*',
+              filters: {
+                name: 'name1',
+              },
+            },
+          ],
+          exclude: [
+            {
+              type: 'type12.*',
+            },
+          ],
+        },
+        {
+          name: ({ instance, filterValue }) => instance.value.name === filterValue,
+        }
+      )
+      expect(query.isTypeMatch('type11')).toBeTruthy()
+    })
+
+    it('isTypeMatch should match if exclude contain filter', () => {
+      query = createElementQuery(
+        {
+          include: [
+            {
+              type: 'type1.*',
+            },
+          ],
+          exclude: [
+            {
+              type: 'type12.*',
+              filters: {
+                name: 'name1',
+              },
+            },
+          ],
+        },
+        {
+          name: ({ instance, filterValue }) => instance.value.name === filterValue,
+        }
+      )
+      expect(query.isTypeMatch('type12')).toBeTruthy()
+    })
+
+    it('isInstanceMatch should match when there is no filter', () => {
+      expect(query.isInstanceMatch(inst)).toBeTruthy()
+    })
+
+    it('isInstanceMatch should if include filter match', () => {
+      query = createElementQuery(
+        {
+          include: [
+            {
+              type: 'type1.*',
+              filters: {
+                name: 'name1',
+              },
+            },
+          ],
+          exclude: [],
+        },
+        {
+          name: ({ instance, filterValue }) => instance.value.name === filterValue,
+        }
+      )
+      expect(query.isInstanceMatch(inst)).toBeFalsy()
+      inst.value.name = 'name1'
+      expect(query.isInstanceMatch(inst)).toBeTruthy()
+    })
+
+    it('isInstanceMatch should if exclude filter does not match', () => {
+      query = createElementQuery(
+        {
+          include: [
+            {
+              type: 'type1.*',
+            },
+          ],
+          exclude: [
+            {
+              type: 'type1.*',
+              filters: {
+                name: 'name1',
+              },
+            },
+          ],
+        },
+        {
+          name: ({ instance, filterValue }) => instance.value.name === filterValue,
+        }
+      )
+      expect(query.isInstanceMatch(inst)).toBeTruthy()
+      inst.value.name = 'name1'
+      expect(query.isInstanceMatch(inst)).toBeFalsy()
     })
   })
 })

--- a/packages/adapter-components/test/filters/ducktype/hide_types.test.ts
+++ b/packages/adapter-components/test/filters/ducktype/hide_types.test.ts
@@ -17,6 +17,7 @@ import { ObjectType, ElemID, isObjectType, CORE_ANNOTATIONS } from '@salto-io/ad
 import { FilterWith } from '../../../src/filter_utils'
 import { Paginator } from '../../../src/client'
 import { hideTypesFilterCreator } from '../../../src/filters/ducktype/hide_types'
+import { createMockQuery } from '../../../src/elements/query'
 
 describe('hide types filter', () => {
   type FilterType = FilterWith<'onFetch'>
@@ -31,6 +32,7 @@ describe('hide types filter', () => {
   hideTypesFilterCreator()({
     client: {} as unknown,
     paginator: undefined as unknown as Paginator,
+    fetchQuery: createMockQuery(),
     config: {
       fetch: {
         hideTypes,

--- a/packages/adapter-components/test/filters/query.test.ts
+++ b/packages/adapter-components/test/filters/query.test.ts
@@ -1,0 +1,73 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { MockInterface } from '@salto-io/test-utils'
+import { FilterWith } from '../../src/filter_utils'
+import { Paginator } from '../../src/client'
+import { queryFilterCreator } from '../../src/filters/query'
+import { createMockQuery, ElementQuery } from '../../src/elements/query'
+
+describe('query filter', () => {
+  let filter: FilterWith<'onFetch'>
+  let instance: InstanceElement
+  let fetchQuery: MockInterface<ElementQuery>
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    fetchQuery = createMockQuery()
+    filter = queryFilterCreator()({
+      client: {} as unknown,
+      paginator: undefined as unknown as Paginator,
+      fetchQuery,
+      config: {
+        apiDefinitions: {
+          types: {
+            role: {
+              transformation: {
+                serviceUrl: '/roles/{id}',
+              },
+            },
+          },
+          typeDefaults: {
+            transformation: { idFields: ['id'] },
+          },
+          supportedTypes: {},
+        },
+      },
+    }) as FilterWith<'onFetch'>
+
+    instance = new InstanceElement(
+      'instance',
+      new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+    )
+  })
+
+  describe('onFetch', () => {
+    it('should remove instance if not matched in the query', async () => {
+      fetchQuery.isInstanceMatch.mockReturnValue(false)
+      const elements = [instance]
+      await filter.onFetch(elements)
+      expect(elements).toHaveLength(0)
+    })
+
+    it('should not remove instance if matched in the query', async () => {
+      fetchQuery.isInstanceMatch.mockReturnValue(true)
+      const elements = [instance]
+      await filter.onFetch(elements)
+      expect(elements).toHaveLength(1)
+    })
+  })
+})

--- a/packages/adapter-components/test/filters/referenced_instance_name.test.ts
+++ b/packages/adapter-components/test/filters/referenced_instance_name.test.ts
@@ -19,6 +19,7 @@ import { references } from '@salto-io/adapter-utils'
 import { addReferencesToInstanceNames, updateAllReferences, referencedInstanceNamesFilterCreator } from '../../src/filters/referenced_instance_names'
 import { FilterWith } from '../../src/filter_utils'
 import { Paginator } from '../../src/client'
+import { createMockQuery } from '../../src/elements/query'
 
 const { getReferences } = references
 const ADAPTER_NAME = 'myAdapter'
@@ -134,6 +135,7 @@ describe('referenced instances', () => {
         client: {} as unknown,
         paginator: undefined as unknown as Paginator,
         config,
+        fetchQuery: createMockQuery(),
       }) as FilterType
     })
     it('should rename the elements correctly when the filter is called', async () => {

--- a/packages/adapter-components/test/filters/service_url.test.ts
+++ b/packages/adapter-components/test/filters/service_url.test.ts
@@ -17,6 +17,7 @@ import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS, toChange, getCha
 import { FilterWith } from '../../src/filter_utils'
 import { Paginator } from '../../src/client'
 import { serviceUrlFilterCreator } from '../../src/filters/service_url'
+import { createMockQuery } from '../../src/elements/query'
 
 describe('service url filter', () => {
   type FilterType = FilterWith<'onFetch' | 'onDeploy'>
@@ -32,6 +33,7 @@ describe('service url filter', () => {
     filter = serviceUrlFilterCreator(baseUrl)({
       client: {} as unknown,
       paginator: undefined as unknown as Paginator,
+      fetchQuery: createMockQuery(),
       config: {
         apiDefinitions: {
           types: {

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -22,7 +22,7 @@ jira {
     exclude = [
       {
         type = "Webhook"
-        filters = {
+        criteria = {
           name = "name.*"
         }
       }
@@ -80,9 +80,9 @@ jira {
 | Name                                        | Default when undefined            | Description
 |---------------------------------------------|-----------------------------------|------------
 | type                                        | ""                                | A regex of the Salto type name to include in the entry
-| [filters](#fetch-entry-filters)             |                                   | A List of filters to filter specific instance of certain types
+| [criteria](#fetch-entry-criteria)             |                                   | A List of criteria to filter specific instance of certain types
 
-## Fetch entry filters
+## Fetch entry criteria
 
 | Name                                        | Default when undefined            | Description
 |---------------------------------------------|-----------------------------------|------------

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -22,6 +22,9 @@ jira {
     exclude = [
       {
         type = "Webhook"
+        filters = {
+          name = "name.*"
+        }
       }
     ]
   }
@@ -77,3 +80,10 @@ jira {
 | Name                                        | Default when undefined            | Description
 |---------------------------------------------|-----------------------------------|------------
 | type                                        | ""                                | A regex of the Salto type name to include in the entry
+| [filters](#fetch-entry-filters)             |                                   | A List of filters to filter specific instance of certain types
+
+## Fetch entry filters
+
+| Name                                        | Default when undefined            | Description
+|---------------------------------------------|-----------------------------------|------------
+| name                                        | .*                                | A regex used to filter instances by matching the regex to their name value

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -69,6 +69,7 @@ import fieldDeploymentFilter from './filters/fields/field_deployment_filter'
 import contextDeploymentFilter from './filters/fields/context_deployment_filter'
 import fieldTypeReferencesFilter from './filters/fields/field_type_references_filter'
 import contextReferencesFilter from './filters/fields/context_references_filter'
+import queryFilter from './filters/query'
 import resolutionFilter from './filters/resolution'
 import priorityFilter from './filters/priority'
 import statusDeploymentFilter from './filters/statuses/status_deployment'
@@ -85,6 +86,7 @@ import { JIRA } from './constants'
 import { removeScopedObjects } from './client/pagination'
 import { dependencyChanger } from './dependency_changers'
 import { getChangeGroupIds } from './group_change'
+import fetchPredicates from './fetch_predicates'
 
 const {
   generateTypes,
@@ -163,6 +165,7 @@ export const DEFAULT_FILTERS = [
   // Must run after fieldReferencesFilter
   mapListsFilter,
   hiddenValuesInListsFilter,
+  queryFilter,
   // Must be last
   defaultInstancesDeployFilter,
 ]
@@ -204,7 +207,10 @@ export default class JiraAdapter implements AdapterOperations {
       customEntryExtractor: removeScopedObjects,
     })
 
-    this.fetchQuery = elementUtils.query.createElementQuery(this.userConfig.fetch)
+    this.fetchQuery = elementUtils.query.createElementQuery(
+      this.userConfig.fetch,
+      fetchPredicates,
+    )
 
     this.paginator = paginator
     this.createFiltersRunner = () => (

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -86,7 +86,7 @@ import { JIRA } from './constants'
 import { removeScopedObjects } from './client/pagination'
 import { dependencyChanger } from './dependency_changers'
 import { getChangeGroupIds } from './group_change'
-import fetchPredicates from './fetch_predicates'
+import fetchCriteria from './fetch_criteria'
 
 const {
   generateTypes,
@@ -209,7 +209,7 @@ export default class JiraAdapter implements AdapterOperations {
 
     this.fetchQuery = elementUtils.query.createElementQuery(
       this.userConfig.fetch,
-      fetchPredicates,
+      fetchCriteria,
     )
 
     this.paginator = paginator

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1775,7 +1775,11 @@ type JiraDeployConfig = {
   forceDelete: boolean
 }
 
-type JiraFetchConfig = configUtils.UserFetchConfig & {
+type JiraFetchFilters = {
+  name?: string
+}
+
+type JiraFetchConfig = configUtils.UserFetchConfig<JiraFetchFilters> & {
   fallbackToInternalId?: boolean
 }
 
@@ -1877,8 +1881,20 @@ const jiraDeployConfigType = new ObjectType({
   },
 })
 
-const fetchConfigType = createUserFetchConfigType(JIRA)
-fetchConfigType.fields.fallbackToInternalId = new Field(fetchConfigType, 'fallbackToInternalId', BuiltinTypes.BOOLEAN)
+const fetchFiltersType = createMatchingObjectType<JiraFetchFilters>({
+  elemID: new ElemID(JIRA, 'FetchFilters'),
+  fields: {
+    name: { refType: BuiltinTypes.STRING },
+  },
+})
+
+const fetchConfigType = createUserFetchConfigType(
+  JIRA,
+  {
+    fallbackToInternalId: { refType: BuiltinTypes.BOOLEAN },
+  },
+  fetchFiltersType,
+)
 
 const maskingConfigType = createMatchingObjectType<Partial<MaskingConfig>>({
   elemID: new ElemID(JIRA),

--- a/packages/jira-adapter/src/fetch_criteria.ts
+++ b/packages/jira-adapter/src/fetch_criteria.ts
@@ -16,11 +16,11 @@
 import { elements as elementUtils } from '@salto-io/adapter-components'
 import { regex } from '@salto-io/lowerdash'
 
-const namePredicate: elementUtils.query.QueryPredicate = ({
+const nameCriterion: elementUtils.query.QueryCriterion = ({
   instance,
-  filterValue,
-}): boolean => regex.isFullRegexMatch(instance.value.name, filterValue)
+  value,
+}): boolean => regex.isFullRegexMatch(instance.value.name, value)
 
 export default {
-  name: namePredicate,
+  name: nameCriterion,
 }

--- a/packages/jira-adapter/src/fetch_predicates.ts
+++ b/packages/jira-adapter/src/fetch_predicates.ts
@@ -13,7 +13,14 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { serviceUrlFilterCreator } from './service_url'
-export { referencedInstanceNamesFilterCreator } from './referenced_instance_names'
-export { queryFilterCreator } from './query'
-export * as ducktype from './ducktype'
+import { elements as elementUtils } from '@salto-io/adapter-components'
+import { regex } from '@salto-io/lowerdash'
+
+const namePredicate: elementUtils.query.QueryPredicate = ({
+  instance,
+  filterValue,
+}): boolean => regex.isFullRegexMatch(instance.value.name, filterValue)
+
+export default {
+  name: namePredicate,
+}

--- a/packages/jira-adapter/src/filter.ts
+++ b/packages/jira-adapter/src/filter.ts
@@ -26,7 +26,14 @@ export type FilterResult = {
 
 export type Filter = filterUtils.Filter<FilterResult>
 
-export type FilterCreator = filterUtils.FilterCreator<JiraClient, JiraConfig, FilterResult, {
+export type FilterAdditionParams = {
   elementsSource: ReadOnlyElementsSource
   fetchQuery: elementUtils.query.ElementQuery
-}>
+}
+
+export type FilterCreator = filterUtils.FilterCreator<
+  JiraClient,
+  JiraConfig,
+  FilterResult,
+  FilterAdditionParams
+>

--- a/packages/jira-adapter/src/filters/query.ts
+++ b/packages/jira-adapter/src/filters/query.ts
@@ -13,7 +13,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { serviceUrlFilterCreator } from './service_url'
-export { referencedInstanceNamesFilterCreator } from './referenced_instance_names'
-export { queryFilterCreator } from './query'
-export * as ducktype from './ducktype'
+import { filters } from '@salto-io/adapter-components'
+import { JiraConfig } from '../config'
+import JiraClient from '../client/client'
+import { FilterAdditionParams, FilterCreator, FilterResult } from '../filter'
+
+const filter: FilterCreator = params =>
+  filters.queryFilterCreator<JiraClient, JiraConfig, FilterResult, FilterAdditionParams>(
+  )(params)
+
+export default filter

--- a/packages/jira-adapter/test/fetch_criteria.test.ts
+++ b/packages/jira-adapter/test/fetch_criteria.test.ts
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
-import fetchPredicates from '../src/fetch_predicates'
+import fetchCriteria from '../src/fetch_criteria'
 
-describe('fetch_predicates', () => {
+describe('fetch_criteria', () => {
   describe('name', () => {
     it('should match element name', () => {
       const instance = new InstanceElement(
@@ -27,8 +27,8 @@ describe('fetch_predicates', () => {
         }
       )
 
-      expect(fetchPredicates.name({ instance, filterValue: '.ame' })).toBeTruthy()
-      expect(fetchPredicates.name({ instance, filterValue: 'ame' })).toBeFalsy()
+      expect(fetchCriteria.name({ instance, value: '.ame' })).toBeTruthy()
+      expect(fetchCriteria.name({ instance, value: 'ame' })).toBeFalsy()
     })
   })
 })

--- a/packages/jira-adapter/test/fetch_predicates.test.ts
+++ b/packages/jira-adapter/test/fetch_predicates.test.ts
@@ -13,7 +13,22 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { serviceUrlFilterCreator } from './service_url'
-export { referencedInstanceNamesFilterCreator } from './referenced_instance_names'
-export { queryFilterCreator } from './query'
-export * as ducktype from './ducktype'
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import fetchPredicates from '../src/fetch_predicates'
+
+describe('fetch_predicates', () => {
+  describe('name', () => {
+    it('should match element name', () => {
+      const instance = new InstanceElement(
+        'instance',
+        new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+        {
+          name: 'name',
+        }
+      )
+
+      expect(fetchPredicates.name({ instance, filterValue: '.ame' })).toBeTruthy()
+      expect(fetchPredicates.name({ instance, filterValue: 'ame' })).toBeFalsy()
+    })
+  })
+})

--- a/packages/stripe-adapter/src/adapter.ts
+++ b/packages/stripe-adapter/src/adapter.ts
@@ -49,6 +49,7 @@ export default class StripeAdapter implements AdapterOperations {
   private client: StripeClient
   private paginator: clientUtils.Paginator
   private userConfig: StripeConfig
+  private fetchQuery: elementUtils.query.ElementQuery
 
   public constructor({
     filterCreators = DEFAULT_FILTERS,
@@ -61,11 +62,13 @@ export default class StripeAdapter implements AdapterOperations {
       client: this.client,
       paginationFuncCreator: () => getWithCursorPagination(),
     })
+    this.fetchQuery = elementUtils.query.createElementQuery(this.userConfig[FETCH_CONFIG])
     this.filtersRunner = filtersRunner(
       {
         client: this.client,
         paginator: this.paginator,
         config,
+        fetchQuery: this.fetchQuery,
       },
       filterCreators,
     )
@@ -103,7 +106,7 @@ export default class StripeAdapter implements AdapterOperations {
       objectTypes: _.pickBy(allTypes, isObjectType),
       apiConfig: updatedApiDefinitionsConfig,
       supportedTypes: this.userConfig[API_DEFINITIONS_CONFIG].supportedTypes,
-      fetchQuery: elementUtils.query.createElementQuery(this.userConfig[FETCH_CONFIG]),
+      fetchQuery: this.fetchQuery,
     })
   }
 

--- a/packages/stripe-adapter/test/filters/field_references.test.ts
+++ b/packages/stripe-adapter/test/filters/field_references.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, BuiltinTypes, isInstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/field_references'
 import StripeClient from '../../src/client/client'
 import { STRIPE } from '../../src/constants'
@@ -36,6 +36,7 @@ describe('Field references filter', () => {
         paginationFuncCreator: () => clientUtils.getWithCursorPagination(),
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -63,6 +63,7 @@ export default class WorkatoAdapter implements AdapterOperations {
   private paginator: clientUtils.Paginator
   private userConfig: WorkatoConfig
   private getElemIdFunc?: ElemIdGetter
+  private fetchQuery: elementUtils.query.ElementQuery
 
   public constructor({
     filterCreators = DEFAULT_FILTERS,
@@ -78,6 +79,7 @@ export default class WorkatoAdapter implements AdapterOperations {
       paginationFuncCreator: paginate,
     })
     this.paginator = paginator
+    this.fetchQuery = elementUtils.query.createElementQuery(this.userConfig[FETCH_CONFIG])
     this.createFiltersRunner = () => filtersRunner(
       {
         client,
@@ -86,6 +88,7 @@ export default class WorkatoAdapter implements AdapterOperations {
           fetch: config.fetch,
           apiDefinitions: config.apiDefinitions,
         },
+        fetchQuery: this.fetchQuery,
       },
       filterCreators,
     )
@@ -97,7 +100,7 @@ export default class WorkatoAdapter implements AdapterOperations {
       adapterName: WORKATO,
       types: this.userConfig.apiDefinitions.types,
       supportedTypes: this.userConfig.apiDefinitions.supportedTypes,
-      fetchQuery: elementUtils.query.createElementQuery(this.userConfig[FETCH_CONFIG]),
+      fetchQuery: this.fetchQuery,
       paginator: this.paginator,
       nestedFieldFinder: returnFullEntry,
       computeGetArgs: simpleGetArgs,

--- a/packages/workato-adapter/test/filters/add_root_folder.test.ts
+++ b/packages/workato-adapter/test/filters/add_root_folder.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType, Element, BuiltinTypes, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/add_root_folder'
 import WorkatoClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -38,6 +38,7 @@ describe('Add root filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/workato-adapter/test/filters/field_references.test.ts
+++ b/packages/workato-adapter/test/filters/field_references.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, BuiltinTypes, isInstanceElement, ListType } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/field_references'
 import WorkatoClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -38,6 +38,7 @@ describe('Field references filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/workato-adapter/test/filters/fix_multienv_ids.test.ts
+++ b/packages/workato-adapter/test/filters/fix_multienv_ids.test.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { ElemID, InstanceElement, ObjectType, Element, BuiltinTypes, CORE_ANNOTATIONS, ReferenceExpression, isInstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { getParents } from '@salto-io/adapter-utils'
 import filterCreator from '../../src/filters/fix_multienv_ids'
 import WorkatoClient from '../../src/client/client'
@@ -65,6 +65,7 @@ describe('Fix multienv ids filter', () => {
           supportedTypes: SUPPORTED_TYPES,
         },
       },
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 
@@ -205,6 +206,7 @@ describe('Fix multienv ids filter', () => {
             supportedTypes: SUPPORTED_TYPES,
           },
         },
+        fetchQuery: elementUtils.query.createMockQuery(),
       }) as FilterType
       const elements = generateElements()
       const lengthBefore = elements.length

--- a/packages/workato-adapter/test/filters/recipe_references.test.ts
+++ b/packages/workato-adapter/test/filters/recipe_references.test.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, BuiltinTypes, ListType, CORE_ANNOTATIONS, isReferenceExpression } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DetailedDependency } from '@salto-io/adapter-utils'
 import filterCreator from '../../src/filters/cross_service/recipe_references'
 import WorkatoClient from '../../src/client/client'
@@ -67,6 +67,7 @@ describe('Recipe references filter', () => {
           supportedTypes: SUPPORTED_TYPES,
         },
       },
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 
@@ -987,6 +988,7 @@ describe('Recipe references filter', () => {
             supportedTypes: SUPPORTED_TYPES,
           },
         },
+        fetchQuery: elementUtils.query.createMockQuery(),
       }) as FilterType
 
       currentAdapterElements = generateCurrentAdapterElements()
@@ -1304,6 +1306,7 @@ describe('Recipe references filter', () => {
             supportedTypes: SUPPORTED_TYPES,
           },
         },
+        fetchQuery: elementUtils.query.createMockQuery(),
       }) as FilterType
 
       expect(await otherFilter.onPostFetch({
@@ -1351,6 +1354,7 @@ describe('Recipe references filter', () => {
             supportedTypes: SUPPORTED_TYPES,
           },
         },
+        fetchQuery: elementUtils.query.createMockQuery(),
       }) as FilterType
 
       // should still resolve the netsuite references
@@ -1421,6 +1425,7 @@ describe('Recipe references filter', () => {
             supportedTypes: SUPPORTED_TYPES,
           },
         },
+        fetchQuery: elementUtils.query.createMockQuery(),
       }) as FilterType
 
       currentAdapterElements = generateCurrentAdapterElements()

--- a/packages/workato-adapter/test/filters/service_url.test.ts
+++ b/packages/workato-adapter/test/filters/service_url.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/service_url'
 import WorkatoClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -93,6 +93,7 @@ describe('service_url', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
 
     await filter.onFetch([

--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -149,6 +149,7 @@ export default class ZendeskAdapter implements AdapterOperations {
   private userConfig: ZendeskConfig
   private getElemIdFunc?: ElemIdGetter
   private configInstance?: InstanceElement
+  private fetchQuery: elementUtils.query.ElementQuery
 
   public constructor({
     filterCreators = DEFAULT_FILTERS,
@@ -165,6 +166,9 @@ export default class ZendeskAdapter implements AdapterOperations {
       client: this.client,
       paginationFuncCreator: paginate,
     })
+
+    this.fetchQuery = elementUtils.query.createElementQuery(this.userConfig[FETCH_CONFIG])
+
     this.createFiltersRunner = async () => (
       filtersRunner(
         {
@@ -175,6 +179,7 @@ export default class ZendeskAdapter implements AdapterOperations {
             apiDefinitions: config.apiDefinitions,
           },
           getElemIdFunc,
+          fetchQuery: this.fetchQuery,
         },
         filterCreators,
         concatObjects,
@@ -188,7 +193,7 @@ export default class ZendeskAdapter implements AdapterOperations {
       adapterName: ZENDESK_SUPPORT,
       types: this.userConfig.apiDefinitions.types,
       supportedTypes: this.userConfig.apiDefinitions.supportedTypes,
-      fetchQuery: elementUtils.query.createElementQuery(this.userConfig[FETCH_CONFIG]),
+      fetchQuery: this.fetchQuery,
       paginator: this.paginator,
       nestedFieldFinder: findDataField,
       computeGetArgs,

--- a/packages/zendesk-support-adapter/src/filters/reorder/trigger.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/trigger.ts
@@ -81,7 +81,7 @@ const deployFunc: DeployFuncType = async (change, client, apiDefinitions) => {
 /**
  * Add trigger order element with all the triggers ordered
  */
-const filterCreator: FilterCreator = ({ config, client, paginator }) => ({
+const filterCreator: FilterCreator = ({ config, client, paginator, fetchQuery }) => ({
   onFetch: async (elements: Element[]): Promise<void> => {
     const orderTypeName = createOrderTypeName(TYPE_NAME)
     const triggerObjType = elements
@@ -168,7 +168,7 @@ const filterCreator: FilterCreator = ({ config, client, paginator }) => ({
     orderFieldName: 'order',
     deployFunc,
     activeFieldName: 'active',
-  })({ client, config, paginator }).deploy,
+  })({ client, config, paginator, fetchQuery }).deploy,
 })
 
 export default filterCreator

--- a/packages/zendesk-support-adapter/test/filters/account_settings.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/account_settings.test.ts
@@ -16,7 +16,7 @@
 import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -70,6 +70,7 @@ describe('account settings filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
   it('should remove autorouting_tag if it is empty', async () => {

--- a/packages/zendesk-support-adapter/test/filters/add_field_options.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/add_field_options.test.ts
@@ -16,7 +16,7 @@
 import {
   ObjectType, ElemID, InstanceElement, toChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../src/constants'
@@ -42,6 +42,7 @@ describe('add field options filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
   describe('preDeploy', () => {

--- a/packages/zendesk-support-adapter/test/filters/app.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/app.test.ts
@@ -16,7 +16,7 @@
 import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -62,6 +62,7 @@ describe('app installation filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/business_hours_schedule.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/business_hours_schedule.test.ts
@@ -16,7 +16,7 @@
 import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -63,6 +63,7 @@ describe('business hours schedule filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/collistion_errors.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/collistion_errors.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../src/constants'
@@ -43,6 +43,7 @@ describe('collision errors', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/custom_field_options/ticket_field.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/custom_field_options/ticket_field.test.ts
@@ -17,7 +17,7 @@ import {
   ObjectType, ElemID, InstanceElement, isObjectType, isInstanceElement,
   ReferenceExpression, CORE_ANNOTATIONS, toChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../../src/config'
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../../src/constants'
@@ -87,6 +87,7 @@ describe('ticket field filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/dynamic_content.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/dynamic_content.test.ts
@@ -17,7 +17,7 @@ import {
   ObjectType, ElemID, InstanceElement,
   ReferenceExpression, CORE_ANNOTATIONS, toChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../src/constants'
@@ -129,6 +129,7 @@ describe('dynmaic content filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/dynamic_content_references.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/dynamic_content_references.test.ts
@@ -16,7 +16,7 @@
 import {
   ObjectType, ElemID, InstanceElement, ReferenceExpression, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../src/constants'
@@ -49,6 +49,7 @@ describe('dynamic content references filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/field_references.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/field_references.test.ts
@@ -15,7 +15,7 @@
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element,
   BuiltinTypes, isInstanceElement, ListType } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/field_references'
 import ZendeskClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -38,6 +38,7 @@ describe('References by id filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 
@@ -395,6 +396,7 @@ describe('References by id filter', () => {
               enableMissingReferences: false,
             },
           },
+          fetchQuery: elementUtils.query.createMockQuery(),
         }) as FilterType
         const clonedElements = originalElements.map(element => element.clone())
         await newFilter.onFetch(clonedElements)

--- a/packages/zendesk-support-adapter/test/filters/hardcoded_channel.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/hardcoded_channel.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, isObjectType } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../src/constants'
@@ -64,6 +64,7 @@ describe('hardcoded channel filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/macro_attachments.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/macro_attachments.test.ts
@@ -18,7 +18,7 @@ import {
   ObjectType, ElemID, InstanceElement, isInstanceElement, StaticFile,
   CORE_ANNOTATIONS, ReferenceExpression, ListType, BuiltinTypes, getChangeData, ModificationChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -68,6 +68,7 @@ describe('macro attachment filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/omit_inactive.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/omit_inactive.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { API_DEFINITIONS_CONFIG, DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../src/constants'
@@ -78,6 +78,7 @@ describe('omit inactive', () => {
           },
         },
       },
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/organization_field.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/organization_field.test.ts
@@ -17,7 +17,7 @@ import {
   ObjectType, ElemID, InstanceElement,
   ReferenceExpression, CORE_ANNOTATIONS, toChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../src/constants'
@@ -63,6 +63,7 @@ describe('organization field filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
   describe('deploy', () => {

--- a/packages/zendesk-support-adapter/test/filters/referenced_id_fields.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/referenced_id_fields.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG, FETCH_CONFIG, SUPPORTED_TYPES } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../src/constants'
@@ -49,6 +49,7 @@ describe('referenced id fields filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
     await filter.onFetch(elements)
     expect(elements.map(e => e.elemID.getFullName()).sort())
@@ -80,6 +81,7 @@ describe('referenced id fields filter', () => {
           supportedTypes: SUPPORTED_TYPES,
         },
       },
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
     await filter.onFetch(elements)
     expect(elements.map(e => e.elemID.getFullName()).sort())

--- a/packages/zendesk-support-adapter/test/filters/remove_definition_instances.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/remove_definition_instances.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../src/constants'
@@ -45,6 +45,7 @@ describe('remove definition instances', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/reorder/automation.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/automation.test.ts
@@ -18,7 +18,7 @@ import {
   isInstanceElement, ReferenceExpression, ModificationChange,
   toChange, getChangeData,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../../src/config'
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../../src/constants'
@@ -61,6 +61,7 @@ describe('automation reorder filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/reorder/ticket_form.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/ticket_form.test.ts
@@ -18,7 +18,7 @@ import {
   isInstanceElement, ReferenceExpression, ModificationChange,
   toChange, getChangeData,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../../src/config'
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../../src/constants'
@@ -61,6 +61,7 @@ describe('ticket form reorder filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/reorder/trigger.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/trigger.test.ts
@@ -17,7 +17,7 @@ import {
   ObjectType, ElemID, InstanceElement, isObjectType, isInstanceElement,
   ReferenceExpression, ModificationChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../../src/config'
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../../src/constants'
@@ -67,6 +67,7 @@ describe('trigger reorder filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/reorder/view.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/reorder/view.test.ts
@@ -18,7 +18,7 @@ import {
   isInstanceElement, ReferenceExpression, ModificationChange,
   toChange, getChangeData,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../../src/config'
 import ZendeskClient from '../../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../../src/constants'
@@ -62,6 +62,7 @@ describe('view reorder filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/restriction.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/restriction.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../src/constants'
@@ -70,6 +70,7 @@ describe('restriction filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/routing_attribute.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/routing_attribute.test.ts
@@ -16,7 +16,7 @@
 import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -57,6 +57,7 @@ describe('routing attribute filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/service_url.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/service_url.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS, toChange, getChangeData } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK_SUPPORT } from '../../src/constants'
@@ -42,6 +42,7 @@ describe('service url filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/sla_policy.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/sla_policy.test.ts
@@ -16,7 +16,7 @@
 import {
   ObjectType, ElemID, InstanceElement,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -94,6 +94,7 @@ describe('sla policy filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/tag.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/tag.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, isInstanceElement, toChange, getChangeData, ReferenceExpression } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { mockFunction } from '@salto-io/test-utils'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
@@ -137,6 +137,7 @@ describe('tags filter', () => {
       client,
       paginator: mockPaginator,
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/unordered_lists.test.ts
@@ -16,7 +16,7 @@
 import {
   ObjectType, ElemID, InstanceElement, Element, isInstanceElement, ReferenceExpression,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -133,6 +133,7 @@ describe('Unordered lists filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
 
     elements = generateElements()

--- a/packages/zendesk-support-adapter/test/filters/user.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/user.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, isInstanceElement, toChange, getChangeData } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { mockFunction } from '@salto-io/test-utils'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
@@ -245,6 +245,7 @@ describe('user filter', () => {
       client,
       paginator: mockPaginator,
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 
@@ -410,7 +411,12 @@ describe('user filter', () => {
             ] },
           ]
         })
-      const newFilter = filterCreator({ client, paginator, config: DEFAULT_CONFIG }) as FilterType
+      const newFilter = filterCreator({
+        client,
+        paginator,
+        config: DEFAULT_CONFIG,
+        fetchQuery: elementUtils.query.createMockQuery(),
+      }) as FilterType
       await newFilter.onFetch(elements)
       expect(elements.map(e => e.elemID.getFullName()).sort())
         .toEqual([
@@ -439,7 +445,12 @@ describe('user filter', () => {
             ] },
           ]
         })
-      const newFilter = filterCreator({ client, paginator, config: DEFAULT_CONFIG }) as FilterType
+      const newFilter = filterCreator({
+        client,
+        paginator,
+        config: DEFAULT_CONFIG,
+        fetchQuery: elementUtils.query.createMockQuery(),
+      }) as FilterType
       await newFilter.onFetch(elements)
       const instances = elements.filter(isInstanceElement)
       const macro = instances.find(e => e.elemID.typeName === 'macro')
@@ -627,7 +638,12 @@ describe('user filter', () => {
             ] },
           ]
         })
-      const newFilter = filterCreator({ client, paginator, config: DEFAULT_CONFIG }) as FilterType
+      const newFilter = filterCreator({
+        client,
+        paginator,
+        config: DEFAULT_CONFIG,
+        fetchQuery: elementUtils.query.createMockQuery(),
+      }) as FilterType
       const changes = instances.map(instance => toChange({ after: instance }))
       // We call preDeploy here because it sets the mappings
       await newFilter.preDeploy(changes)

--- a/packages/zendesk-support-adapter/test/filters/view.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/view.test.ts
@@ -16,7 +16,7 @@
 import {
   ObjectType, ElemID, InstanceElement, toChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -140,6 +140,7 @@ describe('views filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zendesk-support-adapter/test/filters/webhook.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/webhook.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -68,6 +68,7 @@ describe('webhook filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
   describe('deploy', () => {

--- a/packages/zendesk-support-adapter/test/filters/workspace.test.ts
+++ b/packages/zendesk-support-adapter/test/filters/workspace.test.ts
@@ -16,7 +16,7 @@
 import {
   ObjectType, ElemID, InstanceElement, toChange,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DEFAULT_CONFIG } from '../../src/config'
 import ZendeskClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -87,6 +87,7 @@ describe('workspace filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: DEFAULT_CONFIG,
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
   describe('preDeploy', () => {

--- a/packages/zuora-billing-adapter/src/adapter.ts
+++ b/packages/zuora-billing-adapter/src/adapter.ts
@@ -86,10 +86,10 @@ export default class ZuoraAdapter implements AdapterOperations {
       paginationFuncCreator: paginate,
     })
     this.paginator = paginator
-    this.createFiltersRunner = () => (
-      filtersRunner({ client, paginator, config }, filterCreators)
-    )
     this.fetchQuery = elementUtils.query.createElementQuery(config[FETCH_CONFIG])
+    this.createFiltersRunner = () => (
+      filtersRunner({ client, paginator, config, fetchQuery: this.fetchQuery }, filterCreators)
+    )
   }
 
   private apiDefinitions(
@@ -174,17 +174,15 @@ export default class ZuoraAdapter implements AdapterOperations {
     // standard objects are not included in the swagger and need special handling - done in a filter
     const standardObjectTypeName = getStandardObjectTypeName(this.apiDefinitions(parsedConfigs))
 
-    const fetchQuery: elementUtils.query.ElementQuery = {
-      isTypeMatch: typeName => typeName !== standardObjectTypeName
-        && this.fetchQuery.isTypeMatch(typeName),
-    }
-
     return getAllInstances({
       paginator: this.paginator,
       objectTypes: _.pickBy(allTypes, isObjectType),
       apiConfig: this.apiDefinitions(parsedConfigs),
       supportedTypes: this.userConfig[API_DEFINITIONS_CONFIG].supportedTypes,
-      fetchQuery,
+      fetchQuery: {
+        isTypeMatch: typeName => typeName !== standardObjectTypeName
+          && this.fetchQuery.isTypeMatch(typeName),
+      },
     })
   }
 

--- a/packages/zuora-billing-adapter/test/filters/field_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/field_references.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element, BuiltinTypes, isInstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/field_references'
 import ZuoraClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -53,6 +53,7 @@ describe('Field references filter', () => {
           supportedTypes: SUPPORTED_TYPES,
         },
       },
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zuora-billing-adapter/test/filters/finance_information_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/finance_information_references.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, Element, ReferenceExpression } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { SUPPORTED_TYPES } from '../../src/config'
 import ZuoraClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -105,6 +105,7 @@ describe('finance information references filter', () => {
           supportedTypes: SUPPORTED_TYPES,
         },
       },
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zuora-billing-adapter/test/filters/object_defs.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/object_defs.test.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import {
   ObjectType, ElemID, InstanceElement, Element, isEqualElements, isObjectType, ReferenceExpression,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DetailedDependency } from '@salto-io/adapter-utils'
 import ZuoraClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -325,6 +325,7 @@ describe('Object defs filter', () => {
           supportedTypes: SUPPORTED_TYPES,
         },
       },
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
   describe('nothing to do', () => {

--- a/packages/zuora-billing-adapter/test/filters/object_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/object_references.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { ObjectType, ElemID, InstanceElement, Element, ReferenceExpression, BuiltinTypes } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { SUPPORTED_TYPES } from '../../src/config'
 import ZuoraClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -147,6 +147,7 @@ describe('object references filter', () => {
           supportedTypes: SUPPORTED_TYPES,
         },
       },
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
 

--- a/packages/zuora-billing-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/unordered_lists.test.ts
@@ -16,7 +16,7 @@
 import {
   ObjectType, ElemID, InstanceElement, Element, isInstanceElement,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { SUPPORTED_TYPES } from '../../src/config'
 import ZuoraClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -112,6 +112,7 @@ describe('Unordered lists filter', () => {
           supportedTypes: SUPPORTED_TYPES,
         },
       },
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
 
     elements = generateElements()

--- a/packages/zuora-billing-adapter/test/filters/workflow_and_task_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/workflow_and_task_references.test.ts
@@ -18,7 +18,7 @@ import {
   ObjectType, ElemID, InstanceElement, Element, ReferenceExpression, BuiltinTypes,
   isInstanceElement, isReferenceExpression, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
-import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { DetailedDependency } from '@salto-io/adapter-utils'
 import ZuoraClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
@@ -364,6 +364,7 @@ describe('Workflow and task references filter', () => {
           supportedTypes: SUPPORTED_TYPES,
         },
       },
+      fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })
   describe('fail when there are no types or instances', () => {


### PR DESCRIPTION
Added support for fetch filters in adapter-component and added a filter to filter instances by name in Jira

---
_Release Notes_: 
_Jira adapter_:
Added an option to filter instances by name in the fetch configuration

---
_User Notifications_: 
None