### PR TITLE
SALTO-2256: Do not return undefined occurrences in generated dependencies

### DIFF
--- a/packages/adapter-utils/src/dependencies.ts
+++ b/packages/adapter-utils/src/dependencies.ts
@@ -117,9 +117,11 @@ export const extendGeneratedDependencies = (
     },
   )
 
-  const filteredUniqueDeps = Object.values(allDeps).map(dep => ({
-    ...dep, occurrences: preferSpecific(dep.occurrences),
-  }))
+  const filteredUniqueDeps = Object.values(allDeps)
+    .map(dep => ({
+      ...dep, occurrences: preferSpecific(dep.occurrences),
+    }))
+    .map(dep => ((dep.occurrences === undefined) ? _.omit(dep, 'occurrences') : dep))
 
   elem.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] = _.sortBy(
     filteredUniqueDeps,

--- a/packages/adapter-utils/test/dependencies.test.ts
+++ b/packages/adapter-utils/test/dependencies.test.ts
@@ -287,10 +287,10 @@ describe('dependencies', () => {
       it('should have an empty list of occurrences when no additional details are provided', () => {
         const type123Refs = findRefDeps(new ElemID('adapter', 'type123'))
         expect(type123Refs).toBeDefined()
-        expect(type123Refs.occurrences).toBeUndefined()
+        expect(type123Refs).not.toHaveProperty('occurrences')
         const aaaRefs = findRefDeps(new ElemID('adapter', 'aaa'))
         expect(aaaRefs).toBeDefined()
-        expect(aaaRefs.occurrences).toBeUndefined()
+        expect(aaaRefs).not.toHaveProperty('occurrences')
       })
       it('should keep the existing annotation value when no new details are addded', () => {
         const type789Refs = findRefDeps(new ElemID('adapter', 'type789'))


### PR DESCRIPTION


---



---
_Release Notes_: 
Core:
- Fix issue where _generated_dependencies would sometimes get an invalid `occurrences = undefined` value in them

---
_User Notifications_: 
_None_
