### PR TITLE
SALTO-1989: Add dependency changer to modification of values in Zendesk's custom fields 

### DIFF
--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -21,7 +21,6 @@ import {
 import {
   client as clientUtils,
   elements as elementUtils,
-  deployment as deploymentUtils,
 } from '@salto-io/adapter-components'
 import { logDuration, resolveChangeElement, resolveValues, restoreChangeElement, restoreValues } from '@salto-io/adapter-utils'
 import { collections, objects } from '@salto-io/lowerdash'
@@ -71,6 +70,7 @@ import ducktypeCommonFilters from './filters/ducktype_common'
 // referencedIdFieldsFilter will be used again after SALTO-2312
 // import referencedIdFieldsFilter from './filters/referenced_id_fields'
 import { getConfigFromConfigChanges } from './config_change'
+import { dependencyChanger } from './dependency_changers'
 
 const log = logger(module)
 const { createPaginator } = clientUtils
@@ -288,7 +288,7 @@ export default class ZendeskAdapter implements AdapterOperations {
         typesDeployedViaParent: ['organization_field__custom_field_options', 'macro_attachment'],
         typesWithNoDeploy: ['tag'],
       }),
-      dependencyChanger: deploymentUtils.dependency.removeStandaloneFieldDependency,
+      dependencyChanger,
       getChangeGroupIds,
     }
   }

--- a/packages/zendesk-support-adapter/src/change_validators/duplicate_option_values.ts
+++ b/packages/zendesk-support-adapter/src/change_validators/duplicate_option_values.ts
@@ -29,7 +29,7 @@ export const RELEVANT_PARENT_AND_CHILD_TYPES: ParentAndChildTypePair[] = [
   { parent: 'organization_field', child: 'organization_field__custom_field_options' },
 ]
 
-const CHECKBOX_TYPE_NAME = 'checkbox'
+export const CHECKBOX_TYPE_NAME = 'checkbox'
 
 export const isRelevantChange = (change: Change<InstanceElement>): boolean => {
   const instance = getChangeData(change)

--- a/packages/zendesk-support-adapter/src/change_validators/duplicate_option_values.ts
+++ b/packages/zendesk-support-adapter/src/change_validators/duplicate_option_values.ts
@@ -23,7 +23,7 @@ import {
 const { awu } = collections.asynciterable
 
 type ParentAndChildTypePair = { parent: string; child: string }
-const RELEVANT_PARENT_AND_CHILD_TYPES: ParentAndChildTypePair[] = [
+export const RELEVANT_PARENT_AND_CHILD_TYPES: ParentAndChildTypePair[] = [
   { parent: 'ticket_field', child: 'ticket_field__custom_field_options' },
   { parent: 'user_field', child: 'user_field__custom_field_options' },
   { parent: 'organization_field', child: 'organization_field__custom_field_options' },
@@ -31,7 +31,7 @@ const RELEVANT_PARENT_AND_CHILD_TYPES: ParentAndChildTypePair[] = [
 
 const CHECKBOX_TYPE_NAME = 'checkbox'
 
-const isRelevantChange = (change: Change<InstanceElement>): boolean => {
+export const isRelevantChange = (change: Change<InstanceElement>): boolean => {
   const instance = getChangeData(change)
   const changeTypeName = instance.elemID.typeName
   if (RELEVANT_PARENT_AND_CHILD_TYPES.some(pair => pair.parent === changeTypeName)) {

--- a/packages/zendesk-support-adapter/src/change_validators/index.ts
+++ b/packages/zendesk-support-adapter/src/change_validators/index.ts
@@ -15,7 +15,7 @@
 */
 export { accountSettingsValidator } from './account_settings'
 export { duplicateCustomFieldOptionValuesValidator, isRelevantChange,
-  RELEVANT_PARENT_AND_CHILD_TYPES } from './duplicate_option_values'
+  RELEVANT_PARENT_AND_CHILD_TYPES, CHECKBOX_TYPE_NAME } from './duplicate_option_values'
 export { emptyCustomFieldOptionsValidator } from './empty_custom_field_options'
 export { emptyVariantsValidator } from './empty_variants'
 export { noDuplicateLocaleIdInDynamicContentItemValidator } from './unique_locale_per_variant'

--- a/packages/zendesk-support-adapter/src/change_validators/index.ts
+++ b/packages/zendesk-support-adapter/src/change_validators/index.ts
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 export { accountSettingsValidator } from './account_settings'
-export { duplicateCustomFieldOptionValuesValidator } from './duplicate_option_values'
+export { duplicateCustomFieldOptionValuesValidator, isRelevantChange,
+  RELEVANT_PARENT_AND_CHILD_TYPES } from './duplicate_option_values'
 export { emptyCustomFieldOptionsValidator } from './empty_custom_field_options'
 export { emptyVariantsValidator } from './empty_variants'
 export { noDuplicateLocaleIdInDynamicContentItemValidator } from './unique_locale_per_variant'

--- a/packages/zendesk-support-adapter/src/dependency_changers/custom_field_option_change.ts
+++ b/packages/zendesk-support-adapter/src/dependency_changers/custom_field_option_change.ts
@@ -1,0 +1,66 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, dependencyChange, DependencyChanger, getChangeData, InstanceElement,
+  isInstanceChange, isAdditionOrModificationChange, isRemovalOrModificationChange,
+  DependencyChange } from '@salto-io/adapter-api'
+import { collections, values } from '@salto-io/lowerdash'
+import { isRelevantChange, RELEVANT_PARENT_AND_CHILD_TYPES } from '../change_validators/duplicate_option_values'
+
+export const customFieldOptionDependencyChanger: DependencyChanger = async changes => {
+  const getRelevantValue = (instance: InstanceElement) : string => {
+    const instanceType = instance.elemID.typeName
+    if (RELEVANT_PARENT_AND_CHILD_TYPES.some(types => types.parent === instanceType)) {
+      return instance.value.tag
+    }
+    return instance.value.value
+  }
+
+  const getDependencies = (
+    customFieldOptionChanges: {key: collections.set.SetId; change: Change<InstanceElement>}[],
+  )
+  : DependencyChange[] => customFieldOptionChanges.map(({ change, key }) => {
+    if (isRemovalOrModificationChange(change)) {
+      const beforeValue = getRelevantValue(change.data.before)
+      const instanceWithSameValue = customFieldOptionChanges
+        .find(otherChange => isAdditionOrModificationChange(otherChange.change)
+        && getRelevantValue(getChangeData(otherChange.change)) === beforeValue)
+      return instanceWithSameValue !== undefined ? dependencyChange(
+        'add',
+        instanceWithSameValue.key,
+        key,
+      )
+        : undefined
+    }
+    return undefined
+  }).filter(values.isDefined)
+
+  // We don't support the case the change in value A was x->y and the change value B was y->x,
+  // therfore we remove the dependency to avoid a circular dependency
+  const removeCyclicDependencies = (dependencies: DependencyChange[])
+   : DependencyChange[] => dependencies.filter(dependency =>
+    !dependencies.some(d => d.dependency.source === dependency.dependency.target
+        && d.dependency.target === dependency.dependency.source))
+
+  const relevantChanges = Array.from(changes.entries())
+    .map(([key, change]) => ({ key, change }))
+    .filter(
+      (change): change is { key: collections.set.SetId; change: Change<InstanceElement> } =>
+        isInstanceChange(change.change)
+    ).filter(({ change }) => isRelevantChange(change))
+
+  const dependencies = getDependencies(relevantChanges)
+  return removeCyclicDependencies(dependencies)
+}

--- a/packages/zendesk-support-adapter/src/dependency_changers/index.ts
+++ b/packages/zendesk-support-adapter/src/dependency_changers/index.ts
@@ -1,0 +1,30 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { DependencyChanger } from '@salto-io/adapter-api'
+import { deployment } from '@salto-io/adapter-components'
+import { collections } from '@salto-io/lowerdash'
+import { customFieldOptionDependencyChanger } from './custom_field_option_change'
+
+const { awu } = collections.asynciterable
+
+const DEPENDENCY_CHANGERS: DependencyChanger[] = [
+  deployment.dependency.removeStandaloneFieldDependency,
+  customFieldOptionDependencyChanger,
+]
+
+export const dependencyChanger: DependencyChanger = async (
+  changes, deps
+) => awu(DEPENDENCY_CHANGERS).flatMap(changer => changer(changes, deps)).toArray()

--- a/packages/zendesk-support-adapter/test/dependency_changers/custom_field_option_change.test.ts
+++ b/packages/zendesk-support-adapter/test/dependency_changers/custom_field_option_change.test.ts
@@ -83,22 +83,4 @@ describe('customFieldsOptionsDependencyChanger', () => {
     expect(dependencyChanges[0].dependency.source).toEqual(1)
     expect(dependencyChanges[0].dependency.target).toEqual(0)
   })
-
-  it('should filter out changes that causes circular dependency', async () => {
-    const ticketFieldOption1After = ticketFieldOption1.clone()
-    ticketFieldOption1After.value.value = 'v2'
-    const ticketFieldOption2After = ticketFieldOption2.clone()
-    ticketFieldOption2After.value.value = 'v1'
-    const inputChanges = new Map([
-      [0, toChange({ before: ticketFieldOption1, after: ticketFieldOption1After })],
-      [1, toChange({ before: ticketFieldOption2, after: ticketFieldOption2After })],
-    ])
-    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
-      [0, new Set()],
-      [1, new Set()],
-    ])
-
-    const dependencyChanges = [...await customFieldOptionDependencyChanger(inputChanges, inputDeps)]
-    expect(dependencyChanges).toHaveLength(0)
-  })
 })

--- a/packages/zendesk-support-adapter/test/dependency_changers/custom_field_option_change.test.ts
+++ b/packages/zendesk-support-adapter/test/dependency_changers/custom_field_option_change.test.ts
@@ -1,0 +1,104 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, InstanceElement, ElemID, toChange } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { customFieldOptionDependencyChanger } from '../../src/dependency_changers/custom_field_option_change'
+import { ZENDESK_SUPPORT } from '../../src/constants'
+
+describe('customFieldsOptionsDependencyChanger', () => {
+  const ticketFieldType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'ticket_field') })
+  const ticketFieldOptionType = new ObjectType({ elemID: new ElemID(ZENDESK_SUPPORT, 'ticket_field__custom_field_options') })
+  const ticketFieldOption1 = new InstanceElement(
+    'option1',
+    ticketFieldOptionType,
+    { name: 'v1', value: 'v1' },
+  )
+  const ticketFieldOption2 = new InstanceElement(
+    'option2',
+    ticketFieldOptionType,
+    { name: 'v2', value: 'v2' },
+  )
+
+  it('should add dependency from the modified instance to the other in the right order', async () => {
+    const ticketFieldOption1After = ticketFieldOption1.clone()
+    ticketFieldOption1After.value.value = 'v3'
+    const ticketFieldOption2After = ticketFieldOption2.clone()
+    ticketFieldOption2After.value.value = 'v1'
+    const checkboxTicketField = new InstanceElement(
+      'checkbox',
+      ticketFieldType,
+      { type: 'checkbox', title: 'myCheckbox', tag: 'v2' },
+    )
+    const inputChanges = new Map([
+      [0, toChange({ before: ticketFieldOption2, after: ticketFieldOption2After })],
+      [1, toChange({ before: ticketFieldOption1, after: ticketFieldOption1After })],
+      [2, toChange({ after: checkboxTicketField })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set()],
+      [1, new Set()],
+      [2, new Set()],
+    ])
+
+    const dependencyChanges = [...await customFieldOptionDependencyChanger(inputChanges, inputDeps)]
+    expect(dependencyChanges).toHaveLength(2)
+    expect([dependencyChanges[0].action,
+      dependencyChanges[0].dependency.source,
+      dependencyChanges[0].dependency.target])
+      .toEqual(['add', 2, 0])
+    expect([dependencyChanges[1].action,
+      dependencyChanges[1].dependency.source,
+      dependencyChanges[1].dependency.target])
+      .toEqual(['add', 0, 1])
+  })
+
+  it('should add dependency from the removed to the modified instance', async () => {
+    const ticketFieldOption2After = ticketFieldOption2.clone()
+    ticketFieldOption2After.value.value = 'v1'
+    const inputChanges = new Map([
+      [0, toChange({ before: ticketFieldOption1 })],
+      [1, toChange({ before: ticketFieldOption2, after: ticketFieldOption2After })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set()],
+      [1, new Set()],
+    ])
+
+    const dependencyChanges = [...await customFieldOptionDependencyChanger(inputChanges, inputDeps)]
+    expect(dependencyChanges).toHaveLength(1)
+    expect(dependencyChanges[0].action).toEqual('add')
+    expect(dependencyChanges[0].dependency.source).toEqual(1)
+    expect(dependencyChanges[0].dependency.target).toEqual(0)
+  })
+
+  it('should filter out changes that causes circular dependency', async () => {
+    const ticketFieldOption1After = ticketFieldOption1.clone()
+    ticketFieldOption1After.value.value = 'v2'
+    const ticketFieldOption2After = ticketFieldOption2.clone()
+    ticketFieldOption2After.value.value = 'v1'
+    const inputChanges = new Map([
+      [0, toChange({ before: ticketFieldOption1, after: ticketFieldOption1After })],
+      [1, toChange({ before: ticketFieldOption2, after: ticketFieldOption2After })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set()],
+      [1, new Set()],
+    ])
+
+    const dependencyChanges = [...await customFieldOptionDependencyChanger(inputChanges, inputDeps)]
+    expect(dependencyChanges).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Add dependency changer to order changes in zendesk's `custom_field_options` values

---

In Zendesk, `custom_field_options` of the same type (organization, user or ticket) cannot have the same value.
The same applies to `tag` in the organization/user/ticket from type `checkbox`.
We want to allow changes of 2 values in the following way: value_1: a->b , value_2: b->c, and therefore we added a dependency changer to make sure the deploy happens in the right order (value_2 -> value_1).

---
_Release Notes_: 
None

---
_User Notifications_: 
None