### PR TITLE
SALTO-2274: wrong message error on invalid credentials in Zendesk

### DIFF
--- a/packages/zendesk-support-adapter/src/client/client.ts
+++ b/packages/zendesk-support-adapter/src/client/client.ts
@@ -61,7 +61,7 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
     try {
       return await super.getSinglePage(args)
     } catch (e) {
-      if (e.response.status === 404) {
+      if (e.response?.status === 404) {
         log.warn('Suppressing 404 error %o', e)
         return {
           data: [],

--- a/packages/zendesk-support-adapter/test/client/client.test.ts
+++ b/packages/zendesk-support-adapter/test/client/client.test.ts
@@ -37,5 +37,12 @@ describe('client', () => {
       expect(res.data).toEqual([])
       expect(res.status).toEqual(404)
     })
+    it('should throw if there is no status in the error', async () => {
+      // The first replyOnce with 200 is for the client authentication
+      mockAxios.onGet().replyOnce(200).onGet().replyOnce(() => { throw new Error('Err') })
+      await expect(
+        client.getSinglePage({ url: 'http://myBrand.zendesk.com/api/v2/routing/attributes' })
+      ).rejects.toThrow()
+    })
   })
 })


### PR DESCRIPTION
_Wrong message error on invalid credentials in Zendesk_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
