### PR TITLE
SALTO-2276: Removed new values from permission scheme

### DIFF
--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -660,6 +660,10 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'id', fieldType: 'string' },
         { fieldName: 'notificationType', fieldType: 'string' },
       ],
+      fieldsToOmit: [
+        { fieldName: 'value' },
+        { fieldName: 'expand' },
+      ],
     },
   },
 


### PR DESCRIPTION
Removed redundant fields that were recently added to the NaCls

---
_Release Notes_: 
None

---
_User Notifications_: 
_Jira adapter_:
- Redundant fields that were recently added to the NaCls will be removed 