### PR TITLE
SALTO-2288: fix zendesk config suggestion bug

### DIFF
--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -303,6 +303,11 @@ export const getAllElements = async ({
     supportedTypes,
     typeNames => typeNames.filter(typeName => types[typeName].request?.url !== undefined)
   )
+  const supportedTypesReversedMapping = Object.fromEntries(
+    Object.entries(supportedTypesWithEndpoints)
+      .flatMap(([typeName, values]) =>
+        values.map(value => [value, typeName] as [string, string]))
+  )
 
   const configSuggestions: ConfigChangeSuggestion[] = []
   const elements = await getElementsWithContext({
@@ -318,7 +323,7 @@ export const getAllElements = async ({
       } catch (e) {
         if (isErrorTurnToConfigSuggestion?.(e)) {
           configSuggestions.push({
-            typeToExclude: args.typeName,
+            typeToExclude: supportedTypesReversedMapping[args.typeName] ?? args.typeName,
           })
           return []
         }

--- a/packages/adapter-components/src/elements/ducktype/transformer.ts
+++ b/packages/adapter-components/src/elements/ducktype/transformer.ts
@@ -321,9 +321,10 @@ export const getAllElements = async ({
           ...args,
         })
       } catch (e) {
-        if (isErrorTurnToConfigSuggestion?.(e)) {
+        if (isErrorTurnToConfigSuggestion?.(e)
+          && (supportedTypesReversedMapping[args.typeName] !== undefined)) {
           configSuggestions.push({
-            typeToExclude: supportedTypesReversedMapping[args.typeName] ?? args.typeName,
+            typeToExclude: supportedTypesReversedMapping[args.typeName],
           })
           return []
         }

--- a/packages/adapter-components/test/elements/ducktype/transformer.test.ts
+++ b/packages/adapter-components/test/elements/ducktype/transformer.test.ts
@@ -669,12 +669,12 @@ describe('ducktype_transformer', () => {
           exclude: [],
         }),
         supportedTypes: {
-          folder: ['folder'],
+          folder: ['folders'],
         },
         computeGetArgs: simpleGetArgs,
         nestedFieldFinder: returnFullEntry,
         types: {
-          folder: {
+          folders: {
             request: {
               url: '/folders',
             },

--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -194,8 +194,6 @@ export default class ZendeskAdapter implements AdapterOperations {
       computeGetArgs,
       typeDefaults: this.userConfig.apiDefinitions.typeDefaults,
       getElemIdFunc: this.getElemIdFunc,
-      isErrorTurnToConfigSuggestion: error =>
-        error instanceof clientUtils.HTTPError && (error.response.status === 403),
     })
   }
 

--- a/packages/zendesk-support-adapter/src/client/client.ts
+++ b/packages/zendesk-support-adapter/src/client/client.ts
@@ -61,12 +61,12 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
     try {
       return await super.getSinglePage(args)
     } catch (e) {
-      if (e.response?.status === 404) {
-        log.warn('Suppressing 404 error %o', e)
-        return {
-          data: [],
-          status: 404,
-        }
+      const status = e.response?.status
+      // Zendesk returns 404 when it doesn't have permissions for objects (not enabled features)
+      // Specifically for workspaces, it returns 403
+      if (status === 404 || (status === 403 && args.url === '/workspaces')) {
+        log.warn('Suppressing %d error %o', status, e)
+        return { data: [], status }
       }
       throw e
     }

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -683,46 +683,6 @@ describe('adapter', () => {
         'zendesk_support.group.instance.Support',
       ])
     })
-    it('should return config changes', async () => {
-      mockAxiosAdapter.onGet('/test').replyOnce(403)
-      const { updatedConfig } = await adapter.operations({
-        credentials: new InstanceElement(
-          'config',
-          usernamePasswordCredentialsType,
-          { username: 'user123', password: 'pwd456', subdomain: 'abc' },
-        ),
-        config: new InstanceElement(
-          'config',
-          configType,
-          {
-            [FETCH_CONFIG]: {
-              include: [{
-                type: 'test',
-              }],
-              exclude: [],
-            },
-            [API_DEFINITIONS_CONFIG]: {
-              types: {
-                test: {
-                  request: {
-                    url: '/test',
-                  },
-                  transformation: {
-                    dataField: 'test',
-                  },
-                },
-              },
-              supportedTypes: { test: ['test'] },
-            },
-          },
-        ),
-        elementsSource: buildElementsSourceFromElements([]),
-      }).fetch({ progressReporter: { reportProgress: () => null } })
-      expect(updatedConfig?.config).toHaveLength(1)
-      expect(updatedConfig?.config[0].value.fetch.exclude).toEqual([{
-        type: 'test',
-      }])
-    })
   })
 
   describe('deploy', () => {

--- a/packages/zendesk-support-adapter/test/client/client.test.ts
+++ b/packages/zendesk-support-adapter/test/client/client.test.ts
@@ -33,15 +33,27 @@ describe('client', () => {
     it('should return an empty result when there is a 404 response', async () => {
       // The first replyOnce with 200 is for the client authentication
       mockAxios.onGet().replyOnce(200).onGet().replyOnce(404)
-      const res = await client.getSinglePage({ url: 'http://myBrand.zendesk.com/api/v2/routing/attributes' })
+      const res = await client.getSinglePage({ url: '/routing/attributes' })
       expect(res.data).toEqual([])
       expect(res.status).toEqual(404)
+    })
+    it('should return an empty result when there is a 403 response and we asked for workspaces', async () => {
+      // The first replyOnce with 200 is for the client authentication
+      mockAxios.onGet().replyOnce(200).onGet().replyOnce(403)
+      const res = await client.getSinglePage({ url: '/workspaces' })
+      expect(res.data).toEqual([])
+      expect(res.status).toEqual(403)
+    })
+    it('should throw when there is a 403 response but we did not ask for workspaces', async () => {
+      // The first replyOnce with 200 is for the client authentication
+      mockAxios.onGet().replyOnce(200).onGet().replyOnce(403)
+      await expect(client.getSinglePage({ url: '/routing/attributes' })).rejects.toThrow()
     })
     it('should throw if there is no status in the error', async () => {
       // The first replyOnce with 200 is for the client authentication
       mockAxios.onGet().replyOnce(200).onGet().replyOnce(() => { throw new Error('Err') })
       await expect(
-        client.getSinglePage({ url: 'http://myBrand.zendesk.com/api/v2/routing/attributes' })
+        client.getSinglePage({ url: '/routing/attributes' })
       ).rejects.toThrow()
     })
   })


### PR DESCRIPTION
_fix zendesk config suggestion bug_

---

_Additional context for reviewer_
We wrote `workspaces` instead of `workspace` to the config. We will now use the reverse mapping of the supported types to get the correct typeName.
For this case, we decided to return empty result if we get 403 on workspaces, because we want similar behavior as we have with other unenabled features

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
