### PR TITLE
Revert "SALTO-2234: Salesforce - Handle LIMIT_EXCEEDED on retrieve (#2989)"

### DIFF
--- a/packages/salesforce-adapter/src/config_change.ts
+++ b/packages/salesforce-adapter/src/config_change.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { ListMetadataQuery, RetrieveResult } from 'jsforce-types'
 import { collections, values } from '@salto-io/lowerdash'
 import { Values, InstanceElement, ElemID } from '@salto-io/adapter-api'
-import { ConfigChangeSuggestion, configType, isDataManagementConfigSuggestions, isMetadataConfigSuggestions, SalesforceConfig, DataManagementConfig, isRetrieveSizeConfigSuggstion } from './types'
+import { ConfigChangeSuggestion, configType, isDataManagementConfigSuggestions, isMetadataConfigSuggestions, SalesforceConfig, DataManagementConfig } from './types'
 import * as constants from './constants'
 
 const { isDefined } = values
@@ -107,13 +107,8 @@ export const getConfigFromConfigChanges = (
     .filter(isDataManagementConfigSuggestions)
     .map(config => config.value)
 
-  const retrieveSize = configChanges
-    .filter(isRetrieveSizeConfigSuggstion)
-    .map(config => config.value)
-    .map(value => Math.max(value, constants.MINIMUM_MAX_ITEMS_IN_RETRIEVE_REQUEST))
-    .sort((a, b) => a - b)[0]
-
-  if ([newMetadataExclude, dataObjectsToExclude].every(_.isEmpty) && retrieveSize === undefined) {
+  if ([newMetadataExclude, dataObjectsToExclude]
+    .every(_.isEmpty)) {
     return undefined
   }
 
@@ -138,8 +133,6 @@ export const getConfigFromConfigChanges = (
     ...dataManagementOverrides,
   }, isDefined) as DataManagementConfig | undefined
 
-  const maxItemsInRetrieveRequest = retrieveSize ?? currentConfig.maxItemsInRetrieveRequest
-
   return {
     config: [new InstanceElement(
       ElemID.CONFIG_NAME,
@@ -159,7 +152,7 @@ export const getConfigFromConfigChanges = (
             saltoIDSettings: _.pickBy(data.saltoIDSettings, isDefined),
           },
         }, isDefined),
-        maxItemsInRetrieveRequest,
+        maxItemsInRetrieveRequest: currentConfig.maxItemsInRetrieveRequest,
         useOldProfiles: currentConfig.useOldProfiles,
         client: currentConfig.client,
       }, isDefined)

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -292,8 +292,6 @@ export const DEFAULT_MAX_CONCURRENT_API_REQUESTS = {
   deploy: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
 }
 export const DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST = 2500
-export const MINIMUM_MAX_ITEMS_IN_RETRIEVE_REQUEST = 500
-export const MAXIMUM_MAX_ITEMS_IN_RETRIEVE_REQUEST = 10000
 export const DEFAULT_USE_OLD_PROFILES = false
 export const MAX_QUERY_LENGTH = 2000
 export const DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS = {
@@ -345,7 +343,6 @@ export const CURRENCY_CODE_TYPE_NAME = 'CurrencyIsoCodes'
 
 // Retrieve constants
 export const RETRIEVE_LOAD_OF_METADATA_ERROR_REGEX = /Load of metadata from db failed for metadata of type:(?<type>\w+) and file name:(?<instance>\w+).$/
-export const RETRIEVE_SIZE_LIMIT_ERROR = 'LIMIT_EXCEEDED'
 
 // According to Salesforce spec the keyPrefix length is 3
 // If this changes in the future we need to change this and add further logic where it's used

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -19,8 +19,8 @@ import { FileProperties, MetadataInfo, MetadataObject } from 'jsforce-types'
 import { InstanceElement, ObjectType, TypeElement } from '@salto-io/adapter-api'
 import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
-import { FetchElements, ConfigChangeSuggestion, MAX_ITEMS_IN_RETRIEVE_REQUEST } from './types'
-import { METADATA_CONTENT_FIELD, NAMESPACE_SEPARATOR, INTERNAL_ID_FIELD, DEFAULT_NAMESPACE, RETRIEVE_SIZE_LIMIT_ERROR } from './constants'
+import { FetchElements, ConfigChangeSuggestion } from './types'
+import { METADATA_CONTENT_FIELD, NAMESPACE_SEPARATOR, INTERNAL_ID_FIELD, DEFAULT_NAMESPACE } from './constants'
 import SalesforceClient, { ErrorFilter } from './client/client'
 import { createListMetadataObjectsConfigChange, createRetrieveConfigChange, createSkippedListConfigChange } from './config_change'
 import { apiName, createInstanceElement, MetadataObjectType, createMetadataTypeElements, getAuthorAnnotations } from './transformers/transformer'
@@ -242,26 +242,10 @@ export const retrieveMetadataInstances = async ({
     log.debug('retrieving types %s', typesToRetrieve)
     const request = toRetrieveRequest(filesToRetrieve)
     const result = await client.retrieve(request)
-
     log.debug(
       'retrieve result for types %s: %o',
       typesToRetrieve, _.omit(result, ['zipFile', 'fileProperties']),
     )
-
-    if (result.errorStatusCode === RETRIEVE_SIZE_LIMIT_ERROR) {
-      if (fileProps.length <= 1) {
-        configChanges.push(...fileProps.map(fileProp =>
-          createSkippedListConfigChange(fileProp.type, fileProp.fullName)))
-        log.warn(`retrieve request for ${typesToRetrieve} failed: ${result.errorStatusCode} ${result.errorMessage}, adding to skip list`)
-        return []
-      }
-
-      const chunkSize = Math.ceil(fileProps.length / 2)
-      log.debug('reducing retrieve item count %d -> %d', fileProps.length, chunkSize)
-      configChanges.push({ type: MAX_ITEMS_IN_RETRIEVE_REQUEST, value: chunkSize })
-      return (await Promise.all(_.chunk(fileProps, chunkSize).map(retrieveInstances))).flat()
-    }
-
     configChanges.push(...createRetrieveConfigChange(result))
     // Unclear when / why this can happen, but it seems like sometimes zipFile is not a string
     // TODO: investigate further why this happens and find a better solution than just failing
@@ -288,12 +272,9 @@ export const retrieveMetadataInstances = async ({
     .filter(notInSkipList)
 
   log.info('going to retrieve %d files', filesToRetrieve.length)
-
-  const instances = await Promise.all(
-    _.chunk(filesToRetrieve, maxItemsInRetrieveRequest)
-      .filter(filesChunk => filesChunk.length > 0)
-      .map(filesChunk => retrieveInstances(filesChunk))
-  )
+  const instances = await Promise.all(_.chunk(filesToRetrieve, maxItemsInRetrieveRequest)
+    .filter(filesChunk => filesChunk.length > 0)
+    .map(filesChunk => retrieveInstances(filesChunk)))
 
   return {
     elements: _.flatten(instances),

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -226,25 +226,13 @@ export type MetadataConfigSuggestion = {
   reason?: string
 }
 
-export type RetrieveSizeConfigSuggstion = {
-  type: typeof MAX_ITEMS_IN_RETRIEVE_REQUEST
-  value: number
-  reason?: string
-}
-
-export type ConfigChangeSuggestion =
-    DataManagementConfigSuggestions
-  | MetadataConfigSuggestion
-  | RetrieveSizeConfigSuggstion
+export type ConfigChangeSuggestion = DataManagementConfigSuggestions | MetadataConfigSuggestion
 
 export const isDataManagementConfigSuggestions = (suggestion: ConfigChangeSuggestion):
   suggestion is DataManagementConfigSuggestions => suggestion.type === 'dataObjectsExclude'
 
 export const isMetadataConfigSuggestions = (suggestion: ConfigChangeSuggestion):
   suggestion is MetadataConfigSuggestion => suggestion.type === 'metadataExclude'
-
-export const isRetrieveSizeConfigSuggstion = (suggestion: ConfigChangeSuggestion):
-  suggestion is RetrieveSizeConfigSuggstion => suggestion.type === MAX_ITEMS_IN_RETRIEVE_REQUEST
 
 export type FetchElements<T> = {
   configChanges: ConfigChangeSuggestion[]
@@ -551,10 +539,7 @@ export const configType = createMatchingObjectType<SalesforceConfig>({
       refType: BuiltinTypes.NUMBER,
       annotations: {
         [CORE_ANNOTATIONS.DEFAULT]: constants.DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST,
-        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
-          min: constants.MINIMUM_MAX_ITEMS_IN_RETRIEVE_REQUEST,
-          max: constants.MAXIMUM_MAX_ITEMS_IN_RETRIEVE_REQUEST,
-        }),
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ min: 1000, max: 10000 }),
       },
     },
     [USE_OLD_PROFILES]: {

--- a/packages/salesforce-adapter/test/config_change.test.ts
+++ b/packages/salesforce-adapter/test/config_change.test.ts
@@ -15,9 +15,8 @@
 */
 import { InstanceElement } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { ConfigChangeSuggestion, SalesforceConfig, MAX_ITEMS_IN_RETRIEVE_REQUEST } from '../src/types'
+import { ConfigChangeSuggestion, SalesforceConfig } from '../src/types'
 import { getConfigFromConfigChanges, getConfigChangeMessage, ConfigChange } from '../src/config_change'
-import { MINIMUM_MAX_ITEMS_IN_RETRIEVE_REQUEST } from '../src/constants'
 
 describe('Config Changes', () => {
   const includedObjectName = '.*Object.*'
@@ -149,26 +148,6 @@ In order to complete the fetch operation, Salto needs to stop managing these ite
 
       it('should not change the currentConfig', () => {
         expect(cloneOfCurrentConfig).toEqual(currentConfig)
-      })
-    })
-    describe('maxItemInRetrieveRequest suggestions', () => {
-      it('should use the smallest suggested value', () => {
-        const suggestions = [
-          { type: MAX_ITEMS_IN_RETRIEVE_REQUEST, value: 3000 },
-          { type: MAX_ITEMS_IN_RETRIEVE_REQUEST, value: 2400 },
-          { type: MAX_ITEMS_IN_RETRIEVE_REQUEST, value: 5000 },
-        ] as ConfigChangeSuggestion[]
-        const newConfig = getConfigFromConfigChanges(suggestions, currentConfig)?.config
-        expect(newConfig?.[0].value.maxItemsInRetrieveRequest).toEqual(2400)
-      })
-
-      it('should suggest no less than the minimum', () => {
-        const suggestions = [
-          { type: MAX_ITEMS_IN_RETRIEVE_REQUEST, value: 50 },
-        ] as ConfigChangeSuggestion[]
-        const newConfig = getConfigFromConfigChanges(suggestions, currentConfig)?.config
-        expect(newConfig?.[0].value.maxItemsInRetrieveRequest)
-          .toEqual(MINIMUM_MAX_ITEMS_IN_RETRIEVE_REQUEST)
       })
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7208,7 +7208,7 @@ jsesc@^2.5.1:
 
 "jsforce-types@https://github.com/salto-io/jsforce-types.git":
   version "0.1.0"
-  resolved "https://github.com/salto-io/jsforce-types.git#20b33d28914afd524345bf06d9528d1b886e85f3"
+  resolved "https://github.com/salto-io/jsforce-types.git#c4769ae5cb243711bb940c0be6a771305edc315f"
 
 "jsforce@https://github.com/salto-io/jsforce.git":
   version "1.9.3"


### PR DESCRIPTION
This reverts commit 28969cf3d60ae7e368716dd20a1ac974fb9ccc56.

---
_Release Notes_: 
None

---
_User Notifications_: 
None