### PR TITLE
SALTO-2287: added locked fields validator

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -31,6 +31,7 @@ import { dashboardGadgetsValidator } from './dashboard_gadgets'
 import { dashboardLayoutValidator } from './dashboard_layout'
 import { maskingValidator } from './masking'
 import { automationsValidator } from './automations'
+import { lockedFieldsValidator } from './locked_fields'
 
 const {
   deployTypesNotSupportedValidator,
@@ -55,6 +56,7 @@ export default (
     dashboardLayoutValidator,
     automationsValidator,
     maskingValidator(client),
+    lockedFieldsValidator,
   ]
 
   return createChangeValidator(validators)

--- a/packages/jira-adapter/src/change_validators/locked_fields.ts
+++ b/packages/jira-adapter/src/change_validators/locked_fields.ts
@@ -1,0 +1,35 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { FIELD_TYPE_NAME } from '../filters/fields/constants'
+
+const { awu } = collections.asynciterable
+
+export const lockedFieldsValidator: ChangeValidator = async changes => (
+  awu(changes)
+    .filter(isInstanceChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === FIELD_TYPE_NAME)
+    .filter(instance => instance.value.isLocked)
+    .map(async instance => ({
+      elemID: instance.elemID,
+      severity: 'Error' as SeverityLevel,
+      message: 'Cannot deploy a locked field',
+      detailedMessage: `The field ${instance.elemID.getFullName()} is locked and cannot be deployed`,
+    }))
+    .toArray()
+)

--- a/packages/jira-adapter/test/change_validators/locked_fields.test.ts
+++ b/packages/jira-adapter/test/change_validators/locked_fields.test.ts
@@ -1,0 +1,52 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { FIELD_TYPE_NAME } from '../../src/filters/fields/constants'
+import { lockedFieldsValidator } from '../../src/change_validators/locked_fields'
+import { JIRA } from '../../src/constants'
+
+describe('lockedFieldsValidator', () => {
+  let type: ObjectType
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    type = new ObjectType({ elemID: new ElemID(JIRA, FIELD_TYPE_NAME) })
+    instance = new InstanceElement('instance', type)
+  })
+  it('should return an error if a field is locked', async () => {
+    instance.value.isLocked = true
+    expect(await lockedFieldsValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: 'Cannot deploy a locked field',
+        detailedMessage: 'The field jira.Field.instance.instance is locked and cannot be deployed',
+      },
+    ])
+  })
+
+  it('should not return an error if field is not locked', async () => {
+    expect(await lockedFieldsValidator([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([])
+  })
+})


### PR DESCRIPTION
Added change validator to prevent deploying locked fields

---
_Release Notes_: 
_Jira Adapter_:
- Added a change validator error when attempting to deploy a locked field

---
_User Notifications_: 
None