### PR TITLE
SALTO-1463: Fetch layouts of installed packages

### DIFF
--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -104,7 +104,7 @@ const getFullName = (obj: FileProperties): string => {
   // <namespace>__<objectName>-<layoutName> where it should be
   // <namespace>__<objectName>-<namespace>__<layoutName>
     const [objectName, ...layoutName] = fullNameWithCorrectedObjectName.split('-')
-    if (!layoutName[0].startsWith(obj.namespacePrefix)) {
+    if (layoutName.length !== 0 && !layoutName[0].startsWith(obj.namespacePrefix)) {
       return `${objectName}-${namePrefix}${layoutName.join('-')}`
     }
   }

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -20,7 +20,7 @@ import { InstanceElement, ObjectType, TypeElement } from '@salto-io/adapter-api'
 import { values as lowerDashValues, collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { FetchElements, ConfigChangeSuggestion } from './types'
-import { METADATA_CONTENT_FIELD, NAMESPACE_SEPARATOR, INTERNAL_ID_FIELD, DEFAULT_NAMESPACE } from './constants'
+import { METADATA_CONTENT_FIELD, NAMESPACE_SEPARATOR, INTERNAL_ID_FIELD, DEFAULT_NAMESPACE, LAYOUT_TYPE_ID_METADATA_TYPE } from './constants'
 import SalesforceClient, { ErrorFilter } from './client/client'
 import { createListMetadataObjectsConfigChange, createRetrieveConfigChange, createSkippedListConfigChange } from './config_change'
 import { apiName, createInstanceElement, MetadataObjectType, createMetadataTypeElements, getAuthorAnnotations } from './transformers/transformer'
@@ -97,7 +97,18 @@ const getFullName = (obj: FileProperties): string => {
   // Ensure fullName starts with the namespace prefix if there is one
   // needed due to a SF quirk where sometimes metadata instances return without a namespace
   // in the fullName even when they should have it
-  return obj.fullName.startsWith(namePrefix) ? obj.fullName : `${namePrefix}${obj.fullName}`
+  const fullNameWithCorrectedObjectName = obj.fullName.startsWith(namePrefix) ? obj.fullName : `${namePrefix}${obj.fullName}`
+  if (obj.type === LAYOUT_TYPE_ID_METADATA_TYPE && obj.namespacePrefix) {
+  // Ensure layout name starts with the namespace prefix if there is one.
+  // needed due to a SF quirk where sometimes layout metadata instances fullNames return as
+  // <namespace>__<objectName>-<layoutName> where it should be
+  // <namespace>__<objectName>-<namespace>__<layoutName>
+    const [objectName, ...layoutName] = fullNameWithCorrectedObjectName.split('-')
+    if (!layoutName[0].startsWith(obj.namespacePrefix)) {
+      return `${objectName}-${namePrefix}${layoutName.join('-')}`
+    }
+  }
+  return fullNameWithCorrectedObjectName
 }
 
 const getNamespace = (obj: FileProperties): string => (

--- a/packages/salesforce-adapter/test/fetch_installed_packages_layout.test.ts
+++ b/packages/salesforce-adapter/test/fetch_installed_packages_layout.test.ts
@@ -1,0 +1,130 @@
+/*
+*                      Copyright 2022 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, isInstanceElement } from '@salto-io/adapter-api'
+import { naclCase } from '@salto-io/adapter-utils'
+import { LAYOUT_TYPE_ID } from '../src/filters/layouts'
+import * as constants from '../src/constants'
+import mockClient from './client'
+import { fetchMetadataInstances } from '../src/fetch'
+import { buildMetadataQuery } from '../src/fetch_profile/metadata_query'
+
+describe('Test fetching layouts of installed packages', () => {
+  const fetch = async ({
+    apiName,
+    namespacePrefix,
+    layoutNameIncludesPrefix = false,
+  }:
+    {
+        apiName: string
+        namespacePrefix?: string
+        layoutNameIncludesPrefix?: boolean
+        customObject?: boolean
+
+    }): Promise<void> => {
+    const fileProps = [
+      {
+        createdById: 'aaaaaaaaa',
+        createdByName: 'aaaaaaaaa',
+        createdDate: '2020-08-25T11:39:01.000Z',
+        fileName: 'layouts/Test.layout',
+        fullName: layoutNameIncludesPrefix ? `${apiName}-SBQQ__Test Layout` : `${apiName}-Test Layout`,
+        id: 'aaaaaaaaa',
+        lastModifiedById: 'aaaaaaaaa',
+        lastModifiedByName: 'aaaaaaaaa',
+        lastModifiedDate: '2020-08-25T11:40:45.000Z',
+        manageableState: 'installed',
+        type: 'Layout',
+        namespacePrefix,
+      },
+    ]
+    const testLayoutType = new ObjectType({
+      elemID: new ElemID(constants.SALESFORCE,
+        constants.LAYOUT_TYPE_ID_METADATA_TYPE),
+      annotations: {
+        metadataType: constants.LAYOUT_TYPE_ID_METADATA_TYPE,
+      },
+    })
+    const { client } = mockClient()
+    client.readMetadata = jest.fn()
+      .mockImplementation(async (_typeName: string, names: string[])
+        : Promise<{result: {}[]; errors: string[]}> => {
+        const result = names.map(name => {
+          const testLayoutMetadataInfo = {
+            [constants.INSTANCE_FULL_NAME_FIELD]: name,
+            layoutSections: {
+              layoutColumns: {
+                layoutItems: [{
+                  field: 'foo',
+                }, {
+                  field: 'bar',
+                }, {
+                  customLink: 'link',
+                }, {
+                  field: 'moo',
+                }],
+              },
+            },
+          }
+          return testLayoutMetadataInfo
+        })
+
+        return { result, errors: [] }
+      })
+
+    const metadataQuery = buildMetadataQuery(
+      {
+        include: [{ metadataType: '.*' }],
+      }
+    )
+
+    const { elements } = await fetchMetadataInstances({
+      client,
+      metadataType: testLayoutType,
+      fileProps,
+      metadataQuery,
+    })
+    const instance = elements
+      .filter(isInstanceElement)
+      .find(inst => inst.elemID.typeName === constants.LAYOUT_TYPE_ID_METADATA_TYPE)
+    const targetFullName = namespacePrefix ? 'SBQQ__TestApiName__c-SBQQ__Test Layout' : `${apiName}-Test Layout`
+    expect(instance).toBeDefined()
+    expect(instance?.elemID).toEqual(LAYOUT_TYPE_ID.createNestedID('instance', naclCase(targetFullName)))
+  }
+  describe('if the API name already includes namespacePrefix', () => {
+    describe('if layout name does not include prefix', () => {
+      it('should add prefix to layout name', async () => {
+        await fetch({ apiName: 'SBQQ__TestApiName__c', namespacePrefix: 'SBQQ', layoutNameIncludesPrefix: false })
+      })
+    })
+    describe('if layout name already includes prefix', () => {
+      it('should not add prefix to layout name', async () => {
+        await fetch({ apiName: 'SBQQ__TestApiName__c', namespacePrefix: 'SBQQ', layoutNameIncludesPrefix: true })
+      })
+    })
+  })
+  describe('if the API name does not include namespacePrefix', () => {
+    describe('if layout  name does not include prefix', () => {
+      it('should add prefix to the layout\'s name', async () => {
+        await fetch({ apiName: 'TestApiName__c', namespacePrefix: 'SBQQ', layoutNameIncludesPrefix: false })
+      })
+    })
+    describe('if layout name already includes namespacePrefix', () => {
+      it('should not add prefix to the layout\'s name', async () => {
+        await fetch({ apiName: 'TestApiName__c', namespacePrefix: 'SBQQ', layoutNameIncludesPrefix: true })
+      })
+    })
+  })
+})


### PR DESCRIPTION
replacing both of those closed PRs: https://github.com/salto-io/salto/pull/2412, https://github.com/salto-io/salto/pull/2999
bug: Layouts of objects of installed packages have a namespace field (e.g "SBQQ" ) in their fileprops. They do not get fetched.
This is because the name we receive from `listMetadataObjects` is not the same name that `readMetadata` expects to get in order to fetch those instances.
The fix was to manipulate the name in the fileprops we receive from `listMetadataObjects` so that it will include the namespace prefix in the beginning of the layout name (and not just in the beginning of the related object's name).

---
_Release Notes_: 
Salesforce Adapter: bug fix: Layouts of Installed Packages objects will now be fetched.

---
_User Notifications_: 
Salesforce Adapter: bug fix: Layouts of Installed Packages objects will now be fetched.
