### PR TITLE
SALTO-2281: changed to save references in state

### DIFF
--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -21,6 +21,7 @@ import {
   ReferenceExpression, TemplateExpression, VariableExpression,
   isReferenceExpression, Variable, StaticFile, isStaticFile,
   isPrimitiveType, FieldDefinition, Value, TypeRefMap, TypeReference, isTypeReference,
+  isVariableExpression,
 } from '@salto-io/adapter-api'
 import { DuplicateAnnotationError, MergeError, isMergeError } from '../merger/internal/common'
 import { DuplicateInstanceKeyError } from '../merger/internal/instances'
@@ -135,7 +136,7 @@ export const serialize = <T = Element>(
   )
   const referenceExpressionReplacer = (e: ReferenceExpression):
     ReferenceExpression & SerializedClass => {
-    if (e.value === undefined || referenceSerializerMode === 'keepRef') {
+    if (e.value === undefined || referenceSerializerMode === 'keepRef' || !isVariableExpression(e)) {
       return saltoClassReplacer(e.createWithValue(undefined))
     }
     // Replace ref with value in order to keep the result from changing between

--- a/packages/workspace/test/serializer/serializer.test.ts
+++ b/packages/workspace/test/serializer/serializer.test.ts
@@ -268,20 +268,14 @@ describe('State/cache serialization', () => {
       e => e.elemID.getFullName() === innerRefsInstance.elemID.getFullName()
     ) as InstanceElement
     expect(refInst.value.name).toEqual('I am a var')
-    expect(refInst.value.num).toEqual(7)
+    expect(refInst.value.num).toBeInstanceOf(ReferenceExpression)
     expect(refInst2.value.name).toBeInstanceOf(ReferenceExpression)
     expect(refInst2.value.name.elemID.getFullName()).toEqual(instance.elemID.getFullName())
     expect(refInst3.value.name).toBeInstanceOf(ReferenceExpression)
-    expect(refInst3.value.name.elemID.getFullName()).toEqual(instance.elemID.getFullName())
-    expect(innerRefsInst.value).toEqual({
-      a: {
-        b: 2,
-      },
-      b: {
-        b: 2,
-      },
-      c: 2,
-    })
+    expect(refInst3.value.name.elemID.getFullName()).toEqual(refInstance2.elemID.createNestedID('name').getFullName())
+    expect(innerRefsInst.value.a).toBeInstanceOf(ReferenceExpression)
+    expect(innerRefsInst.value.b.b).toBeInstanceOf(ReferenceExpression)
+    expect(innerRefsInst.value.c).toBe(2)
   })
 
   it('should create the same result for the same input regardless of elements order', () => {


### PR DESCRIPTION
Changed to save referecens in state and not only their value

---
_Release Notes_: 
_Core_:
- Fixed a rare merge error issue of instances with inner referneces

---
_User Notifications_: 
None