### PR TITLE
fix clone to include paths

### DIFF
--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -352,6 +352,7 @@ export class PrimitiveType<Primitive extends PrimitiveTypes = PrimitiveTypes> ex
       primitive: this.primitive,
       annotationRefsOrTypes: this.cloneAnnotationTypes(),
       annotations: this.cloneAnnotations(),
+      path: this.path !== undefined ? [...this.path] : undefined,
     })
     res.annotate(additionalAnnotations)
     return res

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -67,6 +67,17 @@ describe('Test elements.ts', () => {
     expect(primNum.primitive).toBe(PrimitiveTypes.NUMBER)
   })
 
+  it('should clone path when a primitive type is cloned', () => {
+    const primToClone = new PrimitiveType({
+      elemID: primID,
+      primitive: PrimitiveTypes.STRING,
+      annotationRefsOrTypes: {},
+      annotations: {},
+      path: ['testPath'],
+    })
+    expect(primToClone.clone().path).toEqual(['testPath'])
+  })
+
   it('should create a basic object type with all params passed to the constructor', async () => {
     expect(ot.elemID).toEqual(otID)
     expect(await ot.fields.num_field.getType()).toBeInstanceOf(PrimitiveType)


### PR DESCRIPTION
Clones of primitive types didn't include paths, fixing that. This could theoretically have caused bugs in all sorts of places but specifically caused an issue for the multiple app connections feature:
https://salto-io.atlassian.net/jira/software/c/projects/SAAS/issues/SAAS-5044?filter=myopenissues
This is because that feature uses the clone functionality on all elements from a fetch.
---
---
_Release Notes_:
---
_User Notifications_: 