### PR TITLE
SALTO-2280: add logs for duration of filters in salesforce and zendesk

### DIFF
--- a/packages/adapter-components/src/filter_utils.ts
+++ b/packages/adapter-components/src/filter_utils.ts
@@ -39,10 +39,15 @@ export type FilterCreator<
   FilterOpts<TClient, TContext, TAdditional>
 >
 
+export type FilterRunner<
+  TResult extends void | filter.FilterResult,
+  DeployInfo=void
+> = filter.FilterRunner<TResult, DeployInfo>
+
 export const filtersRunner = <
   TClient, TContext, TResult extends void | filter.FilterResult = void, TAdditional={}
 >(
     opts: FilterOpts<TClient, TContext, TAdditional>,
     filterCreators: ReadonlyArray<FilterCreator<TClient, TContext, TResult, TAdditional>>,
     onFetchAggregator: (results: TResult[]) => TResult | void = () => undefined,
-  ): Required<Filter<TResult>> => filter.filtersRunner(opts, filterCreators, onFetchAggregator)
+  ): filter.FilterRunner<TResult> => filter.filtersRunner(opts, filterCreators, onFetchAggregator)

--- a/packages/adapter-components/src/filters/ducktype/hide_types.ts
+++ b/packages/adapter-components/src/filters/ducktype/hide_types.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { Element, isObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { filter } from '@salto-io/adapter-utils'
 import { DuckTypeUserFetchConfig } from '../../config/ducktype'
@@ -26,6 +27,7 @@ export const hideTypesFilterCreator: <
  TContext extends { fetch: DuckTypeUserFetchConfig },
  TResult extends void | filter.FilterResult = void,
  > () => FilterCreator<TClient, TContext, TResult> = () => ({ config }) => ({
+   name: path.parse(path.basename(__filename)).name,
    onFetch: async (elements: Element[]) => {
      if (config.fetch.hideTypes) {
        elements

--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import { Element, isInstanceElement, isReferenceExpression, InstanceElement, ElemID, ElemIdGetter } from '@salto-io/adapter-api'
 import { filter, setPath, references, getParents, transformElement } from '@salto-io/adapter-utils'
@@ -263,6 +264,7 @@ export const referencedInstanceNamesFilterCreator: <
   TContext extends { apiDefinitions: AdapterApiConfig },
   TResult extends void | filter.FilterResult = void
 >() => FilterCreator<TClient, TContext, TResult> = () => ({ config, getElemIdFunc }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const transformationDefault = config.apiDefinitions.typeDefaults.transformation
     const configByType = config.apiDefinitions.types

--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { Change, CORE_ANNOTATIONS, Element, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
 import { filter } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter_utils'
@@ -36,6 +37,7 @@ export const serviceUrlFilterCreator: <
   TContext extends { apiDefinitions: AdapterApiConfig },
   TResult extends void | filter.FilterResult = void
 >(baseUrl: string) => FilterCreator<TClient, TContext, TResult> = baseUrl => ({ config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     elements
       .filter(isInstanceElement)

--- a/packages/adapter-utils/test/filter.test.ts
+++ b/packages/adapter-utils/test/filter.test.ts
@@ -16,7 +16,7 @@
 import { Change, DeployResult, ElemID, ObjectType, toChange } from '@salto-io/adapter-api'
 import { objects } from '@salto-io/lowerdash'
 import each from 'jest-each'
-import { Filter, FilterCreator, filtersRunner, FilterWith } from '../src/filter'
+import { FilterCreator, filtersRunner, FilterWith } from '../src/filter'
 
 const { concatObjects } = objects
 
@@ -48,7 +48,7 @@ describe('filtersRunner', () => {
     'preDeploy',
     'onDeploy',
     'onPostFetch',
-  ]).describe('%s', (operation: keyof Filter<void>) => {
+  ]).describe('%s', (operation: keyof ReturnType<typeof filtersRunner>) => {
     const operation1 = jest.fn()
     const operation2 = jest.fn()
     let filterRunnerPromise: Promise<unknown>

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -22,7 +22,7 @@ import { objects } from '@salto-io/lowerdash'
 import JiraClient from './client/client'
 import changeValidator from './change_validators'
 import { JiraConfig, getApiDefinitions } from './config'
-import { FilterCreator, Filter, filtersRunner } from './filter'
+import { FilterCreator, filtersRunner, FilterRunner } from './filter'
 import fieldReferencesFilter from './filters/field_references'
 import referenceBySelfLinkFilter from './filters/references_by_self_link'
 import removeSelfFilter from './filters/remove_self'
@@ -188,7 +188,7 @@ type AdapterSwaggers = {
 }
 
 export default class JiraAdapter implements AdapterOperations {
-  private createFiltersRunner: () => Required<Filter>
+  private createFiltersRunner: () => FilterRunner
   private client: JiraClient
   private userConfig: JiraConfig
   private paginator: clientUtils.Paginator

--- a/packages/jira-adapter/src/filter.ts
+++ b/packages/jira-adapter/src/filter.ts
@@ -26,6 +26,8 @@ export type FilterResult = {
 
 export type Filter = filterUtils.Filter<FilterResult>
 
+export type FilterRunner = filterUtils.FilterRunner<FilterResult>
+
 export type FilterAdditionParams = {
   elementsSource: ReadOnlyElementsSource
   fetchQuery: elementUtils.query.ElementQuery

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -56,7 +56,7 @@ import systemNoteAuthorInformation from './filters/author_information/system_not
 import savedSearchesAuthorInformation from './filters/author_information/saved_searches'
 import suiteAppConfigElementsFilter from './filters/suiteapp_config_elements'
 import configFeaturesFilter from './filters/config_features'
-import { createFilterCreatorsWithLogs, Filter, FilterCreator } from './filter'
+import { createFilterCreatorsWithLogs, FilterRunner, FilterCreator } from './filter'
 import { getConfigFromConfigChanges, NetsuiteConfig, DEFAULT_DEPLOY_REFERENCED_ELEMENTS, DEFAULT_WARN_STALE_DATA, DEFAULT_USE_CHANGES_DETECTION } from './config'
 import { andQuery, buildNetsuiteQuery, NetsuiteQuery, NetsuiteQueryParameters, notQuery, QueryParams, convertToQueryParams } from './query'
 import { createServerTimeElements, getLastServerTime } from './server_time'
@@ -110,7 +110,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
   private readonly fetchTarget?: NetsuiteQueryParameters
   private readonly skipList?: NetsuiteQueryParameters // old version
   private readonly useChangesDetection: boolean
-  private createFiltersRunner: (isPartial: boolean) => Required<Filter>
+  private createFiltersRunner: (isPartial: boolean) => FilterRunner
   private elementsSourceIndex: LazyElementsSourceIndexes
 
 

--- a/packages/netsuite-adapter/src/filter.ts
+++ b/packages/netsuite-adapter/src/filter.ts
@@ -41,6 +41,8 @@ export type FilterCreator = filter.FilterCreator<
   DeployResult
 >
 
+export type FilterRunner = filter.FilterRunner<void, DeployResult>
+
 const wrapFilterWithLog = (filterName: string, filterCreator: FilterCreator): FilterCreator => {
   const wrap: FilterCreator = opts => {
     const {

--- a/packages/netsuite-adapter/test/filter.test.ts
+++ b/packages/netsuite-adapter/test/filter.test.ts
@@ -22,7 +22,7 @@ describe('filter', () => {
   const mockDeploy = jest.fn()
   const mockOnDeploy = jest.fn()
   const mockOnPostFetch = jest.fn()
-  const filterWithAllMethods: Required<Filter> = {
+  const filterWithAllMethods: Filter = {
     onFetch: mockOnFetch,
     preDeploy: mockPreDeploy,
     deploy: mockDeploy,

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -72,7 +72,7 @@ import customMetadataRecordsFilter from './filters/custom_metadata'
 import currencyIsoCodeFilter from './filters/currency_iso_code'
 import { FetchElements, SalesforceConfig } from './types'
 import { getConfigFromConfigChanges } from './config_change'
-import { FilterCreator, Filter, FilterResult } from './filter'
+import { FilterCreator, FilterRunner, FilterResult } from './filter'
 import { addDefaults } from './filters/utils'
 import { retrieveMetadataInstances, fetchMetadataType, fetchMetadataInstances, listMetadataObjects } from './fetch'
 import { isCustomObjectInstanceChanges, deployCustomObjectInstancesGroup } from './custom_object_instances_deploy'
@@ -245,7 +245,7 @@ export default class SalesforceAdapter implements AdapterOperations {
   private metadataToRetrieve: string[]
   private metadataTypesOfInstancesFetchedInFilters: string[]
   private nestedMetadataTypes: Record<string, NestedMetadataTypeInfo>
-  private createFiltersRunner: () => Required<Filter>
+  private createFiltersRunner: () => FilterRunner
   private client: SalesforceClient
   private userConfig: SalesforceConfig
   private fetchProfile: FetchProfile

--- a/packages/salesforce-adapter/src/filter.ts
+++ b/packages/salesforce-adapter/src/filter.ts
@@ -39,6 +39,8 @@ export type FilterResult = {
 
 export type Filter = filter.Filter<FilterResult>
 
+export type FilterRunner = filter.FilterRunner<FilterResult>
+
 export type FilterWith<M extends keyof Filter> = filter.FilterWith<FilterResult, M>
 
 export type FilterCreator = filter.FilterCreator<FilterResult, FilterOpts>

--- a/packages/salesforce-adapter/src/filters/add_missing_ids.ts
+++ b/packages/salesforce-adapter/src/filters/add_missing_ids.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import {
   Element, isObjectType, isInstanceElement, isField,
 } from '@salto-io/adapter-api'
@@ -74,6 +75,7 @@ export const WARNING_MESSAGE = 'Encountered an error while trying populate inter
  * Add missing env-specific ids using listMetadataObjects.
  */
 const filter: FilterCreator = ({ client, config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/animation_rules.ts
+++ b/packages/salesforce-adapter/src/filters/animation_rules.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import wu from 'wu'
 import {
   Element, ElemID, ObjectType, InstanceElement, getRestriction,
@@ -39,6 +40,7 @@ const filterCreator = (): FilterWith<'onFetch'> => ({
    *
    * @param elements the already fetched elements
    */
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const transformShortValues = (animationRule: InstanceElement, fieldName: string,
       fieldFullValueNames: ReadonlyArray<string>): void => {

--- a/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { Element, Field, ObjectType } from '@salto-io/adapter-api'
 import { FileProperties } from 'jsforce-types'
 import { logger } from '@salto-io/logging'
@@ -103,6 +104,7 @@ export const WARNING_MESSAGE = 'Encountered an error while trying to populate au
  * add author information to object types and fields.
  */
 const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/author_information/data_instances.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/data_instances.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { CORE_ANNOTATIONS, Element, InstanceElement } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { isInstanceOfCustomObject } from '../../transformers/transformer'
@@ -58,6 +59,7 @@ export const WARNING_MESSAGE = 'Encountered an error while trying to populate au
  * add author information to data instance elements.
  */
 const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/author_information/sharing_rules.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/sharing_rules.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { CORE_ANNOTATIONS, Element, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { FileProperties } from 'jsforce-types'
 import { logger } from '@salto-io/logging'
@@ -68,6 +69,7 @@ export const WARNING_MESSAGE = 'Encountered an error while trying to populate au
  * add author information to sharing rules instances.
  */
 const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/author_information/validation_rules.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/validation_rules.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { Element, isInstanceElement } from '@salto-io/adapter-api'
 import { FileProperties } from 'jsforce-types'
 import { logger } from '@salto-io/logging'
@@ -54,6 +55,7 @@ export const WARNING_MESSAGE = 'Encountered an error while trying to populate au
  * Add author information to validation rules instances.
  */
 const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/convert_lists.ts
+++ b/packages/salesforce-adapter/src/filters/convert_lists.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import {
   ElemID, Element, isObjectType, Field, Values, Value, ObjectType, isInstanceElement,
@@ -204,6 +205,7 @@ export const makeFilter = (
    *
    * @param elements the already fetched elements
    */
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const instances = await awu(elements)
       .filter(isInstanceElement)

--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
+import path from 'path'
 import _ from 'lodash'
 import {
   Element, ObjectType, isContainerType, MapType, ListType, InstanceElement, CORE_ANNOTATIONS,
@@ -340,6 +340,7 @@ export const findInstancesToConvert = (
  * could be referenced, and can be split across multiple files.
  */
 const filter: FilterCreator = ({ config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     await awu(Object.keys(metadataTypeToFieldToMapDef)).forEach(async targetMetadataType => {
       if (targetMetadataType === PROFILE_METADATA_TYPE && config.useOldProfiles) {

--- a/packages/salesforce-adapter/src/filters/convert_types.ts
+++ b/packages/salesforce-adapter/src/filters/convert_types.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import {
   Element, isObjectType, isInstanceElement,
 } from '@salto-io/adapter-api'
@@ -37,6 +38,7 @@ const filterCreator: FilterCreator = () => ({
    *
    * @param elements the already fetched elements
    */
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     await awu(elements)
       .filter(isInstanceElement)

--- a/packages/salesforce-adapter/src/filters/cpq/custom_script.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/custom_script.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import { Element, ObjectType, ListType, InstanceElement, isAdditionOrModificationChange, getChangeData, Change, ChangeDataType, isListType, Field, isPrimitiveType, isObjectTypeChange, StaticFile, isFieldChange, isAdditionChange, isInstanceElement, createRefToElmWithValue } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
@@ -155,6 +156,7 @@ const applyFuncOnCustomScriptFieldChange = async (
 }
 
 const filter: FilterCreator = () => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const customObjects = await awu(elements).filter(isCustomObject).toArray() as ObjectType[]
     const cpqCustomScriptObject = await awu(customObjects)

--- a/packages/salesforce-adapter/src/filters/cpq/hide_read_only_values.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/hide_read_only_values.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { Element, CORE_ANNOTATIONS, isObjectType } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../../filter'
@@ -22,6 +23,7 @@ import { FIELD_ANNOTATIONS } from '../../constants'
 const { awu } = collections.asynciterable
 
 const filter: FilterCreator = ({ config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     if (config.fetchProfile.dataManagement?.showReadOnlyValues === true) {
       // eslint-disable-next-line no-useless-return

--- a/packages/salesforce-adapter/src/filters/cpq/lookup_fields.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/lookup_fields.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import { Element, ObjectType, ReferenceExpression, Value, Change, ChangeDataType, isAdditionOrModificationChange, getChangeData, isObjectTypeChange, Field, isAdditionChange, isFieldChange } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
@@ -254,6 +255,7 @@ const applyFuncOnCustomObjectWithMappingLookupChange = async (
 }
 
 const filter: FilterCreator = () => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     log.debug('Started replacing lookupObject values with references')
     await replaceLookupObjectValueSetValuesWithReferences(

--- a/packages/salesforce-adapter/src/filters/currency_iso_code.ts
+++ b/packages/salesforce-adapter/src/filters/currency_iso_code.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { Element, isObjectType, ObjectType, ElemID, ListType, InstanceElement, CORE_ANNOTATIONS, ReferenceExpression } from '@salto-io/adapter-api'
 import Joi from 'joi'
 import { FilterWith } from '../filter'
@@ -95,6 +96,7 @@ const createCurrencyCodesInstance = (supportedCurrencies: ValueSet): InstanceEle
  * with ValueSetName which points to it
  */
 const filterCreator = (): FilterWith<'onFetch'> => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const affectedElements = elements.filter(isObjectType).filter(isTypeWithCurrencyIsoCode)
     if (affectedElements.length === 0) {

--- a/packages/salesforce-adapter/src/filters/custom_feed_filter.ts
+++ b/packages/salesforce-adapter/src/filters/custom_feed_filter.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { FileProperties } from 'jsforce-types'
 import { Element, ElemID } from '@salto-io/adapter-api'
 import { findObjectType } from '@salto-io/adapter-utils'
@@ -30,6 +31,7 @@ const fixCustomFeedFullName = (props: FileProperties): FileProperties => ({
 })
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     const customFeedFilterType = findObjectType(
       elements, CUSTOM_FEED_FILTER_METADATA_TYPE_ID

--- a/packages/salesforce-adapter/src/filters/custom_metadata.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { isInstanceElement, Values, isInstanceChange, isAdditionOrModificationChange } from '@salto-io/adapter-api'
@@ -128,6 +129,7 @@ const formatRecordValuesForService = (values: Values): Values => {
 }
 
 const filterCreator: FilterCreator = () => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async elements => {
     await awu(elements)
       .filter(isInstanceElement)

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import { collections, values as lowerdashValues, promises } from '@salto-io/lowerdash'
 import {
@@ -258,6 +259,7 @@ const buildCustomObjectPrefixKeyMap = async (
 }
 
 const filter: FilterCreator = ({ client, config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     const { dataManagement } = config.fetchProfile
     if (dataManagement === undefined) {

--- a/packages/salesforce-adapter/src/filters/custom_object_split.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_split.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import { Element, isObjectType, ObjectType } from '@salto-io/adapter-api'
 import { pathNaclCase } from '@salto-io/adapter-utils'
@@ -59,6 +60,7 @@ const customObjectToSplitElements = async (customObject: ObjectType): Promise<Ob
 }
 
 const filterCreator = (): FilterWith<'onFetch'> => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const customObjects = await awu(elements).filter(isCustomObject).toArray() as ObjectType[]
     const newSplitCustomObjects = await awu(customObjects)

--- a/packages/salesforce-adapter/src/filters/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import pathModule from 'path'
 import { logger } from '@salto-io/logging'
 import { collections, strings, multiIndex, promises, values as lowerdashValues } from '@salto-io/lowerdash'
 import {
@@ -850,6 +851,7 @@ const isSideEffectRemoval = (
 const filterCreator: FilterCreator = ({ client, config }) => {
   let originalChanges: Record<string, Change[]> = {}
   return {
+    name: pathModule.parse(pathModule.basename(__filename)).name,
     onFetch: async (elements: Element[]): Promise<void> => {
       const customObjectInstances = await keyByAsync(
         await awu(elements).filter(isInstanceOfType(CUSTOM_OBJECT)).toArray(),

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import { collections, values, promises } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
@@ -411,6 +412,7 @@ export const getCustomObjectsFetchSettings = async (
 }
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     const { dataManagement } = config.fetchProfile
     if (dataManagement === undefined) {

--- a/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
+++ b/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { Element, isObjectType, ObjectType } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
@@ -38,6 +39,7 @@ const logInvalidCustomSettings = async (
 )
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     if (!config.fetchProfile.shouldFetchAllCustomSettings()) {
       return {}

--- a/packages/salesforce-adapter/src/filters/elements_url.ts
+++ b/packages/salesforce-adapter/src/filters/elements_url.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { logger } from '@salto-io/logging'
 import { CORE_ANNOTATIONS, Element } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
@@ -31,6 +32,7 @@ const getRelevantElements = (elements: Element[]): AsyncIterable<Element> =>
 export const WARNING_MESSAGE = 'Encountered an error while trying to populate URLs for some of your salesforce configuration elements. This might affect the availability of the ‘go to service’ functionality in your workspace.'
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/extra_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/extra_dependencies.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import {
   Element, isObjectType, ReferenceExpression, ElemID, ReadOnlyElementsSource,
@@ -189,6 +190,7 @@ export const WARNING_MESSAGE = 'Encountered an error while trying to query your 
  * Add references using the tooling API.
  */
 const creator: FilterCreator = ({ client, config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { Element, isInstanceElement, isReferenceExpression, isField, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { getParents } from '@salto-io/adapter-utils'
@@ -132,6 +133,7 @@ export const addReferences = async (
  *
  */
 const filter: FilterCreator = ({ config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async elements => {
     await addReferences(
       elements,

--- a/packages/salesforce-adapter/src/filters/flow.ts
+++ b/packages/salesforce-adapter/src/filters/flow.ts
@@ -13,12 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import {
-  Element, ElemID, getRestriction,
-} from '@salto-io/adapter-api'
-import {
-  findObjectType,
-} from '@salto-io/adapter-utils'
+import path from 'path'
+import { Element, ElemID, getRestriction } from '@salto-io/adapter-api'
+import { findObjectType } from '@salto-io/adapter-utils'
 import { FilterWith } from '../filter'
 import { SALESFORCE } from '../constants'
 
@@ -33,6 +30,7 @@ const filterCreator = (): FilterWith<'onFetch'> => ({
    *
    * @param elements the already fetched elements
    */
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<void> => {
     // fix flowMetadataValue - mark restriction values as not enforced, see: SALTO-93
     const flowMetadataValue = findObjectType(elements, FLOW_METADATA_TYPE_ID)

--- a/packages/salesforce-adapter/src/filters/foreign_key_references.ts
+++ b/packages/salesforce-adapter/src/filters/foreign_key_references.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import {
   Element, InstanceElement, ReferenceExpression,
   isInstanceElement, isReferenceExpression, ElemID,
@@ -66,6 +67,7 @@ const resolveReferences = async (
  * names into reference expressions.
  */
 const filter: FilterCreator = ({ config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const referenceElements = buildElementsSourceForFetch(elements, config)
     const elementsWithFields = flatMapAsync(

--- a/packages/salesforce-adapter/src/filters/global_value_sets.ts
+++ b/packages/salesforce-adapter/src/filters/global_value_sets.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { Element, ObjectType, Field, ReferenceExpression, ElemID, isObjectType } from '@salto-io/adapter-api'
 import { multiIndex } from '@salto-io/lowerdash'
 import { FilterWith, FilterCreator } from '../filter'
@@ -51,6 +52,7 @@ const filterCreator: FilterCreator = ({ config }): FilterWith<'onFetch'> => ({
   /**
    * @param elements the already fetched elements
    */
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<void> => {
     const referenceElements = buildElementsSourceForFetch(elements, config)
     const valueSetNameToRef = await multiIndex.keyByAsync({

--- a/packages/salesforce-adapter/src/filters/layouts.ts
+++ b/packages/salesforce-adapter/src/filters/layouts.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { logger } from '@salto-io/logging'
 import {
   Element, InstanceElement, ObjectType, ElemID, isInstanceElement,
@@ -66,6 +67,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
    *
    * @param elements the already fetched elements
    */
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<void> => {
     const layouts = await awu(elements)
       .filter(isInstanceElement)

--- a/packages/salesforce-adapter/src/filters/profile_instance_split.ts
+++ b/packages/salesforce-adapter/src/filters/profile_instance_split.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import { strings, collections, promises } from '@salto-io/lowerdash'
 import { Element, ObjectType, isMapType, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
@@ -71,6 +72,7 @@ const isProfileInstance = async (elem: Element): Promise<boolean> => (
  * to Attributes.nacl.
  */
 const filterCreator: FilterCreator = ({ config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     if (config.useOldProfiles) {
       return

--- a/packages/salesforce-adapter/src/filters/profile_paths.ts
+++ b/packages/salesforce-adapter/src/filters/profile_paths.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { Element, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { pathNaclCase, naclCase } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -61,6 +62,7 @@ export const WARNING_MESSAGE = 'Failed to update the NaCl file names for some of
  * replace paths for profile instances upon fetch
  */
 const filterCreator: FilterCreator = ({ client, config }): FilterWith<'onFetch'> => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/reference_annotations.ts
+++ b/packages/salesforce-adapter/src/filters/reference_annotations.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import {
   ElemID, Element, Field, ReferenceExpression, ObjectType, isObjectType,
 } from '@salto-io/adapter-api'
@@ -70,6 +71,7 @@ const convertAnnotationsToReferences = async (
  * Convert referenceTo and foreignKeyDomain annotations into reference expressions.
  */
 const filter: FilterCreator = ({ config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const referenceElements = buildElementsSourceForFetch(elements, config)
     const typeToElemID = await multiIndex.keyByAsync({

--- a/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
+++ b/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import {
   isObjectType, Element, isInstanceElement,
 } from '@salto-io/adapter-api'
@@ -77,6 +78,7 @@ const removeValuesFromInstances = async (
 export const makeFilter = (
   typeNameToFieldRemovals: Map<string, string[]>,
 ): FilterCreator => () => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     await removeValuesFromInstances(elements, typeNameToFieldRemovals)
     await removeFieldsFromTypes(elements, typeNameToFieldRemovals)

--- a/packages/salesforce-adapter/src/filters/remove_restriction_annotations.ts
+++ b/packages/salesforce-adapter/src/filters/remove_restriction_annotations.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { isObjectType, Element, ObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
@@ -40,6 +41,7 @@ const FIELDS_TO_REMOVE_RESTRICTION_FROM_BY_TYPE: Record<string, string[]> = {
 export const makeFilter = (
   typeNameToFieldMapping: Record<string, string[]>,
 ): FilterCreator => () => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const removeRestrictionsFromTypeFields = async (type: ObjectType): Promise<void> => {
       const relevantFields = typeNameToFieldMapping[await metadataType(type)]

--- a/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
+++ b/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { Element, isInstanceElement, InstanceElement, getChangeData, Change, Field, ReadOnlyElementsSource, isObjectType } from '@salto-io/adapter-api'
 import { transformValues, TransformFunc } from '@salto-io/adapter-utils'
 import _ from 'lodash'
@@ -117,6 +118,7 @@ const replaceInstancesValues = async (
  * Replace specific field values that are fetched as ids, to their names.
  */
 const filter: FilterCreator = ({ config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const referenceElements = buildElementsSourceForFetch(elements, config)
     const idToApiNameLookUp = await getRelevantFieldMapping({

--- a/packages/salesforce-adapter/src/filters/saml_initiation_method.ts
+++ b/packages/salesforce-adapter/src/filters/saml_initiation_method.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import wu from 'wu'
 import {
   Element, ElemID, getRestriction,
@@ -36,6 +37,7 @@ const filterCreator = (): FilterWith<'onFetch'> => ({
    *
    * @param elements the already discovered elements
    */
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const canvasType = findObjectType(elements, CANVAS_METADATA_TYPE_ID)
     const initMethods = canvasType ? canvasType.fields[SAML_INIT_METHOD_FIELD_NAME] : undefined

--- a/packages/salesforce-adapter/src/filters/settings_type.ts
+++ b/packages/salesforce-adapter/src/filters/settings_type.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { Element, ObjectType, TypeElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
@@ -66,6 +67,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
    *
    * @param elements
    */
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     // Fetch list of all settings types
     const {

--- a/packages/salesforce-adapter/src/filters/standard_value_sets.ts
+++ b/packages/salesforce-adapter/src/filters/standard_value_sets.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import { FileProperties } from 'jsforce-types'
 import {
@@ -203,6 +204,7 @@ export const makeFilter = (
    *
    * @param elements the already fetched elements
    */
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     const svsMetadataType: ObjectType | undefined = await findStandardValueSetType(elements)
     let configChanges: ConfigChangeSuggestion[] = []

--- a/packages/salesforce-adapter/src/filters/static_resource_file_ext.ts
+++ b/packages/salesforce-adapter/src/filters/static_resource_file_ext.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import {
   Element, ElemID, InstanceElement, isStaticFile, StaticFile,
 } from '@salto-io/adapter-api'
@@ -60,6 +61,7 @@ const filterCreator = (): FilterWith<'onFetch'> => ({
    * Upon fetch modify the extension of the StaticResource's static file CONTENT field
    * from '.resource' to the correct extension based on the CONTENT_TYPE field
    */
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<void> => {
     const staticResourceInstances = findInstances(elements, STATIC_RESOURCE_METADATA_TYPE_ID)
     wu(staticResourceInstances).forEach(modifyFileExtension)

--- a/packages/salesforce-adapter/src/filters/territory.ts
+++ b/packages/salesforce-adapter/src/filters/territory.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { Element, isInstanceElement, InstanceElement, getChangeData, Change, isInstanceChange, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
@@ -71,6 +72,7 @@ const setTerritoryDeployPkgStructure = async (element: InstanceElement): Promise
 }
 
 const filterCreator: FilterCreator = () => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async elements => {
     // Territory2 and Territory2Model support custom fields - these are returned
     // in a CustomObject with the appropriate name and also in each instance of these types

--- a/packages/salesforce-adapter/src/filters/topics_for_objects.ts
+++ b/packages/salesforce-adapter/src/filters/topics_for_objects.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import {
   ObjectType, Element, Values, getAnnotationValue, isObjectTypeChange, InstanceElement,
   isAdditionOrModificationChange, getChangeData, isAdditionChange, isModificationChange,
@@ -59,6 +60,7 @@ const createTopicsForObjectsInstance = (values: TopicsForObjectsInfo): InstanceE
 )
 
 const filterCreator: FilterCreator = (): FilterWith<'onFetch' | 'onDeploy'> => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<void> => {
     const customObjectTypes = await awu(elements).filter(isCustomObject).toArray() as ObjectType[]
     if (_.isEmpty(customObjectTypes)) {

--- a/packages/salesforce-adapter/src/filters/trim_keys.ts
+++ b/packages/salesforce-adapter/src/filters/trim_keys.ts
@@ -13,9 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import {
-  Element, isInstanceElement,
-} from '@salto-io/adapter-api'
+import path from 'path'
+import { Element, isInstanceElement } from '@salto-io/adapter-api'
 import {
   MapKeyFunc, mapKeysRecursive,
 } from '@salto-io/adapter-utils'
@@ -42,6 +41,7 @@ const filterCreator = (): FilterWith<'onFetch'> => ({
    * Remove the leading and trailing whitespaces and new line chars from the
    * LightningComponentBundle keys to fix potential parsing error
    */
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<void> => {
     await awu(elements)
       .filter(isInstanceElement)

--- a/packages/salesforce-adapter/src/filters/value_to_static_file.ts
+++ b/packages/salesforce-adapter/src/filters/value_to_static_file.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import {
   Element, InstanceElement, Field, isInstanceElement, Value, StaticFile,
 } from '@salto-io/adapter-api'
@@ -89,6 +90,7 @@ const extractToStaticFile = async (instance: InstanceElement): Promise<void> => 
  * Extract field value to static-resources for chosen intstances.
  */
 const filter: FilterCreator = () => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     await awu(elements)
       .filter(isInstanceElement)

--- a/packages/salesforce-adapter/src/filters/workflow.ts
+++ b/packages/salesforce-adapter/src/filters/workflow.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import {
   Element, InstanceElement, isInstanceElement, isObjectType,
   ObjectType, getChangeData, Change, BuiltinTypes, ElemID,
@@ -172,6 +173,7 @@ const filterCreator: FilterCreator = () => {
      * Upon fetch, modify the full_names of the inner types of the workflow to contain
      * the workflow full_name (e.g. MyWorkflowAlert -> Lead.MyWorkflowAlert)
      */
+    name: path.parse(path.basename(__filename)).name,
     onFetch: async (elements: Element[]) => {
       const splitWorkflow = async (
         workflowInst: InstanceElement

--- a/packages/salesforce-adapter/src/filters/xml_attributes.ts
+++ b/packages/salesforce-adapter/src/filters/xml_attributes.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import {
   Element, isInstanceElement,
 } from '@salto-io/adapter-api'
@@ -34,6 +35,7 @@ const filterCreator = (): FilterWith<'onFetch'> => ({
   /**
    * Upon fetch remove the XML_ATTRIBUTE_PREFIX from the instance.value keys so it'll match the type
    */
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<void> => {
     await awu(elements)
       .filter(isInstanceElement)

--- a/packages/salesforce-adapter/test/filters/filters.test.ts
+++ b/packages/salesforce-adapter/test/filters/filters.test.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { toChange, Change, FetchOptions } from '@salto-io/adapter-api'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import SalesforceAdapter from '../../src/adapter'
@@ -34,6 +35,7 @@ describe('SalesforceAdapter filters', () => {
 
     beforeEach(() => {
       filter = {
+        name: path.parse(path.basename(__filename)).name,
         onFetch: mockFunction<(typeof filter)['onFetch']>().mockResolvedValue(),
         preDeploy: mockFunction<(typeof filter)['preDeploy']>().mockResolvedValue(),
         deploy: mockFunction<(typeof filter)['deploy']>(),

--- a/packages/stripe-adapter/src/adapter.ts
+++ b/packages/stripe-adapter/src/adapter.ts
@@ -23,7 +23,7 @@ import { logDuration } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import StripeClient from './client/client'
 import { StripeConfig, API_DEFINITIONS_CONFIG, FETCH_CONFIG } from './config'
-import { FilterCreator, Filter, filtersRunner } from './filter'
+import { FilterCreator, FilterRunner, filtersRunner } from './filter'
 import { STRIPE } from './constants'
 import changeValidator from './change_validator'
 import fieldReferencesFilter from './filters/field_references'
@@ -45,7 +45,7 @@ export interface StripeAdapterParams {
 }
 
 export default class StripeAdapter implements AdapterOperations {
-  private filtersRunner: Required<Filter>
+  private filtersRunner: FilterRunner
   private client: StripeClient
   private paginator: clientUtils.Paginator
   private userConfig: StripeConfig

--- a/packages/stripe-adapter/src/filter.ts
+++ b/packages/stripe-adapter/src/filter.ts
@@ -21,4 +21,6 @@ export const { filtersRunner } = filterUtils
 
 export type Filter = filterUtils.Filter
 
+export type FilterRunner = filterUtils.FilterRunner<void>
+
 export type FilterCreator = filterUtils.FilterCreator<StripeClient, FilterContext>

--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -21,7 +21,7 @@ import { client as clientUtils, elements as elementUtils } from '@salto-io/adapt
 import { logDuration } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import WorkatoClient from './client/client'
-import { FilterCreator, Filter, filtersRunner } from './filter'
+import { FilterCreator, FilterRunner, filtersRunner } from './filter'
 import { FETCH_CONFIG, WorkatoConfig } from './config'
 import addRootFolderFilter from './filters/add_root_folder'
 import fieldReferencesFilter from './filters/field_references'
@@ -58,7 +58,7 @@ export interface WorkatoAdapterParams {
 }
 
 export default class WorkatoAdapter implements AdapterOperations {
-  private createFiltersRunner: () => Required<Filter>
+  private createFiltersRunner: () => FilterRunner
   private client: WorkatoClient
   private paginator: clientUtils.Paginator
   private userConfig: WorkatoConfig

--- a/packages/workato-adapter/src/filter.ts
+++ b/packages/workato-adapter/src/filter.ts
@@ -21,4 +21,6 @@ export const { filtersRunner } = filterUtils
 
 export type Filter = filterUtils.Filter
 
+export type FilterRunner = filterUtils.FilterRunner<void>
+
 export type FilterCreator = filterUtils.FilterCreator<WorkatoClient, FilterContext>

--- a/packages/zendesk-support-adapter/src/filter.ts
+++ b/packages/zendesk-support-adapter/src/filter.ts
@@ -26,4 +26,6 @@ export type FilterResult = {
 
 export type Filter = filterUtils.Filter<FilterResult>
 
+export type FilterRunner = filterUtils.FilterRunner<FilterResult>
+
 export type FilterCreator = filterUtils.FilterCreator<ZendeskClient, FilterContext, FilterResult>

--- a/packages/zendesk-support-adapter/src/filters/account_settings.ts
+++ b/packages/zendesk-support-adapter/src/filters/account_settings.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import {
   Change, getChangeData, InstanceElement,
@@ -26,6 +27,7 @@ export const ACCOUNT_SETTING_TYPE_NAME = 'account_setting'
  * Deploys account settings
  */
 const filterCreator: FilterCreator = ({ config, client }) => ({
+  name: path.parse(path.basename(__filename)).name,
   deploy: async (changes: Change<InstanceElement>[]) => {
     const [accountSettingChanges, leftoverChanges] = _.partition(
       changes,

--- a/packages/zendesk-support-adapter/src/filters/add_field_options.ts
+++ b/packages/zendesk-support-adapter/src/filters/add_field_options.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { InstanceElement } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
@@ -25,6 +26,7 @@ const { makeArray } = collections.array
 const RELEVANT_TYPE_NAMES = [ORG_FIELD_TYPE_NAME, USER_FIELD_TYPE_NAME]
 
 const filterCreator: FilterCreator = () => ({
+  name: path.parse(path.basename(__filename)).name,
   preDeploy: async changes => {
     await applyforInstanceChangesOfType(
       changes,

--- a/packages/zendesk-support-adapter/src/filters/app.ts
+++ b/packages/zendesk-support-adapter/src/filters/app.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import Joi from 'joi'
 import {
@@ -83,6 +84,7 @@ Promise<void> => {
  * Deploys app installation
  */
 const filterCreator: FilterCreator = ({ config, client }) => ({
+  name: path.parse(path.basename(__filename)).name,
   deploy: async (changes: Change<InstanceElement>[]) => {
     const [relevantChanges, leftoverChanges] = _.partition(
       changes,

--- a/packages/zendesk-support-adapter/src/filters/business_hours_schedule.ts
+++ b/packages/zendesk-support-adapter/src/filters/business_hours_schedule.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import {
   Change, getChangeData, InstanceElement, isAdditionChange, isModificationChange, Values,
@@ -77,6 +78,7 @@ Promise<void> => {
  * Deploys business hours schedules and their intervals
  */
 const filterCreator: FilterCreator = ({ config, client }) => ({
+  name: path.parse(path.basename(__filename)).name,
   deploy: async (changes: Change<InstanceElement>[]) => {
     const [scheduleChanges, leftoverChanges] = _.partition(
       changes,

--- a/packages/zendesk-support-adapter/src/filters/collision_errors.ts
+++ b/packages/zendesk-support-adapter/src/filters/collision_errors.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { isInstanceElement, Element } from '@salto-io/adapter-api'
 import { config as configUtils } from '@salto-io/adapter-components'
 import { getAndLogCollisionWarnings, getInstancesWithCollidingElemID } from '@salto-io/adapter-utils'
@@ -24,6 +25,7 @@ import { API_DEFINITIONS_CONFIG } from '../config'
  * Adds collision warnings
  */
 const filterCreator: FilterCreator = ({ config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const collistionWarnings = await getAndLogCollisionWarnings({
       adapterName: ZENDESK_SUPPORT,

--- a/packages/zendesk-support-adapter/src/filters/custom_field_options/creator.ts
+++ b/packages/zendesk-support-adapter/src/filters/custom_field_options/creator.ts
@@ -38,6 +38,7 @@ const { makeArray } = collections.array
 export const createCustomFieldOptionsFilterCreator = (
   { parentTypeName, childTypeName }: CustomFieldOptionsFilterCreatorParams
 ): FilterCreator => ({ config, client }) => ({
+  name: `${parentTypeName}-customFieldOptions`,
   onFetch: async (elements: Element[]): Promise<void> => {
     const parentType = elements
       .filter(isObjectType)

--- a/packages/zendesk-support-adapter/src/filters/default_deploy.ts
+++ b/packages/zendesk-support-adapter/src/filters/default_deploy.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import { Change, InstanceElement, isInstanceChange } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
 import { deployChange, deployChanges } from '../deployment'
@@ -21,6 +22,7 @@ import { deployChange, deployChanges } from '../deployment'
  * Deploys all the changes that were not deployed by the previous filters
  */
 const filterCreator: FilterCreator = ({ config, client }) => ({
+  name: path.parse(path.basename(__filename)).name,
   deploy: async (changes: Change<InstanceElement>[]) => {
     const deployResult = await deployChanges(
       changes.filter(isInstanceChange),

--- a/packages/zendesk-support-adapter/src/filters/dynamic_content.ts
+++ b/packages/zendesk-support-adapter/src/filters/dynamic_content.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import {
   Change, getChangeData, InstanceElement, isAdditionChange, isModificationChange, isRemovalChange,
@@ -30,6 +31,7 @@ export const DYNAMIC_CONTENT_ITEM_VARIANT_TYPE_NAME = 'dynamic_content_item__var
 const { makeArray } = collections.array
 
 const filterCreator: FilterCreator = ({ config, client }) => ({
+  name: path.parse(path.basename(__filename)).name,
   preDeploy: async (changes: Change<InstanceElement>[]) => {
     const localeIdToVariant = Object.fromEntries(changes
       .filter(

--- a/packages/zendesk-support-adapter/src/filters/dynamic_content_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/dynamic_content_references.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import pathModule from 'path'
 import {
   Element, InstanceElement, isInstanceElement, ReferenceExpression,
 } from '@salto-io/adapter-api'
@@ -59,6 +60,7 @@ const getDynamicContentDependencies = (
  * the _generated_ dependencies annotation
  */
 const filterCreator: FilterCreator = () => ({
+  name: pathModule.parse(pathModule.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<void> => {
     const instances = elements.filter(isInstanceElement)
 

--- a/packages/zendesk-support-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-support-adapter/src/filters/field_references.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import { Element, ElemID, InstanceElement, isInstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
@@ -783,6 +784,7 @@ export const lookupFunc = referenceUtils.generateLookupFunc(
  * Convert field values into references, based on predefined rules.
  */
 const filter: FilterCreator = ({ config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const addReferences = async (refDefs: ZendeskSupportFieldReferenceDefinition[]):
     Promise<void> => {

--- a/packages/zendesk-support-adapter/src/filters/hardcoded_channel.ts
+++ b/packages/zendesk-support-adapter/src/filters/hardcoded_channel.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import Joi from 'joi'
 import {
   BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, isInstanceElement, ObjectType, Values,
@@ -55,6 +56,7 @@ const isChannels = (values: unknown): values is Channel[] => {
  * Adds the hardcoded channel instances in order to add references to them
  */
 const filterCreator: FilterCreator = () => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async elements => {
     // We are ok with picking the first instance because triggerDefinition is a singleton
     const triggerDefinitionInstance = elements

--- a/packages/zendesk-support-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-support-adapter/src/filters/macro_attachments.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import Joi from 'joi'
 import FormData from 'form-data'
@@ -202,6 +203,7 @@ const getMacroAttachments = async ({
  * Adds the macro attachments instances
  */
 const filterCreator: FilterCreator = ({ config, client }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async elements => {
     const macrosWithAttachments = elements
       .filter(isInstanceElement)

--- a/packages/zendesk-support-adapter/src/filters/omit_inactive.ts
+++ b/packages/zendesk-support-adapter/src/filters/omit_inactive.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import { isInstanceElement, Element } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
@@ -31,6 +32,7 @@ const CAN_NOT_OMIT_INACTIVE_TYPE_NAMES = [
  * Omit inactive instances
  */
 const filterCreator: FilterCreator = ({ config }) => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const shouldRemoveElement = (element: Element): boolean =>
       (isInstanceElement(element)

--- a/packages/zendesk-support-adapter/src/filters/organization_field.ts
+++ b/packages/zendesk-support-adapter/src/filters/organization_field.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import { Change, getChangeData, InstanceElement } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
@@ -25,6 +26,7 @@ export const ORG_FIELD_TYPE_NAME = 'organization_field'
 export const ORG_FIELD_OPTION_TYPE_NAME = 'organization_field__custom_field_options'
 
 const filterCreator: FilterCreator = ({ config, client }) => ({
+  name: path.parse(path.basename(__filename)).name,
   deploy: async (changes: Change<InstanceElement>[]) => {
     const [relevantChanges, leftoverChanges] = _.partition(
       changes,

--- a/packages/zendesk-support-adapter/src/filters/remove_definition_instances.ts
+++ b/packages/zendesk-support-adapter/src/filters/remove_definition_instances.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import { isInstanceElement } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
@@ -32,6 +33,7 @@ const DEFINITION_TYPE_NAMES = [
  * Removes the definition instances
  */
 const filterCreator: FilterCreator = () => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async elements => {
     _.remove(elements,
       element =>

--- a/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/creator.ts
@@ -57,6 +57,7 @@ export const createReorderFilterCreator = (
     activeFieldName,
   }: ReorderFilterCreatorParams
 ): FilterCreator => ({ config, client }) => ({
+  name: `${typeName}-reorder`,
   onFetch: async (elements: Element[]): Promise<void> => {
     const orderTypeName = createOrderTypeName(typeName)
     const objType = elements

--- a/packages/zendesk-support-adapter/src/filters/reorder/trigger.ts
+++ b/packages/zendesk-support-adapter/src/filters/reorder/trigger.ts
@@ -82,6 +82,7 @@ const deployFunc: DeployFuncType = async (change, client, apiDefinitions) => {
  * Add trigger order element with all the triggers ordered
  */
 const filterCreator: FilterCreator = ({ config, client, paginator, fetchQuery }) => ({
+  name: `${TYPE_NAME}-reorder`,
   onFetch: async (elements: Element[]): Promise<void> => {
     const orderTypeName = createOrderTypeName(TYPE_NAME)
     const triggerObjType = elements

--- a/packages/zendesk-support-adapter/src/filters/restriction.ts
+++ b/packages/zendesk-support-adapter/src/filters/restriction.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import { isInstanceElement, Element, Values } from '@salto-io/adapter-api'
 import { FilterCreator } from '../filter'
@@ -29,6 +30,7 @@ const removeIdField = (instanceValue: Values): void => {
  * Fix the restriction object on multiple types
  */
 const filterCreator: FilterCreator = () => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]) => {
     const instances = elements.filter(isInstanceElement)
     instances

--- a/packages/zendesk-support-adapter/src/filters/routing_attribute.ts
+++ b/packages/zendesk-support-adapter/src/filters/routing_attribute.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import {
   Change, getChangeData, InstanceElement, isRemovalChange,
@@ -26,6 +27,7 @@ const ROUTING_ATTRIBUTE_TYPE_NAME = 'routing_attribute'
  * Deploys routing attribute
  */
 const filterCreator: FilterCreator = ({ config, client }) => ({
+  name: path.parse(path.basename(__filename)).name,
   deploy: async (changes: Change<InstanceElement>[]) => {
     const [relevantChanges, leftoverChanges] = _.partition(
       changes,

--- a/packages/zendesk-support-adapter/src/filters/sla_policy.ts
+++ b/packages/zendesk-support-adapter/src/filters/sla_policy.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import {
   Change, getChangeData, InstanceElement, isAdditionOrModificationChange,
@@ -27,6 +28,7 @@ export const SLA_POLICY_TYPE_NAME = 'sla_policy'
  * Deploys sla policy
  */
 const filterCreator: FilterCreator = ({ config, client }) => ({
+  name: path.parse(path.basename(__filename)).name,
   deploy: async (changes: Change<InstanceElement>[]) => {
     const [slaPoliciesChanges, leftoverChanges] = _.partition(
       changes,

--- a/packages/zendesk-support-adapter/src/filters/tag.ts
+++ b/packages/zendesk-support-adapter/src/filters/tag.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import {
   BuiltinTypes, Change, Element, ElemID, getChangeData, InstanceElement,
   isInstanceElement, ObjectType, ReferenceExpression,
@@ -92,6 +93,7 @@ const serializeReferencesToTags = (instance: InstanceElement): void => {
  * Extract tags references from business rules that refers to them
  */
 const filterCreator: FilterCreator = () => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<void> => {
     const instances = elements
       .filter(isInstanceElement)

--- a/packages/zendesk-support-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-support-adapter/src/filters/unordered_lists.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import {
   Element, InstanceElement, isInstanceElement, isReferenceExpression,
@@ -57,6 +58,7 @@ const orderTriggerDefinitions = (instances: InstanceElement[]): void => {
  * Sort lists whose order changes between fetches, to avoid unneeded noise.
  */
 const filterCreator: FilterCreator = () => ({
+  name: path.parse(path.basename(__filename)).name,
   onFetch: async (elements: Element[]): Promise<void> => {
     const instances = elements.filter(isInstanceElement)
     orderDynamicContentItems(instances)

--- a/packages/zendesk-support-adapter/src/filters/user.ts
+++ b/packages/zendesk-support-adapter/src/filters/user.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import Joi from 'joi'
 import { logger } from '@salto-io/logging'
@@ -191,6 +192,7 @@ const deployModificationFunc = async (
 const filterCreator: FilterCreator = ({ paginator }) => {
   let userIdToEmail: Record<string, string> = {}
   return {
+    name: path.parse(path.basename(__filename)).name,
     onFetch: async elements => {
       const users = await getUsers(paginator)
       if (_.isEmpty(users)) {

--- a/packages/zendesk-support-adapter/src/filters/view.ts
+++ b/packages/zendesk-support-adapter/src/filters/view.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import {
   Change, getChangeData, InstanceElement, isRemovalChange, Values,
@@ -28,6 +29,7 @@ export const VIEW_TYPE_NAME = 'view'
  * Deploys views
  */
 const filterCreator: FilterCreator = ({ config, client }) => ({
+  name: path.parse(path.basename(__filename)).name,
   preDeploy: async changes => {
     await applyforInstanceChangesOfType(
       changes,

--- a/packages/zendesk-support-adapter/src/filters/webhook.ts
+++ b/packages/zendesk-support-adapter/src/filters/webhook.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import {
   Change, getChangeData, InstanceElement, isAdditionOrModificationChange, isModificationChange,
@@ -31,6 +32,7 @@ export const AUTH_TYPE_TO_PLACEHOLDER_AUTH_DATA: Record<string, unknown> = {
  * Removes the authentication data from webhook if it wasn't changed
  */
 const filterCreator: FilterCreator = ({ config, client }) => ({
+  name: path.parse(path.basename(__filename)).name,
   deploy: async (changes: Change<InstanceElement>[]) => {
     const [webhookModificationChanges, leftoverChanges] = _.partition(
       changes,

--- a/packages/zendesk-support-adapter/src/filters/workspace.ts
+++ b/packages/zendesk-support-adapter/src/filters/workspace.ts
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import path from 'path'
 import _ from 'lodash'
 import {
   Change, getChangeData, InstanceElement, isRemovalChange, Values,
@@ -28,6 +29,7 @@ const WORKSPACE_TYPE_NAME = 'workspace'
  * Deploys workspaces
  */
 const filterCreator: FilterCreator = ({ config, client }) => ({
+  name: path.parse(path.basename(__filename)).name,
   preDeploy: async changes => {
     await applyforInstanceChangesOfType(
       changes,

--- a/packages/zuora-billing-adapter/src/adapter.ts
+++ b/packages/zuora-billing-adapter/src/adapter.ts
@@ -23,7 +23,7 @@ import { logDuration } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import ZuoraClient from './client/client'
 import { ZuoraConfig, API_DEFINITIONS_CONFIG, FETCH_CONFIG, ZuoraApiConfig, getUpdatedConfig, SETTING_TYPES, SUPPORTED_TYPES } from './config'
-import { FilterCreator, Filter, filtersRunner } from './filter'
+import { FilterCreator, FilterRunner, filtersRunner } from './filter'
 import fieldReferencesFilter from './filters/field_references'
 import objectDefsFilter from './filters/object_defs'
 import objectDefSplitFilter from './filters/object_def_split'
@@ -68,7 +68,7 @@ export interface ZuoraAdapterParams {
 }
 
 export default class ZuoraAdapter implements AdapterOperations {
-  private createFiltersRunner: () => Required<Filter>
+  private createFiltersRunner: () => FilterRunner
   private client: ZuoraClient
   private paginator: clientUtils.Paginator
   private userConfig: ZuoraConfig

--- a/packages/zuora-billing-adapter/src/filter.ts
+++ b/packages/zuora-billing-adapter/src/filter.ts
@@ -21,4 +21,6 @@ export const { filtersRunner } = filterUtils
 
 export type Filter = filterUtils.Filter
 
+export type FilterRunner = filterUtils.FilterRunner<void>
+
 export type FilterCreator = filterUtils.FilterCreator<ZuoraClient, FilterContext>


### PR DESCRIPTION
_add logs for duration of filters in salesforce and zendesk_

---

_Additional context for reviewer_
Adds logs for the duration of filters. Currently, added it just for salesforce and zendesk

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
