### PR TITLE
SALTO-2298: fixed creating context with default value

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/field.ts
+++ b/packages/jira-adapter/e2e_test/instances/field.ts
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 import { ElemID, Values, Element, ReferenceExpression } from '@salto-io/adapter-api'
+import _ from 'lodash'
 import { createReference } from '../utils'
 import { ISSUE_TYPE_NAME, JIRA } from '../../src/constants'
 
@@ -42,7 +43,11 @@ export const createFieldValues = (name: string): Values => ({
   type: 'com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect',
 })
 
-export const createContextValues = (name: string, allElements: Element[]): Values => ({
+export const createContextValues = (
+  name: string,
+  instanceName: string,
+  allElements: Element[]
+): Values => ({
   name,
   options: {
     p1: p1Option,
@@ -72,12 +77,12 @@ export const createContextValues = (name: string, allElements: Element[]): Value
   defaultValue: {
     type: 'option.cascading',
     optionId: new ReferenceExpression(
-      new ElemID(JIRA, 'Field', 'instance', name, 'contexts', 'CustomConfigurationScheme_for_CustomSelectList@s', 'options', 'p1'),
-      p1Option
+      new ElemID(JIRA, 'CustomFieldContext', 'instance', instanceName, 'options', 'p1'),
+      _.cloneDeep(p1Option)
     ),
     cascadingOptionId: new ReferenceExpression(
-      new ElemID(JIRA, 'Field', 'instance', name, 'contexts', 'CustomConfigurationScheme_for_CustomSelectList@s', 'options', 'p1', 'cascadingOptions', 'c11'),
-      p1Option.cascadingOptions.c11
+      new ElemID(JIRA, 'CustomFieldContext', 'instance', instanceName, 'options', 'p1', 'cascadingOptions', 'c11'),
+      _.cloneDeep(p1Option.cascadingOptions.c11)
     ),
   },
   issueTypeIds: [

--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -52,10 +52,11 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[][]
     createFieldValues(randomString),
   )
 
+  const fieldContextName = naclCase(`${randomString}${CUSTOM_FIELDS_SUFFIX}_${randomString}`)
   const fieldContext = new InstanceElement(
-    naclCase(`${randomString}${CUSTOM_FIELDS_SUFFIX}_${randomString}`),
+    fieldContextName,
     findType('CustomFieldContext', fetchedElements),
-    createContextValues(randomString, fetchedElements),
+    createContextValues(randomString, fieldContextName, fetchedElements),
     undefined,
     { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(field.elemID, field)] }
   )

--- a/packages/jira-adapter/test/filters/fields/default_values.test.ts
+++ b/packages/jira-adapter/test/filters/fields/default_values.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import { setDefaultValueTypeDeploymentAnnotations, updateDefaultValues } from '../../../src/filters/fields/default_values'
@@ -43,9 +43,17 @@ describe('default values', () => {
         {
           name: 'a',
           id: 3,
+          options: {
+            p1: {
+              id: 1,
+            },
+            p2: {
+              id: 2,
+            },
+          },
           defaultValue: {
             type: 'float',
-            number: 9,
+            optionId: new ReferenceExpression(type.elemID.createNestedID('instance', 'instance', 'options', 'p1')),
           },
         }
       )
@@ -56,9 +64,17 @@ describe('default values', () => {
         {
           name: 'a',
           id: 3,
+          options: {
+            p1: {
+              id: 1,
+            },
+            p2: {
+              id: 2,
+            },
+          },
           defaultValue: {
             type: 'float',
-            number: 10,
+            optionId: new ReferenceExpression(type.elemID.createNestedID('instance', 'instance', 'options', 'p2')),
           },
         },
         undefined,
@@ -79,7 +95,7 @@ describe('default values', () => {
             {
               contextId: 3,
               type: 'float',
-              number: 10,
+              optionId: 2,
             },
           ],
         },


### PR DESCRIPTION
fixed creating context with default value

---
_Release Notes_: 
_Jira adapter_:
- Fixed a bug where a context of an options type field would be created without default values

---
_User Notifications_: 
None
