### PR TITLE
Added timeout to each request retry to Salesforce of 15 minutes

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -19,21 +19,46 @@ import requestretry, { RequestRetryOptions, RetryStrategies, RetryStrategy } fro
 import Bottleneck from 'bottleneck'
 import { collections, decorators, hash } from '@salto-io/lowerdash'
 import {
-  Connection as RealConnection, MetadataObject, DescribeGlobalSObjectResult, FileProperties,
-  MetadataInfo, SaveResult, DescribeSObjectResult, DeployResult, RetrieveRequest, RetrieveResult,
-  ListMetadataQuery, UpsertResult, QueryResult, DescribeValueTypeResult,
-  BatchResultInfo, BulkLoadOperation,
+  BatchResultInfo,
+  BulkLoadOperation,
+  Connection as RealConnection,
+  DeployResult,
+  DescribeGlobalSObjectResult,
+  DescribeSObjectResult,
+  DescribeValueTypeResult,
+  FileProperties,
+  ListMetadataQuery,
+  MetadataInfo,
+  MetadataObject,
+  QueryResult,
+  RetrieveRequest,
+  RetrieveResult,
+  SaveResult,
+  UpsertResult,
 } from 'jsforce'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { flatValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { Options, RequestCallback } from 'request'
 import { AccountId, Value } from '@salto-io/adapter-api'
-import { CUSTOM_OBJECT_ID_FIELD, DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS, DEFAULT_MAX_CONCURRENT_API_REQUESTS, SALESFORCE } from '../constants'
-import { CompleteSaveResult, SfError, SalesforceRecord } from './types'
-import { UsernamePasswordCredentials, OauthAccessTokenCredentials, Credentials,
-  SalesforceClientConfig, ClientRateLimitConfig, ClientRetryConfig, ClientPollingConfig,
-  CustomObjectsDeployRetryConfig, ReadMetadataChunkSizeConfig } from '../types'
+import {
+  CUSTOM_OBJECT_ID_FIELD,
+  DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS,
+  DEFAULT_MAX_CONCURRENT_API_REQUESTS,
+  SALESFORCE,
+} from '../constants'
+import { CompleteSaveResult, SalesforceRecord, SfError } from './types'
+import {
+  ClientPollingConfig,
+  ClientRateLimitConfig,
+  ClientRetryConfig,
+  Credentials,
+  CustomObjectsDeployRetryConfig,
+  OauthAccessTokenCredentials,
+  ReadMetadataChunkSizeConfig,
+  SalesforceClientConfig,
+  UsernamePasswordCredentials,
+} from '../types'
 import Connection from './jsforce'
 
 const { makeArray } = collections.array
@@ -67,6 +92,7 @@ const DEFAULT_RETRY_OPTS: Required<ClientRetryConfig> = {
   maxAttempts: 5, // try 5 times
   retryDelay: 5000, // wait for 5s before trying again
   retryStrategy: 'NetworkError', // retry on network errors
+  timeout: 15 * 1000 * 60, // timeout per request retry in milliseconds
 }
 
 const DEFAULT_READ_METADATA_CHUNK_SIZE: Required<ReadMetadataChunkSizeConfig> = {

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -92,7 +92,7 @@ const DEFAULT_RETRY_OPTS: Required<ClientRetryConfig> = {
   maxAttempts: 5, // try 5 times
   retryDelay: 5000, // wait for 5s before trying again
   retryStrategy: 'NetworkError', // retry on network errors
-  timeout: 15 * 1000 * 60, // timeout per request retry in milliseconds
+  timeout: 60 * 1000 * 15, // timeout per request retry in milliseconds
 }
 
 const DEFAULT_READ_METADATA_CHUNK_SIZE: Required<ReadMetadataChunkSizeConfig> = {
@@ -330,6 +330,7 @@ const retry400ErrorWrapper = (strategy: RetryStrategy): RetryStrategy =>
 const createRetryOptions = (retryOptions: Required<ClientRetryConfig>): RequestRetryOptions => ({
   maxAttempts: retryOptions.maxAttempts,
   retryStrategy: retry400ErrorWrapper(RetryStrategies[retryOptions.retryStrategy]),
+  timeout: retryOptions.timeout,
   delayStrategy: (err, _response, _body) => {
     log.error('failed to run SFDC call for reason: %s. Retrying in %ss.',
       err?.message ?? '', (retryOptions.retryDelay / 1000))

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -15,8 +15,15 @@
 */
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import {
-  ElemID, ObjectType, InstanceElement, BuiltinTypes, CORE_ANNOTATIONS, ListType, createRestriction,
-  FieldDefinition, MapType,
+  BuiltinTypes,
+  CORE_ANNOTATIONS,
+  createRestriction,
+  ElemID,
+  FieldDefinition,
+  InstanceElement,
+  ListType,
+  MapType,
+  ObjectType,
 } from '@salto-io/adapter-api'
 import * as constants from './constants'
 
@@ -184,6 +191,7 @@ export type ClientRetryConfig = Partial<{
   maxAttempts: number
   retryDelay: number
   retryStrategy: RetryStrategy
+  timeout: number
 }>
 
 export type CustomObjectsDeployRetryConfig = {


### PR DESCRIPTION
Added timeout on requests to Salesforce to avoid stuck fetch operations.

---

Decided to set a reasonable default timeout of 15 minutes after discussing with @ori-moisis. This timeout can be configured like the other RetryOptions in Salesforce's adapter config.

---
_Release Notes_: 
Salesforce Adapter:
- Added timeout on requests to service.

---
_User Notifications_: 
_None_ (infra change)
