### PR TITLE
SALTO-2304: fixed creating automations

### DIFF
--- a/packages/jira-adapter/src/filters/automation/automation_fetch.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_fetch.ts
@@ -25,6 +25,7 @@ import JiraClient from '../../client/client'
 import { FilterCreator } from '../../filter'
 import { createAutomationTypes } from './types'
 import { getCloudId } from './cloud_id'
+import { JiraConfig } from '../../config'
 
 const DEFAULT_PAGE_SIZE = 100
 
@@ -109,6 +110,16 @@ const createInstance = (
   )
 }
 
+export const getAutomations = async (
+  client: JiraClient,
+  config: JiraConfig,
+  cloudId: string,
+): Promise<Values[]> => postPaginated(
+  `/gateway/api/automation/internal-api/jira/${cloudId}/pro/rest/GLOBAL/rules`,
+  client,
+    config.client.pageSize?.get ?? DEFAULT_PAGE_SIZE
+)
+
 /**
  * Fetching automations from Jira using internal API endpoint.
  * We first use `/resources` endpoint to get the cloud id of the account.
@@ -133,11 +144,7 @@ const filter: FilterCreator = ({ client, getElemIdFunc, config, fetchQuery }) =>
       .keyBy(instance => instance.value.id)
       .value()
 
-    const automations = await postPaginated(
-      `/gateway/api/automation/internal-api/jira/${cloudId}/pro/rest/GLOBAL/rules`,
-      client,
-      config.client.pageSize?.get ?? DEFAULT_PAGE_SIZE
-    )
+    const automations = await getAutomations(client, config, cloudId)
 
     const { automationType, subTypes } = createAutomationTypes()
 

--- a/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
@@ -25,7 +25,6 @@ import { AUTOMATION_TYPE, JIRA } from '../../../src/constants'
 import JiraClient, { PRIVATE_API_HEADERS } from '../../../src/client/client'
 import { CLOUD_RESOURCE_FIELD } from '../../../src/filters/automation/cloud_id'
 
-
 describe('automationDeploymentFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
   let type: ObjectType
@@ -133,19 +132,29 @@ describe('automationDeploymentFilter', () => {
         if (url === '/gateway/api/automation/internal-api/jira/cloudId/pro/rest/GLOBAL/rule/import') {
           return {
             status: 200,
-            data: [
-              existingAutomationValues,
-              {
-                name: 'someName',
-                id: 3,
-                created: 1,
-                projects: [
-                  {
-                    projectId: '1',
-                  },
-                ],
-              },
-            ],
+            data: null,
+          }
+        }
+
+        if (url === '/gateway/api/automation/internal-api/jira/cloudId/pro/rest/GLOBAL/rules') {
+          return {
+            status: 200,
+            data: {
+              total: 2,
+              values: [
+                existingAutomationValues,
+                {
+                  name: 'someName',
+                  id: 3,
+                  created: 1,
+                  projects: [
+                    {
+                      projectId: '1',
+                    },
+                  ],
+                },
+              ],
+            },
           }
         }
         throw new Error(`Unexpected url ${url}`)


### PR DESCRIPTION
Fixed automation creation that recently break due to a change in the service

---
Before the change in the service, the request to create an automations would return all the existing automation (including the new one). Now it returns `null` so we need to query all the automations ourself.

---
_Release Notes_: 
_Jira Adapter_:
- Fixed automation creation that recently break due to a change in the service

---
_User Notifications_: 
None