### PR TITLE
SALTO-2305: temporarily disable tagsFilter

### DIFF
--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -64,7 +64,8 @@ import serviceUrlFilter from './filters/service_url'
 import slaPolicyFilter from './filters/sla_policy'
 import macroAttachmentsFilter from './filters/macro_attachments'
 import omitInactiveFilter from './filters/omit_inactive'
-import tagsFilter from './filters/tag'
+// tagsFilter is disabled due to SALTO-2305
+// import tagsFilter from './filters/tag'
 import webhookFilter from './filters/webhook'
 import defaultDeployFilter from './filters/default_deploy'
 import ducktypeCommonFilters from './filters/ducktype_common'
@@ -107,7 +108,8 @@ export const DEFAULT_FILTERS = [
   hardcodedChannelFilter,
   // fieldReferencesFilter should be after usersFilter, macroAttachmentsFilter and tagsFilter
   usersFilter,
-  tagsFilter,
+  // tagsFilter is disabled due to SALTO-2305
+  // tagsFilter,
   macroAttachmentsFilter,
   fieldReferencesFilter,
   appsFilter,

--- a/packages/zendesk-support-adapter/test/adapter.test.ts
+++ b/packages/zendesk-support-adapter/test/adapter.test.ts
@@ -310,8 +310,9 @@ describe('adapter', () => {
           'zendesk_support.support_address',
           'zendesk_support.support_address.instance.myBrand',
           'zendesk_support.support_addresses',
-          'zendesk_support.tag',
-          'zendesk_support.tag.instance.Social',
+          // Disabled due to SALTO-2305
+          // 'zendesk_support.tag',
+          // 'zendesk_support.tag.instance.Social',
           'zendesk_support.target',
           'zendesk_support.target.instance.Slack_integration_Endpoint_url_target_v2@ssuuu',
           'zendesk_support.targets',


### PR DESCRIPTION
_temporarily disable tagsFilter_

---

_Additional context for reviewer_
just in case

---
_Release Notes_: 
_Zendesk support adapter:_
* disable tagsFilter - tags will stop appearing as instances


---
_User Notifications_: 
_Zendesk support adapter:_
* disable tags - tags will stop appearing as instances
