### PR TITLE
SALTO-2306: fixed to fetch all project pages

### DIFF
--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -731,6 +731,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   Projects: {
     request: {
       url: '/rest/api/3/project/search',
+      paginationField: 'startAt',
       queryParams: {
         expand: 'description,lead,url,projectKeys,permissions',
       },

--- a/packages/jira-adapter/system_config_doc.md
+++ b/packages/jira-adapter/system_config_doc.md
@@ -1019,6 +1019,7 @@ jira {
       Projects = {
         request = {
           url = "/rest/api/3/project/search"
+          paginationField = "startAt"
           queryParams = {
             expand = "description,lead,url,projectKeys,permissions"
           }


### PR DESCRIPTION
Fixed a bug were only the first 50 projects (first page) were fetched

---
_Release Notes_: 
_Jira Adapter_:
- Fixed a bug were only the first 50 projects were fetched

---
_User Notifications_: 
_Jira Adapter_:
- Additional projects might be fetched in the next fetch