### PR TITLE
SALTO-2305: change the order of the remove definition instance filter

### DIFF
--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -105,6 +105,8 @@ export const DEFAULT_FILTERS = [
   restrictionFilter,
   organizationFieldFilter,
   hardcodedChannelFilter,
+  // removeDefinitionInstancesFilter should be after hardcodedChannelFilter
+  removeDefinitionInstancesFilter,
   // fieldReferencesFilter should be after usersFilter, macroAttachmentsFilter and tagsFilter
   usersFilter,
   tagsFilter,
@@ -115,8 +117,6 @@ export const DEFAULT_FILTERS = [
   routingAttributeFilter,
   addFieldOptionsFilter,
   webhookFilter,
-  // removeDefinitionInstancesFilter should be after hardcodedChannelFilter
-  removeDefinitionInstancesFilter,
   // unorderedListsFilter should run after fieldReferencesFilter
   unorderedListsFilter,
   dynamicContentReferencesFilter,

--- a/packages/zendesk-support-adapter/src/filters/remove_definition_instances.ts
+++ b/packages/zendesk-support-adapter/src/filters/remove_definition_instances.ts
@@ -14,7 +14,8 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { isInstanceElement } from '@salto-io/adapter-api'
+import { cloneDeepWithoutRefs, isInstanceElement } from '@salto-io/adapter-api'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 
@@ -36,6 +37,19 @@ const DEFINITION_TYPE_NAMES = [
  */
 const filterCreator: FilterCreator = () => ({
   onFetch: async elements => log.time(async () => {
+    // ---- Start debugging SALTO-2305 ----
+    const triggerDefs = elements
+      .filter(isInstanceElement)
+      .find(inst => inst.elemID.typeName === 'trigger_definition')
+    if (triggerDefs) {
+      const triggerDefsVal = safeJsonStringify(cloneDeepWithoutRefs(triggerDefs?.value))
+      const chunks = _.chunk(triggerDefsVal, 200 * 1024).map(chunk => chunk.join(''))
+      chunks.forEach((chunk, i) => {
+        log.debug(`DEBUGGING2305:${i}:${chunk}`)
+      })
+    }
+    // ---- End debugging SALTO-2305 ----
+
     _.remove(elements,
       element =>
         isInstanceElement(element) && DEFINITION_TYPE_NAMES.includes(element.elemID.typeName))


### PR DESCRIPTION
_change the order of the remove definition instance filter_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
