### PR TITLE
SALTO-2295: added masking.secretMatchers

### DIFF
--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -74,7 +74,7 @@ jira {
 | Name                                        | Default when undefined            | Description
 |---------------------------------------------|-----------------------------------|------------
 | automationHeaders                           | []                                | List of regexes of header keys in Automations to mask their values
-| secretMatchers                              | []                                | List of regexes of strings to mask all across the workspace
+| secretRegexps                               | []                                | List of regexes of strings to mask all across the workspace
 
 ## Fetch entry options
 

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -73,7 +73,8 @@ jira {
 ## Masking configuration options
 | Name                                        | Default when undefined            | Description
 |---------------------------------------------|-----------------------------------|------------
-| automationHeaders                                     | []                                | List of regexes of header keys in Automations to mask their values
+| automationHeaders                           | []                                | List of regexes of header keys in Automations to mask their values
+| secretMatchers                              | []                                | List of regexes of strings to mask all across the workspace
 
 ## Fetch entry options
 

--- a/packages/jira-adapter/src/change_validators/masking.ts
+++ b/packages/jira-adapter/src/change_validators/masking.ts
@@ -17,8 +17,11 @@ import { Change, ChangeError, ChangeValidator, CORE_ANNOTATIONS, getChangeData,
   InstanceElement,
   isAdditionOrModificationChange, isInstanceChange, isModificationChange } from '@salto-io/adapter-api'
 import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 import JiraClient from '../client/client'
 import { MASK_VALUE } from '../filters/masking'
+
+const log = logger(module)
 
 export const createChangeError = (
   change: Change<InstanceElement>,
@@ -65,10 +68,10 @@ const doesHaveMaskedValues = (instance: InstanceElement): boolean => {
 }
 
 export const maskingValidator: (client: JiraClient) =>
-  ChangeValidator = client => async changes => (
+  ChangeValidator = client => async changes => log.time(() => (
     changes
       .filter(isAdditionOrModificationChange)
       .filter(isInstanceChange)
       .filter(change => doesHaveMaskedValues(getChangeData(change)))
       .map(change => createChangeError(change, client))
-  )
+  ), 'masking change validator')

--- a/packages/jira-adapter/src/change_validators/masking.ts
+++ b/packages/jira-adapter/src/change_validators/masking.ts
@@ -33,7 +33,7 @@ export const createChangeError = (
     severity: isModificationChange(change) ? 'Warning' : 'Info',
     message: 'Masked data will be deployed to the service',
     detailedMessage: isModificationChange(change)
-      ? `${getChangeData(change).elemID.getFullName()} contains masked values which will override the real values in the service when deploying and may prevent this instance from operating correctly`
+      ? `${getChangeData(change).elemID.getFullName()} contains masked values which will override the real values in the service when deploying and may prevent it from operating correctly`
       : '',
     deployActions: {
       postAction: {
@@ -43,7 +43,7 @@ export const createChangeError = (
           serviceUrl !== undefined
             ? `Go to ${serviceUrl}`
             : `Go to ${client.baseUrl} and open the relevant page for ${getChangeData(change).elemID.getFullName()}`,
-          'Go over the values with masked values (values with <SECRET_TOKEN> value) and set the real values',
+          'Search for masked values (which contain <SECRET_TOKEN>) and set them to the correct value',
           'Save the page',
         ],
       },

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1822,7 +1822,7 @@ type JiraFetchConfig = configUtils.UserFetchConfig<JiraFetchFilters> & {
   fallbackToInternalId?: boolean
 }
 
-type MaskingConfig = {
+export type MaskingConfig = {
   automationHeaders: string[]
   secretMatchers: string[]
 }

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1824,7 +1824,7 @@ type JiraFetchConfig = configUtils.UserFetchConfig<JiraFetchFilters> & {
 
 export type MaskingConfig = {
   automationHeaders: string[]
-  secretMatchers: string[]
+  secretRegexps: string[]
 }
 
 export type JiraConfig = {
@@ -1896,7 +1896,7 @@ export const DEFAULT_CONFIG: JiraConfig = {
   apiDefinitions: DEFAULT_API_DEFINITIONS,
   masking: {
     automationHeaders: [],
-    secretMatchers: [],
+    secretRegexps: [],
   },
 }
 
@@ -1943,7 +1943,7 @@ const maskingConfigType = createMatchingObjectType<Partial<MaskingConfig>>({
     automationHeaders: {
       refType: new ListType(BuiltinTypes.STRING),
     },
-    secretMatchers: {
+    secretRegexps: {
       refType: new ListType(BuiltinTypes.STRING),
     },
   },

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1824,6 +1824,7 @@ type JiraFetchConfig = configUtils.UserFetchConfig<JiraFetchFilters> & {
 
 type MaskingConfig = {
   automationHeaders: string[]
+  secretMatchers: string[]
 }
 
 export type JiraConfig = {
@@ -1895,6 +1896,7 @@ export const DEFAULT_CONFIG: JiraConfig = {
   apiDefinitions: DEFAULT_API_DEFINITIONS,
   masking: {
     automationHeaders: [],
+    secretMatchers: [],
   },
 }
 
@@ -1939,6 +1941,9 @@ const maskingConfigType = createMatchingObjectType<Partial<MaskingConfig>>({
   elemID: new ElemID(JIRA),
   fields: {
     automationHeaders: {
+      refType: new ListType(BuiltinTypes.STRING),
+    },
+    secretMatchers: {
       refType: new ListType(BuiltinTypes.STRING),
     },
   },

--- a/packages/jira-adapter/src/filters/masking.ts
+++ b/packages/jira-adapter/src/filters/masking.ts
@@ -72,7 +72,7 @@ const maskValues = async (
       }
 
       if (_.isString(value)
-      && masking.secretMatchers.some(matcher => lowerdashRegex.isFullRegexMatch(value, matcher))) {
+      && masking.secretRegexps.some(matcher => lowerdashRegex.isFullRegexMatch(value, matcher))) {
         log.debug(`Masked value ${path?.getFullName()}`)
         return MASK_VALUE
       }
@@ -87,7 +87,7 @@ const maskValues = async (
 const filter: FilterCreator = ({ config }) => ({
   onFetch: async elements => log.time(async () => {
     if (config.masking.automationHeaders.length === 0
-      && config.masking.secretMatchers.length === 0) {
+      && config.masking.secretRegexps.length === 0) {
       return
     }
 

--- a/packages/jira-adapter/src/filters/masking.ts
+++ b/packages/jira-adapter/src/filters/masking.ts
@@ -80,7 +80,7 @@ const maskByMatchers = async (
  * Replace sensitive data in the NaCls with some placeholder
  */
 const filter: FilterCreator = ({ config }) => ({
-  onFetch: async elements => {
+  onFetch: async elements => log.time(async () => {
     await awu(elements)
       .filter(isInstanceElement)
       .forEach(async instance => {
@@ -101,7 +101,7 @@ const filter: FilterCreator = ({ config }) => ({
           })
         }
       })
-  },
+  }, 'masking filter'),
 })
 
 export default filter

--- a/packages/jira-adapter/test/change_validators/masking.test.ts
+++ b/packages/jira-adapter/test/change_validators/masking.test.ts
@@ -63,7 +63,7 @@ describe('maskingValidator', () => {
             description: 'Please update the masked values that were deployed to Jira in jira.Automation.instance.instance',
             subActions: [
               'Go to https://ori-salto-test.atlassian.net/ and open the relevant page for jira.Automation.instance.instance',
-              'Go over the values with masked values (values with <SECRET_TOKEN> value) and set the real values',
+              'Search for masked values (which contain <SECRET_TOKEN>) and set them to the correct value',
               'Save the page',
             ],
           },
@@ -91,7 +91,7 @@ describe('maskingValidator', () => {
             description: 'Please update the masked values that were deployed to Jira in jira.Automation.instance.instance',
             subActions: [
               'Go to http://url',
-              'Go over the values with masked values (values with <SECRET_TOKEN> value) and set the real values',
+              'Search for masked values (which contain <SECRET_TOKEN>) and set them to the correct value',
               'Save the page',
             ],
           },
@@ -111,14 +111,14 @@ describe('maskingValidator', () => {
         elemID: instance.elemID,
         severity: 'Warning',
         message: 'Masked data will be deployed to the service',
-        detailedMessage: 'jira.Automation.instance.instance contains masked values which will override the real values in the service when deploying and may prevent this instance from operating correctly',
+        detailedMessage: 'jira.Automation.instance.instance contains masked values which will override the real values in the service when deploying and may prevent it from operating correctly',
         deployActions: {
           postAction: {
             title: 'Update deployed masked data',
             description: 'Please update the masked values that were deployed to Jira in jira.Automation.instance.instance',
             subActions: [
               'Go to https://ori-salto-test.atlassian.net/ and open the relevant page for jira.Automation.instance.instance',
-              'Go over the values with masked values (values with <SECRET_TOKEN> value) and set the real values',
+              'Search for masked values (which contain <SECRET_TOKEN>) and set them to the correct value',
               'Save the page',
             ],
           },

--- a/packages/jira-adapter/test/change_validators/masking.test.ts
+++ b/packages/jira-adapter/test/change_validators/masking.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { toChange, ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { MASK_VALUE } from '../../src/filters/masking'
 import { maskingValidator } from '../../src/change_validators/masking'
 import { AUTOMATION_TYPE, JIRA } from '../../src/constants'
@@ -60,12 +60,39 @@ describe('maskingValidator', () => {
         deployActions: {
           postAction: {
             title: 'Update deployed masked data',
-            description: 'Please update the masked values that were deployed to Jira in the jira.Automation.instance.instance automation',
+            description: 'Please update the masked values that were deployed to Jira in jira.Automation.instance.instance',
             subActions: [
-              'Go to https://ori-salto-test.atlassian.net/jira/settings/automation#/rule-list, and open the jira.Automation.instance.instance automation',
-              'Go over the headers with masked values (headers with <SECRET_TOKEN> value) and set the real values',
-              'Click "Save"',
-              'Click "Publish changes"',
+              'Go to https://ori-salto-test.atlassian.net/ and open the relevant page for jira.Automation.instance.instance',
+              'Go over the values with masked values (values with <SECRET_TOKEN> value) and set the real values',
+              'Save the page',
+            ],
+          },
+        },
+      },
+    ])
+  })
+
+  it('should return the service URL when have one', async () => {
+    instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] = 'http://url'
+
+    expect(await maskingValidator(client)([
+      toChange({
+        after: instance,
+      }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Info',
+        message: 'Masked data will be deployed to the service',
+        detailedMessage: '',
+        deployActions: {
+          postAction: {
+            title: 'Update deployed masked data',
+            description: 'Please update the masked values that were deployed to Jira in jira.Automation.instance.instance',
+            subActions: [
+              'Go to http://url',
+              'Go over the values with masked values (values with <SECRET_TOKEN> value) and set the real values',
+              'Save the page',
             ],
           },
         },
@@ -84,16 +111,15 @@ describe('maskingValidator', () => {
         elemID: instance.elemID,
         severity: 'Warning',
         message: 'Masked data will be deployed to the service',
-        detailedMessage: 'jira.Automation.instance.instance contains masked values which will override the real values in the service when deploying and may prevent this automation from operating correctly',
+        detailedMessage: 'jira.Automation.instance.instance contains masked values which will override the real values in the service when deploying and may prevent this instance from operating correctly',
         deployActions: {
           postAction: {
             title: 'Update deployed masked data',
-            description: 'Please update the masked values that were deployed to Jira in the jira.Automation.instance.instance automation',
+            description: 'Please update the masked values that were deployed to Jira in jira.Automation.instance.instance',
             subActions: [
-              'Go to https://ori-salto-test.atlassian.net/jira/settings/automation#/rule-list, and open the jira.Automation.instance.instance automation',
-              'Go over the headers with masked values (headers with <SECRET_TOKEN> value) and set the real values',
-              'Click "Save"',
-              'Click "Publish changes"',
+              'Go to https://ori-salto-test.atlassian.net/ and open the relevant page for jira.Automation.instance.instance',
+              'Go over the values with masked values (values with <SECRET_TOKEN> value) and set the real values',
+              'Save the page',
             ],
           },
         },

--- a/packages/jira-adapter/test/filters/masking.test.ts
+++ b/packages/jira-adapter/test/filters/masking.test.ts
@@ -69,28 +69,57 @@ describe('maskingFilter', () => {
   })
 
   describe('onFetch', () => {
-    it('should mask the sensitive headers', async () => {
-      config.masking.automationHeaders = [
-        'name.*',
-      ]
+    describe('automationHeaders', () => {
+      it('should mask the sensitive headers', async () => {
+        config.masking.automationHeaders = [
+          'name.*',
+        ]
 
-      await filter.onFetch?.([instance])
+        await filter.onFetch?.([instance])
 
-      expect(instance.value).toEqual({
-        headers: [
-          {
-            name: 'name1',
-            value: MASK_VALUE,
-          },
-          {
-            name: 'name2',
-            value: MASK_VALUE,
-          },
-          {
-            name: 'aname3',
-            value: 'avalue3',
-          },
-        ],
+        expect(instance.value).toEqual({
+          headers: [
+            {
+              name: 'name1',
+              value: MASK_VALUE,
+            },
+            {
+              name: 'name2',
+              value: MASK_VALUE,
+            },
+            {
+              name: 'aname3',
+              value: 'avalue3',
+            },
+          ],
+        })
+      })
+    })
+
+    describe('secretMatchers', () => {
+      it('should mask the sensitive strings', async () => {
+        config.masking.secretMatchers = [
+          'name.*',
+        ]
+
+        await filter.onFetch?.([instance])
+
+        expect(instance.value).toEqual({
+          headers: [
+            {
+              name: MASK_VALUE,
+              value: 'value1',
+            },
+            {
+              name: MASK_VALUE,
+              value: 'value2',
+            },
+            {
+              name: 'aname3',
+              value: 'avalue3',
+            },
+          ],
+        })
       })
     })
   })

--- a/packages/jira-adapter/test/filters/masking.test.ts
+++ b/packages/jira-adapter/test/filters/masking.test.ts
@@ -96,9 +96,9 @@ describe('maskingFilter', () => {
       })
     })
 
-    describe('secretMatchers', () => {
+    describe('secretRegexps', () => {
       it('should mask the sensitive strings', async () => {
-        config.masking.secretMatchers = [
+        config.masking.secretRegexps = [
           'name.*',
         ]
 


### PR DESCRIPTION
Added `masking.secretRegexps` configuration option to mask strings that match a given regex all over the workspace.
The names and messages are not final, will discuss @liorn before merging

---
_Release Notes_: 
_Jira Adapter_:
- Added `masking.secretRegexps` configuration option to mask strings that match a given regex all over the workspace

---
_User Notifications_: 
None