### PR TITLE
Added log for the values of duplicate instances

### DIFF
--- a/packages/jira-adapter/src/filters/duplicate_ids.ts
+++ b/packages/jira-adapter/src/filters/duplicate_ids.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
-import { naclCase, referenceExpressionStringifyReplacer } from '@salto-io/adapter-utils'
+import { naclCase, referenceExpressionStringifyReplacer, safeJsonStringify } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
@@ -57,7 +57,7 @@ const filter: FilterCreator = ({ config }) => ({
     duplicateInstances
       .filter(isInstanceElement)
       .forEach(instance => {
-        log.debug(`Found a duplicate instance ${instance.elemID.getFullName()} with values: ${JSON.stringify(instance.value, referenceExpressionStringifyReplacer, 2)}`)
+        log.debug(`Found a duplicate instance ${instance.elemID.getFullName()} with values: ${safeJsonStringify(instance.value, referenceExpressionStringifyReplacer, 2)}`)
       })
 
     if (!config.fetch.fallbackToInternalId) {

--- a/packages/jira-adapter/src/filters/duplicate_ids.ts
+++ b/packages/jira-adapter/src/filters/duplicate_ids.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
-import { naclCase } from '@salto-io/adapter-utils'
+import { naclCase, referenceExpressionStringifyReplacer } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
@@ -44,6 +44,7 @@ const filter: FilterCreator = ({ config }) => ({
       return {}
     }
 
+
     log.warn(`Found ${duplicateIds.size} duplicate instance names: ${Array.from(duplicateIds).join(', ')}`)
 
     const duplicateInstances = _.remove(
@@ -52,6 +53,12 @@ const filter: FilterCreator = ({ config }) => ({
         && isInstanceElement(element)
         && element.value.id !== undefined
     )
+
+    duplicateInstances
+      .filter(isInstanceElement)
+      .forEach(instance => {
+        log.debug(`Found a duplicate instance ${instance.elemID.getFullName()} with values: ${JSON.stringify(instance.value, referenceExpressionStringifyReplacer, 2)}`)
+      })
 
     if (!config.fetch.fallbackToInternalId) {
       return {


### PR DESCRIPTION
Added log for the values of duplicate instances
I don't think I can use here the `getAndLogCollisionWarnings` because of the custom logic for `fallbackToInternalId`

---
_Release Notes_: 
None

---
_User Notifications_: 
None