### PR TITLE
SALTO-2257 features type bugfix on partial fetch

### DIFF
--- a/packages/netsuite-adapter/src/filters/config_features.ts
+++ b/packages/netsuite-adapter/src/filters/config_features.ts
@@ -31,7 +31,12 @@ const filterCreator = (): FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'> => ({
     const featuresInstance = elements.filter(isInstanceElement)
       .find(instance => instance.elemID.typeName === CONFIG_FEATURES)
 
-    if (!featuresInstance) return
+    if (!featuresInstance) {
+      // removing the features type from elements because otherwise the current type
+      // (in case of partial fetch) will be override without the real fields.
+      _.remove(elements, element => element.elemID.typeName === CONFIG_FEATURES)
+      return
+    }
 
     const type = await featuresInstance.getType()
     const features = _.keyBy(featuresInstance.value.feature, feature => feature.id)

--- a/packages/netsuite-adapter/test/filters/config_features.test.ts
+++ b/packages/netsuite-adapter/test/filters/config_features.test.ts
@@ -41,24 +41,20 @@ const getChange = (): Change<InstanceElement> => {
 }
 
 describe('config features filter', () => {
-  // eslint-disable-next-line camelcase
-  const companyFeatures = featuresType()
   describe('onFetch', () => {
-    const origInstance = new InstanceElement(
-      '_config',
-      companyFeatures,
-      {
-        feature: [
-          { id: 'ABC', label: 'A Blue Cat', status: 'ENABLED' },
-          { id: 'DEF', label: 'Delightful Elephents Family', status: 'DISABLED' },
-          { id: 'NO', label: 'Not O', status: 'UNKNOWN' },
-        ],
-      }
-    )
-
     let instance: InstanceElement
     beforeEach(() => {
-      instance = origInstance.clone()
+      instance = new InstanceElement(
+        '_config',
+        featuresType(),
+        {
+          feature: [
+            { id: 'ABC', label: 'A Blue Cat', status: 'ENABLED' },
+            { id: 'DEF', label: 'Delightful Elephents Family', status: 'DISABLED' },
+            { id: 'NO', label: 'Not O', status: 'UNKNOWN' },
+          ],
+        }
+      )
     })
 
     it('should transform values', async () => {
@@ -69,6 +65,11 @@ describe('config features filter', () => {
       expect(type.fields.DEF.annotations).toEqual({ label: 'Delightful Elephents Family' })
       expect(type.fields.NO.annotations).toEqual({ label: 'Not O' })
       expect(instance.value).toEqual({ ABC: true, DEF: false, NO: 'UNKNOWN' })
+    })
+    it('should remove features type when there is no instance', async () => {
+      const elements = [featuresType()]
+      await filterCreator().onFetch(elements)
+      expect(elements.length).toEqual(0)
     })
   })
   describe('preDeploy', () => {


### PR DESCRIPTION
Removing `companyFeatures` type from fetched elements if the `companyFeatures` instance wasn't fetched (like in case of partial fetch) because otherwise the current type in the workspace will be override without the real fields.

---
_Release Notes_: 
NetSuite Adapter:
- `companyFeatures` type bugfix on partial fetch

---
_User Notifications_: 
None