### PR TITLE
SALTO-2219: add oauth global client to the default skip list

### DIFF
--- a/packages/zendesk-support-adapter/src/config.ts
+++ b/packages/zendesk-support-adapter/src/config.ts
@@ -1562,6 +1562,7 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
     }],
     exclude: [
       { type: 'organization' },
+      { type: 'oauth_global_client' },
     ],
     hideTypes: true,
     enableMissingReferences: true,


### PR DESCRIPTION
_add oauth global client for the default skip list_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Zendesk support adapter:_
* add oauth global client to the default skip list

---
_User Notifications_: 
_None_
