### PR TITLE
SALTO-2314: Handle case when a field change is applied for a field that was not deployed yet

### DIFF
--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -777,9 +777,12 @@ export const filterOutHiddenChanges = async (
         }
 
         // idType === 'field'
+        const field = baseElem.fields[path[0]]
         return {
           // changeType will be undefined if the path is too short
-          changeType: (await elementAnnotationTypes(baseElem.fields[path[0]], state))[path[1]],
+          changeType: field === undefined
+            ? undefined
+            : (await elementAnnotationTypes(field, state))[path[1]],
           changePath: path.slice(2),
         }
       }

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -708,4 +708,38 @@ describe('handleHiddenChanges', () => {
       })
     })
   })
+
+  describe('field annotation change when the field is not in the state', () => {
+    let result: { visible: DetailedChange[]; hidden: DetailedChange[]}
+    let change: DetailedChange
+    beforeAll(async () => {
+      const stateObject = new ObjectType({ elemID: new ElemID('test', 'type') })
+      const fullObject = new ObjectType({
+        elemID: stateObject.elemID,
+        fields: {
+          field: {
+            refType: BuiltinTypes.STRING,
+          },
+        },
+      })
+      change = {
+        id: fullObject.fields.field.elemID.createNestedID(CORE_ANNOTATIONS.SERVICE_URL),
+        action: 'add',
+        data: { after: 'someUrl' },
+      }
+      result = await handleHiddenChanges(
+        [change],
+        mockState([stateObject]),
+        createInMemoryElementSource(),
+      )
+    })
+
+    it('should make the change visible', () => {
+      expect(result.visible).toHaveLength(1)
+      expect(result.visible[0]).toMatchObject(change)
+    })
+    it('should not have a hidden change', () => {
+      expect(result.hidden).toHaveLength(0)
+    })
+  })
 })


### PR DESCRIPTION


---

When using the workspace interface programmatically (e.g. - not from our CLI fetch flow), it is possible to create and apply a nacl change on an element that was not deployed yet.
Currently the code that handles hidden values assumes changes only happen for things that exist in the state.

This fix removes this assumption where it caused a crash and defines the behavior such that if something does not exist in the state, it cannot have anything hidden in it

---
_Release Notes_: 
_None_ (the affected scenario would not happen in Salto flows)

---
_User Notifications_: 
_None_