### PR TITLE
(Salto-1376) clean tmp dbs on init

### DIFF
--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -24,6 +24,7 @@ import { remoteMap } from '@salto-io/workspace'
 import { collections, promises, values } from '@salto-io/lowerdash'
 import type rocksdb from '@salto-io/rocksdb'
 import { logger } from '@salto-io/logging'
+import _ from 'lodash'
 
 const { asynciterable } = collections
 const { awu } = asynciterable
@@ -58,6 +59,7 @@ const getRemoteDbImpl = (): any => {
 
 const isDBLockErr = (error: Error): boolean => (
   error.message.includes('LOCK: Resource temporarily unavailable')
+  || error.message.includes('lock hold by current process')
 )
 
 const isDBNotExistErr = (error: Error): boolean => (
@@ -279,26 +281,35 @@ export const closeAllRemoteMaps = async (): Promise<void> => {
   })
 }
 
-const cleanDatabase = async (loc: string): Promise<void> => {
+const cleanTmpDatabases = async (loc: string, ignoreUsed = false): Promise<void> => {
   const tmpDir = getDBTmpDir(loc)
   await awu(await fileUtils.readDir(tmpDir)).forEach(async tmpLoc => {
     try {
       await deleteLocation(path.join(tmpDir, tmpLoc))
+      log.debug('cleaning tmp db %s', tmpLoc)
     } catch (e) {
       if (isDBLockErr(e)) {
-        throw new DBLockError()
+        if (ignoreUsed) {
+          log.debug('will not clean tmp db %s as it is being used', tmpLoc)
+        } else {
+          throw new DBLockError()
+        }
+      } else {
+        throw e
       }
-      throw e
     }
   })
-  delete tmpDBConnections[loc]
-  await deleteLocation(loc)
+  if (_.isEmpty(tmpDBConnections[loc])) {
+    delete tmpDBConnections[loc]
+  }
 }
-
 export const cleanDatabases = async (): Promise<void> => {
   const persistentDBs = Object.entries(persistentDBConnections)
   await closeAllRemoteMaps()
-  await awu(persistentDBs).forEach(async ([loc]) => cleanDatabase(loc))
+  await awu(persistentDBs).forEach(async ([loc]) => {
+    await cleanTmpDatabases(loc)
+    return deleteLocation(loc)
+  })
 }
 
 export const replicateDB = async (
@@ -570,9 +581,6 @@ remoteMap.RemoteMapCreator => {
     const createDBIfNotExist = async (loc: string): Promise<void> => {
       const newDb: rocksdb = getRemoteDbImpl()(loc)
       const readOnly = !persistent
-      if (persistent) {
-        await cleanDatabase(loc)
-      }
       try {
         await promisify(newDb.open.bind(newDb, { readOnly }))()
         await promisify(newDb.close.bind(newDb))()
@@ -603,6 +611,9 @@ remoteMap.RemoteMapCreator => {
       if (location in mainDBConnections) {
         persistentDB = await mainDBConnections[location]
         return
+      }
+      if (persistent) {
+        await cleanTmpDatabases(location, true)
       }
       if (currentConnectionsCount > MAX_CONNECTIONS) {
         throw new Error('Failed to open rocksdb connection - too much open connections already')

--- a/packages/core/test/workspace/local/remote_map.test.ts
+++ b/packages/core/test/workspace/local/remote_map.test.ts
@@ -21,7 +21,7 @@ import { promisify } from 'util'
 import { serialization, remoteMap as rm, merger } from '@salto-io/workspace'
 import rocksdb from '@salto-io/rocksdb'
 import path from 'path'
-import { readdirSync } from 'fs-extra'
+import { readdirSync, mkdirpSync } from 'fs-extra'
 import {
   createRemoteMapCreator,
   createReadOnlyRemoteMapCreator,
@@ -506,6 +506,7 @@ describe('tmp db deletion', () => {
   const EXISTING_LOCATION = path.join(TMP_DIR, 'existing')
   it('should delete existing tmp dbs on startup', async () => {
     // Ensure no leftovers from previous tests.
+    mkdirpSync(TMP_DIR)
     expect(readdirSync(TMP_DIR)).toHaveLength(0)
 
     // We open and close a rocksdb connection to create a DB that simulates an existing tmp db

--- a/packages/core/test/workspace/local/remote_map.test.ts
+++ b/packages/core/test/workspace/local/remote_map.test.ts
@@ -31,6 +31,9 @@ import {
   cleanDatabases,
 } from '../../../src/local-workspace/remote_map'
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const rocksdbImpl = require('../../../src/local-workspace/rocksdb').default
+
 const { serialize, deserialize } = serialization
 const { awu } = collections.asynciterable
 
@@ -494,6 +497,31 @@ describe('test operations on remote db', () => {
   })
   it('should throw exception if the namespace is invalid', async () => {
     await expect(createMap('inval:d')).rejects.toThrow()
+  })
+})
+
+describe('tmp db deletion', () => {
+  const DB_LOCATION_TMP = path.join(DB_LOCATION, 'tmp')
+  const TMP_DIR = path.join(DB_LOCATION_TMP, TMP_DB_DIR)
+  const EXISTING_LOCATION = path.join(TMP_DIR, 'existing')
+  it('should delete existing tmp dbs on startup', async () => {
+    // Ensure no leftovers from previous tests.
+    expect(readdirSync(TMP_DIR)).toHaveLength(0)
+
+    // We open and close a rocksdb connection to create a DB that simulates an existing tmp db
+    // which was not closed in the previous run (For example, Ctrl-C)
+    const newDb = rocksdbImpl(EXISTING_LOCATION)
+    await promisify(newDb.open.bind(newDb, { readOnly: false }))()
+    await promisify(newDb.close.bind(newDb))()
+    expect(readdirSync(TMP_DIR)).toHaveLength(1)
+
+    // Creating a new map should delete the old tmp db, and create a new one
+    await createMap('new_map', true, DB_LOCATION_TMP)
+    expect(readdirSync(TMP_DIR)).toHaveLength(1)
+
+    // Closing the map should remove the newly created tmp db
+    await closeRemoteMapsOfLocation(DB_LOCATION_TMP)
+    expect(readdirSync(TMP_DIR)).toHaveLength(0)
   })
 })
 

--- a/packages/core/test/workspace/local/remote_map_connection.test.ts
+++ b/packages/core/test/workspace/local/remote_map_connection.test.ts
@@ -51,8 +51,9 @@ describe('connection creation', () => {
       const mockCalls = mockOpen.mock.calls
       const writeCalls = mockCalls.filter(args => args[0].readOnly === false)
       const readOnlyCalls = mockCalls.filter(args => args[0].readOnly === true)
-      // 1 for the creation, 2 tmp connections and 1 (persistent) db connection
-      expect(writeCalls).toHaveLength(4)
+      // 1 for the creation, 2 tmp connections and 1 (persistent) db connection,
+      // 2 load time destroys attempts
+      expect(writeCalls).toHaveLength(6)
       expect(readOnlyCalls).toHaveLength(0)
     })
     it('should try to open with read only mode if remote map is not persistent', async () => {


### PR DESCRIPTION
_clean temporary databases on init_

---

_The remote map should clean the temporary databases when closed. If a Salto invocation fails to close the connection (sig kill etc.), the temporary databases will remain in place. The remote map implementation will close all dangling temporary databases on startup to avoid stall data accumulation. _

---
_Release Notes_: 
_Fix excessive disk space usage due to stale cache not being clean._

---
_User Notifications_: 
_NA_
