### PR TITLE
SAAS-5129: Improve performance of update nacl file with many changes

### DIFF
--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -1847,7 +1847,7 @@ describe('workspace', () => {
     it('should add different cased elements to the same file', () => {
       expect(dirStore.set).toHaveBeenCalledWith(expect.objectContaining({
         filename: 'Records/Queue/QueueInstance.nacl',
-        buffer: expect.stringMatching(/.*salesforce.Queue QueueInstance.*salesforce.Queue queueInstance.*/s),
+        buffer: expect.stringMatching(/.*salesforce.Queue queueInstance.*salesforce.Queue QueueInstance.*/s),
       }))
     })
 


### PR DESCRIPTION
Changed the implementation of building the new content of a nacl file to perform less string manipulations
This increases performance in cases where we have multiple changes in the same file
Also, performing less manipulations on the entire file content means there is less stress on the garbage collector.
in some scenarios this may help us consume less memory overall.

---


---
_Release Notes_: 
Core:
- Improve performance of updating nacl files

---
_User Notifications_: 
_None_
