### PR TITLE
SALTO-2330: fix Zendesk pathChecker to allow url without a suffix of json

### DIFF
--- a/packages/zendesk-support-adapter/src/client/pagination.ts
+++ b/packages/zendesk-support-adapter/src/client/pagination.ts
@@ -18,7 +18,7 @@ import { client as clientUtils } from '@salto-io/adapter-components'
 const { getWithCursorPagination } = clientUtils
 
 const pathChecker: clientUtils.PathCheckerFunc = (current, next) => (
-  next === `/api/v2${current}.json`
+  next === `/api/v2${current}.json` || next === `/api/v2${current}`
 )
 export const paginate: clientUtils.PaginationFuncCreator = () => (
   getWithCursorPagination(pathChecker)


### PR DESCRIPTION
_fix Zendesk pathChecker to allow url without a suffix of json_

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Zendesk support adapter:_
* Fix a bug that prevent fetches of accounts with more than 100 webhooks to work

---
_User Notifications_: 
_None_
