### PR TITLE
SALTO-2331: changed to not fail when getting 400 from workflows requests

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -205,7 +205,7 @@ export abstract class AdapterHTTPClient<
         status,
       }
     } catch (e) {
-      log.warn(`failed to ${method} ${url} ${queryParams}: ${e}, stack: ${e.stack}, data: ${safeJsonStringify(e?.response?.data)}`)
+      log.warn(`failed to ${method} ${url} ${safeJsonStringify(queryParams)}: ${e}, stack: ${e.stack}, data: ${safeJsonStringify(e?.response?.data)}`)
       if (e.code === 'ETIMEDOUT') {
         throw new TimeoutError(`Failed to ${method} ${url} with error: ${e}`)
       }

--- a/packages/jira-adapter/test/filters/workflow/step_ids_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/step_ids_filter.test.ts
@@ -111,6 +111,27 @@ describe('stepIdsFilter', () => {
       )
     })
 
+    it('should remove element if failed to get step ids', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'workflowName',
+          statuses: [
+            { id: '1' },
+            { id: '2' },
+            { id: '3' },
+          ],
+        },
+      )
+
+      mockConnection.get.mockRejectedValue(new Error())
+
+      const elements = [instance]
+      await filter.onFetch(elements)
+      expect(elements).toHaveLength(0)
+    })
+
     it('should do nothing if usePrivateAPI is false', async () => {
       const instance = new InstanceElement(
         'instance',

--- a/packages/jira-adapter/test/filters/workflow/triggers_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/triggers_filter.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { ElemID, InstanceElement, isInstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { filterUtils, client as clientUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { MockInterface } from '@salto-io/test-utils'
@@ -99,6 +99,25 @@ describe('triggersFilter', () => {
           configuration: {},
         },
       ])
+    })
+
+    it('should remove workflow if failed to get triggers', async () => {
+      const instance = new InstanceElement(
+        'instance',
+        workflowType,
+        {
+          name: 'name',
+          transitionIds: { '4-5-transition1': '1' },
+          transitions: [
+            { id: '1', name: 'transition1', from: ['4', '5'] },
+          ],
+        },
+      )
+
+      mockConnection.get.mockRejectedValue(new Error())
+      const elements = [instance]
+      await filter.onFetch(elements)
+      expect(elements.filter(isInstanceElement)).toHaveLength(0)
     })
 
     it('do nothing if transition id not found', async () => {


### PR DESCRIPTION
Changed omit a specific workflow when one of its requests failed instead of failing the whole fetch, and fixed some of the logs to get more information the next time it will fail.


---
_Release Notes_: 
None

---
_User Notifications_: 
None