### PR TITLE
Salto 2254 add dependencies tag to manifest.xml if missing

### DIFF
--- a/packages/netsuite-adapter/src/client/manifest_utils.ts
+++ b/packages/netsuite-adapter/src/client/manifest_utils.ts
@@ -163,9 +163,15 @@ export const fixManifest = (
 ): string => {
   const manifestXml = xmlParser.parse(manifestContent, { ignoreAttributes: false })
 
-  if (!_.isPlainObject(manifestXml.manifest?.dependencies)) {
-    log.warn('manifest.xml is missing dependencies tag')
+  if (!_.isPlainObject(manifestXml.manifest)) {
+    log.warn('manifest.xml is missing manifest tag')
     return manifestContent
+  }
+  if (_.isInteger(manifestXml.manifest.frameworkversion)) {
+    manifestXml.manifest.frameworkversion = manifestXml.manifest.frameworkversion.toFixed(1)
+  }
+  if (manifestXml.manifest.dependencies === undefined) {
+    manifestXml.manifest.dependencies = {}
   }
 
   const { dependencies } = manifestXml.manifest
@@ -174,11 +180,8 @@ export const fixManifest = (
   addRequiredDependencies(dependencies, customizationInfos, additionalDependencies)
 
   // eslint-disable-next-line new-cap
-  const fixedDependencies = new xmlParser.j2xParser({
+  return new xmlParser.j2xParser({
     ignoreAttributes: false,
     format: true,
-  }).parse({ dependencies })
-  return manifestContent.replace(
-    new RegExp('<dependencies>.*</dependencies>\\n?', 'gs'), fixedDependencies
-  )
+  }).parse(manifestXml)
 }

--- a/packages/netsuite-adapter/test/client/manifest_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/manifest_utils.test.ts
@@ -46,39 +46,32 @@ describe('manifest.xml utils', () => {
     },
   ]
 
-  it('should return with no dependencies tag', () => {
-    const manifest = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
+  it('should return with no manifest tag', () => {
+    const manifest = `<nomanifest projecttype="ACCOUNTCUSTOMIZATION">
 <projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
 <frameworkversion>1.0</frameworkversion>
-</manifest>`
+</nomanifest>`
     expect(fixManifest(manifest, custInfos, DEFAULT_ADDITIONAL_DEPS)).toEqual(manifest)
   })
-  it('should fix empty dependencies tag', () => {
+  it('should fix dependencies tag', () => {
     const manifest = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
 <projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
 <frameworkversion>1.0</frameworkversion>
-<dependencies>
-  <files>
-    <file>/SuiteScripts/clientScript_2_0.js</file>
-  </files>
-</dependencies>
 </manifest>`
     const fixedManifest = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
-<projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
-<frameworkversion>1.0</frameworkversion>
-<dependencies>
-  <files>
-    <file>/SuiteScripts/clientScript_2_0.js</file>
-  </files>
-  <features>
-    <feature required="true">EXPREPORTS</feature>
-  </features>
-  <objects>
-    <object>somescriptid</object>
-    <object>secondscriptid</object>
-  </objects>
-</dependencies>
-</manifest>`
+  <projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
+  <frameworkversion>1.0</frameworkversion>
+  <dependencies>
+    <features>
+      <feature required="true">EXPREPORTS</feature>
+    </features>
+    <objects>
+      <object>somescriptid</object>
+      <object>secondscriptid</object>
+    </objects>
+  </dependencies>
+</manifest>
+`
     expect(fixManifest(manifest, custInfos, DEFAULT_ADDITIONAL_DEPS)).toEqual(fixedManifest)
   })
   it('should remove invalid dependencies', () => {
@@ -113,31 +106,32 @@ describe('manifest.xml utils', () => {
 </dependencies>
 </manifest>`
     const fixedManifest = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
-<projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
-<frameworkversion>1.0</frameworkversion>
-<dependencies>
-  <features>
-    <feature required="true">SFA</feature>
-    <feature required="true">MULTICURRENCYVENDOR</feature>
-    <feature required="true">ACCOUNTING</feature>
-    <feature required="true">ADDRESSCUSTOMIZATION</feature>
-    <feature required="true">SUBSIDIARIES</feature>
-    <feature required="true">RECEIVABLES</feature>
-  </features>
-  <objects>
-    <object>custentity2edited</object>
-    <object>custentity13</object>
-    <object>custentity_14</object>
-    <object>custentity10</object>
-    <object>custentitycust_active</object>
-    <object>custentity11</object>
-    <object>custentity_slt_tax_reg</object>
-  </objects>
-  <files>
-    <file>/SuiteScripts/clientScript_2_0.js</file>
-  </files>
-</dependencies>
-</manifest>`
+  <projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
+  <frameworkversion>1.0</frameworkversion>
+  <dependencies>
+    <features>
+      <feature required="true">SFA</feature>
+      <feature required="true">MULTICURRENCYVENDOR</feature>
+      <feature required="true">ACCOUNTING</feature>
+      <feature required="true">ADDRESSCUSTOMIZATION</feature>
+      <feature required="true">SUBSIDIARIES</feature>
+      <feature required="true">RECEIVABLES</feature>
+    </features>
+    <objects>
+      <object>custentity2edited</object>
+      <object>custentity13</object>
+      <object>custentity_14</object>
+      <object>custentity10</object>
+      <object>custentitycust_active</object>
+      <object>custentity11</object>
+      <object>custentity_slt_tax_reg</object>
+    </objects>
+    <files>
+      <file>/SuiteScripts/clientScript_2_0.js</file>
+    </files>
+  </dependencies>
+</manifest>
+`
     expect(fixManifest(manifest, [], DEFAULT_ADDITIONAL_DEPS))
       .toEqual(fixedManifest)
   })
@@ -173,34 +167,35 @@ describe('manifest.xml utils', () => {
 </dependencies>
 </manifest>`
     const fixedManifest = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
-<projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
-<frameworkversion>1.0</frameworkversion>
-<dependencies>
-  <features>
-    <feature required="true">SFA</feature>
-    <feature required="true">MULTICURRENCYVENDOR</feature>
-    <feature required="true">ACCOUNTING</feature>
-    <feature required="true">ADDRESSCUSTOMIZATION</feature>
-    <feature required="true">SUBSIDIARIES</feature>
-    <feature required="true">RECEIVABLES</feature>
-    <feature required="true">EXPREPORTS</feature>
-  </features>
-  <objects>
-    <object>custentity2edited</object>
-    <object>custentity13</object>
-    <object>custentity_14</object>
-    <object>custentity10</object>
-    <object>custentitycust_active</object>
-    <object>custentity11</object>
-    <object>custentity_slt_tax_reg</object>
-    <object>somescriptid</object>
-    <object>secondscriptid</object>
-  </objects>
-  <files>
-    <file>/SuiteScripts/clientScript_2_0.js</file>
-  </files>
-</dependencies>
-</manifest>`
+  <projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
+  <frameworkversion>1.0</frameworkversion>
+  <dependencies>
+    <features>
+      <feature required="true">SFA</feature>
+      <feature required="true">MULTICURRENCYVENDOR</feature>
+      <feature required="true">ACCOUNTING</feature>
+      <feature required="true">ADDRESSCUSTOMIZATION</feature>
+      <feature required="true">SUBSIDIARIES</feature>
+      <feature required="true">RECEIVABLES</feature>
+      <feature required="true">EXPREPORTS</feature>
+    </features>
+    <objects>
+      <object>custentity2edited</object>
+      <object>custentity13</object>
+      <object>custentity_14</object>
+      <object>custentity10</object>
+      <object>custentitycust_active</object>
+      <object>custentity11</object>
+      <object>custentity_slt_tax_reg</object>
+      <object>somescriptid</object>
+      <object>secondscriptid</object>
+    </objects>
+    <files>
+      <file>/SuiteScripts/clientScript_2_0.js</file>
+    </files>
+  </dependencies>
+</manifest>
+`
     expect(fixManifest(manifest, custInfos, DEFAULT_ADDITIONAL_DEPS))
       .toEqual(fixedManifest)
   })
@@ -236,31 +231,32 @@ describe('manifest.xml utils', () => {
 </dependencies>
 </manifest>`
     const fixedManifest = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
-<projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
-<frameworkversion>1.0</frameworkversion>
-<dependencies>
-  <features>
-    <feature required="true">SFA</feature>
-    <feature required="true">MULTICURRENCYVENDOR</feature>
-    <feature required="true">ACCOUNTING</feature>
-    <feature required="true">ADDRESSCUSTOMIZATION</feature>
-    <feature required="true">SUBSIDIARIES</feature>
-    <feature required="true">addedFeature</feature>
-  </features>
-  <objects>
-    <object>custentity13</object>
-    <object>custentity_14</object>
-    <object>custentity10</object>
-    <object>custentitycust_active</object>
-    <object>custentity11</object>
-    <object>custentity_slt_tax_reg</object>
-    <object>addedObject</object>
-  </objects>
-  <files>
-    <file>/SuiteScripts/clientScript_2_0.js</file>
-  </files>
-</dependencies>
-</manifest>`
+  <projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
+  <frameworkversion>1.0</frameworkversion>
+  <dependencies>
+    <features>
+      <feature required="true">SFA</feature>
+      <feature required="true">MULTICURRENCYVENDOR</feature>
+      <feature required="true">ACCOUNTING</feature>
+      <feature required="true">ADDRESSCUSTOMIZATION</feature>
+      <feature required="true">SUBSIDIARIES</feature>
+      <feature required="true">addedFeature</feature>
+    </features>
+    <objects>
+      <object>custentity13</object>
+      <object>custentity_14</object>
+      <object>custentity10</object>
+      <object>custentitycust_active</object>
+      <object>custentity11</object>
+      <object>custentity_slt_tax_reg</object>
+      <object>addedObject</object>
+    </objects>
+    <files>
+      <file>/SuiteScripts/clientScript_2_0.js</file>
+    </files>
+  </dependencies>
+</manifest>
+`
     expect(fixManifest(manifest, [], {
       include: {
         objects: ['addedObject'],

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -82,31 +82,32 @@ const MOCK_MANIFEST_INVALID_DEPENDENCIES = `<manifest projecttype="ACCOUNTCUSTOM
 </manifest>`
 
 const MOCK_MANIFEST_VALID_DEPENDENCIES = `<manifest projecttype="ACCOUNTCUSTOMIZATION">
-<projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
-<frameworkversion>1.0</frameworkversion>
-<dependencies>
-  <features>
-    <feature required="true">SFA</feature>
-    <feature required="true">MULTICURRENCYVENDOR</feature>
-    <feature required="true">ACCOUNTING</feature>
-    <feature required="true">ADDRESSCUSTOMIZATION</feature>
-    <feature required="true">SUBSIDIARIES</feature>
-    <feature required="true">RECEIVABLES</feature>
-  </features>
-  <objects>
-    <object>custentity2edited</object>
-    <object>custentity13</object>
-    <object>custentity_14</object>
-    <object>custentity10</object>
-    <object>custentitycust_active</object>
-    <object>custentity11</object>
-    <object>custentity_slt_tax_reg</object>
-  </objects>
-  <files>
-    <file>/SuiteScripts/clientScript_2_0.js</file>
-  </files>
-</dependencies>
-</manifest>`
+  <projectname>TempSdfProject-56067b34-18db-4372-a35b-e2ed2c3aaeb3</projectname>
+  <frameworkversion>1.0</frameworkversion>
+  <dependencies>
+    <features>
+      <feature required="true">SFA</feature>
+      <feature required="true">MULTICURRENCYVENDOR</feature>
+      <feature required="true">ACCOUNTING</feature>
+      <feature required="true">ADDRESSCUSTOMIZATION</feature>
+      <feature required="true">SUBSIDIARIES</feature>
+      <feature required="true">RECEIVABLES</feature>
+    </features>
+    <objects>
+      <object>custentity2edited</object>
+      <object>custentity13</object>
+      <object>custentity_14</object>
+      <object>custentity10</object>
+      <object>custentitycust_active</object>
+      <object>custentity11</object>
+      <object>custentity_slt_tax_reg</object>
+    </objects>
+    <files>
+      <file>/SuiteScripts/clientScript_2_0.js</file>
+    </files>
+  </dependencies>
+</manifest>
+`
 
 const MOCK_FEATURES_XML = '<features><feature><id>SUITEAPPCONTROLCENTER</id><status>ENABLED</status></feature></features>'
 


### PR DESCRIPTION
add dependencies tag to manifest.xml if missing

---
_Release Notes_: 
NetSuite Adapter:
- add dependencies tag to manifest.xml if missing

---
_User Notifications_: 
none