### PR TITLE
SaaS-2339 Fetch From Workspace fromState static files fix

### DIFF
--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -414,6 +414,7 @@ export const mockWorkspace = ({
     listUnresolvedReferences: mockFunction<Workspace['listUnresolvedReferences']>(),
     getElementSourceOfPath: mockFunction<Workspace['getElementSourceOfPath']>(),
     getFileEnvs: mockFunction<Workspace['getFileEnvs']>(),
+    getStaticFile: mockFunction<Workspace['getStaticFile']>(),
   }
 }
 

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -812,28 +812,19 @@ const fixStaticFilesForFromStateChanges = async (
             staticFile.encoding,
             env
           )
-          console.log('path')
-          console.log(staticFileChangeFullName)
           if (!actualStaticFile || actualStaticFile.hash !== staticFile.hash) {
-            console.log('The hashes are different!')
-            console.log(actualStaticFile?.hash)
-            console.log(staticFile.hash)
             invalidChangeIDs.add(change.id.getFullName())
             return
           }
           const staticFileValElemID = ElemID.fromFullName(staticFileChangeFullName)
-          console.log(staticFileValElemID.getFullName())
           if (isElement(change.data.after)) {
-            console.log('got here a')
             setPath(change.data.after, staticFileValElemID, actualStaticFile)
             return
           }
           if (isStaticFile(change.data.after)) {
-            console.log('got here b')
             change.data.after = actualStaticFile
             return
           }
-          console.log('not element nor static')
           const changeFullNameParts = change.id.getFullNameParts()
           const relativePath = _.dropWhile(
             staticFileChangeFullName.split('.'),

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -773,10 +773,10 @@ const createEmptyFetchChangeDueToError = (errMsg: string): FetchChangesResult =>
 
 const getPathsToStaticFiles = async (
   value: Value,
-  valPath: readonly string[],
+  elemId: ElemID,
 ): Promise<Map<string, StaticFile>> => {
   const pathToStaticFiles: Map<string, StaticFile> = new Map<string, StaticFile>()
-  const func: WalkOnFunc = ({ path, value: val }) => {
+  const findStaticFilesFn: WalkOnFunc = ({ path, value: val }) => {
     if (isStaticFile(val)) {
       pathToStaticFiles.set(path.getFullName(), val)
       return WALK_NEXT_STEP.SKIP
@@ -784,28 +784,76 @@ const getPathsToStaticFiles = async (
     return WALK_NEXT_STEP.RECURSE
   }
   if (isElement(value)) {
-    walkOnElement({ element: value, func })
+    walkOnElement({ element: value, func: findStaticFilesFn })
   } else {
-    walkOnValue({ elemId: new ElemID('ahi', 'sim po from the detail change'), value, func })
+    walkOnValue({ elemId, value, func: findStaticFilesFn })
   }
   return pathToStaticFiles
-  if (_.isArray(value)) {
-    await awu(value)
-      .flatMap((v, index) => getPathsToStaticFiles(v, [...valPath, index.toString()]))
-      .forEach(([path, val]) =>
-        pathToStaticFiles.set(path, val))
+}
+
+const fixStaticFilesForFromStateChanges = async (
+  fetchChangesResult: FetchChangesResult,
+  otherWorkspace: Workspace,
+  env: string,
+): Promise<FetchChangesResult> => {
+  const invalidChangeIDs: Set<string> = new Set()
+  await awu(fetchChangesResult.changes)
+    .map(fetchChange => fetchChange.change)
+    .filter(isAdditionOrModificationChange)
+    .forEach(async change => {
+      if (isAdditionOrModificationChange(change)) {
+        const pathsToStaticFiles = await getPathsToStaticFiles(
+          change.data.after,
+          change.id,
+        )
+        await awu(pathsToStaticFiles).forEach(async ([staticFileChangeFullName, staticFile]) => {
+          const actualStaticFile = await otherWorkspace.getStaticFile(
+            staticFile.filepath,
+            staticFile.encoding,
+            env
+          )
+          console.log('path')
+          console.log(staticFileChangeFullName)
+          if (!actualStaticFile || actualStaticFile.hash !== staticFile.hash) {
+            console.log('The hashes are different!')
+            console.log(actualStaticFile?.hash)
+            console.log(staticFile.hash)
+            invalidChangeIDs.add(change.id.getFullName())
+            return
+          }
+          const staticFileValElemID = ElemID.fromFullName(staticFileChangeFullName)
+          console.log(staticFileValElemID.getFullName())
+          if (isElement(change.data.after)) {
+            console.log('got here a')
+            setPath(change.data.after, staticFileValElemID, actualStaticFile)
+            return
+          }
+          if (isStaticFile(change.data.after)) {
+            console.log('got here b')
+            change.data.after = actualStaticFile
+            return
+          }
+          console.log('not element nor static')
+          const changeFullNameParts = change.id.getFullNameParts()
+          const relativePath = _.dropWhile(
+            staticFileChangeFullName.split('.'),
+            (namePart, index) => namePart === changeFullNameParts[index],
+          )
+          _.set(change.data.after, relativePath, actualStaticFile)
+        })
+      }
+    })
+  return {
+    ...fetchChangesResult,
+    changes: wu(fetchChangesResult.changes)
+      .filter(change => !invalidChangeIDs.has(change.change.id.getFullName())),
+    errors: fetchChangesResult.errors.concat(
+      Array.from(invalidChangeIDs).map(invalidChangeElemID => ({
+        message: `Dropping changes in element: ${invalidChangeElemID} due to static files hashes mismatch`,
+        severity: 'Error',
+      }))
+    ),
   }
-  if (_.isPlainObject(value)) {
-    await awu(Object.entries(value))
-      .flatMap(([key, val]) =>
-        getPathsToStaticFiles(val, [...valPath, key]))
-      .forEach(([path, val]) =>
-        pathToStaticFiles.set(path, val))
-  }
-  if (isStaticFile(value)) {
-    return pathToStaticFiles.set(valPath.join('.'), value)
-  }
-  return pathToStaticFiles
 }
 
 export const fetchChangesFromWorkspace = async (
@@ -877,10 +925,6 @@ export const fetchChangesFromWorkspace = async (
   const fullElements = await awu(await (otherElementsSource).getAll())
     .filter(elem => fetchAccounts.includes(elem.elemID.adapter))
     .toArray()
-  // const apexClasses = fullElements.filter(fe => fe.elemID.typeName === 'ApexClass')
-  // .filter(fe => fe.elemID.idType === 'instance')
-  // log.debug('%s', apexClasses.map(e => safeJsonStringify(e)).join('\n'))
-  // console.log('%s', apexClasses.map(e => safeJsonStringify(e)).join('\n'))
 
   const otherPathIndex = await otherWorkspace.state(env).getPathIndex()
   const inMemoryOtherPathIndex = new remoteMap.InMemoryRemoteMap<pathIndex.Path[]>(
@@ -901,7 +945,7 @@ export const fetchChangesFromWorkspace = async (
     )
     ).flat(),
   ]
-  const changes = await createFetchChanges({
+  const fetchChangesResult = await createFetchChanges({
     adapterNames: fetchAccounts,
     currentConfigs,
     getChangesEmitter,
@@ -913,107 +957,11 @@ export const fetchChangesFromWorkspace = async (
     workspaceElements,
     unmergedElements,
   })
-  if (fromState) {
-    await awu(changes.changes)
-      .map(c => c.change)
-      .filter(isAdditionOrModificationChange)
-      .forEach(async c => {
-        if (isAdditionOrModificationChange(c)) {
-          const pathsToStaticFiles = await getPathsToStaticFiles(
-            c.data.after,
-            c.path ?? ([] as readonly string[]),
-          )
-          pathsToStaticFiles.forEach(async (staticFile, path) => {
-            const actualStaticFile = await otherWorkspace.getStaticFile(
-              staticFile.filepath,
-              staticFile.encoding,
-              env
-            )
-            // if the hashes are different we need to remove the change and add an error
-            if (!actualStaticFile) {
-              // Add an error
-              console.log('no static file')
-              return
-            }
-            console.log('path')
-            console.log(path)
-            console.log('%o', c.data.after)
-            if (isElement(c.data.after)) {
-              setPath(c.data.after, ElemID.fromFullName(path), actualStaticFile)
-            }
-            _.set(c.data.after, path.split('.'), actualStaticFile)
-            console.log('%o', c.data.after)
-          })
-        }
-      })
-    // await awu(changes.changes)
-    //   .map(c => c.change)
-    //   .filter(c => (isAdditionOrModificationChange(c)))
-    //   .forEach(async c => {
-    //     if (isAdditionOrModificationChange(c)) {
-    //       const otherWorkspaceStaticFile = await otherWorkspace.getStaticFile(
-    //         c.data.after.filepath, c.data.after.encoding, env,
-    //       )
-    //       if (!otherWorkspaceStaticFile) {
-    //         // add error and remove the change
-    //         console.log('lala')
-    //       }
-    //       c.data.after = otherWorkspaceStaticFile
-    //     }
-    //   })
-    // await awu(changes.changes)
-    //   .filter(c =>
-    //     c.change.id.getFullName().includes('ApexClass'))
-    //   .forEach(c => {
-    //     console.log(c.change.id.getFullName())
-    //     console.log(c.change.action)
-    //   })
-
-    // const lala2 = awu(lala).filter(async l => {
-    //   if (isAdditionOrModificationChange(l) && isStaticFile(l.data.after)) {
-    //     const otherWorkspaceStaticFile = await otherWorkspace.getStaticFile(
-    //       element.filepath, element.encoding, env,
-    //     )
-    //     if (!otherWorkspaceStaticFile) {
-    //       // add error and remove the change
-    //       console.log('lala')
-    //     }
-    //   }
-    // })
-    // lala.forEach(l =>
-    //   applyFunctionToChangeData(
-    //     l,
-    //     async (element: Element) => {
-    //       if (isStaticFile(element)) {
-    // const otherWorkspaceStaticFile = await otherWorkspace.getStaticFile(
-    //   element.filepath, element.encoding, env,
-    // )
-    // if (!otherWorkspaceStaticFile) {
-    //   // add error and remove the change
-    //   console.log('lala')
-    // }
-    //         element.content = await otherWorkspaceStaticFile?.getContent()
-    //       }
-    //     }
-    //   ))
-    // applyFunctionToChangeData(
-    //   changes.changes,
-    //   (element: Element) =>
-    // )
-  }
-  return changes
-  // return createFetchChanges({
-  //   adapterNames: fetchAccounts,
-  //   currentConfigs,
-  //   getChangesEmitter,
-  //   processErrorsResult: {
-  //     keptElements: fullElements,
-  //     errorsWithDroppedElements: [],
-  //   },
-  //   stateElements,
-  //   workspaceElements,
-  //   unmergedElements,
-  // })
+  // fromState case is currently needed to add proper Static Files values to the changes
+  // This will be redundant once the Static Files re-design will be implemented
+  return fromState
+    ? fixStaticFilesForFromStateChanges(fetchChangesResult, otherWorkspace, env)
+    : fetchChangesResult
 }
 
 const id = (elemID: ElemID): string => elemID.getFullName()

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -22,10 +22,7 @@ import {
   FIELD_NAME, INSTANCE_NAME, OBJECT_NAME, ElemIdGetter, DetailedChange, SaltoError,
   isSaltoElementError, ProgressReporter, ReadOnlyElementsSource, TypeMap, isServiceId,
   CORE_ANNOTATIONS, AdapterOperationsContext, FetchResult, isAdditionChange, isStaticFile,
-  isAdditionOrModificationChange,
-  Value,
-  StaticFile,
-  isElement,
+  isAdditionOrModificationChange, Value, StaticFile, isElement,
 } from '@salto-io/adapter-api'
 import { applyInstancesDefaults, resolvePath, flattenElementStr, buildElementsSourceFromElements, safeJsonStringify, walkOnElement, WalkOnFunc, WALK_NEXT_STEP, setPath, walkOnValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'

--- a/packages/core/test/common/workspace.ts
+++ b/packages/core/test/common/workspace.ts
@@ -13,10 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, Element, ElemID, InstanceElement, ObjectType, SaltoError, Value } from '@salto-io/adapter-api'
+import { BuiltinTypes, Element, ElemID, InstanceElement, ObjectType, SaltoError, Value, StaticFile } from '@salto-io/adapter-api'
 import { mockFunction } from '@salto-io/test-utils'
 import * as workspace from '@salto-io/workspace'
-import { elementSource, errors as wsErrors } from '@salto-io/workspace'
+import { elementSource, errors as wsErrors, staticFiles } from '@salto-io/workspace'
 import { mockState } from './state'
 
 const mockService = 'salto'
@@ -66,6 +66,27 @@ export const mockErrors = (errors: SaltoError[]): wsErrors.Errors => new wsError
   validation: errors.map(err => ({ elemID: new ElemID('test'), error: err.message, ...err })),
 })
 
+export const mockStaticFilesSource = (
+  files: StaticFile[] = [],
+): staticFiles.StaticFilesSource => ({
+  getStaticFile: jest.fn().mockImplementation((filepath: string, _encoding: BufferEncoding) => (
+    files.find(sf => sf.filepath === filepath) ?? undefined
+  )),
+  getContent: jest.fn().mockImplementation((filepath: string) => (
+    files.find(sf => sf.filepath === filepath)?.content ?? undefined
+  )),
+  persistStaticFile: jest.fn().mockReturnValue([]),
+  flush: jest.fn(),
+  clone: jest.fn(),
+  rename: jest.fn(),
+  getTotalSize: jest.fn(),
+  clear: jest.fn(),
+  delete: jest.fn(),
+  isPathIncluded: jest.fn().mockImplementation(
+    filePath => files.find(f => f.filepath === filePath) !== undefined
+  ),
+})
+
 export const mockWorkspace = ({
   elements = [],
   name = undefined,
@@ -76,6 +97,7 @@ export const mockWorkspace = ({
   accountConfigs = {},
   accountToServiceName = {},
   parsedNaclFiles = {},
+  staticFilesSource = undefined,
 }: {
   elements?: Element[]
   name?: string
@@ -87,6 +109,7 @@ export const mockWorkspace = ({
   getValue?: Promise<Value | undefined>
   accountToServiceName?: Record<string, string>
   parsedNaclFiles?: Record<string, Element[]>
+  staticFilesSource?: staticFiles.StaticFilesSource
 }): workspace.Workspace => {
   const elementIDtoFileMap = Object.entries(parsedNaclFiles).reduce(
     (acc, entry) => {
@@ -137,5 +160,7 @@ export const mockWorkspace = ({
     getParsedNaclFile: async (filename: string) => ({
       elements: async () => parsedNaclFiles[filename],
     }),
+    getStaticFile: (filePath: string, encoding: BufferEncoding) =>
+      (staticFilesSource ? staticFilesSource.getStaticFile(filePath, encoding) : undefined),
   } as unknown as workspace.Workspace
 }

--- a/packages/core/test/common/workspace.ts
+++ b/packages/core/test/common/workspace.ts
@@ -160,7 +160,9 @@ export const mockWorkspace = ({
     getParsedNaclFile: async (filename: string) => ({
       elements: async () => parsedNaclFiles[filename],
     }),
-    getStaticFile: (filePath: string, encoding: BufferEncoding) =>
-      (staticFilesSource ? staticFilesSource.getStaticFile(filePath, encoding) : undefined),
+    getStaticFile: ({ filepath, encoding }: { filepath: string; encoding: BufferEncoding }) =>
+      (staticFilesSource
+        ? staticFilesSource.getStaticFile(filepath, encoding)
+        : undefined),
   } as unknown as workspace.Workspace
 }

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -22,12 +22,14 @@ import {
   ReadOnlyElementsSource,
   createRefToElmWithValue,
   TypeReference,
+  StaticFile,
+  isStaticFile,
 } from '@salto-io/adapter-api'
 import * as utils from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { elementSource, pathIndex, remoteMap, createAdapterReplacedID } from '@salto-io/workspace'
 import { mockFunction } from '@salto-io/test-utils'
-import { mockWorkspace } from '../common/workspace'
+import { mockWorkspace, mockStaticFilesSource } from '../common/workspace'
 import {
   fetchChanges, FetchChange, generateServiceIdToStateElemId,
   FetchChangesResult, FetchProgressEvents, getAdaptersFirstFetchPartial,
@@ -1477,7 +1479,6 @@ describe('fetch from workspace', () => {
       },
       path: ['salto', 'obj', 'annotations'],
     })
-
     const objFull = new ObjectType({
       elemID: objElemId,
       fields: {
@@ -1505,10 +1506,96 @@ describe('fetch from workspace', () => {
       elemID: new ElemID('other', 'obj'),
       path: ['other', 'obj', 'all'],
     })
+    const existingSubType = new ObjectType({
+      elemID: new ElemID('salto', 'existingSubType'),
+      fields: {
+        staticFileField: { refType: BuiltinTypes.STRING },
+        staticFilesArr: { refType: new ListType(BuiltinTypes.STRING) },
+      },
+      path: ['salto', 'existing', 'subtype'],
+    })
     const existingElement = new ObjectType({
       elemID: new ElemID('salto', 'existing'),
+      fields: {
+        staticFileField: { refType: BuiltinTypes.STRING },
+        hashMismatchField: { refType: BuiltinTypes.STRING },
+        complexField: { refType: existingSubType },
+      },
       path: ['salto', 'existing', 'all'],
     })
+    const fileOne = new StaticFile({ filepath: 'file1', encoding: 'utf-8', content: Buffer.from('1') })
+    const fileTwo = new StaticFile({ filepath: 'file2', encoding: 'utf-8', content: Buffer.from('2') })
+    const fileThree = new StaticFile({ filepath: 'file3', encoding: 'utf-8', content: Buffer.from('3') })
+    const fileFour = new StaticFile({ filepath: 'file4', encoding: 'utf-8', content: Buffer.from('4') })
+    const validFileContents = [fileOne, fileTwo, fileThree].map(f => f.content)
+    const existingInstance = new InstanceElement(
+      'existing',
+      existingElement,
+      {
+        staticFileField: new StaticFile({ filepath: 'file1', encoding: 'utf-8', hash: 'hash1' }),
+        complexField: {
+          staticFileField: new StaticFile({ filepath: 'file2', encoding: 'utf-8', hash: 'hash2' }),
+          staticFilesArr: [
+            new StaticFile({ filepath: 'file3', encoding: 'utf-8', hash: 'hash3' }),
+          ],
+        },
+        hashMismatchField: new StaticFile({ filepath: 'file4', encoding: 'utf-8', hash: 'hash4' }),
+      },
+    )
+    const editStateExistingInstance = new InstanceElement(
+      'existing',
+      existingElement,
+      {
+        staticFileField: new StaticFile({ filepath: 'file1', encoding: 'utf-8', hash: fileOne.hash }),
+        complexField: {
+          staticFileField: new StaticFile({ filepath: 'file2', encoding: 'utf-8', hash: fileTwo.hash }),
+          staticFilesArr: [
+            new StaticFile({ filepath: 'file3', encoding: 'utf-8', hash: fileThree.hash }),
+          ],
+        },
+        hashMismatchField: new StaticFile({ filepath: 'file4', encoding: 'utf-8', hash: 'miss!' }),
+      },
+    )
+    const editNaclExistingInstance = new InstanceElement(
+      'existing',
+      existingElement,
+      {
+        staticFileField: fileOne,
+        complexField: {
+          staticFileField: fileTwo,
+          staticFilesArr: [
+            fileThree,
+          ],
+        },
+        hashMismatchField: new StaticFile({ filepath: 'file4', encoding: 'utf-8', hash: 'hash4' }),
+      },
+    )
+    const newStateStaticInstance = new InstanceElement(
+      'new',
+      existingElement,
+      {
+        staticFileField: new StaticFile({ filepath: 'file1', encoding: 'utf-8', hash: fileOne.hash }),
+        complexField: {
+          staticFileField: new StaticFile({ filepath: 'file2', encoding: 'utf-8', hash: fileTwo.hash }),
+          staticFilesArr: [
+            new StaticFile({ filepath: 'file3', encoding: 'utf-8', hash: fileThree.hash }),
+          ],
+        },
+      }
+    )
+    const newNaclStaticInstance = new InstanceElement(
+      'new',
+      existingElement,
+      {
+        staticFileField: fileOne,
+        complexField: {
+          staticFileField: fileTwo,
+          staticFilesArr: [
+            fileThree,
+          ],
+        },
+      }
+    )
     const editElemID = new ElemID('salto', 'edit')
     const editStateElem = new ObjectType({
       elemID: editElemID,
@@ -1540,7 +1627,6 @@ describe('fetch from workspace', () => {
       },
       path: ['salto', 'here'],
     })
-
     const noPathElemID = ElemID.fromFullName('salto.partially')
     const noPathElementFull = new ObjectType({
       elemID: noPathElemID,
@@ -1557,7 +1643,6 @@ describe('fetch from workspace', () => {
       },
       path: ['salto', 'nopath'],
     })
-
     const movedElem = new ObjectType({
       elemID: ElemID.fromFullName('salto.moved'),
       annotations: {
@@ -1565,18 +1650,29 @@ describe('fetch from workspace', () => {
       },
       path: ['salto', 'origLocation'],
     })
-    const mergedElements = [objFull, existingElement, otherAdapterElem, editNaclElem,
-      noPathElementFull, movedElem]
-    const stateElements = [objFull, existingElement, otherAdapterElem, editStateElem,
-      noPathElementFull, movedElem]
+    const mergedElements = [
+      objFull, existingElement, otherAdapterElem, editNaclElem, newNaclStaticInstance,
+      noPathElementFull, movedElem, editNaclExistingInstance, existingSubType,
+    ]
+    const stateElements = [
+      objFull, existingElement, otherAdapterElem, editStateElem, newStateStaticInstance,
+      noPathElementFull, movedElem, editStateExistingInstance, existingSubType,
+    ]
     const unmergedElements = [
       objFragStdFields, objFragCustomFields, editStateElem,
-      objFragAnnotations, existingElement, otherAdapterElem,
-      noPathElementFull, movedElem,
+      objFragAnnotations, existingElement, otherAdapterElem, newStateStaticInstance,
+      noPathElementFull, movedElem, editStateExistingInstance, existingSubType,
     ]
-    const unmergedElementsWithEditNaclElem = [
-      ...(unmergedElements.filter(e => !e.elemID.isEqual(editElemID))),
+    const edits = [
       editNaclElem,
+      editNaclExistingInstance,
+      newNaclStaticInstance,
+    ]
+    const editsIDs = edits.map(edit => edit.elemID.getFullName())
+    const unmergedElementsWithEditNaclElem = [
+      ...(unmergedElements.filter(e =>
+        !editsIDs.includes(e.elemID.getFullName()))),
+      ...edits,
     ]
     const configs = [
       new InstanceElement('_config', new TypeReference(new ElemID('salto'))),
@@ -1594,6 +1690,10 @@ describe('fetch from workspace', () => {
       }
       return 0
     }
+
+    const otherWorkspaceStaticFilesSource = mockStaticFilesSource(
+      [fileOne, fileTwo, fileThree, fileFour],
+    )
 
     beforeEach(async () => {
       await pathIndex.overridePathIndex(pi, unmergedElements.filter(
@@ -1614,10 +1714,11 @@ describe('fetch from workspace', () => {
                 'salto/nopath.nacl': [noPathElementNACL],
                 'salto/moved.nacl': [movedElem],
               },
+              staticFilesSource: otherWorkspaceStaticFilesSource,
             }),
             ['salto'],
-            createInMemoryElementSource([existingElement]),
-            createInMemoryElementSource([existingElement]),
+            createInMemoryElementSource([existingElement, existingInstance, existingSubType]),
+            createInMemoryElementSource([existingElement, existingInstance, existingSubType]),
             configs,
             'default',
             false,
@@ -1659,6 +1760,28 @@ describe('fetch from workspace', () => {
         })
       })
 
+      it('should return changes with static files content from the elements', () => {
+        const changes = [...fetchRes.changes]
+        const newStaticInst = changes
+          .filter(change => change.change.id.isEqual(newNaclStaticInstance.elemID))
+          .map(change => getChangeData(change.change))
+        expect(newStaticInst).toHaveLength(1)
+        expect(newStaticInst[0].value.staticFileField.content).toEqual(fileOne.content)
+        expect(newStaticInst[0].value.complexField.staticFileField.content)
+          .toEqual(fileTwo.content)
+        expect(newStaticInst[0].value.complexField.staticFilesArr[0].content)
+          .toEqual(fileThree.content)
+        const modifyStaticVals = changes
+          .filter(change =>
+            change.change.id.createTopLevelParentID().parent
+              .isEqual(editNaclExistingInstance.elemID))
+          .map(change => getChangeData(change.change))
+        expect(modifyStaticVals).toHaveLength(3)
+        const staticFileModifies = modifyStaticVals.filter(val => isStaticFile(val))
+        expect(staticFileModifies).toHaveLength(3)
+        staticFileModifies.forEach(modify => validFileContents.includes(modify.content))
+      })
+
       describe('With warnings', () => {
         beforeEach(async () => {
           fetchRes = await fetchChangesFromWorkspace(
@@ -1668,10 +1791,11 @@ describe('fetch from workspace', () => {
               accountConfigs: { salto: configs[0] },
               stateElements,
               errors: [{ message: 'A warnings', severity: 'Warning' }],
+              staticFilesSource: otherWorkspaceStaticFilesSource,
             }),
             ['salto'],
-            createInMemoryElementSource([existingElement]),
-            createInMemoryElementSource([existingElement]),
+            createInMemoryElementSource([existingElement, existingInstance, existingSubType]),
+            createInMemoryElementSource([existingElement, existingInstance, existingSubType]),
             configs,
             'default',
             false,
@@ -1697,10 +1821,11 @@ describe('fetch from workspace', () => {
               index: await awu(pi.entries()).toArray(),
               accountConfigs: { salto: configs[0] },
               stateElements,
+              staticFilesSource: otherWorkspaceStaticFilesSource,
             }),
             ['salto'],
-            createInMemoryElementSource([existingElement]),
-            createInMemoryElementSource([existingElement]),
+            createInMemoryElementSource([existingElement, existingInstance, existingSubType]),
+            createInMemoryElementSource([existingElement, existingInstance, existingSubType]),
             configs,
             'default',
             true,
@@ -1740,6 +1865,37 @@ describe('fetch from workspace', () => {
             .forEach(frag => expect(changesElements.filter(e => e.isEqual(frag)))
               .toHaveLength(1))
         })
+
+        it('should return changes with static files content from otherWorkspace when hashes match', () => {
+          const changes = [...fetchRes.changes]
+          const newStaticInst = changes
+            .filter(change => change.change.id.isEqual(newStateStaticInstance.elemID))
+            .map(change => getChangeData(change.change))
+          expect(newStaticInst).toHaveLength(1)
+          expect(newStaticInst[0].value.staticFileField.content).toEqual(fileOne.content)
+          expect(newStaticInst[0].value.complexField.staticFileField.content)
+            .toEqual(fileTwo.content)
+          expect(newStaticInst[0].value.complexField.staticFilesArr[0].content)
+            .toEqual(fileThree.content)
+          const modifyStaticVals = changes
+            .filter(change =>
+              change.change.id.createTopLevelParentID().parent.isEqual(editStateExistingInstance.elemID))
+            .map(change => getChangeData(change.change))
+          expect(modifyStaticVals).toHaveLength(3)
+          const staticFileModifies = modifyStaticVals.filter(val => isStaticFile(val))
+          expect(staticFileModifies).toHaveLength(3)
+          staticFileModifies.forEach(modify => validFileContents.includes(modify.content))
+        })
+
+        it('should not have a change on the val and a error if there is a hashes mismatch', () => {
+          const changes = [...fetchRes.changes]
+          const mismatchValFullName = `${editStateExistingInstance.elemID.getFullName()}.hashMismatchField`
+          const hasMismatchFieldChange = changes
+            .find(c => c.change.id.getFullName() === mismatchValFullName)
+          expect(hasMismatchFieldChange).toBeUndefined()
+          expect(fetchRes.errors).toHaveLength(1)
+          expect(fetchRes.errors[0].message).toContain(mismatchValFullName)
+        })
       })
 
       describe('With errors and warnings', () => {
@@ -1754,10 +1910,11 @@ describe('fetch from workspace', () => {
                 { message: 'what is this madness', severity: 'Error' },
                 { message: 'A warnings', severity: 'Warning' },
               ],
+              staticFilesSource: otherWorkspaceStaticFilesSource,
             }),
             ['salto'],
-            createInMemoryElementSource([existingElement]),
-            createInMemoryElementSource([existingElement]),
+            createInMemoryElementSource([existingElement, existingInstance, existingSubType]),
+            createInMemoryElementSource([existingElement, existingInstance, existingSubType]),
             configs,
             'default',
             true,
@@ -1765,11 +1922,11 @@ describe('fetch from workspace', () => {
           resElements = [...fetchRes.elements]
         })
 
-        it('Should return with changes and no errors', () => {
+        it('Should return with changes and a single expected error', () => {
           expect([...fetchRes.changes]).not.toHaveLength(0)
           expect(fetchRes.elements).not.toHaveLength(0)
           expect(fetchRes.unmergedElements).not.toHaveLength(0)
-          expect(fetchRes.errors).toHaveLength(0)
+          expect(fetchRes.errors).toHaveLength(1)
         })
       })
     })

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -1879,7 +1879,8 @@ describe('fetch from workspace', () => {
             .toEqual(fileThree.content)
           const modifyStaticVals = changes
             .filter(change =>
-              change.change.id.createTopLevelParentID().parent.isEqual(editStateExistingInstance.elemID))
+              change.change.id.createTopLevelParentID().parent
+                .isEqual(editStateExistingInstance.elemID))
             .map(change => getChangeData(change.change))
           expect(modifyStaticVals).toHaveLength(3)
           const staticFileModifies = modifyStaticVals.filter(val => isStaticFile(val))

--- a/packages/workspace/salto.log
+++ b/packages/workspace/salto.log
@@ -1,0 +1,93 @@
+2022-05-23T18:33:42.307Z debug workspace/src/expressions resolve 1 elements starting
+2022-05-23T18:33:42.331Z debug workspace/src/expressions resolve handled a total of 14 elements
+2022-05-23T18:33:42.332Z debug workspace/src/expressions resolve 1 elements took 26 ms
+2022-05-23T18:33:42.360Z debug workspace/src/expressions resolve 1 elements starting
+2022-05-23T18:33:42.361Z debug workspace/src/expressions resolve handled a total of 14 elements
+2022-05-23T18:33:42.361Z debug workspace/src/expressions resolve 1 elements took 1 ms
+2022-05-23T18:33:45.882Z debug workspace/src/workspace/nacl_files/nacl_files_source building elements indices for 0 NaCl files
+2022-05-23T18:33:45.890Z info workspace/src/workspace/nacl_files/elements_cache going to merge new elements to the existing elements
+2022-05-23T18:33:45.890Z debug workspace/src/merger/index merged 0 elements to 0 elements [errors=0]
+2022-05-23T18:33:45.896Z debug workspace/src/workspace/nacl_files/nacl_files_source going to update 1 NaCl files
+2022-05-23T18:33:45.897Z debug workspace/src/workspace/nacl_files/nacl_files_source building elements indices for 1 NaCl files
+2022-05-23T18:33:45.898Z info workspace/src/workspace/nacl_files/elements_cache going to merge new elements to the existing elements
+2022-05-23T18:33:45.898Z debug workspace/src/merger/index merged 0 elements to 0 elements [errors=0]
+2022-05-23T18:33:46.502Z debug workspace/src/workspace/workspace Loading workspace with id: 
+2022-05-23T18:33:46.510Z debug workspace/src/workspace/nacl_files/elements_cache Merging components: default, COMMON_
+2022-05-23T18:33:46.511Z debug workspace/src/workspace/nacl_files/elements_cache Setting hash multi_env-multi_env_mergeManagermerge_manager::default_COMMON__merged_hash to ead244bc1646d9915c741130a00108a868b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.513Z debug workspace/src/merger/index merged 1 elements to 1 elements [errors=0]
+2022-05-23T18:33:46.514Z debug workspace/src/workspace/nacl_files/elements_cache Setting default source hash in namespace multi_env-multi_env_mergeManagermerge_manager to ead244bc1646d9915c741130a00108a8
+2022-05-23T18:33:46.514Z debug workspace/src/workspace/nacl_files/elements_cache Setting COMMON_ source hash in namespace multi_env-multi_env_mergeManagermerge_manager to 68b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.515Z debug workspace/src/workspace/nacl_files/elements_cache Applying merged changes to cache.
+2022-05-23T18:33:46.517Z debug workspace/src/workspace/nacl_files/elements_cache Change type: add, on 1 elements. The first 1 ids are: salto.withStatic
+2022-05-23T18:33:46.517Z debug workspace/src/workspace/nacl_files/elements_cache Merging components: inactive, COMMON_
+2022-05-23T18:33:46.517Z debug workspace/src/workspace/nacl_files/elements_cache Setting hash multi_env-multi_env_mergeManagermerge_manager::inactive_COMMON__merged_hash to edf1b3655f0ca128d6bee028591ed5e968b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.517Z debug workspace/src/merger/index merged 1 elements to 1 elements [errors=0]
+2022-05-23T18:33:46.518Z debug workspace/src/workspace/nacl_files/elements_cache Setting inactive source hash in namespace multi_env-multi_env_mergeManagermerge_manager to edf1b3655f0ca128d6bee028591ed5e9
+2022-05-23T18:33:46.518Z debug workspace/src/workspace/nacl_files/elements_cache Setting COMMON_ source hash in namespace multi_env-multi_env_mergeManagermerge_manager to 68b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.518Z debug workspace/src/workspace/nacl_files/elements_cache Applying merged changes to cache.
+2022-05-23T18:33:46.519Z debug workspace/src/workspace/nacl_files/elements_cache Change type: add, on 1 elements. The first 1 ids are: salto.withStatic
+2022-05-23T18:33:46.524Z debug workspace/src/workspace/nacl_files/elements_cache Merging components: multi_env_element_sourcedefault, state_element_sourcedefault
+2022-05-23T18:33:46.524Z debug workspace/src/workspace/nacl_files/elements_cache Setting hash workspaceMergeManagermerge_manager::multi_env_element_sourcedefault_state_element_sourcedefault_merged_hash to ead244bc1646d9915c741130a00108a868b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.524Z debug workspace/src/merger/index merged 1 elements to 1 elements [errors=0]
+2022-05-23T18:33:46.525Z debug workspace/src/workspace/nacl_files/elements_cache Setting multi_env_element_sourcedefault source hash in namespace workspaceMergeManagermerge_manager to ead244bc1646d9915c741130a00108a868b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.525Z debug workspace/src/workspace/nacl_files/elements_cache Applying merged changes to cache.
+2022-05-23T18:33:46.526Z debug workspace/src/workspace/nacl_files/elements_cache Change type: add, on 1 elements. The first 1 ids are: salto.withStatic
+2022-05-23T18:33:46.526Z debug workspace/src/workspace/reference_indexes updating references indexes starting
+2022-05-23T18:33:46.528Z info workspace/src/workspace/reference_indexes references indexes maps are out of date, re-indexing
+2022-05-23T18:33:46.530Z debug workspace/src/workspace/reference_indexes updating references indexes took 4 ms
+2022-05-23T18:33:46.531Z debug workspace/src/expressions resolve 1 elements starting
+2022-05-23T18:33:46.533Z debug workspace/src/expressions resolve handled a total of 13 elements
+2022-05-23T18:33:46.534Z debug workspace/src/expressions resolve 1 elements took 3 ms
+2022-05-23T18:33:46.536Z debug workspace/src/workspace/nacl_files/elements_cache Merging components: multi_env_element_sourceinactive, state_element_sourceinactive
+2022-05-23T18:33:46.536Z debug workspace/src/workspace/nacl_files/elements_cache Setting hash workspaceMergeManagermerge_manager::multi_env_element_sourceinactive_state_element_sourceinactive_merged_hash to edf1b3655f0ca128d6bee028591ed5e968b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.536Z debug workspace/src/merger/index merged 1 elements to 1 elements [errors=0]
+2022-05-23T18:33:46.536Z debug workspace/src/workspace/nacl_files/elements_cache Setting multi_env_element_sourceinactive source hash in namespace workspaceMergeManagermerge_manager to edf1b3655f0ca128d6bee028591ed5e968b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.536Z debug workspace/src/workspace/nacl_files/elements_cache Applying merged changes to cache.
+2022-05-23T18:33:46.537Z debug workspace/src/workspace/nacl_files/elements_cache Change type: add, on 1 elements. The first 1 ids are: salto.withStatic
+2022-05-23T18:33:46.537Z debug workspace/src/workspace/reference_indexes updating references indexes starting
+2022-05-23T18:33:46.538Z info workspace/src/workspace/reference_indexes references indexes maps are out of date, re-indexing
+2022-05-23T18:33:46.538Z debug workspace/src/workspace/reference_indexes updating references indexes took 1 ms
+2022-05-23T18:33:46.538Z debug workspace/src/expressions resolve 1 elements starting
+2022-05-23T18:33:46.539Z debug workspace/src/expressions resolve handled a total of 13 elements
+2022-05-23T18:33:46.539Z debug workspace/src/expressions resolve 1 elements took 1 ms
+2022-05-23T18:33:46.546Z debug workspace/src/workspace/workspace Loading workspace with id: 
+2022-05-23T18:33:46.548Z debug workspace/src/workspace/nacl_files/elements_cache Merging components: default, COMMON_
+2022-05-23T18:33:46.548Z debug workspace/src/workspace/nacl_files/elements_cache Setting hash multi_env-multi_env_mergeManagermerge_manager::default_COMMON__merged_hash to ead244bc1646d9915c741130a00108a868b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.548Z debug workspace/src/merger/index merged 1 elements to 1 elements [errors=0]
+2022-05-23T18:33:46.549Z debug workspace/src/workspace/nacl_files/elements_cache Setting default source hash in namespace multi_env-multi_env_mergeManagermerge_manager to ead244bc1646d9915c741130a00108a8
+2022-05-23T18:33:46.549Z debug workspace/src/workspace/nacl_files/elements_cache Setting COMMON_ source hash in namespace multi_env-multi_env_mergeManagermerge_manager to 68b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.549Z debug workspace/src/workspace/nacl_files/elements_cache Applying merged changes to cache.
+2022-05-23T18:33:46.550Z debug workspace/src/workspace/nacl_files/elements_cache Change type: add, on 1 elements. The first 1 ids are: salto.withStatic
+2022-05-23T18:33:46.550Z debug workspace/src/workspace/nacl_files/elements_cache Merging components: inactive, COMMON_
+2022-05-23T18:33:46.550Z debug workspace/src/workspace/nacl_files/elements_cache Setting hash multi_env-multi_env_mergeManagermerge_manager::inactive_COMMON__merged_hash to edf1b3655f0ca128d6bee028591ed5e968b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.550Z debug workspace/src/merger/index merged 1 elements to 1 elements [errors=0]
+2022-05-23T18:33:46.550Z debug workspace/src/workspace/nacl_files/elements_cache Setting inactive source hash in namespace multi_env-multi_env_mergeManagermerge_manager to edf1b3655f0ca128d6bee028591ed5e9
+2022-05-23T18:33:46.550Z debug workspace/src/workspace/nacl_files/elements_cache Setting COMMON_ source hash in namespace multi_env-multi_env_mergeManagermerge_manager to 68b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.551Z debug workspace/src/workspace/nacl_files/elements_cache Applying merged changes to cache.
+2022-05-23T18:33:46.551Z debug workspace/src/workspace/nacl_files/elements_cache Change type: add, on 1 elements. The first 1 ids are: salto.withStatic
+2022-05-23T18:33:46.552Z debug workspace/src/workspace/nacl_files/elements_cache Merging components: multi_env_element_sourcedefault, state_element_sourcedefault
+2022-05-23T18:33:46.552Z debug workspace/src/workspace/nacl_files/elements_cache Setting hash workspaceMergeManagermerge_manager::multi_env_element_sourcedefault_state_element_sourcedefault_merged_hash to ead244bc1646d9915c741130a00108a868b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.552Z debug workspace/src/merger/index merged 1 elements to 1 elements [errors=0]
+2022-05-23T18:33:46.553Z debug workspace/src/workspace/nacl_files/elements_cache Setting multi_env_element_sourcedefault source hash in namespace workspaceMergeManagermerge_manager to ead244bc1646d9915c741130a00108a868b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.553Z debug workspace/src/workspace/nacl_files/elements_cache Applying merged changes to cache.
+2022-05-23T18:33:46.553Z debug workspace/src/workspace/nacl_files/elements_cache Change type: add, on 1 elements. The first 1 ids are: salto.withStatic
+2022-05-23T18:33:46.553Z debug workspace/src/workspace/reference_indexes updating references indexes starting
+2022-05-23T18:33:46.554Z info workspace/src/workspace/reference_indexes references indexes maps are out of date, re-indexing
+2022-05-23T18:33:46.554Z debug workspace/src/workspace/reference_indexes updating references indexes took 1 ms
+2022-05-23T18:33:46.554Z debug workspace/src/expressions resolve 1 elements starting
+2022-05-23T18:33:46.555Z debug workspace/src/expressions resolve handled a total of 13 elements
+2022-05-23T18:33:46.555Z debug workspace/src/expressions resolve 1 elements took 1 ms
+2022-05-23T18:33:46.556Z debug workspace/src/workspace/nacl_files/elements_cache Merging components: multi_env_element_sourceinactive, state_element_sourceinactive
+2022-05-23T18:33:46.556Z debug workspace/src/workspace/nacl_files/elements_cache Setting hash workspaceMergeManagermerge_manager::multi_env_element_sourceinactive_state_element_sourceinactive_merged_hash to edf1b3655f0ca128d6bee028591ed5e968b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.556Z debug workspace/src/merger/index merged 1 elements to 1 elements [errors=0]
+2022-05-23T18:33:46.556Z debug workspace/src/workspace/nacl_files/elements_cache Setting multi_env_element_sourceinactive source hash in namespace workspaceMergeManagermerge_manager to edf1b3655f0ca128d6bee028591ed5e968b329da9893e34099c7d8ad5cb9c940
+2022-05-23T18:33:46.557Z debug workspace/src/workspace/nacl_files/elements_cache Applying merged changes to cache.
+2022-05-23T18:33:46.557Z debug workspace/src/workspace/nacl_files/elements_cache Change type: add, on 1 elements. The first 1 ids are: salto.withStatic
+2022-05-23T18:33:46.557Z debug workspace/src/workspace/reference_indexes updating references indexes starting
+2022-05-23T18:33:46.558Z info workspace/src/workspace/reference_indexes references indexes maps are out of date, re-indexing
+2022-05-23T18:33:46.558Z debug workspace/src/workspace/reference_indexes updating references indexes took 1 ms
+2022-05-23T18:33:46.558Z debug workspace/src/expressions resolve 1 elements starting
+2022-05-23T18:33:46.559Z debug workspace/src/expressions resolve handled a total of 13 elements
+2022-05-23T18:33:46.559Z debug workspace/src/expressions resolve 1 elements took 1 ms
+2022-05-23T18:33:46.561Z debug workspace/src/workspace/workspace Loading workspace with id: 
+2022-05-23T18:33:46.563Z debug workspace/src/workspace/workspace Loading workspace with id: 

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -236,11 +236,11 @@ export type Workspace = {
   listUnresolvedReferences(completeFromEnv?: string): Promise<UnresolvedElemIDs>
   getElementSourceOfPath(filePath: string, includeHidden?: boolean): Promise<ReadOnlyElementsSource>
   getFileEnvs(filePath: string): {envName: string; isStatic?: boolean}[]
-  getStaticFile(
-    filePath: string,
-    encoding: BufferEncoding,
-    env: string,
-  ): Promise<StaticFile | undefined>
+  getStaticFile(params: {
+    filepath: string
+    encoding: BufferEncoding
+    env?: string
+  }): Promise<StaticFile | undefined>
 }
 
 type SingleState = {
@@ -1262,8 +1262,8 @@ export const loadWorkspace = async (
         : elementsImpl(includeHidden)
     ),
     getFileEnvs: filePath => naclFilesSource.getFileEnvs(filePath),
-    getStaticFile: async (filePath, encoding, env) =>
-      (naclFilesSource.getStaticFile(filePath, encoding, env)),
+    getStaticFile: async ({ filepath, encoding, env }) =>
+      (naclFilesSource.getStaticFile(filepath, encoding, env ?? currentEnv())),
   }
 }
 

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import path from 'path'
 import { Element, SaltoError, SaltoElementError, ElemID, InstanceElement, DetailedChange, Change,
   Value, toChange, isRemovalChange, getChangeData,
-  ReadOnlyElementsSource, isAdditionOrModificationChange } from '@salto-io/adapter-api'
+  ReadOnlyElementsSource, isAdditionOrModificationChange, StaticFile } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { applyDetailedChanges, naclCase, resolvePath, safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections, promises, values } from '@salto-io/lowerdash'
@@ -236,6 +236,11 @@ export type Workspace = {
   listUnresolvedReferences(completeFromEnv?: string): Promise<UnresolvedElemIDs>
   getElementSourceOfPath(filePath: string, includeHidden?: boolean): Promise<ReadOnlyElementsSource>
   getFileEnvs(filePath: string): {envName: string; isStatic?: boolean}[]
+  getStaticFile(
+    filePath: string,
+    encoding: BufferEncoding,
+    env: string,
+  ): Promise<StaticFile | undefined>
 }
 
 type SingleState = {
@@ -1257,6 +1262,8 @@ export const loadWorkspace = async (
         : elementsImpl(includeHidden)
     ),
     getFileEnvs: filePath => naclFilesSource.getFileEnvs(filePath),
+    getStaticFile: async (filePath, encoding, env) =>
+      (naclFilesSource.getStaticFile(filePath, encoding, env)),
   }
 }
 

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -41,7 +41,7 @@ import { Workspace, initWorkspace, loadWorkspace, EnvironmentSource,
   COMMON_ENV_PREFIX, UnresolvedElemIDs, UpdateNaclFilesResult, isValidEnvName } from '../../src/workspace/workspace'
 import { DeleteCurrentEnvError, UnknownEnvError, EnvDuplicationError,
   AccountDuplicationError, InvalidEnvNameError, Errors, MAX_ENV_NAME_LEN, UnknownAccountError, InvalidAccountNameError } from '../../src/workspace/errors'
-import { StaticFilesSource } from '../../src/workspace/static_files'
+import { StaticFilesSource, MissingStaticFile } from '../../src/workspace/static_files'
 import * as dump from '../../src/parser/dump'
 import { mockDirStore } from '../common/nacl_file_store'
 import { EnvConfig } from '../../src/workspace/config/workspace_config_types'
@@ -3222,7 +3222,7 @@ describe('workspace', () => {
   })
 
 
-  describe('static files deserialization', () => {
+  describe('static files', () => {
     let workspace: Workspace
     const elemID = ElemID.fromFullName('salto.withStatic')
     const defaultStaticFile = new StaticFile({
@@ -3295,18 +3295,38 @@ describe('workspace', () => {
         }
       )
     })
-    it('should deserialize static files from the active env', async () => {
-      const elem = await (await workspace.elements()).get(elemID) as Element
-      expect(isStaticFile(elem.annotations.static)).toBeTruthy()
-      const elemStaticFile = elem.annotations.static as StaticFile
-      expect(elemStaticFile.content).toEqual(defaultStaticFile.content)
+    describe('deserialization', () => {
+      it('should deserialize static files from the active env', async () => {
+        const elem = await (await workspace.elements()).get(elemID) as Element
+        expect(isStaticFile(elem.annotations.static)).toBeTruthy()
+        const elemStaticFile = elem.annotations.static as StaticFile
+        expect(elemStaticFile.content).toEqual(defaultStaticFile.content)
+      })
+
+      it('should deserialize static files from the non-active env', async () => {
+        const elem = await (await workspace.elements(true, 'inactive')).get(elemID) as Element
+        expect(isStaticFile(elem.annotations.static)).toBeTruthy()
+        const elemStaticFile = elem.annotations.static as StaticFile
+        expect(elemStaticFile.content).toEqual(inactiveStaticFile.content)
+      })
     })
 
-    it('should deserialize static files from the non-active env', async () => {
-      const elem = await (await workspace.elements(true, 'inactive')).get(elemID) as Element
-      expect(isStaticFile(elem.annotations.static)).toBeTruthy()
-      const elemStaticFile = elem.annotations.static as StaticFile
-      expect(elemStaticFile.content).toEqual(inactiveStaticFile.content)
+    describe('getStaticFile', () => {
+      it('should get staticFile by env', async () => {
+        const defaultStaticFileRes = (await workspace.getStaticFile('salto/static.txt', 'utf-8', 'default'))
+        expect(defaultStaticFileRes).toBeDefined()
+        expect(defaultStaticFileRes?.isEqual(defaultStaticFile)).toBeTruthy()
+        const inactiveStaticFileRes = (await workspace.getStaticFile('salto/static.txt', 'utf-8', 'inactive'))
+        expect(inactiveStaticFileRes).toBeDefined()
+        expect(inactiveStaticFileRes?.isEqual(inactiveStaticFile)).toBeTruthy()
+      })
+
+      it('should return missing staticFile if it does not exist', async () => {
+        const defaultMissing = (await workspace.getStaticFile('no', 'utf-8', 'default'))
+        expect(defaultMissing).toBeInstanceOf(MissingStaticFile)
+        const inactiveMissing = (await workspace.getStaticFile('no', 'utf-8', 'default'))
+        expect(inactiveMissing).toBeInstanceOf(MissingStaticFile)
+      })
     })
   })
 

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -3313,18 +3313,18 @@ describe('workspace', () => {
 
     describe('getStaticFile', () => {
       it('should get staticFile by env', async () => {
-        const defaultStaticFileRes = (await workspace.getStaticFile('salto/static.txt', 'utf-8', 'default'))
+        const defaultStaticFileRes = (await workspace.getStaticFile({ filepath: 'salto/static.txt', encoding: 'utf-8' }))
         expect(defaultStaticFileRes).toBeDefined()
         expect(defaultStaticFileRes?.isEqual(defaultStaticFile)).toBeTruthy()
-        const inactiveStaticFileRes = (await workspace.getStaticFile('salto/static.txt', 'utf-8', 'inactive'))
+        const inactiveStaticFileRes = (await workspace.getStaticFile({ filepath: 'salto/static.txt', encoding: 'utf-8', env: 'inactive' }))
         expect(inactiveStaticFileRes).toBeDefined()
         expect(inactiveStaticFileRes?.isEqual(inactiveStaticFile)).toBeTruthy()
       })
 
       it('should return missing staticFile if it does not exist', async () => {
-        const defaultMissing = (await workspace.getStaticFile('no', 'utf-8', 'default'))
+        const defaultMissing = (await workspace.getStaticFile({ filepath: 'no', encoding: 'utf-8' }))
         expect(defaultMissing).toBeInstanceOf(MissingStaticFile)
-        const inactiveMissing = (await workspace.getStaticFile('no', 'utf-8', 'default'))
+        const inactiveMissing = (await workspace.getStaticFile({ filepath: 'no', encoding: 'utf-8', env: 'inactive' }))
         expect(inactiveMissing).toBeInstanceOf(MissingStaticFile)
       })
     })


### PR DESCRIPTION
Before this Fetch From Workspace, when being used with the fromState flag, did not fetch the actual content of Static Files that are part of the changes fetched. This is cause the content is not available in the state.

This uses the sourceWorkspace’s staticFileSource as the source and to make sure the hashes match (+ remove the change and add an error if it doesn’t).
This also adds a new function to workspace, `getStaticFile` that is being used here.

---
Context for the reviewer - 
* This should definitely be deleted when we complete the Static Files redesign
* The new workspace function - `getStaticFile`, I am not sure about the interface to be honest. I am not sure it's super aligned with the whole api cause it always requires env, and the encoding has no default so it's a bit explicit in it's nature, but it might be a good idea. I didn't convince myself.
* Commits have no meaning, ignore them and review as a whole

---
_Release Notes_: 
*Core* - 
*Bug Fix* - 
* Fixed a bug in Fetch From Workspace in fromState mode that did not fetch changes with Static Files properly

