### PR TITLE
SALTO-2319: On Jira Field instances, add `type` to the salto id to avoid duplicates

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -47,12 +47,12 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[][]
   )
 
   const field = new InstanceElement(
-    `${randomString}${CUSTOM_FIELDS_SUFFIX}`,
+    `${randomString}__${CUSTOM_FIELDS_SUFFIX}`,
     findType('Field', fetchedElements),
     createFieldValues(randomString),
   )
 
-  const fieldContextName = naclCase(`${randomString}${CUSTOM_FIELDS_SUFFIX}_${randomString}`)
+  const fieldContextName = naclCase(`${randomString}__${CUSTOM_FIELDS_SUFFIX}_${randomString}`)
   const fieldContext = new InstanceElement(
     fieldContextName,
     findType('CustomFieldContext', fetchedElements),

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1820,6 +1820,7 @@ type JiraFetchFilters = {
 
 type JiraFetchConfig = configUtils.UserFetchConfig<JiraFetchFilters> & {
   fallbackToInternalId?: boolean
+  addTypeToFieldName?: boolean
 }
 
 export type MaskingConfig = {
@@ -1933,6 +1934,7 @@ const fetchConfigType = createUserFetchConfigType(
   JIRA,
   {
     fallbackToInternalId: { refType: BuiltinTypes.BOOLEAN },
+    addTypeToFieldName: { refType: BuiltinTypes.BOOLEAN },
   },
   fetchFiltersType,
 )

--- a/packages/jira-adapter/test/filters/fields/field_name_filter.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_name_filter.test.ts
@@ -68,8 +68,49 @@ describe('field_name_filter', () => {
     const elements = [custom, standard]
     await filter.onFetch(elements)
     expect(elements.map(e => e.elemID.name)).toEqual([
-      'standard',
       'custom__c',
+      'standard',
+    ])
+  })
+
+  it('should add field type if configured to', async () => {
+    config.fetch.addTypeToFieldName = true
+    const custom = new InstanceElement(
+      'custom',
+      fieldType,
+      {
+        name: 'custom',
+        schema: {
+          custom: 'prefix:someType',
+        },
+      }
+    )
+
+    const custom2 = new InstanceElement(
+      'custom2',
+      fieldType,
+      {
+        name: 'custom2',
+      }
+    )
+
+    const standard = new InstanceElement(
+      'standard',
+      fieldType,
+      {
+        name: 'standard',
+        schema: {
+          type: 'someType2',
+        },
+      }
+    )
+
+    const elements = [custom, custom2, standard]
+    await filter.onFetch(elements)
+    expect(elements.map(e => e.elemID.name)).toEqual([
+      'custom__someType__c',
+      'custom2',
+      'standard__someType2',
     ])
   })
 


### PR DESCRIPTION
Added option to add the field type to its Salto ID

---
_Release Notes_: 
__Jira Adapter__:
- Added option to add the field type to its Salto ID

---
_User Notifications_: 
None
