### PR TITLE
SALTO-1936: Fetch and deploy groups

### DIFF
--- a/packages/adapter-components/src/elements/swagger/deployment/annotations.ts
+++ b/packages/adapter-components/src/elements/swagger/deployment/annotations.ts
@@ -46,7 +46,8 @@ const getFields = (
 
 const getSwaggerEndpoint = (url: string, baseUrls: string[]): string => {
   const matchingBase = baseUrls.find(baseUrl => url.startsWith(baseUrl))
-  return matchingBase === undefined ? url : url.slice(matchingBase.length)
+  const urlWithoutBase = matchingBase === undefined ? url : url.slice(matchingBase.length)
+  return urlWithoutBase.split('?')[0]
 }
 
 const getInnerSchemaAndType = async (

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -268,7 +268,9 @@ export const generateLookupFunc = <
       log.debug('could not determine field for path %s', args.path?.getFullName())
       return undefined
     }
+
     const strategies = (await resolverFinder(args.field))
+      .filter(def => def.target?.type === undefined || args.ref.elemID.typeName === def.target.type)
       .map(def => def.serializationStrategy)
 
     if (strategies.length === 0) {

--- a/packages/adapter-components/test/elements/swagger/deployment/annotations.test.ts
+++ b/packages/adapter-components/test/elements/swagger/deployment/annotations.test.ts
@@ -78,7 +78,7 @@ describe('addDeploymentAnnotations', () => {
               method: 'post',
             },
             remove: {
-              url: '/rest/test/endpoint',
+              url: '/rest/test/endpoint?id={id}',
               method: 'delete',
             },
           },

--- a/packages/adapter-components/test/references/field_references.test.ts
+++ b/packages/adapter-components/test/references/field_references.test.ts
@@ -398,6 +398,11 @@ describe('Field references', () => {
         serializationStrategy: 'id',
         target: { type: 'api_collection' },
       },
+      {
+        src: { field: 'api_collection_ids', parentTypes: ['api_access_profile'] },
+        serializationStrategy: 'id',
+        target: { type: 'api_client' },
+      },
     ]
 
     beforeAll(async () => {
@@ -428,6 +433,19 @@ describe('Field references', () => {
       })
 
       expect(res).toEqual('name')
+    })
+
+    it('should resolve using the reference type', async () => {
+      const res = await lookupNameFunc({
+        ref: new ReferenceExpression(
+          new ElemID('adapter', 'api_client', 'instance', 'instance'),
+          new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'api_collection') }), { id: 2, name: 'name' }),
+        ),
+        field: new Field(new ObjectType({ elemID: new ElemID('adapter', 'api_access_profile') }), 'api_collection_ids', BuiltinTypes.NUMBER),
+        path: new ElemID('adapter', 'somePath'),
+      })
+
+      expect(res).toEqual(2)
     })
 
     it('should resolve using full value strategy when no rule is matched', async () => {
@@ -488,8 +506,8 @@ describe('Field references', () => {
       )
       const res = await customLookupNameFunc({
         ref: new ReferenceExpression(
-          new ElemID('adapter', 'obj', 'instance', 'instance'),
-          new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'obj') }), { realId: 2 }),
+          new ElemID('adapter', 'typeWithDifferentIdField', 'instance', 'instance'),
+          new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'typeWithDifferentIdField') }), { realId: 2 }),
         ),
         field: new Field(new ObjectType({ elemID: new ElemID('adapter', 'obj2') }), 'refValue', BuiltinTypes.NUMBER),
         path: new ElemID('adapter', 'somePath'),

--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -222,6 +222,14 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[][]
     createWebhookValues(randomString),
   )
 
+  const group = new InstanceElement(
+    randomString,
+    findType('Group', fetchedElements),
+    {
+      name: randomString,
+    },
+  )
+
   return [
     [issueType],
     [field],
@@ -247,5 +255,6 @@ export const createInstances = (fetchedElements: Element[]): InstanceElement[][]
     [notificationScheme],
     [automation],
     [webhook],
+    [group],
   ]
 }

--- a/packages/jira-adapter/e2e_test/instances/securityScheme.ts
+++ b/packages/jira-adapter/e2e_test/instances/securityScheme.ts
@@ -59,7 +59,7 @@ export const createSecurityLevelValues = (name: string, allElements: Element[]):
     {
       holder: {
         type: 'group',
-        parameter: 'atlassian-addons-admin',
+        parameter: createReference(new ElemID(JIRA, 'Group', 'instance', 'atlassian_addons_admin@b'), allElements),
       },
     },
   ],

--- a/packages/jira-adapter/src/config.ts
+++ b/packages/jira-adapter/src/config.ts
@@ -1393,6 +1393,25 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
     },
   },
 
+  Group: {
+    transformation: {
+      fieldsToHide: [
+        { fieldName: 'groupId' },
+      ],
+      serviceIdField: 'groupId',
+    },
+    deployRequests: {
+      add: {
+        url: '/rest/api/3/group',
+        method: 'post',
+      },
+      remove: {
+        url: '/rest/api/3/group?groupId={groupId}',
+        method: 'delete',
+      },
+    },
+  },
+
   Board: {
     transformation: {
       fieldTypeOverrides: [
@@ -1526,6 +1545,8 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       fieldsToOmit: [
         { fieldName: 'userCount' },
         { fieldName: 'remainingSeats' },
+        { fieldName: 'groupDetails' },
+        { fieldName: 'defaultGroupsDetails' },
       ],
     },
   },
@@ -1628,6 +1649,7 @@ const SUPPORTED_TYPES = {
   WorkflowScheme: ['WorkflowSchemes'],
   ServerInformation: ['ServerInformation'],
   Board: ['Boards'],
+  Group: ['Groups'],
   Automation: [],
   Webhook: [],
 }
@@ -1767,6 +1789,14 @@ export const DEFAULT_API_DEFINITIONS: JiraApiConfig = {
       {
         originalName: 'Webhook',
         newName: 'AppWebhook',
+      },
+      {
+        originalName: 'PageBeanGroupDetails',
+        newName: 'Groups',
+      },
+      {
+        originalName: 'GroupDetails',
+        newName: 'Group',
       },
     ],
     additionalTypes: [

--- a/packages/jira-adapter/src/filters/workflow/conditions_types.ts
+++ b/packages/jira-adapter/src/filters/workflow/conditions_types.ts
@@ -92,6 +92,10 @@ export const createConditionConfigurationTypes = (): {
         refType: new ListType(conditionStatusType),
         annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
       },
+      group: {
+        refType: BuiltinTypes.STRING,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+      },
       groups: {
         refType: new ListType(BuiltinTypes.STRING),
         annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -297,6 +297,16 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
     target: { type: 'Field' },
   },
   {
+    src: { field: 'groups', parentTypes: ['ConditionConfiguration'] },
+    serializationStrategy: 'name',
+    target: { type: 'Group' },
+  },
+  {
+    src: { field: 'group', parentTypes: ['ConditionConfiguration'] },
+    serializationStrategy: 'name',
+    target: { type: 'Group' },
+  },
+  {
     src: { field: 'id', parentTypes: ['ConditionStatus'] },
     serializationStrategy: 'id',
     target: { type: 'Status' },
@@ -305,6 +315,21 @@ export const referencesRules: referenceUtils.FieldReferenceDefinition<never>[] =
     src: { field: 'id', parentTypes: ['ConditionProjectRole'] },
     serializationStrategy: 'id',
     target: { type: 'ProjectRole' },
+  },
+  {
+    src: { field: 'groups', parentTypes: ['ApplicationRole'] },
+    serializationStrategy: 'name',
+    target: { type: 'Group' },
+  },
+  {
+    src: { field: 'defaultGroups', parentTypes: ['ApplicationRole'] },
+    serializationStrategy: 'name',
+    target: { type: 'Group' },
+  },
+  {
+    src: { field: 'parameter', parentTypes: ['PermissionHolder'] },
+    serializationStrategy: 'name',
+    target: { type: 'Group' },
   },
 ]
 


### PR DESCRIPTION
Added support for fetching and deploying groups

---
_Release Notes_: 
_Jira Adapter_:
- Added support for managing user groups

---
_User Notifications_: 
_Jira Adapter_:
- Group instances will be added to the workspace after the next fetch
