### PR TITLE
SAAS-4962: Quick restore of "before" changes in restoreValues

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -557,7 +557,6 @@ export const restoreValues: RestoreValuesFunc = async (
 export const restoreChangeElement = async (
   change: Change,
   sourceChanges: Record<string, Change>,
-  // sourceElements: Record<string, ChangeDataType>,
   getLookUpName: GetLookupNameFunc,
   restoreValuesFunc = restoreValues,
 ): Promise<Change> => {

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -26,6 +26,7 @@ import {
   ChangeData, ListType, CoreAnnotationTypes, isMapType, MapType, isContainerType, isTypeReference,
   ReadOnlyElementsSource, ReferenceMap, TypeReference, createRefToElmWithValue, isElement,
   compareSpecialValues,
+  getChangeData,
 } from '@salto-io/adapter-api'
 import Joi from 'joi'
 import { walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from './walk_element'
@@ -555,15 +556,49 @@ export const restoreValues: RestoreValuesFunc = async (
 
 export const restoreChangeElement = async (
   change: Change,
-  sourceElements: Record<string, ChangeDataType>,
+  sourceChanges: Record<string, Change>,
+  // sourceElements: Record<string, ChangeDataType>,
   getLookUpName: GetLookupNameFunc,
   restoreValuesFunc = restoreValues,
-): Promise<Change> => applyFunctionToChangeData(
-  change,
-  changeData => restoreValuesFunc(
-    sourceElements[changeData.elemID.getFullName()], changeData, getLookUpName,
+): Promise<Change> => {
+  // We only need to restore the "after" part. "before" could not have changed so we can just use
+  // the "before" from the source change
+  const sourceChange = sourceChanges[getChangeData(change).elemID.getFullName()]
+  if (isRemovalChange(change) && isRemovalChange(sourceChange)) {
+    return sourceChange
+  }
+  const restoredAfter = await restoreValuesFunc(
+    getChangeData(sourceChange),
+    getChangeData(change),
+    getLookUpName,
   )
-)
+  if (isModificationChange(change) && isModificationChange(sourceChange)) {
+    return {
+      ...change,
+      data: {
+        before: sourceChange.data.before,
+        after: restoredAfter,
+      },
+    }
+  }
+  if (isAdditionChange(change) && isAdditionChange(sourceChange)) {
+    return {
+      ...change,
+      data: {
+        after: restoredAfter,
+      },
+    }
+  }
+  // We should never get here, but if there is a mis-match between the source change and the change
+  // we got, we warn and return the change we got without restoring
+  log.warn(
+    'Could not find matching source change for %s, change type %s, source type %s',
+    getChangeData(change).elemID.getFullName(),
+    change.action,
+    sourceChange.action,
+  )
+  return change
+}
 
 export const resolveChangeElement = <T extends Change<ChangeDataType> = Change<ChangeDataType>>(
   change: T,

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -20,9 +20,8 @@ import {
   isListType, ListType, BuiltinTypes, StaticFile, isPrimitiveType,
   Element, isReferenceExpression, isPrimitiveValue, CORE_ANNOTATIONS, FieldMap, AdditionChange,
   RemovalChange, ModificationChange, isInstanceElement, isObjectType, MapType, isMapType,
-  ContainerType, TypeReference, createRefToElmWithValue, VariableExpression,
+  ContainerType, TypeReference, createRefToElmWithValue, VariableExpression, getChangeData,
 } from '@salto-io/adapter-api'
-import { AdditionDiff, RemovalDiff, ModificationDiff } from '@salto-io/dag'
 import { collections } from '@salto-io/lowerdash'
 import { mockFunction } from '@salto-io/test-utils'
 import Joi from 'joi'
@@ -1271,38 +1270,90 @@ describe('Test utils.ts', () => {
   })
 
   describe('restore/ResolveChangeElement functions', () => {
-    const afterData = mockInstance.clone()
-    const beforeData = mockInstance.clone()
-    const additionChange = { action: 'add', data: { after: afterData } } as AdditionDiff<InstanceElement>
-    const removalChange = { action: 'remove', data: { before: beforeData } } as RemovalDiff<InstanceElement>
-    const modificationChange = { action: 'modify', data: { before: beforeData, after: afterData } } as ModificationDiff<InstanceElement>
+    let afterData: InstanceElement
+    let beforeData: InstanceElement
+    let additionChange: AdditionChange<InstanceElement>
+    let removalChange: RemovalChange<InstanceElement>
+    let modificationChange: ModificationChange<InstanceElement>
+    beforeEach(() => {
+      afterData = mockInstance.clone()
+      beforeData = mockInstance.clone()
+      additionChange = { action: 'add', data: { after: afterData } }
+      removalChange = { action: 'remove', data: { before: beforeData } }
+      modificationChange = { action: 'modify', data: { before: beforeData, after: afterData } }
+    })
 
     describe('restoreChangeElement func', () => {
       let mockRestore: RestoreValuesFunc
-      const sourceBeforeData = beforeData.clone()
-      const sourceAfterData = afterData.clone()
-      const sourceElements = _.keyBy(
-        [sourceBeforeData, sourceAfterData],
-        elem => elem.elemID.getFullName()
-      )
       beforeEach(() => {
         mockRestore = jest.fn().mockImplementation(
           <T extends Element>(_source: T, targetElement: T, _getLookUpName: GetLookupNameFunc) =>
             targetElement
         )
       })
-      it('should call restore func on after data when add change', async () => {
-        await restoreChangeElement(additionChange, sourceElements, getName, mockRestore)
-        expect(mockRestore).toHaveBeenCalledWith(sourceAfterData, afterData, getName)
+      describe('with addition change', () => {
+        let sourceChange: AdditionChange<InstanceElement>
+        beforeEach(async () => {
+          sourceChange = { action: 'add', data: { after: afterData.clone() } }
+          const sourceChanges = _.keyBy(
+            [sourceChange],
+            c => getChangeData(c).elemID.getFullName(),
+          )
+          await restoreChangeElement(additionChange, sourceChanges, getName, mockRestore)
+        })
+        it('should call restore func on the after data', () => {
+          expect(mockRestore).toHaveBeenCalledWith(sourceChange.data.after, afterData, getName)
+        })
       })
-      it('should call restore func for both before and after if modify change', async () => {
-        await restoreChangeElement(modificationChange, sourceElements, getName, mockRestore)
-        expect(mockRestore).toHaveBeenCalledWith(sourceAfterData, afterData, getName)
-        expect(mockRestore).toHaveBeenCalledWith(sourceBeforeData, beforeData, getName)
+      describe('with removal change', () => {
+        let sourceChange: RemovalChange<InstanceElement>
+        let restoredChange: RemovalChange<InstanceElement>
+        beforeEach(async () => {
+          sourceChange = { action: 'remove', data: { before: beforeData.clone() } }
+          const sourceChanges = _.keyBy(
+            [sourceChange],
+            c => getChangeData(c).elemID.getFullName(),
+          )
+          restoredChange = await restoreChangeElement(
+            removalChange,
+            sourceChanges,
+            getName,
+            mockRestore,
+          ) as RemovalChange<InstanceElement>
+        })
+        it('should not call restore func on the before data', () => {
+          expect(mockRestore).not.toHaveBeenCalled()
+        })
+        it('should return the before data from the source change', () => {
+          expect(restoredChange.data.before).toBe(sourceChange.data.before)
+        })
       })
-      it('should call restore func on before if removal change', async () => {
-        await restoreChangeElement(removalChange, sourceElements, getName, mockRestore)
-        expect(mockRestore).toHaveBeenCalledWith(sourceBeforeData, beforeData, getName)
+      describe('with modification change', () => {
+        let sourceChange: ModificationChange<InstanceElement>
+        let restoredChange: ModificationChange<InstanceElement>
+        beforeEach(async () => {
+          sourceChange = {
+            action: 'modify',
+            data: { before: beforeData.clone(), after: afterData.clone() },
+          }
+          const sourceChanges = _.keyBy(
+            [sourceChange],
+            c => getChangeData(c).elemID.getFullName(),
+          )
+          restoredChange = await restoreChangeElement(
+            modificationChange,
+            sourceChanges,
+            getName,
+            mockRestore,
+          ) as ModificationChange<InstanceElement>
+        })
+        it('should call the restore func only on the after data', () => {
+          expect(mockRestore).toHaveBeenCalledTimes(1)
+          expect(mockRestore).toHaveBeenCalledWith(sourceChange.data.after, afterData, getName)
+        })
+        it('should return the before data from the source change', () => {
+          expect(restoredChange.data.before).toBe(sourceChange.data.before)
+        })
       })
     })
 

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -405,13 +405,13 @@ export default class SalesforceAdapter implements AdapterOperations {
     const appliedChangesBeforeRestore = [...result.appliedChanges]
     await filtersRunner.onDeploy(appliedChangesBeforeRestore)
 
-    const sourceElements = _.keyBy(
-      changeGroup.changes.map(getChangeData),
-      elem => elem.elemID.getFullName(),
+    const sourceChanges = _.keyBy(
+      changeGroup.changes,
+      change => getChangeData(change).elemID.getFullName(),
     )
 
     const appliedChanges = await awu(appliedChangesBeforeRestore)
-      .map(change => restoreChangeElement(change, sourceElements, getLookUpName))
+      .map(change => restoreChangeElement(change, sourceChanges, getLookUpName))
       .toArray()
     return {
       appliedChanges,

--- a/packages/zendesk-support-adapter/src/adapter.ts
+++ b/packages/zendesk-support-adapter/src/adapter.ts
@@ -259,15 +259,15 @@ export default class ZendeskAdapter implements AdapterOperations {
     const appliedChangesBeforeRestore = [...deployResult.appliedChanges]
     await runner.onDeploy(appliedChangesBeforeRestore)
 
-    const sourceElements = _.keyBy(
-      changesToDeploy.map(getChangeData),
-      elem => elem.elemID.getFullName(),
+    const sourceChanges = _.keyBy(
+      changesToDeploy,
+      change => getChangeData(change).elemID.getFullName(),
     )
 
     const appliedChanges = await awu(appliedChangesBeforeRestore)
       .map(change => restoreChangeElement(
         change,
-        sourceElements,
+        sourceChanges,
         lookupFunc,
         async (source, targetElement, getLookUpName) =>
           restoreValues(source, targetElement, getLookUpName, true),


### PR DESCRIPTION
The "before" part of changes cannot really change, so we can use the original change for that value
This solves an issue where in modification changes we would try to restore the "before" value with
the "after" value from the original change

---

This solves a more basic cause for the issue of SAAS-4962 where we'd perform a lot of unnecessary calculations.
The previous fix is still valid, but this takes away the problematic scenario earlier in the flow and saves even more operations

---
_Release Notes_: 
_None_ (any noticeable effects of this issue should have been handled in the previous fix)

---
_User Notifications_: 
_None_
