### PR TITLE
fix build after previous PR changed the interface of static files source

### DIFF
--- a/packages/core/test/common/workspace.ts
+++ b/packages/core/test/common/workspace.ts
@@ -69,6 +69,7 @@ export const mockErrors = (errors: SaltoError[]): wsErrors.Errors => new wsError
 export const mockStaticFilesSource = (
   files: StaticFile[] = [],
 ): staticFiles.StaticFilesSource => ({
+  load: jest.fn(),
   getStaticFile: jest.fn().mockImplementation((filepath: string, _encoding: BufferEncoding) => (
     files.find(sf => sf.filepath === filepath) ?? undefined
   )),


### PR DESCRIPTION

---

While I disagree with the change to the interface and would very much like to revert it...
looks like this mock is only used as part of another mock, so having an incorrect "load" function on it shouldn't be an immediate problem

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
