### PR TITLE
SALTO-2354 - Fix pathIndex Instance annotations elemID bug

### DIFF
--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -74,10 +74,13 @@ const getAnnotationTypesPathHints = (
 
 const getAnnotationPathHints = (
   fragments: Fragment<Element>[],
-): PathHint[] => getValuePathHints(
-  fragments.map(f => ({ value: f.value.annotations, path: f.path })),
-  fragments[0].value.elemID.createNestedID('attr')
-)
+): PathHint[] => {
+  const elem = fragments[0].value
+  return getValuePathHints(
+    fragments.map(f => ({ value: f.value.annotations, path: f.path })),
+    isInstanceElement(elem) ? elem.elemID : elem.elemID.createNestedID('attr'),
+  )
+}
 
 const getFieldPathHints = (
   fragments: Fragment<Field>[],
@@ -234,7 +237,6 @@ export const splitElementByPath = async (
     clonedElement.path = pathToSet
     return [clonedElement]
   }
-
   return (await Promise.all(pathHints.map(async hint => {
     const filterByPathHint = async (id: ElemID): Promise<boolean> => {
       const idHints = await getFromPathIndex(id, index)


### PR DESCRIPTION
Instance annotation’s elemIDs do not include the `attr` part. In our current pathIndex implementation, they do and this creates a wrong index.

In cases where there are Instances with annotations that are split across multiple files (ie. Profiles), this means that FetchFrom and Restore that use the pathIndex will be wrong when using splitByPathIndex, which can lead to duplications in these annotations and major errors in the workspace

---

There is no need for migration here cause the next fetches will override the pathIndexes for existing workspaces.

---
_Release Notes_: 
*Core*:
*Bug Fix*:
* Fixed a bug in restore and fetchFrom when there are changes of Instances with annotations that caused workspace errors (duplicate values)


