### PR TITLE
SAAS-4004

### DIFF
--- a/packages/core/src/local-workspace/adapters_config.ts
+++ b/packages/core/src/local-workspace/adapters_config.ts
@@ -40,7 +40,7 @@ const createNaclSource = async (
 
   const staticFileSource = staticFiles.buildStaticFilesSource(
     naclStaticFilesStore,
-    buildLocalStaticFilesCache(localStorage, 'config-cache'),
+    buildLocalStaticFilesCache(localStorage, 'config-cache', remoteMapCreator),
   )
 
   const source = await nacl.naclFilesSource(

--- a/packages/core/src/local-workspace/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map.ts
@@ -601,10 +601,10 @@ remoteMap.RemoteMapCreator => {
       }
     }
     const createDBConnections = async (): Promise<void> => {
-      tmpDBConnections[location] = tmpDBConnections[location] ?? {}
       if (tmpDB === undefined) {
         const tmpConnection = getOpenDBConnection(tmpLocation, false)
         tmpDB = await tmpConnection
+        tmpDBConnections[location] = tmpDBConnections[location] ?? {}
         tmpDBConnections[location][tmpLocation] = tmpConnection
       }
       const mainDBConnections = persistent ? persistentDBConnections : readonlyDBConnections

--- a/packages/core/src/local-workspace/static_files_cache.ts
+++ b/packages/core/src/local-workspace/static_files_cache.ts
@@ -14,56 +14,87 @@
 * limitations under the License.
 */
 import path from 'path'
-import { readTextFile, exists, mkdirp, replaceContents, rm, rename } from '@salto-io/file'
-import { staticFiles } from '@salto-io/workspace'
+import { readTextFile, exists, rm } from '@salto-io/file'
+import { staticFiles, remoteMap } from '@salto-io/workspace'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 
-export const CACHE_FILENAME = 'static-file-cache'
+const log = logger(module)
 
-export type StaticFilesCacheState = Record<string, staticFiles.StaticFilesCacheResult>
+type StaticFilesCacheState = remoteMap.RemoteMap<staticFiles.StaticFilesCacheResult>
+
+const migrateLegacyStaticFilesCache = async (
+  cacheDir: string,
+  name: string,
+  remoteCache: StaticFilesCacheState
+): Promise<void> => {
+  const CACHE_FILENAME = 'static-file-cache'
+  const currentCacheFile = path.join(cacheDir, name, CACHE_FILENAME)
+
+  if (await exists(currentCacheFile)) {
+    if (remoteCache.isEmpty()) {
+      log.debug('importing legacy static files cache from file: %s', currentCacheFile)
+      const oldCache: Record<string, staticFiles.StaticFilesCacheResult> = JSON.parse(
+        await readTextFile(currentCacheFile)
+      )
+      await remoteCache.setAll(
+        Object.values(oldCache).map(item => ({ value: item, key: item.filepath }))
+      )
+      await remoteCache.flush()
+    } else {
+      log.debug('static files cache already populated, ignoring legacy static files cache file: %s', currentCacheFile)
+    }
+    log.debug('deleting legeacy static files cache file: %s', currentCacheFile)
+    await rm(currentCacheFile)
+  }
+}
 
 export const buildLocalStaticFilesCache = (
-  baseDir: string,
+  cacheDir: string,
   name: string,
-  initCacheState?: Promise<StaticFilesCacheState>,
+  remoteMapCreator: remoteMap.RemoteMapCreator,
 ): staticFiles.StaticFilesCache => {
-  let currentName = name
-  let cacheDir = path.join(baseDir, currentName)
-  let currentCacheFile = path.join(cacheDir, CACHE_FILENAME)
+  const createRemoteMap = async (
+    cacheName: string
+  ): Promise<StaticFilesCacheState> =>
+    remoteMapCreator<staticFiles.StaticFilesCacheResult>({
+      namespace: `staticFilesCache-${cacheName}`,
+      serialize: cacheEntry => safeJsonStringify(cacheEntry),
+      deserialize: async data => JSON.parse(data),
+      persistent: true,
+    })
 
-  const initCache = async (): Promise<StaticFilesCacheState> =>
-    (!(await exists(currentCacheFile)) ? {} : JSON.parse(await readTextFile(currentCacheFile)))
 
-  let cache: Promise<StaticFilesCacheState> = initCacheState || initCache()
+  const initCache = async (): Promise<StaticFilesCacheState> => {
+    const remoteCache = createRemoteMap(name)
+    await migrateLegacyStaticFilesCache(cacheDir, name, await remoteCache)
+    return remoteCache
+  }
+
+  let cache = initCache()
 
   return {
-    get: async (filepath: string): Promise<staticFiles.StaticFilesCacheResult> => (
-      (await cache)[filepath]
+    get: async (filepath: string): Promise<staticFiles.StaticFilesCacheResult | undefined> => (
+      (await cache).get(filepath)
     ),
     put: async (item: staticFiles.StaticFilesCacheResult): Promise<void> => {
-      (await cache)[item.filepath] = item
+      await (await cache).set(item.filepath, item)
     },
     flush: async () => {
-      if (!await exists(cacheDir)) {
-        await mkdirp(cacheDir)
-      }
-      await replaceContents(currentCacheFile, safeJsonStringify((await cache)))
+      await (await cache).flush()
     },
     clear: async () => {
-      await rm(currentCacheFile)
-      cache = Promise.resolve({})
+      await (await cache).clear()
     },
     rename: async (newName: string) => {
-      const newCacheDir = path.join(baseDir, newName)
-      const newCacheFile = path.join(newCacheDir, CACHE_FILENAME)
-      if (await exists(currentCacheFile)) {
-        await mkdirp(newCacheDir)
-        await rename(currentCacheFile, newCacheFile)
-      }
-      currentName = newName
-      currentCacheFile = newCacheFile
-      cacheDir = newCacheDir
+      const currentCache = await cache
+      const newCache = await createRemoteMap(newName)
+      await newCache.setAll(currentCache.entries())
+      cache = Promise.resolve(newCache)
+      await currentCache.clear()
     },
-    clone: () => buildLocalStaticFilesCache(cacheDir, currentName, cache),
+    clone: () => (
+      buildLocalStaticFilesCache(cacheDir, name, remoteMapCreator)
+    ),
   }
 }

--- a/packages/core/test/workspace/local/static_files_cache.test.ts
+++ b/packages/core/test/workspace/local/static_files_cache.test.ts
@@ -13,102 +13,95 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
-import path from 'path'
 import * as file from '@salto-io/file'
+import { collections } from '@salto-io/lowerdash'
+import { mockFunction } from '@salto-io/test-utils'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
-import { staticFiles } from '@salto-io/workspace'
+import { staticFiles, remoteMap } from '@salto-io/workspace'
+import { buildLocalStaticFilesCache } from '../../../src/local-workspace/static_files_cache'
 
-import {
-  buildLocalStaticFilesCache, CACHE_FILENAME,
-} from '../../../src/local-workspace/static_files_cache'
+const { DefaultMap } = collections.map
 
 jest.mock('@salto-io/file')
 describe('Static Files Cache', () => {
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
   const mockFileExists = file.exists as jest.Mock
-  const mockReplaceContents = file.replaceContents as jest.Mock
-  const mockRm = file.rm as jest.Mock
-  const mockRename = file.rename as unknown as jest.Mock
   const mockReadFile = file.readTextFile as unknown as jest.Mock
+
   let staticFilesCache: staticFiles.StaticFilesCache
 
   const baseMetaData = {
     hash: 'hashz',
     filepath: 'some/path.ext',
   }
-
   const expectedResult = {
     filepath: baseMetaData.filepath,
     hash: baseMetaData.hash,
     modified: 123,
   }
 
-  const expectedCacheKey = baseMetaData.filepath
-
-  const expectedCacheContent = safeJsonStringify({
-    [expectedCacheKey]: expectedResult,
-  })
-
   beforeEach(() => {
-    jest.resetAllMocks()
-    staticFilesCache = buildLocalStaticFilesCache('', 'cacheDir')
+    jest.clearAllMocks()
   })
-  it('does not fail if no cache file exists', async () => {
-    expect((await staticFilesCache.get(baseMetaData.filepath))).toBeUndefined()
-  })
-  it('uses content of cache file if existed', async () => {
-    mockFileExists.mockResolvedValueOnce(true)
-    mockReadFile.mockResolvedValueOnce(expectedCacheContent)
-    staticFilesCache = buildLocalStaticFilesCache('', 'cacheDir')
-    return expect(staticFilesCache.get(baseMetaData.filepath)).resolves.toEqual(expectedResult)
-  })
-  it('puts and retrieves value', async () => {
-    await staticFilesCache.put(expectedResult)
-    return expect(staticFilesCache.get(baseMetaData.filepath)).resolves.toEqual(expectedResult)
-  })
-  it('flushes state to cache file', async () => {
-    await staticFilesCache.put(expectedResult)
-    await staticFilesCache.flush()
-    expect(mockReplaceContents).toHaveBeenCalledTimes(1)
-    const [filepath, content] = mockReplaceContents.mock.calls[0]
-    expect(filepath).toMatch(new RegExp(`cacheDir\\/${CACHE_FILENAME}`))
-    expect(content).toEqual(expectedCacheContent)
-  })
-  it('clear', async () => {
-    await staticFilesCache.clear()
-    expect(mockRm).toHaveBeenCalledTimes(1)
-    expect(mockRm).toHaveBeenCalledWith(path.join('cacheDir', CACHE_FILENAME))
-  })
+  describe('new cache', () => {
+    let remoteMapCreator: jest.MockedFunction<remoteMap.RemoteMapCreator>
 
-  it('creates an empty cache when flushing after clear', async () => {
-    await staticFilesCache.put(expectedResult)
-    await staticFilesCache.clear()
-    await staticFilesCache.flush()
-    expect(mockRm).toHaveBeenCalledTimes(1)
-    expect(mockRm).toHaveBeenCalledWith(path.join('cacheDir', CACHE_FILENAME))
-    expect(mockReplaceContents).toHaveBeenCalledTimes(1)
-    const [filepath, content] = mockReplaceContents.mock.calls[0]
-    expect(filepath).toMatch(new RegExp(`cacheDir\\/${CACHE_FILENAME}`))
-    expect(content).toEqual('{}')
+    beforeEach(() => {
+      // We keep a cache to simulate the fact that remote maps
+      // with the same namespace point to the same entries.
+      const remoteMaps = new DefaultMap(() => new remoteMap.InMemoryRemoteMap())
+      remoteMapCreator = mockFunction<remoteMap.RemoteMapCreator>().mockImplementation(
+        async opts => remoteMaps.get(opts.namespace)
+      )
+      staticFilesCache = buildLocalStaticFilesCache('path', 'test-env', remoteMapCreator)
+    })
+    it('should handle unknown file paths', async () => {
+      expect((await staticFilesCache.get(baseMetaData.filepath))).toBeUndefined()
+    })
+    it('puts and retrieves value', async () => {
+      await staticFilesCache.put(expectedResult)
+      expect(await staticFilesCache.get(baseMetaData.filepath)).toEqual(expectedResult)
+    })
+    it('clear', async () => {
+      await staticFilesCache.put(expectedResult)
+      await staticFilesCache.clear()
+      expect(await staticFilesCache.get(baseMetaData.filepath)).toBeUndefined()
+    })
+    it('rename', async () => {
+      await staticFilesCache.put(expectedResult)
+      await staticFilesCache.rename('new-env')
+      expect(remoteMapCreator).toHaveBeenCalledTimes(2)
+      expect(remoteMapCreator).toHaveBeenLastCalledWith(expect.objectContaining({ namespace: 'staticFilesCache-new-env' }))
+      expect(await staticFilesCache.get(baseMetaData.filepath)).toEqual(expectedResult)
+    })
+    it('clone', async () => {
+      await staticFilesCache.put(expectedResult)
+      const cloned = staticFilesCache.clone()
+      expect(await cloned.get(baseMetaData.filepath)).toEqual(expectedResult)
+      expect(cloned).not.toBe(staticFilesCache)
+    })
   })
-
-  it('rename', async () => {
-    mockFileExists.mockResolvedValueOnce(true)
-    await staticFilesCache.rename('new')
-    expect(mockRename).toHaveBeenCalledTimes(1)
-    expect(mockRename).toHaveBeenCalledWith(
-      path.join('cacheDir', CACHE_FILENAME),
-      path.join('new', CACHE_FILENAME)
+  describe('when migrating cache', () => {
+    const expectedCacheKey = baseMetaData.filepath
+    const expectedCacheContent = safeJsonStringify({
+      [expectedCacheKey]: expectedResult,
+    })
+    const remoteMapCreator = mockFunction<remoteMap.RemoteMapCreator>().mockImplementation(
+      async () => new remoteMap.InMemoryRemoteMap()
     )
-  })
-  it('clones', async () => {
-    await staticFilesCache.put(expectedResult)
-    const staticFilesCacheClone = staticFilesCache.clone()
-    return expect(staticFilesCacheClone.get(baseMetaData.filepath))
-      .resolves.toEqual(expectedResult)
+
+    it('migrates old cache file if exists', async () => {
+      mockFileExists.mockResolvedValueOnce(true)
+      mockReadFile.mockResolvedValueOnce(expectedCacheContent)
+      staticFilesCache = buildLocalStaticFilesCache('path', 'test-env', remoteMapCreator)
+      return expect(staticFilesCache.get(baseMetaData.filepath)).resolves.toEqual(expectedResult)
+    })
+    it('does not import old cache file if cache already populated', async () => {
+      const oldCache = buildLocalStaticFilesCache('path', 'test-env', remoteMapCreator)
+      await oldCache.put({ filepath: 'something.txt', hash: 'bla', modified: 123 })
+      mockFileExists.mockResolvedValueOnce(true)
+      mockReadFile.mockResolvedValueOnce(expectedCacheContent)
+      staticFilesCache = buildLocalStaticFilesCache('path', 'test-env', remoteMapCreator)
+      return expect(staticFilesCache.get(baseMetaData.filepath)).resolves.toEqual(expectedResult)
+    })
   })
 })


### PR DESCRIPTION
Move static files cache to RocksDB, so it will also exist in the operation repo.

---

This PR also tries to fix some races when opening the RocksDB connection 

---

_Release Notes_: 

None

---

_User Notifications_: 

None