### PR TITLE
Remove usage of deprecated circleci docker images

### DIFF
--- a/.circleci/build-images/e2e-test/Dockerfile
+++ b/.circleci/build-images/e2e-test/Dockerfile
@@ -1,7 +1,6 @@
-FROM circleci/node:14.15
+FROM cimg/node:14.15
 # install open jdk 11 as it's a requirement of netsuite-adapter
-RUN echo 'deb http://deb.debian.org/debian stretch-backports main' | sudo tee -a /etc/apt/sources.list.d/stretch-backports.list; \
-        sudo apt-get update && sudo apt-get install -y openjdk-11-jdk; \
+RUN sudo apt-get update && sudo apt-get install -y openjdk-11-jdk; \
         # Fix "Error - trustAnchors parameter must be non-empty", taken from https://github.com/infosiftr/openjdk/blob/258870647c5a4281c4cc81d0d17b6fd95bcf4141/11/jdk/Dockerfile
         # ca-certificates-java does not work on src:openjdk-11: (https://bugs.debian.org/914424, https://bugs.debian.org/894979, https://salsa.debian.org/java-team/ca-certificates-java/commit/813b8c4973e6c4bb273d5d02f8d4e0aa0b226c50#d4b95d176f05e34cd0b718357c532dc5a6d66cd7_54_56)
         sudo keytool -importkeystore -srckeystore /etc/ssl/certs/java/cacerts -destkeystore /etc/ssl/certs/java/cacerts.jks -deststoretype JKS -srcstorepass changeit -deststorepass changeit -noprompt; \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: circleci/node:14.15
+      - image: cimg/node:14.15
 
     resource_class: xlarge
     working_directory: /mnt/ramdisk/project
@@ -113,7 +113,7 @@ jobs:
 
   unit_test:
     docker:
-      - image: circleci/node:14.15
+      - image: cimg/node:14.15
 
     resource_class: xlarge
     working_directory: /mnt/ramdisk/project
@@ -135,7 +135,7 @@ jobs:
 
   publish_on_version_change:
     docker:
-      - image: circleci/node:14.15
+      - image: cimg/node:14.15
 
     steps:
       - attach_workspace:
@@ -158,7 +158,7 @@ jobs:
 
   e2e_test:
     docker:
-      - image: saltolabs/salto-e2e:latest
+      - image: saltolabs/salto-e2e
 
     resource_class: large
     working_directory: /mnt/ramdisk/project
@@ -186,7 +186,7 @@ jobs:
 
   package_cli:
     docker:
-      - image: circleci/node:14.15
+      - image: cimg/node:14.15
 
     steps:
       - attach_workspace:
@@ -220,7 +220,7 @@ jobs:
 
   test_cli_linux:
     docker:
-      - image: circleci/node:14.15
+      - image: cimg/node:14.15
 
     steps:
       - set_s3_pkg_urls
@@ -260,7 +260,7 @@ jobs:
 
   package_vscode_extension:
     docker:
-      - image: circleci/node:14.15
+      - image: cimg/node:14.15
 
     steps:
       - attach_workspace:
@@ -297,7 +297,7 @@ jobs:
 
   publish_canary:
     docker:
-      - image: circleci/node:14.15
+      - image: cimg/node:14.15
 
     steps:
       - attach_workspace:


### PR DESCRIPTION

---

Missed these in #2885 

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_