### PR TITLE
SALTO-2358: Salesforce - split specific types to a file per field

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -135,6 +135,7 @@ salesforce {
 | ------------------------------------------------------------| -------------------------------------------------| -----------
 | [include](#metadata-query)                                  | Include everything                               | Specified the metadata to fetch. Metadata that does not match any of the include criteria will not be fetched
 | [exclude](#metadata-query)                                  | [] (Exclude nothing)                             | Specified the metadata to not fetch. Metadata that matches any of the exclude criteria will not be fetched even if it also matches some of the include criteria
+| objectsToSeperateFieldsToFiles                              | [] (Don't split any objects)                     | Specified a list of objects which will be stored as one field per nacl file
 
 ## Metadata Query
 | Name                                                        | Default when undefined                           | Description

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -324,7 +324,7 @@ export default class SalesforceAdapter implements AdapterOperations {
           useOldProfiles: config.useOldProfiles ?? useOldProfiles,
           fetchProfile,
           elementsSource,
-          separateFieldToFiles: config.fetch?.metadata?.separateFieldToFiles,
+          separateFieldToFiles: config.fetch?.metadata?.objectsToSeperateFieldsToFiles,
         },
       },
       filterCreators,

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -324,6 +324,7 @@ export default class SalesforceAdapter implements AdapterOperations {
           useOldProfiles: config.useOldProfiles ?? useOldProfiles,
           fetchProfile,
           elementsSource,
+          separateFieldToFiles: config.fetch?.metadata?.separateFieldToFiles,
         },
       },
       filterCreators,

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -304,6 +304,7 @@ export const DEFAULT_CUSTOM_OBJECTS_DEFAULT_RETRY_OPTIONS = {
     'UNABLE_TO_LOCK_ROW',
   ],
 }
+export const MAX_TYPES_TO_SEPARATE_TO_FILE_PER_FIELD = 20
 
 // Metadata types
 export const TOPICS_FOR_OBJECTS_METADATA_TYPE = 'TopicsForObjects'

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -278,6 +278,7 @@ export const OBJECTS_PATH = 'Objects'
 export const TYPES_PATH = 'Types'
 export const SUBTYPES_PATH = 'Subtypes'
 export const INSTALLED_PACKAGES_PATH = 'InstalledPackages'
+export const OBJECT_FIELDS_PATH = 'Fields'
 
 // Limits
 export const MAX_METADATA_RESTRICTION_VALUES = 500

--- a/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
@@ -111,11 +111,11 @@ export const validateMetadataParams = (
   validateMetadataQueryParams(params.include ?? [], [...fieldPath, METADATA_INCLUDE_LIST])
   validateMetadataQueryParams(params.exclude ?? [], [...fieldPath, METADATA_EXCLUDE_LIST])
 
-  if (params.separateFieldToFiles !== undefined
-    && params.separateFieldToFiles.length > MAX_TYPES_TO_SEPARATE_TO_FILE_PER_FIELD) {
+  if (params.objectsToSeperateFieldsToFiles !== undefined
+    && params.objectsToSeperateFieldsToFiles.length > MAX_TYPES_TO_SEPARATE_TO_FILE_PER_FIELD) {
     throw new ConfigValidationError(
       [...fieldPath, METADATA_SEPARATE_FIELD_LIST],
-      `${METADATA_SEPARATE_FIELD_LIST} should not be larger than ${MAX_TYPES_TO_SEPARATE_TO_FILE_PER_FIELD}. current length is ${params.separateFieldToFiles.length}`
+      `${METADATA_SEPARATE_FIELD_LIST} should not be larger than ${MAX_TYPES_TO_SEPARATE_TO_FILE_PER_FIELD}. current length is ${params.objectsToSeperateFieldsToFiles.length}`
     )
   }
 }

--- a/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 import { regex } from '@salto-io/lowerdash'
-import { DEFAULT_NAMESPACE, SETTINGS_METADATA_TYPE, TOPICS_FOR_OBJECTS_METADATA_TYPE, CUSTOM_OBJECT } from '../constants'
-import { validateRegularExpressions } from '../config_validation'
-import { MetadataInstance, MetadataParams, MetadataQueryParams } from '../types'
+import { DEFAULT_NAMESPACE, SETTINGS_METADATA_TYPE, TOPICS_FOR_OBJECTS_METADATA_TYPE, CUSTOM_OBJECT, MAX_TYPES_TO_SEPARATE_TO_FILE_PER_FIELD } from '../constants'
+import { validateRegularExpressions, ConfigValidationError } from '../config_validation'
+import { MetadataInstance, MetadataParams, MetadataQueryParams, METADATA_INCLUDE_LIST, METADATA_EXCLUDE_LIST, METADATA_SEPARATE_FIELD_LIST } from '../types'
 
 export type MetadataQuery = {
   isTypeMatch: (type: string) => boolean
@@ -108,6 +108,14 @@ export const validateMetadataParams = (
   params: Partial<MetadataParams>,
   fieldPath: string[],
 ): void => {
-  validateMetadataQueryParams(params.include ?? [], [...fieldPath, 'include'])
-  validateMetadataQueryParams(params.exclude ?? [], [...fieldPath, 'include'])
+  validateMetadataQueryParams(params.include ?? [], [...fieldPath, METADATA_INCLUDE_LIST])
+  validateMetadataQueryParams(params.exclude ?? [], [...fieldPath, METADATA_EXCLUDE_LIST])
+
+  if (params.separateFieldToFiles !== undefined
+    && params.separateFieldToFiles.length > MAX_TYPES_TO_SEPARATE_TO_FILE_PER_FIELD) {
+    throw new ConfigValidationError(
+      [...fieldPath, METADATA_SEPARATE_FIELD_LIST],
+      `${METADATA_SEPARATE_FIELD_LIST} should not be larger than ${MAX_TYPES_TO_SEPARATE_TO_FILE_PER_FIELD}. current length is ${params.separateFieldToFiles.length}`
+    )
+  }
 }

--- a/packages/salesforce-adapter/src/filter.ts
+++ b/packages/salesforce-adapter/src/filter.ts
@@ -25,6 +25,7 @@ export type FilterContext = {
   useOldProfiles?: boolean
   fetchProfile: FetchProfile
   elementsSource: ReadOnlyElementsSource
+  separateFieldToFiles?: string[]
 }
 
 export type FilterOpts = {

--- a/packages/salesforce-adapter/src/filters/custom_object_split.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_split.ts
@@ -28,7 +28,7 @@ export const annotationsFileName = (objectName: string): string => `${pathNaclCa
 export const standardFieldsFileName = (objectName: string): string => `${pathNaclCase(objectName)}StandardFields`
 export const customFieldsFileName = (objectName: string): string => `${pathNaclCase(objectName)}CustomFields`
 
-const perFieldFileName = (fieldName: string): string => `${pathNaclCase(fieldName)}`
+const perFieldFileName = (fieldName: string): string => pathNaclCase(fieldName)
 
 const splitFields = async (
   customObject: ObjectType,

--- a/packages/salesforce-adapter/src/filters/custom_object_split.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_split.ts
@@ -27,7 +27,7 @@ export const annotationsFileName = (objectName: string): string => `${pathNaclCa
 export const standardFieldsFileName = (objectName: string): string => `${pathNaclCase(objectName)}StandardFields`
 export const customFieldsFileName = (objectName: string): string => `${pathNaclCase(objectName)}CustomFields`
 
-const fieldFileName = (objectName: string, fieldName: string): string =>
+const perFieldFileName = (objectName: string, fieldName: string): string =>
   `${pathNaclCase(objectName)}Field${pathNaclCase(fieldName)}`
 
 const customObjectToSplitElements = async (
@@ -54,7 +54,7 @@ const customObjectToSplitElements = async (
           fields: { [fieldName]: field },
           path: [
             ...await getObjectDirectoryPath(customObject),
-            fieldFileName(customObject.elemID.name, fieldName),
+            perFieldFileName(customObject.elemID.name, fieldName),
           ],
         }
       ))

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -38,7 +38,7 @@ export const METADATA_EXCLUDE_LIST = 'exclude'
 const METADATA_TYPE = 'metadataType'
 const METADATA_NAME = 'name'
 const METADATA_NAMESPACE = 'namespace'
-export const METADATA_SEPARATE_FIELD_LIST = 'separateFieldToFiles'
+export const METADATA_SEPARATE_FIELD_LIST = 'objectsToSeperateFieldsToFiles'
 export const DATA_CONFIGURATION = 'data'
 export const METADATA_TYPES_SKIPPED_LIST = 'metadataTypesSkippedList'
 export const DATA_MANAGEMENT = 'dataManagement'
@@ -62,7 +62,7 @@ export type MetadataQueryParams = Partial<MetadataInstance>
 export type MetadataParams = {
   include?: MetadataQueryParams[]
   exclude?: MetadataQueryParams[]
-  separateFieldToFiles?: string[]
+  objectsToSeperateFieldsToFiles?: string[]
 }
 
 export type OptionalFeatures = {

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -33,11 +33,12 @@ export const CUSTOM_OBJECTS_DEPLOY_RETRY_OPTIONS = 'customObjectsDeployRetryOpti
 export const USE_OLD_PROFILES = 'useOldProfiles'
 export const FETCH_CONFIG = 'fetch'
 export const METADATA_CONFIG = 'metadata'
-const METADATA_INCLUDE_LIST = 'include'
-const METADATA_EXCLUDE_LIST = 'exclude'
+export const METADATA_INCLUDE_LIST = 'include'
+export const METADATA_EXCLUDE_LIST = 'exclude'
 const METADATA_TYPE = 'metadataType'
 const METADATA_NAME = 'name'
 const METADATA_NAMESPACE = 'namespace'
+export const METADATA_SEPARATE_FIELD_LIST = 'separateFieldToFiles'
 export const DATA_CONFIGURATION = 'data'
 export const METADATA_TYPES_SKIPPED_LIST = 'metadataTypesSkippedList'
 export const DATA_MANAGEMENT = 'dataManagement'
@@ -61,6 +62,7 @@ export type MetadataQueryParams = Partial<MetadataInstance>
 export type MetadataParams = {
   include?: MetadataQueryParams[]
   exclude?: MetadataQueryParams[]
+  separateFieldToFiles?: string[]
 }
 
 export type OptionalFeatures = {
@@ -468,6 +470,14 @@ const metadataConfigType = createMatchingObjectType<MetadataParams>({
   fields: {
     [METADATA_INCLUDE_LIST]: { refType: new ListType(metadataQueryType) },
     [METADATA_EXCLUDE_LIST]: { refType: new ListType(metadataQueryType) },
+    [METADATA_SEPARATE_FIELD_LIST]: {
+      refType: new ListType(BuiltinTypes.STRING),
+      annotations: {
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
+          max_length: constants.MAX_TYPES_TO_SEPARATE_TO_FILE_PER_FIELD,
+        }),
+      },
+    },
   },
 })
 

--- a/packages/salesforce-adapter/test/config_change.test.ts
+++ b/packages/salesforce-adapter/test/config_change.test.ts
@@ -28,6 +28,7 @@ describe('Config Changes', () => {
         exclude: [
           { metadataType: 'Type1' },
         ],
+        objectsToSeperateFieldsToFiles: ['Type2'],
       },
       data: {
         includeObjects: [includedObjectName],
@@ -170,6 +171,27 @@ In order to complete the fetch operation, Salto needs to stop managing these ite
         expect(newConfig?.[0].value.maxItemsInRetrieveRequest)
           .toEqual(MINIMUM_MAX_ITEMS_IN_RETRIEVE_REQUEST)
       })
+    })
+  })
+
+  describe('metadata suggestions', () => {
+    let newConfig: InstanceElement | undefined
+
+    beforeEach(() => {
+      const suggestions: ConfigChangeSuggestion[] = [
+        {
+          type: 'metadataExclude',
+          value: { metadataType: 'ExcludedType' },
+        },
+      ]
+
+      newConfig = getConfigFromConfigChanges(suggestions, currentConfig)?.config[0]
+    })
+    it('should add new exlcuded type', () => {
+      expect(newConfig?.value?.fetch?.metadata?.exclude).toEqual([{ metadataType: 'Type1' }, { metadataType: 'ExcludedType' }])
+    })
+    it('should not overwrite other settings', () => {
+      expect(newConfig?.value?.fetch?.metadata?.objectsToSeperateFieldsToFiles).toEqual(['Type2'])
     })
   })
 })

--- a/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
+++ b/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
@@ -50,7 +50,7 @@ describe('validateMetadataParams', () => {
         exclude: [
           { metadataType: '(' },
         ],
-      }, ['aaa'])).toThrow('Failed to load config due to an invalid aaa.include.metadataType value. The following regular expressions are invalid: (')
+      }, ['aaa'])).toThrow('Failed to load config due to an invalid aaa.exclude.metadataType value. The following regular expressions are invalid: (')
     })
 
     it('invalid namespace', () => {
@@ -58,7 +58,7 @@ describe('validateMetadataParams', () => {
         exclude: [
           { namespace: '(' },
         ],
-      }, ['aaa'])).toThrow('Failed to load config due to an invalid aaa.include.namespace value. The following regular expressions are invalid: (')
+      }, ['aaa'])).toThrow('Failed to load config due to an invalid aaa.exclude.namespace value. The following regular expressions are invalid: (')
     })
 
     it('invalid name', () => {
@@ -66,7 +66,7 @@ describe('validateMetadataParams', () => {
         exclude: [
           { name: '(' },
         ],
-      }, ['aaa'])).toThrow('Failed to load config due to an invalid aaa.include.name value. The following regular expressions are invalid: (')
+      }, ['aaa'])).toThrow('Failed to load config due to an invalid aaa.exclude.name value. The following regular expressions are invalid: (')
     })
   })
 

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -27,6 +27,7 @@ import {
   METADATA_TYPE,
   OBJECTS_PATH,
   SALESFORCE,
+  OBJECT_FIELDS_PATH,
 } from '../../src/constants'
 import mockClient from '../client'
 import { defaultFilterContext, createCustomObjectType } from '../utils'
@@ -317,10 +318,10 @@ describe('Custom Object Split filter', () => {
       expect(elements).toBeArrayOfSize(4)
       expect(getElementPaths(elements)).toEqual(
         [
+          `${SALESFORCE}/${OBJECTS_PATH}/SpecialObject__c/Fields/Custom__c`,
+          `${SALESFORCE}/${OBJECTS_PATH}/SpecialObject__c/Fields/OtherCustom__c`,
+          `${SALESFORCE}/${OBJECTS_PATH}/SpecialObject__c/Fields/Standard`,
           `${SALESFORCE}/${OBJECTS_PATH}/SpecialObject__c/SpecialObject__cAnnotations`,
-          `${SALESFORCE}/${OBJECTS_PATH}/SpecialObject__c/SpecialObject__cFieldCustom__c`,
-          `${SALESFORCE}/${OBJECTS_PATH}/SpecialObject__c/SpecialObject__cFieldOtherCustom__c`,
-          `${SALESFORCE}/${OBJECTS_PATH}/SpecialObject__c/SpecialObject__cFieldStandard`,
         ]
       )
     })
@@ -339,7 +340,7 @@ describe('Custom Object Split filter', () => {
       const elements = elementsByElemId['salesforce.SpecialObject__c']
       const customField = elements.find(obj =>
         _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
-          'SpecialObject__c', 'SpecialObject__cFieldCustom__c'])) as ObjectType
+          'SpecialObject__c', OBJECT_FIELDS_PATH, 'Custom__c'])) as ObjectType
       expect(customField).toBeDefined()
       expect(Object.values(customField.fields).length).toEqual(1)
       expect(customField.fields.Custom__c).toBeDefined()

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -28,11 +28,17 @@ import {
   OBJECTS_PATH,
   SALESFORCE,
 } from '../../src/constants'
+import mockClient from '../client'
+import { defaultFilterContext } from '../utils'
 
 
 describe('Custom Object Split filter', () => {
   type FilterType = FilterWith<'onFetch'>
-  const filter = (): FilterType => filterCreator() as FilterType
+  const filter = (): FilterType => filterCreator({
+    client: mockClient().client,
+    config: defaultFilterContext,
+  }) as FilterType
+
   const runFilter = async (...customObjects: ObjectType[]): Promise<Element[]> => {
     const elements = [...customObjects]
     await filter().onFetch(elements)

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -357,9 +357,5 @@ describe('Custom Object Split filter', () => {
         ]
       )
     })
-    it('should not split instances', () => {
-      const elements = elementsByElemId['salesforce.SpecialObject__c.instance.bla'] ?? []
-      expect(elements).toBeArrayOfSize(0)
-    })
   })
 })

--- a/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_split.test.ts
@@ -29,161 +29,216 @@ import {
   SALESFORCE,
 } from '../../src/constants'
 import mockClient from '../client'
-import { defaultFilterContext } from '../utils'
+import { defaultFilterContext, createCustomObjectType } from '../utils'
 
+type FilterType = FilterWith<'onFetch'>
+
+const getElementPaths = (elements: Element[]): string[] => elements
+  .map(elem => elem.path ?? [])
+  .map(path => path.join('/'))
+  .sort()
 
 describe('Custom Object Split filter', () => {
-  type FilterType = FilterWith<'onFetch'>
-  const filter = (): FilterType => filterCreator({
-    client: mockClient().client,
-    config: defaultFilterContext,
-  }) as FilterType
+  describe('when using default file split', () => {
+    const filter = (): FilterType => filterCreator({
+      client: mockClient().client,
+      config: defaultFilterContext,
+    }) as FilterType
 
-  const runFilter = async (...customObjects: ObjectType[]): Promise<Element[]> => {
-    const elements = [...customObjects]
-    await filter().onFetch(elements)
-    return elements
-  }
-  const noNameSpaceObject = new ObjectType({
-    elemID: CUSTOM_OBJECT_TYPE_ID,
-    fields: {
-      standard: {
-        refType: BuiltinTypes.STRING,
-      },
-      // eslint-disable-next-line camelcase
-      custom__c: {
-        refType: BuiltinTypes.STRING,
-      },
-      // eslint-disable-next-line camelcase
-      custom_namespace__c: {
-        refType: BuiltinTypes.STRING,
-        annotations: {
-          [API_NAME]: 'objectRandom__c.namespace__random__c',
-        },
-      },
-    },
-    annotations: {
-      [METADATA_TYPE]: CUSTOM_OBJECT,
-      [API_NAME]: 'objectRandom__c',
-    },
-  })
-  const namespaceObject = new ObjectType({
-    elemID: CUSTOM_OBJECT_TYPE_ID,
-    fields: {
-      standard: {
-        refType: BuiltinTypes.STRING,
-      },
-      // eslint-disable-next-line camelcase
-      custom__c: {
-        refType: BuiltinTypes.STRING,
-      },
-      // eslint-disable-next-line camelcase
-      custom_namespace__c: {
-        refType: BuiltinTypes.STRING,
-        annotations: {
-          [API_NAME]: 'namespace__objectRandom__c.namespace__api_name',
-        },
-      },
-    },
-    annotations: {
-      [METADATA_TYPE]: CUSTOM_OBJECT,
-      [API_NAME]: 'namespace__objectRandom__c',
-    },
-  })
-
-  describe('should split non-Namespace Custom Object to elements', () => {
-    let elements: Element[]
-    beforeEach(async () => {
-      elements = await runFilter(noNameSpaceObject)
-    })
-
-    it('should create annotations object', () => {
-      const annotationsObj = elements.find(obj =>
-        _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
-          'CustomObject', 'CustomObjectAnnotations'])) as ObjectType
-      expect(annotationsObj).toBeDefined()
-      expect(Object.values(annotationsObj.fields).length).toEqual(0)
-      expect(annotationsObj.annotations[METADATA_TYPE]).toEqual(CUSTOM_OBJECT)
-    })
-
-    it('should create standard fields object', () => {
-      const standardFieldsObj = elements.find(obj =>
-        _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
-          'CustomObject', 'CustomObjectStandardFields'])) as ObjectType
-      expect(standardFieldsObj).toBeDefined()
-      expect(Object.values(standardFieldsObj.annotations).length).toEqual(0)
-      expect(standardFieldsObj.fields.standard).toBeDefined()
-      expect(standardFieldsObj.fields.standard
-        .isEqual(noNameSpaceObject.fields.standard)).toBeTruthy()
-    })
-
-    it('should create custom fields object with all custom fields', () => {
-      const customFieldsObj = elements.find(obj =>
-        _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
-          'CustomObject', 'CustomObjectCustomFields'])) as ObjectType
-      expect(customFieldsObj).toBeDefined()
-      expect(Object.values(customFieldsObj.annotations).length).toEqual(0)
-      expect(customFieldsObj.fields.custom__c).toBeDefined()
-      expect(customFieldsObj.fields.custom__c
-        .isEqual(noNameSpaceObject.fields.custom__c)).toBeTruthy()
-      expect(customFieldsObj.fields.custom_namespace__c).toBeDefined()
-      expect(customFieldsObj.fields.custom_namespace__c
-        .isEqual(noNameSpaceObject.fields.custom_namespace__c)).toBeTruthy()
-    })
-  })
-
-  describe('should split namespace Custom Object to elements', () => {
-    let elements: Element[]
-    beforeEach(async () => {
-      elements = await runFilter(namespaceObject)
-    })
-
-    it('should create annotations object inside the installed packages folder', () => {
-      const annotationsObj = elements.find(obj =>
-        _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
-          'CustomObject', 'CustomObjectAnnotations'])) as ObjectType
-      expect(annotationsObj).toBeDefined()
-      expect(Object.values(annotationsObj.fields).length).toEqual(0)
-      expect(annotationsObj.annotations[METADATA_TYPE]).toEqual(CUSTOM_OBJECT)
-    })
-
-    it('should create standard fields object inside the installed packages folder', () => {
-      const standardFieldsObj = elements.find(obj =>
-        _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
-          'CustomObject', 'CustomObjectStandardFields'])) as ObjectType
-      expect(standardFieldsObj).toBeDefined()
-      expect(Object.values(standardFieldsObj.annotations).length).toEqual(0)
-      expect(standardFieldsObj.fields.standard).toBeDefined()
-      expect(standardFieldsObj.fields.standard
-        .isEqual(namespaceObject.fields.standard)).toBeTruthy()
-    })
-
-    it('should create namespace custom fields object with all custom fields inside the installed packages folder', () => {
-      const customFieldsObj = elements.find(obj =>
-        _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
-          'CustomObject', 'CustomObjectCustomFields'])) as ObjectType
-      expect(customFieldsObj).toBeDefined()
-      expect(Object.values(customFieldsObj.annotations).length).toEqual(0)
-      expect(customFieldsObj.fields.custom_namespace__c).toBeDefined()
-      expect(customFieldsObj.fields.custom_namespace__c
-        .isEqual(namespaceObject.fields.custom_namespace__c)).toBeTruthy()
-      expect(customFieldsObj.fields.custom__c).toBeDefined()
-      expect(customFieldsObj.fields.custom__c
-        .isEqual(namespaceObject.fields.custom__c)).toBeTruthy()
-    })
-  })
-
-  describe('when split elements contain empty objects', () => {
-    const getSplitElementsPaths = async (...customObjects: ObjectType[])
-      : Promise<(readonly string[])[]> => {
-      const splitElements = await runFilter(...customObjects)
-      return splitElements.map(customObject => (customObject.path)).filter(values.isDefined)
+    const runFilter = async (...customObjects: ObjectType[]): Promise<Element[]> => {
+      const elements = [...customObjects]
+      await filter().onFetch(elements)
+      return elements
     }
+    const noNameSpaceObject = new ObjectType({
+      elemID: CUSTOM_OBJECT_TYPE_ID,
+      fields: {
+        standard: {
+          refType: BuiltinTypes.STRING,
+        },
+        // eslint-disable-next-line camelcase
+        custom__c: {
+          refType: BuiltinTypes.STRING,
+        },
+        // eslint-disable-next-line camelcase
+        custom_namespace__c: {
+          refType: BuiltinTypes.STRING,
+          annotations: {
+            [API_NAME]: 'objectRandom__c.namespace__random__c',
+          },
+        },
+      },
+      annotations: {
+        [METADATA_TYPE]: CUSTOM_OBJECT,
+        [API_NAME]: 'objectRandom__c',
+      },
+    })
+    const namespaceObject = new ObjectType({
+      elemID: CUSTOM_OBJECT_TYPE_ID,
+      fields: {
+        standard: {
+          refType: BuiltinTypes.STRING,
+        },
+        // eslint-disable-next-line camelcase
+        custom__c: {
+          refType: BuiltinTypes.STRING,
+        },
+        // eslint-disable-next-line camelcase
+        custom_namespace__c: {
+          refType: BuiltinTypes.STRING,
+          annotations: {
+            [API_NAME]: 'namespace__objectRandom__c.namespace__api_name',
+          },
+        },
+      },
+      annotations: {
+        [METADATA_TYPE]: CUSTOM_OBJECT,
+        [API_NAME]: 'namespace__objectRandom__c',
+      },
+    })
 
-    it('should filter out empty standard fields object', async () => {
-      const objectWithNoStandardFields = new ObjectType({
-        elemID: CUSTOM_OBJECT_TYPE_ID,
+    describe('should split non-Namespace Custom Object to elements', () => {
+      let elements: Element[]
+      beforeEach(async () => {
+        elements = await runFilter(noNameSpaceObject)
+      })
+
+      it('should create annotations object', () => {
+        const annotationsObj = elements.find(obj =>
+          _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
+            'CustomObject', 'CustomObjectAnnotations'])) as ObjectType
+        expect(annotationsObj).toBeDefined()
+        expect(Object.values(annotationsObj.fields).length).toEqual(0)
+        expect(annotationsObj.annotations[METADATA_TYPE]).toEqual(CUSTOM_OBJECT)
+      })
+
+      it('should create standard fields object', () => {
+        const standardFieldsObj = elements.find(obj =>
+          _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
+            'CustomObject', 'CustomObjectStandardFields'])) as ObjectType
+        expect(standardFieldsObj).toBeDefined()
+        expect(Object.values(standardFieldsObj.annotations).length).toEqual(0)
+        expect(standardFieldsObj.fields.standard).toBeDefined()
+        expect(standardFieldsObj.fields.standard
+          .isEqual(noNameSpaceObject.fields.standard)).toBeTruthy()
+      })
+
+      it('should create custom fields object with all custom fields', () => {
+        const customFieldsObj = elements.find(obj =>
+          _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
+            'CustomObject', 'CustomObjectCustomFields'])) as ObjectType
+        expect(customFieldsObj).toBeDefined()
+        expect(Object.values(customFieldsObj.annotations).length).toEqual(0)
+        expect(customFieldsObj.fields.custom__c).toBeDefined()
+        expect(customFieldsObj.fields.custom__c
+          .isEqual(noNameSpaceObject.fields.custom__c)).toBeTruthy()
+        expect(customFieldsObj.fields.custom_namespace__c).toBeDefined()
+        expect(customFieldsObj.fields.custom_namespace__c
+          .isEqual(noNameSpaceObject.fields.custom_namespace__c)).toBeTruthy()
+      })
+    })
+
+    describe('should split namespace Custom Object to elements', () => {
+      let elements: Element[]
+      beforeEach(async () => {
+        elements = await runFilter(namespaceObject)
+      })
+
+      it('should create annotations object inside the installed packages folder', () => {
+        const annotationsObj = elements.find(obj =>
+          _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
+            'CustomObject', 'CustomObjectAnnotations'])) as ObjectType
+        expect(annotationsObj).toBeDefined()
+        expect(Object.values(annotationsObj.fields).length).toEqual(0)
+        expect(annotationsObj.annotations[METADATA_TYPE]).toEqual(CUSTOM_OBJECT)
+      })
+
+      it('should create standard fields object inside the installed packages folder', () => {
+        const standardFieldsObj = elements.find(obj =>
+          _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
+            'CustomObject', 'CustomObjectStandardFields'])) as ObjectType
+        expect(standardFieldsObj).toBeDefined()
+        expect(Object.values(standardFieldsObj.annotations).length).toEqual(0)
+        expect(standardFieldsObj.fields.standard).toBeDefined()
+        expect(standardFieldsObj.fields.standard
+          .isEqual(namespaceObject.fields.standard)).toBeTruthy()
+      })
+
+      it('should create namespace custom fields object with all custom fields inside the installed packages folder', () => {
+        const customFieldsObj = elements.find(obj =>
+          _.isEqual(obj.path, [SALESFORCE, INSTALLED_PACKAGES_PATH, 'namespace', OBJECTS_PATH,
+            'CustomObject', 'CustomObjectCustomFields'])) as ObjectType
+        expect(customFieldsObj).toBeDefined()
+        expect(Object.values(customFieldsObj.annotations).length).toEqual(0)
+        expect(customFieldsObj.fields.custom_namespace__c).toBeDefined()
+        expect(customFieldsObj.fields.custom_namespace__c
+          .isEqual(namespaceObject.fields.custom_namespace__c)).toBeTruthy()
+        expect(customFieldsObj.fields.custom__c).toBeDefined()
+        expect(customFieldsObj.fields.custom__c
+          .isEqual(namespaceObject.fields.custom__c)).toBeTruthy()
+      })
+    })
+
+    describe('when split elements contain empty objects', () => {
+      const getSplitElementsPaths = async (...customObjects: ObjectType[])
+        : Promise<(readonly string[])[]> => {
+        const splitElements = await runFilter(...customObjects)
+        return splitElements.map(customObject => (customObject.path)).filter(values.isDefined)
+      }
+
+      it('should filter out empty standard fields object', async () => {
+        const objectWithNoStandardFields = new ObjectType({
+          elemID: CUSTOM_OBJECT_TYPE_ID,
+          fields: {
+            custom__c: {
+              refType: BuiltinTypes.STRING,
+            },
+            custom_namespace__c: {
+              refType: BuiltinTypes.STRING,
+              annotations: {
+                [API_NAME]: 'objectRandom__c.namespace__random__c',
+              },
+            },
+          },
+          annotations: {
+            [METADATA_TYPE]: CUSTOM_OBJECT,
+            [API_NAME]: 'objectRandom__c',
+          },
+        })
+        const splitElementsPaths = await getSplitElementsPaths(objectWithNoStandardFields)
+        expect(splitElementsPaths).toIncludeSameMembers([
+          [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectCustomFields'],
+          [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectAnnotations'],
+        ])
+      })
+      it('should filter out empty custom fields object', async () => {
+        const objectWithNoCustomFields = new ObjectType({
+          elemID: CUSTOM_OBJECT_TYPE_ID,
+          fields: {
+            standard: {
+              refType: BuiltinTypes.STRING,
+            },
+          },
+          annotations: {
+            [METADATA_TYPE]: CUSTOM_OBJECT,
+            [API_NAME]: 'objectRandom__c',
+          },
+        })
+        const splitElementsPaths = await getSplitElementsPaths(objectWithNoCustomFields)
+        expect(splitElementsPaths).toIncludeSameMembers([
+          [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectStandardFields'],
+          [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectAnnotations'],
+        ])
+      })
+    })
+
+    it('should not split non-custom object', async () => {
+      const nonCustomObject = new ObjectType({
+        elemID: new ElemID(SALESFORCE, 'NonCustomObject'),
         fields: {
+          standard: {
+            refType: BuiltinTypes.STRING,
+          },
           custom__c: {
             refType: BuiltinTypes.STRING,
           },
@@ -195,60 +250,115 @@ describe('Custom Object Split filter', () => {
           },
         },
         annotations: {
-          [METADATA_TYPE]: CUSTOM_OBJECT,
+          [METADATA_TYPE]: 'NonCustomObject',
           [API_NAME]: 'objectRandom__c',
         },
       })
-      const splitElementsPaths = await getSplitElementsPaths(objectWithNoStandardFields)
-      expect(splitElementsPaths).toIncludeSameMembers([
-        [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectCustomFields'],
-        [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectAnnotations'],
-      ])
+      const splitElements = await runFilter(nonCustomObject)
+      expect(splitElements).toEqual([nonCustomObject])
     })
-    it('should filter out empty custom fields object', async () => {
-      const objectWithNoCustomFields = new ObjectType({
-        elemID: CUSTOM_OBJECT_TYPE_ID,
+  })
+  describe('when using per field file split', () => {
+    const filter = (separateFieldToFiles: string[]): FilterType => filterCreator({
+      client: mockClient().client,
+      config: { ...defaultFilterContext, separateFieldToFiles },
+    }) as FilterType
+
+    const runFilter = async (...customObjects: ObjectType[]): Promise<Element[]> => {
+      const elements = [...customObjects]
+      await filter(['SpecialObject__c']).onFetch(elements)
+      return elements
+    }
+    const typeToSplit = createCustomObjectType(
+      'SpecialObject__c',
+      {
         fields: {
-          standard: {
+          Standard: {
+            refType: BuiltinTypes.STRING,
+          },
+          // eslint-disable-next-line camelcase
+          Custom__c: {
+            refType: BuiltinTypes.STRING,
+          },
+          // eslint-disable-next-line camelcase
+          OtherCustom__c: {
             refType: BuiltinTypes.STRING,
           },
         },
-        annotations: {
-          [METADATA_TYPE]: CUSTOM_OBJECT,
-          [API_NAME]: 'objectRandom__c',
-        },
-      })
-      const splitElementsPaths = await getSplitElementsPaths(objectWithNoCustomFields)
-      expect(splitElementsPaths).toIncludeSameMembers([
-        [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectStandardFields'],
-        [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectAnnotations'],
-      ])
-    })
-  })
-
-  it('should not split non-custom object', async () => {
-    const nonCustomObject = new ObjectType({
-      elemID: new ElemID(SALESFORCE, 'NonCustomObject'),
-      fields: {
-        standard: {
-          refType: BuiltinTypes.STRING,
-        },
-        custom__c: {
-          refType: BuiltinTypes.STRING,
-        },
-        custom_namespace__c: {
-          refType: BuiltinTypes.STRING,
-          annotations: {
-            [API_NAME]: 'objectRandom__c.namespace__random__c',
+      },
+    )
+    const otherType = createCustomObjectType(
+      'OtherType__c',
+      {
+        fields: {
+          Standard: {
+            refType: BuiltinTypes.STRING,
+          },
+          // eslint-disable-next-line camelcase
+          Custom__c: {
+            refType: BuiltinTypes.STRING,
+          },
+          // eslint-disable-next-line camelcase
+          OtherCustom__c: {
+            refType: BuiltinTypes.STRING,
           },
         },
       },
-      annotations: {
-        [METADATA_TYPE]: 'NonCustomObject',
-        [API_NAME]: 'objectRandom__c',
-      },
+    )
+    let elementsByElemId: Record<string, Element[]>
+
+    beforeEach(async () => {
+      const elements = await runFilter(typeToSplit, otherType)
+      elementsByElemId = _.groupBy(elements, value => value.elemID.getFullName())
     })
-    const splitElements = await runFilter(nonCustomObject)
-    expect(splitElements).toEqual([nonCustomObject])
+
+    it('should split the selected type', () => {
+      const elements = elementsByElemId['salesforce.SpecialObject__c']
+      expect(elements).toBeArrayOfSize(4)
+      expect(getElementPaths(elements)).toEqual(
+        [
+          `${SALESFORCE}/${OBJECTS_PATH}/SpecialObject__c/SpecialObject__cAnnotations`,
+          `${SALESFORCE}/${OBJECTS_PATH}/SpecialObject__c/SpecialObject__cFieldCustom__c`,
+          `${SALESFORCE}/${OBJECTS_PATH}/SpecialObject__c/SpecialObject__cFieldOtherCustom__c`,
+          `${SALESFORCE}/${OBJECTS_PATH}/SpecialObject__c/SpecialObject__cFieldStandard`,
+        ]
+      )
+    })
+    it('should still split all the annotations to a single file', () => {
+      const elements = elementsByElemId['salesforce.SpecialObject__c']
+      const annotationsObj = elements.find(obj =>
+        _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
+          'SpecialObject__c', 'SpecialObject__cAnnotations'])) as ObjectType
+      expect(annotationsObj).toBeDefined()
+      expect(Object.values(annotationsObj.annotations).length).toEqual(2)
+      expect(Object.values(annotationsObj.fields).length).toEqual(0)
+      expect(annotationsObj.annotations[METADATA_TYPE]).toEqual(CUSTOM_OBJECT)
+    })
+
+    it('should put a single field into each file', () => {
+      const elements = elementsByElemId['salesforce.SpecialObject__c']
+      const customField = elements.find(obj =>
+        _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH,
+          'SpecialObject__c', 'SpecialObject__cFieldCustom__c'])) as ObjectType
+      expect(customField).toBeDefined()
+      expect(Object.values(customField.fields).length).toEqual(1)
+      expect(customField.fields.Custom__c).toBeDefined()
+      expect(Object.values(customField.annotations).length).toEqual(0)
+    })
+    it('should not split any other type', () => {
+      const elements = elementsByElemId['salesforce.OtherType__c']
+      expect(elements).toBeArrayOfSize(3)
+      expect(getElementPaths(elements)).toEqual(
+        [
+          `${SALESFORCE}/${OBJECTS_PATH}/OtherType__c/OtherType__cAnnotations`,
+          `${SALESFORCE}/${OBJECTS_PATH}/OtherType__c/OtherType__cCustomFields`,
+          `${SALESFORCE}/${OBJECTS_PATH}/OtherType__c/OtherType__cStandardFields`,
+        ]
+      )
+    })
+    it('should not split instances', () => {
+      const elements = elementsByElemId['salesforce.SpecialObject__c.instance.bla'] ?? []
+      expect(elements).toBeArrayOfSize(0)
+    })
   })
 })

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -333,6 +333,15 @@ const validateAnnotationsValue = async (
     return validateRequiredValue()
   }
 
+  if (isListType(type) && shouldEnforceValue()) {
+    const maxLength = restrictions.max_length
+    if ((values.isDefined(maxLength) && _.isArray(value) && value.length > maxLength)) {
+      return [new InvalidValueMaxLengthValidationError(
+        { elemID, value: value.toString(), fieldName: elemID.name, maxLength }
+      )]
+    }
+  }
+
   // Checking restrictions
   if ((isPrimitiveType(type)
     || (isContainerType(type) && isPrimitiveType(await type.getInnerType(elementsSource)))

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -219,6 +219,14 @@ describe('Elements validation', () => {
           }),
         },
       },
+      restrictedListLength: {
+        refType: new ListType(BuiltinTypes.NUMBER),
+        annotations: {
+          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
+            max_length: 5,
+          }),
+        },
+      },
       restrictedAnnotation: {
         refType: restrictedAnnotation,
         annotations: {
@@ -498,6 +506,7 @@ describe('Elements validation', () => {
         listOfMaps: [{ key: 'value' }, { another: 'one' }],
         restrictStr: 'restriction1',
         restrictedStringMaxLengthType: '1',
+        restrictedListLength: [1, 2, 3],
       }
     )
 
@@ -1159,6 +1168,23 @@ describe('Elements validation', () => {
           expect(errors[0]).toBeInstanceOf(RegexMismatchValidationError)
           expect(errors[0].message).toMatch('Value "211" is not valid for field restrictNumberRegex. expected value to match "^1[0-9]*$" regular expression')
           expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('restrictNumberRegex'))
+        })
+
+        it('should return an error when list is longer than restriction', async () => {
+          extInst.value.restrictedListLength = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+          const errors = await validateElements(
+            [extInst],
+            createInMemoryElementSource([
+              extInst,
+              nestedType,
+              ...await getFieldsAndAnnoTypes(extType),
+            ])
+          )
+          expect(errors).toHaveLength(1)
+          expect(errors[0]).toBeInstanceOf(InvalidValueMaxLengthValidationError)
+          expect(errors[0].message).toMatch('Value "1,2,3,4,5,6,7,8,9,10" is too long for field')
+          expect(errors[0].message).toMatch('restrictedListLength maximum length is 5')
+          expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('restrictedListLength'))
         })
       })
     })


### PR DESCRIPTION
Add a configuration option to specify a short list of types which will be split to a file per field (instead of 
the usual 2 files: one for custom fields and one for standard fields). 

This will make committing changes easier when done per file.

---

None

---
_Release Notes_: 

Salesforce - Add a configuration to split specific type nacls to one file per field

---
_User Notifications_: 

None
